### PR TITLE
backstage: shared-checkout dev workflow + ff-only deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,35 @@
 Default to using Bun instead of Node.js.
 
+## Backstage dev workflow (self-hosting — read this first)
+
+Backstage runs itself: the live server is `bun --hot` from this main checkout
+(`/home/ubuntu/projects/tella-backstage`), so the fastest way to see a change is
+to **edit the main checkout on `master` directly** — `bun --hot` reloads it live.
+Because of that, backstage code sessions do **not** get their own worktree
+(`sharedCheckout` in `src/server/worktree.ts`); they all work in this one shared
+checkout on `master`. That's intentional wild-west iteration. The rules that keep
+it from descending into chaos:
+
+- **Only `add` → `commit` → `push`. Never `git reset --hard`, `git checkout .`,
+  `git revert`, or `git checkout <other-branch>` in the shared checkout.** A reset
+  or branch-switch yanks the working tree out from under the live server *and*
+  every other session — that's the "sessions undoing each other's work" trap. If
+  something looks wrong, inspect and fix forward; don't roll back the shared tree.
+- **`git add <specific files>`, not `git add -A`** — multiple sessions may have
+  uncommitted edits in this tree; only commit your own.
+- **Commit + push frequently.** Un-pushed work is the only thing a sync can't
+  protect (the deploy is now `merge --ff-only`, never `reset --hard`, so it aborts
+  loudly instead of wiping — but push anyway).
+- **Don't `systemctl restart` casually.** Most edits hot-reload. Only runner
+  internals / agent-loop / scheduler changes need a real restart, and a restart
+  drains every session — treat it as a deliberate, announced action. Frontend
+  changes never need it (`kill -USR2 <pid>` or the watcher rebuilds the bundle).
+- Want isolation for a risky/breaking change? Make a worktree by hand and run a
+  second instance on another `PORT` — but note `BACKSTAGE_DEV=1` only swaps the
+  frontend build; it does **not** yet disable the Slack/Linear/Stripe loops,
+  webhook server, or schedulers, so a naive second instance double-sends. (A real
+  isolated dev mode is a future task.)
+
 - Use `bun run backstage.ts` to start the server
 - Server binds to Tailscale IP (100.65.135.7:3850) — not publicly accessible
 - Access at `http://michael:3850/backstage/`

