### PR TITLE
reviews: batch inline PR comments into a submittable review + mobile fixes

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -46,7 +46,7 @@ import { createSessionsMcpServer } from "./src/agents/slack/sessions-tools";
 import { createAdminMcpServer } from "./src/agents/slack/admin-tools";
 import { createHumansMcpServer } from "./src/agents/slack/humans-tools";
 import { initHumanAsks, onSessionIdle as onHumanAsksSessionIdle } from "./src/server/human-asks";
-import { getPrDetails, getPrDiff, postPrComment, mergePr } from "./src/server/pr-info";
+import { getPrDetails, getPrDiff, postPrComment, submitPrReview, mergePr } from "./src/server/pr-info";
 import {
   listAutomations,
   getAutomation,
@@ -1320,6 +1320,45 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
         startSide: body.startSide,
       });
       if ("error" in result) return Response.json(result, { status: 502 });
+      return Response.json(result);
+    }
+
+    // Submit a batched review (all pending inline comments + an event) on the PR.
+    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/) && req.method === "POST") {
+      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/)![1]);
+      const session = findSession(sessionId);
+      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
+      if (!session.branch) return Response.json({ error: "Session has no branch" }, { status: 400 });
+
+      const body = await req.json().catch(() => null);
+      const event =
+        body?.event === "APPROVE" || body?.event === "REQUEST_CHANGES" ? body.event : "COMMENT";
+      const comments = Array.isArray(body?.comments) ? body.comments : [];
+      if (!comments.length && !body?.summary?.trim()) {
+        return Response.json({ error: "Nothing to submit" }, { status: 400 });
+      }
+
+      const user = body?.user || "Someone";
+      const summary = body?.summary?.trim();
+      const reviewBody = summary
+        ? `**${user}** via Michael:\n\n${summary}`
+        : `Review by **${user}** via Michael.`;
+      const result = await submitPrReview(session.branch, {
+        event,
+        body: reviewBody,
+        comments: comments
+          .filter((c: any) => c?.text?.trim() && c?.path && c?.line)
+          .map((c: any) => ({
+            path: c.path,
+            line: c.line,
+            startLine: c.startLine,
+            side: c.side,
+            startSide: c.startSide,
+            body: `**${user}**: ${c.text.trim()}`,
+          })),
+      });
+      if ("error" in result) return Response.json(result, { status: 502 });
+      sessionsCache = null; // a review can change reviewDecision in the list
       return Response.json(result);
     }
 

--- a/src/frontend/components/CommentableDiff.tsx
+++ b/src/frontend/components/CommentableDiff.tsx
@@ -10,6 +10,11 @@ export interface CommentTarget {
   side: "additions" | "deletions";
 }
 
