### PR TITLE
Render session videos in the viewer

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -737,6 +737,63 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
     const url = new URL(req.url);
     const path = url.pathname;
 
+    // Stream a local media file referenced by a `BACKSTAGE_VIDEO:` marker in a
+    // tool's output, so the session viewer can play it inline (tools can't return
+    // video blocks the way Read returns images). Path-scoped: absolute path under
+    // /tmp or /home/ubuntu, no traversal, known media extension. Range-enabled
+    // so the <video> scrubber can seek.
+    if (path === "/backstage/media" && req.method === "GET") {
+      const mediaPath = url.searchParams.get("path") || "";
+      const mediaTypes: Record<string, string> = {
+        ".mp4": "video/mp4",
+        ".webm": "video/webm",
+        ".mov": "video/quicktime",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+      };
+      const ext = mediaPath.slice(mediaPath.lastIndexOf(".")).toLowerCase();
+      const scoped = mediaPath.startsWith("/tmp/") || mediaPath.startsWith("/home/ubuntu/");
+      if (!mediaPath.startsWith("/") || mediaPath.includes("..") || !scoped || !mediaTypes[ext]) {
+        return new Response("forbidden", { status: 403 });
+      }
+      const file = Bun.file(mediaPath);
+      if (!(await file.exists())) return new Response("not found", { status: 404 });
+
+      const type = mediaTypes[ext];
+      const size = file.size;
+      const range = req.headers.get("range");
+      const baseHeaders: Record<string, string> = {
+        "Content-Type": type,
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "private, max-age=60",
+      };
+      if (range) {
+        const m = range.match(/bytes=(\d*)-(\d*)/);
+        let start = m && m[1] ? parseInt(m[1], 10) : 0;
+        let end = m && m[2] ? parseInt(m[2], 10) : size - 1;
+        if (Number.isNaN(start) || start < 0) start = 0;
+        if (Number.isNaN(end) || end >= size) end = size - 1;
+        if (start > end) {
+          return new Response("range not satisfiable", {
+            status: 416,
+            headers: { "Content-Range": `bytes */${size}` },
+          });
+        }
+        return new Response(file.slice(start, end + 1), {
+          status: 206,
+          headers: {
+            ...baseHeaders,
+            "Content-Range": `bytes ${start}-${end}/${size}`,
+            "Content-Length": String(end - start + 1),
+          },
+        });
+      }
+      return new Response(file, { headers: { ...baseHeaders, "Content-Length": String(size) } });
+    }
+
     // App icons (KITT/red-M) — real PNGs so iOS home-screen and PWA installs
     // pick them up; data-URI apple-touch-icons don't work on iOS. Short cache
     // + must-revalidate so a refreshed design isn't pinned by a stale copy.

--- a/src/frontend/components/ToolCallBlock.tsx
+++ b/src/frontend/components/ToolCallBlock.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState } from "react";
+import React, { Suspense, lazy, useEffect, useState } from "react";
 import type { TranscriptEntry } from "../lib/types";
 import { langForFile, langForGrep } from "../lib/lang";
 
@@ -35,7 +35,13 @@ export function parseMcpTool(name: string): { server: string; tool: string } | n
 }
 
 export function ToolCallBlock({ entry, result }: Props) {
-  const [expanded, setExpanded] = useState(false);
+  const hasMedia = Boolean(result?.images?.length || result?.videos?.length);
+  // Default closed for text-only output, but auto-open when media arrives
+  // (covers both initial render and a tool_result streaming in later).
+  const [expanded, setExpanded] = useState(hasMedia);
+  useEffect(() => {
+    if (hasMedia) setExpanded(true);
+  }, [hasMedia]);
   const toolName = entry.toolName || "Tool";
   const mcp = parseMcpTool(toolName);
   const summary = getSummary(toolName, entry.toolInput, entry.content);
@@ -62,7 +68,7 @@ export function ToolCallBlock({ entry, result }: Props) {
           ) : (
             <pre className="tool-pre">{formatInput(entry.toolInput)}</pre>
           )}