--- a/backstage.ts
+++ b/backstage.ts
@@ -1799,6 +1799,10 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
             } else if (isAsk) {
               // Ask sessions run read-only on the main checkout — no worktree
               wtPath = project.repo;
+            } else if (project.sharedCheckout) {
+              // Backstage: code sessions edit the live main checkout on the
+              // default branch (hot-reloads in the running server). No worktree.
+              wtPath = project.repo;
             } else {
               // Check if worktree exists, create if needed
               const worktrees = await listWorktrees(project.id);
@@ -1821,7 +1825,13 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
                 claudeSessionId: isCodex ? "" : engineSessionId,
                 ...(isCodex && engineSessionId ? { codexThreadId: engineSessionId } : {}),
                 ...(model ? { model } : {}),
-                branch: forkSource ? forkSource.branch || "" : isAsk ? "" : branch,
+                branch: forkSource
+                  ? forkSource.branch || ""
+                  : isAsk
+                    ? ""
+                    : project.sharedCheckout
+                      ? project.defaultBranch
+                      : branch,
                 worktreeDir: wtPath,
                 project: projectForPath(wtPath).id,
                 createdBy: user || "Anonymous",

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,9 +18,19 @@ MAX_DRAIN_WAIT="${MAX_DRAIN_WAIT:-480}"   # wait up to 8 min for idle before for
 
 run_as_ubuntu() { runuser -u ubuntu -- "$@"; }
 
-echo "[deploy] fetching origin, checking out ${TARGET_SHA}"
+echo "[deploy] fetching origin, fast-forwarding to ${TARGET_SHA}"
 run_as_ubuntu git -C "$REPO_DIR" fetch --prune origin
-run_as_ubuntu git -C "$REPO_DIR" reset --hard "$TARGET_SHA"
+# Fast-forward only — never `reset --hard`. The box's checkout is shared, live,
+# and hot-reloading; sessions edit and commit on it directly. A hard reset would
+# silently delete any uncommitted or un-pushed work mid-flight (it bit us before).
+# ff-only advances cleanly when the box is on master and clean, and ABORTS loudly
+# if the checkout diverged or has local edits — surface that, don't destroy it.
+if ! run_as_ubuntu git -C "$REPO_DIR" merge --ff-only "$TARGET_SHA"; then
+  echo "[deploy] ERROR: cannot fast-forward to ${TARGET_SHA}." >&2
+  echo "[deploy] The checkout has local commits or uncommitted changes. On the box:" >&2
+  echo "[deploy]   cd $REPO_DIR && git status   # then commit+push, or stash, then re-run the deploy" >&2
+  exit 1
+fi
 
 # Install deps only when the lockfile/manifest actually changed (fast path otherwise).
 if ! run_as_ubuntu git -C "$REPO_DIR" diff --quiet 'HEAD@{1}' HEAD -- bun.lock package.json 2>/dev/null; then

--- a/src/server/worktree.ts
+++ b/src/server/worktree.ts
@@ -13,11 +13,18 @@ export interface Project {
   repo: string;
   wtPrefix: string;
   defaultBranch: string;
+  // When true, code sessions run directly in the main checkout on the default
+  // branch instead of an isolated worktree. Backstage is self-hosting — the live
+  // server runs `bun --hot` from its main checkout, so editing there is the only
+  // way a change is testable without a second instance. Sessions share one tree
+  // and commit straight to the default branch (see "Backstage dev workflow" in
+  // CLAUDE.md: add → commit → push, never reset/discard the shared repo).
+  sharedCheckout?: boolean;
 }
 
 export const PROJECTS: Record<string, Project> = {
   "tella-fusion": { id: "tella-fusion", repo: TELLA_FUSION, wtPrefix: "tella-fusion", defaultBranch: "main" },
-  backstage: { id: "backstage", repo: "/home/ubuntu/projects/tella-backstage", wtPrefix: "backstage", defaultBranch: "master" },
+  backstage: { id: "backstage", repo: "/home/ubuntu/projects/tella-backstage", wtPrefix: "backstage", defaultBranch: "master", sharedCheckout: true },
 };
 
 export function getProject(id?: string): Project {
@@ -240,6 +247,13 @@ export async function createWorktreeForPrBranch(headRef: string): Promise<string
 
 export async function createWorktree(branch: string, projectId?: string): Promise<string> {
   const project = getProject(projectId);
+
+  // Shared-checkout projects (backstage) don't get a per-session worktree: the
+  // session works in the live main checkout on the default branch so its edits
+  // hot-reload in the running server. No branch is created or switched — every
+  // session stays on the default branch and commits there.
+  if (project.sharedCheckout) return project.repo;
+
   const wtPath = `${WORKTREES_DIR}/${project.wtPrefix}-${branch}`;
 
   await withGitLock(async () => {


### PR DESCRIPTION
Fixes the "we're stepping on each other's toes" problem now that backstage is a session project.

## Why
Backstage is self-hosting: the live server runs `bun --hot` from the main checkout. But code sessions against `project=backstage` got an **isolated worktree** the running server never reads — so a change isn't testable until it's merged to master and the checkout is updated + restarted. Combined with `deploy.sh`'s `git reset --hard`, work got silently wiped and sessions undid each other.

## What
- **`worktree.ts`** — new `sharedCheckout` project flag (on `backstage`). Code sessions for such projects skip the per-session worktree and run in the **main checkout on the default branch**, so edits hot-reload in the live server. Session records `branch=master`.
- **`deploy.sh`** — `git reset --hard` → `git merge --ff-only`. A sync can no longer silently delete uncommitted/un-pushed work; it aborts loudly if the checkout diverged.
- **`CLAUDE.md`** — documents the wild-west rules: only `add`→`commit`→`push`; never `reset`/`revert`/branch-switch the shared tree; commit+push often; restart deliberately.

## Activation (one-time, after merge)
1. Free `master`: a session worktree (`backstage-factorio`) is currently checked out on `master`, which blocks the main checkout from being on it. Move that worktree to its own branch (or close that session), then `git checkout master` in the main checkout.
2. `systemctl restart backstage` so the new session-creation path loads (server-internal change; hot-reload won't propagate it).

After that, new backstage code sessions edit master live — no worktree, no merge-to-see-it loop.

## Not included (deferred, per scope)
A true isolated dev mode (disable Slack/Linear loops + webhook server on a second instance) — `BACKSTAGE_DEV=1` only swaps the frontend build today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)