### PR TITLE
tabs: show the active session as a transient tab, Chrome-style

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -174,6 +174,16 @@ function App() {
     .map((id) => sessions.find((s) => s.id === id || s.aliasIds?.includes(id)))
     .filter((s): s is UnifiedSession => Boolean(s));
 
+  // The currently-open session always gets a tab, even when it isn't pinned —
+  // like Chrome, this transient tab lives only while its session is the active
+  // route and closes the moment you navigate away. Pinned tabs persist; the ☆
+  // on a transient tab promotes it to a pinned one.
+  const pinnedIds = new Set(pinnedTabs.map((s) => s.id));
+  const tabs =
+    currentSession && !pinnedIds.has(currentSession.id)
+      ? [...pinnedTabs, currentSession]
+      : pinnedTabs;
+
   const activeView =
     route.view === "automations" ||
     route.view === "wiki" ||
@@ -250,10 +260,11 @@ function App() {
 
           <main className="detail-pane">
             <SessionTabs
-              tabs={pinnedTabs}
+              tabs={tabs}
               activeId={currentSession?.id || null}
+              pinnedIds={pinnedIds}
               onSelect={(s) => navigate({ view: "session", id: s.id })}
-              onUnpin={(id) => setPins(togglePin(id))}
+              onTogglePin={(id) => setPins(togglePin(id))}
             />
             {route.view === "new" ? (
               <NewSession

--- a/src/frontend/components/SessionTabs.tsx
+++ b/src/frontend/components/SessionTabs.tsx
@@ -4,45 +4,55 @@ import type { UnifiedSession } from "../lib/types";
 interface Props {
   tabs: UnifiedSession[];
   activeId: string | null;
+  /** IDs of sessions that are pinned; the rest are transient (current route only). */
+  pinnedIds: Set<string>;
   onSelect: (session: UnifiedSession) => void;
-  onUnpin: (id: string) => void;
+  onTogglePin: (id: string) => void;
 }
 
 /**
- * Horizontal strip of pinned sessions, rendered above the session title on
- * every view so you can jump between the sessions you care about. Pin/unpin is
- * the existing pins store (star on Home, or the ★ in the session header).
+ * Horizontal strip of session tabs above the session title, on every view.
+ * Pinned tabs persist (the pins store — star on Home, or the ★ in the session
+ * header). The currently-open session also shows as a *transient* tab even when
+ * unpinned: like Chrome, it closes as soon as you navigate away. Clicking the
+ * ☆ on a transient tab promotes it to a pinned one; the ★ on a pinned tab
+ * unpins (removing the tab).
  */
-export function SessionTabs({ tabs, activeId, onSelect, onUnpin }: Props) {
+export function SessionTabs({ tabs, activeId, pinnedIds, onSelect, onTogglePin }: Props) {
   if (tabs.length === 0) return null;
 
   return (
     <div className="session-tabs" role="tablist">
-      {tabs.map((s) => (
-        <div
-          key={s.id}
-          role="tab"
-          aria-selected={s.id === activeId}
-          className={`session-tab ${s.id === activeId ? "session-tab-active" : ""}`}
-          onClick={() => onSelect(s)}
-          title={s.title}
-        >
-          {s.isRunning && <span className="session-tab-dot" />}
-          <span className="session-tab-title">{s.title}</span>
-          <span
-            className="session-tab-unstar"
-            role="button"
-            aria-label="Unstar (remove tab)"
-            title="Unstar"
-            onClick={(e) => {
-              e.stopPropagation();
-              onUnpin(s.id);
-            }}
+      {tabs.map((s) => {
+        const pinned = pinnedIds.has(s.id);
+        return (
+          <div
+            key={s.id}
+            role="tab"
+            aria-selected={s.id === activeId}
+            className={`session-tab ${s.id === activeId ? "session-tab-active" : ""} ${
+              pinned ? "" : "session-tab-transient"
+            }`}
+            onClick={() => onSelect(s)}
+            title={s.title}
           >
-            ★
-          </span>
-        </div>
-      ))}
+            {s.isRunning && <span className="session-tab-dot" />}
+            <span className="session-tab-title">{s.title}</span>
+            <span
+              className={`session-tab-pin ${pinned ? "session-tab-pin-on" : ""}`}
+              role="button"
+              aria-label={pinned ? "Unpin (remove tab)" : "Pin tab"}
+              title={pinned ? "Unpin" : "Pin tab"}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTogglePin(s.id);
+              }}
+            >
+              {pinned ? "★" : "☆"}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -561,9 +561,17 @@ a {
   animation: pulse 1.4s ease-in-out infinite;
 }
 
-/* Unstar control: removes the tab (a tab IS a starred session). Always shown
-   on touch; reveal-on-hover (or for the active tab) on desktop. */
-.session-tab-unstar {
+/* A transient tab (the current session when it isn't pinned) reads as
+   provisional: dashed top edge, like a Chrome tab that hasn't been pinned. */
+.session-tab-transient {
+  border-style: dashed;
+}
+
+/* Pin control: ★ on a pinned tab unpins (removes it); ☆ on a transient tab
+   pins it. Always shown on touch; reveal-on-hover (or for the active tab) on
+   desktop. The ☆ stays visible on transient tabs so the pin affordance is
+   discoverable. */
+.session-tab-pin {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -572,19 +580,20 @@ a {
   border-radius: 4px;
   font-size: 11px;
   line-height: 1;
-  color: var(--yellow);
+  color: var(--text-dim);
   flex-shrink: 0;
 }
-.session-tab-unstar:hover { background: var(--bg-active); color: #e3b341; }
+.session-tab-pin-on { color: var(--yellow); }
+.session-tab-pin:hover { background: var(--bg-active); color: #e3b341; }
 
 @media (hover: hover) and (pointer: fine) {
-  .session-tab-unstar {
+  .session-tab-pin {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.12s ease;
   }
-  .session-tab:hover .session-tab-unstar,
-  .session-tab-active .session-tab-unstar {
+  .session-tab:hover .session-tab-pin,
+  .session-tab-active .session-tab-pin {
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
The currently-open session now always gets a tab, even when it isn't pinned. Like a Chrome tab, this transient tab lives only while its session is the active route and closes the moment you navigate away. Pinned tabs persist.

- **App.tsx** — append `currentSession` to the tab list when it isn't pinned; pass a `pinnedIds` set down so the strip distinguishes pinned vs transient.
- **SessionTabs.tsx** — ★ on a pinned tab unpins (removes it); ☆ on a transient tab pins it (promotes to permanent). Transient tabs get a `session-tab-transient` class.
- **global.css** — renamed `.session-tab-unstar` → `.session-tab-pin` (+`-on` for the yellow filled state); transient tabs get a dashed top edge to read as provisional.

Frontend-only, so it hot-reloads — no service restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)