### PR TITLE
frontend: center system notices, restyle Cancel as a quiet Stop

### DIFF
--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -725,8 +725,9 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
                         {queued.length > 0 && `${queued.length} queued`}
                       </span>
                     )}
-                    <button className="btn-cancel" onClick={handleCancel}>
-                      Cancel
+                    <button className="btn-cancel" onClick={handleCancel} title="Stop the current run">
+                      <span className="btn-cancel-icon" />
+                      Stop
                     </button>
                   </div>
                 )}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -1471,7 +1471,10 @@ a {
 
 .msg-system {
   text-align: center;
-  margin: 12px 0;
+  /* `auto` left/right keeps this in the same centered column as user/assistant
+     bubbles — a bare `0` here pins it to the left edge and the pill reads
+     off-center against the conversation. */
+  margin: 12px auto;
 }
 .msg-system-text {
   display: inline-block;
@@ -2381,14 +2384,30 @@ a {
 
 .btn-cancel {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 6px;
-  color: var(--text-dim);
-  padding: 5px 14px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: var(--text-faint);
+  padding: 5px 12px;
   font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
 }
-.btn-cancel:hover { color: var(--red); border-color: var(--red); }
+.btn-cancel-icon {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: currentColor;
+}
+.btn-cancel:hover {
+  color: var(--red);
+  background: var(--red-soft);
+  border-color: var(--red-soft);
+}
 
 .input-disabled {
   color: var(--text-faint);


### PR DESCRIPTION
## What

Two small composer/transcript polish fixes (reported via the live UI).

### 1. System-notice pill was off-center
Notices like `"Michiel interrupted — redirecting Michael now."` rendered left-of-center. `.msg-system` set `margin: 12px 0`, and the shorthand reset the `margin-left/right: auto` it inherits from `.msg` — pinning the 860px column to the left edge. `text-align: center` then only centered the pill *within that left-pinned band*. Switched to `margin: 12px auto` so it shares the same centered column as the user/assistant bubbles.

### 2. Cancel button restyled
The outlined "Cancel" box sat awkwardly on the busy bar. It's now a quieter **Stop** control — a stop-square glyph + label, transparent border at rest, warming to a red-soft tint on hover.

## Verification
Rendered the real `global.css` with the exact `MessageBubble` markup in headless Chrome at a wide viewport: the pill now centers on the conversation column (midpoint matches viewport center) instead of pinning left.

## Deploy note
Production builds the CSS bundle once per process and caches it on `globalThis`, so `--hot` won't pick this up — a real `systemctl restart` is needed after this lands on the deployed checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)