-          {result && (result.content || result.images?.length) && (
+          {result && (result.content || result.images?.length || result.videos?.length) && (
             <>
               <div className="tool-result-divider">Output</div>
               {result.content && renderResultContent(toolName, entry.toolInput, result.content)}
@@ -72,6 +78,13 @@ export function ToolCallBlock({ entry, result }: Props) {
                     <a key={i} href={src} target="_blank" rel="noopener noreferrer" className="md-image-link">
                       <img className="md-image" src={src} alt="" loading="lazy" />
                     </a>
+                  ))}
+                </div>
+              )}
+              {result.videos && result.videos.length > 0 && (
+                <div className="tool-result-videos">
+                  {result.videos.map((src, i) => (
+                    <video key={i} className="md-video" src={src} controls preload="metadata" />
                   ))}
                 </div>
               )}

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -40,6 +40,9 @@ export interface TranscriptEntry {
   // Ready-to-render image srcs (http(s) URLs or data: URLs), e.g. from a Read
   // of an image file or a pasted image.
   images?: string[];
+  // Ready-to-render video srcs (served via /backstage/media), parsed from
+  // `BACKSTAGE_VIDEO: <path>` markers a tool printed — e.g. tella-local rec.mjs.
+  videos?: string[];
 }
 
 export interface DiffFile {

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -3233,6 +3233,21 @@ a {
   margin: 6px 0;
   display: block;
 }
+.tool-result-videos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+.md-video {
+  max-width: 100%;
+  max-height: 480px;
+  border-radius: 8px;
+  border: 1px solid rgba(127, 127, 127, 0.25);
+  margin: 6px 0;
+  display: block;
+  background: #000;
+}
 
 /* Composer image attachments (pasted/dropped screenshots) */
 .composer-images {

--- a/src/server/jsonl-parser.ts
+++ b/src/server/jsonl-parser.ts
@@ -79,6 +79,20 @@ function extractImages(content: any): string[] {
   return out;
 }
 
+// Tools can't return video blocks (unlike Read-of-image), so a tool that
+// produces a video prints `BACKSTAGE_VIDEO: <abs-path>` and we turn each marker
+// into a /backstage/media URL the frontend streams. Used by tella-local rec.mjs.
+const VIDEO_MARKER = /^\s*BACKSTAGE_VIDEO:\s*(\/\S+)\s*$/gm;
+
+function extractVideos(text: string): string[] {
+  if (!text) return [];
+  const out: string[] = [];
+  for (const m of text.matchAll(VIDEO_MARKER)) {
+    out.push(`/backstage/media?path=${encodeURIComponent(m[1])}`);
+  }
+  return out;
+}
+
 /**
  * Harness-injected user turns (not typed by a person). Task notifications get
  * a system line built from their <summary>; system-reminders are dropped.
@@ -124,6 +138,7 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
                     .join("\n")
                 : "";
           const images = extractImages(block.content);
+          const videos = extractVideos(resultText);
           entries.push({
             // Keyed on the tool_use id: one jsonl line can carry several
             // tool_result blocks (parallel calls), and the live-stream copy
@@ -134,6 +149,7 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
             timestamp: ts,
             toolUseId: block.tool_use_id,
             ...(images.length > 0 ? { images } : {}),
+            ...(videos.length > 0 ? { videos } : {}),
           });
         } else if (block.type === "text" && !raw.isMeta) {
           const harness = harnessEntryFor(block.text || "", ts);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -110,6 +110,9 @@ export interface TranscriptEntry {
   // Ready-to-render image srcs (http(s) URLs or data: URLs) extracted from
   // image blocks — e.g. a Read of an image file, or a pasted image.
   images?: string[];
+  // Ready-to-render video srcs (served via /backstage/media) parsed from
+  // `BACKSTAGE_VIDEO: <path>` markers a tool printed — e.g. tella-local rec.mjs.
+  videos?: string[];
 }
 
 export interface FileWatcherState {


### PR DESCRIPTION
## What

Adds video rendering to the backstage session viewer, alongside the existing image rendering. Now a session can produce a video (e.g. a screen recording of the local webapp) and have it play inline in the transcript.

## How

Tools can't return video blocks the way `Read` returns image blocks, so the contract is an explicit marker: a tool that produces a video prints `BACKSTAGE_VIDEO: <abs-path>`.

- **Parser** (`jsonl-parser.ts`): extracts the marker from `tool_result` text into a `videos[]` of `/backstage/media?path=...` URLs — mirrors how `extractImages` works.
- **Server** (`backstage.ts`): new `/backstage/media` route streams a local media file with HTTP **range** support (so the `<video>` scrubber can seek). Path-scoped for safety: must be absolute, no `..`, under `/tmp` or `/home/ubuntu`, and a known media extension — otherwise `403`/`404`.
- **Frontend** (`ToolCallBlock.tsx` + `global.css`): renders `result.videos` as inline `<video controls>`, and auto-expands the tool block when media (images **or** videos) arrives.

Transcript stays light — it stores a URL, not inlined base64 — and large clips stream with range requests.

## Producer

The `tella-local` skill's new `rec.mjs` records the local tella-fusion webapp over CDP (webm screencast → H.264 mp4) and prints `BACKSTAGE_VIDEO: <path>`, so recordings show up automatically.

## Testing

- Endpoint logic validated in isolation: full GET `200` (`video/mp4`, correct length, `accept-ranges`), range GET `206` with correct `Content-Range`, and `403`/`404` on out-of-scope paths, `..` traversal, missing files, and disallowed extensions.
- Parser verified to extract the marker into a `/backstage/media?path=...` URL.
- `tsc` introduces no new errors (pre-existing baseline errors are unrelated to these files).

> Note: shipping requires one backstage restart to pick up the server route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)