### PR TITLE
Slack: stop injecting channel history into new mention sessions

### DIFF
--- a/src/agents/slack/handlers.ts
+++ b/src/agents/slack/handlers.ts
@@ -24,7 +24,6 @@ import {
   removeReaction,
   getUserInfo,
   fetchThreadContext,
-  fetchChannelContext,
   postSlackBlocks,
   updateSlackBlocks,
   openSlackModal,
@@ -992,12 +991,12 @@ Please help with this request. Start by exploring the codebase to understand wha
 
   // Regular (non-worktree) channel mention — existing behavior
 
-  // Fetch context
+  // Only thread mentions get surrounding context: a thread is one coherent
+  // conversation, while channel history is mostly other people's unrelated
+  // requests and would leak into the session prompt.
   let context = "";
   if (thread_ts) {
     context = await fetchThreadContext(channel, thread_ts);
-  } else {
-    context = await fetchChannelContext(channel, 10);
   }
 
   let worktreeDir: string | undefined;
@@ -1008,13 +1007,17 @@ Please help with this request. Start by exploring the codebase to understand wha
     branch = await generateBranchName(cleanText);
     worktreeDir = createWorktree(branch, user, cleanText);
 
-    prompt = `${userName} tagged me in a Slack ${thread_ts ? "thread" : "channel"} with this context:
+    const intro = context
+      ? `${userName} tagged me in a Slack thread with this context:
 
 ---
 ${context}
 ---
 
-Their message: "${cleanText}"
+Their message: "${cleanText}"`
+      : `${userName} tagged me in a Slack channel with this message: "${cleanText}"`;
+
+    prompt = `${intro}
 
 I'm now in a worktree (branch: ${branch}) for this task. Please help with this request. Start by exploring the codebase to understand the relevant code.`;
   } catch (e) {

--- a/src/agents/slack/slack-api.ts
+++ b/src/agents/slack/slack-api.ts
@@ -243,27 +243,6 @@ export async function fetchThreadContext(
     .join("\n\n");
 }
 
-export async function fetchChannelContext(
-  channel: string,
-  limit: number = 10
-): Promise<string> {
-  const response = await fetchWithTimeout(
-    `https://slack.com/api/conversations.history?channel=${channel}&limit=${limit}`,
-    { headers: { Authorization: `Bearer ${SLACK_BOT_TOKEN}` } }
-  );
-  const data = (await response.json()) as any;
-
-  if (!data.ok || !data.messages) {
-    console.error("[slack] Failed to fetch channel history:", data.error);
-    return "";
-  }
-
-  return data.messages
-    .reverse()
-    .map((msg: any) => `[${msg.user || "bot"}]: ${msg.text}`)
-    .join("\n\n");
-}
-
 // ---------------------------------------------------------------------------
 // User info
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Michiel tagged the bot top-level in a channel with a one-line request, but the session started with ~10 unrelated channel messages in its prompt — including other people's requests to the bot (Johnny's Plain card issues, Snyk cleanup, docs tasks, etc.).

Cause: `handleMentionEvent` fetched the last 10 channel messages via `fetchChannelContext(channel, 10)` for any mention outside a thread, regardless of author or relevance.

## What changed

- Top-level channel mentions no longer fetch channel history — the mention message itself is the request.
- Thread mentions keep fetching the thread (a thread is one coherent conversation).
- Removed the now-unused `fetchChannelContext` from `slack-api.ts`.

No slack-agent type errors (`bunx tsc --noEmit` failures are pre-existing in linear/plain/frontend files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)