### PR TITLE
github: persist @mentions on receipt so a restart can't drop them

### DIFF
--- a/src/agents/github/index.ts
+++ b/src/agents/github/index.ts
@@ -17,7 +17,7 @@ import { githubConfigured } from "./github-rest";
 import { PR_EVENT_KEY, REVIEW_AUTOMATION_NAME } from "./constants";
 import { DEFAULT_REVIEW_PROMPT } from "./prompts";
 import { setGithubSessionInvalidate, resolveReviewConfig } from "./webhook";
-import { listPrStates, activeCodeLoops } from "./state";
+import { listPrStates, activeCodeLoops, clearPendingMention } from "./state";
 import type { PrRef } from "./review";
 
 const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || "";
@@ -87,6 +87,37 @@ async function recoverMentions(): Promise<void> {
   }
 }
 
+/**
+ * Replay @mentions that were received but dropped before their run could
+ * self-persist — the classic case being a webhook that landed during shutdown
+ * drain (acked 200, so GitHub won't redeliver). PRs already owned by a richer
+ * recovery (activeMention mid-run, or an action's activeRun/autoFix) are handed
+ * off to it and their stale receipt marker cleared, so nothing fires twice.
+ */
+async function recoverPendingMentions(): Promise<void> {
+  const pending = listPrStates().filter((s) => s.pendingMention);
+  if (!pending.length) return;
+  const { dispatchMention } = await import("./mention");
+  for (const s of pending) {
+    if (s.activeMention || s.activeRun || s.autoFix?.active) {
+      clearPendingMention(s.prNumber); // a more specific recovery owns it
+      continue;
+    }
+    const p = s.pendingMention!;
+    console.log(`[github] Recovering dropped mention for PR #${s.prNumber} (from @${p.author})`);
+    void dispatchMention({
+      prNumber: s.prNumber,
+      kind: p.kind,
+      body: p.body,
+      author: p.author,
+      replyToId: p.replyToId,
+      inline: p.inline,
+    })
+      .catch((e) => console.error(`[github] dropped-mention recovery failed for PR #${s.prNumber}:`, e))
+      .finally(() => clearPendingMention(s.prNumber));
+  }
+}
+
 export class GithubAgent implements AgentModule {
   name = "github";
   private readonly onSessionInvalidate?: () => void;
@@ -143,6 +174,7 @@ export class GithubAgent implements AgentModule {
     await recoverFixLoops();
     await recoverOneShots();
     await recoverMentions();
+    await recoverPendingMentions();
     const { autoEnabled } = resolveReviewConfig();
     console.log(`[github] Agent started — review automation ${autoEnabled ? "ENABLED (all non-draft PRs)" : "disabled (label-only)"}`);
   }

--- a/src/agents/github/mention.ts
+++ b/src/agents/github/mention.ts
@@ -10,7 +10,14 @@
 import { getPrDetails } from "../../server/pr-info";
 import { listAutomations } from "../../server/automations";
 import { createWorktreeForPrBranch } from "../../server/worktree";
-import { claimLock, releaseLock, getOrInitPrState, writePrState } from "./state";
+import {
+  claimLock,
+  releaseLock,
+  getOrInitPrState,
+  writePrState,
+  setPendingMention,
+  clearPendingMention,
+} from "./state";
 import { runGithubAgent, authorForLogin, finalSummary, sessionUrl } from "./run";
 import { buildMentionPrompt } from "./prompts";
 import { triggerPrAction } from "./trigger";
@@ -80,6 +87,41 @@ export async function handleMention(kind: MentionKind, payload: any): Promise<vo
   if (!prNumber || !comment?.id) return;
   if (alreadyHandled(`${kind}:${comment.id}`)) return;
 
+  // Persist the mention on receipt, BEFORE the slow classify + worktree window. If
+  // the process dies in that window — e.g. this webhook landed mid-shutdown-drain,
+  // which we still ack 200 so GitHub won't redeliver — startup recovery replays it.
+  // The run self-persists its richer activeMention/activeRun only seconds later.
+  setPendingMention(prNumber, {
+    kind,
+    commentId: comment.id,
+    body,
+    author: authorLogin,
+    replyToId,
+    inline,
+    receivedAt: new Date().toISOString(),
+  });
+  try {
+    await dispatchMention({ prNumber, kind, body, author: authorLogin, replyToId, inline });
+  } finally {
+    clearPendingMention(prNumber);
+  }
+}
+
+/**
+ * Classify the mention and route it: a whole-PR action (review/simplify/etc.) or a
+ * conversational reply. Shared by the live webhook path (handleMention) and startup
+ * recovery of a mention that was dropped before its run could self-persist.
+ */
+export async function dispatchMention(args: {
+  prNumber: number;
+  kind: MentionKind;
+  body: string;
+  author: string;
+  replyToId?: number;
+  inline?: { path: string; line?: number; diffHunk?: string };
+}): Promise<void> {
+  const { prNumber, kind, body, author, replyToId, inline } = args;
+
   // A whole-PR action request ("@michael adversarial review plz") → run the dedicated
   // behavior. Classified before any lock, since triggerPrAction claims the "code" lock.
   const action = await classifyPrActionIntent(body);
@@ -87,7 +129,7 @@ export async function handleMention(kind: MentionKind, payload: any): Promise<vo
     // Pass the full comment as steer: the classifier reduced it to a verb, but the
     // body may carry specific guidance ("…the Update.call change wasn't needed.
     // /simplify") that the run should honor — not just a generic pass.
-    const res = await triggerPrAction(action, prNumber, authorLogin, body);
+    const res = await triggerPrAction(action, prNumber, author, body);
     const ack = `${REPLY_MARKER}\nOn it — ${res.message}`;
     if (kind === "review" && replyToId) await replyToReviewComment(prNumber, replyToId, ack).catch(() => {});
     else await postIssueComment(prNumber, ack).catch(() => {});
@@ -95,7 +137,7 @@ export async function handleMention(kind: MentionKind, payload: any): Promise<vo
   }
 
   // Otherwise it's a conversational request — answer (and act) in a worktree session.
