### PR TITLE
Stripe dispute webhook → investigation automation

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -1287,6 +1287,18 @@ async function loadAgents(): Promise<AgentModule[]> {
     }
   }
 
+  // Gated on the signing secret: without it every webhook fails verification, so
+  // there's no point exposing the route. Set STRIPE_WEBHOOK_SECRET to activate.
+  if (process.env.ENABLE_STRIPE_AGENT !== "false" && process.env.STRIPE_WEBHOOK_SECRET) {
+    try {
+      const { StripeAgent } = await import("./src/agents/stripe/index");
+      agents.push(new StripeAgent());
+      console.log("[agents] Stripe agent loaded");
+    } catch (e) {
+      console.error("[agents] Failed to load stripe agent:", e);
+    }
+  }
+
   return agents;
 }
 

--- a/src/agents/stripe/handlers.ts
+++ b/src/agents/stripe/handlers.ts
@@ -1,0 +1,73 @@
+/**
+ * Stripe webhook handlers.
+ *
+ * The only event we act on is `charge.dispute.created` — a chargeback was filed.
+ * We fire the `stripe:charge.dispute.created` automation event with the dispute's
+ * identifiers and headline facts. The investigation automation treats Stripe as
+ * source of truth and re-fetches the full dispute itself via the Stripe MCP, so
+ * we deliberately forward a small payload (no 10KB-truncation risk) rather than
+ * the whole event object.
+ */
+
+export const DISPUTE_CREATED_EVENT = "stripe:charge.dispute.created";
+
+interface StripeDispute {
+  id: string;
+  amount?: number;
+  currency?: string;
+  reason?: string;
+  status?: string;
+  charge?: string | { id?: string };
+  payment_intent?: string | { id?: string } | null;
+  created?: number;
+  evidence_details?: { due_by?: number | null } | null;
+}
+
+interface StripeEvent {
+  id: string;
+  type: string;
+  livemode?: boolean;
+  data?: { object?: StripeDispute };
+}
+
+function idOf(value: string | { id?: string } | null | undefined): string | null {
+  if (!value) return null;
+  return typeof value === "string" ? value : value.id ?? null;
+}
+
+/**
+ * Parse a verified Stripe event and, for a created dispute, fire the automation
+ * event. Returns the number of automations fired (0 for ignored event types).
+ */
+export async function handleStripeEvent(event: StripeEvent): Promise<number> {
+  if (event.type !== "charge.dispute.created") {
+    console.log(`[stripe] Ignoring event ${event.type}`);
+    return 0;
+  }
+
+  const dispute = event.data?.object;
+  if (!dispute?.id) {
+    console.error("[stripe] charge.dispute.created with no dispute object");
+    return 0;
+  }
+
+  const payload = {
+    source: "stripe-webhook",
+    eventId: event.id,
+    livemode: event.livemode ?? false,
+    disputeId: dispute.id,
+    reason: dispute.reason ?? null,
+    status: dispute.status ?? null,
+    amount: dispute.amount ?? null,
+    currency: dispute.currency ?? null,
+    dueBy: dispute.evidence_details?.due_by ?? null,
+    charge: idOf(dispute.charge),
+    paymentIntent: idOf(dispute.payment_intent),
+    created: dispute.created ?? null,
+  };
+
+  const { fireAutomationsForEvent } = await import("../../server/automations");
+  const fired = fireAutomationsForEvent(DISPUTE_CREATED_EVENT, JSON.stringify(payload, null, 2));
+  console.log(`[stripe] Dispute ${dispute.id} (${dispute.reason ?? "?"}) → fired ${fired} automation(s)`);
+  return fired;
+}

--- a/src/agents/stripe/index.ts
+++ b/src/agents/stripe/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Stripe Agent Module — receives Stripe webhooks and fires automation events.
+ *
+ * Currently it handles `charge.dispute.created`: when a chargeback is filed,
+ * it fires the `stripe:charge.dispute.created` event, which the dispute
+ * investigation automation subscribes to via its eventKey.
+ */
+import type { AgentModule } from "../types";
+import { verifyStripeSignature } from "../../server/shared/signature";
+import { handleStripeEvent } from "./handlers";
+
+const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || "";
+
+export class StripeAgent implements AgentModule {
+  name = "stripe";
+
+  getRoutes(): Map<string, (req: Request, url: URL) => Promise<Response>> {
+    const routes = new Map<string, (req: Request, url: URL) => Promise<Response>>();
+
+    routes.set("POST /stripe/webhook", async (req) => {
+      const body = await req.text();
+      const signature = req.headers.get("stripe-signature") || "";
+
+      if (!verifyStripeSignature(body, signature, STRIPE_WEBHOOK_SECRET)) {
+        console.error("[stripe] Invalid webhook signature");
+        return Response.json({ error: "Invalid signature" }, { status: 401 });
+      }
+
+      let event;
+      try {
+        event = JSON.parse(body);
+      } catch (e) {
+        console.error("[stripe] Error parsing webhook payload:", e);
+        return Response.json({ error: "Invalid payload" }, { status: 400 });
+      }
+
+      // Fire-and-forget: ack Stripe immediately, run the automation async.
+      void handleStripeEvent(event).catch((e) =>
+        console.error("[stripe] Error handling event:", e)
+      );
+
+      return Response.json({ ok: true });
+    });
+
+    return routes;
+  }
+
+  async startup(): Promise<void> {
+    console.log("[stripe] Agent started");
+  }
+
+  async shutdown(): Promise<void> {
+    console.log("[stripe] Agent shut down");
+  }
+
+  health(): Record<string, unknown> {
+    return {
+      status: STRIPE_WEBHOOK_SECRET ? "operational" : "missing STRIPE_WEBHOOK_SECRET",
+    };
+  }
+}

