### PR TITLE
Per-user pinned tabs (server-side, with localStorage migration)

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -21,6 +21,7 @@ import {
 } from "./src/server/agent-runner";
 import type { ImageInput } from "./src/server/claude-runner";
 import type { ActiveRunRecord } from "./src/server/claude-runner";
+import { getPins as getUserPins, setPins as setUserPins } from "./src/server/pins";
 import {
   KNOWN_MODELS,
   getDefaultModel,
@@ -1688,6 +1689,23 @@ const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.
       } catch (e: any) {
         return Response.json({ error: e?.message || "Failed to set default model" }, { status: 400 });
       }
+    }
+
+    // ── Per-user pinned tabs ──
+    // Keyed on the self-selected `user` name (team-internal, not auth). GET reads
+    // a user's pins; PUT replaces them wholesale (the frontend sends the full list
+    // on every toggle and on first-load localStorage migration).
+    if (path === "/backstage/api/pins" && req.method === "GET") {
+      const user = url.searchParams.get("user") || "Anonymous";
+      return Response.json({ pins: getUserPins(user) });
+    }
+
+    if (path === "/backstage/api/pins" && req.method === "PUT") {
+      const body = await req.json().catch(() => null);
+      if (!body || typeof body.user !== "string" || !Array.isArray(body.pins)) {
+        return Response.json({ error: "user (string) and pins (array) are required" }, { status: 400 });
+      }
+      return Response.json({ pins: setUserPins(body.user, body.pins) });
     }
 
     // ── Codex (OpenAI) account pool ──

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -217,6 +217,26 @@ export async function runAutomationApi(id: string) {
   if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
 }
 
