### PR TITLE
One-off scheduled runs (reminders / "do this again later")

### DIFF
--- a/src/agents/slack/admin-tools.ts
+++ b/src/agents/slack/admin-tools.ts
@@ -37,12 +37,19 @@ import {
   type MemoryContext,
   type MemoryEntry,
 } from "./memory";
+import { parseWhen } from "./parse-when";
 
 export interface AdminToolContext extends MemoryContext {
   /** Display name credited as the author of memories/automations. */
   createdBy: string;
   /** Trusted user — gates automation + MCP management tools. */
   isAdmin: boolean;
+  /**
+   * Slack thread anchor (thread_ts) of the originating message, when this runs
+   * from a Slack thread. Lets schedule_once post a reminder back into "this"
+   * thread. Absent in Backstage sessions (no Slack thread).
+   */
+  threadTs?: string;
 }
 
 function text(s: string) {
@@ -125,11 +132,13 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
           const all = listAutomations();
           if (!all.length) return text("No automations configured.");
           const lines = all.map((a) => {
-            const trig = a.schedule
-              ? `cron \`${a.schedule}\` (UTC)`
-              : a.eventKey
-                ? `event \`${a.eventKey}\``
-                : "manual/webhook";
+            const trig = a.runOnceAt
+              ? `once at ${a.runOnceAt}`
+              : a.schedule
+                ? `cron \`${a.schedule}\` (UTC)`
+                : a.eventKey
+                  ? `event \`${a.eventKey}\``
+                  : "manual/webhook";
             const next = a.nextRunAt ? `, next ${a.nextRunAt}` : "";
             const last = a.lastRunStatus ? `, last ${a.lastRunStatus}` : "";
             return `• *${a.name}* [\`${a.id}\`] — ${trig}, ${a.mode}, ${a.enabled ? "enabled" : "disabled"}${next}${last}`;
@@ -247,6 +256,79 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
             console.error("[admin] run_automation failed:", e)
           );
           return text(`Triggered *${a.name}* [\`${a.id}\`] — running now.`);
+        }
+      ),
+      tool(
+        "schedule_once",
+        "Schedule a ONE-OFF run at a future time, after which it auto-deletes — use for 'remind me about this next week', 'run this again in a week', or any one-time scheduled task. `when` is a natural time expression ('next Tuesday 9am', 'in a week', 'tomorrow morning', 'in 3 hours') — just pass the user's phrasing through; it's resolved to an exact instant for you. `prompt` is what you (Michael) should do when it fires, written to yourself — it runs as a normal Michael session, so it can post to a channel, DM someone via the Slack MCP, or carry out a task. By default, when this is invoked from a Slack thread, the run is told to post its reminder back into that thread; set replyInThread:false to suppress (e.g. when the prompt should DM someone else instead). Omit mcpServers to give the run the full toolset; pass it to restrict (least-privilege).",
+        {
+          when: z
+            .string()
+            .describe("When to fire, in natural language — e.g. 'next Tuesday 9am', 'in a week', 'tomorrow at 14:00', 'in 3 hours'. Pass the user's wording; it's resolved to an exact UTC instant."),
+          prompt: z
+            .string()
+            .describe("What to do when it fires, addressed to yourself (e.g. 'Remind Michiel to review the Q3 deck' or 'DM Johnny the latest MRR figure')."),
+          name: z.string().optional().describe("Short label; defaults to a snippet of the prompt."),
+          mode: z
+            .enum(["ask", "code"])
+            .optional()
+            .describe("'ask' = read-only (default), 'code' = worktree + can open PRs."),
+          mcpServers: z
+            .array(z.string())
+            .optional()
+            .describe("Optional allowlist of MCP servers the run may use. Omit for the full toolset."),
+          replyInThread: z
+            .boolean()
+            .optional()
+            .describe("Post the reminder/result back into the originating Slack thread (default true when in a Slack thread)."),
+        },
+        async (args: {
+          when: string;
+          prompt: string;
+          name?: string;
+          mode?: "ask" | "code";
+          mcpServers?: string[];
+          replyInThread?: boolean;
+        }) => {
+          if (!args.prompt?.trim()) return text("Nothing to schedule (empty prompt).");
+          const iso = await parseWhen(args.when);
+          if (!iso) {
+            return text(
+              `Couldn't read "${args.when}" as a future time. Try something like "next Tuesday 9am", "in a week", or "tomorrow at 14:00".`
+            );
+          }
+
+          // Post back into "this" Slack thread by default — only possible when we
+          // actually have one (Slack runs carry channel+threadTs; Backstage doesn't).
+          const inSlackThread = !!ctx.threadTs && !!ctx.channel && ctx.channel !== "backstage";
+          const replyInThread = args.replyInThread !== false && inSlackThread;
+
+          let prompt = args.prompt.trim();
+          let mcpServers = args.mcpServers;
+          if (replyInThread) {
+            prompt +=
+              `\n\nDeliver this by posting to Slack channel \`${ctx.channel}\` in thread \`${ctx.threadTs}\` ` +
+              "via the Slack MCP `conversations_add_message` (content_type text/markdown). Open with \"⏰ \", " +
+              "say it's you, Michael, and keep it concise.";
+            // Make sure the run can reach Slack even if the caller restricted servers.
+            if (mcpServers) mcpServers = Array.from(new Set([...mcpServers, "slack"]));
+          }
+
+          const res = createAutomation({
+            name: args.name?.trim() || `Reminder: ${args.prompt.trim().slice(0, 48)}`,
+            prompt,
+            schedule: "",
+            runOnceAt: iso,
+            mode: args.mode || "ask",
+            createdBy: ctx.createdBy,
+            mcpServers,
+          });
+          if ("error" in res) return text(`Couldn't schedule it: ${res.error}`);
+          return text(
+            `Scheduled *${res.name}* [\`${res.id}\`] for ${iso} (UTC)` +
+              (replyInThread ? ", posting back to this thread" : "") +
+              ". It runs once, then cleans itself up. Cancel with delete_automation."
+          );
         }
       ),
       // ---------------------------------------------------------------------