--- a/src/server/shared/signature.ts
+++ b/src/server/shared/signature.ts
@@ -76,3 +76,40 @@ export function verifyPlainSignature(
   const computed = createHmac("sha256", secret).update(body).digest("hex");
   return computed === signature;
 }
+
+/**
+ * Verify Stripe webhook signature.
+ * Header: stripe-signature
+ * Format: t=<timestamp>,v1=<hmac-sha256(secret, "{t}.{body}")>[,v1=<rotated>]
+ * The secret is the endpoint signing secret (whsec_…), not the API key.
+ */
+export function verifyStripeSignature(
+  body: string,
+  signature: string,
+  secret: string
+): boolean {
+  if (!signature || !secret) return false;
+
+  const parts = signature.split(",").map((p) => p.trim());
+  const timestamp = parts.find((p) => p.startsWith("t="))?.slice(2);
+  // A secret rotation yields multiple v1 signatures; accept a match on any.
+  const candidates = parts.filter((p) => p.startsWith("v1=")).map((p) => p.slice(3));
+  if (!timestamp || candidates.length === 0) return false;
+
+  // Reject signatures outside a 5-minute tolerance (replay protection).
+  const ts = parseInt(timestamp, 10);
+  if (!Number.isFinite(ts) || Math.abs(Date.now() / 1000 - ts) > 300) return false;
+
+  const expected = createHmac("sha256", secret).update(`${timestamp}.${body}`, "utf8").digest("hex");
+  const expectedBuf = Buffer.from(expected);
+
+  return candidates.some((candidate) => {
+    const candidateBuf = Buffer.from(candidate);
+    if (candidateBuf.length !== expectedBuf.length) return false;
+    try {
+      return timingSafeEqual(candidateBuf, expectedBuf);
+    } catch {
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
## What

Replaces the earlier tella-fusion approach (per Michiel: *"backstage has webhooks, use those, not tella fusion"*). Adds a first-class **`stripe` agent module** so Stripe can post dispute webhooks straight to backstage, which fires the dispute-investigation automation. **Nothing is submitted to Stripe automatically** — the automation produces a recommendation for a human to review and submit.

Flow: `Stripe → michael.tella.dev/stripe/webhook (Caddy → :3848) → StripeAgent (verify signature) → fireAutomationsForEvent("stripe:charge.dispute.created", …) → automation run → report in #stripe-disputes`.

## Changes

| File | Change |
| --- | --- |
| `src/server/shared/signature.ts` | New `verifyStripeSignature` — HMAC-SHA256 over `{t}.{body}`, 5-minute replay tolerance, accepts any `v1=` (handles secret rotation), length-checked `timingSafeEqual`. |
| `src/agents/stripe/index.ts` | `StripeAgent` implementing `AgentModule`. Registers `POST /stripe/webhook`, verifies the signature, acks Stripe immediately, runs the handler async. |
| `src/agents/stripe/handlers.ts` | Parses the event; only `charge.dispute.created` acts. Fires the automation event with the dispute's identifiers + headline facts (id, reason, status, amount, currency, due_by, charge, payment_intent, livemode). Small payload — the automation re-fetches from Stripe (source of truth), so no 10KB-truncation risk. |
| `backstage.ts` | Loads the agent in `loadAgents()`, gated on `STRIPE_WEBHOOK_SECRET` (no secret ⇒ no point exposing an always-401 route). |

Mirrors the existing Plain/Linear/Slack agent modules and the shared signature helpers.

## Testing

- `bunx tsc --noEmit`: no new errors (the 5 reported are all pre-existing in unrelated files — `mcp-config.json` JSON-import quirk, etc.).
- Unit-tested `verifyStripeSignature`: valid, secret-rotation, wrong-secret, tampered-body, stale-timestamp, empty sig/secret — all pass.
- Smoke-tested the agent: route registers, non-dispute events ignored, dispute path fires cleanly through the real `fireAutomationsForEvent` import.

## Companion: the automation

The investigation automation (Johnny's prompt, `eventKey: stripe:charge.dispute.created`, `mode: ask`, posts to **#stripe-disputes**) is being created via the backstage automations API — it lives as runtime data in `~/.backstage-automations/`, not in this repo.

## Ops to go live (not in this PR)

1. Set `STRIPE_WEBHOOK_SECRET` (endpoint signing secret, `whsec_…`) in `~/.backstage.env`.
2. Restart backstage to load the agent (kills in-flight runs — pick a quiet moment).
3. Add a Stripe webhook endpoint → `https://michael.tella.dev/stripe/webhook`, event `charge.dispute.created`.
4. Create **#stripe-disputes** and invite the bot so the automation can post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)