### PR TITLE
Render tool images live in the session viewer

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -487,6 +487,7 @@ async function runSessionPrompt(
             content: event.content || "",
             timestamp: new Date().toISOString(),
             toolUseId: event.toolUseId,
+            ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
           },
         });
         break;
@@ -681,19 +682,24 @@ if (!IS_DEV && !g.__backstageFrontend) {
   // source shell (icons, splash, manifest links) and point it at the hashed
   // entry + the extracted CSS.
   const entry = result.outputs.find((o) => o.kind === "entry-point");
-  const css = result.outputs.find((o) => o.path.endsWith(".css"));
   if (!entry) throw new Error("frontend build produced no entry point");
   const entryName = entry.path.split("/").pop();
-  const cssName = css?.path.split("/").pop();
+
+  // Bun 1.3.14's CSS minifier strips the space after var(...) and breaks the
+  // .panel-overlay / .sidebar-overlay inset (and a few color-mix percentages),
+  // which knocks out the mobile overlay layer. Bypass it: write the source CSS
+  // unmodified with a content-hashed name and serve it ourselves.
+  const cssSrc = await Bun.file(`${srcDir}/styles/global.css`).text();
+  const cssHash = Bun.hash(cssSrc).toString(36);
+  const cssName = `global-${cssHash}.css`;
+  await Bun.write(`${FRONTEND_DIST}/${cssName}`, cssSrc);
 
   let indexHtml = await Bun.file(`${srcDir}/index.html`).text();
   indexHtml = indexHtml.replace(
     '<script type="module" src="./App.tsx"></script>',
     `<script type="module" crossorigin src="/backstage/${entryName}"></script>`
   );
-  if (cssName) {
-    indexHtml = indexHtml.replace("</head>", `  <link rel="stylesheet" href="/backstage/${cssName}">\n</head>`);
-  }
+  indexHtml = indexHtml.replace("</head>", `  <link rel="stylesheet" href="/backstage/${cssName}">\n</head>`);
   g.__backstageFrontend = { indexHtml, gzip: new Map<string, Blob>() };
   console.log(`Frontend built: ${result.outputs.length} files → ${FRONTEND_DIST}`);
 }
@@ -1536,6 +1542,31 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
                 ws.send(JSON.stringify({ type: "stream_text", text: event.text }));
                 broadcastToSession(bksId, { type: "stream_text", text: event.text }, ws);
               }
+              if (event.type === "tool_use") {
+                const entry = {
+                  id: event.toolUseId || crypto.randomUUID(),
+                  type: "tool_use" as const,
+                  content: `Using ${event.toolName}`,
+                  timestamp: new Date().toISOString(),
+                  toolName: event.toolName,
+                  toolInput: event.toolInput,
+                  toolUseId: event.toolUseId,
+                };
+                ws.send(JSON.stringify({ type: "stream_tool_use", entry }));
+                broadcastToSession(bksId, { type: "stream_tool_use", entry }, ws);
+              }
+              if (event.type === "tool_result") {
+                const entry = {
+                  id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
+                  type: "tool_result" as const,
+                  content: event.content || "",
+                  timestamp: new Date().toISOString(),
+                  toolUseId: event.toolUseId,
+                  ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
+                };
+                ws.send(JSON.stringify({ type: "stream_tool_result", entry }));
+                broadcastToSession(bksId, { type: "stream_tool_result", entry }, ws);
+              }
               if (event.type === "done") {
                 engineSessionId = event.sessionId || engineSessionId;
               }