-  await runConversationalMention({ prNumber, author: authorLogin, body, kind, replyToId, inline });
+  await runConversationalMention({ prNumber, author, body, kind, replyToId, inline });
 }
 
 export interface ConversationalMentionArgs {
@@ -142,6 +184,9 @@ export async function runConversationalMention(
       progressCommentId: progressId ?? undefined,
       startedAt: new Date().toISOString(),
     };
+    // This run now owns recovery via activeMention; drop the on-receipt marker in
+    // the same write so recovery never replays it twice.
+    st.pendingMention = undefined;
     writePrState(st);
 
     // Code mode in the PR-branch worktree so Michael can make + push changes if asked.

--- a/src/agents/github/state.ts
+++ b/src/agents/github/state.ts
@@ -67,6 +67,22 @@ export interface GithubPrState {
     progressCommentId?: number;
     startedAt: string;
   };
+  /**
+   * A just-received @mention, persisted synchronously on receipt — before the run
+   * self-persists (the classify + worktree window, several seconds). If the process
+   * dies in that window — e.g. a webhook that lands during shutdown drain, which we
+   * still ack 200 so GitHub won't redeliver — startup recovery replays it. Cleared
+   * once a run takes ownership (activeMention/activeRun) or the dispatch completes.
+   */
+  pendingMention?: {
+    kind: "issue" | "review";
+    commentId: number;
+    body: string;
+    author: string;
+    replyToId?: number;
+    inline?: { path: string; line?: number; diffHunk?: string };
+    receivedAt: string;
+  };
   updatedAt: string;
 }
 
@@ -111,6 +127,25 @@ export function updatePrState(
   patch(s);
   writePrState(s);
   return s;
+}
+
+/** Persist a just-received mention so a crash/restart before the run self-persists
+ *  can still recover it. headRef may be unknown here; the run backfills the real one. */
+export function setPendingMention(
+  prNumber: number,
+  pending: NonNullable<GithubPrState["pendingMention"]>
+): void {
+  updatePrState(prNumber, `pr-${prNumber}`, (s) => {
+    s.pendingMention = pending;
+  });
+}
+
+/** Clear the pending-mention marker once a run owns the mention or it completes. */
+export function clearPendingMention(prNumber: number): void {
+  const s = readPrState(prNumber);
+  if (!s?.pendingMention) return;
+  s.pendingMention = undefined;
+  writePrState(s);
 }
 
 /** Every PR state file (for the startup recovery sweep). */


### PR DESCRIPTION
## What

Fixes a silent-drop bug where a PR `@tella-butler` mention is lost if its webhook lands during a backstage **shutdown drain**. Found live on PR #4322: the comment arrived **3 seconds into a deploy restart's drain window**, got acked `200` (so GitHub won't redeliver), but Michael never replied.

## Root cause

The mention handler is fire-and-forget and only persists recovery state (`activeMention`) **after** the slow part — the Haiku action-classify + `getPrDetails` + worktree creation + progress comment (several seconds). When the old process received SIGTERM, it still accepted the webhook and returned 200, then exited before that handler reached the persist step. Startup recovery (`recoverMentions`) only replays mentions that had already self-persisted, so there was nothing to recover.

```
11:55:39  [shutdown] SIGTERM — stopping intake and draining…
11:55:40  [slack] GitHub webhook: event=issue_comment, action=created   ← the comment (acked 200)
11:55:40  [shutdown] all in-flight runs drained cleanly → exit
          (handler killed before persisting activeMention; nothing to recover)
```

## Fix

Persist the mention **synchronously on receipt** (`pendingMention`), before the classify/worktree window, and replay it on startup.

- **state.ts** — `pendingMention` field + `setPendingMention`/`clearPendingMention`.
- **mention.ts** — write the marker on receipt; split routing into a shared `dispatchMention` so recovery can replay the exact same path; clear the marker atomically when the run takes ownership (sets `activeMention`) and again in `finally`.
- **index.ts** — `recoverPendingMentions()` added to the startup sweep. PRs already owned by a richer recovery (`activeMention` mid-run, or an action's `activeRun`/`autoFix`) are handed off and their stale marker cleared, so **nothing fires twice**.

## Notes
- Typechecks clean; the new state helpers were unit-sanity-checked (set → read → clear).
- **Needs a real `systemctl restart`** to take effect (github agent lifecycle code; doesn't hot-reload).
- The immediate #4322 miss was already replayed manually, so Michael has answered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)