### PR TITLE
factory: pixel-art Factorio sprites (assemblers, drills, inserters, bots)

### DIFF
--- a/src/frontend/components/Factory.tsx
+++ b/src/frontend/components/Factory.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import type { UnifiedSession } from "../lib/types";
 import { relativeTime } from "../lib/api";
+import { Assembler, Drill, Inserter, Chest, Siren, Bot, Cog } from "./factory-sprites";
 
 // A Factorio-flavoured overview of everything moving through Michael: sources
 // "mine" raw work on the left, sessions get "assembled" in the middle (running /
@@ -90,7 +91,11 @@ export function Factory({ sessions, loading, onOpenSession }: Props) {
       <div className="fac-scene">
         <header className="fac-hud">
           <div className="fac-hud-title">
-            <span className="fac-hud-gear">⚙</span>
+            <span className="fac-hud-gear">
+              <svg width="18" height="18" viewBox="0 0 18 18">
+                <Cog cx={9} cy={9} r={8} spin="spr-spin" color="#e6bd3f" />
+              </svg>
+            </span>
             <span>Production Floor</span>
             <span className="fac-hud-sub">{active.length} sessions on the line</span>
           </div>
@@ -117,7 +122,9 @@ export function Factory({ sessions, loading, onOpenSession }: Props) {
                     }`}
                     style={cssVar(SOURCE_META[k].color)}
                   >
-                    <span className="fac-drill-glyph">{SOURCE_META[k].glyph}</span>
+                    <span className="fac-drill-glyph">
+                      <Drill size={24} color={SOURCE_META[k].color} />
+                    </span>
                     <span className="fac-drill-name">{SOURCE_META[k].label}</span>
                     <span className="fac-drill-count">{c.total}</span>
                     <span className="fac-drill-bit" aria-hidden />
@@ -160,6 +167,12 @@ export function Factory({ sessions, loading, onOpenSession }: Props) {
           <section className="fac-col fac-col-island">
             <div className="fac-island">
               <div className="fac-island-water" aria-hidden />
+              <span className="fac-bot fac-bot-1" aria-hidden>
+                <Bot size={20} />
+              </span>
+              <span className="fac-bot fac-bot-2" aria-hidden>
+                <Bot size={15} />
+              </span>
               <h3 className="fac-island-label">
                 <span className="fac-hex">⬡</span> GitHub Island
               </h3>
@@ -183,13 +196,27 @@ function Stat({ tone, label, value }: { tone: string; label: string; value: numb
   );
 }
 
+const BELT_ITEMS = [
+  { delay: "0s", color: "#b8bcc2" },
+  { delay: "-1.1s", color: "#c8803a" },
+  { delay: "-2.2s", color: "#b8bcc2" },
+];
+
 function Belt({ toIsland }: { toIsland?: boolean }) {
   return (
     <div className={`fac-belt${toIsland ? " fac-belt-island" : ""}`} aria-hidden>
       <div className="fac-belt-lane" />
-      <span className="fac-belt-item" style={{ animationDelay: "0s" }} />
-      <span className="fac-belt-item" style={{ animationDelay: "-1.1s" }} />
-      <span className="fac-belt-item" style={{ animationDelay: "-2.2s" }} />
+      {BELT_ITEMS.map((it, i) => (
+        <span key={i} className="fac-belt-item" style={{ animationDelay: it.delay }}>
+          <svg width="15" height="15" viewBox="0 0 16 16">
+            <Cog cx={8} cy={8} r={6.4} spin="spr-spin" color={it.color} />
+          </svg>
+        </span>
+      ))}
+      {/* an inserter plucking items off the belt at the machine end */}
+      <span className="fac-belt-inserter">
+        <Inserter size={26} />
+      </span>
     </div>
   );
 }
@@ -209,12 +236,15 @@ function Station({
 }) {
   const shown = sessions.slice(0, STATION_CAP);
   const overflow = sessions.length - shown.length;
+  const Machine = kind === "run" ? Assembler : kind === "wait" ? Siren : Chest;
   return (
     <div className={`fac-station fac-station-${kind}`}>
       <div className="fac-machine-head">
+        <span className="fac-machine-sprite">
+          <Machine size={30} />
+        </span>
         <span className={`fac-lamp fac-lamp-${kind}`} />
         <span className="fac-machine-title">{title}</span>
-        {kind === "run" && <span className="fac-gear">⚙</span>}
         <span className="fac-machine-count">{sessions.length}</span>
       </div>
       <div className="fac-machine-body">

--- a/src/frontend/components/factory-sprites.tsx
+++ b/src/frontend/components/factory-sprites.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+
+// Hand-built pixel-art SVG sprites in the *style* of Factorio — no ripped game
+// art (Factorio's sprites are Wube Software's copyright). Limited industrial
+// palette, crisp edges, CSS-animated moving parts (cogs spin, drill bits bob,
+// inserter arms swing, logistic bots hover). All driven by classes defined in
+// global.css (.spr-*).
+
+const STEEL = "#aab0b8";
+const STEEL_D = "#71777f";
+const STEEL_DD = "#42464c";
+const BLUE = "#4f7cab";
+const BLUE_D = "#2f5074";
+const YEL = "#e6bd3f";
+const YEL_D = "#a9851f";
+const BLK = "#1a1206";
+const COPPER = "#c8803a";
+const RED = "#e5484d";
+
+/** Parametric cog — teeth generated around the origin so it spins cleanly via CSS. */
+export function Cog({
+  cx,
+  cy,
+  r,
+  spin = "spr-spin",
+  color = STEEL,
+}: {
+  cx: number;
+  cy: number;
+  r: number;
+  spin?: string;
+  color?: string;
+}) {
+  const teeth = [0, 45, 90, 135, 180, 225, 270, 315];
+  return (
+    <g transform={`translate(${cx} ${cy})`}>
+      {/* spinning group carries NO attribute transform, so the CSS rotate isn't
+          clobbered; transform-box:fill-box centres it on its own bbox (the origin). */}
+      <g className={spin}>
+        {teeth.map((a) => (
+          <rect
+            key={a}
+            x={-r * 0.2}
+            y={-r * 1.16}
+            width={r * 0.4}
+            height={r * 0.42}
+            fill={color}
+            transform={`rotate(${a})`}
+          />
+        ))}
+        <circle r={r * 0.86} fill={color} />
+        <circle r={r * 0.4} fill={BLK} />
+        <circle r={r * 0.18} fill={color} />
+      </g>
+    </g>
+  );
+}
+
+/** Assembling machine — steel body, blue window, hazard base, two counter-rotating cogs. */
+export function Assembler({ size = 34 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 32 32" className="spr">
+      {/* hazard base */}
+      <rect x="3" y="26" width="26" height="5" fill={YEL} />
+      <g stroke={BLK} strokeWidth="2.4">
+        <line x1="4" y1="31" x2="9" y2="26" />
+        <line x1="10" y1="31" x2="15" y2="26" />
+        <line x1="16" y1="31" x2="21" y2="26" />
+        <line x1="22" y1="31" x2="27" y2="26" />
+      </g>
+      {/* body */}
+      <rect x="4" y="11" width="24" height="16" fill={STEEL_D} stroke={STEEL_DD} shapeRendering="crispEdges" />
+      <rect x="4" y="11" width="24" height="3" fill={STEEL} shapeRendering="crispEdges" />
+      {/* blue assembler window */}
+      <rect x="10" y="16" width="12" height="8" fill={BLUE_D} shapeRendering="crispEdges" />
+      <rect x="11" y="17" width="10" height="6" fill={BLUE} shapeRendering="crispEdges" />
+      {/* corner bolts */}
+      <rect x="5.5" y="24.5" width="2" height="2" fill={STEEL_DD} />
+      <rect x="24.5" y="24.5" width="2" height="2" fill={STEEL_DD} />
+      {/* cogs on top */}
+      <Cog cx={11} cy={10} r={5.2} spin="spr-spin" color={STEEL} />
+      <Cog cx={21} cy={10} r={5.2} spin="spr-spin-rev" color={STEEL} />
+    </svg>
+  );
+}
+
+/** Electric mining drill — yellow body, a coloured source band, a bobbing bit. */
+export function Drill({ size = 24, color = YEL }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className="spr">
+      {/* legs */}
+      <rect x="3" y="18" width="4" height="4" fill={STEEL_DD} />
+      <rect x="17" y="18" width="4" height="4" fill={STEEL_DD} />
+      {/* body */}
+      <rect x="3" y="5" width="18" height="14" fill={YEL} stroke={BLK} strokeWidth="1" shapeRendering="crispEdges" />
+      <rect x="3" y="5" width="18" height="3" fill={color} shapeRendering="crispEdges" />
+      {/* drill shaft opening */}
+      <rect x="9" y="15" width="6" height="7" fill={BLK} shapeRendering="crispEdges" />
+      {/* bobbing bit */}
+      <g className="spr-bob">
+        <path d="M9 14 L12 21 L15 14 Z" fill={STEEL} />
+        <path d="M10.5 14 L12 18 L13.5 14 Z" fill={STEEL_DD} />
+      </g>
+      {/* little cog detail */}
+      <Cog cx={17.5} cy={11} r={3} spin="spr-spin" color={YEL_D} />
+    </svg>
+  );
+}
+
+/** Inserter — pivoting arm that swings, carrying a cog. Decorative on belt ends. */
+export function Inserter({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className="spr">
+      <rect x="9" y="17" width="6" height="5" fill={STEEL_D} stroke={STEEL_DD} strokeWidth="0.6" />
+      <circle cx="12" cy="18" r="2" fill={STEEL_DD} />
+      <g className="spr-arm">
+        <rect x="11" y="6" width="2" height="12" fill={STEEL} />
+        <Cog cx={12} cy={6} r={3} spin="spr-spin" color={COPPER} />
+      </g>
+    </svg>
+  );
+}
+
+/** Steel chest — the buffer. */
+export function Chest({ size = 26 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className="spr">
+      <rect x="3" y="8" width="18" height="13" fill={STEEL_D} stroke={STEEL_DD} strokeWidth="1" shapeRendering="crispEdges" />
+      <rect x="3" y="8" width="18" height="4" fill={STEEL} shapeRendering="crispEdges" />
+      <rect x="3" y="19" width="18" height="2" fill={STEEL_DD} shapeRendering="crispEdges" />
+      <rect x="10" y="11" width="4" height="4" fill={STEEL_DD} shapeRendering="crispEdges" />
+      <rect x="5" y="9.5" width="1.6" height="1.6" fill={STEEL_DD} />
+      <rect x="17.4" y="9.5" width="1.6" height="1.6" fill={STEEL_DD} />
+    </svg>
+  );
+}
+
+/** Alarm siren — a red beacon that flashes. Marks the "awaiting input" station. */
+export function Siren({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" className="spr">
+      <rect x="6" y="17" width="12" height="5" fill={STEEL_D} stroke={STEEL_DD} strokeWidth="1" shapeRendering="crispEdges" />
+      <rect x="8" y="13" width="8" height="4" fill={STEEL_DD} shapeRendering="crispEdges" />
+      {/* dome */}
+      <path d="M8 13 a4 4 0 0 1 8 0 Z" fill={RED} className="spr-flash" />
+      <circle cx="12" cy="11" r="1.6" fill="#ffd2d2" className="spr-flash" />
+      {/* glow */}
+      <circle cx="12" cy="11" r="6" fill={RED} opacity="0.18" className="spr-flash" />
+    </svg>
+  );
+}
+
+/** Logistic bot — hovers and flaps, carrying a package. Drifts over the island. */
+export function Bot({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 20 20" className="spr">
+      <g className="spr-hover">
+        <rect x="1" y="6" width="5" height="2" fill={STEEL} className="spr-flap" />
+        <rect x="14" y="6" width="5" height="2" fill={STEEL} className="spr-flap" />
+        <rect x="7" y="5" width="6" height="6" fill={BLUE} stroke={BLUE_D} strokeWidth="0.6" />
+        <rect x="8" y="6" width="4" height="2" fill="#9ec8ef" />
+        <rect x="8" y="11" width="4" height="4" fill={COPPER} stroke={BLK} strokeWidth="0.5" />
+      </g>
+    </svg>
+  );
+}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -3850,9 +3850,8 @@ a {
   color: var(--text);
 }
 .fac-hud-gear {
-  color: var(--yellow);
-  font-size: 18px;
-  animation: fac-spin 9s linear infinite;
+  display: inline-flex;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
 }
 .fac-hud-sub {
   color: var(--text-faint);
@@ -3918,8 +3917,11 @@ a {
   position: relative;
   flex: 0 0 54px;
   width: 54px;
-  align-self: stretch;
-  min-height: 120px;
+  /* a compact connector pinned near the top row of machines, rather than
+     stretching (and stranding the belt mid-page on tall columns) */
+  align-self: flex-start;
+  height: 150px;
+  margin-top: 18px;
 }
 .fac-belt-lane {
   position: absolute;
@@ -3943,13 +3945,22 @@ a {
 .fac-belt-item {
   position: absolute;
   top: 50%;
-  margin-top: -7px;
-  width: 14px;
-  height: 14px;
-  border-radius: 2px;
-  background: linear-gradient(180deg, #4a3d1c, #2a2210);
-  box-shadow: inset 0 0 0 2px #7a6228, 0 1px 2px rgba(0, 0, 0, 0.6);
+  margin-top: -8px;
+  width: 15px;
+  height: 15px;
+  display: flex;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.6));
   animation: fac-belt-travel 3.3s linear infinite;
+}
+/* inserter sitting at the machine end of each belt, plucking items off */
+.fac-belt-inserter {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  margin-top: -23px;
+  display: flex;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+  pointer-events: none;
 }
 @keyframes fac-belt-travel {
   0% { left: -16px; opacity: 0; }
@@ -3983,12 +3994,12 @@ a {
     0 0 14px color-mix(in srgb, var(--src) 22%, transparent);
 }
 .fac-drill-glyph {
-  font-family: var(--mono);
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--src);
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
 }
+.fac-drill.is-cold .fac-drill-glyph { filter: grayscale(0.7) brightness(0.8); }
 .fac-drill-name { font-size: 12.5px; color: var(--text); font-weight: 500; }
 .fac-drill-count {
   font-family: var(--mono);
@@ -4248,6 +4259,65 @@ a {
   border: 1px solid #2a2f55;
   border-radius: 4px;
   padding: 1px 4px;
+}
+
+/* ── Pixel-art sprites & their moving parts ── */
+.spr { display: block; }
+/* SVG parts spin/translate about their own centre */
+.spr-spin, .spr-spin-rev, .spr-bob, .spr-hover, .spr-flap {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.spr-spin { animation: fac-spin 4.5s linear infinite; }
+.spr-spin-rev { animation: fac-spin 4.5s linear infinite reverse; }
+.spr-bob { animation: spr-bob 0.9s ease-in-out infinite; }
+@keyframes spr-bob { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(2px); } }
+.spr-hover { animation: spr-hover 2.4s ease-in-out infinite; }
+@keyframes spr-hover { 0%, 100% { transform: translateY(-1px); } 50% { transform: translateY(2px); } }
+.spr-flap { animation: spr-flap 0.16s steps(2) infinite; }
+@keyframes spr-flap { from { transform: scaleY(0.55); } to { transform: scaleY(1); } }
+.spr-flash { animation: spr-flash 0.9s steps(1) infinite; }
+@keyframes spr-flash { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0.25; } }
+/* inserter arm pivots about its base (in viewBox user units) */
+.spr-arm {
+  transform-box: view-box;
+  transform-origin: 12px 18px;
+  animation: spr-arm 1.7s ease-in-out infinite;
+}
+@keyframes spr-arm { 0%, 100% { transform: rotate(-34deg); } 50% { transform: rotate(34deg); } }
+
+/* machine sprite in a station header */
+.fac-machine-sprite {
+  display: inline-flex;
+  flex: 0 0 auto;
+  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.fac-station-run .fac-machine-sprite { filter: drop-shadow(0 0 5px rgba(63, 185, 80, 0.4)); }
+.fac-station-wait .fac-machine-sprite { filter: drop-shadow(0 0 5px rgba(229, 72, 77, 0.45)); }
+
+/* logistic bots drifting over the island */
+.fac-bot {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.5));
+}
+.fac-bot-1 { top: 8px; right: 14px; animation: fac-bot-drift1 7s ease-in-out infinite; }
+.fac-bot-2 { top: 30px; right: 78px; animation: fac-bot-drift2 9s ease-in-out infinite; }
+@keyframes fac-bot-drift1 {
+  0%, 100% { transform: translate(0, 0); }
+  33% { transform: translate(-30px, 14px); }
+  66% { transform: translate(-10px, 26px); }
+}
+@keyframes fac-bot-drift2 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(34px, -16px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spr-spin, .spr-spin-rev, .spr-bob, .spr-hover, .spr-flap, .spr-arm,
+  .fac-bot-1, .fac-bot-2, .fac-belt-item, .fac-belt-lane,
+  .fac-island-water, .fac-drill.is-active .fac-drill-bit { animation: none; }
 }
 
 /* ── Responsive: stack the line vertically on narrow screens ── */


### PR DESCRIPTION
Follow-up to make the Factory view actually *fun*. The abstract glyphs/lamps read flat, so this adds hand-built pixel-art SVG sprites in the **style** of Factorio — no ripped game art (Factorio's sprites are Wube Software's copyright); these are original SVGs with a limited industrial palette and CSS-animated moving parts.

New `factory-sprites.tsx`:
- **Cog** — parametric spinning gear, reused in the HUD, on belts, and inside machines
- **Assembler** — steel body + blue window + hazard base + counter-rotating cogs → *Assembling* station
- **Drill** — mining drill with a bobbing bit + a source-coloured band → one per intake source (greys out when that source is cold)
- **Siren** — red flashing beacon → *Awaiting input* station
- **Chest** — steel chest → *Buffer* station
- **Inserter** — arm that swings, plucking cogs off the belt ends
- **Bot** — logistic robot that hovers + flaps, drifting over the GitHub island

Belts now carry spinning cogs instead of plain squares, and are pinned to a compact top connector so they read as a trunk line rather than stranding mid-page on tall columns. All motion respects `prefers-reduced-motion`.

Verified on desktop + mobile (390×844) with headless-Chrome screenshots. Frontend-only, so it hot-applies on the bundle rebuild — no restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)