### PR TITLE
Sub-agent right sidebar (Codex-style)

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -5,6 +5,7 @@ import { mkdirSync, existsSync, writeFileSync, readFileSync, watch } from "fs";
 import homepage from "./src/frontend/index.html";
 import { getAllSessions, deleteSession } from "./src/server/sessions";
 import { parseTranscript } from "./src/server/jsonl-parser";
+import { getSubagentTranscript } from "./src/server/subagents";
 import { startWatching, stopAllWatchesForClient } from "./src/server/file-watcher";
 import { listWorktrees, createWorktree, removeWorktree, reviveWorktree, sweepArchivedWorktrees, getProject, projectForPath } from "./src/server/worktree";
 import { STRIPE_CONFIRM_TOOLS, activeRunRecords } from "./src/server/claude-runner";
@@ -1233,6 +1234,20 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
       if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
       if (!session.transcriptPath) return Response.json([]);
       return Response.json(parseTranscript(session.transcriptPath));
+    }
+
+    // Sub-agent (Task/Agent) conversation for a session. The agentId comes from
+    // a Task tool_result's `agentId` field in the parent transcript.
+    {
+      const m = path.match(/^\/backstage\/api\/sessions\/(.+)\/subagent\/([^/]+)$/);
+      if (m && req.method === "GET") {
+        const session = findSession(decodeURIComponent(m[1]));
+        if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
+        if (!session.transcriptPath) return Response.json({ error: "No transcript" }, { status: 404 });
+        const sub = getSubagentTranscript(session.transcriptPath, decodeURIComponent(m[2]));
+        if (!sub) return Response.json({ error: "Sub-agent not found" }, { status: 404 });
+        return Response.json({ ...sub, sessionRunning: session.isRunning });
+      }
     }
 
     // Live git diff for a session's worktree (Changes tab)

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "re
 import { renderMarkdown } from "../lib/markdown";
 import { parseHumanReply } from "../lib/humanReply";
 import type { UnifiedSession, TranscriptEntry, WSServerMessage, AskQuestion } from "../lib/types";
-import { MessageBubble } from "./MessageBubble";
-import { WorkBlock } from "./WorkBlock";
+import { TranscriptBlocks } from "./TranscriptBlocks";
+import { SubagentPanel, type SubagentRef } from "./SubagentPanel";
 import { TerminalPanel } from "./TerminalPanel";
 import { getCurrentUser } from "./UserPicker";
 import { deleteSessionApi, fetchModels, type ModelOption } from "../lib/api";
@@ -24,10 +24,6 @@ interface Props {
 }
 
 type PanelTab = "changes" | "terminal" | "pr";
-
-type RenderBlock =
-  | { kind: "entry"; entry: TranscriptEntry }
-  | { kind: "work"; items: TranscriptEntry[] };
 
 /** Upsert incoming entries by id so stream events and the file watcher never duplicate. */
 function mergeEntries(prev: TranscriptEntry[], incoming: TranscriptEntry[]): TranscriptEntry[] {
@@ -73,6 +69,15 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
   const [copied, setCopied] = useState(false);
   const [pinned, setPinned] = useState(() => isPinned(session.id));
   const [panelTab, setPanelTab] = useState<PanelTab>("changes");
+  // Sub-agent sidebar: a breadcrumb stack of opened sub-agents (clicking a Task
+  // call pushes; nested Task calls push further). Non-empty → the right region
+  // shows the sub-agent conversation instead of the Workspace panel.
+  const [subagentStack, setSubagentStack] = useState<SubagentRef[]>([]);
+  function openSubagent(agentId: string, label: string) {
+    setSubagentStack((prev) =>
+      prev.some((s) => s.agentId === agentId) ? prev : [...prev, { agentId, label }]
+    );
+  }
   // Remembered per browser; on phones the panel overlays the chat, so default closed there
   const [panelOpen, setPanelOpenState] = useState(() => {
     const stored = localStorage.getItem("michael-panel-open");
@@ -467,28 +472,6 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
     });
   }
 