@@ -1719,6 +1750,33 @@ registerSessionControl({
           }
           if (event.type === "text_chunk") {
             broadcastToSession(bksId, { type: "stream_text", text: event.text });
+          }
+          if (event.type === "tool_use") {
+            broadcastToSession(bksId, {
+              type: "stream_tool_use",
+              entry: {
+                id: event.toolUseId || crypto.randomUUID(),
+                type: "tool_use",
+                content: `Using ${event.toolName}`,
+                timestamp: new Date().toISOString(),
+                toolName: event.toolName,
+                toolInput: event.toolInput,
+                toolUseId: event.toolUseId,
+              },
+            });
+          }
+          if (event.type === "tool_result") {
+            broadcastToSession(bksId, {
+              type: "stream_tool_result",
+              entry: {
+                id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
+                type: "tool_result",
+                content: event.content || "",
+                timestamp: new Date().toISOString(),
+                toolUseId: event.toolUseId,
+                ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
+              },
+            });
           }
           if (event.type === "done") {
             engineSessionId = event.sessionId || engineSessionId;

--- a/src/agents/github/state.ts
+++ b/src/agents/github/state.ts
@@ -54,6 +54,16 @@ export interface GithubPrState {
     /** The run's progress comment id — reused only on restart recovery, not on a fresh re-trigger. */
     progressCommentId?: number;
   };
+  /** An in-flight @mention reply (conversational), persisted so a restart can re-run it. */
+  activeMention?: {
+    author: string;
+    body: string;
+    kind: "issue" | "review";
+    replyToId?: number;
+    inline?: { path: string; line?: number; diffHunk?: string };
+    progressCommentId?: number;
+    startedAt: string;
+  };
   updatedAt: string;
 }
 

--- a/src/frontend/components/ToolCallBlock.tsx
+++ b/src/frontend/components/ToolCallBlock.tsx
@@ -37,7 +37,7 @@ export function parseMcpTool(name: string): { server: string; tool: string } | n
 export function ToolCallBlock({ entry, result }: Props) {
   const hasMedia = Boolean(result?.images?.length || result?.videos?.length);
   // Default closed for text-only output, but auto-open when media arrives
-  // (covers both initial render and a tool_result streaming in later).
+  // (covers both initial render and the live tool_result streaming in later).
   const [expanded, setExpanded] = useState(hasMedia);
   useEffect(() => {
     if (hasMedia) setExpanded(true);

--- a/src/frontend/components/WorkBlock.tsx
+++ b/src/frontend/components/WorkBlock.tsx
@@ -10,12 +10,17 @@ interface Props {
 
 /** Devin-style collapsed segment: "Worked for 12s · 5 steps". */
 export function WorkBlock({ items, toolResults, live }: Props) {
-  const [expanded, setExpanded] = useState(live);
+  // If any tool in the block returned an image, keep the block open so the
+  // screenshot stays visible after the run finishes (otherwise the user has
+  // to expand "Worked" then expand the tool to see what the model showed them).
+  const hasImages = items.some((it) =>
+    it.toolUseId ? (toolResults.get(it.toolUseId)?.images?.length ?? 0) > 0 : false,
+  );
+  const [expanded, setExpanded] = useState(live || hasImages);
 
-  // Follow the stream while live; collapse once the block is finished
   useEffect(() => {
-    if (live) setExpanded(true);
-  }, [live]);
+    if (live || hasImages) setExpanded(true);
+  }, [live, hasImages]);
 
   const duration = blockDuration(items, toolResults);
   const last = items[items.length - 1];

--- a/src/server/claude-runner.ts
+++ b/src/server/claude-runner.ts
@@ -24,6 +24,12 @@ export interface StreamEvent {
   toolUseId?: string;
   content?: string;
   result?: string;
+  /**
+   * Renderable image sources on a tool_result (data: URLs from base64 blocks,
+   * or direct urls). Forwarded to viewers so screenshots show up the moment
+   * the tool returns instead of waiting for the jsonl tail to catch up.
+   */
+  images?: string[];
   /** Which backend emitted this event (set on init/done). */
   provider?: "claude" | "codex";
   /** Effective model for the run (set on init/done). */
@@ -791,6 +797,21 @@ export async function* runClaude(opts: {
                 : Array.isArray(block.content)
                   ? block.content.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n")
                   : "";
+              // Pull image blocks out so the live stream carries them too
+              // (mirrors jsonl-parser.extractImages so a streamed result and
+              // the persisted one render identically).
+              const images: string[] = [];
+              if (Array.isArray(block.content)) {
+                for (const c of block.content) {
+                  if (c?.type !== "image" || !c.source) continue;
+                  const s = c.source;
+                  if (s.type === "base64" && s.media_type && s.data) {
+                    images.push(`data:${s.media_type};base64,${s.data}`);
+                  } else if (s.type === "url" && s.url) {
+                    images.push(s.url);
+                  }
+                }
+              }
               turnEvent({
                 direction: "in",
                 kind: "tool_result",
@@ -802,6 +823,7 @@ export async function* runClaude(opts: {
                 type: "tool_result",
                 toolUseId: block.tool_use_id,
                 content: text.length > 500 ? text.slice(0, 500) + "..." : text,
+                ...(images.length > 0 ? { images } : {}),
               };
             }
           }


### PR DESCRIPTION
## What

Commits the work that was running uncommitted in the live backstage checkout (the inline **image rendering** Michiel asked to ship), now that the sibling video feature (#4) is merged. Two separate commits:

### 1. Render tool images live in the session viewer
Images already rendered from the persisted jsonl; this forwards them on the **live stream** too, so a screenshot appears the moment the tool returns instead of after the jsonl tail catches up.
- `claude-runner` extracts image blocks (base64 → data URL, or direct url) into the `tool_result` StreamEvent — mirrors `jsonl-parser.extractImages` so streamed and persisted results render identically.
- `backstage.ts` forwards `images` on streamed `tool_use`/`tool_result` events and on the persisted entry.
- `WorkBlock` / `ToolCallBlock` auto-expand (and stay open after the run) when a result carries images.
- Bypass Bun 1.3.14's CSS minifier (it strips the space after `var(...)` and broke the mobile `.panel-overlay`/`.sidebar-overlay` inset) by serving the source `global.css` with a content-hashed name.

### 2. Add `activeMention` to `GithubPrState`
The github mention handler already reads/writes `state.activeMention` to persist an in-flight @mention reply across restarts, but the field was missing from the type. This adds it (also clears the pre-existing `activeMention does not exist` tsc errors).

## Notes
- This is **already deployed and running** on the VPS (the live checkout was serving exactly this code; verified healthy after restart — `/backstage/` 200, media endpoint 200). This PR just gets it committed + reviewable.
- Stacks logically on top of #4 (video rendering), which is already on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)