### PR TITLE
github: review bot-opened PRs (e.g. automated security fixes)

### DIFF
--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -64,11 +64,17 @@ export function resolveReviewConfig(): { autoEnabled: boolean; config: ReviewCon
 export async function handleGithubPrEvent(event: string, payload: any): Promise<void> {
   try {
     if (payload?.repository?.full_name && payload.repository.full_name !== GITHUB_REPO) return;
-    // Ignore our own actions to avoid self-trigger loops.
-    if (payload?.sender?.login && payload.sender.login === BOT_LOGIN) return;
 
-    // @mention replies on PR comments (inline + conversation).
+    // Our bot account shows up as `sender` both when we comment/review AND when we
+    // push (auto-fix/simplify/mention commits land as a `synchronize`). We must not
+    // react to those self-triggers — but we DO want to review PRs the bot *opens*
+    // (e.g. automated security fixes). So apply the guard per-event below, not blanket.
+    const senderIsBot = !!payload?.sender?.login && payload.sender.login === BOT_LOGIN;
+
+    // @mention replies on PR comments (inline + conversation). Never react to our own
+    // comments/reviews (mention.ts also re-checks the author + our hidden markers).
     if (event === "issue_comment" || event === "pull_request_review_comment") {
+      if (senderIsBot) return;
       const { handleMention } = await import("./mention");
       void handleMention(event === "issue_comment" ? "issue" : "review", payload).catch((e) =>
         console.error("[github] handleMention failed:", e),
@@ -83,8 +89,9 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
     if (!ref) return;
     const action: string = payload.action || "";
 
-    // ── Label actions ──
+    // ── Label actions ── (ignore labels we applied to ourselves)
     if (action === "labeled") {
+      if (senderIsBot) return;
       const label: string = payload.label?.name || "";
       const requestedBy: string = payload.sender?.login || "";
       if (label === LABEL_REVIEW) {
@@ -111,6 +118,10 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
     // ── Open / update actions → review when opted in and non-draft ──
     if (REVIEW_ACTIONS.has(action)) {
       if (pr.draft) return; // skip drafts until ready_for_review
+      // A `synchronize` from the bot is our own push (auto-fix/simplify/mention) —
+      // skip it so we don't review our own work mid-loop. But reviewing a PR the bot
+      // *opened* (opened/reopened/ready_for_review) is fine: read-only, no push, no loop.
+      if (senderIsBot && action === "synchronize") return;
       const labeled = (pr.labels || []).some((l) => l.name === LABEL_REVIEW);
       const { autoEnabled } = resolveReviewConfig();
       if (labeled || autoEnabled) void fireReview(ref, false);


### PR DESCRIPTION
## Why
`github-pr-review` didn't fire for #4329 (a `[deepsec][security]` PR) — and won't for any PR opened by `tella-butler`. The webhook handler had a blanket guard that skips **every** event whose `sender` is our bot account:

```js
if (payload.sender.login === BOT_LOGIN) return;  // too coarse
```

That guard exists to prevent self-trigger loops (our own comments/reviews/pushes), but it also blocks reviewing PRs the bot legitimately **opens** (automated security fixes, changelog/SEO sweeps).

## Change
Apply the self-trigger guard per-event instead of blanket (`src/agents/github/webhook.ts`):
- **Comments / reviews** (`issue_comment`, `pull_request_review_comment`) — still skip the bot (and `mention.ts` independently re-checks the comment author + our hidden markers).
- **Labels** — still skip bot-applied labels.
- **`synchronize` from the bot** — still skip: our auto-fix/simplify/mention pushes land as a `synchronize` from `tella-butler`, and we must not review our own work mid-loop. (We can't distinguish "the bot pushed more commits to its PR" from "Michael's auto-fix pushed" — both are bot `synchronize` — so the conservative choice keeps skipping those.)
- **`opened` / `reopened` / `ready_for_review` from the bot** — now reviewed. This is a one-shot, read-only pass (no push), so it can't loop.

## Notes
- Typechecks clean.
- **Needs a `systemctl restart`** to take effect (github agent webhook/lifecycle code; doesn't hot-reload).
- #4329 itself can be reviewed right now via the `michael-review` label (sender = human, so it already passes the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)