### PR TITLE
Stream tool videos live (no reload)

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -488,6 +488,7 @@ async function runSessionPrompt(
             timestamp: new Date().toISOString(),
             toolUseId: event.toolUseId,
             ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
+            ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
           },
         });
         break;
@@ -1563,6 +1564,7 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
                   timestamp: new Date().toISOString(),
                   toolUseId: event.toolUseId,
                   ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
+                  ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
                 };
                 ws.send(JSON.stringify({ type: "stream_tool_result", entry }));
                 broadcastToSession(bksId, { type: "stream_tool_result", entry }, ws);
@@ -1775,6 +1777,7 @@ registerSessionControl({
                 timestamp: new Date().toISOString(),
                 toolUseId: event.toolUseId,
                 ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
+                ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
               },
             });
           }

--- a/src/server/claude-runner.ts
+++ b/src/server/claude-runner.ts
@@ -30,6 +30,12 @@ export interface StreamEvent {
    * the tool returns instead of waiting for the jsonl tail to catch up.
    */
   images?: string[];
+  /**
+   * Renderable video sources on a tool_result, parsed from `BACKSTAGE_VIDEO:`
+   * markers in the (full, pre-truncation) tool output. Forwarded so recordings
+   * play the moment the tool returns, no reload needed.
+   */
+  videos?: string[];
   /** Which backend emitted this event (set on init/done). */
   provider?: "claude" | "codex";
   /** Effective model for the run (set on init/done). */
@@ -812,6 +818,14 @@ export async function* runClaude(opts: {
                   }
                 }
               }
+              // Parse BACKSTAGE_VIDEO markers out of the FULL text (before the
+              // 500-char truncation below, since the marker is usually printed
+              // last) so recordings stream in without a reload. Mirrors
+              // jsonl-parser.extractVideos so streamed and persisted match.
+              const videos: string[] = [];
+              for (const m of text.matchAll(/^\s*BACKSTAGE_VIDEO:\s*(\/\S+)\s*$/gm)) {
+                videos.push(`/backstage/media?path=${encodeURIComponent(m[1])}`);
+              }
               turnEvent({
                 direction: "in",
                 kind: "tool_result",
@@ -824,6 +838,7 @@ export async function* runClaude(opts: {
                 toolUseId: block.tool_use_id,
                 content: text.length > 500 ? text.slice(0, 500) + "..." : text,
                 ...(images.length > 0 ? { images } : {}),
+                ...(videos.length > 0 ? { videos } : {}),
               };
             }
           }


### PR DESCRIPTION
Images already streamed over the WebSocket; videos only showed up after a transcript re-parse (reload). This wires videos through the live path too.

- `claude-runner` parses `BACKSTAGE_VIDEO` markers out of the **full** tool output (before the 500-char stream truncation — the marker is printed last) into the `tool_result` StreamEvent's `videos`.
- `backstage` forwards `event.videos` on all three `stream_tool_result` emitters, alongside `images`.

Frontend already renders `videos` and stores streamed entries as-is, so a recording now plays the moment the tool returns — no reload. Follow-up to #4/#5/#6/#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)