+export interface PendingComment extends CommentTarget {
+  id: string;
+  text: string;
+}
+
 interface Props {
   patch: string;
   submitLabel: string;
@@ -17,6 +22,13 @@ interface Props {
   disabled?: boolean;
   disabledHint?: string;
   onSubmit: (target: CommentTarget, text: string) => Promise<void>;
+  /**
+   * Review-batching mode: when provided, already-added comments render inline as
+   * pending cards (the parent owns the list and submits them as one review).
+   * Without it the component stays single-shot (e.g. session feedback).
+   */
+  pendingComments?: PendingComment[];
+  onRemovePending?: (id: string) => void;
 }
 
 interface Draft {
@@ -25,7 +37,7 @@ interface Draft {
   range: SelectedLineRange;
 }
 
-type Meta = { kind: "draft" };
+type Meta = { kind: "draft" } | { kind: "pending"; comment: PendingComment };
 
 const BASE_OPTIONS = {
   theme: "pierre-dark",
@@ -49,7 +61,10 @@ export function CommentableDiff({
   disabled,
   disabledHint,
   onSubmit,
+  pendingComments,
+  onRemovePending,
 }: Props) {
+  const reviewMode = pendingComments !== undefined;
   const files = useMemo<FileDiffMetadata[]>(() => {
     try {
       return parsePatchFiles(patch).flatMap((p) => p.files);
@@ -97,8 +112,11 @@ export function CommentableDiff({
       );
       setDraft(null);
       setText("");
-      setConfirmation(`${submitLabel} ✓`);
-      setTimeout(() => setConfirmation(null), 4000);
+      // In review mode the pending card is the confirmation; skip the toast.
+      if (!reviewMode) {
+        setConfirmation(`${submitLabel} ✓`);
+        setTimeout(() => setConfirmation(null), 4000);
+      }
     } catch (e: any) {
       setError(e.message || "Failed to submit");
     } finally {
@@ -106,7 +124,37 @@ export function CommentableDiff({
     }
   }
 
-  function renderAnnotation(): React.ReactNode {
+  function renderPending(comment: PendingComment): React.ReactNode {
+    const lineLabel =
+      comment.startLine === comment.endLine
+        ? `line ${comment.startLine}`
+        : `lines ${comment.startLine}–${comment.endLine}`;
+    return (
+      <div className="diff-pending-comment" onClick={(e) => e.stopPropagation()}>
+        <div className="diff-pending-head">
+          <span className="diff-comment-target">
+            {comment.path} · {lineLabel}
+            {comment.side === "deletions" ? " (removed)" : ""}
+          </span>
+          {onRemovePending && (
+            <button
+              className="diff-pending-remove"
+              onClick={() => onRemovePending(comment.id)}
+              title="Remove this pending comment"
+            >
+              Remove
+            </button>
+          )}
+        </div>
+        <div className="diff-pending-text">{comment.text}</div>
+      </div>
+    );
+  }
+
+  function renderAnnotation(annotation: DiffLineAnnotation<Meta>): React.ReactNode {
+    if (annotation.metadata?.kind === "pending") {
+      return renderPending(annotation.metadata.comment);
+    }
     const d = draftRef.current;
     if (!d) return null;
     const lineLabel =
@@ -169,16 +217,22 @@ export function CommentableDiff({
     <div className="commentable-diff">
       {confirmation && <div className="diff-comment-confirmation">{confirmation}</div>}
       {files.map((file, i) => {
-        const annotations: DiffLineAnnotation<Meta>[] =
-          draft && draft.fileIndex === i
-            ? [
-                {
-                  side: draft.range.side === "deletions" ? "deletions" : "additions",
-                  lineNumber: Math.max(draft.range.start, draft.range.end),
-                  metadata: { kind: "draft" },
-                },
-              ]
-            : [];
+        const annotations: DiffLineAnnotation<Meta>[] = [];
+        for (const c of pendingComments || []) {
+          if (c.path !== file.name) continue;
+          annotations.push({
+            side: c.side === "deletions" ? "deletions" : "additions",
+            lineNumber: c.endLine,
+            metadata: { kind: "pending", comment: c },
+          });
+        }
+        if (draft && draft.fileIndex === i) {
+          annotations.push({
+            side: draft.range.side === "deletions" ? "deletions" : "additions",
+            lineNumber: Math.max(draft.range.start, draft.range.end),
+            metadata: { kind: "draft" },
+          });
+        }
 
         return (
           <FileDiffWithSelection
@@ -192,7 +246,11 @@ export function CommentableDiff({
           />
         );
       })}
-      <div className="diff-comment-hint">Click a line number (drag for a range) to comment.</div>
+      <div className="diff-comment-hint">
+        {reviewMode
+          ? "Click a line number (drag for a range) to add a comment. They stay pending until you finish the review."
+          : "Click a line number (drag for a range) to comment."}
+      </div>
     </div>
   );
 }
@@ -210,7 +268,7 @@ function FileDiffWithSelection({
   annotations: DiffLineAnnotation<Meta>[];
   selectedLines: SelectedLineRange | null;
   onSelect: (fileIndex: number, path: string, range: SelectedLineRange | null) => void;
-  renderAnnotation: () => React.ReactNode;
+  renderAnnotation: (annotation: DiffLineAnnotation<Meta>) => React.ReactNode;
 }) {
   const options = useMemo(
     () => ({

--- a/src/frontend/components/PrPanel.tsx
+++ b/src/frontend/components/PrPanel.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import type { PrDetails } from "../lib/types";
-import { fetchPr, fetchPrDiff, postPrCommentApi, mergePrApi } from "../lib/api";
-import { CommentableDiff, type CommentTarget } from "./CommentableDiff";
+import { fetchPr, fetchPrDiff, submitPrReviewApi, mergePrApi } from "../lib/api";
+import { CommentableDiff, type CommentTarget, type PendingComment } from "./CommentableDiff";
 import { getCurrentUser } from "./UserPicker";
+
+type ReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
 
 interface Props {
   sessionId: string;
@@ -22,7 +24,13 @@ export function PrPanel({ sessionId, onOpenSession, split }: Props) {
   const [pr, setPr] = useState<PrDetails | null>(null);
   const [diff, setDiff] = useState<PrDiffData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [lastCommentUrl, setLastCommentUrl] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingComment[]>([]);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [reviewEvent, setReviewEvent] = useState<ReviewEvent>("COMMENT");
+  const [summary, setSummary] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  const [reviewDone, setReviewDone] = useState<string | null>(null);
   const [merging, setMerging] = useState(false);
   const [confirmMerge, setConfirmMerge] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
@@ -49,16 +57,53 @@ export function PrPanel({ sessionId, onOpenSession, split }: Props) {
     return () => clearInterval(interval);
   }, [load]);
 
-  async function handlePrComment(target: CommentTarget, text: string) {
-    const result = await postPrCommentApi(sessionId, {
-      text,
-      user: getCurrentUser(),
-      path: target.path,
-      line: target.endLine,
-      startLine: target.startLine !== target.endLine ? target.startLine : undefined,
-      side: target.side === "deletions" ? "LEFT" : "RIGHT",
-    });
-    setLastCommentUrl(result.url || null);
+  // Inline comments don't post one-by-one — they accumulate as pending and ship
+  // together when the reviewer finishes the review (GitHub's native flow).
+  async function handleAddPending(target: CommentTarget, text: string) {
+    setPending((prev) => [
+      ...prev,
+      { ...target, text, id: crypto.randomUUID() },
+    ]);
+    setReviewDone(null);
+  }
+
+  function handleRemovePending(id: string) {
+    setPending((prev) => prev.filter((c) => c.id !== id));
+  }
+
+  async function handleSubmitReview() {
+    if (submitting) return;
+    if (pending.length === 0 && !summary.trim()) {
+      setReviewError("Add a comment or a summary first");
+      return;
+    }
+    setSubmitting(true);
+    setReviewError(null);
+    try {
+      const result = await submitPrReviewApi(sessionId, {
+        user: getCurrentUser(),
+        event: reviewEvent,
+        summary: summary.trim() || undefined,
+        comments: pending.map((c) => ({
+          text: c.text,
+          path: c.path,
+          line: c.endLine,
+          startLine: c.startLine !== c.endLine ? c.startLine : undefined,
+          side: c.side === "deletions" ? "LEFT" : "RIGHT",
+        })),
+      });
+      setPending([]);
+      setSummary("");
+      setReviewOpen(false);
+      setReviewEvent("COMMENT");
+      setReviewDone(result.url || "submitted");
+      setTimeout(() => setReviewDone(null), 6000);
+      await load();
+    } catch (e: any) {
+      setReviewError(e.message || "Failed to submit review");
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   // Two-click confirm guards against accidental merges (this mutates the repo).
@@ -229,20 +274,79 @@ export function PrPanel({ sessionId, onOpenSession, split }: Props) {
         <div className="pr-panel-diff">
         <div className="pr-diff-section">
           <div className="pr-checks-title">
-            Review — comments land on the PR
-            {lastCommentUrl && (
-              <a className="pr-comment-link" href={lastCommentUrl} target="_blank" rel="noopener">
-                last comment ↗
-              </a>
+            Review — comments stay pending until you submit
+            {reviewDone && (
+              reviewDone === "submitted" ? (
+                <span className="pr-comment-link">review submitted ✓</span>
+              ) : (
+                <a className="pr-comment-link" href={reviewDone} target="_blank" rel="noopener">
+                  review submitted ↗
+                </a>
+              )
             )}
           </div>
           <CommentableDiff
             patch={diff.patch}
-            submitLabel="Comment on PR"
-            placeholder={`Review comment — posts on #${diff.number} as an inline comment…`}
-            onSubmit={handlePrComment}
+            submitLabel="Add comment"
+            placeholder={`Comment on #${diff.number} — added to your pending review…`}
+            pendingComments={pending}
+            onRemovePending={handleRemovePending}
+            onSubmit={handleAddPending}
           />
         </div>
+
+        {pending.length > 0 && (
+          <div className="pr-review-bar">
+            <div className="pr-review-bar-row">
+              <span className="pr-review-count">
+                {pending.length} pending comment{pending.length === 1 ? "" : "s"}
+              </span>
+              <button
+                className="pr-review-toggle"
+                onClick={() => setReviewOpen((o) => !o)}
+              >
+                {reviewOpen ? "Hide" : "Finish review"}
+              </button>
+            </div>
+
+            {reviewOpen && (
+              <div className="pr-review-form">
+                <textarea
+                  className="pr-review-summary"
+                  rows={3}
+                  placeholder="Overall review summary (optional)…"
+                  value={summary}
+                  onChange={(e) => setSummary(e.target.value)}
+                />
+                <div className="pr-review-events">
+                  {([
+                    ["COMMENT", "Comment"],
+                    ["APPROVE", "Approve"],
+                    ["REQUEST_CHANGES", "Request changes"],
+                  ] as Array<[ReviewEvent, string]>).map(([key, label]) => (
+                    <button
+                      key={key}
+                      className={`pr-review-event ${reviewEvent === key ? "active" : ""}`}
+                      onClick={() => setReviewEvent(key)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                {reviewError && <div className="diff-comment-error">{reviewError}</div>}
+                <button
+                  className="pr-review-submit"
+                  onClick={handleSubmitReview}
+                  disabled={submitting}
+                >
+                  {submitting
+                    ? "Submitting…"
+                    : `Submit review (${pending.length})`}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
         </div>
       )}
     </div>

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -85,6 +85,32 @@ export async function postPrCommentApi(
   return body as { ok: true; url?: string };
 }
 
+export async function submitPrReviewApi(
+  sessionId: string,
+  payload: {
+    user: string;
+    event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+    summary?: string;
+    comments: Array<{
+      text: string;
+      path: string;
+      line: number;
+      startLine?: number;
+      side?: "RIGHT" | "LEFT";
+      startSide?: "RIGHT" | "LEFT";
+    }>;
+  }
+) {
+  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-review`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+  return body as { ok: true; url?: string };
+}
+
 export async function mergePrApi(
   sessionId: string,
   method: "squash" | "merge" | "rebase" = "squash"

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -1173,6 +1173,137 @@ a {
   padding-bottom: 8px;
 }
 
+/* A saved-but-not-yet-submitted inline comment, shown in-place on the diff. */
+.diff-pending-comment {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 9px 10px;
+  margin: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: var(--sans);
+}
+.diff-pending-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.diff-pending-remove {
+  background: none;
+  border: none;
+  color: var(--text-faint);
+  font-size: 11.5px;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+.diff-pending-remove:hover { color: var(--red); }
+.diff-pending-text {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Floating "you have pending comments" bar — sticks to the bottom of whichever
+   container scrolls the diff (the split drawer's diff pane, or the panel body). */
+.pr-review-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  margin-top: 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.35);
+  padding: 10px 12px;
+  padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pr-review-bar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pr-review-count {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.pr-review-toggle {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 7px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.pr-review-toggle:hover { filter: brightness(1.1); }
+.pr-review-form {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+.pr-review-summary {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  color: var(--text);
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: var(--sans);
+  line-height: 1.45;
+  resize: vertical;
+  outline: none;
+}
+.pr-review-summary:focus { border-color: var(--accent); }
+.pr-review-events {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.pr-review-event {
+  flex: 1 1 auto;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  color: var(--text-dim);
+  padding: 7px 10px;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pr-review-event:hover { color: var(--text); }
+.pr-review-event.active {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border-color: var(--accent);
+  color: var(--text);
+}
+.pr-review-submit {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 7px;
+  padding: 9px 12px;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.pr-review-submit:disabled { opacity: 0.5; cursor: default; }
+.pr-review-submit:not(:disabled):hover { filter: brightness(1.1); }
+
 .pr-diff-section { display: flex; flex-direction: column; gap: 8px; }
 
 .pr-comment-link {
@@ -3126,6 +3257,10 @@ a {
   display: flex;
   flex-direction: column;
   height: 100%;
+  /* The form can outgrow the viewport (especially on phones, where the keyboard
+     shrinks it further) — let it scroll so the Start button is always reachable. */
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .btn-back {
@@ -3967,7 +4102,11 @@ a {
 
   .pr-panel { padding: 10px; }
 
-  .new-session-form { margin: 16px auto; }
+  .new-session-form {
+    margin: 16px auto;
+    /* Clear the home indicator / nav so the Start button isn't flush to the edge. */
+    padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
+  }
 
   .user-gate-card { padding: 22px; }
 }

--- a/src/server/pr-info.ts
+++ b/src/server/pr-info.ts
@@ -125,6 +125,87 @@ export async function postPrComment(
   }
 }
 
+export interface PrReviewComment {
+  path: string;
+  /** Line in the file the comment anchors to (end line of a range). */
+  line: number;
+  side?: "RIGHT" | "LEFT";
+  startLine?: number;
+  startSide?: "RIGHT" | "LEFT";
+  body: string;
+}
+
+export type PrReviewEvent = "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+
+export interface PrReviewInput {
+  event: PrReviewEvent;
+  body?: string;
+  comments: PrReviewComment[];
+}
+
+/**
+ * Submit a single GitHub review bundling all pending inline comments, GitHub's
+ * native review flow (POST .../pulls/{n}/reviews). The whole batch posts at once
+ * with one event (comment / approve / request changes) instead of each inline
+ * comment landing as a loose standalone comment. Audited since approving or
+ * requesting changes affects the PR's merge state.
+ */
+export async function submitPrReview(
+  branch: string,
+  input: PrReviewInput
+): Promise<{ ok: true; url?: string } | { error: string }> {
+  const diff = await getPrDiff(branch);
+  if (!diff) return { error: "No PR found for this branch" };
+  if (!input.comments.length && !input.body?.trim()) {
+    return { error: "Nothing to submit" };
+  }
+
+  const payload = {
+    commit_id: diff.headRefOid,
+    event: input.event,
+    ...(input.body?.trim() ? { body: input.body.trim() } : {}),
+    comments: input.comments.map((c) => ({
+      path: c.path,
+      line: c.line,
+      side: c.side || "RIGHT",
+      ...(c.startLine && c.startLine !== c.line
+        ? { start_line: c.startLine, start_side: c.startSide || c.side || "RIGHT" }
+        : {}),
+      body: c.body,
+    })),
+  };
+
+  return audited(
+    {
+      context: "reviews",
+      action: "pr_review",
+      args: { branch, number: diff.number, event: input.event, comments: input.comments.length },
+    },
+    async () => {
+      const proc = Bun.spawn(
+        ["gh", "api", "-X", "POST", `repos/${REPO}/pulls/${diff.number}/reviews`, "--input", "-"],
+        { stdin: "pipe", stdout: "pipe", stderr: "pipe" }
+      );
+      proc.stdin.write(JSON.stringify(payload));
+      await proc.stdin.end();
+      const [out, err, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      if (code !== 0) return { error: (err || "gh api failed").slice(0, 300) } as const;
+      const url = (() => {
+        try {
+          return JSON.parse(out).html_url as string;
+        } catch {
+          return undefined;
+        }
+      })();
+      return { ok: true, url } as const;
+    }
+  );
+}
+
 export type MergeMethod = "squash" | "merge" | "rebase";
 
 /**


### PR DESCRIPTION
## What

Two fixes to the Reviews feature, both reported on mobile.

### 1. Inline PR comments now batch into a submittable review
Previously every inline comment posted immediately as a loose standalone comment, with no overall review wrapper and nothing surfacing that you had comments in flight. Switched to GitHub's native review flow:

- Comments accumulate as **pending** and render inline on the diff (with a Remove button).
- A **floating sticky bar** appears at the bottom of the diff — *"N pending comments · Finish review"* — expanding to a summary box + event toggle (Comment / Approve / Request changes) + **Submit review (N)**.
- Ships as a single review via `POST /repos/.../pulls/{n}/reviews` (new `submitPrReview` in `pr-info.ts`, audited as `reviews/pr_review`).

### 2. New Session "Start session" button cut off on mobile
`.new-session` was a `height:100%` flex column with no `overflow-y`, so a tall form (worse with the keyboard up) ran off-screen and the Start button couldn't be reached. Now scrolls, with safe-area bottom padding.

## Notes
- `tsc --noEmit` and the frontend bundle pass clean for all changed files.
- Per the hot-reload caveats in CLAUDE.md, the `pr-info.ts` runner-adjacent change needs a real `systemctl restart` (not just `--hot`) to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)