### PR TITLE
Factory: Factorio-style production-floor view of all sessions

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -1223,7 +1223,16 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
 
     // List sessions
     if (path === "/backstage/api/sessions" && req.method === "GET") {
-      return Response.json(getCachedSessions());
+      // Enrich with live, in-process signals that aren't on the cached session
+      // objects: whether a run is blocked on a human question (pendingAsks) and
+      // how many prompts are queued behind it. Powers the Factory view's
+      // "waiting" station without a second round-trip.
+      const enriched = getCachedSessions().map((s) => ({
+        ...s,
+        waitingForInput: pendingAsks.has(s.id),
+        queuedCount: promptQueues.get(s.id)?.length || 0,
+      }));
+      return Response.json(enriched);
     }
 
     // Get transcript for a session

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -7,6 +7,7 @@ import { Home } from "./components/Home";
 import { Automations } from "./components/Automations";
 import { Wiki } from "./components/Wiki";
 import { Connections } from "./components/Connections";
+import { Factory } from "./components/Factory";
 import { Archived } from "./components/Archived";
 import { Reviews } from "./components/Reviews";
 import { UserPicker, UserGate } from "./components/UserPicker";
@@ -30,6 +31,7 @@ type Route =
   | { view: "automations" }
   | { view: "wiki"; path: string | null }
   | { view: "connections" }
