### PR TITLE
Add playsInline to inline tool videos

### DIFF
--- a/src/frontend/components/ToolCallBlock.tsx
+++ b/src/frontend/components/ToolCallBlock.tsx
@@ -84,7 +84,7 @@ export function ToolCallBlock({ entry, result }: Props) {
               {result.videos && result.videos.length > 0 && (
                 <div className="tool-result-videos">
                   {result.videos.map((src, i) => (
-                    <video key={i} className="md-video" src={src} controls preload="metadata" />
+                    <video key={i} className="md-video" src={src} controls playsInline preload="metadata" />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
Without `playsInline`, iOS Safari forces the inline tool `<video>` into fullscreen on play. This keeps recordings playing inline in the session viewer. Follow-up to #4/#5/#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)