-  // Build tool_use → tool_result map
-  const toolResults = new Map<string, TranscriptEntry>();
-  for (const e of entries) {
-    if (e.type === "tool_result" && e.toolUseId) {
-      toolResults.set(e.toolUseId, e);
-    }
-  }
-
-  // Group consecutive tool calls into Devin-style work blocks
-  const blocks: RenderBlock[] = [];
-  for (const entry of entries) {
-    if (entry.type === "tool_use") {
-      const last = blocks[blocks.length - 1];
-      if (last?.kind === "work") last.items.push(entry);
-      else blocks.push({ kind: "work", items: [entry] });
-    } else if (entry.type === "tool_result") {
-      continue; // rendered inside work blocks via toolResults
-    } else {
-      blocks.push({ kind: "entry", entry });
-    }
-  }
-
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -579,8 +562,17 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
           <SpinOffMenu session={session} entries={entries} send={send} connected={connected} />
           {hasWorkspace && (
             <button
-              className={`btn-panel-toggle btn-workspace ${panelOpen ? "active" : ""}`}
-              onClick={() => setPanelOpen(!panelOpen)}
+              className={`btn-panel-toggle btn-workspace ${panelOpen && subagentStack.length === 0 ? "active" : ""}`}
+              onClick={() => {
+                // The sub-agent panel and Workspace share the right slot; opening
+                // Workspace closes the sub-agent view.
+                if (subagentStack.length > 0) {
+                  setSubagentStack([]);
+                  setPanelOpen(true);
+                } else {
+                  setPanelOpen(!panelOpen);
+                }
+              }}
               title="Toggle workspace panel (changes, terminal, PR)"
             >
               <span className="btn-panel-toggle-icon">◨</span>
@@ -640,22 +632,12 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
             ) : entries.length === 0 ? (
               <div className="empty">Empty transcript</div>
             ) : (
-              blocks.map((block, i) =>
-                block.kind === "work" ? (
-                  <WorkBlock
-                    key={block.items[0].id}
-                    items={block.items}
-                    toolResults={toolResults}
-                    live={isBusy && i === blocks.length - 1}
-                  />
-                ) : (
-                  <MessageBubble
-                    key={block.entry.id}
-                    entry={block.entry}
-                    onFork={isClaudeSession ? handleFork : undefined}
-                  />
-                )
-              )
+              <TranscriptBlocks
+                entries={entries}
+                live={isBusy}
+                onFork={isClaudeSession ? handleFork : undefined}
+                onOpenSubagent={openSubagent}
+              />
             )}
 
             {streamText && <StreamingMessage text={streamText} />}
@@ -809,10 +791,25 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
           </div>
         </div>
 
