### PR TITLE
Human in the loop: ask teammates over Slack and fold replies into sessions

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -43,6 +43,8 @@ import {
 import { gitIdentityFor } from "./src/server/shared/user-mappings";
 import { createSessionsMcpServer } from "./src/agents/slack/sessions-tools";
 import { createAdminMcpServer } from "./src/agents/slack/admin-tools";
+import { createHumansMcpServer } from "./src/agents/slack/humans-tools";
+import { initHumanAsks, onSessionIdle as onHumanAsksSessionIdle } from "./src/server/human-asks";
 import { getPrDetails, getPrDiff, postPrComment, mergePr } from "./src/server/pr-info";
 import {
   listAutomations,
@@ -136,7 +138,7 @@ function getCachedSessions(): UnifiedSession[] {
 // sessions — untrusted ticket text must not reach session-control / config
 // tools. Backstage is Tailscale- and team-gated and already exposes all of this
 // through its UI, so interactive users are treated as admin.
-function interactiveMcpServers(user?: string): Record<string, unknown> {
+function interactiveMcpServers(user?: string, sessionId?: string): Record<string, unknown> {
   const createdBy = user || "Backstage";
   return {
     "michael-sessions": createSessionsMcpServer({ createdBy, isAdmin: true }),
@@ -148,6 +150,12 @@ function interactiveMcpServers(user?: string): Record<string, unknown> {
       createdBy,
       isAdmin: true,
     }),
+    // Human-in-the-loop: ask a teammate and fold the answer back into this
+    // session. Needs the session id so the answer routes home. Withheld (like
+    // the others) from automation runs — see the runSessionPrompt call site.
+    ...(sessionId
+      ? { "michael-humans": createHumansMcpServer({ sessionId, createdBy, isAdmin: true }) }
+      : {}),
   };
 }
 
@@ -622,7 +630,7 @@ async function runSessionPrompt(
     mcpServers,
     // Self-management tools for normal sessions; withheld from automation
     // sessions (and their interactive resumes) — same gate as deniedTools above.
-    inProcessMcp: isAutomationSession ? undefined : interactiveMcpServers(user),
+    inProcessMcp: isAutomationSession ? undefined : interactiveMcpServers(user, sessionId),
     deniedTools,
     confirmTools: STRIPE_CONFIRM_TOOLS,
     aws: true, // sessions keep AWS read access (via injected creds)
@@ -698,6 +706,10 @@ async function runSessionPrompt(
 
   broadcastToSession(sessionId, { type: "stream_done" });
   broadcastToSession(sessionId, { type: "session_status", isRunning: false });
+
+  // The session just finished a turn; if nothing's queued it's idle now, so fire
+  // any "when_done" / "on_pr" human asks waiting on this session. Idempotent.
+  if (!(promptQueues.get(sessionId)?.length)) onHumanAsksSessionIdle(sessionId);
 }
 
 /**
@@ -1816,7 +1828,7 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
                     resumeSessionAt: forkFrom?.messageId,
                   }
                 : {}),
-              inProcessMcp: interactiveMcpServers(user),
+              inProcessMcp: interactiveMcpServers(user, bksId),
               confirmTools: STRIPE_CONFIRM_TOOLS,
               aws: true, // interactive sessions keep AWS read access (via injected creds)
               journal: { bksSessionId: bksId, kind: "create" },
@@ -1878,6 +1890,7 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
             ws.send(JSON.stringify({ type: "stream_done" }));
             broadcastToSession(bksId, { type: "stream_done" }, ws);
             broadcastToSession(bksId, { type: "session_status", isRunning: false });
+            if (!(promptQueues.get(bksId)?.length)) onHumanAsksSessionIdle(bksId);
           } catch (e: any) {
             ws.send(JSON.stringify({ type: "error", message: e.message || String(e) }));
           }
@@ -2032,7 +2045,7 @@ registerSessionControl({
           cwd: wtPath,
           mode: isAsk ? "ask" : "code",
           model,
-          inProcessMcp: interactiveMcpServers(user),
+          inProcessMcp: interactiveMcpServers(user, bksId),
           confirmTools: STRIPE_CONFIRM_TOOLS,
           aws: true,
           journal: { bksSessionId: bksId, kind: "create" },
@@ -2088,6 +2101,7 @@ registerSessionControl({
           );
         broadcastToSession(bksId, { type: "stream_done" });
         broadcastToSession(bksId, { type: "session_status", isRunning: false });
+        if (!(promptQueues.get(bksId)?.length)) onHumanAsksSessionIdle(bksId);
       } catch (e) {
         console.error(`[sessions-mcp] create session ${bksId} failed:`, e);
       }
@@ -2237,6 +2251,9 @@ if (!g.__backstageBooted) {
     resumeDrainedSessions(new Set(resumedIds));
     // Re-deliver messages that were queued/steered when the process went down.
     restorePromptQueues();
+    // Restore human-in-the-loop asks: re-arm scheduled timers, and degrade any
+    // block asks that lost their held turn to async so late replies still land.
+    initHumanAsks();
   }, 3000);
 
   // Ongoing hygiene (every 6h): archive sessions idle for more than a week,

--- a/src/agents/slack/handlers.ts
+++ b/src/agents/slack/handlers.ts
@@ -37,6 +37,8 @@ import { SlackProgress } from "./progress";
 import { createAdminMcpServer } from "./admin-tools";
 import { createGithubMcpServer } from "./github-tools";
 import { createSessionsMcpServer } from "./sessions-tools";
+import { createHumansMcpServer } from "./humans-tools";
+import { matchReply as matchHumanAskReply } from "../../server/human-asks";
 import { triggerPrAction } from "../github/trigger";
 import { classifyMention } from "./mention-intent";
 import { renderMemoryForPrompt, type MemoryContext } from "./memory";
@@ -833,6 +835,11 @@ export async function processMessage(
         createdBy: userName || msg.userId,
         isAdmin,
       }),
+      "michael-humans": createHumansMcpServer({
+        sessionId: `slack-${sessionKey}`,
+        createdBy: userName || msg.userId,
+        isAdmin,
+      }),
     };
   } catch (e) {
     console.warn("[slack] failed to build admin tools / memory:", e);
@@ -854,7 +861,12 @@ export async function processMessage(
     "to inspect state and transcripts. For trusted users: answer_session_question unblocks a session paused on a question, " +
     "send_to_session messages/redirects a running or idle session, cancel_session stops a run, and create_session spins up a new " +
     "ask- or code-mode session. When asked things like \"what's still running?\", \"what's waiting on me?\", or \"tell session X to …\", " +
-    "use these tools. Combine with the gh CLI (Bash) for deeper PR status (CI checks, review state) beyond the PR link list_sessions already shows.";
+    "use these tools. Combine with the gh CLI (Bash) for deeper PR status (CI checks, review state) beyond the PR link list_sessions already shows." +
+    "\n\n## Human in the loop\nYou can pull a teammate into the loop via the michael-humans MCP: ask_human DMs them (as you, Michael) and folds their reply back into this session. " +
+    "Use mode 'block' when you can't continue without the answer (your turn pauses until they reply — e.g. \"ask Grant for the copy\"), or 'async' (default) to keep working while you wait. " +
+    "For async, deliver_when controls timing: 'now', 'when_done' (when this session next goes idle), 'on_pr' (once a PR is open — best for \"ask John for a review when done\"), or 'at_time' with a natural-language at_time. " +
+    "Pass `options` for one-tap button choices, and `context` to attach background (the copy slot, a diff, a screen). Use list_pending_asks / cancel_ask to manage outstanding ones. " +
+    "When the user says things like \"ask Grant for X\", \"get John to review when I'm done\", or \"check with Jaap before shipping\", use ask_human rather than just telling them to do it.";
 
   rotation: for (;;) {
   let limitHit = false;
@@ -1154,6 +1166,25 @@ export async function handleMessageEvent(event: any): Promise<void> {
   const text = event.text || "";
 
   if (!text.trim()) return;
+
+  // Human-in-the-loop: is this a teammate replying to a question Michael DM'd
+  // them on behalf of a session? If so, route it back into that session and stop
+  // — do NOT treat it as a new request to Michael. This is the one path that
+  // deliberately accepts a message from someone other than the trusted user
+  // (matchReply only matches the exact person asked, in that ask's DM). Runs
+  // before the allow-list gate below for exactly that reason; it's tightly
+  // scoped and every accepted reply is audited.
+  const matchedAsk = matchHumanAskReply({ channel, user, threadTs: thread_ts, text });
+  if (matchedAsk) {
+    console.log(`[slack] Routed reply from ${user} into session ${matchedAsk.sessionId} (ask ${matchedAsk.id})`);
+    await addReaction(channel, ts, "white_check_mark").catch(() => {});
+    await sendSlackMessage(
+      channel,
+      ":inbox_tray: Got it — passing that straight to the session. Thanks!",
+      thread_ts || ts
+    ).catch(() => {});
+    return;
+  }
 
   const isDM = channel.startsWith("D");
   // For DMs: thread_ts means a reply in an existing thread; no thread_ts means

--- a/src/agents/slack/humans-tools.ts
+++ b/src/agents/slack/humans-tools.ts
@@ -1,0 +1,204 @@
+/**
+ * michael-humans — an in-process MCP server that lets a Backstage session pull a
+ * *teammate* into the loop: ask them a question over Slack and fold their answer
+ * back into the session. The "human in the loop" surface.
+ *
+ * Like michael-sessions / michael-admin, this is an in-process SDK MCP wired ONLY
+ * into interactive runs (Slack processMessage + Backstage interactiveMcpServers),
+ * never into automation runs — untrusted ticket text must not be able to DM the
+ * team as Michael. Its tools go through src/server/human-asks.ts, which owns the
+ * ask registry, the Slack delivery, reply matching, and routing the answer back
+ * through the session-control registry.
+ *
+ * Gating: creating/cancelling asks is gated to the trusted user via `isAdmin`
+ * (sending DMs to the team as Michael is outward-facing); listing is open to any
+ * whitelisted user. In Backstage sessions everyone is treated as admin (the UI is
+ * Tailscale- and team-gated already), matching michael-sessions.
+ */
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import {
+  registerAsk,
+  awaitBlockingAnswer,
+  listAsks,
+  cancelAsk,
+  type DeliverWhen,
+  type HumanAsk,
+} from "../../server/human-asks";
+import { resolveTeammate } from "../../server/shared/user-mappings";
+import { parseWhen } from "./parse-when";
+
+export interface HumansToolContext {
+  /** Backstage session this MCP instance belongs to — answers route back here. */
+  sessionId: string;
+  /** Display name credited as the asker in the teammate's DM. */
+  createdBy: string;
+  /** Trusted user — gates ask_human / cancel_ask. */
+  isAdmin: boolean;
+}
+
+function text(s: string) {
+  return { content: [{ type: "text" as const, text: s }] };
+}
+
+function describeDeliver(d: DeliverWhen): string {
+  if (d === "now") return "now";
+  if (d === "when_done") return "when this session next goes idle";
+  if (d === "on_pr") return "once this session has opened a PR";
+  return `at ${d.atIso}`;
+}
+
+function oneLine(a: HumanAsk): string {
+  const bits = [`\`${a.id}\` → *${a.person.name}*`, a.state, a.mode, describeDeliver(a.deliver)];
+  if (a.state === "answered" && a.answer) {
+    bits.push(`answered: "${a.answer.slice(0, 60)}${a.answer.length > 60 ? "…" : ""}"`);
+  }
+  return `• ${bits.join(" · ")}\n   _${a.question.slice(0, 120)}_`;
+}
+
+export function createHumansMcpServer(ctx: HumansToolContext) {
+  const tools: any[] = [
+    tool(
+      "list_pending_asks",
+      "List the human-in-the-loop questions this session has out to teammates (scheduled or awaiting a reply). Pass include_answered to also see ones already answered. Use this to check what you're still waiting on.",
+      {
+        include_answered: z
+          .boolean()
+          .optional()
+          .describe("Also include asks that have already been answered/cancelled."),
+        all_sessions: z
+          .boolean()
+          .optional()
+          .describe("List asks across all sessions, not just this one."),
+      },
+      async (args: { include_answered?: boolean; all_sessions?: boolean }) => {
+        const list = listAsks({
+          sessionId: args.all_sessions ? undefined : ctx.sessionId,
+          includeAnswered: args.include_answered,
+        });
+        if (!list.length) return text("No outstanding human asks.");
+        return text([`${list.length} ask(s):`, "", ...list.map(oneLine)].join("\n"));
+      }
+    ),
+  ];
+
+  if (ctx.isAdmin) {
+    tools.push(
+      tool(
+        "ask_human",
+        [
+          "Ask a teammate a question over Slack and fold their answer back into this session — the 'human in the loop' tool. Michael DMs them (as Michael), and when they reply it comes back to you.",
+          "",
+          "person: who to ask — a first name ('grant', 'john'), full name, or Slack id.",
+          "question: what you need from them. Be specific and self-contained.",
+          "context (optional): extra background to include in the DM — paste the copy slot, a diff, a screenshot description, the decision at stake. Higher-quality context → faster, better answers.",
+          "options (optional): a short list of choices → they get one-tap buttons (plus an 'Other…' free-text fallback). Omit for an open-ended reply.",
+          "",
+          "mode:",
+          "- 'block' — you NEED the answer to keep going right now. Your turn pauses (up to ~20 min) until they reply, then this tool returns their answer and you continue. If they don't reply in time it returns empty and the ask becomes async, so a later reply still resumes the session. Use for 'ask Grant for the copy' when you can't proceed without it.",
+          "- 'async' (default) — you DON'T need it right now. Returns immediately so you keep working; when they reply, the answer is delivered into this session as a new message. Use for 'get John's review' etc.",
+          "",
+          "deliver_when (async only — when the teammate is actually pinged):",
+          "- 'now' (default) — ping immediately.",
+          "- 'when_done' — hold the ping until this session next finishes its work (goes idle).",
+          "- 'on_pr' — hold the ping until this session has opened a PR. Best for 'ask John for a review when done' — a review needs the PR.",
+          "- 'at_time' — ping at a future time given in at_time (e.g. 'in 3 hours', 'tomorrow 9am').",
+        ].join("\n"),
+        {
+          person: z.string().describe("Teammate to ask: first name, full name, or Slack id."),
+          question: z.string().describe("The specific, self-contained question."),
+          context: z.string().optional().describe("Extra background to include in the DM."),
+          options: z
+            .array(z.string())
+            .optional()
+            .describe("Quick-pick choices → buttons. Omit for free-text."),
+          mode: z
+            .enum(["block", "async"])
+            .optional()
+            .describe("'block' = pause and wait; 'async' (default) = keep going, answer comes back later."),
+          deliver_when: z
+            .enum(["now", "when_done", "on_pr", "at_time"])
+            .optional()
+            .describe("When to ping (async only). Default 'now'."),
+          at_time: z
+            .string()
+            .optional()
+            .describe("Required when deliver_when='at_time': a natural-language time, e.g. 'in 3 hours'."),
+        },
+        async (args: {
+          person: string;
+          question: string;
+          context?: string;
+          options?: string[];
+          mode?: "block" | "async";
+          deliver_when?: "now" | "when_done" | "on_pr" | "at_time";
+          at_time?: string;
+        }) => {
+          if (!args.question?.trim()) return text("Need a question to ask.");
+          const person = resolveTeammate(args.person);
+          if (!person) {
+            return text(
+              `I don't know who "${args.person}" is — give me a teammate's first name (grant, john, johnny, jaap, kent, louise, thibault, michiel) or their Slack id.`
+            );
+          }
+
+          const mode = args.mode || "async";
+          let deliver: DeliverWhen = "now";
+          if (mode === "block") {
+            deliver = "now"; // blocking is always immediate
+          } else {
+            const dw = args.deliver_when || "now";
+            if (dw === "at_time") {
+              if (!args.at_time?.trim()) {
+                return text("deliver_when='at_time' needs an at_time like 'in 3 hours'.");
+              }
+              const iso = await parseWhen(args.at_time);
+              if (!iso) {
+                return text(`I couldn't read "${args.at_time}" as a future time. Try 'in 3 hours' or 'tomorrow 9am'.`);
+              }
+              deliver = { atIso: iso };
+            } else {
+              deliver = dw; // 'now' | 'when_done' | 'on_pr'
+            }
+          }
+
+          const ask = registerAsk({
+            sessionId: ctx.sessionId,
+            createdBy: ctx.createdBy,
+            person,
+            question: args.question.trim(),
+            context: args.context?.trim() || undefined,
+            options: args.options,
+            mode,
+            deliver,
+          });
+
+          if (mode === "block") {
+            const answer = await awaitBlockingAnswer(ask.id);
+            if (answer === null) {
+              return text(
+                `No reply from ${person.name} within the wait window. I've left the question open (\`${ask.id}\`) — when they answer, it'll come back into this session. For now, proceed with your best judgment and note the open question.`
+              );
+            }
+            return text(`${person.name} replied:\n\n${answer}`);
+          }
+
+          return text(
+            `Asked ${person.name} (${describeDeliver(deliver)}). \`${ask.id}\` — I'll keep working; their reply will come back into this session as a new message.`
+          );
+        }
+      ),
+      tool(
+        "cancel_ask",
+        "Cancel an outstanding human ask by id (from list_pending_asks). If it was already sent, the teammate gets a quick 'never mind' note.",
+        { id: z.string().describe("The ask id, e.g. 'ask-…'.") },
+        async (args: { id: string }) => {
+          const ok = cancelAsk(args.id);
+          return text(ok ? `Cancelled \`${args.id}\`.` : `Nothing to cancel for \`${args.id}\`.`);
+        }
+      )
+    );
+  }
+
+  return createSdkMcpServer({ name: "michael-humans", version: "1.0.0", tools });
+}

--- a/src/agents/slack/index.ts
+++ b/src/agents/slack/index.ts
@@ -41,7 +41,13 @@ import {
   sendSlackMessage,
   updateSlackBlocks,
   openSlackModal,
+  openHumanAskModal,
 } from "./slack-api";
+import {
+  resolveByOption as resolveHumanAsk,
+  isAwaiting as isHumanAskAwaiting,
+  getAsk as getHumanAsk,
+} from "../../server/human-asks";
 import {
   SESSION_DIR,
   GITHUB_REPO,
@@ -207,6 +213,17 @@ export class SlackAgent implements AgentModule {
 
         // Check if this is an "Other..." button — must open modal BEFORE returning
         if (actionId.endsWith("-other")) {
+          // Human-in-the-loop ask "Other…" — open the free-text modal.
+          const haOther = actionId.match(/^humanask-(.+)-other$/);
+          if (haOther?.[1]) {
+            const askId = haOther[1];
+            const ask = getHumanAsk(askId);
+            if (ask && isHumanAskAwaiting(askId) && payload.trigger_id) {
+              const r = await openHumanAskModal(payload.trigger_id, askId, ask.question);
+              if (!r?.ok) console.error("[slack] human-ask modal open failed:", r);
+            }
+            return new Response("", { status: 200 });
+          }
           // Extract questionId: "askq-{questionId}-other"
           const match = actionId.match(/^askq-(.+)-other$/);
           if (match?.[1]) {
@@ -244,6 +261,25 @@ export class SlackAgent implements AgentModule {
               pending.resolve(selectedLabel);
             }
           });
+          return new Response("", { status: 200 });
+        }
+
+        // Human-in-the-loop ask — option button picked.
+        const haOpt = actionId.match(/^humanask-(.+)-opt-(\d+)$/);
+        if (haOpt?.[1]) {
+          const askId = haOpt[1];
+          const label = action.value;
+          setImmediate(() => resolveHumanAsk(askId, label));
+          const msgChannel = payload.channel?.id;
+          const msgTs = payload.message?.ts;
+          if (msgChannel && msgTs) {
+            const kept = (payload.message?.blocks || []).filter((b: any) => b.type !== "actions");
+            kept.push({
+              type: "context",
+              elements: [{ type: "mrkdwn", text: `:white_check_mark: _You answered: ${label}_` }],
+            });
+            await updateSlackBlocks(msgChannel, msgTs, `Answered: ${label}`, kept);
+          }
           return new Response("", { status: 200 });
         }
 
@@ -399,6 +435,17 @@ Please address this feedback:
       // Handle view_submission (modal submit for "Other...")
       if (payload.type === "view_submission") {
         const callbackId: string = payload.view?.callback_id || "";
+
+        // Human-in-the-loop ask — free-text "Other…" answer.
+        const haModal = callbackId.match(/^humanask-modal-(.+)$/);
+        if (haModal?.[1]) {
+          const askId = haModal[1];
+          const answer: string =
+            payload.view?.state?.values?.answer_block?.answer_input?.value || "";
+          if (answer.trim()) setImmediate(() => resolveHumanAsk(askId, answer.trim()));
+          return new Response("", { status: 200 });
+        }
+
         const match = callbackId.match(/^askq-modal-(.+)$/);
 
         if (match?.[1]) {

--- a/src/agents/slack/slack-api.ts
+++ b/src/agents/slack/slack-api.ts
@@ -219,6 +219,50 @@ export async function openSlackModal(
   return response.json();
 }
 
+/**
+ * Open the "Other…" free-text modal for a human-in-the-loop ask (mirrors
+ * openSlackModal, but with the humanask callback prefix so the interactivity
+ * endpoint routes the submission to the human-asks registry).
+ */
+export async function openHumanAskModal(
+  triggerId: string,
+  askId: string,
+  questionText: string
+): Promise<any> {
+  const response = await fetchWithTimeout("https://slack.com/api/views.open", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${SLACK_BOT_TOKEN}`,
+    },
+    body: JSON.stringify({
+      trigger_id: triggerId,
+      view: {
+        type: "modal",
+        callback_id: `humanask-modal-${askId}`,
+        title: { type: "plain_text", text: "Your answer", emoji: true },
+        submit: { type: "plain_text", text: "Send", emoji: true },
+        close: { type: "plain_text", text: "Cancel", emoji: true },
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text: questionText } },
+          {
+            type: "input",
+            block_id: "answer_block",
+            element: {
+              type: "plain_text_input",
+              action_id: "answer_input",
+              multiline: true,
+              placeholder: { type: "plain_text", text: "Type your answer…" },
+            },
+            label: { type: "plain_text", text: "Your answer", emoji: true },
+          },
+        ],
+      },
+    }),
+  });
+  return response.json();
+}
+
 // ---------------------------------------------------------------------------
 // Context fetchers
 // ---------------------------------------------------------------------------
@@ -283,6 +327,16 @@ export async function getChannelKind(
 // ---------------------------------------------------------------------------
 // User info
 // ---------------------------------------------------------------------------
+
+/**
+ * Open (or fetch the existing) DM channel with a user and return its channel id,
+ * so we can post a message into a teammate's DM. Used by the human-in-the-loop
+ * asks (src/server/human-asks.ts). Returns null if Slack refuses.
+ */
+export async function openDirectMessage(slackUserId: string): Promise<string | null> {
+  const data = await slackApiCall("conversations.open", { users: slackUserId });
+  return data.ok && data.channel?.id ? data.channel.id : null;
+}
 
 export async function getUserInfo(
   userId: string

--- a/src/frontend/components/MessageBubble.tsx
+++ b/src/frontend/components/MessageBubble.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import type { TranscriptEntry } from "../lib/types";
 import { renderMarkdown } from "../lib/markdown";
+import { parseHumanReply } from "../lib/humanReply";
 
 interface Props {
   entry: TranscriptEntry;
@@ -24,11 +25,31 @@ function EntryImages({ images }: { images?: string[] }) {
 
 export function MessageBubble({ entry, onFork }: Props) {
   const html = useMemo(() => renderMarkdown(entry.content), [entry.content]);
+  // A routed-back teammate reply (human-in-the-loop): credit the teammate and
+  // render just their words (the header is stripped — the label carries "who").
+  const humanReply = useMemo(() => {
+    if (entry.type !== "user") return null;
+    const parsed = parseHumanReply(entry.content);
+    return parsed ? { name: parsed.name, html: renderMarkdown(parsed.body) } : null;
+  }, [entry.type, entry.content]);
 
   if (entry.type === "system") {
     return (
       <div className="msg msg-system">
         <span className="msg-system-text">{entry.content}</span>
+      </div>
+    );
+  }
+
+  if (entry.type === "user" && humanReply) {
+    return (
+      <div className="msg msg-human">
+        <div className="msg-label msg-label-human">💬 {humanReply.name} · via Slack</div>
+        <div
+          className="msg-body msg-body-human markdown"
+          dangerouslySetInnerHTML={{ __html: humanReply.html || "" }}
+        />
+        <EntryImages images={entry.images} />
       </div>
     );
   }

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "../lib/markdown";
+import { parseHumanReply } from "../lib/humanReply";
 import type { UnifiedSession, TranscriptEntry, WSServerMessage, AskQuestion } from "../lib/types";
 import { MessageBubble } from "./MessageBubble";
 import { WorkBlock } from "./WorkBlock";
@@ -674,23 +675,39 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
               />
             )}
 
-            {visibleSteered.map((s, i) => (
-              <div key={`steered-${i}`} className="msg msg-user msg-queued">
-                <div className="msg-label msg-label-user">
-                  {s.user || "You"} · folded in
+            {visibleSteered.map((s, i) => {
+              const hr = parseHumanReply(s.content);
+              return (
+                <div
+                  key={`steered-${i}`}
+                  className={`msg msg-queued ${hr ? "msg-human" : "msg-user"}`}
+                >
+                  <div className={`msg-label ${hr ? "msg-label-human" : "msg-label-user"}`}>
+                    {hr ? `💬 ${hr.name} · via Slack` : s.user || "You"} · folded in
+                  </div>
+                  <div className={`msg-body ${hr ? "msg-body-human" : "msg-body-user"}`}>
+                    {hr ? hr.body : s.content}
+                  </div>
                 </div>
-                <div className="msg-body msg-body-user">{s.content}</div>
-              </div>
-            ))}
+              );
+            })}
 
-            {queued.map((q, i) => (
-              <div key={`queued-${i}`} className="msg msg-user msg-queued">
-                <div className="msg-label msg-label-user">
-                  {q.user || "You"} · queued
+            {queued.map((q, i) => {
+              const hr = parseHumanReply(q.content);
+              return (
+                <div
+                  key={`queued-${i}`}
+                  className={`msg msg-queued ${hr ? "msg-human" : "msg-user"}`}
+                >
+                  <div className={`msg-label ${hr ? "msg-label-human" : "msg-label-user"}`}>
+                    {hr ? `💬 ${hr.name} · via Slack` : q.user || "You"} · queued
+                  </div>
+                  <div className={`msg-body ${hr ? "msg-body-human" : "msg-body-user"}`}>
+                    {hr ? hr.body : q.content}
+                  </div>
                 </div>
-                <div className="msg-body msg-body-user">{q.content}</div>
-              </div>
-            ))}
+              );
+            })}
 
             {pending.map((p) => (
               <div key={p.id} className="msg msg-user msg-sending">

--- a/src/frontend/lib/humanReply.ts
+++ b/src/frontend/lib/humanReply.ts
@@ -1,0 +1,23 @@
+/**
+ * Detect a teammate's answer that the human-in-the-loop feature
+ * (src/server/human-asks.ts) routed back into a session. Such a message arrives
+ * as a "user" turn (or a transient steer/queue receipt), but it's not the
+ * session driver — so the UI credits the teammate in a distinct bubble.
+ *
+ * Tolerant of:
+ *  - an optional "[Name] " steer-attribution prefix,
+ *  - the current 💬 + **bold** format and the older :speech_balloon: + *italic*
+ *    (or bare, when copied from rendered text) forms.
+ */
+const HEAD =
+  "(?:\\[[^\\]]+\\]\\s*)?(?:💬|:speech_balloon:)\\s*\\*{0,2}\\s*(.+?)\\s*\\*{0,2}\\s+(?:answered|replied)\\b";
+const HUMAN_REPLY_RE = new RegExp("^" + HEAD);
+const HUMAN_REPLY_HEADER = new RegExp("^" + HEAD + "[^\\n]*\\n+");
+
+export function parseHumanReply(content?: string): { name: string; body: string } | null {
+  if (!content) return null;
+  const m = content.match(HUMAN_REPLY_RE);
+  if (!m) return null;
+  const body = content.replace(HUMAN_REPLY_HEADER, "").trim();
+  return { name: m[1].trim(), body };
+}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -1619,6 +1619,26 @@ a {
 
 .msg-body-assistant { color: var(--text); }
 
+/* Human-in-the-loop: a teammate's reply routed back into the session. Distinct
+   from the driver's own blue "You" bubbles — a warm teal, to read as someone
+   else stepping in. */
+.msg-human { margin-top: 22px; }
+.msg-label-human { color: #1f9e8a; }
+.msg-label-human::before {
+  border-radius: 50%;
+  background: linear-gradient(135deg, #28d3b4, #0f8f7a);
+}
+.msg-body-human {
+  display: inline-block;
+  max-width: 100%;
+  background: rgba(31, 158, 138, 0.12);
+  border: 1px solid rgba(31, 158, 138, 0.3);
+  border-radius: 12px;
+  border-top-left-radius: 4px;
+  padding: 9px 14px;
+  color: var(--text);
+}
+
 .msg-streaming .msg-body-assistant::after {
   content: "";
   display: inline-block;

--- a/src/server/human-asks.ts
+++ b/src/server/human-asks.ts
@@ -1,0 +1,502 @@
+/**
+ * human-asks — the "human in the loop" registry. Lets a Backstage session ask a
+ * *teammate* a question over Slack and fold the answer back into the session,
+ * the way the AskUserQuestion machinery asks the session's own driver.
+ *
+ * Two axes (see src/agents/slack/humans-tools.ts for the tool surface):
+ *  - mode: "block" holds the agent's turn open until the teammate replies (bounded
+ *    by BLOCK_TIMEOUT_MS, then it degrades to async so a late reply still lands);
+ *    "async" returns immediately and the reply is steered into the session later.
+ *  - deliver: "now" pings immediately; "when_done" / "on_pr" hold the ping until the
+ *    session next goes idle / has opened a PR; { atIso } fires at a scheduled time.
+ *
+ * This module owns the ask *data* (the map + disk persistence + reply matching +
+ * audit). The two things only the main backstage process can do — steer an answer
+ * into a live session and broadcast — it reaches through the session-control
+ * registry (tryGetSessionControl), exactly like the michael-sessions MCP does.
+ * The Slack transport (DM send + option cards) is imported directly from the
+ * Slack agent's slack-api helpers; nothing there imports back into the server, so
+ * there's no import cycle.
+ *
+ * Wired into interactive runs only (Slack + Backstage sessions), never automation
+ * runs — same privilege boundary as michael-sessions/michael-admin: untrusted
+ * ticket text must not be able to DM the team as Michael.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { audit } from "./audit";
+import { tryGetSessionControl } from "./session-control";
+import {
+  openDirectMessage,
+  postSlackBlocks,
+  sendSlackMessage,
+} from "../agents/slack/slack-api";
+
+const HOME = process.env.HOME || "/home/ubuntu";
+const STORE = `${HOME}/.backstage-sessions/human-asks.json`;
+const UI_BASE =
+  process.env.MICHAEL_UI_BASE || "https://michael.taila5d766.ts.net/backstage";
+
+/** How long a "block" ask holds the agent's turn before degrading to async. */
+const BLOCK_TIMEOUT_MS = 20 * 60 * 1000;
+/** Terminal asks older than this are pruned from the store on load. */
+const TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type HumanAskState =
+  | "scheduled" // registered, not yet delivered (deferred trigger pending)
+  | "delivered" // DM sent, awaiting a reply
+  | "answered"
+  | "timeout"
+  | "cancelled";
+
+/** When the teammate is actually pinged. A string atIso means "at that instant". */
+export type DeliverWhen = "now" | "when_done" | "on_pr" | { atIso: string };
+
+export interface HumanAsk {
+  id: string;
+  /** Backstage session that raised the ask (answers route back here). */
+  sessionId: string;
+  /** Display name of whoever drove the session when it asked. */
+  createdBy: string;
+  person: { slackId: string; name: string };
+  question: string;
+  /** Extra background included in the DM (a file, a screen, a decision, …). */
+  context?: string;
+  /** Quick-pick option labels → buttons; absent → free-text reply. */
+  options?: string[];
+  mode: "block" | "async";
+  deliver: DeliverWhen;
+  state: HumanAskState;
+  /** Set once delivered: the DM channel and the question message's ts (thread root). */
+  slack?: { channel: string; rootTs: string };
+  answer?: string;
+  answeredBy?: string;
+  createdAt: string;
+  deliveredAt?: string;
+  answeredAt?: string;
+}
+
+interface Stored {
+  asks: HumanAsk[];
+}
+
+const g = globalThis as any;
+/** All asks, by id. Persisted to disk. */
+const asks: Map<string, HumanAsk> = (g.__humanAsks ??= new Map());
+/** Block-mode resolvers, in-memory only — their presence marks an ask as a live
+ *  blocking wait (vs. an async ask, or a block that timed out / lost its process). */
+const resolvers: Map<string, (answer: string | null) => void> = (g.__humanAskResolvers ??=
+  new Map());
+/** Armed timers for { atIso } deliveries, in-memory only (re-armed on boot). */
+const atTimers: Map<string, ReturnType<typeof setTimeout>> = (g.__humanAskTimers ??= new Map());
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+function persist(): void {
+  try {
+    const data: Stored = { asks: [...asks.values()] };
+    writeFileSync(STORE, JSON.stringify(data));
+  } catch (e) {
+    console.error("[human-asks] persist failed:", e);
+  }
+}
+
+function isTerminal(a: HumanAsk): boolean {
+  return a.state === "answered" || a.state === "cancelled" || a.state === "timeout";
+}
+
+/**
+ * Load persisted asks on boot. Prune old terminal asks. Block asks that were
+ * mid-flight at the last exit lost their in-process resolver, so degrade them to
+ * async — a late teammate reply then still steers into the (resumed) session
+ * instead of vanishing. Re-arm timers for scheduled { atIso } deliveries.
+ */
+export function initHumanAsks(): void {
+  if (existsSync(STORE)) {
+    try {
+      const data: Stored = JSON.parse(readFileSync(STORE, "utf-8"));
+      const cutoff = Date.now() - TERMINAL_RETENTION_MS;
+      for (const a of data.asks || []) {
+        if (isTerminal(a)) {
+          const t = new Date(a.answeredAt || a.createdAt).getTime();
+          if (t && t < cutoff) continue; // prune
+        }
+        // A delivered block ask can't resume its held turn after a restart.
+        if (a.state === "delivered" && a.mode === "block") a.mode = "async";
+        asks.set(a.id, a);
+      }
+    } catch (e) {
+      console.error("[human-asks] load failed:", e);
+    }
+  }
+  // Re-arm scheduled time deliveries.
+  for (const a of asks.values()) {
+    if (a.state === "scheduled" && typeof a.deliver === "object" && a.deliver.atIso) {
+      armTimer(a);
+    }
+  }
+}
+
+function armTimer(a: HumanAsk): void {
+  if (typeof a.deliver !== "object") return;
+  if (atTimers.has(a.id)) return;
+  const fireAt = new Date(a.deliver.atIso).getTime();
+  const delay = Math.max(0, fireAt - Date.now());
+  // setTimeout caps at ~24.8 days; for anything further, re-check hourly.
+  const MAX = 6 * 60 * 60 * 1000;
+  const timer = setTimeout(
+    () => {
+      atTimers.delete(a.id);
+      const cur = asks.get(a.id);
+      if (!cur || cur.state !== "scheduled") return;
+      if (typeof cur.deliver === "object" && new Date(cur.deliver.atIso).getTime() > Date.now()) {
+        armTimer(cur); // not due yet (long-delay re-check) — re-arm
+        return;
+      }
+      void deliverAsk(a.id).catch((e) => console.error("[human-asks] timed delivery failed:", e));
+    },
+    Math.min(delay, MAX)
+  );
+  atTimers.set(a.id, timer);
+}
+
+// ---------------------------------------------------------------------------
+// Creating + delivering
+// ---------------------------------------------------------------------------
+
+export interface CreateAskInput {
+  sessionId: string;
+  createdBy: string;
+  person: { slackId: string; name: string };
+  question: string;
+  context?: string;
+  options?: string[];
+  mode: "block" | "async";
+  deliver: DeliverWhen;
+}
+
+/** Register an ask and trigger its delivery if it's due now / arm its timer. */
+export function registerAsk(input: CreateAskInput): HumanAsk {
+  const ask: HumanAsk = {
+    id: `ask-${crypto.randomUUID()}`,
+    sessionId: input.sessionId,
+    createdBy: input.createdBy,
+    person: input.person,
+    question: input.question,
+    context: input.context,
+    options: input.options?.length ? input.options : undefined,
+    mode: input.mode,
+    deliver: input.deliver,
+    state: "scheduled",
+    createdAt: new Date().toISOString(),
+  };
+  asks.set(ask.id, ask);
+  persist();
+  audit({
+    context: "human_ask",
+    action: "created",
+    ask_id: ask.id,
+    session_id: ask.sessionId,
+    created_by: ask.createdBy,
+    person: ask.person.name,
+    mode: ask.mode,
+    deliver: typeof ask.deliver === "object" ? `at:${ask.deliver.atIso}` : ask.deliver,
+  });
+
+  if (ask.deliver === "now") {
+    void deliverAsk(ask.id).catch((e) => console.error("[human-asks] deliver failed:", e));
+  } else if (typeof ask.deliver === "object") {
+    armTimer(ask);
+  } // when_done / on_pr stay scheduled until onSessionIdle fires them.
+
+  return ask;
+}
+
+const firstName = (full: string) => full.split(" ")[0] || full;
+
+function deliveryBlocks(a: HumanAsk): { fallback: string; blocks: any[] } {
+  const link = `${UI_BASE}/session/${a.sessionId}`;
+  const intro =
+    `Hey ${firstName(a.person.name)} — it's *Michael* :robot_face:. ` +
+    `${a.createdBy} has me working on something and needs your input:`;
+  const blocks: any[] = [
+    { type: "section", text: { type: "mrkdwn", text: intro } },
+    { type: "section", text: { type: "mrkdwn", text: `> ${a.question.replace(/\n/g, "\n> ")}` } },
+  ];
+  if (a.context) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: a.context.slice(0, 2900) } });
+  }
+  if (a.options?.length) {
+    const buttons: any[] = a.options.slice(0, 9).map((label, i) => ({
+      type: "button",
+      text: { type: "plain_text", text: label.slice(0, 75), emoji: true },
+      action_id: `humanask-${a.id}-opt-${i}`,
+      value: label,
+    }));
+    buttons.push({
+      type: "button",
+      text: { type: "plain_text", text: "Other…", emoji: true },
+      action_id: `humanask-${a.id}-other`,
+      style: "primary",
+    });
+    blocks.push({ type: "actions", elements: buttons });
+  } else {
+    blocks.push({
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: "_Reply here and I'll bring it straight back into the session._" },
+      ],
+    });
+  }
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: `<${link}|Open the session in Backstage>` }],
+  });
+  return { fallback: `Michael needs your input: ${a.question}`, blocks };
+}
+
+/** Open a DM with the teammate and post the question. Marks the ask delivered. */
+export async function deliverAsk(id: string): Promise<boolean> {
+  const a = asks.get(id);
+  if (!a || a.state !== "scheduled") return false;
+  const channel = await openDirectMessage(a.person.slackId);
+  if (!channel) {
+    console.error(`[human-asks] couldn't open DM with ${a.person.name} (${a.person.slackId})`);
+    return false;
+  }
+  const { fallback, blocks } = deliveryBlocks(a);
+  const res = await postSlackBlocks(channel, fallback, blocks);
+  if (!res?.ok || !res.ts) {
+    console.error(`[human-asks] DM post failed for ${id}:`, res?.error);
+    return false;
+  }
+  a.state = "delivered";
+  a.slack = { channel, rootTs: res.ts };
+  a.deliveredAt = new Date().toISOString();
+  asks.set(id, a);
+  persist();
+  audit({
+    context: "human_ask",
+    action: "delivered",
+    ask_id: id,
+    session_id: a.sessionId,
+    person: a.person.name,
+    channel,
+  });
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Blocking await
+// ---------------------------------------------------------------------------
+
+/**
+ * For a "block" ask: register a resolver and return a promise that settles when
+ * the teammate replies (the answer), or after BLOCK_TIMEOUT_MS (null). On
+ * timeout the ask degrades to async so a later reply still steers into the
+ * session rather than being dropped.
+ */
+export function awaitBlockingAnswer(id: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolvers.delete(id);
+      const a = asks.get(id);
+      if (a && a.state === "delivered") {
+        a.mode = "async"; // a late reply now routes back via deliverToSession
+        persist();
+      }
+      resolve(null);
+    }, BLOCK_TIMEOUT_MS);
+    resolvers.set(id, (answer) => {
+      clearTimeout(timer);
+      resolvers.delete(id);
+      resolve(answer);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Resolving (a teammate answered)
+// ---------------------------------------------------------------------------
+
+function shortQ(a: HumanAsk): string {
+  return a.question.length > 80 ? `${a.question.slice(0, 80)}…` : a.question;
+}
+
+/** Mark an ask answered, audit it, and route the answer (block resolver if the
+ *  wait is still live in this process, otherwise steer it into the session). */
+function resolveAsk(a: HumanAsk, answer: string, answeredBy: string): void {
+  a.state = "answered";
+  a.answer = answer;
+  a.answeredBy = answeredBy;
+  a.answeredAt = new Date().toISOString();
+  asks.set(a.id, a);
+  persist();
+  audit({
+    context: "human_ask",
+    action: "answered",
+    ask_id: a.id,
+    session_id: a.sessionId,
+    person: a.person.name,
+    answered_by: answeredBy,
+    answer_len: answer.length,
+  });
+
+  const resolver = resolvers.get(a.id);
+  if (resolver) {
+    resolver(answer); // live block — the awaiting tool call returns the answer
+    return;
+  }
+  // Async (or a block whose wait already timed out / lost its process): steer
+  // the answer into the session like a human typing in the web UI.
+  const ctrl = tryGetSessionControl();
+  if (!ctrl) {
+    console.error(`[human-asks] no session control to deliver answer for ${a.id}`);
+    return;
+  }
+  // Unicode emoji (the Backstage markdown renderer doesn't expand :shortcodes:)
+  // and a structured header the web UI keys on to render this as a distinct
+  // "human reply" bubble rather than one of the session driver's own messages.
+  const msg = `💬 **${a.person.name}** answered (via Slack) — "${shortQ(a)}":\n\n${answer}`;
+  void ctrl
+    .deliverToSession(a.sessionId, msg, a.person.name)
+    .catch((e) => console.error(`[human-asks] deliver answer to ${a.sessionId} failed:`, e));
+}
+
+/**
+ * Try to match an inbound Slack message to an outstanding ask. Accepts a reply
+ * ONLY from the exact teammate the ask was sent to, in that ask's DM channel.
+ * Prefers a reply threaded under the question; falls back to the most recent
+ * delivered ask in the channel (teammates often reply without threading in a DM).
+ * Returns the matched ask (now answered) or null. This is the one place that
+ * deliberately accepts a message from someone other than the trusted user.
+ */
+export function matchReply(input: {
+  channel: string;
+  user: string;
+  threadTs?: string;
+  text: string;
+}): HumanAsk | null {
+  const text = (input.text || "").trim();
+  if (!text) return null;
+  const candidates = [...asks.values()].filter(
+    (a) =>
+      a.state === "delivered" &&
+      a.slack?.channel === input.channel &&
+      a.person.slackId === input.user
+  );
+  if (!candidates.length) return null;
+
+  let match =
+    (input.threadTs && candidates.find((a) => a.slack!.rootTs === input.threadTs)) || undefined;
+  if (!match) {
+    // Newest delivered ask in this DM wins for an un-threaded reply.
+    match = candidates.sort(
+      (x, y) => new Date(y.deliveredAt!).getTime() - new Date(x.deliveredAt!).getTime()
+    )[0];
+  }
+  if (!match) return null;
+
+  audit({
+    context: "human_ask",
+    action: "reply_accepted",
+    ask_id: match.id,
+    session_id: match.sessionId,
+    person: match.person.name,
+    from_user: input.user,
+    threaded: !!(input.threadTs && match.slack!.rootTs === input.threadTs),
+  });
+  resolveAsk(match, text, match.person.name);
+  return match;
+}
+
+/** Resolve an option-button / modal answer by ask id (from the Slack interactivity
+ *  endpoint). Returns true if it was an outstanding ask. */
+export function resolveByOption(askId: string, label: string): boolean {
+  const a = asks.get(askId);
+  if (!a || a.state !== "delivered") return false;
+  audit({
+    context: "human_ask",
+    action: "reply_accepted",
+    ask_id: a.id,
+    session_id: a.sessionId,
+    person: a.person.name,
+    via: "button",
+  });
+  resolveAsk(a, label, a.person.name);
+  return true;
+}
+
+/** True if this ask is still awaiting a reply (used to gate the modal "Other…"). */
+export function isAwaiting(askId: string): boolean {
+  return asks.get(askId)?.state === "delivered";
+}
+
+// ---------------------------------------------------------------------------
+// Deferred-trigger firing
+// ---------------------------------------------------------------------------
+
+/**
+ * Called when a session finishes a run with nothing queued (it just went idle).
+ * Fires any scheduled "when_done" asks for it, plus "on_pr" asks once the
+ * session has a PR. Idempotent — a delivered ask won't re-fire.
+ */
+export function onSessionIdle(sessionId: string): void {
+  const pending = [...asks.values()].filter(
+    (a) => a.sessionId === sessionId && a.state === "scheduled"
+  );
+  if (!pending.length) return;
+  let hasPr = false;
+  const ctrl = tryGetSessionControl();
+  if (ctrl) hasPr = !!ctrl.getSession(sessionId)?.prUrl;
+  for (const a of pending) {
+    if (a.deliver === "when_done" || (a.deliver === "on_pr" && hasPr)) {
+      void deliverAsk(a.id).catch((e) =>
+        console.error(`[human-asks] idle delivery failed for ${a.id}:`, e)
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Listing + cancelling (for the MCP)
+// ---------------------------------------------------------------------------
+
+export function listAsks(opts?: { sessionId?: string; includeAnswered?: boolean }): HumanAsk[] {
+  let out = [...asks.values()];
+  if (opts?.sessionId) out = out.filter((a) => a.sessionId === opts.sessionId);
+  if (!opts?.includeAnswered) {
+    out = out.filter((a) => a.state === "scheduled" || a.state === "delivered");
+  }
+  return out.sort((x, y) => new Date(y.createdAt).getTime() - new Date(x.createdAt).getTime());
+}
+
+export function getAsk(id: string): HumanAsk | undefined {
+  return asks.get(id);
+}
+
+export function cancelAsk(id: string): boolean {
+  const a = asks.get(id);
+  if (!a || isTerminal(a)) return false;
+  a.state = "cancelled";
+  asks.set(id, a);
+  const timer = atTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    atTimers.delete(id);
+  }
+  const resolver = resolvers.get(id);
+  if (resolver) resolver(null);
+  persist();
+  audit({ context: "human_ask", action: "cancelled", ask_id: id, session_id: a.sessionId });
+  // If it was already delivered, let the teammate know it's moot.
+  if (a.slack) {
+    void sendSlackMessage(
+      a.slack.channel,
+      ":heavy_multiplication_x: _Never mind — Michael no longer needs an answer to that one._",
+      a.slack.rootTs
+    ).catch(() => {});
+  }
+  return true;
+}

--- a/src/server/shared/user-mappings.ts
+++ b/src/server/shared/user-mappings.ts
@@ -52,6 +52,34 @@ export function slackIdToFirstName(id: string): string | null {
   return name ? name.split(" ")[0] : null;
 }
 
+/**
+ * Resolve a teammate reference — a Slack user id, a first name / alias, a full
+ * name, or a GitHub login — to their Slack id + display name, for the
+ * human-in-the-loop asks (src/server/human-asks.ts). Reuses the same identity
+ * table as commit attribution so "ask Grant" / "grant" / "9ranty" / a raw U-id
+ * all land on the same person. Returns null for unknown references.
+ */
+export function resolveTeammate(ref?: string | null): { slackId: string; name: string } | null {
+  if (!ref) return null;
+  const key = ref.trim().replace(/^@/, "");
+  if (!key) return null;
+
+  // Raw Slack id.
+  if (/^U[A-Z0-9]{6,}$/.test(key)) {
+    const name = SLACK_ID_TO_NAME[key];
+    return name ? { slackId: key, name } : null;
+  }
+  // Name / alias / GitHub login → identity → slackId.
+  const id = gitIdentityFor(key);
+  if (id) {
+    const member = TEAM_GIT_IDENTITY.find((p) => p.name === id.name);
+    if (member?.slackId) {
+      return { slackId: member.slackId, name: SLACK_ID_TO_NAME[member.slackId] || member.name };
+    }
+  }
+  return null;
+}
+
 export function githubUsernameToSlackId(username: string): string | null {
   return GITHUB_TO_SLACK[username] || null;
 }


### PR DESCRIPTION
Poke-style "human in the loop", but with our team. A session can pull a teammate in via the new **`michael-humans`** MCP: `ask_human` DMs them (as Michael) and routes their answer back into the session.

## What it does
- **`ask_human(person, question, …)`** — `mode: block` pauses the turn until they reply (degrades to async after ~20m or a restart so a late reply still lands); `mode: async` (default) keeps working and steers the reply in when it arrives.
- **Delivery triggers (async):** `now`, `when_done` (next idle), `on_pr` (once a PR is open — best for "review when done"), or `at_time` (natural-language, via parseWhen).
- **Replies:** free-text in the DM thread, or one-tap **buttons** + an `Other…` modal when `options` are given.
- `list_pending_asks` / `cancel_ask` to manage outstanding ones.

## How it's wired
- `src/server/human-asks.ts` — disk-persisted registry, Slack delivery, reply matching, blocking await, deferred triggers, audit at every step.
- `src/agents/slack/humans-tools.ts` — the MCP, wired into interactive Slack + Backstage runs **only, never automations** (same privilege boundary as `michael-sessions`).
- `matchReply` runs before the allow-list gate — the one path that accepts a message from someone other than the trusted user, scoped to the **exact person asked, in that ask's DM**, and every accepted reply is audited (`human_reply_accepted`).

## UI
A routed-back reply renders as a distinct **teal "via Slack"** bubble crediting the teammate (not the driver's "You"), in both the transcript and the steer/queue receipts. Shared `parseHumanReply` handles the unicode/shortcode + bold/italic/bare forms.

## Tested live
End-to-end verified: async free-text (DM reply intercepted + routed back), and the team fan-out (Grant, Kent, John, Jaap, Louise replied; allow-list relaxation confirmed working for non-allowed teammates). Block mode, buttons, and deferred triggers are wired + typecheck-clean but not yet exercised by a live run.

## Note on deploy
Merging auto-deploys to the VPS. The runner-path MCP wiring + the Slack loop's `matchReply` only take effect on a real restart (per CLAUDE.md), which the deploy handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)