### PR TITLE
Reviews: GitHub/Conductor-style PR table with rich columns

### DIFF
--- a/src/frontend/components/PrPanel.tsx
+++ b/src/frontend/components/PrPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import type { PrDetails } from "../lib/types";
 import { fetchPr, fetchPrDiff, postPrCommentApi, mergePrApi } from "../lib/api";
 import { CommentableDiff, type CommentTarget } from "./CommentableDiff";
@@ -8,6 +8,8 @@ interface Props {
   sessionId: string;
   /** When provided, renders an "Open session →" action (used by the Reviews view). */
   onOpenSession?: () => void;
+  /** Side-by-side info|diff layout for wide containers (the Reviews drawer). */
+  split?: boolean;
 }
 
 interface PrDiffData {
@@ -16,7 +18,7 @@ interface PrDiffData {
   patch: string;
 }
 
-export function PrPanel({ sessionId, onOpenSession }: Props) {
+export function PrPanel({ sessionId, onOpenSession, split }: Props) {
   const [pr, setPr] = useState<PrDetails | null>(null);
   const [diff, setDiff] = useState<PrDiffData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -24,6 +26,7 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
   const [merging, setMerging] = useState(false);
   const [confirmMerge, setConfirmMerge] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
+  const [checksOpen, setChecksOpen] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -79,6 +82,27 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
     }
   }
 
+  // Roll the per-check list up into headline counts, and surface failing checks
+  // first so a reviewer sees what's broken without expanding the whole list.
+  const checkSummary = useMemo(() => {
+    const checks = pr?.checks || [];
+    let passed = 0,
+      failed = 0,
+      pending = 0;
+    for (const c of checks) {
+      const cls = checkClass(c.status, c.conclusion);
+      if (cls === "check-success") passed++;
+      else if (cls === "check-failure") failed++;
+      else if (cls === "check-pending") pending++;
+    }
+    const sorted = [...checks].sort((a, b) => {
+      const rank = (c: PrCheckRank) =>
+        c === "check-failure" ? 0 : c === "check-pending" ? 1 : c === "check-success" ? 3 : 2;
+      return rank(checkClass(a.status, a.conclusion)) - rank(checkClass(b.status, b.conclusion));
+    });
+    return { passed, failed, pending, total: checks.length, sorted };
+  }, [pr]);
+
   if (loading) return <div className="panel-placeholder">Loading PR…</div>;
   if (!pr) return <div className="panel-placeholder">No pull request for this branch yet</div>;
 
@@ -87,7 +111,8 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
   const stateLabel = pr.state === "OPEN" && pr.isDraft ? "Draft" : pr.state.charAt(0) + pr.state.slice(1).toLowerCase();
 
   return (
-    <div className="pr-panel">
+    <div className={`pr-panel ${split ? "pr-panel-split" : ""}`}>
+      <div className="pr-panel-info">
       <div className="pr-head">
         <span className={`pr-pill ${stateClass}`}>{stateLabel}</span>
         <a className="pr-number" href={pr.url} target="_blank" rel="noopener">
@@ -118,22 +143,55 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
 
       {pr.checks.length > 0 && (
         <div className="pr-checks">
-          <div className="pr-checks-title">Checks</div>
-          {pr.checks.map((check, i) => (
-            <a
-              key={i}
-              className="pr-check"
-              href={check.url}
-              target="_blank"
-              rel="noopener"
+          <button
+            className="pr-checks-summary"
+            onClick={() => setChecksOpen((o) => !o)}
+            aria-expanded={checksOpen}
+          >
+            <span
+              className={`pr-checks-status ${
+                checkSummary.failed > 0
+                  ? "pr-sum-fail"
+                  : checkSummary.pending > 0
+                    ? "pr-sum-pending"
+                    : "pr-sum-pass"
+              }`}
             >
-              <span className={`pr-check-dot ${checkClass(check.status, check.conclusion)}`} />
-              <span className="pr-check-name">{check.name}</span>
-              <span className="pr-check-state">
-                {(check.conclusion || check.status).toLowerCase()}
-              </span>
-            </a>
-          ))}
+              {checkSummary.failed > 0
+                ? "Some checks failed"
+                : checkSummary.pending > 0
+                  ? "Checks running"
+                  : "All checks passed"}
+            </span>
+            <span className="pr-checks-counts">
+              {checkSummary.passed > 0 && (
+                <span className="pr-count check-success-text">✓ {checkSummary.passed}</span>
+              )}
+              {checkSummary.failed > 0 && (
+                <span className="pr-count check-failure-text">✕ {checkSummary.failed}</span>
+              )}
+              {checkSummary.pending > 0 && (
+                <span className="pr-count check-pending-text">● {checkSummary.pending}</span>
+              )}
+            </span>
+            <span className="pr-checks-chevron">{checksOpen ? "▾" : "▸"}</span>
+          </button>
+          {checksOpen &&
+            checkSummary.sorted.map((check, i) => (
+              <a
+                key={i}
+                className="pr-check"
+                href={check.url}
+                target="_blank"
+                rel="noopener"
+              >
+                <span className={`pr-check-dot ${checkClass(check.status, check.conclusion)}`} />
+                <span className="pr-check-name">{check.name}</span>
+                <span className="pr-check-state">
+                  {(check.conclusion || check.status).toLowerCase()}
+                </span>
+              </a>
+            ))}
         </div>
       )}
 
@@ -165,8 +223,10 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
         )}
       </div>
       {mergeError && <div className="pr-merge-error">{mergeError}</div>}