-        {hasWorkspace && panelOpen && (
-          <div className="panel-overlay" onClick={() => setPanelOpen(false)} />
+        {/* Right region: a sub-agent conversation takes precedence over the
+            Workspace panel when one is open. */}
+        {(subagentStack.length > 0 || (hasWorkspace && panelOpen)) && (
+          <div
+            className="panel-overlay"
+            onClick={() =>
+              subagentStack.length > 0 ? setSubagentStack([]) : setPanelOpen(false)
+            }
+          />
         )}
-        {hasWorkspace && panelOpen && (
+        {subagentStack.length > 0 ? (
+          <SubagentPanel
+            sessionId={session.id}
+            stack={subagentStack}
+            onOpenSubagent={openSubagent}
+            onBack={() => setSubagentStack((prev) => prev.slice(0, -1))}
+            onClose={() => setSubagentStack([])}
+          />
+        ) : hasWorkspace && panelOpen ? (
           <div className="viewer-panel">
             <div className="panel-tabs">
               <button
@@ -860,7 +857,7 @@ export function SessionViewer({ session, onBack, send, addHandler, connected }: 
               )}
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/frontend/components/SubagentPanel.tsx
+++ b/src/frontend/components/SubagentPanel.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useRef, useState } from "react";
+import { fetchSubagent, type SubagentTranscript } from "../lib/api";
+import { TranscriptBlocks } from "./TranscriptBlocks";
+
+export interface SubagentRef {
+  agentId: string;
+  /** Human label for the breadcrumb (the Task summary, e.g. "Explore: find X"). */
+  label: string;
+}
+
+interface Props {
+  sessionId: string;
+  /** Breadcrumb stack; the last entry is the sub-agent currently shown. */
+  stack: SubagentRef[];
+  /** Open a nested sub-agent (a Task call inside this sub-agent). */
+  onOpenSubagent: (agentId: string, label: string) => void;
+  /** Pop back to the parent sub-agent in the stack. */
+  onBack: () => void;
+  /** Close the panel entirely. */
+  onClose: () => void;
+}
+
+/**
+ * Right sidebar showing a sub-agent's conversation, mirroring the Workspace
+ * panel. Fetches over REST and, while the parent session is still running,
+ * polls so a live sub-agent's transcript fills in. Sub-agents that spawn their
+ * own sub-agents are navigable via the breadcrumb stack.
+ */
+export function SubagentPanel({ sessionId, stack, onOpenSubagent, onBack, onClose }: Props) {
+  const current = stack[stack.length - 1];
+  const [data, setData] = useState<SubagentTranscript | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  // Stick to the bottom only while the reader is already there, so polling a
+  // live sub-agent doesn't yank them up from scrollback.
+  const followRef = useRef(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    async function load(initial: boolean) {
+      if (initial) {
+        setLoading(true);
+        setError(null);
+        setData(null);
+        followRef.current = true;
+      }
+      try {
+        const next = await fetchSubagent(sessionId, current.agentId);
+        if (cancelled) return;
+        setData(next);
+        setLoading(false);
+        // Keep polling only while the parent session is live (the sub-agent may
+        // still be streaming); once idle the transcript is final.
+        if (next.sessionRunning) timer = setTimeout(() => load(false), 1500);
+      } catch (e: any) {
+        if (cancelled) return;
+        setError(e?.message || "Failed to load sub-agent");
+        setLoading(false);
+      }
+    }
+
+    load(true);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [sessionId, current.agentId]);
+
+  // After new content lands, keep a following reader pinned to the live edge.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el && followRef.current) el.scrollTop = el.scrollHeight;
+  }, [data]);
+
+  function onScroll() {
+    const el = bodyRef.current;
+    if (!el) return;
+    followRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }
+
+  const meta = data?.meta;
+  const title = meta?.agentType || current.label || "Sub-agent";
+
+  return (
+    <div className="viewer-panel subagent-panel">
+      <div className="subagent-head">
+        <div className="subagent-head-top">
+          <span className="subagent-chip">sub-agent</span>
+          <span className="subagent-title" title={meta?.description || current.label}>
+            {title}
+          </span>
+          {data?.sessionRunning && <span className="subagent-live-dot" title="Session running" />}
+          <button className="panel-close" onClick={onClose} aria-label="Close sub-agent panel">
+            ✕
+          </button>
+        </div>
+        {stack.length > 1 && (
+          <button className="subagent-back" onClick={onBack}>
+            ← {stack[stack.length - 2].label}
+          </button>
+        )}
+        {meta?.description && <div className="subagent-desc">{meta.description}</div>}
+      </div>
+
+      <div className="panel-body subagent-body" ref={bodyRef} onScroll={onScroll}>
+        {loading ? (
+          <div className="panel-placeholder">Loading sub-agent…</div>
+        ) : error ? (
+          <div className="panel-placeholder panel-error">{error}</div>
+        ) : data && data.entries.length > 0 ? (
+          <div className="subagent-messages">
+            <TranscriptBlocks
+              entries={data.entries}
+              live={data.sessionRunning}
+              onOpenSubagent={onOpenSubagent}
+            />
+          </div>
+        ) : (
+          <div className="panel-placeholder">No transcript yet for this sub-agent.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/components/ToolCallBlock.tsx
+++ b/src/frontend/components/ToolCallBlock.tsx
@@ -25,6 +25,8 @@ function CodeHighlight(props: {
 interface Props {
   entry: TranscriptEntry;
   result?: TranscriptEntry;
+  /** For Task/Agent calls with a known sub-agent id: open its conversation. */
+  onOpenSubagent?: (agentId: string, label: string) => void;
 }
 
 /** Split "mcp__linear__list_issues" into { server: "linear", tool: "list_issues" }. */
@@ -34,7 +36,7 @@ export function parseMcpTool(name: string): { server: string; tool: string } | n
   return { server: parts[1], tool: parts.slice(2).join("__") };
 }
 
-export function ToolCallBlock({ entry, result }: Props) {
+export function ToolCallBlock({ entry, result, onOpenSubagent }: Props) {
   const hasMedia = Boolean(result?.images?.length || result?.videos?.length);
   // Default closed for text-only output, but auto-open when media arrives
   // (covers both initial render and the live tool_result streaming in later).
@@ -46,8 +48,13 @@ export function ToolCallBlock({ entry, result }: Props) {
   const mcp = parseMcpTool(toolName);
   const summary = getSummary(toolName, entry.toolInput, entry.content);
 
+  // A Task/Agent call whose sub-agent transcript we can open in the sidebar.
+  const isAgent = toolName === "Task" || toolName === "Agent";
+  const agentId = result?.agentId;
+  const canOpenSubagent = isAgent && agentId && onOpenSubagent;
+
   return (
-    <div className="tool">
+    <div className={`tool ${canOpenSubagent ? "tool-agent" : ""}`}>
       <div className="tool-header" onClick={() => setExpanded(!expanded)}>
         <span className="tool-icon">{expanded ? "▾" : "▸"}</span>
         {mcp ? (
@@ -59,6 +66,18 @@ export function ToolCallBlock({ entry, result }: Props) {
           <span className="tool-name">{toolName}</span>
         )}
         <span className="tool-summary">{summary}</span>
+        {canOpenSubagent && (
+          <button
+            className="tool-open-subagent"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenSubagent!(agentId!, summary);
+            }}
+            title="Open this sub-agent's conversation"
+          >
+            Open ↗
+          </button>
+        )}
         {result && <span className="tool-ok">✓</span>}
       </div>
       {expanded && (

--- a/src/frontend/components/TranscriptBlocks.tsx
+++ b/src/frontend/components/TranscriptBlocks.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { TranscriptEntry } from "../lib/types";
+import { MessageBubble } from "./MessageBubble";
+import { WorkBlock } from "./WorkBlock";
+
+type RenderBlock =
+  | { kind: "entry"; entry: TranscriptEntry }
+  | { kind: "work"; items: TranscriptEntry[] };
+
+interface Props {
+  entries: TranscriptEntry[];
+  /** Whether the conversation is live (last work block shows a spinner / stays open). */
+  live?: boolean;
+  /** Assistant messages show a "Fork from here" action when provided. */
+  onFork?: (entryId: string) => void;
+  /** Called when a Task/Agent block's "Open sub-agent" affordance is clicked. */
+  onOpenSubagent?: (agentId: string, label: string) => void;
+}
+
+/**
+ * Groups a flat transcript into Devin-style work blocks (consecutive tool calls)
+ * and message bubbles, then renders them. Shared by the main session view and
+ * the sub-agent sidebar so both render identically.
+ */
+export function TranscriptBlocks({ entries, live, onFork, onOpenSubagent }: Props) {
+  // Build tool_use → tool_result map
+  const toolResults = new Map<string, TranscriptEntry>();
+  for (const e of entries) {
+    if (e.type === "tool_result" && e.toolUseId) toolResults.set(e.toolUseId, e);
+  }
+
+  const blocks: RenderBlock[] = [];
+  for (const entry of entries) {
+    if (entry.type === "tool_use") {
+      const last = blocks[blocks.length - 1];
+      if (last?.kind === "work") last.items.push(entry);
+      else blocks.push({ kind: "work", items: [entry] });
+    } else if (entry.type === "tool_result") {
+      continue; // rendered inside work blocks via toolResults
+    } else {
+      blocks.push({ kind: "entry", entry });
+    }
+  }
+
+  return (
+    <>
+      {blocks.map((block, i) =>
+        block.kind === "work" ? (
+          <WorkBlock
+            key={block.items[0].id}
+            items={block.items}
+            toolResults={toolResults}
+            live={Boolean(live) && i === blocks.length - 1}
+            onOpenSubagent={onOpenSubagent}
+          />
+        ) : (
+          <MessageBubble key={block.entry.id} entry={block.entry} onFork={onFork} />
+        )
+      )}
+    </>
+  );
+}

--- a/src/frontend/components/WorkBlock.tsx
+++ b/src/frontend/components/WorkBlock.tsx
@@ -6,10 +6,11 @@ interface Props {
   items: TranscriptEntry[]; // tool_use entries, in order
   toolResults: Map<string, TranscriptEntry>;
   live: boolean; // this is the active block of a running stream
+  onOpenSubagent?: (agentId: string, label: string) => void;
 }
 
 /** Devin-style collapsed segment: "Worked for 12s · 5 steps". */
-export function WorkBlock({ items, toolResults, live }: Props) {
+export function WorkBlock({ items, toolResults, live, onOpenSubagent }: Props) {
   // If any tool in the block returned media (image or video), keep the block
   // open so the screenshot/recording stays visible after the run finishes
   // (otherwise the user has to expand "Worked" then the tool to see what the
@@ -53,6 +54,7 @@ export function WorkBlock({ items, toolResults, live }: Props) {
               key={entry.id}
               entry={entry}
               result={entry.toolUseId ? toolResults.get(entry.toolUseId) : undefined}
+              onOpenSubagent={onOpenSubagent}
             />
           ))}
         </div>

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -14,6 +14,20 @@ export async function fetchTranscript(sessionId: string) {
   return res.json();
 }
 
+export interface SubagentTranscript {
+  meta: { agentId: string; agentType?: string; description?: string; toolUseId?: string; spawnDepth?: number };
+  entries: import("./types").TranscriptEntry[];
+  sessionRunning: boolean;
+}
+
+export async function fetchSubagent(sessionId: string, agentId: string): Promise<SubagentTranscript> {
+  const res = await fetch(
+    `${BASE}/sessions/${encodeURIComponent(sessionId)}/subagent/${encodeURIComponent(agentId)}`
+  );
+  if (!res.ok) throw new Error(`Failed to fetch sub-agent: ${res.status}`);
+  return res.json();
+}
+
 export async function fetchWorktrees(project?: string) {
   const qs = project ? `?project=${encodeURIComponent(project)}` : "";
   const res = await fetch(`${BASE}/worktrees${qs}`);

--- a/src/frontend/lib/types.ts
+++ b/src/frontend/lib/types.ts
@@ -37,6 +37,9 @@ export interface TranscriptEntry {
   toolInput?: unknown;
   toolUseId?: string;
   requestId?: string;
+  // Set on a Task/Agent tool_result: the spawned sub-agent's id. Lets the UI
+  // open that sub-agent's conversation in the right sidebar.
+  agentId?: string;
   // Ready-to-render image srcs (http(s) URLs or data: URLs), e.g. from a Read
   // of an image file or a pasted image.
   images?: string[];

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -963,6 +963,88 @@ a {
 }
 .panel-error { color: var(--red); }
 
+/* ── Sub-agent sidebar ───────────────────────────────────── */
+
+/* A Task/Agent tool block that can open its sub-agent conversation. */
+.tool-open-subagent {
+  margin-left: auto;
+  background: var(--accent-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+.tool-open-subagent:hover { border-color: var(--accent); }
+/* Keep the ✓ tight to the open button rather than pushed to the far edge. */
+.tool-agent .tool-summary { margin-right: 4px; }
+
+.subagent-head {
+  padding: 8px 10px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-raised);
+}
+.subagent-head-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.subagent-chip {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 5px;
+  padding: 2px 6px;
+  white-space: nowrap;
+}
+.subagent-title {
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.subagent-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  flex-shrink: 0;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.subagent-head-top .panel-close { margin-left: auto; }
+.subagent-back {
+  margin-top: 8px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.subagent-back:hover { color: var(--text); }
+.subagent-desc {
+  margin-top: 6px;
+  color: var(--text-dim);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.subagent-body { padding: 12px 14px; }
+.subagent-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 /* ── Diff panel ──────────────────────────────────────────── */
 
 .diff-panel {

--- a/src/server/jsonl-parser.ts
+++ b/src/server/jsonl-parser.ts
@@ -45,6 +45,9 @@ interface RawJsonlEntry {
   requestId?: string;
   // Harness-injected user lines (skill bodies, command output) — not typed by the user
   isMeta?: boolean;
+  // Present on a Task/Agent tool_result line: carries the spawned sub-agent's id
+  // (and its type/description), used to link the call to its sub-agent transcript.
+  toolUseResult?: { agentId?: string; agentType?: string; description?: string };
   message?: {
     role?: string;
     content?: any;
@@ -143,6 +146,9 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
                 : "";
           const images = extractImages(block.content);
           const videos = extractVideos(resultText);
+          // A Task/Agent result carries the spawned sub-agent's id on the line's
+          // toolUseResult; attach it so the UI can open the sub-agent transcript.
+          const agentId = raw.toolUseResult?.agentId;
           entries.push({
             // Keyed on the tool_use id: one jsonl line can carry several
             // tool_result blocks (parallel calls), and the live-stream copy
@@ -152,6 +158,7 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
             content: resultText,
             timestamp: ts,
             toolUseId: block.tool_use_id,
+            ...(agentId ? { agentId } : {}),
             ...(images.length > 0 ? { images } : {}),
             ...(videos.length > 0 ? { videos } : {}),
           });

--- a/src/server/subagents.ts
+++ b/src/server/subagents.ts
@@ -1,0 +1,96 @@
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { parseTranscript } from "./jsonl-parser";
+import type { TranscriptEntry } from "./types";
+
+// When a session spawns sub-agents (Task/Agent tool), the Claude Agent SDK writes
+// each sub-agent's own conversation to a sibling directory next to the parent
+// transcript:
+//
+//   <project>/<sessionUuid>.jsonl              ← parent transcript
+//   <project>/<sessionUuid>/subagents/         ← one pair per sub-agent:
+//     agent-<agentId>.jsonl                       its transcript (same schema)
+//     agent-<agentId>.meta.json                   { agentType, description, toolUseId, spawnDepth }
+//
+// The agentId links a Task tool_result (its toolUseResult.agentId, surfaced on
+// the parsed entry) to the sub-agent's transcript. Sub-agents can themselves
+// spawn sub-agents, so a nested agent's files live under ITS OWN subagents dir;
+// all of them share one flat `subagents/` folder keyed by agentId, so a lookup
+// by agentId works regardless of depth.
+
+export interface SubagentMeta {
+  agentId: string;
+  agentType?: string;
+  description?: string;
+  toolUseId?: string;
+  spawnDepth?: number;
+}
+
+export interface SubagentTranscript {
+  meta: SubagentMeta;
+  entries: TranscriptEntry[];
+}
+
+/** The `subagents/` directory for a parent transcript path, or null for Codex
+ *  rollouts (which don't use this layout). */
+function subagentsDir(transcriptPath: string): string | null {
+  if (!transcriptPath.endsWith(".jsonl")) return null;
+  return transcriptPath.replace(/\.jsonl$/, "") + "/subagents";
+}
+
+function readMeta(dir: string, agentId: string): SubagentMeta {
+  const metaPath = join(dir, `agent-${agentId}.meta.json`);
+  if (existsSync(metaPath)) {
+    try {
+      const m = JSON.parse(readFileSync(metaPath, "utf-8"));
+      return {
+        agentId,
+        agentType: m.agentType,
+        description: m.description,
+        toolUseId: m.toolUseId,
+        spawnDepth: m.spawnDepth,
+      };
+    } catch {
+      // fall through to the bare id
+    }
+  }
+  return { agentId };
+}
+
+/** List every sub-agent spawned under a session, newest meta first is not
+ *  guaranteed — callers sort as needed. */
+export function listSubagents(transcriptPath: string): SubagentMeta[] {
+  const dir = subagentsDir(transcriptPath);
+  if (!dir || !existsSync(dir)) return [];
+  const out: SubagentMeta[] = [];
+  for (const name of readdirSync(dir)) {
+    const m = name.match(/^agent-(.+)\.jsonl$/);
+    if (!m) continue;
+    out.push(readMeta(dir, m[1]));
+  }
+  return out;
+}
+
+/** Load a single sub-agent's conversation (meta + parsed transcript), or null if
+ *  its transcript file doesn't exist. */
+export function getSubagentTranscript(
+  transcriptPath: string,
+  agentId: string
+): SubagentTranscript | null {
+  const dir = subagentsDir(transcriptPath);
+  if (!dir) return null;
+  const file = join(dir, `agent-${agentId}.jsonl`);
+  if (!existsSync(file)) return null;
+  return { meta: readMeta(dir, agentId), entries: parseTranscript(file) };
+}
+
+/** Absolute path to a sub-agent's transcript file (for live file-watching). */
+export function subagentTranscriptPath(
+  transcriptPath: string,
+  agentId: string
+): string | null {
+  const dir = subagentsDir(transcriptPath);
+  if (!dir) return null;
+  const file = join(dir, `agent-${agentId}.jsonl`);
+  return existsSync(file) ? file : null;
+}

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -109,6 +109,10 @@ export interface TranscriptEntry {
   toolInput?: unknown;
   toolUseId?: string;
   requestId?: string;
+  // Set on a Task/Agent tool_result: the spawned sub-agent's id. The SDK writes
+  // the sub-agent's own transcript to <transcript>/subagents/agent-<agentId>.jsonl,
+  // so this links a tool call to its sub-agent conversation (see subagents.ts).
+  agentId?: string;
   // Ready-to-render image srcs (http(s) URLs or data: URLs) extracted from
   // image blocks — e.g. a Read of an image file, or a pasted image.
   images?: string[];


### PR DESCRIPTION
Adds a right sidebar that shows a sub-agent's full conversation when you click a Task/Agent tool block in a session — mirroring the Workspace panel layout (left list · main session · right sub-agent).

## How it works
When the main agent spawns a sub-agent, the Claude Agent SDK writes the sub-agent's own transcript to `<transcript>/subagents/agent-<agentId>.jsonl`. The parent's Task `tool_result` carries `toolUseResult.agentId`, which we surface on the parsed entry to link a call to its sub-agent conversation.

## Changes
- **server/subagents.ts** (new): resolve + parse sub-agent transcripts (same JSONL schema, existing parser reused)
- **jsonl-parser.ts / types.ts**: capture `agentId` on Task `tool_result` entries
- **backstage.ts**: `GET /api/sessions/:id/subagent/:agentId`
- **SubagentPanel.tsx** (new): REST fetch, polls while the session is running, breadcrumb stack for nested sub-agents
- **TranscriptBlocks.tsx** (new): shared block rendering so the sidebar matches the main view
- **ToolCallBlock / WorkBlock**: "Open ↗" affordance on Task/Agent calls
- **global.css**: sidebar styles

Sub-agent and Workspace share the right slot (mutually exclusive) to stay usable on narrow screens. Typechecks clean (no new errors); frontend bundles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)