+  | { view: "factory" }
   | { view: "archived" };
 
 function parseRoute(pathname: string): Route {
@@ -38,6 +40,7 @@ function parseRoute(pathname: string): Route {
   if (pathname === "/backstage/new") return { view: "new" };
   if (pathname === "/backstage/automations") return { view: "automations" };
   if (pathname === "/backstage/connections") return { view: "connections" };
+  if (pathname === "/backstage/factory") return { view: "factory" };
   if (pathname === "/backstage/archived") return { view: "archived" };
   const reviewsMatch = pathname.match(/^\/backstage\/reviews(?:\/(.+))?$/);
   if (reviewsMatch) return { view: "reviews", id: reviewsMatch[1] ? decodeURIComponent(reviewsMatch[1]) : undefined };
@@ -58,6 +61,8 @@ function routePath(route: Route): string {
       return "/backstage/automations";
     case "connections":
       return "/backstage/connections";
+    case "factory":
+      return "/backstage/factory";
     case "archived":
       return "/backstage/archived";
     case "reviews":
@@ -178,6 +183,7 @@ function App() {
     route.view === "automations" ||
     route.view === "wiki" ||
     route.view === "connections" ||
+    route.view === "factory" ||
     route.view === "reviews"
       ? route.view
       : ("sessions" as const);
@@ -266,6 +272,12 @@ function App() {
               <Automations onOpenSession={(id) => navigate({ view: "session", id })} />
             ) : route.view === "connections" ? (
               <Connections />
+            ) : route.view === "factory" ? (
+              <Factory
+                sessions={sessions}
+                loading={loading}
+                onOpenSession={(id) => navigate({ view: "session", id })}
+              />
             ) : route.view === "reviews" ? (
               <Reviews
                 sessions={sessions}

--- a/src/frontend/components/Factory.tsx
+++ b/src/frontend/components/Factory.tsx
@@ -1,0 +1,304 @@
+import React, { useMemo } from "react";
+import type { UnifiedSession } from "../lib/types";
+import { relativeTime } from "../lib/api";
+
+// A Factorio-flavoured overview of everything moving through Michael: sources
+// "mine" raw work on the left, sessions get "assembled" in the middle (running /
+// waiting / buffer), and anything with a PR floats out to the GitHub island on
+// the right. Pure derived view over the polled sessions list — no extra fetch.
+
+interface Props {
+  sessions: UnifiedSession[];
+  loading: boolean;
+  onOpenSession: (id: string) => void;
+}
+
+type SrcKey = "slack" | "linear" | "backstage" | "cli" | "automation";
+
+const SOURCE_META: Record<SrcKey, { label: string; color: string; glyph: string }> = {
+  slack: { label: "Slack", color: "#a36ba5", glyph: "#" },
+  linear: { label: "Linear", color: "#7b86e8", glyph: "◳" },
+  backstage: { label: "Backstage", color: "#5eead4", glyph: "▣" },
+  cli: { label: "CLI", color: "#8b94a3", glyph: ">_" },
+  automation: { label: "Automation", color: "#d29922", glyph: "⚙" },
+};
+
+const SOURCE_ORDER: SrcKey[] = ["slack", "linear", "backstage", "cli", "automation"];
+
+const STATION_CAP = 9;
+const RECENT_MS = 24 * 60 * 60 * 1000;
+
+function srcKey(s: UnifiedSession): SrcKey {
+  if (s.automation) return "automation";
+  return (["slack", "linear", "backstage", "cli"].includes(s.source) ? s.source : "cli") as SrcKey;
+}
+
+const cssVar = (color: string) => ({ ["--src"]: color } as React.CSSProperties);
+
+export function Factory({ sessions, loading, onOpenSession }: Props) {
+  const model = useMemo(() => {
+    const active = sessions.filter((s) => !s.archived);
+
+    const waiting = active.filter((s) => s.waitingForInput);
+    const running = active.filter((s) => s.isRunning && !s.waitingForInput);
+    const queued = active.filter(
+      (s) => !s.isRunning && !s.waitingForInput && (s.queuedCount || 0) > 0
+    );
+
+    const busy = new Set([...waiting, ...running, ...queued].map((s) => s.id));
+    const now = Date.now();
+    const idle = active
+      .filter((s) => !busy.has(s.id) && now - new Date(s.lastActivity).getTime() < RECENT_MS)
+      .sort((a, b) => +new Date(b.lastActivity) - +new Date(a.lastActivity));
+
+    // Per-source drill counts (over all active sessions).
+    const counts = new Map<SrcKey, { total: number; running: number }>();
+    for (const k of SOURCE_ORDER) counts.set(k, { total: 0, running: 0 });
+    for (const s of active) {
+      const c = counts.get(srcKey(s))!;
+      c.total++;
+      if (s.isRunning) c.running++;
+    }
+
+    // GitHub island: one crate per distinct PR, freshest session wins.
+    const byUrl = new Map<string, UnifiedSession>();
+    for (const s of [...active].sort(
+      (a, b) => +new Date(b.lastActivity) - +new Date(a.lastActivity)
+    )) {
+      if (s.prUrl && !byUrl.has(s.prUrl)) byUrl.set(s.prUrl, s);
+    }
+    const prs = [...byUrl.values()];
+    const open = prs.filter((s) => s.prState === "OPEN" || !s.prState);
+    const merged = prs.filter((s) => s.prState === "MERGED");
+    const closed = prs.filter((s) => s.prState === "CLOSED");
+
+    return { active, waiting, running, queued, idle, counts, open, merged, closed };
+  }, [sessions]);
+
+  if (loading && sessions.length === 0) {
+    return (
+      <div className="factory">
+        <div className="fac-boot">⚙ Spinning up the factory…</div>
+      </div>
+    );
+  }
+
+  const { active, waiting, running, queued, idle, counts, open, merged, closed } = model;
+
+  return (
+    <div className="factory">
+      <div className="fac-scene">
+        <header className="fac-hud">
+          <div className="fac-hud-title">
+            <span className="fac-hud-gear">⚙</span>
+            <span>Production Floor</span>
+            <span className="fac-hud-sub">{active.length} sessions on the line</span>
+          </div>
+          <div className="fac-stats">
+            <Stat tone="run" label="Assembling" value={running.length} />
+            <Stat tone="wait" label="Awaiting input" value={waiting.length} />
+            <Stat tone="queue" label="Queued" value={queued.length} />
+            <Stat tone="pr" label="PRs open" value={open.length} />
+          </div>
+        </header>
+
+        <div className="fac-floor">
+          {/* ── Intake: a mining drill per source ── */}
+          <section className="fac-col fac-col-intake">
+            <h3 className="fac-col-label">Intake</h3>
+            <div className="fac-drills">
+              {SOURCE_ORDER.map((k) => {
+                const c = counts.get(k)!;
+                return (
+                  <div
+                    key={k}
+                    className={`fac-drill${c.running > 0 ? " is-active" : ""}${
+                      c.total === 0 ? " is-cold" : ""
+                    }`}
+                    style={cssVar(SOURCE_META[k].color)}
+                  >
+                    <span className="fac-drill-glyph">{SOURCE_META[k].glyph}</span>
+                    <span className="fac-drill-name">{SOURCE_META[k].label}</span>
+                    <span className="fac-drill-count">{c.total}</span>
+                    <span className="fac-drill-bit" aria-hidden />
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <Belt />
+
+          {/* ── Assemblers ── */}
+          <section className="fac-col fac-col-assembly">
+            <Station
+              kind="run"
+              title="Assembling"
+              empty="No active assemblers"
+              sessions={running}
+              onOpen={onOpenSession}
+            />
+            <Station
+              kind="wait"
+              title="Awaiting input"
+              empty="All clear — nothing blocked"
+              sessions={waiting}
+              onOpen={onOpenSession}
+            />
+            <Station
+              kind="idle"
+              title="Buffer"
+              empty="Belt empty"
+              sessions={[...queued, ...idle]}
+              onOpen={onOpenSession}
+            />
+          </section>
+
+          <Belt toIsland />
+
+          {/* ── GitHub island ── */}
+          <section className="fac-col fac-col-island">
+            <div className="fac-island">
+              <div className="fac-island-water" aria-hidden />
+              <h3 className="fac-island-label">
+                <span className="fac-hex">⬡</span> GitHub Island
+              </h3>
+              <PrShelf tone="open" label="Open" prs={open} onOpen={onOpenSession} />
+              <PrShelf tone="merged" label="Merged" prs={merged} onOpen={onOpenSession} />
+              <PrShelf tone="closed" label="Closed" prs={closed} onOpen={onOpenSession} />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ tone, label, value }: { tone: string; label: string; value: number }) {
+  return (
+    <div className={`fac-stat fac-stat-${tone}`}>
+      <span className="fac-stat-val">{value}</span>
+      <span className="fac-stat-label">{label}</span>
+    </div>
+  );
+}
+
+function Belt({ toIsland }: { toIsland?: boolean }) {
+  return (
+    <div className={`fac-belt${toIsland ? " fac-belt-island" : ""}`} aria-hidden>
+      <div className="fac-belt-lane" />
+      <span className="fac-belt-item" style={{ animationDelay: "0s" }} />
+      <span className="fac-belt-item" style={{ animationDelay: "-1.1s" }} />
+      <span className="fac-belt-item" style={{ animationDelay: "-2.2s" }} />
+    </div>
+  );
+}
+
+function Station({
+  kind,
+  title,
+  empty,
+  sessions,
+  onOpen,
+}: {
+  kind: "run" | "wait" | "idle";
+  title: string;
+  empty: string;
+  sessions: UnifiedSession[];
+  onOpen: (id: string) => void;
+}) {
+  const shown = sessions.slice(0, STATION_CAP);
+  const overflow = sessions.length - shown.length;
+  return (
+    <div className={`fac-station fac-station-${kind}`}>
+      <div className="fac-machine-head">
+        <span className={`fac-lamp fac-lamp-${kind}`} />
+        <span className="fac-machine-title">{title}</span>
+        {kind === "run" && <span className="fac-gear">⚙</span>}
+        <span className="fac-machine-count">{sessions.length}</span>
+      </div>
+      <div className="fac-machine-body">
+        {shown.length === 0 ? (
+          <div className="fac-empty">{empty}</div>
+        ) : (
+          shown.map((s) => <Crate key={s.id} session={s} onOpen={onOpen} />)
+        )}
+        {overflow > 0 && <div className="fac-more">+{overflow} more on the belt</div>}
+      </div>
+    </div>
+  );
+}
+
+function Crate({ session, onOpen }: { session: UnifiedSession; onOpen: (id: string) => void }) {
+  const k = srcKey(session);
+  const meta = SOURCE_META[k];
+  const sub =
+    session.automation || session.startedBy || meta.label;
+  return (
+    <button
+      className="fac-crate"
+      style={cssVar(meta.color)}
+      onClick={() => onOpen(session.id)}
+      title={session.title}
+    >
+      <span className="fac-crate-glyph">{meta.glyph}</span>
+      <span className="fac-crate-main">
+        <span className="fac-crate-title">{session.title}</span>
+        <span className="fac-crate-meta">
+          {sub} · {relativeTime(session.lastActivity)}
+          {session.branch ? ` · ${session.branch}` : ""}
+        </span>
+      </span>
+      {session.waitingForInput ? (
+        <span className="fac-crate-flag fac-crate-flag-wait">!</span>
+      ) : session.isRunning ? (
+        <span className="fac-crate-flag fac-crate-flag-run" />
+      ) : (session.queuedCount || 0) > 0 ? (
+        <span className="fac-crate-flag fac-crate-flag-queue">{session.queuedCount}</span>
+      ) : null}
+    </button>
+  );
+}
+
+function PrShelf({
+  tone,
+  label,
+  prs,
+  onOpen,
+}: {
+  tone: "open" | "merged" | "closed";
+  label: string;
+  prs: UnifiedSession[];
+  onOpen: (id: string) => void;
+}) {
+  const shown = prs.slice(0, STATION_CAP);
+  const overflow = prs.length - shown.length;
+  return (
+    <div className={`fac-shelf fac-shelf-${tone}`}>
+      <div className="fac-shelf-head">
+        <span className={`fac-lamp fac-lamp-${tone}`} />
+        <span className="fac-shelf-label">{label}</span>
+        <span className="fac-shelf-count">{prs.length}</span>
+      </div>
+      <div className="fac-shelf-body">
+        {shown.length === 0 ? (
+          <div className="fac-empty">—</div>
+        ) : (
+          shown.map((s) => (
+            <button
+              key={s.id}
+              className="fac-pr"
+              onClick={() => onOpen(s.id)}
+              title={s.title}
+            >
+              <span className="fac-pr-hex">⬡</span>
+              <span className="fac-pr-title">{s.title}</span>
+              {s.linearIssue && <span className="fac-pr-tag">{s.linearIssue.identifier}</span>}
+            </button>
+          ))
+        )}
+        {overflow > 0 && <div className="fac-more">+{overflow} more</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -18,7 +18,7 @@ const AUTOMATION_COLOR = "#d29922";
 
 const SOURCE_ORDER: SessionSource[] = ["slack", "linear", "backstage", "cli"];
 
-export type NavView = "sessions" | "reviews" | "automations" | "wiki" | "connections";
+export type NavView = "sessions" | "reviews" | "automations" | "wiki" | "connections" | "factory";
 
 interface Props {
   sessions: UnifiedSession[];
@@ -82,6 +82,15 @@ const NAV_ITEMS: Array<{ view: NavView; label: string; icon: React.ReactNode }> 
         <circle cx="11.5" cy="4" r="2" />
         <circle cx="11.5" cy="12" r="2" />
         <path d="M6.3 7.1l3.4-2.2M6.3 8.9l3.4 2.2" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    view: "factory",
+    label: "Factory",
+    icon: (
+      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+        <path d="M2 13.5h12M2.5 13.5V7l3.5 2.2V7l3.5 2.2V4.2l3.5-1v10.3" strokeLinejoin="round" strokeLinecap="round" />
       </svg>
     ),
   },

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -26,6 +26,10 @@ export interface UnifiedSession {
   modelHistory?: Array<{ model: string; at: string; by?: string }>;
   linearIssue?: { identifier: string; title: string; url?: string };
   slackThread?: { channel: string; threadTs: string };
+  /** Blocked on an AskUserQuestion — a human needs to answer. Set by /api/sessions. */
+  waitingForInput?: boolean;
+  /** Number of prompts queued behind the current run. Set by /api/sessions. */
+  queuedCount?: number;
 }
 
 export interface TranscriptEntry {

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -3779,3 +3779,475 @@ a {
   white-space: nowrap;
   flex-shrink: 0;
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Factory — a Factorio-style overview of sessions on the line.
+   Sources mine work (left) → assemblers run / wait (middle) →
+   PRs ship to the GitHub island (right). Belts animate the flow.
+   ───────────────────────────────────────────────────────────── */
+
+.factory {
+  height: 100%;
+  overflow: auto;
+  background:
+    radial-gradient(120% 80% at 50% -10%, #1c1410 0%, var(--bg) 60%);
+  -webkit-overflow-scrolling: touch;
+}
+
+.fac-boot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+}
+
+.fac-scene {
+  position: relative;
+  min-height: 100%;
+  padding: 18px 20px 60px;
+  /* Engineering grid + faint factory haze */
+  background-image:
+    linear-gradient(rgba(210, 153, 34, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(210, 153, 34, 0.045) 1px, transparent 1px);
+  background-size: 32px 32px, 32px 32px;
+}
+
+/* ── HUD ── */
+.fac-hud {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 14px;
+  margin-bottom: 18px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #1a1411, #120d0b);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+.fac-hud-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.03em;
+  color: var(--text);
+}
+.fac-hud-gear {
+  color: var(--yellow);
+  font-size: 18px;
+  animation: fac-spin 9s linear infinite;
+}
+.fac-hud-sub {
+  color: var(--text-faint);
+  font-weight: 400;
+  font-size: 12px;
+  border-left: 1px solid var(--border-strong);
+  padding-left: 10px;
+}
+.fac-stats {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.fac-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 78px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: #100b0a;
+}
+.fac-stat-val {
+  font-family: var(--mono);
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1;
+}
+.fac-stat-label {
+  margin-top: 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-faint);
+}
+.fac-stat-run .fac-stat-val { color: var(--green); }
+.fac-stat-wait .fac-stat-val { color: var(--yellow); }
+.fac-stat-queue .fac-stat-val { color: var(--purple); }
+.fac-stat-pr .fac-stat-val { color: #58a6ff; }
+
+/* ── Floor layout ── */
+.fac-floor {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+}
+.fac-col { display: flex; flex-direction: column; }
+.fac-col-intake { width: 180px; flex: 0 0 180px; }
+.fac-col-assembly { flex: 1 1 auto; min-width: 0; gap: 14px; }
+.fac-col-island { width: 230px; flex: 0 0 230px; }
+.fac-col-label {
+  margin: 0 0 10px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+/* ── Belts (animated connectors) ── */
+.fac-belt {
+  position: relative;
+  flex: 0 0 54px;
+  width: 54px;
+  align-self: stretch;
+  min-height: 120px;
+}
+.fac-belt-lane {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 30px;
+  margin-top: -15px;
+  border-top: 2px solid #3a2f14;
+  border-bottom: 2px solid #14100a;
+  background: repeating-linear-gradient(
+    115deg,
+    #d8b24a 0 8px,
+    #ab8a2c 8px 16px
+  );
+  background-size: 22px 100%;
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.5);
+  animation: fac-belt-run 0.55s linear infinite;
+}
+@keyframes fac-belt-run { to { background-position: 22px 0; } }
+.fac-belt-item {
+  position: absolute;
+  top: 50%;
+  margin-top: -7px;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #4a3d1c, #2a2210);
+  box-shadow: inset 0 0 0 2px #7a6228, 0 1px 2px rgba(0, 0, 0, 0.6);
+  animation: fac-belt-travel 3.3s linear infinite;
+}
+@keyframes fac-belt-travel {
+  0% { left: -16px; opacity: 0; }
+  12% { opacity: 1; }
+  88% { opacity: 1; }
+  100% { left: 100%; opacity: 0; }
+}
+.fac-belt-island .fac-belt-lane {
+  /* the bridge to the island runs over water */
+  filter: saturate(0.85);
+}
+
+/* ── Mining drills (sources) ── */
+.fac-drills { display: flex; flex-direction: column; gap: 10px; }
+.fac-drill {
+  position: relative;
+  display: grid;
+  grid-template-columns: 26px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 11px;
+  border-radius: 7px;
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--src);
+  background: linear-gradient(180deg, #1b1512, #120d0b);
+  overflow: hidden;
+}
+.fac-drill.is-cold { opacity: 0.5; }
+.fac-drill.is-active {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--src) 40%, transparent),
+    0 0 14px color-mix(in srgb, var(--src) 22%, transparent);
+}
+.fac-drill-glyph {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--src);
+  text-align: center;
+}
+.fac-drill-name { font-size: 12.5px; color: var(--text); font-weight: 500; }
+.fac-drill-count {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-dim);
+  min-width: 18px;
+  text-align: right;
+}
+.fac-drill-bit {
+  position: absolute;
+  left: 0; bottom: 0;
+  height: 3px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, var(--src), transparent);
+  opacity: 0;
+}
+.fac-drill.is-active .fac-drill-bit {
+  opacity: 0.9;
+  animation: fac-extract 1.4s ease-in-out infinite;
+}
+@keyframes fac-extract {
+  0%, 100% { transform: translateX(-100%); }
+  50% { transform: translateX(100%); }
+}
+
+/* ── Assembler stations (machines) ── */
+.fac-station {
+  border-radius: 9px;
+  border: 1px solid var(--border-strong);
+  background:
+    radial-gradient(6px 6px at 10px 10px, rgba(255,255,255,0.05), transparent),
+    radial-gradient(6px 6px at calc(100% - 10px) 10px, rgba(255,255,255,0.05), transparent),
+    linear-gradient(180deg, #1d1714, #140f0d);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+.fac-machine-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(255,255,255,0.03), transparent);
+}
+.fac-machine-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+.fac-machine-count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-faint);
+  background: #0d0908;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+.fac-gear { color: var(--green); font-size: 13px; animation: fac-spin 3.5s linear infinite; }
+@keyframes fac-spin { to { transform: rotate(360deg); } }
+
+.fac-machine-body {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 11px;
+  min-height: 56px;
+}
+
+/* status lamps */
+.fac-lamp {
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  box-shadow: 0 0 6px currentColor;
+}
+.fac-lamp-run { color: var(--green); background: var(--green); animation: fac-pulse 1.6s ease-in-out infinite; }
+.fac-lamp-wait { color: var(--yellow); background: var(--yellow); animation: fac-blink 1s steps(1) infinite; }
+.fac-lamp-idle { color: var(--text-faint); background: var(--text-faint); }
+.fac-lamp-open { color: var(--yellow); background: var(--yellow); }
+.fac-lamp-merged { color: var(--purple); background: var(--purple); }
+.fac-lamp-closed { color: var(--red); background: var(--red); }
+@keyframes fac-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+@keyframes fac-blink { 0%,49% { opacity: 1; } 50%,100% { opacity: 0.25; } }
+
+.fac-station-run { border-color: color-mix(in srgb, var(--green) 30%, var(--border-strong)); }
+.fac-station-wait { border-color: color-mix(in srgb, var(--yellow) 32%, var(--border-strong)); }
+
+/* ── Session crates ── */
+.fac-crate {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--src);
+  background: linear-gradient(180deg, #181210, #110c0a);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  transition: transform 0.08s ease, border-color 0.12s ease, background 0.12s ease;
+}
+.fac-crate:hover {
+  transform: translateX(2px);
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+.fac-crate-glyph {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--src);
+  width: 20px;
+  text-align: center;
+  flex: 0 0 auto;
+}
+.fac-crate-main { min-width: 0; flex: 1 1 auto; display: flex; flex-direction: column; gap: 2px; }
+.fac-crate-title {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fac-crate-meta {
+  font-size: 11px;
+  color: var(--text-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fac-crate-flag { flex: 0 0 auto; font-family: var(--mono); font-size: 11px; font-weight: 700; }
+.fac-crate-flag-run {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+  animation: fac-pulse 1.6s ease-in-out infinite;
+}
+.fac-crate-flag-wait {
+  width: 16px; height: 16px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  color: #1a1206; background: var(--yellow);
+  animation: fac-blink 1s steps(1) infinite;
+}
+.fac-crate-flag-queue {
+  min-width: 16px; height: 16px; border-radius: 8px; padding: 0 4px;
+  display: flex; align-items: center; justify-content: center;
+  color: #fff; background: color-mix(in srgb, var(--purple) 70%, #000);
+}
+
+.fac-empty {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-style: italic;
+  padding: 4px 2px;
+}
+.fac-more {
+  font-size: 11px;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  padding: 2px;
+}
+
+/* ── GitHub island ── */
+.fac-island {
+  position: relative;
+  border-radius: 14px;
+  padding: 12px 12px 14px;
+  border: 1px solid #1e3a3a;
+  background:
+    radial-gradient(120% 60% at 50% 0%, #14201f, #0c1413);
+  box-shadow: 0 0 0 4px rgba(46, 160, 160, 0.05), 0 10px 30px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+.fac-island-water {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(90deg, rgba(88, 166, 255, 0.05) 0 6px, transparent 6px 12px);
+  opacity: 0.5;
+  animation: fac-water 6s linear infinite;
+}
+@keyframes fac-water { to { background-position: 24px 0; } }
+.fac-island-label {
+  position: relative;
+  margin: 2px 0 11px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #7fd9d2;
+}
+.fac-hex { font-size: 14px; }
+
+.fac-shelf { position: relative; margin-bottom: 10px; }
+.fac-shelf:last-child { margin-bottom: 0; }
+.fac-shelf-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+.fac-shelf-count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--text-faint);
+}
+.fac-shelf-body { display: flex; flex-direction: column; gap: 6px; }
+.fac-pr {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 9px;
+  border-radius: 6px;
+  border: 1px solid #1d2f2f;
+  background: linear-gradient(180deg, #0f1817, #0c1312);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  transition: transform 0.08s ease, border-color 0.12s ease;
+}
+.fac-pr:hover { transform: translateY(-1px); border-color: #2c4a48; }
+.fac-pr-hex { color: #58a6ff; font-size: 12px; flex: 0 0 auto; }
+.fac-shelf-merged .fac-pr-hex { color: var(--purple); }
+.fac-shelf-closed .fac-pr-hex { color: var(--red); }
+.fac-pr-title {
+  font-size: 12.5px;
+  min-width: 0;
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fac-pr-tag {
+  flex: 0 0 auto;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: #7b86e8;
+  border: 1px solid #2a2f55;
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+
+/* ── Responsive: stack the line vertically on narrow screens ── */
+@media (max-width: 760px) {
+  .fac-floor { flex-direction: column; }
+  .fac-col-intake, .fac-col-island { width: 100%; flex: 1 1 auto; }
+  .fac-drills { flex-direction: row; flex-wrap: wrap; }
+  .fac-drill { flex: 1 1 130px; }
+  .fac-belt { width: 100%; flex-basis: 40px; min-height: 40px; }
+  .fac-belt-lane { top: 50%; }
+  .fac-col-label { margin-top: 4px; }
+}


### PR DESCRIPTION
A fun overview view, themed after Factorio: see automations/sources come in and sessions come out.

## What it does
New **Factory** tab in the sidebar (under Connections). Everything is derived from the polled sessions list — no new polling.

- **Intake (left)** — a mining drill per source (Slack, Linear, Backstage, CLI, Automation) with live counts; active drills glow + animate, cold ones dim.
- **Belts** — animated conveyors (chevrons + traveling crates) connect each stage.
- **Assemblers (middle)** — three machine panels with status lamps: **Assembling** (running, spinning gear), **Awaiting input** (blocked on an AskUserQuestion, blinking alarm), **Buffer** (queued + recently-active idle).
- **GitHub Island (right)** — a landmass with water/bridge, shelving distinct PRs by Open / Merged / Closed (deduped by URL, with Linear tags).
- **HUD** — Factorio-style production stats.

Session crates and PRs are clickable → open the session.

## Server change
`/api/sessions` now enriches each session with `waitingForInput` (from `pendingAsks`) and `queuedCount` (from `promptQueues`) so the "Awaiting input"/queue signals are in-process truth, not guesses. This is a **route-handler** change, so it hot-applies (no runner-path internals touched).

## Files
- `src/frontend/components/Factory.tsx` *(new)*
- `backstage.ts` — enrich `/api/sessions`
- `src/frontend/lib/types.ts` — `waitingForInput` / `queuedCount` fields
- `src/frontend/App.tsx` — `factory` route + nav wiring
- `src/frontend/components/Sidebar.tsx` — nav item + icon
- `src/frontend/styles/global.css` — `.fac-*` industrial theme, responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)