--- a/src/agents/slack/handlers.ts
+++ b/src/agents/slack/handlers.ts
@@ -823,6 +823,7 @@ export async function processMessage(
         ...memCtx,
         createdBy: userName || msg.userId,
         isAdmin,
+        threadTs: msg.threadTs,
       }),
       "michael-github": createGithubMcpServer({
         requestedBy: msg.userId,
@@ -840,9 +841,11 @@ export async function processMessage(
   const ADMIN_TOOLS_PROMPT =
     "\n\n## Self-management\nYou can manage your own setup via the michael-admin MCP tools: " +
     "channel memory (remember / list_memory / forget) and, for trusted users, automations " +
-    "(list/create/update/delete/run_automation — routines on a UTC cron, or event/webhook) and " +
-    "MCP connections (list/add/remove_mcp_server). When a user asks you to remember something, " +
-    "set up a recurring job, or connect a tool, use these tools rather than just describing how." +
+    "(list/create/update/delete/run_automation — routines on a UTC cron, or event/webhook), one-off " +
+    "scheduled runs (schedule_once — 'remind me about this next week', 'run this again in a week', or any " +
+    "one-time task at a future time; it posts back to this thread by default and can DM/act via its MCPs), " +
+    "and MCP connections (list/add/remove_mcp_server). When a user asks you to remember something, " +
+    "set up a recurring job, schedule a reminder or future task, or connect a tool, use these tools rather than just describing how." +
     "\n\n## GitHub PR actions\nWhen asked to review, auto-fix, simplify, or adversarially review a tella-fusion PR " +
     "(e.g. \"review PR 4296\", \"auto-fix PR 4296\", \"adversarial review PR 4296\"), use the michael-github MCP tools " +
     "(review_pr / auto_fix_pr / simplify_pr / adversarial_review_pr) — they run the same actions as the PR labels and " +

--- a/src/agents/slack/parse-when.ts
+++ b/src/agents/slack/parse-when.ts
@@ -1,0 +1,69 @@
+/**
+ * Turn a human time expression ("next Tuesday 9am", "in a week", "tomorrow
+ * morning", "in 3 hours") into one exact future ISO8601 UTC instant, via a
+ * single no-tools Haiku call (mirrors mention-intent.ts) — no regex/keyword
+ * date parsing. The model has no clock, so we anchor it to a `now` we pass in.
+ *
+ * Returns the ISO string, or null if the text isn't a usable time expression
+ * (caller surfaces a friendly error). Fail-closed: any hiccup returns null.
+ */
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const WHEN_MODEL = process.env.SCHEDULE_WHEN_MODEL || "claude-haiku-4-5";
+
+export async function parseWhen(when: string, now = new Date()): Promise<string | null> {
+  const text = (when || "").trim();
+  if (!text) return null;
+
+  const system = `You convert a human time expression into one exact future instant, given the current time.
+
+Current time: ${now.toISOString()} (UTC). The server clock is UTC.
+
+Rules:
+- Interpret the expression relative to the current time: "in a week" = 7 days later; "tomorrow at 9am" = the next calendar day at 09:00; "in 3 hours" = 3 hours later; "next Tuesday" = the next Tuesday; "+30m" = 30 minutes later.
+- Times are UTC unless the user names a timezone — then convert to UTC.
+- If a date is given with no time of day, use 09:00 UTC.
+- The result must be in the future relative to the current time. If the most natural reading is already past, roll forward to the next sensible occurrence.
+- If the text is not a time/date expression at all, return null.
+
+Respond with ONLY a JSON object: {"iso": "<ISO8601 UTC, e.g. 2026-07-06T16:00:00Z>"} or {"iso": null}.`;
+
+  try {
+    let resultText = "";
+    const q = query({
+      prompt: `Convert this to an instant:\n\n${text.slice(0, 200)}`,
+      options: {
+        model: WHEN_MODEL,
+        maxTurns: 1,
+        allowedTools: [],
+        canUseTool: async () => ({ behavior: "deny" as const, message: "No tools available." }),
+        mcpServers: {},
+        strictMcpConfig: true,
+        systemPrompt: system,
+        settingSources: [],
+        env: { PATH: process.env.PATH, HOME: process.env.HOME, LANG: process.env.LANG },
+        pathToClaudeCodeExecutable: "/home/ubuntu/.local/bin/claude",
+        executable: "bun",
+      },
+    });
+    for await (const msg of q) {
+      if (msg.type === "result") {
+        const rm = msg as any;
+        if (rm.subtype !== "success") return null;
+        resultText = rm.result || "";
+      }
+    }
+    // Extract the JSON object from the model's reply (same approach as
+    // mention-intent.ts) — this is JSON extraction, not date parsing.
+    const m = resultText.match(/\{[\s\S]*?\}/);
+    if (!m) return null;
+    const iso = JSON.parse(m[0]).iso;
+    if (typeof iso !== "string") return null;
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return null;
+    return new Date(t).toISOString();
+  } catch (e) {
+    console.error("[schedule] when parsing failed:", e);
+    return null;
+  }
+}

--- a/src/server/automations.ts
+++ b/src/server/automations.ts
@@ -50,6 +50,14 @@ export interface Automation {
   name: string;
   prompt: string;
   schedule: string; // 5-field cron, UTC; "" = webhook/manual only
+  /**
+   * One-off scheduled run: ISO8601 instant. When set, the scheduler fires this
+   * automation once at/after this time and then deletes it (auto-cleanup).
+   * Mutually exclusive with `schedule` (recurring cron) — setting it forces
+   * `schedule` to "". Used for reminders, "run this again later", and any
+   * one-time scheduled prompt (see schedule_once in admin-tools.ts).
+   */
+  runOnceAt?: string;
   mode: "ask" | "code";
   enabled: boolean;
   createdBy: string;
@@ -101,8 +109,13 @@ export function listAutomations(): AutomationWithNext[] {
       const a = JSON.parse(readFileSync(`${AUTOMATIONS_DIR}/${file}`, "utf-8")) as Automation;
       out.push({
         ...a,
-        nextRunAt:
-          a.enabled && a.schedule ? nextRun(a.schedule)?.toISOString() || null : null,
+        nextRunAt: !a.enabled
+          ? null
+          : a.runOnceAt
+            ? a.runOnceAt
+            : a.schedule
+              ? nextRun(a.schedule)?.toISOString() || null
+              : null,
       });
     } catch {}
   }
@@ -151,6 +164,16 @@ function sanitizeGrafanaPoll(cfg?: unknown): GrafanaPollConfig | { error: string
   return out;
 }
 
+/** Validate + normalize a one-off ISO8601 instant. "" / nullish → undefined
+ *  (no one-off). Past times are allowed (they fire on the next tick). */
+function sanitizeRunOnceAt(v?: unknown): string | { error: string } | undefined {
+  if (v === undefined || v === null || v === "") return undefined;
+  if (typeof v !== "string") return { error: "runOnceAt must be an ISO8601 string" };
+  const t = Date.parse(v.trim());
+  if (Number.isNaN(t)) return { error: `Invalid date/time: "${v}"` };
+  return new Date(t).toISOString();
+}
+
 function generateSecret(): string {
   return Array.from(crypto.getRandomValues(new Uint8Array(24)), (b) =>
     b.toString(16).padStart(2, "0")
@@ -169,6 +192,8 @@ export function createAutomation(input: {
   name: string;
   prompt: string;
   schedule: string;
+  /** One-off ISO8601 instant; when set, `schedule` is ignored (forced to ""). */
+  runOnceAt?: string;
   mode: "ask" | "code";
   createdBy: string;
   eventKey?: string;
@@ -179,7 +204,10 @@ export function createAutomation(input: {
 }): Automation | { error: string } {
   if (!input.name.trim()) return { error: "Name is required" };
   if (!input.prompt.trim()) return { error: "Prompt is required" };
-  const schedule = (input.schedule || "").trim();
+  const runOnceAt = sanitizeRunOnceAt(input.runOnceAt);
+  if (runOnceAt && typeof runOnceAt === "object") return runOnceAt;
+  // A one-off and a recurring cron are mutually exclusive — the one-off wins.
+  const schedule = runOnceAt ? "" : (input.schedule || "").trim();
   if (schedule && !parseCron(schedule)) {
     return { error: `Invalid cron expression: "${schedule}"` };
   }
@@ -195,6 +223,7 @@ export function createAutomation(input: {
     name: input.name.trim(),
     prompt: input.prompt.trim(),
     schedule,
+    runOnceAt,
     mode: input.mode === "code" ? "code" : "ask",
     enabled: true,
     createdBy: input.createdBy || "Anonymous",
@@ -212,7 +241,7 @@ export function createAutomation(input: {
 
 export function updateAutomation(
   id: string,
-  patch: Partial<Pick<Automation, "name" | "prompt" | "schedule" | "mode" | "enabled" | "eventKey" | "mcpServers" | "model" | "fallbackModel" | "grafanaPoll">>
+  patch: Partial<Pick<Automation, "name" | "prompt" | "schedule" | "runOnceAt" | "mode" | "enabled" | "eventKey" | "mcpServers" | "model" | "fallbackModel" | "grafanaPoll">>
 ): Automation | { error: string } {
   const a = getAutomation(id);
   if (!a) return { error: "Automation not found" };
@@ -220,6 +249,12 @@ export function updateAutomation(
     return { error: `Invalid cron expression: "${patch.schedule}"` };
   }
   const next = { ...a, ...patch };
+  if ("runOnceAt" in patch) {
+    const runOnceAt = sanitizeRunOnceAt(patch.runOnceAt);
+    if (runOnceAt && typeof runOnceAt === "object") return runOnceAt;
+    next.runOnceAt = runOnceAt;
+    if (runOnceAt) next.schedule = ""; // one-off and cron are mutually exclusive
+  }
   if ("mcpServers" in patch) next.mcpServers = sanitizeMcpList(patch.mcpServers);
   if ("grafanaPoll" in patch) {
     const grafanaPoll = sanitizeGrafanaPoll(patch.grafanaPoll);
@@ -519,7 +554,23 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
     lastFiredMinute = minuteKey;
 
     for (const automation of listAutomations()) {
-      if (!automation.enabled || !automation.schedule) continue;
+      if (!automation.enabled) continue;
+
+      // One-off runs (reminders / "do this again later"): fire once at/after the
+      // target instant, then delete. We persist a "consumed" copy (runOnceAt
+      // cleared, disabled) BEFORE firing so a long-running or crashed run can
+      // never double-fire on a later tick; the file is deleted once it settles.
+      if (automation.runOnceAt) {
+        if (Date.parse(automation.runOnceAt) <= now.getTime()) {
+          saveAutomation({ ...automation, runOnceAt: undefined, enabled: false });
+          void runAutomation({ ...automation, runOnceAt: undefined, enabled: false }, onSessionCreated, {
+            trigger: "cron",
+          }).finally(() => deleteAutomation(automation.id));
+        }
+        continue;
+      }
+
+      if (!automation.schedule) continue;
       if (cronMatches(automation.schedule, now)) {
         // Fire and forget — runner guards against overlap per automation
         void runAutomation(automation, onSessionCreated, { trigger: "cron" });


### PR DESCRIPTION
## What

Lets Michael schedule a **one-off** future run from a conversation — "remind me about this next week", "run this again in a week", or any one-time task — and have it clean itself up after firing. Automations were recurring-cron-only until now.

Works in **both** interactive Slack threads and Backstage/Michael sessions.

## How it works

- **`runOnceAt`** — new optional ISO8601 field on `Automation`, mutually exclusive with `schedule` (cron). The existing 20s scheduler fires it once at/after that instant.
- **No double-fire / auto-cleanup** — before firing, the scheduler persists a *consumed* copy (`runOnceAt` cleared, `enabled:false`) so a long-running or crashed run can never re-fire on a later tick; the record is deleted once the run settles.
- **`schedule_once` tool** on the `michael-admin` MCP (admin-gated, like the other automation tools). From a Slack thread it defaults to posting the reminder back into *that* thread; otherwise the run is a normal Michael session, so the scheduled prompt can DM people or post anywhere via its MCPs. Cancel/reschedule via the existing `delete_automation` / `update_automation`.
- **Natural-language time parsing** via a no-tools Haiku call (`parse-when.ts`, mirrors `mention-intent.ts`) — "next Tuesday 9am" / "in a week" / "in 3 hours" → exact UTC instant. No regex date parsing.

## Smoke test (Haiku parser, anchored to 2026-06-29 11:45 UTC)

```
in a week         → 2026-07-06T11:45:00Z
next Tuesday 9am  → 2026-06-30T09:00:00Z   (Jun 30 is the next Tuesday)
tomorrow at 14:00 → 2026-06-30T14:00:00Z
in 3 hours        → 2026-06-29T14:45:00Z
banana            → null
```

## Deploy note

The scheduler firing logic is one-time boot setup, so it needs a real `systemctl restart backstage` to go live (the `admin-tools`/`handlers` parts hot-reload). Until restart, `schedule_once` can create one-offs but they won't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)