### PR TITLE
Auto-open Worked blocks for videos, not just images

### DIFF
--- a/src/frontend/components/WorkBlock.tsx
+++ b/src/frontend/components/WorkBlock.tsx
@@ -10,17 +10,19 @@ interface Props {
 
 /** Devin-style collapsed segment: "Worked for 12s · 5 steps". */
 export function WorkBlock({ items, toolResults, live }: Props) {
-  // If any tool in the block returned an image, keep the block open so the
-  // screenshot stays visible after the run finishes (otherwise the user has
-  // to expand "Worked" then expand the tool to see what the model showed them).
-  const hasImages = items.some((it) =>
-    it.toolUseId ? (toolResults.get(it.toolUseId)?.images?.length ?? 0) > 0 : false,
-  );
-  const [expanded, setExpanded] = useState(live || hasImages);
+  // If any tool in the block returned media (image or video), keep the block
+  // open so the screenshot/recording stays visible after the run finishes
+  // (otherwise the user has to expand "Worked" then the tool to see what the
+  // model showed them).
+  const hasMedia = items.some((it) => {
+    const r = it.toolUseId ? toolResults.get(it.toolUseId) : undefined;
+    return (r?.images?.length ?? 0) > 0 || (r?.videos?.length ?? 0) > 0;
+  });
+  const [expanded, setExpanded] = useState(live || hasMedia);
 
   useEffect(() => {
-    if (live || hasImages) setExpanded(true);
-  }, [live, hasImages]);
+    if (live || hasMedia) setExpanded(true);
+  }, [live, hasMedia]);
 
   const duration = blockDuration(items, toolResults);
   const last = items[items.length - 1];


### PR DESCRIPTION
`WorkBlock` (the collapsed "Worked for Ns" segments) only auto-expanded when a tool result carried an **image**, so inline **video** recordings (`BACKSTAGE_VIDEO` markers) stayed hidden inside a collapsed block — you'd see nothing until manually expanding. This generalizes the check to any media (image or video).

Follow-up to #4 (video rendering) / #5 (live image rendering). The backend already serves videos correctly; this is the last UI gap to make them visible by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)