+// ── Pins (per-user pinned tabs) ──
+
+export async function fetchPins(user: string): Promise<string[]> {
+  const res = await fetch(`${BASE}/pins?user=${encodeURIComponent(user)}`);
+  if (!res.ok) throw new Error(`Failed to fetch pins: ${res.status}`);
+  const body = await res.json();
+  return Array.isArray(body?.pins) ? body.pins : [];
+}
+
+export async function savePinsApi(user: string, pins: string[]): Promise<string[]> {
+  const res = await fetch(`${BASE}/pins`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user, pins }),
+  });
+  if (!res.ok) throw new Error(`Failed to save pins: ${res.status}`);
+  const body = await res.json();
+  return Array.isArray(body?.pins) ? body.pins : pins;
+}
+
 // ── Wiki ──
 
 export async function fetchWikiTree() {

--- a/src/frontend/lib/pins.ts
+++ b/src/frontend/lib/pins.ts
@@ -1,35 +1,84 @@
-const KEY = "michael-pins";
-const CHANGE_EVENT = "michael-pins-changed";
+// Pinned tabs, stored server-side per user (keyed on the UserPicker name) so
+// they follow you across devices instead of living in one browser. The public
+// API stays synchronous (an in-memory cache) so callers don't change: the cache
+// is hydrated from the server on load and on user switch, and writes are
+// optimistic — update the cache + fire the change event immediately, then PUT.
+import { fetchPins, savePinsApi } from "./api";
+import { getCurrentUser } from "../components/UserPicker";
 
-function read(): string[] {
+const LEGACY_KEY = "michael-pins"; // old per-browser store, migrated once
+const MIGRATED_FLAG = "michael-pins-migrated";
+const CHANGE_EVENT = "michael-pins-changed";
+const USER_CHANGE_EVENT = "michael-user-changed";
+
+let cache: string[] = [];
+let loadedFor: string | null = null;
+
+function emit() {
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+function readLegacy(): string[] {
   try {
-    return JSON.parse(localStorage.getItem(KEY) || "[]");
+    const v = JSON.parse(localStorage.getItem(LEGACY_KEY) || "[]");
+    return Array.isArray(v) ? v.filter((x) => typeof x === "string") : [];
   } catch {
     return [];
   }
 }
 
+// Hydrate the cache for `user`. On first run after the server-side switch, fold
+// this browser's old localStorage pins into the user's server store so nobody
+// loses their pins. Migration is deferred until a real user is picked (never
+// "Anonymous") so legacy pins land on the right account, and runs at most once.
+async function load(user: string) {
+  loadedFor = user;
+  let pins: string[] = [];
+  try {
+    pins = await fetchPins(user);
+  } catch {
+    pins = [];
+  }
+
+  if (user !== "Anonymous" && !localStorage.getItem(MIGRATED_FLAG)) {
+    const legacy = readLegacy();
+    if (legacy.length) {
+      pins = Array.from(new Set([...pins, ...legacy]));
+      try {
+        pins = await savePinsApi(user, pins);
+      } catch {
+        /* keep the merged list in memory even if the write fails */
+      }
+    }
+    localStorage.setItem(MIGRATED_FLAG, "1");
+  }
+
+  // A newer load() (user switched mid-flight) wins.
+  if (loadedFor !== user) return;
+  cache = pins;
+  emit();
+}
+
+void load(getCurrentUser());
+window.addEventListener(USER_CHANGE_EVENT, () => void load(getCurrentUser()));
+
 export function getPins(): string[] {
-  return read();
+  return cache;
 }
 
 export function isPinned(id: string): boolean {
-  return read().includes(id);
+  return cache.includes(id);
 }
 
 export function togglePin(id: string): string[] {
-  const pins = read();
-  const next = pins.includes(id) ? pins.filter((p) => p !== id) : [...pins, id];
-  localStorage.setItem(KEY, JSON.stringify(next));
-  window.dispatchEvent(new Event(CHANGE_EVENT));
+  const next = cache.includes(id) ? cache.filter((p) => p !== id) : [...cache, id];
+  cache = next;
+  emit();
+  void savePinsApi(getCurrentUser(), next).catch(() => {});
   return next;
 }
 
 export function onPinsChanged(handler: () => void): () => void {
   window.addEventListener(CHANGE_EVENT, handler);
-  window.addEventListener("storage", handler);
-  return () => {
-    window.removeEventListener(CHANGE_EVENT, handler);
-    window.removeEventListener("storage", handler);
-  };
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
 }

--- a/src/server/pins.ts
+++ b/src/server/pins.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-user pinned tabs. Each user (the self-selected `backstage-user` name from
+ * the frontend UserPicker — not an auth identity, team-internal only) gets one
+ * JSON file `~/.backstage-pins/<user>.json` of shape `{ pins: string[] }`, where
+ * each entry is a session id. Mirrors the flat-file pattern in models.ts.
+ *
+ * Pins used to live in browser localStorage (per-device, shared by anyone on
+ * that browser); moving them here makes them per-user and synced across devices.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+const HOME = process.env.HOME || "/home/ubuntu";
+const PINS_DIR = `${HOME}/.backstage-pins`;
+
+/** Map a free-form user name to a safe filename; empty/odd input → Anonymous. */
+function sanitizeUser(user: string): string {
+  const cleaned = (user || "").trim().replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
+  return cleaned || "Anonymous";
+}
+
+function fileFor(user: string): string {
+  return `${PINS_DIR}/${sanitizeUser(user)}.json`;
+}
+
+export function getPins(user: string): string[] {
+  try {
+    const f = fileFor(user);
+    if (!existsSync(f)) return [];
+    const raw = JSON.parse(readFileSync(f, "utf8"));
+    return Array.isArray(raw?.pins) ? raw.pins.filter((x: unknown) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Replace a user's pins (de-duped, strings only). Returns the stored list. */
+export function setPins(user: string, pins: unknown): string[] {
+  const clean = Array.from(
+    new Set((Array.isArray(pins) ? pins : []).filter((x): x is string => typeof x === "string"))
+  );
+  try {
+    if (!existsSync(PINS_DIR)) mkdirSync(PINS_DIR, { recursive: true });
+    writeFileSync(fileFor(user), JSON.stringify({ pins: clean }, null, 2));
+  } catch {}
+  return clean;
+}


### PR DESCRIPTION
## What

Pinned tabs were stored in browser `localStorage` (`michael-pins`) — per-device, shared by anyone using that browser, and not synced across a user's devices. This moves them to a **server-side per-user store**, keyed on the existing self-selected `UserPicker` name.

## Changes

- **`src/server/pins.ts`** (new) — flat-file store at `~/.backstage-pins/<user>.json` holding `{ pins: string[] }`, modeled on the `models.ts` pattern. User name is sanitized to a safe filename; empty → `Anonymous`.
- **`backstage.ts`** — `GET /backstage/api/pins?user=<name>` and `PUT /backstage/api/pins` (`{ user, pins }`, replaces wholesale).
- **`src/frontend/lib/api.ts`** — `fetchPins` / `savePinsApi` helpers.
- **`src/frontend/lib/pins.ts`** — now server-backed but keeps the **same synchronous public API** (`getPins`/`isPinned`/`togglePin`/`onPinsChanged`), so `App.tsx` is untouched. An in-memory cache hydrates from the server on load and on user switch; writes are optimistic (update cache + fire change event, then PUT).

## Migration (so existing pins aren't lost)

On first load after this ships, `pins.ts` folds the browser's existing `michael-pins` localStorage entries into the current user's server store (union). It's **deferred until a real user is picked** (never runs as `Anonymous`, so pins land on the right account) and runs **at most once** (guarded by a `michael-pins-migrated` flag).

## Notes / caveats

- The `user` key is the unauthenticated, self-selectable `UserPicker` name (gated only by Tailscale + team network). Fine as a team-internal preference; **not a security boundary**.
- Cross-tab live sync via the `storage` event is dropped (pins are server-side now); tabs still converge on reload / user switch.
- Typecheck: no new errors vs. `origin/master` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)