+      </div>
 
       {diff?.patch && (
+        <div className="pr-panel-diff">
         <div className="pr-diff-section">
           <div className="pr-checks-title">
             Review — comments land on the PR
@@ -183,12 +243,15 @@ export function PrPanel({ sessionId, onOpenSession }: Props) {
             onSubmit={handlePrComment}
           />
         </div>
+        </div>
       )}
     </div>
   );
 }
 
-function checkClass(status: string, conclusion: string): string {
+type PrCheckRank = "check-success" | "check-failure" | "check-pending" | "check-neutral";
+
+function checkClass(status: string, conclusion: string): PrCheckRank {
   if (status !== "COMPLETED" && status !== "") return "check-pending";
   switch (conclusion) {
     case "SUCCESS":

--- a/src/frontend/components/Reviews.tsx
+++ b/src/frontend/components/Reviews.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import type { UnifiedSession } from "../lib/types";
 import { relativeTime } from "../lib/api";
 import { PrPanel } from "./PrPanel";
@@ -10,20 +10,142 @@ interface Props {
   onOpenSession: (id: string) => void;
 }
 
-function prNumber(url?: string): string | null {
-  const m = url?.match(/\/pull\/(\d+)/);
-  return m ? `#${m[1]}` : null;
-}
+type FilterKey = "review" | "open" | "merged" | "closed" | "all";
 
 const STATE_RANK: Record<string, number> = { OPEN: 0, CLOSED: 1, MERGED: 2 };
 
-/**
- * Full-page PR review view: a rail of every PR attached to a Michael session on
- * the left, a GitHub-style review (diff + checks + actions) on the right. Reuses
- * PrPanel for the detail pane so it stays in sync with the session PR tab. Open
- * PRs sort first; one entry per PR (deduped by URL across sessions on a branch).
- */
+function prNum(s: UnifiedSession): string | null {
+  if (s.prNumber) return `#${s.prNumber}`;
+  const m = s.prUrl?.match(/\/pull\/(\d+)/);
+  return m ? `#${m[1]}` : null;
+}
+
+// Sessions name themselves "Review · PR #1234 <real title>". Prefer the real PR
+// title when we have it; otherwise strip that bookkeeping prefix so the row
+// shows the actual change, not the automation that opened it.
+function cleanTitle(s: UnifiedSession): string {
+  const t = s.prTitle?.trim();
+  if (t) return t;
+  return (
+    (s.title || "")
+      .replace(/^(Review|Auto-fix|Mention|Simplify|Fix)\s*·\s*PR\s*#\d+\s*/i, "")
+      .trim() || s.title
+  );
+}
+
+function stateMeta(s: UnifiedSession): { key: string; label: string } {
+  const state = s.prState || "OPEN";
+  if (state === "MERGED") return { key: "merged", label: "Merged" };
+  if (state === "CLOSED") return { key: "closed", label: "Closed" };
+  if (s.prIsDraft) return { key: "draft", label: "Draft" };
+  return { key: "open", label: "Open" };
+}
+
+function needsReview(s: UnifiedSession): boolean {
+  return (
+    (s.prState || "OPEN") === "OPEN" &&
+    !s.prIsDraft &&
+    (s.prReviewDecision || "") !== "APPROVED"
+  );
+}
+
+/** A GitHub-style icon for a PR's open/merged/closed/draft state. */
+function StateIcon({ kind }: { kind: string }) {
+  const common = { width: 15, height: 15, viewBox: "0 0 16 16", fill: "currentColor" as const };
+  if (kind === "merged")
+    return (
+      <svg {...common} aria-hidden>
+        <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm0 2.122a2.25 2.25 0 1 0-1.5 0v5.256a2.251 2.251 0 1 0 1.5 0V7.5a3.5 3.5 0 0 0 3.5 3.5h1.128a2.251 2.251 0 1 0 0-1.5H8.5A2 2 0 0 1 6.5 7.5v-2.128ZM4.25 12a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5ZM12 9.25a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5Z" />
+      </svg>
+    );
+  if (kind === "closed")
+    return (
+      <svg {...common} aria-hidden>
+        <path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.251 2.251 0 0 1 3.25 1Zm9.5 5.81-1.97 1.97a.75.75 0 1 1-1.06-1.06l1.97-1.97-1.97-1.97a.75.75 0 0 1 1.06-1.06l1.97 1.97 1.97-1.97a.75.75 0 1 1 1.06 1.06l-1.97 1.97 1.97 1.97a.75.75 0 1 1-1.06 1.06l-1.97-1.97ZM2.5 13.25a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0ZM3.25 4a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" />
+      </svg>
+    );
+  // open + draft share the branch glyph
+  return (
+    <svg {...common} aria-hidden>
+      <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
+    </svg>
+  );
+}
+
+/** Compact CI rollup: a tone dot, count, and a thin proportional bar. */
+function ChecksCell({ s }: { s: UnifiedSession }) {
+  const c = s.prChecks;
+  if (!c || c.total === 0)
+    return <span className="rv-checks rv-checks-empty">—</span>;
+  const tone = c.failed > 0 ? "fail" : c.pending > 0 ? "pending" : "pass";
+  const label =
+    tone === "fail"
+      ? `${c.failed} failing`
+      : tone === "pending"
+        ? `${c.pending} running`
+        : `${c.passed} passed`;
+  const pct = (n: number) => `${(n / c.total) * 100}%`;
+  return (
+    <span className={`rv-checks rv-checks-${tone}`} title={`${c.passed} passed · ${c.failed} failed · ${c.pending} pending · ${c.total} total`}>
+      <span className={`rv-check-dot rv-check-dot-${tone}`} />
+      <span className="rv-checks-label">{label}</span>
+      <span className="rv-checks-bar" aria-hidden>
+        <span className="rv-bar-seg rv-bar-pass" style={{ width: pct(c.passed) }} />
+        <span className="rv-bar-seg rv-bar-fail" style={{ width: pct(c.failed) }} />
+        <span className="rv-bar-seg rv-bar-pending" style={{ width: pct(c.pending) }} />
+      </span>
+    </span>
+  );
+}
+
+function ReviewCell({ s }: { s: UnifiedSession }) {
+  const d = s.prReviewDecision || "";
+  if ((s.prState || "OPEN") !== "OPEN") return <span className="rv-dim">—</span>;
+  if (d === "APPROVED")
+    return <span className="rv-review rv-review-approved">Approved</span>;
+  if (d === "CHANGES_REQUESTED")
+    return <span className="rv-review rv-review-changes">Changes</span>;
+  if (s.prIsDraft) return <span className="rv-review rv-review-pending">Draft</span>;
+  return <span className="rv-review rv-review-pending">Review required</span>;
+}
+
+function ChangesCell({ s }: { s: UnifiedSession }) {
+  const add = s.prAdditions ?? 0;
+  const del = s.prDeletions ?? 0;
+  const files = s.prChangedFiles ?? 0;
+  if (!s.prChangedFiles && !add && !del) return <span className="rv-dim">—</span>;
+  const total = add + del || 1;
+  const blocks = 5;
+  const greens = Math.max(add > 0 ? 1 : 0, Math.round((add / total) * blocks));
+  const reds = Math.max(del > 0 ? 1 : 0, Math.round((del / total) * blocks));
+  const grays = Math.max(0, blocks - greens - reds);
+  return (
+    <span className="rv-changes" title={`${files} file${files === 1 ? "" : "s"} changed`}>
+      <span className="rv-diffstat">
+        <span className="rv-add">+{add}</span>
+        <span className="rv-del">−{del}</span>
+      </span>
+      <span className="rv-diffsquares" aria-hidden>
+        {Array.from({ length: greens }).map((_, i) => (
+          <span key={`g${i}`} className="rv-sq rv-sq-add" />
+        ))}
+        {Array.from({ length: reds }).map((_, i) => (
+          <span key={`r${i}`} className="rv-sq rv-sq-del" />
+        ))}
+        {Array.from({ length: grays }).map((_, i) => (
+          <span key={`n${i}`} className="rv-sq rv-sq-none" />
+        ))}
+      </span>
+    </span>
+  );
+}
+
 export function Reviews({ sessions, selectedId, onSelect, onOpenSession }: Props) {
+  const [filter, setFilter] = useState<FilterKey>("review");
+  const [query, setQuery] = useState("");
+
+  // One row per PR (deduped by URL across the sessions on a branch), newest
+  // session wins for metadata.
   const prSessions = useMemo(() => {
     const byPr = new Map<string, UnifiedSession>();
     for (const s of sessions) {
@@ -40,70 +162,204 @@ export function Reviews({ sessions, selectedId, onSelect, onOpenSession }: Props
     });
   }, [sessions]);
 
-  const selected =
-    prSessions.find((s) => s.id === selectedId) || prSessions[0] || null;
+  const counts = useMemo(() => {
+    const c = { review: 0, open: 0, merged: 0, closed: 0, all: prSessions.length };
+    for (const s of prSessions) {
+      const state = s.prState || "OPEN";
+      if (state === "OPEN") c.open++;
+      else if (state === "MERGED") c.merged++;
+      else if (state === "CLOSED") c.closed++;
+      if (needsReview(s)) c.review++;
+    }
+    return c;
+  }, [prSessions]);
 
-  if (prSessions.length === 0) {
-    return (
-      <div className="reviews reviews-empty">
-        <div className="detail-empty-inner">
-          <div className="detail-empty-title">No pull requests yet</div>
-          <div className="detail-empty-sub">
-            PRs opened by Michael sessions show up here for review.
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return prSessions.filter((s) => {
+      const state = s.prState || "OPEN";
+      const passesFilter =
+        filter === "all"
+          ? true
+          : filter === "review"
+            ? needsReview(s)
+            : filter === "open"
+              ? state === "OPEN"
+              : filter === "merged"
+                ? state === "MERGED"
+                : state === "CLOSED";
+      if (!passesFilter) return false;
+      if (!q) return true;
+      return (
+        cleanTitle(s).toLowerCase().includes(q) ||
+        (s.branch || "").toLowerCase().includes(q) ||
+        (prNum(s) || "").toLowerCase().includes(q) ||
+        (s.prAuthor || "").toLowerCase().includes(q)
+      );
+    });
+  }, [prSessions, filter, query]);
+
+  const selected =
+    (selectedId && filtered.find((s) => s.id === selectedId)) ||
+    (selectedId && prSessions.find((s) => s.id === selectedId)) ||
+    null;
+
+  const TABS: Array<{ key: FilterKey; label: string; count: number }> = [
+    { key: "review", label: "Needs review", count: counts.review },
+    { key: "open", label: "Open", count: counts.open },
+    { key: "merged", label: "Merged", count: counts.merged },
+    { key: "closed", label: "Closed", count: counts.closed },
+    { key: "all", label: "All", count: counts.all },
+  ];
 
   return (
-    <div className="reviews">
-      <div className="reviews-rail">
-        <div className="reviews-rail-title">
-          Pull requests <span className="reviews-rail-count">{prSessions.length}</span>
+    <div className={`reviews ${selected ? "reviews-has-detail" : ""}`}>
+      <div className="reviews-main">
+        <div className="reviews-header">
+          <div className="reviews-header-top">
+            <h1 className="reviews-title">Pull requests</h1>
+            <div className="reviews-search">
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z" />
+              </svg>
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search pull requests…"
+                spellCheck={false}
+              />
+            </div>
+          </div>
+          <div className="reviews-tabs">
+            {TABS.map((t) => (
+              <button
+                key={t.key}
+                className={`reviews-tab ${filter === t.key ? "active" : ""}`}
+                onClick={() => setFilter(t.key)}
+              >
+                {t.label}
+                <span className="reviews-tab-count">{t.count}</span>
+              </button>
+            ))}
+          </div>
         </div>
-        {prSessions.map((s) => {
-          const state = s.prState || "OPEN";
-          const stateClass =
-            state === "MERGED"
-              ? "pr-pill-merged"
-              : state === "CLOSED"
-                ? "pr-pill-closed"
-                : "pr-pill-open";
-          return (
-            <button
-              key={s.prUrl}
-              className={`reviews-rail-item ${selected?.id === s.id ? "active" : ""}`}
-              onClick={() => onSelect(s.id)}
-            >
-              <div className="reviews-rail-item-head">
-                <span className={`pr-pill ${stateClass}`}>{state.toLowerCase()}</span>
-                {prNumber(s.prUrl) && (
-                  <span className="reviews-rail-num">{prNumber(s.prUrl)}</span>
-                )}
-              </div>
-              <div className="reviews-rail-item-title">{s.title}</div>
-              <div className="reviews-rail-item-meta">
-                {s.branch && <span className="reviews-rail-branch">{s.branch}</span>}
-                <span>{relativeTime(s.lastActivity)}</span>
-                {s.linearIssue && <span>{s.linearIssue.identifier}</span>}
-              </div>
-            </button>
-          );
-        })}
-      </div>
 
-      <div className="reviews-detail">
-        {selected ? (
-          <PrPanel
-            key={selected.id}
-            sessionId={selected.id}
-            onOpenSession={() => onOpenSession(selected.id)}
-          />
+        {filtered.length === 0 ? (
+          <div className="reviews-empty">
+            <div className="detail-empty-inner">
+              <div className="detail-empty-title">
+                {prSessions.length === 0 ? "No pull requests yet" : "Nothing here"}
+              </div>
+              <div className="detail-empty-sub">
+                {prSessions.length === 0
+                  ? "PRs opened by Michael sessions show up here for review."
+                  : "No PRs match this filter."}
+              </div>
+            </div>
+          </div>
         ) : (
-          <div className="panel-placeholder">Select a pull request to review</div>
+          <div className="reviews-table" role="table">
+            <div className="reviews-row reviews-row-head" role="row">
+              <span className="rv-c-state">Status</span>
+              <span className="rv-c-title">Pull request</span>
+              <span className="rv-c-checks">Checks</span>
+              <span className="rv-c-review">Review</span>
+              <span className="rv-c-changes">Changes</span>
+              <span className="rv-c-author">Author</span>
+              <span className="rv-c-updated">Updated</span>
+            </div>
+            {filtered.map((s) => {
+              const meta = stateMeta(s);
+              const active = selected?.id === s.id;
+              return (
+                <button
+                  key={s.prUrl}
+                  className={`reviews-row ${active ? "active" : ""}`}
+                  onClick={() => onSelect(s.id)}
+                  role="row"
+                >
+                  <span className={`rv-c-state rv-state-${meta.key}`} role="cell">
+                    <StateIcon kind={meta.key} />
+                    <span className="rv-state-label">{meta.label}</span>
+                  </span>
+                  <span className="rv-c-title" role="cell">
+                    <span className="rv-title-line">
+                      <span className="rv-title-text">{cleanTitle(s)}</span>
+                      {prNum(s) && <span className="rv-num">{prNum(s)}</span>}
+                    </span>
+                    <span className="rv-sub-line">
+                      {s.branch && (
+                        <span className="rv-branch">
+                          <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                            <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+                          </svg>
+                          {s.branch}
+                        </span>
+                      )}
+                      {s.linearIssue && (
+                        <span className="rv-linear">{s.linearIssue.identifier}</span>
+                      )}
+                      {s.isRunning && <span className="rv-running">● running</span>}
+                    </span>
+                  </span>
+                  <span className="rv-c-checks" role="cell">
+                    <ChecksCell s={s} />
+                  </span>
+                  <span className="rv-c-review" role="cell">
+                    <ReviewCell s={s} />
+                  </span>
+                  <span className="rv-c-changes" role="cell">
+                    <ChangesCell s={s} />
+                  </span>
+                  <span className="rv-c-author" role="cell">
+                    {s.prAuthor ? (
+                      <>
+                        <img
+                          className="rv-avatar"
+                          src={`https://github.com/${s.prAuthor}.png?size=40`}
+                          alt=""
+                          loading="lazy"
+                        />
+                        <span className="rv-author-name">{s.prAuthor}</span>
+                      </>
+                    ) : (
+                      <span className="rv-dim">—</span>
+                    )}
+                  </span>
+                  <span className="rv-c-updated" role="cell">
+                    {relativeTime(s.prUpdatedAt || s.lastActivity)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         )}
       </div>
+
+      {selected && (
+        <aside className="reviews-drawer">
+          <div className="reviews-drawer-head">
+            <button
+              className="reviews-drawer-close"
+              onClick={() => onSelect("")}
+              title="Close"
+            >
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.749.749 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.749.749 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+              </svg>
+            </button>
+            <span className="reviews-drawer-title">{cleanTitle(selected)}</span>
+          </div>
+          <div className="reviews-drawer-body">
+            <PrPanel
+              key={selected.id}
+              sessionId={selected.id}
+              onOpenSession={() => onOpenSession(selected.id)}
+              split
+            />
+          </div>
+        </aside>
+      )}
     </div>
   );
 }

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -14,6 +14,18 @@ export interface UnifiedSession {
   transcriptPath: string | null;
   prUrl?: string;
   prState?: "OPEN" | "MERGED" | "CLOSED";
+  // Rich PR fields, populated from the batched gh pr list for the Reviews
+  // table's columns (so the list never fetches per-PR).
+  prNumber?: number;
+  prTitle?: string;
+  prIsDraft?: boolean;
+  prAdditions?: number;
+  prDeletions?: number;
+  prChangedFiles?: number;
+  prReviewDecision?: string;
+  prAuthor?: string;
+  prUpdatedAt?: string;
+  prChecks?: { total: number; passed: number; failed: number; pending: number };
   mode?: "ask" | "code";
   automation?: string;
   archived?: boolean;

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -1199,6 +1199,39 @@ a {
   flex-direction: column;
   gap: 12px;
 }
+/* The info region (header, checks, body, actions) keeps the vertical rhythm
+   whether or not it's beside the diff. */
+.pr-panel-info {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+/* Split layout (Reviews drawer): metadata/checks/actions on the left, the
+   code diff filling the rest — each scrolls on its own. */
+.pr-panel-split {
+  flex-direction: row;
+  align-items: stretch;
+  height: 100%;
+  padding: 0;
+  gap: 0;
+}
+.pr-panel-split .pr-panel-info {
+  width: 384px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 18px;
+  border-right: 1px solid var(--border);
+}
+.pr-panel-split .pr-panel-diff {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 18px 20px;
+  background: var(--bg);
+}
+.pr-panel-split .pr-diff-section { margin-top: 0; }
 
 .pr-head {
   display: flex;
@@ -1272,6 +1305,42 @@ a {
   letter-spacing: 0.04em;
   color: var(--text-faint);
   padding: 8px 12px 6px;
+}
+
+.pr-checks-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 10px 12px;
+  cursor: pointer;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+}
+.pr-checks-summary:hover { background: var(--bg-hover); }
+.pr-checks-status {
+  font-size: 13px;
+  font-weight: 600;
+}
+.pr-checks-status.pr-sum-pass { color: var(--green); }
+.pr-checks-status.pr-sum-fail { color: var(--red); }
+.pr-checks-status.pr-sum-pending { color: var(--yellow); }
+.pr-checks-counts {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.check-success-text { color: var(--green); }
+.check-failure-text { color: var(--red); }
+.check-pending-text { color: var(--yellow); }
+.pr-checks-chevron {
+  margin-left: auto;
+  color: var(--text-faint);
+  font-size: 11px;
 }
 
 .pr-check {
@@ -1403,103 +1472,415 @@ a {
   flex: 1;
   min-height: 0;
   display: flex;
+  position: relative;
 }
-.reviews-empty {
-  align-items: center;
-  justify-content: center;
+.reviews-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
 }
 
-.reviews-rail {
-  width: 300px;
-  flex-shrink: 0;
-  border-right: 1px solid var(--border);
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
+/* ── Header + filter tabs ───────────────────────────────── */
+.reviews-header {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--bg);
+  padding: 16px 22px 0;
+  border-bottom: 1px solid var(--border);
 }
-.reviews-rail-title {
-  padding: 14px 16px 8px;
-  font-size: 11.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-faint);
+.reviews-header-top {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
 }
-.reviews-rail-count {
-  background: var(--bg-active);
+.reviews-title {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.reviews-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 6px 10px;
+  width: 240px;
+  color: var(--text-faint);
+  transition: border-color 0.12s, background 0.12s;
+}
+.reviews-search:focus-within {
+  border-color: var(--border-strong);
+  background: var(--bg-panel);
+}
+.reviews-search input {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 13px;
+}
+.reviews-search input::placeholder { color: var(--text-faint); }
+
+.reviews-tabs {
+  display: flex;
+  gap: 2px;
+}
+.reviews-tab {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 13px 11px;
+  margin-bottom: -1px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--text-dim);
-  border-radius: 99px;
-  padding: 1px 8px;
-  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.12s;
 }
-.reviews-rail-item {
+.reviews-tab:hover { color: var(--text); }
+.reviews-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+.reviews-tab-count {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-dim);
+  background: var(--bg-active);
+  border-radius: 99px;
+  padding: 1px 7px;
+  min-width: 20px;
+  text-align: center;
+}
+.reviews-tab.active .reviews-tab-count {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* ── Table ──────────────────────────────────────────────── */
+.reviews-table {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+}
+.reviews-row {
+  display: grid;
+  grid-template-columns:
+    92px minmax(0, 1fr) 156px 132px 116px 132px 78px;
+  align-items: center;
+  gap: 14px;
   width: 100%;
   text-align: left;
   background: none;
   border: none;
   border-bottom: 1px solid var(--border);
-  padding: 11px 16px;
+  padding: 11px 22px;
   cursor: pointer;
   color: var(--text);
+  font: inherit;
 }
-.reviews-rail-item:hover { background: var(--bg-hover); }
-.reviews-rail-item.active { background: var(--bg-active); }
-.reviews-rail-item-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.reviews-row:hover { background: var(--bg-hover); }
+.reviews-row.active {
+  background: var(--bg-active);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
-.reviews-rail-num {
-  font-size: 12px;
-  color: var(--text-dim);
-}
-.reviews-rail-item-title {
-  font-size: 13.5px;
-  font-weight: 500;
-  line-height: 1.35;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-.reviews-rail-item-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 10px;
-  font-size: 11.5px;
-  color: var(--text-faint);
-  align-items: center;
-}
-.reviews-rail-branch {
-  font-family: var(--mono);
+.reviews-row-head {
+  position: sticky;
+  top: 95px;
+  z-index: 2;
+  background: var(--bg);
+  cursor: default;
+  padding-top: 9px;
+  padding-bottom: 9px;
   font-size: 11px;
-  color: var(--text-dim);
-  max-width: 200px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-faint);
+}
+.reviews-row-head:hover { background: var(--bg); }
+
+/* Columns */
+.rv-c-state {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 500;
+}
+.rv-state-label { white-space: nowrap; }
+.rv-state-open { color: var(--green); }
+.rv-state-draft { color: var(--text-dim); }
+.rv-state-merged { color: var(--purple); }
+.rv-state-closed { color: var(--red); }
+
+.rv-c-title {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.rv-title-line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.rv-title-text {
+  font-size: 14px;
+  font-weight: 550;
+  line-height: 1.3;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.reviews-detail {
-  flex: 1;
+.rv-num {
+  font-size: 12.5px;
+  color: var(--text-faint);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+.rv-sub-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-faint);
   min-width: 0;
-  overflow-y: auto;
+}
+.rv-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+.rv-branch svg { flex-shrink: 0; opacity: 0.7; }
+.rv-linear {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-dim);
+  background: var(--bg-active);
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+.rv-running {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--green);
 }
 
-@media (max-width: 720px) {
-  .reviews { flex-direction: column; }
-  .reviews-rail {
-    width: auto;
-    max-height: 42vh;
-    border-right: none;
-    border-bottom: 1px solid var(--border);
+/* Checks */
+.rv-checks {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+}
+.rv-checks-empty,
+.rv-dim { color: var(--text-faint); font-size: 12.5px; }
+.rv-check-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 99px;
+  flex-shrink: 0;
+}
+.rv-check-dot-pass { background: var(--green); }
+.rv-check-dot-fail { background: var(--red); }
+.rv-check-dot-pending {
+  background: #d9a23a;
+  animation: rv-pulse 1.4s ease-in-out infinite;
+}
+@keyframes rv-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+.rv-checks-pass .rv-checks-label { color: var(--green); }
+.rv-checks-fail .rv-checks-label { color: var(--red); }
+.rv-checks-pending .rv-checks-label { color: #d9a23a; }
+.rv-checks-label { white-space: nowrap; }
+.rv-checks-bar {
+  display: inline-flex;
+  width: 46px;
+  height: 4px;
+  border-radius: 99px;
+  overflow: hidden;
+  background: var(--bg-active);
+  flex-shrink: 0;
+}
+.rv-bar-seg { height: 100%; }
+.rv-bar-pass { background: var(--green); }
+.rv-bar-fail { background: var(--red); }
+.rv-bar-pending { background: #d9a23a; }
+
+/* Review decision */
+.rv-review {
+  font-size: 12px;
+  font-weight: 550;
+  white-space: nowrap;
+}
+.rv-review-approved { color: var(--green); }
+.rv-review-changes { color: #d9a23a; }
+.rv-review-pending { color: var(--text-faint); }
+
+/* Changes / diffstat */
+.rv-changes {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.rv-diffstat {
+  display: inline-flex;
+  gap: 7px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--mono);
+}
+.rv-add { color: var(--green); }
+.rv-del { color: var(--red); }
+.rv-diffsquares { display: inline-flex; gap: 2px; }
+.rv-sq { width: 8px; height: 8px; border-radius: 2px; }
+.rv-sq-add { background: var(--green); }
+.rv-sq-del { background: var(--red); }
+.rv-sq-none { background: var(--border-strong); }
+
+/* Author */
+.rv-c-author {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.rv-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 99px;
+  flex-shrink: 0;
+  background: var(--bg-active);
+}
+.rv-author-name {
+  font-size: 12.5px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rv-c-updated {
+  font-size: 12.5px;
+  color: var(--text-faint);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.reviews-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Detail drawer ──────────────────────────────────────── */
+.reviews-drawer {
+  flex: 1 1 auto;
+  min-width: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.reviews-drawer-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.reviews-drawer-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.reviews-drawer-close:hover { background: var(--bg-hover); color: var(--text); }
+.reviews-drawer-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.reviews-drawer-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* When a PR is open the list collapses to a compact rail (GitHub split view):
+   the diff is the hero, the list just keeps you oriented. */
+.reviews-has-detail .reviews-main {
+  flex: 0 0 360px;
+  border-right: 1px solid var(--border);
+}
+.reviews-has-detail .reviews-search { display: none; }
+.reviews-has-detail .reviews-header { padding: 14px 16px 0; }
+.reviews-has-detail .reviews-title { font-size: 16px; }
+.reviews-has-detail .reviews-tabs { overflow-x: auto; }
+.reviews-has-detail .reviews-row {
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 10px 16px;
+}
+.reviews-has-detail .reviews-row-head,
+.reviews-has-detail .rv-state-label,
+.reviews-has-detail .rv-checks-bar,
+.reviews-has-detail .rv-c-review,
+.reviews-has-detail .rv-c-author,
+.reviews-has-detail .rv-c-changes,
+.reviews-has-detail .rv-c-updated {
+  display: none;
+}
+.reviews-has-detail .rv-checks-label { font-size: 12px; }
+
+@media (max-width: 1180px) {
+  .reviews-row { grid-template-columns: 88px minmax(0, 1fr) 150px 118px 78px; }
+  .rv-c-review, .rv-c-author { display: none; }
+}
+@media (max-width: 860px) {
+  .reviews-drawer {
+    position: absolute;
+    inset: 0 0 0 auto;
+    width: min(560px, 100%);
+    z-index: 10;
+    box-shadow: -16px 0 40px rgba(0, 0, 0, 0.5);
   }
+  .reviews-row { grid-template-columns: 80px minmax(0, 1fr) 120px; }
+  .rv-c-changes, .rv-c-updated { display: none; }
+  .reviews-row-head { top: 0; }
 }
 
 /* ── Messages ────────────────────────────────────────────── */

--- a/src/server/sessions.ts
+++ b/src/server/sessions.ts
@@ -270,11 +270,59 @@ function getRunningPids(): Map<string, number> {
   return running;
 }
 
-// PR cache: branch → { url, state }, refreshed every 60s
-interface PrInfo { url: string; state: "OPEN" | "MERGED" | "CLOSED"; }
+// PR cache: branch → rich PR info, refreshed every 60s. A single batched
+// `gh pr list` carries everything the Reviews table renders as columns
+// (diffstat, review decision, a CI checks rollup summary, author), so the list
+// never has to N+1 fetch per PR — only the detail pane does.
+interface PrChecksSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+}
+interface PrInfo {
+  url: string;
+  state: "OPEN" | "MERGED" | "CLOSED";
+  number: number;
+  title: string;
+  isDraft: boolean;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  reviewDecision: string;
+  author: string;
+  updatedAt: string;
+  checks: PrChecksSummary;
+}
 let prCache: { data: Map<string, PrInfo>; ts: number } = { data: new Map(), ts: 0 };
 const PR_CACHE_TTL = 60_000;
 let prRefreshing = false;
+
+interface RollupCheck { status?: string; conclusion?: string; state?: string }
+
+// Collapse GitHub's per-check rollup into the four counts the UI shows. A check
+// is "pending" until COMPLETED; once complete its conclusion decides pass/fail.
+// Skipped/neutral checks count toward the total but are neither pass nor fail,
+// matching how GitHub's merge box treats them.
+function summarizeChecks(rollup: RollupCheck[] | undefined): PrChecksSummary {
+  const summary: PrChecksSummary = { total: 0, passed: 0, failed: 0, pending: 0 };
+  for (const c of rollup || []) {
+    summary.total++;
+    // StatusContext (legacy commit statuses) report `state`; CheckRun reports
+    // status + conclusion.
+    const status = (c.status || "").toUpperCase();
+    const conclusion = (c.conclusion || c.state || "").toUpperCase();
+    if (status && status !== "COMPLETED") {
+      summary.pending++;
+    } else if (["FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE", "ACTION_REQUIRED", "CANCELLED"].includes(conclusion)) {
+      summary.failed++;
+    } else if (conclusion === "SUCCESS") {
+      summary.passed++;
+    }
+    // SKIPPED / NEUTRAL / "" fall through — counted in total only.
+  }
+  return summary;
+}
 
 // Stale-while-revalidate: never block the event loop on gh (it takes ~10s on
 // this repo, which used to freeze every agent in the process).
@@ -283,20 +331,67 @@ function getPrsByBranch(): Map<string, PrInfo> {
   return prCache.data;
 }
 
+async function ghJson<T>(args: string[]): Promise<T | null> {
+  try {
+    const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "ignore" });
+    const raw = await new Response(proc.stdout).text();
+    if ((await proc.exited) !== 0 || !raw.trim()) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
 async function refreshPrCache(): Promise<void> {
   if (prRefreshing) return;
   prRefreshing = true;
   try {
-    const proc = Bun.spawn(
-      ["gh", "pr", "list", "--repo", "tellahq/tella-fusion", "--state", "all",
-       "--limit", "200", "--json", "headRefName,url,state"],
-      { stdout: "pipe", stderr: "ignore" }
-    );
-    const raw = await new Response(proc.stdout).text();
-    const prs = JSON.parse(raw) as Array<{ headRefName: string; url: string; state: string }>;
+    // GitHub's GraphQL 504s when asked for statusCheckRollup across hundreds of
+    // PRs, so split the work: one cheap bulk call for every PR's metadata, and
+    // a second scoped call that pulls the CI rollup only for the recent open
+    // PRs (the ones a reviewer actually triages). Closed/merged PRs simply show
+    // no checks column.
+    const [bulk, rollups] = await Promise.all([
+      ghJson<Array<{
+        headRefName: string; url: string; state: string; number: number; title: string;
+        isDraft: boolean; additions: number; deletions: number; changedFiles: number;
+        reviewDecision: string; author?: { login?: string; name?: string }; updatedAt: string;
+      }>>([
+        "pr", "list", "--repo", "tellahq/tella-fusion", "--state", "all", "--limit", "200",
+        "--json", "headRefName,url,state,number,title,isDraft,additions,deletions,changedFiles,reviewDecision,author,updatedAt",
+      ]),
+      ghJson<Array<{ number: number; statusCheckRollup?: RollupCheck[] }>>([
+        "pr", "list", "--repo", "tellahq/tella-fusion", "--state", "open", "--limit", "40",
+        "--json", "number,statusCheckRollup",
+      ]),
+    ]);
+
+    if (!bulk) {
+      prCache.ts = Date.now(); // back off on failure, keep stale data
+      return;
+    }
+
+    const checksByNumber = new Map<number, PrChecksSummary>();
+    for (const r of rollups || []) {
+      checksByNumber.set(r.number, summarizeChecks(r.statusCheckRollup));
+    }
+
     const map = new Map<string, PrInfo>();
-    for (const pr of prs) {
-      map.set(pr.headRefName, { url: pr.url, state: pr.state as PrInfo["state"] });
+    for (const pr of bulk) {
+      map.set(pr.headRefName, {
+        url: pr.url,
+        state: pr.state as PrInfo["state"],
+        number: pr.number,
+        title: pr.title || "",
+        isDraft: !!pr.isDraft,
+        additions: pr.additions || 0,
+        deletions: pr.deletions || 0,
+        changedFiles: pr.changedFiles || 0,
+        reviewDecision: pr.reviewDecision || "",
+        author: pr.author?.login || pr.author?.name || "",
+        updatedAt: pr.updatedAt || "",
+        checks: checksByNumber.get(pr.number) || { total: 0, passed: 0, failed: 0, pending: 0 },
+      });
     }
     prCache = { data: map, ts: Date.now() };
   } catch (e) {
@@ -355,6 +450,16 @@ export function getAllSessions(): UnifiedSession[] {
       if (pr) {
         session.prUrl = pr.url;
         session.prState = pr.state;
+        session.prNumber = pr.number;
+        session.prTitle = pr.title;
+        session.prIsDraft = pr.isDraft;
+        session.prAdditions = pr.additions;
+        session.prDeletions = pr.deletions;
+        session.prChangedFiles = pr.changedFiles;
+        session.prReviewDecision = pr.reviewDecision;
+        session.prAuthor = pr.author;
+        session.prUpdatedAt = pr.updatedAt;
+        session.prChecks = pr.checks;
       }
     }
   }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -14,6 +14,18 @@ export interface UnifiedSession {
   transcriptPath: string | null;
   prUrl?: string;
   prState?: "OPEN" | "MERGED" | "CLOSED";
+  // Rich PR fields, populated from the batched gh pr list for the Reviews
+  // table's columns (so the list never fetches per-PR).
+  prNumber?: number;
+  prTitle?: string;
+  prIsDraft?: boolean;
+  prAdditions?: number;
+  prDeletions?: number;
+  prChangedFiles?: number;
+  prReviewDecision?: string;
+  prAuthor?: string;
+  prUpdatedAt?: string;
+  prChecks?: { total: number; passed: number; failed: number; pending: number };
   mode?: "ask" | "code";
   project?: string;
   automation?: string;


### PR DESCRIPTION
Redesigns the **Reviews** view to look and work like a real PR review queue (GitHub / Codex / Conductor), per the ask to add more columns and make it scannable.

## What changed

**Full-width, multi-column PR table** replaces the narrow rail:
- Columns: **Status** (open/draft/merged/closed icon), **Pull request** (real PR title + #, branch, Linear id), **Checks** (CI rollup: tone dot + count + proportional pass/fail/skip bar), **Review** (approved / changes / review required), **Changes** (+/− diffstat with a GitHub-style 5-square block), **Author** (avatar + login), **Updated**.
- **Filter tabs** with counts: Needs review · Open · Merged · Closed · All, plus a search box (title / branch / # / author).

**Detail is now the hero.** Selecting a PR collapses the list to a compact rail and opens a wide detail pane with a **vertical split**: PR metadata + collapsible checks + actions (Open on GitHub / Squash & merge / Open session) on the left, the **code diff** filling the rest.

**Checks collapse into a summary** (All passed / Some failed / Running with ✓/✕/● counts) that expands on click, failures sorted first — instead of dumping 40+ rows.

## Data
The columns are fed by enriching the existing batched `gh pr list` — no N+1 per-PR fetch. One cheap bulk call for metadata (title, diffstat, review decision, author, updatedAt) plus a scoped `statusCheckRollup` call for the ~40 most-recent open PRs (GitHub GraphQL 504s on a bulk rollup across hundreds of PRs). Plumbed through `UnifiedSession`.

## Notes
- `PrPanel`'s split layout is opt-in (`split` prop), so the session PR tab still stacks as before.
- Pre-existing typecheck errors in `plain/handlers.ts`, `useWebSocket.ts`, `claude-runner.ts` are unrelated to this change; the changed files typecheck clean and the frontend bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)