### PR TITLE
Add right-click tab coloring

### DIFF
--- a/backstage.ts
+++ b/backstage.ts
@@ -4,96 +4,139 @@ import { randomUUIDv7 } from "bun";
 import { mkdirSync, existsSync, writeFileSync, readFileSync, watch } from "fs";
 import homepage from "./src/frontend/index.html";
 import { getAllSessions, deleteSession } from "./src/server/sessions";
-import { parseTranscript, parseTranscriptTail } from "./src/server/jsonl-parser";
-import { getSubagentTranscript } from "./src/server/subagents";
-import { startWatching, stopAllWatchesForClient } from "./src/server/file-watcher";
-import { listWorktrees, createWorktree, removeWorktree, reviveWorktree, sweepArchivedWorktrees, getProject, projectForPath, prepareAttachedWorktree, PROJECTS } from "./src/server/worktree";
-import { STRIPE_CONFIRM_TOOLS, activeRunRecords } from "./src/server/claude-runner";
 import {
-  runAgent,
-  isAgentSessionBusy,
-  cancelAgentRun,
-  steerAgentRun,
-  interruptAndSteerAgentRun,
-  resumeInterruptedRuns,
-  RESUME_CONTINUATION_PROMPT,
-  activeAgentRunCount,
+	parseTranscript,
+	parseTranscriptTail,
+} from "./src/server/jsonl-parser";
+import { getSubagentTranscript } from "./src/server/subagents";
+import {
+	startWatching,
+	stopAllWatchesForClient,
+} from "./src/server/file-watcher";
+import {
+	listWorktrees,
+	createWorktree,
+	removeWorktree,
+	reviveWorktree,
+	sweepArchivedWorktrees,
+	getProject,
+	projectForPath,
+	prepareAttachedWorktree,
+	PROJECTS,
+} from "./src/server/worktree";
+import {
+	STRIPE_CONFIRM_TOOLS,
+	activeRunRecords,
+} from "./src/server/claude-runner";
+import {
+	runAgent,
+	isAgentSessionBusy,
+	cancelAgentRun,
+	steerAgentRun,
+	interruptAndSteerAgentRun,
+	resumeInterruptedRuns,
+	RESUME_CONTINUATION_PROMPT,
+	activeAgentRunCount,
 } from "./src/server/agent-runner";
 import type { ImageInput } from "./src/server/claude-runner";
 import type { ActiveRunRecord } from "./src/server/claude-runner";
-import { getPins as getUserPins, setPins as setUserPins } from "./src/server/pins";
 import {
-  KNOWN_MODELS,
-  getDefaultModel,
-  setDefaultModel,
-  resolveModel,
-  providerFor,
-  modelLabel,
-  formatModelList,
+	getPins as getUserPins,
+	setPins as setUserPins,
+} from "./src/server/pins";
+import {
+	getTabColors as getUserTabColors,
+	setTabColors as setUserTabColors,
+} from "./src/server/tab-colors";
+import {
+	KNOWN_MODELS,
+	getDefaultModel,
+	setDefaultModel,
+	resolveModel,
+	providerFor,
+	modelLabel,
+	formatModelList,
 } from "./src/server/models";
 import {
-  listCodexAccountsPublic,
-  addCodexAccount,
-  removeCodexAccount,
+	listCodexAccountsPublic,
+	addCodexAccount,
+	removeCodexAccount,
 } from "./src/server/codex-accounts";
 import { getSessionDiff, type SessionDiff } from "./src/server/git-diff";
 import { searchRepoFiles } from "./src/server/file-index";
 import { getPreviewStatus, stopPreview } from "./src/server/preview";
 import {
-  registerSessionControl,
-  type SessionState,
-  type SessionSummary,
+	registerSessionControl,
+	type SessionState,
+	type SessionSummary,
 } from "./src/server/session-control";
-import { gitIdentityFor, resolveTeammate } from "./src/server/shared/user-mappings";
+import {
+	gitIdentityFor,
+	resolveTeammate,
+} from "./src/server/shared/user-mappings";
 import { createSessionsMcpServer } from "./src/agents/slack/sessions-tools";
 import { createAdminMcpServer } from "./src/agents/slack/admin-tools";
 import { createHumansMcpServer } from "./src/agents/slack/humans-tools";
 import { createReposMcpServer } from "./src/agents/slack/repos-tools";
 import {
-  initHumanAsks,
-  onSessionIdle as onHumanAsksSessionIdle,
-  registerAsk,
-  awaitBlockingAnswer,
-  cancelAsk,
+	initHumanAsks,
+	onSessionIdle as onHumanAsksSessionIdle,
+	registerAsk,
+	awaitBlockingAnswer,
+	cancelAsk,
 } from "./src/server/human-asks";
-import { getPrDetails, getPrDiff, postPrComment, submitPrReview, mergePr } from "./src/server/pr-info";
 import {
-  listAutomations,
-  getAutomation,
-  createAutomation,
-  updateAutomation,
-  deleteAutomation,
-  runAutomation,
-  isAutomationRunning,
-  startScheduler,
-  getWebhookRoutes,
-  setEventSessionCallback,
-  automationDeniedTools,
-  automationMcpServersByName,
+	getPrDetails,
+	getPrDiff,
+	postPrComment,
+	submitPrReview,
+	mergePr,
+} from "./src/server/pr-info";
+import {
+	listAutomations,
+	getAutomation,
+	createAutomation,
+	updateAutomation,
+	deleteAutomation,
+	runAutomation,
+	isAutomationRunning,
+	startScheduler,
+	getWebhookRoutes,
+	setEventSessionCallback,
+	automationDeniedTools,
+	automationMcpServersByName,
 } from "./src/server/automations";
 import {
-  listActions,
-  getAction,
-  createAction,
-  deleteAction,
-  runAction,
-  introspectScript,
-  ensureSeedActions,
+	listActions,
+	getAction,
+	createAction,
+	deleteAction,
+	runAction,
+	introspectScript,
+	ensureSeedActions,
 } from "./src/server/actions";
 import { getWikiTree, getWikiFile, searchWiki } from "./src/server/wiki";
 import { startPlainArchiveSweep } from "./src/server/plain-archive";
 import { setArchived, archiveOlderThan } from "./src/server/archive";
-import { getConnections, addMcpServer, removeMcpServer } from "./src/server/connections";
 import {
-  listAccountsPublic,
-  addAccount,
-  removeAccount,
-  refreshAllUsage,
-  startUsagePoller,
+	getConnections,
+	addMcpServer,
+	removeMcpServer,
+} from "./src/server/connections";
+import {
+	listAccountsPublic,
+	addAccount,
+	removeAccount,
+	refreshAllUsage,
+	startUsagePoller,
 } from "./src/server/claude-accounts";
 import { startWebhookServer } from "./src/server/webhook-server";
 import type { AgentModule } from "./src/agents/types";
-import type { UnifiedSession, BackstageSessionFile, AttachedRepo } from "./src/server/types";
+import type {
+	UnifiedSession,
+	BackstageSessionFile,
+	AttachedRepo,
+} from "./src/server/types";
 
 const PORT = parseInt(process.env.PORT || "3850");
 const HOST = process.env.HOST || "127.0.0.1";
@@ -123,12 +166,12 @@ const BOOT_ID: string = (g.__bootId ??= crypto.randomUUID());
 const allClients: Set<any> = (g.__allClients ??= new Set());
 
 function broadcastToAll(msg: object) {
-  const payload = JSON.stringify(msg);
-  for (const ws of allClients) {
-    try {
-      ws.send(payload);
-    } catch {}
-  }
+	const payload = JSON.stringify(msg);
+	for (const ws of allClients) {
+		try {
+			ws.send(payload);
+		} catch {}
+	}
 }
 
 // Cache sessions with short TTL
@@ -136,18 +179,21 @@ let sessionsCache: { data: UnifiedSession[]; ts: number } | null = null;
 const CACHE_TTL = 2000;
 
 function getCachedSessions(): UnifiedSession[] {
-  if (sessionsCache && Date.now() - sessionsCache.ts < CACHE_TTL) {
-    return sessionsCache.data;
-  }
-  const data = getAllSessions();
-  // Sessions driven from the web UI run in-process; surface those too
-  for (const s of data) {
-    if (!s.isRunning && isAgentSessionBusy(s.claudeSessionId, s.codexThreadId, s.id)) {
-      s.isRunning = true;
-    }
-  }
-  sessionsCache = { data, ts: Date.now() };
-  return data;
+	if (sessionsCache && Date.now() - sessionsCache.ts < CACHE_TTL) {
+		return sessionsCache.data;
+	}
+	const data = getAllSessions();
+	// Sessions driven from the web UI run in-process; surface those too
+	for (const s of data) {
+		if (
+			!s.isRunning &&
+			isAgentSessionBusy(s.claudeSessionId, s.codexThreadId, s.id)
+		) {
+			s.isRunning = true;
+		}
+	}
+	sessionsCache = { data, ts: Date.now() };
+	return data;
 }
 
 // In-process self-management MCP servers for INTERACTIVE Backstage sessions
@@ -158,49 +204,59 @@ function getCachedSessions(): UnifiedSession[] {
 // sessions — untrusted ticket text must not reach session-control / config
 // tools. Backstage is Tailscale- and team-gated and already exposes all of this
 // through its UI, so interactive users are treated as admin.
-function interactiveMcpServers(user?: string, sessionId?: string): Record<string, unknown> {
-  const createdBy = user || "Backstage";
-  return {
-    "michael-sessions": createSessionsMcpServer({ createdBy, isAdmin: true }),
-    "michael-admin": createAdminMcpServer({
-      channel: "backstage",
-      userId: user || "backstage",
-      isDM: false,
-      isPrivate: false,
-      createdBy,
-      isAdmin: true,
-    }),
-    // Human-in-the-loop: ask a teammate and fold the answer back into this
-    // session. Needs the session id so the answer routes home. Withheld (like
-    // the others) from automation runs — see the runSessionPrompt call site.
-    ...(sessionId
-      ? {
-          "michael-humans": createHumansMcpServer({ sessionId, createdBy, isAdmin: true }),
-          // Cross-repo: attach secondary repos as isolated worktrees.
-          "michael-repos": createReposMcpServer({
-            sessionId,
-            attach: (project, branch) => attachRepo(sessionId, project, branch),
-            snapshot: () => {
-              const s = findSession(sessionId);
-              if (!s) return null;
-              return {
-                primaryProject:
-                  s.project || (s.worktreeDir ? projectForPath(s.worktreeDir).id : "tella-fusion"),
-                branch: s.branch,
-                worktreeDir: s.worktreeDir,
-                attached: s.attachedRepos || [],
-              };
-            },
-            projects: () =>
-              Object.values(PROJECTS).map((p) => ({
-                id: p.id,
-                defaultBranch: p.defaultBranch,
-                sharedCheckout: !!p.sharedCheckout,
-              })),
-          }),
-        }
-      : {}),
-  };
+function interactiveMcpServers(
+	user?: string,
+	sessionId?: string,
+): Record<string, unknown> {
+	const createdBy = user || "Backstage";
+	return {
+		"michael-sessions": createSessionsMcpServer({ createdBy, isAdmin: true }),
+		"michael-admin": createAdminMcpServer({
+			channel: "backstage",
+			userId: user || "backstage",
+			isDM: false,
+			isPrivate: false,
+			createdBy,
+			isAdmin: true,
+		}),
+		// Human-in-the-loop: ask a teammate and fold the answer back into this
+		// session. Needs the session id so the answer routes home. Withheld (like
+		// the others) from automation runs — see the runSessionPrompt call site.
+		...(sessionId
+			? {
+					"michael-humans": createHumansMcpServer({
+						sessionId,
+						createdBy,
+						isAdmin: true,
+					}),
+					// Cross-repo: attach secondary repos as isolated worktrees.
+					"michael-repos": createReposMcpServer({
+						sessionId,
+						attach: (project, branch) => attachRepo(sessionId, project, branch),
+						snapshot: () => {
+							const s = findSession(sessionId);
+							if (!s) return null;
+							return {
+								primaryProject:
+									s.project ||
+									(s.worktreeDir
+										? projectForPath(s.worktreeDir).id
+										: "tella-fusion"),
+								branch: s.branch,
+								worktreeDir: s.worktreeDir,
+								attached: s.attachedRepos || [],
+							};
+						},
+						projects: () =>
+							Object.values(PROJECTS).map((p) => ({
+								id: p.id,
+								defaultBranch: p.defaultBranch,
+								sharedCheckout: !!p.sharedCheckout,
+							})),
+					}),
+				}
+			: {}),
+	};
 }
 
 /**
@@ -210,20 +266,24 @@ function interactiveMcpServers(user?: string, sessionId?: string): Record<string
  * so the prompt stays clean.
  */
 function buildReposNote(session: UnifiedSession): string | undefined {
-  const attached = session.attachedRepos || [];
-  if (!attached.length) return undefined;
-  const primaryProject =
-    session.project || (session.worktreeDir ? projectForPath(session.worktreeDir).id : "tella-fusion");
-  const lines = [
-    "## Repos in this session",
-    "This session spans multiple repos. Each is an isolated git worktree — `cd` into the right one to read or edit its files, and commit/push/open PRs in each repo independently (don't edit another repo's shared main checkout).",
-    `- **${primaryProject}** (primary): ${session.worktreeDir}${session.branch ? ` — branch \`${session.branch}\`` : ""}`,
-  ];
-  for (const r of attached) lines.push(`- **${r.project}**: ${r.dir} — branch \`${r.branch}\``);
-  lines.push(
-    "A file mentioned from an attached repo arrives as `@<project>:<path>` — resolve it under that repo's worktree dir above."
-  );
-  return lines.join("\n");
+	const attached = session.attachedRepos || [];
+	if (!attached.length) return undefined;
+	const primaryProject =
+		session.project ||
+		(session.worktreeDir
+			? projectForPath(session.worktreeDir).id
+			: "tella-fusion");
+	const lines = [
+		"## Repos in this session",
+		"This session spans multiple repos. Each is an isolated git worktree — `cd` into the right one to read or edit its files, and commit/push/open PRs in each repo independently (don't edit another repo's shared main checkout).",
+		`- **${primaryProject}** (primary): ${session.worktreeDir}${session.branch ? ` — branch \`${session.branch}\`` : ""}`,
+	];
+	for (const r of attached)
+		lines.push(`- **${r.project}**: ${r.dir} — branch \`${r.branch}\``);
+	lines.push(
+		"A file mentioned from an attached repo arrives as `@<project>:<path>` — resolve it under that repo's worktree dir above.",
+	);
+	return lines.join("\n");
 }
 
 /**
@@ -233,68 +293,85 @@ function buildReposNote(session: UnifiedSession): string | undefined {
  * when there's no branch to act on.
  */
 function resolvePrTarget(
-  session: UnifiedSession,
-  projectId?: string | null
+	session: UnifiedSession,
+	projectId?: string | null,
 ): { ghRepo: string; branch: string } | null {
-  const primaryProject =
-    session.project || (session.worktreeDir ? projectForPath(session.worktreeDir).id : "tella-fusion");
-  if (!projectId || projectId === primaryProject) {
-    if (!session.branch) return null;
-    return { ghRepo: getProject(primaryProject).ghRepo, branch: session.branch };
-  }
-  const att = (session.attachedRepos || []).find((r) => r.project === projectId);
-  if (!att) return null;
-  return { ghRepo: getProject(att.project).ghRepo, branch: att.branch };
+	const primaryProject =
+		session.project ||
+		(session.worktreeDir
+			? projectForPath(session.worktreeDir).id
+			: "tella-fusion");
+	if (!projectId || projectId === primaryProject) {
+		if (!session.branch) return null;
+		return {
+			ghRepo: getProject(primaryProject).ghRepo,
+			branch: session.branch,
+		};
+	}
+	const att = (session.attachedRepos || []).find(
+		(r) => r.project === projectId,
+	);
+	if (!att) return null;
+	return { ghRepo: getProject(att.project).ghRepo, branch: att.branch };
 }
 
 function findSession(sessionId: string): UnifiedSession | undefined {
-  return getCachedSessions().find((s) => s.id === sessionId);
+	return getCachedSessions().find((s) => s.id === sessionId);
 }
 
 /** Derive the at-a-glance state + control surface for a session (for the MCP). */
 function buildSummary(s: UnifiedSession): SessionSummary {
-  const busyHere = isAgentSessionBusy(s.claudeSessionId, s.codexThreadId, s.id);
-  // External runs (CLI in tmux, another process) show as running via PID but
-  // aren't in our activeRuns — observe-only, can't steer/cancel them.
-  const runningExternal = !!s.isRunning && !busyHere;
-  const pending = pendingAsks.get(s.id);
-  const queuedCount = promptQueues.get(s.id)?.length || 0;
+	const busyHere = isAgentSessionBusy(s.claudeSessionId, s.codexThreadId, s.id);
+	// External runs (CLI in tmux, another process) show as running via PID but
+	// aren't in our activeRuns — observe-only, can't steer/cancel them.
+	const runningExternal = !!s.isRunning && !busyHere;
+	const pending = pendingAsks.get(s.id);
+	const queuedCount = promptQueues.get(s.id)?.length || 0;
 
-  let state: SessionState;
-  if (s.archived) state = "archived";
-  else if (pending) state = "waiting_question";
-  else if (busyHere || s.isRunning) state = "running";
-  else if (queuedCount > 0) state = "queued";
-  else state = "idle";
+	let state: SessionState;
+	if (s.archived) state = "archived";
+	else if (pending) state = "waiting_question";
+	else if (busyHere || s.isRunning) state = "running";
+	else if (queuedCount > 0) state = "queued";
+	else state = "idle";
 
-  return {
-    ...s,
-    state,
-    queuedCount,
-    controllable: !runningExternal,
-    ...(pending
-      ? { pendingQuestion: { questionId: pending.questionId, questions: pending.questions } }
-      : {}),
-  };
+	return {
+		...s,
+		state,
+		queuedCount,
+		controllable: !runningExternal,
+		...(pending
+			? {
+					pendingQuestion: {
+						questionId: pending.questionId,
+						questions: pending.questions,
+					},
+				}
+			: {}),
+	};
 }
 
 function touchBackstageSession(
-  bksId: string,
-  patch: Partial<BackstageSessionFile>
+	bksId: string,
+	patch: Partial<BackstageSessionFile>,
 ): void {
-  const path = `${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`;
-  try {
-    const data: BackstageSessionFile = existsSync(path)
-      ? JSON.parse(readFileSync(path, "utf-8"))
-      : ({} as BackstageSessionFile);
-    writeFileSync(
-      path,
-      JSON.stringify({ ...data, ...patch, lastActivity: new Date().toISOString() }, null, 2)
-    );
-    sessionsCache = null;
-  } catch (e) {
-    console.error(`Failed to update backstage session ${bksId}:`, e);
-  }
+	const path = `${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`;
+	try {
+		const data: BackstageSessionFile = existsSync(path)
+			? JSON.parse(readFileSync(path, "utf-8"))
+			: ({} as BackstageSessionFile);
+		writeFileSync(
+			path,
+			JSON.stringify(
+				{ ...data, ...patch, lastActivity: new Date().toISOString() },
+				null,
+				2,
+			),
+		);
+		sessionsCache = null;
+	} catch (e) {
+		console.error(`Failed to update backstage session ${bksId}:`, e);
+	}
 }
 
 /**
@@ -306,77 +383,82 @@ function touchBackstageSession(
  * the primary project itself are rejected.
  */
 async function attachRepo(
-  sessionId: string,
-  projectId: string,
-  branch?: string
+	sessionId: string,
+	projectId: string,
+	branch?: string,
 ): Promise<{ attached: AttachedRepo; all: AttachedRepo[] }> {
-  const session = findSession(sessionId);
-  if (!session) throw new Error("Session not found");
-  if (session.mode === "ask") throw new Error("Can't attach a repo to an Ask (read-only) session");
-  if (!PROJECTS[projectId]) throw new Error(`Unknown project "${projectId}"`);
-  if (session.project === projectId) throw new Error(`${projectId} is this session's primary repo`);
+	const session = findSession(sessionId);
+	if (!session) throw new Error("Session not found");
+	if (session.mode === "ask")
+		throw new Error("Can't attach a repo to an Ask (read-only) session");
+	if (!PROJECTS[projectId]) throw new Error(`Unknown project "${projectId}"`);
+	if (session.project === projectId)
+		throw new Error(`${projectId} is this session's primary repo`);
 
-  const effectiveBranch = (branch || session.branch || "").trim();
-  if (!effectiveBranch) {
-    throw new Error("No branch to attach on — pass a branch name");
-  }
+	const effectiveBranch = (branch || session.branch || "").trim();
+	if (!effectiveBranch) {
+		throw new Error("No branch to attach on — pass a branch name");
+	}
 
-  const attached = await prepareAttachedWorktree(projectId, effectiveBranch);
-  const existing = (session.attachedRepos || []).filter((r) => r.project !== projectId);
-  const all = [...existing, attached];
-  touchBackstageSession(sessionId, { attachedRepos: all });
-  return { attached, all };
+	const attached = await prepareAttachedWorktree(projectId, effectiveBranch);
+	const existing = (session.attachedRepos || []).filter(
+		(r) => r.project !== projectId,
+	);
+	const all = [...existing, attached];
+	touchBackstageSession(sessionId, { attachedRepos: all });
+	return { attached, all };
 }
 
 // WebSocket client state
 interface WSClientData {
-  watchingSessionId: string | null;
-  user: string | null;
+	watchingSessionId: string | null;
+	user: string | null;
 }
 
 // sessionId → sockets currently viewing that session (collaboration fan-out)
-const sessionWatchers: Map<string, Set<any>> = (g.__sessionWatchers ??= new Map());
+const sessionWatchers: Map<string, Set<any>> = (g.__sessionWatchers ??=
+	new Map());
 
 function joinSession(ws: any, sessionId: string) {
-  let set = sessionWatchers.get(sessionId);
-  if (!set) {
-    set = new Set();
-    sessionWatchers.set(sessionId, set);
-  }
-  set.add(ws);
-  broadcastPresence(sessionId);
+	let set = sessionWatchers.get(sessionId);
+	if (!set) {
+		set = new Set();
+		sessionWatchers.set(sessionId, set);
+	}
+	set.add(ws);
+	broadcastPresence(sessionId);
 }
 
 function leaveSession(ws: any) {
-  const sessionId = ws.data?.watchingSessionId;
-  if (!sessionId) return;
-  const set = sessionWatchers.get(sessionId);
-  if (set) {
-    set.delete(ws);
-    if (set.size === 0) sessionWatchers.delete(sessionId);
-    else broadcastPresence(sessionId);
-  }
-  ws.data.watchingSessionId = null;
+	const sessionId = ws.data?.watchingSessionId;
+	if (!sessionId) return;
+	const set = sessionWatchers.get(sessionId);
+	if (set) {
+		set.delete(ws);
+		if (set.size === 0) sessionWatchers.delete(sessionId);
+		else broadcastPresence(sessionId);
+	}
+	ws.data.watchingSessionId = null;
 }
 
 function broadcastToSession(sessionId: string, msg: object, except?: any) {
-  const set = sessionWatchers.get(sessionId);
-  if (!set) return;
-  const payload = JSON.stringify(msg);
-  for (const ws of set) {
-    if (ws === except) continue;
-    try {
-      ws.send(payload);
-    } catch {}
-  }
+	const set = sessionWatchers.get(sessionId);
+	if (!set) return;
+	const payload = JSON.stringify(msg);
+	for (const ws of set) {
+		if (ws === except) continue;
+		try {
+			ws.send(payload);
+		} catch {}
+	}
 }
 
 function broadcastPresence(sessionId: string) {
-  const set = sessionWatchers.get(sessionId);
-  const viewers = set
-    ? Array.from(set, (ws: any) => ws.data?.user || "Anonymous")
-    : [];
-  broadcastToSession(sessionId, { type: "presence", sessionId, viewers });
+	const set = sessionWatchers.get(sessionId);
+	const viewers = set
+		? Array.from(set, (ws: any) => ws.data?.user || "Anonymous")
+		: [];
+	broadcastToSession(sessionId, { type: "presence", sessionId, viewers });
 }
 
 // Interactive AskUserQuestion: questions broadcast to session watchers, answered
@@ -387,16 +469,16 @@ function broadcastPresence(sessionId: string) {
 const ASK_UI_TIMEOUT_MS = 4 * 60 * 1000;
 
 interface AskQuestionInput {
-  question: string;
-  header?: string;
-  options?: Array<{ label: string; description?: string }>;
-  multiSelect?: boolean;
+	question: string;
+	header?: string;
+	options?: Array<{ label: string; description?: string }>;
+	multiSelect?: boolean;
 }
 
 interface PendingAsk {
-  questionId: string;
-  questions: unknown[];
-  resolve: (answers: Record<string, string> | null) => void;
+	questionId: string;
+	questions: unknown[];
+	resolve: (answers: Record<string, string> | null) => void;
 }
 const pendingAsks: Map<string, PendingAsk> = (g.__pendingAsks ??= new Map());
 
@@ -404,145 +486,159 @@ const pendingAsks: Map<string, PendingAsk> = (g.__pendingAsks ??= new Map());
 // buttons are only offered when there's exactly one question (the human-asks card
 // carries one option set); multi-question asks fall back to a free-text reply.
 function askToSlackPrompt(questions: AskQuestionInput[]): {
-  question: string;
-  options?: string[];
+	question: string;
+	options?: string[];
 } {
-  if (questions.length === 1) {
-    const q = questions[0];
-    const text = q.header ? `*${q.header}* — ${q.question}` : q.question;
-    return { question: text, options: q.options?.map((o) => o.label) };
-  }
-  const text = questions
-    .map((q, i) => `${i + 1}. ${q.header ? `*${q.header}* — ` : ""}${q.question}`)
-    .join("\n");
-  return { question: text };
+	if (questions.length === 1) {
+		const q = questions[0];
+		const text = q.header ? `*${q.header}* — ${q.question}` : q.question;
+		return { question: text, options: q.options?.map((o) => o.label) };
+	}
+	const text = questions
+		.map(
+			(q, i) => `${i + 1}. ${q.header ? `*${q.header}* — ` : ""}${q.question}`,
+		)
+		.join("\n");
+	return { question: text };
 }
 
 // A Slack reply is a single string; apply it as the answer to every question so
 // the AskUserQuestion result has a value for each key it expects.
 function slackAnswerToAnswers(
-  questions: AskQuestionInput[],
-  answer: string
+	questions: AskQuestionInput[],
+	answer: string,
 ): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const q of questions) out[q.question] = answer;
-  return out;
+	const out: Record<string, string> = {};
+	for (const q of questions) out[q.question] = answer;
+	return out;
 }
 
 function makeAskHandler(sessionId: string) {
-  return async (
-    input: Record<string, unknown>
-  ): Promise<
-    | { behavior: "allow"; updatedInput: Record<string, unknown> }
-    | { behavior: "deny"; message: string }
-  > => {
-    const questions = input.questions as AskQuestionInput[] | undefined;
-    if (!questions || questions.length === 0) {
-      return { behavior: "allow", updatedInput: input };
-    }
+	return async (
+		input: Record<string, unknown>,
+	): Promise<
+		| { behavior: "allow"; updatedInput: Record<string, unknown> }
+		| { behavior: "deny"; message: string }
+	> => {
+		const questions = input.questions as AskQuestionInput[] | undefined;
+		if (!questions || questions.length === 0) {
+			return { behavior: "allow", updatedInput: input };
+		}
 
-    const questionId = crypto.randomUUID();
-    let settled = false;
-    let escalatedAskId: string | null = null;
+		const questionId = crypto.randomUUID();
+		let settled = false;
+		let escalatedAskId: string | null = null;
 
-    const answers = await new Promise<Record<string, string> | null>((resolve) => {
-      const finish = (a: Record<string, string> | null) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeoutId);
-        pendingAsks.delete(sessionId);
-        // If the web UI answered after we'd already pinged Slack, retract the
-        // Slack ask so the teammate isn't left answering a moot question.
-        if (escalatedAskId) cancelAsk(escalatedAskId);
-        resolve(a);
-      };
+		const answers = await new Promise<Record<string, string> | null>(
+			(resolve) => {
+				const finish = (a: Record<string, string> | null) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timeoutId);
+					pendingAsks.delete(sessionId);
+					// If the web UI answered after we'd already pinged Slack, retract the
+					// Slack ask so the teammate isn't left answering a moot question.
+					if (escalatedAskId) cancelAsk(escalatedAskId);
+					resolve(a);
+				};
 
-      // No UI answer in time → ask the original prompter over Slack and keep
-      // blocking on their reply (the UI question stays live in parallel).
-      const timeoutId = setTimeout(() => {
-        void escalateAskToSlack(sessionId, questions).then((esc) => {
-          if (settled) {
-            // UI answered in the race window — undo the just-created ask.
-            if (esc) cancelAsk(esc.askId);
-            return;
-          }
-          if (!esc) {
-            // No teammate to ask (e.g. automation-owned) — fall back to deny.
-            finish(null);
-            return;
-          }
-          escalatedAskId = esc.askId;
-          void awaitBlockingAnswer(esc.askId).then((slackAnswer) => {
-            if (slackAnswer == null) {
-              finish(null);
-              return;
-            }
-            // The answer folds into the AskUserQuestion tool result (the agent
-            // continues), but that's invisible in the UI — surface it as an
-            // attributed bubble so the human sees their Slack reply land, the
-            // same way the async human-asks path does.
-            broadcastToSession(sessionId, {
-              type: "notice",
-              message: `💬 **${esc.personName}** answered (via Slack): ${slackAnswer}`,
-            });
-            finish(slackAnswerToAnswers(questions, slackAnswer));
-          });
-        });
-      }, ASK_UI_TIMEOUT_MS);
+				// No UI answer in time → ask the original prompter over Slack and keep
+				// blocking on their reply (the UI question stays live in parallel).
+				const timeoutId = setTimeout(() => {
+					void escalateAskToSlack(sessionId, questions).then((esc) => {
+						if (settled) {
+							// UI answered in the race window — undo the just-created ask.
+							if (esc) cancelAsk(esc.askId);
+							return;
+						}
+						if (!esc) {
+							// No teammate to ask (e.g. automation-owned) — fall back to deny.
+							finish(null);
+							return;
+						}
+						escalatedAskId = esc.askId;
+						void awaitBlockingAnswer(esc.askId).then((slackAnswer) => {
+							if (slackAnswer == null) {
+								finish(null);
+								return;
+							}
+							// The answer folds into the AskUserQuestion tool result (the agent
+							// continues), but that's invisible in the UI — surface it as an
+							// attributed bubble so the human sees their Slack reply land, the
+							// same way the async human-asks path does.
+							broadcastToSession(sessionId, {
+								type: "notice",
+								message: `💬 **${esc.personName}** answered (via Slack): ${slackAnswer}`,
+							});
+							finish(slackAnswerToAnswers(questions, slackAnswer));
+						});
+					});
+				}, ASK_UI_TIMEOUT_MS);
 
-      pendingAsks.set(sessionId, {
-        questionId,
-        questions,
-        resolve: (a) => finish(a),
-      });
-      broadcastToSession(sessionId, { type: "ask_question", sessionId, questionId, questions });
-    });
+				pendingAsks.set(sessionId, {
+					questionId,
+					questions,
+					resolve: (a) => finish(a),
+				});
+				broadcastToSession(sessionId, {
+					type: "ask_question",
+					sessionId,
+					questionId,
+					questions,
+				});
+			},
+		);
 
-    broadcastToSession(sessionId, { type: "ask_resolved", sessionId, questionId });
+		broadcastToSession(sessionId, {
+			type: "ask_resolved",
+			sessionId,
+			questionId,
+		});
 
-    if (!answers) {
-      return {
-        behavior: "deny",
-        message:
-          "Nobody answered in time (web or Slack). Proceed with your best judgment and clearly note the open question and the assumption you made.",
-      };
-    }
-    return { behavior: "allow", updatedInput: { ...input, answers } };
-  };
+		if (!answers) {
+			return {
+				behavior: "deny",
+				message:
+					"Nobody answered in time (web or Slack). Proceed with your best judgment and clearly note the open question and the assumption you made.",
+			};
+		}
+		return { behavior: "allow", updatedInput: { ...input, answers } };
+	};
 }
 
 // Escalate an unanswered AskUserQuestion to the session's original prompter over
 // Slack. Returns the human-ask id (await its blocking answer) + who we asked, or
 // null when we can't resolve a teammate. Best-effort: never throws into the handler.
 async function escalateAskToSlack(
-  sessionId: string,
-  questions: AskQuestionInput[]
+	sessionId: string,
+	questions: AskQuestionInput[],
 ): Promise<{ askId: string; personName: string } | null> {
-  try {
-    const session = findSession(sessionId);
-    const person = resolveTeammate(session?.startedBy ?? null);
-    if (!person) return null;
+	try {
+		const session = findSession(sessionId);
+		const person = resolveTeammate(session?.startedBy ?? null);
+		if (!person) return null;
 
-    const { question, options } = askToSlackPrompt(questions);
-    const ask = registerAsk({
-      sessionId,
-      createdBy: session?.startedBy || "Michael",
-      person,
-      question,
-      context: "_Nobody picked this up in Backstage within 4 minutes, so I'm bringing it to you._",
-      options,
-      mode: "block",
-      deliver: "now",
-    });
-    broadcastToSession(sessionId, {
-      type: "notice",
-      message: `No answer in Backstage — asked ${person.name} over Slack.`,
-    });
-    return { askId: ask.id, personName: person.name };
-  } catch (e) {
-    console.error("[ask] Slack escalation failed:", e);
-    return null;
-  }
+		const { question, options } = askToSlackPrompt(questions);
+		const ask = registerAsk({
+			sessionId,
+			createdBy: session?.startedBy || "Michael",
+			person,
+			question,
+			context:
+				"_Nobody picked this up in Backstage within 4 minutes, so I'm bringing it to you._",
+			options,
+			mode: "block",
+			deliver: "now",
+		});
+		broadcastToSession(sessionId, {
+			type: "notice",
+			message: `No answer in Backstage — asked ${person.name} over Slack.`,
+		});
+		return { askId: ask.id, personName: person.name };
+	} catch (e) {
+		console.error("[ask] Slack escalation failed:", e);
+		return null;
+	}
 }
 
 // Messages sent while a run is in flight queue up and deliver afterwards,
@@ -555,49 +651,53 @@ const promptQueues: Map<string, QueueItem[]> = (g.__promptQueues ??= new Map());
 // their turn lands they're invisible on reload, so we keep a display-only
 // receipt here: shown as "folded in" in the UI and reconciled away once the real
 // transcript entry appears. Cleared when the run finishes (or is cancelled).
-const steeredReceipts: Map<string, QueueItem[]> = (g.__steeredReceipts ??= new Map());
+const steeredReceipts: Map<string, QueueItem[]> = (g.__steeredReceipts ??=
+	new Map());
 
 // Both maps are persisted to disk so a real restart/crash (not just a hot
 // reload, which keeps the globalThis maps) doesn't silently drop queued or
 // just-steered messages. Restored + re-drained on boot (restorePromptQueues).
 const QUEUE_STORE = `${BACKSTAGE_SESSIONS_DIR}/prompt-queues.json`;
 function persistQueues(): void {
-  try {
-    const entries = (m: Map<string, QueueItem[]>) =>
-      Object.fromEntries([...m].filter(([, v]) => v.length > 0));
-    writeFileSync(
-      QUEUE_STORE,
-      JSON.stringify({ queued: entries(promptQueues), steered: entries(steeredReceipts) })
-    );
-  } catch (e) {
-    console.error("[queue] Failed to persist prompt queues:", e);
-  }
+	try {
+		const entries = (m: Map<string, QueueItem[]>) =>
+			Object.fromEntries([...m].filter(([, v]) => v.length > 0));
+		writeFileSync(
+			QUEUE_STORE,
+			JSON.stringify({
+				queued: entries(promptQueues),
+				steered: entries(steeredReceipts),
+			}),
+		);
+	} catch (e) {
+		console.error("[queue] Failed to persist prompt queues:", e);
+	}
 }
 
 /** Append a message to a session's drainable queue and persist + broadcast. */
 function enqueuePrompt(sessionId: string, item: QueueItem): void {
-  const queue = promptQueues.get(sessionId) || [];
-  queue.push(item);
-  promptQueues.set(sessionId, queue);
-  persistQueues();
-  broadcastQueue(sessionId);
+	const queue = promptQueues.get(sessionId) || [];
+	queue.push(item);
+	promptQueues.set(sessionId, queue);
+	persistQueues();
+	broadcastQueue(sessionId);
 }
 
 /** Record a steered message as a visible receipt until its run finishes. */
 function recordSteer(sessionId: string, item: QueueItem): void {
-  const list = steeredReceipts.get(sessionId) || [];
-  list.push(item);
-  steeredReceipts.set(sessionId, list);
-  persistQueues();
-  broadcastQueue(sessionId);
+	const list = steeredReceipts.get(sessionId) || [];
+	list.push(item);
+	steeredReceipts.set(sessionId, list);
+	persistQueues();
+	broadcastQueue(sessionId);
 }
 
 /** Clear a session's steer receipts once the run that owned them is done. */
 function clearSteerReceipts(sessionId: string): void {
-  if (!steeredReceipts.has(sessionId)) return;
-  steeredReceipts.delete(sessionId);
-  persistQueues();
-  broadcastQueue(sessionId);
+	if (!steeredReceipts.has(sessionId)) return;
+	steeredReceipts.delete(sessionId);
+	persistQueues();
+	broadcastQueue(sessionId);
 }
 
 /**
@@ -610,33 +710,38 @@ function clearSteerReceipts(sessionId: string): void {
  * watcher waits it out instead of starting a colliding run.
  */
 function restorePromptQueues(): void {
-  if (!existsSync(QUEUE_STORE)) return;
-  let data: { queued?: Record<string, QueueItem[]>; steered?: Record<string, QueueItem[]> };
-  try {
-    data = JSON.parse(readFileSync(QUEUE_STORE, "utf-8"));
-  } catch (e) {
-    console.error("[queue] Failed to read persisted queues:", e);
-    return;
-  }
-  const merged = new Map<string, QueueItem[]>();
-  for (const [id, items] of Object.entries(data.queued || {})) {
-    if (items?.length) merged.set(id, [...items]);
-  }
-  for (const [id, items] of Object.entries(data.steered || {})) {
-    if (items?.length) merged.set(id, [...(merged.get(id) || []), ...items]);
-  }
-  steeredReceipts.clear();
-  let restored = 0;
-  for (const [id, items] of merged) {
-    if (!findSession(id)) continue; // session no longer exists — drop
-    promptQueues.set(id, items);
-    restored += items.length;
-    watchExternalRunAndDrain(id); // drains once idle; waits out a resumed run
-  }
-  persistQueues();
-  if (restored > 0) {
-    console.log(`[queue] Restored ${restored} queued message(s) from before restart`);
-  }
+	if (!existsSync(QUEUE_STORE)) return;
+	let data: {
+		queued?: Record<string, QueueItem[]>;
+		steered?: Record<string, QueueItem[]>;
+	};
+	try {
+		data = JSON.parse(readFileSync(QUEUE_STORE, "utf-8"));
+	} catch (e) {
+		console.error("[queue] Failed to read persisted queues:", e);
+		return;
+	}
+	const merged = new Map<string, QueueItem[]>();
+	for (const [id, items] of Object.entries(data.queued || {})) {
+		if (items?.length) merged.set(id, [...items]);
+	}
+	for (const [id, items] of Object.entries(data.steered || {})) {
+		if (items?.length) merged.set(id, [...(merged.get(id) || []), ...items]);
+	}
+	steeredReceipts.clear();
+	let restored = 0;
+	for (const [id, items] of merged) {
+		if (!findSession(id)) continue; // session no longer exists — drop
+		promptQueues.set(id, items);
+		restored += items.length;
+		watchExternalRunAndDrain(id); // drains once idle; waits out a resumed run
+	}
+	persistQueues();
+	if (restored > 0) {
+		console.log(
+			`[queue] Restored ${restored} queued message(s) from before restart`,
+		);
+	}
 }
 
 // ── Wake-all-active-sessions on restart ──────────────────────────────────────
@@ -653,54 +758,73 @@ const RESUME_SNAPSHOT_PATH = `${BACKSTAGE_SESSIONS_DIR}/active-at-shutdown.json`
 /** Capture the sessions with an in-flight run, for boot-time wake-up. Called at
  *  the very start of graceful shutdown, before the drain empties the journal. */
 function snapshotActiveSessions(): void {
-  try {
-    const records = activeRunRecords();
-    if (records.length === 0) {
-      if (existsSync(RESUME_SNAPSHOT_PATH)) writeFileSync(RESUME_SNAPSHOT_PATH, "[]");
-      return;
-    }
-    writeFileSync(RESUME_SNAPSHOT_PATH, JSON.stringify(records));
-    console.log(`[resume] Snapshotted ${records.length} active session(s) for wake-up on restart`);
-  } catch (e) {
-    console.error("[resume] Failed to snapshot active sessions:", e);
-  }
+	try {
+		const records = activeRunRecords();
+		if (records.length === 0) {
+			if (existsSync(RESUME_SNAPSHOT_PATH))
+				writeFileSync(RESUME_SNAPSHOT_PATH, "[]");
+			return;
+		}
+		writeFileSync(RESUME_SNAPSHOT_PATH, JSON.stringify(records));
+		console.log(
+			`[resume] Snapshotted ${records.length} active session(s) for wake-up on restart`,
+		);
+	} catch (e) {
+		console.error("[resume] Failed to snapshot active sessions:", e);
+	}
 }
 
 /** Wake sessions that were active at the last graceful shutdown but finished
  *  their turn during the drain (so they weren't in the journal to resume).
  *  `alreadyResumed` are the bksSessionIds the journal resume already handled. */
 function resumeDrainedSessions(alreadyResumed: Set<string>): void {
-  let records: ActiveRunRecord[] = [];
-  try {
-    if (!existsSync(RESUME_SNAPSHOT_PATH)) return;
-    records = JSON.parse(readFileSync(RESUME_SNAPSHOT_PATH, "utf-8"));
-  } catch (e) {
-    console.error("[resume] Failed to read active-session snapshot:", e);
-    return;
-  }
-  // Consume the snapshot so the next (non-graceful) boot doesn't replay it.
-  try {
-    writeFileSync(RESUME_SNAPSHOT_PATH, "[]");
-  } catch {}
+	let records: ActiveRunRecord[] = [];
+	try {
+		if (!existsSync(RESUME_SNAPSHOT_PATH)) return;
+		records = JSON.parse(readFileSync(RESUME_SNAPSHOT_PATH, "utf-8"));
+	} catch (e) {
+		console.error("[resume] Failed to read active-session snapshot:", e);
+		return;
+	}
+	// Consume the snapshot so the next (non-graceful) boot doesn't replay it.
+	try {
+		writeFileSync(RESUME_SNAPSHOT_PATH, "[]");
+	} catch {}
 
-  let woken = 0;
-  for (const r of records) {
-    const id = r.bksSessionId;
-    if (!id || alreadyResumed.has(id)) continue; // journal already resumed it
-    if (r.kind?.startsWith("github-")) continue; // github agent owns its recovery
-    const session = findSession(id);
-    // Only interactive backstage sessions — never re-trigger automations/loops,
-    // which are one-shot and would re-run their whole task.
-    if (!session || session.source !== "backstage" || session.automation) continue;
-    if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) continue;
-    if (providerFor(session.model) === "claude" && !session.claudeSessionId) continue;
-    woken++;
-    console.log(`[resume] Waking session ${id} that finished its turn during the drain`);
-    void runSessionPromptAndDrain(id, RESUME_CONTINUATION_PROMPT, "system (restart)").catch((e) =>
-      console.error(`[resume] Wake failed for ${id}:`, e)
-    );
-  }
-  if (woken > 0) console.log(`[resume] Woke ${woken} drained session(s) from before restart`);
+	let woken = 0;
+	for (const r of records) {
+		const id = r.bksSessionId;
+		if (!id || alreadyResumed.has(id)) continue; // journal already resumed it
+		if (r.kind?.startsWith("github-")) continue; // github agent owns its recovery
+		const session = findSession(id);
+		// Only interactive backstage sessions — never re-trigger automations/loops,
+		// which are one-shot and would re-run their whole task.
+		if (!session || session.source !== "backstage" || session.automation)
+			continue;
+		if (
+			isAgentSessionBusy(
+				session.claudeSessionId,
+				session.codexThreadId,
+				session.id,
+			)
+		)
+			continue;
+		if (providerFor(session.model) === "claude" && !session.claudeSessionId)
+			continue;
+		woken++;
+		console.log(
+			`[resume] Waking session ${id} that finished its turn during the drain`,
+		);
+		void runSessionPromptAndDrain(
+			id,
+			RESUME_CONTINUATION_PROMPT,
+			"system (restart)",
+		).catch((e) => console.error(`[resume] Wake failed for ${id}:`, e));
+	}
+	if (woken > 0)
+		console.log(
+			`[resume] Woke ${woken} drained session(s) from before restart`,
+		);
 }
 
 // Loaded agents (Plain/Linear/Slack/Stripe/…). Module-scoped because request
@@ -709,48 +833,51 @@ function resumeDrainedSessions(alreadyResumed: Set<string>): void {
 let agents: AgentModule[] = (g.__agents as AgentModule[] | undefined) ?? [];
 
 function broadcastQueue(sessionId: string) {
-  broadcastToSession(sessionId, {
-    type: "queue_update",
-    sessionId,
-    queued: promptQueues.get(sessionId) || [],
-    steered: steeredReceipts.get(sessionId) || [],
-  });
+	broadcastToSession(sessionId, {
+		type: "queue_update",
+		sessionId,
+		queued: promptQueues.get(sessionId) || [],
+		steered: steeredReceipts.get(sessionId) || [],
+	});
 }
 
 async function drainQueue(sessionId: string): Promise<void> {
-  let queue;
-  while ((queue = promptQueues.get(sessionId)) && queue.length > 0) {
-    const batch = queue.splice(0, queue.length);
-    if (queue.length === 0) promptQueues.delete(sessionId);
-    persistQueues();
-    broadcastQueue(sessionId);
-    const combined = batch
-      .map((m) => (batch.length > 1 && m.user ? `[${m.user}] ${m.content}` : m.content))
-      .join("\n\n");
-    await runSessionPrompt(sessionId, combined, batch[0].user);
-  }
+	let queue;
+	while ((queue = promptQueues.get(sessionId)) && queue.length > 0) {
+		const batch = queue.splice(0, queue.length);
+		if (queue.length === 0) promptQueues.delete(sessionId);
+		persistQueues();
+		broadcastQueue(sessionId);
+		const combined = batch
+			.map((m) =>
+				batch.length > 1 && m.user ? `[${m.user}] ${m.content}` : m.content,
+			)
+			.join("\n\n");
+		await runSessionPrompt(sessionId, combined, batch[0].user);
+	}
 }
 
 async function runSessionPromptAndDrain(
-  sessionId: string,
-  content: string,
-  user?: string,
-  images?: ImageInput[]
+	sessionId: string,
+	content: string,
+	user?: string,
+	images?: ImageInput[],
 ): Promise<void> {
-  await runSessionPrompt(sessionId, content, user, images);
-  await drainQueue(sessionId);
+	await runSessionPrompt(sessionId, content, user, images);
+	await drainQueue(sessionId);
 }
 
 /** Decode composer `data:<mediatype>;base64,<data>` URLs into runner ImageInputs. */
 function parseImageDataUrls(urls?: unknown): ImageInput[] | undefined {
-  if (!Array.isArray(urls)) return undefined;
-  const out: ImageInput[] = [];
-  for (const u of urls) {
-    if (typeof u !== "string") continue;
-    const m = u.match(/^data:([^;]+);base64,(.+)$/s);
-    if (m && m[1].startsWith("image/")) out.push({ mediaType: m[1], data: m[2] });
-  }
-  return out.length ? out : undefined;
+	if (!Array.isArray(urls)) return undefined;
+	const out: ImageInput[] = [];
+	for (const u of urls) {
+		if (typeof u !== "string") continue;
+		const m = u.match(/^data:([^;]+);base64,(.+)$/s);
+		if (m && m[1].startsWith("image/"))
+			out.push({ mediaType: m[1], data: m[2] });
+	}
+	return out.length ? out : undefined;
 }
 
 // Messages queued while a run we didn't start is in flight (Slack runs, CLI
@@ -758,192 +885,224 @@ function parseImageDataUrls(urls?: unknown): ImageInput[] | undefined {
 // busy state and deliver the queue once the external run finishes.
 const drainWatchers: Set<string> = (g.__drainWatchers ??= new Set());
 function watchExternalRunAndDrain(sessionId: string): void {
-  if (drainWatchers.has(sessionId)) return;
-  drainWatchers.add(sessionId);
-  const timer = setInterval(async () => {
-    const session = findSession(sessionId);
-    if (!session || !(promptQueues.get(sessionId) || []).length) {
-      clearInterval(timer);
-      drainWatchers.delete(sessionId);
-      return;
-    }
-    if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) return;
-    clearInterval(timer);
-    drainWatchers.delete(sessionId);
-    try {
-      await drainQueue(sessionId);
-    } catch (e) {
-      console.error(`[queue] Drain after external run failed for ${sessionId}:`, e);
-    }
-  }, 3000);
+	if (drainWatchers.has(sessionId)) return;
+	drainWatchers.add(sessionId);
+	const timer = setInterval(async () => {
+		const session = findSession(sessionId);
+		if (!session || !(promptQueues.get(sessionId) || []).length) {
+			clearInterval(timer);
+			drainWatchers.delete(sessionId);
+			return;
+		}
+		if (
+			isAgentSessionBusy(
+				session.claudeSessionId,
+				session.codexThreadId,
+				session.id,
+			)
+		)
+			return;
+		clearInterval(timer);
+		drainWatchers.delete(sessionId);
+		try {
+			await drainQueue(sessionId);
+		} catch (e) {
+			console.error(
+				`[queue] Drain after external run failed for ${sessionId}:`,
+				e,
+			);
+		}
+	}, 3000);
 }
 
 /** Run a prompt against an existing session, broadcasting to all watchers. */
 async function runSessionPrompt(
-  sessionId: string,
-  content: string,
-  user?: string,
-  images?: ImageInput[]
+	sessionId: string,
+	content: string,
+	user?: string,
+	images?: ImageInput[],
 ): Promise<void> {
-  const session = findSession(sessionId);
-  if (!session) return;
+	const session = findSession(sessionId);
+	if (!session) return;
 
-  // The engine session id depends on the session's model: codex models resume
-  // the codex thread, claude models the claude session. A missing engine id
-  // just means "first run on this provider" — a fresh thread/session starts.
-  const provider = providerFor(session.model);
-  const engineSessionId =
-    provider === "codex" ? session.codexThreadId : session.claudeSessionId;
-  if (provider === "claude" && !engineSessionId) {
-    // Never swallow a message silently (queued ones land here on drain)
-    console.error(`[queue] Can't deliver prompt for ${sessionId} — no claude session id`);
-    broadcastToSession(sessionId, {
-      type: "notice",
-      message: "Couldn't deliver your message — the session has no Claude session id yet. Try again in a moment.",
-    });
-    return;
-  }
+	// The engine session id depends on the session's model: codex models resume
+	// the codex thread, claude models the claude session. A missing engine id
+	// just means "first run on this provider" — a fresh thread/session starts.
+	const provider = providerFor(session.model);
+	const engineSessionId =
+		provider === "codex" ? session.codexThreadId : session.claudeSessionId;
+	if (provider === "claude" && !engineSessionId) {
+		// Never swallow a message silently (queued ones land here on drain)
+		console.error(
+			`[queue] Can't deliver prompt for ${sessionId} — no claude session id`,
+		);
+		broadcastToSession(sessionId, {
+			type: "notice",
+			message:
+				"Couldn't deliver your message — the session has no Claude session id yet. Try again in a moment.",
+		});
+		return;
+	}
 
-  // A cleaned-up worktree makes the SDK spawn fail with a misleading "binary
-  // not found" (ENOENT on the missing cwd) — revive it first. Same path as
-  // before, so resuming the claude session keeps its history.
-  let cwd = session.worktreeDir || `${HOME}/projects/tella-fusion`;
-  if (session.worktreeDir && !existsSync(session.worktreeDir)) {
-    const project = session.project ? getProject(session.project) : projectForPath(session.worktreeDir);
-    if (session.branch) {
-      broadcastToSession(sessionId, {
-        type: "notice",
-        message: `This session's worktree was cleaned up — recreating it from branch ${session.branch}…`,
-      });
-      try {
-        cwd = await reviveWorktree(session.branch, project.id);
-      } catch (e) {
-        broadcastToSession(sessionId, {
-          type: "notice",
-          message: `Couldn't recreate the worktree (${e}); running in the main checkout instead.`,
-        });
-        cwd = project.repo;
-      }
-    } else {
-      broadcastToSession(sessionId, {
-        type: "notice",
-        message: "This session's worktree is gone; running in the main checkout.",
-      });
-      cwd = project.repo;
-    }
-  }
-  let prompt = content;
-  if (session.goal) {
-    prompt += `\n\n[Pinned session goal — keep working toward it and note how this turn advanced it: ${session.goal}]`;
-  }
+	// A cleaned-up worktree makes the SDK spawn fail with a misleading "binary
+	// not found" (ENOENT on the missing cwd) — revive it first. Same path as
+	// before, so resuming the claude session keeps its history.
+	let cwd = session.worktreeDir || `${HOME}/projects/tella-fusion`;
+	if (session.worktreeDir && !existsSync(session.worktreeDir)) {
+		const project = session.project
+			? getProject(session.project)
+			: projectForPath(session.worktreeDir);
+		if (session.branch) {
+			broadcastToSession(sessionId, {
+				type: "notice",
+				message: `This session's worktree was cleaned up — recreating it from branch ${session.branch}…`,
+			});
+			try {
+				cwd = await reviveWorktree(session.branch, project.id);
+			} catch (e) {
+				broadcastToSession(sessionId, {
+					type: "notice",
+					message: `Couldn't recreate the worktree (${e}); running in the main checkout instead.`,
+				});
+				cwd = project.repo;
+			}
+		} else {
+			broadcastToSession(sessionId, {
+				type: "notice",
+				message:
+					"This session's worktree is gone; running in the main checkout.",
+			});
+			cwd = project.repo;
+		}
+	}
+	let prompt = content;
+	if (session.goal) {
+		prompt += `\n\n[Pinned session goal — keep working toward it and note how this turn advanced it: ${session.goal}]`;
+	}
 
-  // Resuming an automation-owned session must keep that automation's scoping
-  // (MCP allowlist + tool denials) — otherwise a resume would silently hand it
-  // every MCP server and drop the customer/identity write denials.
-  const isAutomationSession = !!session.automation;
-  const mcpServers = isAutomationSession
-    ? automationMcpServersByName(session.automation!)
-    : undefined;
-  const deniedTools = isAutomationSession ? automationDeniedTools() : undefined;
+	// Resuming an automation-owned session must keep that automation's scoping
+	// (MCP allowlist + tool denials) — otherwise a resume would silently hand it
+	// every MCP server and drop the customer/identity write denials.
+	const isAutomationSession = !!session.automation;
+	const mcpServers = isAutomationSession
+		? automationMcpServersByName(session.automation!)
+		: undefined;
+	const deniedTools = isAutomationSession ? automationDeniedTools() : undefined;
 
-  // Everyone viewing this session sees the prompt and the live run
-  broadcastToSession(sessionId, { type: "stream_start", sessionId, by: user || "Anonymous" });
-  broadcastToSession(sessionId, { type: "session_status", isRunning: true });
+	// Everyone viewing this session sees the prompt and the live run
+	broadcastToSession(sessionId, {
+		type: "stream_start",
+		sessionId,
+		by: user || "Anonymous",
+	});
+	broadcastToSession(sessionId, { type: "session_status", isRunning: true });
 
-  let finalSessionId = engineSessionId || "";
-  let endedWithError = false;
+	let finalSessionId = engineSessionId || "";
+	let endedWithError = false;
 
-  for await (const event of runAgent({
-    prompt,
-    sessionId: engineSessionId || undefined,
-    cwd,
-    mode: session.mode,
-    model: session.model,
-    images,
-    mcpServers,
-    // Self-management tools for normal sessions; withheld from automation
-    // sessions (and their interactive resumes) — same gate as deniedTools above.
-    inProcessMcp: isAutomationSession ? undefined : interactiveMcpServers(user, sessionId),
-    reposNote: isAutomationSession ? undefined : buildReposNote(session),
-    deniedTools,
-    confirmTools: STRIPE_CONFIRM_TOOLS,
-    aws: true, // sessions keep AWS read access (via injected creds)
-    // Attribute any commits this turn makes to whoever sent the prompt.
-    author: gitIdentityFor(user),
-    journal: { bksSessionId: session.id, kind: "prompt" },
-    onAskUser: makeAskHandler(sessionId),
-  })) {
-    switch (event.type) {
-      case "init":
-        finalSessionId = event.sessionId || finalSessionId;
-        break;
-      case "text_chunk":
-        broadcastToSession(sessionId, { type: "stream_text", text: event.text });
-        break;
-      case "tool_use":
-        broadcastToSession(sessionId, {
-          type: "stream_tool_use",
-          entry: {
-            id: event.toolUseId || crypto.randomUUID(),
-            type: "tool_use",
-            content: `Using ${event.toolName}`,
-            timestamp: new Date().toISOString(),
-            toolName: event.toolName,
-            toolInput: event.toolInput,
-            toolUseId: event.toolUseId,
-          },
-        });
-        break;
-      case "tool_result":
-        broadcastToSession(sessionId, {
-          type: "stream_tool_result",
-          entry: {
-            // Same id scheme as the jsonl tail so the full (untruncated)
-            // transcript entry upserts over this streamed copy
-            id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
-            type: "tool_result",
-            content: event.content || "",
-            timestamp: new Date().toISOString(),
-            toolUseId: event.toolUseId,
-            ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
-            ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
-          },
-        });
-        break;
-      case "done":
-        finalSessionId = event.sessionId || finalSessionId;
-        sessionsCache = null;
-        break;
-      case "error":
-        endedWithError = true;
-        broadcastToSession(sessionId, { type: "error", message: event.content });
-        break;
-    }
-  }
+	for await (const event of runAgent({
+		prompt,
+		sessionId: engineSessionId || undefined,
+		cwd,
+		mode: session.mode,
+		model: session.model,
+		images,
+		mcpServers,
+		// Self-management tools for normal sessions; withheld from automation
+		// sessions (and their interactive resumes) — same gate as deniedTools above.
+		inProcessMcp: isAutomationSession
+			? undefined
+			: interactiveMcpServers(user, sessionId),
+		reposNote: isAutomationSession ? undefined : buildReposNote(session),
+		deniedTools,
+		confirmTools: STRIPE_CONFIRM_TOOLS,
+		aws: true, // sessions keep AWS read access (via injected creds)
+		// Attribute any commits this turn makes to whoever sent the prompt.
+		author: gitIdentityFor(user),
+		journal: { bksSessionId: session.id, kind: "prompt" },
+		onAskUser: makeAskHandler(sessionId),
+	})) {
+		switch (event.type) {
+			case "init":
+				finalSessionId = event.sessionId || finalSessionId;
+				break;
+			case "text_chunk":
+				broadcastToSession(sessionId, {
+					type: "stream_text",
+					text: event.text,
+				});
+				break;
+			case "tool_use":
+				broadcastToSession(sessionId, {
+					type: "stream_tool_use",
+					entry: {
+						id: event.toolUseId || crypto.randomUUID(),
+						type: "tool_use",
+						content: `Using ${event.toolName}`,
+						timestamp: new Date().toISOString(),
+						toolName: event.toolName,
+						toolInput: event.toolInput,
+						toolUseId: event.toolUseId,
+					},
+				});
+				break;
+			case "tool_result":
+				broadcastToSession(sessionId, {
+					type: "stream_tool_result",
+					entry: {
+						// Same id scheme as the jsonl tail so the full (untruncated)
+						// transcript entry upserts over this streamed copy
+						id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
+						type: "tool_result",
+						content: event.content || "",
+						timestamp: new Date().toISOString(),
+						toolUseId: event.toolUseId,
+						...(event.images && event.images.length > 0
+							? { images: event.images }
+							: {}),
+						...(event.videos && event.videos.length > 0
+							? { videos: event.videos }
+							: {}),
+					},
+				});
+				break;
+			case "done":
+				finalSessionId = event.sessionId || finalSessionId;
+				sessionsCache = null;
+				break;
+			case "error":
+				endedWithError = true;
+				broadcastToSession(sessionId, {
+					type: "error",
+					message: event.content,
+				});
+				break;
+		}
+	}
 
-  // Persist activity on our own session store (slack/linear stores are read-only)
-  if (session.source === "backstage") {
-    touchBackstageSession(
-      session.id,
-      provider === "codex"
-        ? { codexThreadId: finalSessionId || undefined }
-        : { claudeSessionId: finalSessionId || undefined }
-    );
-  }
+	// Persist activity on our own session store (slack/linear stores are read-only)
+	if (session.source === "backstage") {
+		touchBackstageSession(
+			session.id,
+			provider === "codex"
+				? { codexThreadId: finalSessionId || undefined }
+				: { claudeSessionId: finalSessionId || undefined },
+		);
+	}
 
-  // On a clean finish any steered messages already landed in the transcript, so
-  // drop their display-only receipts. But if the run ended in error/abort (e.g.
-  // a restart killed the SDK stream mid-turn), a steered message may NOT have
-  // been delivered yet — keep the receipt so persistQueues/restorePromptQueues
-  // can re-deliver it on the next boot instead of silently dropping it.
-  if (!endedWithError) clearSteerReceipts(sessionId);
+	// On a clean finish any steered messages already landed in the transcript, so
+	// drop their display-only receipts. But if the run ended in error/abort (e.g.
+	// a restart killed the SDK stream mid-turn), a steered message may NOT have
+	// been delivered yet — keep the receipt so persistQueues/restorePromptQueues
+	// can re-deliver it on the next boot instead of silently dropping it.
+	if (!endedWithError) clearSteerReceipts(sessionId);
 
-  broadcastToSession(sessionId, { type: "stream_done" });
-  broadcastToSession(sessionId, { type: "session_status", isRunning: false });
+	broadcastToSession(sessionId, { type: "stream_done" });
+	broadcastToSession(sessionId, { type: "session_status", isRunning: false });
 
-  // The session just finished a turn; if nothing's queued it's idle now, so fire
-  // any "when_done" / "on_pr" human asks waiting on this session. Idempotent.
-  if (!(promptQueues.get(sessionId)?.length)) onHumanAsksSessionIdle(sessionId);
+	// The session just finished a turn; if nothing's queued it's idle now, so fire
+	// any "when_done" / "on_pr" human asks waiting on this session. Idempotent.
+	if (!promptQueues.get(sessionId)?.length) onHumanAsksSessionIdle(sessionId);
 }
 
 /**
@@ -951,138 +1110,159 @@ async function runSessionPrompt(
  * was consumed as a command, or null to send it to Claude as a normal prompt.
  */
 function handleSlashCommand(
-  session: UnifiedSession,
-  text: string,
-  user?: string
+	session: UnifiedSession,
+	text: string,
+	user?: string,
 ): string | null {
-  if (
-    !text.startsWith("/goal") &&
-    !text.startsWith("/loop") &&
-    !text.startsWith("/model") &&
-    text !== "/help"
-  ) {
-    return null;
-  }
-  if (session.source !== "backstage") {
-    if (text.startsWith("/model") && session.source === "slack") {
-      return "Set the model from Slack instead — send /model <name> in the Slack thread (its session file is agent-owned).";
-    }
-    return "Slash commands only work on backstage-created sessions (Slack/Linear session files are agent-owned).";
-  }
+	if (
+		!text.startsWith("/goal") &&
+		!text.startsWith("/loop") &&
+		!text.startsWith("/model") &&
+		text !== "/help"
+	) {
+		return null;
+	}
+	if (session.source !== "backstage") {
+		if (text.startsWith("/model") && session.source === "slack") {
+			return "Set the model from Slack instead — send /model <name> in the Slack thread (its session file is agent-owned).";
+		}
+		return "Slash commands only work on backstage-created sessions (Slack/Linear session files are agent-owned).";
+	}
 
-  if (text === "/help") {
-    return [
-      "Backstage commands:",
-      "/goal <text> — pin a goal, appended to every prompt until cleared",
-      "/goal clear — remove the goal",
-      "/loop <interval> <prompt> — re-run a prompt on an interval (e.g. /loop 30m check CI and fix failures)",
-      "/loop stop — stop the loop",
-      "/model — show the session's model and what's available",
-      "/model <name> — switch model (e.g. /model opus, /model gpt-5.5)",
-    ].join("\n");
-  }
+	if (text === "/help") {
+		return [
+			"Backstage commands:",
+			"/goal <text> — pin a goal, appended to every prompt until cleared",
+			"/goal clear — remove the goal",
+			"/loop <interval> <prompt> — re-run a prompt on an interval (e.g. /loop 30m check CI and fix failures)",
+			"/loop stop — stop the loop",
+			"/model — show the session's model and what's available",
+			"/model <name> — switch model (e.g. /model opus, /model gpt-5.5)",
+		].join("\n");
+	}
 
-  if (text === "/model" || text === "/model show" || text === "/model list") {
-    return [
-      `Current model: ${session.model || getDefaultModel()}${session.model ? "" : " (default)"}`,
-      "",
-      "Available models (set with /model <name or alias>):",
-      formatModelList(session.model),
-    ].join("\n");
-  }
-  if (text.startsWith("/model ")) {
-    const input = text.slice("/model ".length).trim();
-    const resolved = resolveModel(input);
-    if (!resolved) {
-      return [
-        `Unknown model "${input}". Available:`,
-        formatModelList(session.model),
-      ].join("\n");
-    }
-    const prevProvider = providerFor(session.model);
-    touchBackstageSession(session.id, {
-      model: resolved.id,
-      modelHistory: [
-        ...(session.modelHistory || []),
-        { model: resolved.id, at: new Date().toISOString(), by: user },
-      ],
-    });
-    // Everyone watching sees the switch (pill + inline divider) immediately
-    broadcastToSession(session.id, {
-      type: "model_changed",
-      sessionId: session.id,
-      model: resolved.id,
-      by: user,
-    });
-    const switchedProvider = prevProvider !== resolved.provider;
-    return (
-      `Model set to ${resolved.id} (${modelLabel(resolved.id)}). Applies from the next prompt.` +
-      (switchedProvider
-        ? resolved.provider === "codex"
-          ? " Heads up: this switches the engine to Codex — the Claude conversation history doesn't carry over, so the next prompt starts a fresh Codex thread (switching back to a Claude model resumes the old history)."
-          : " Heads up: this switches the engine back to Claude — the Codex thread's history doesn't carry over, but the earlier Claude history (if any) resumes."
-        : "")
-    );
-  }
+	if (text === "/model" || text === "/model show" || text === "/model list") {
+		return [
+			`Current model: ${session.model || getDefaultModel()}${session.model ? "" : " (default)"}`,
+			"",
+			"Available models (set with /model <name or alias>):",
+			formatModelList(session.model),
+		].join("\n");
+	}
+	if (text.startsWith("/model ")) {
+		const input = text.slice("/model ".length).trim();
+		const resolved = resolveModel(input);
+		if (!resolved) {
+			return [
+				`Unknown model "${input}". Available:`,
+				formatModelList(session.model),
+			].join("\n");
+		}
+		const prevProvider = providerFor(session.model);
+		touchBackstageSession(session.id, {
+			model: resolved.id,
+			modelHistory: [
+				...(session.modelHistory || []),
+				{ model: resolved.id, at: new Date().toISOString(), by: user },
+			],
+		});
+		// Everyone watching sees the switch (pill + inline divider) immediately
+		broadcastToSession(session.id, {
+			type: "model_changed",
+			sessionId: session.id,
+			model: resolved.id,
+			by: user,
+		});
+		const switchedProvider = prevProvider !== resolved.provider;
+		return (
+			`Model set to ${resolved.id} (${modelLabel(resolved.id)}). Applies from the next prompt.` +
+			(switchedProvider
+				? resolved.provider === "codex"
+					? " Heads up: this switches the engine to Codex — the Claude conversation history doesn't carry over, so the next prompt starts a fresh Codex thread (switching back to a Claude model resumes the old history)."
+					: " Heads up: this switches the engine back to Claude — the Codex thread's history doesn't carry over, but the earlier Claude history (if any) resumes."
+				: "")
+		);
+	}
 
-  if (text === "/goal" || text === "/goal show") {
-    return session.goal ? `Current goal: ${session.goal}` : "No goal set. Use /goal <text>.";
-  }
-  if (text === "/goal clear") {
-    touchBackstageSession(session.id, { goal: undefined });
-    return "Goal cleared.";
-  }
-  if (text.startsWith("/goal ")) {
-    const goal = text.slice("/goal ".length).trim();
-    if (!goal) return "Usage: /goal <text>";
-    touchBackstageSession(session.id, { goal });
-    return `Goal pinned: ${goal} — it will ride along with every prompt until /goal clear.`;
-  }
+	if (text === "/goal" || text === "/goal show") {
+		return session.goal
+			? `Current goal: ${session.goal}`
+			: "No goal set. Use /goal <text>.";
+	}
+	if (text === "/goal clear") {
+		touchBackstageSession(session.id, { goal: undefined });
+		return "Goal cleared.";
+	}
+	if (text.startsWith("/goal ")) {
+		const goal = text.slice("/goal ".length).trim();
+		if (!goal) return "Usage: /goal <text>";
+		touchBackstageSession(session.id, { goal });
+		return `Goal pinned: ${goal} — it will ride along with every prompt until /goal clear.`;
+	}
 
-  if (text === "/loop" || text === "/loop status") {
-    return session.loop
-      ? `Loop active: every ${session.loop.intervalMinutes}m — "${session.loop.prompt}"`
-      : "No loop set. Use /loop <interval> <prompt> (e.g. /loop 30m check CI).";
-  }
-  if (text === "/loop stop" || text === "/loop off" || text === "/loop clear") {
-    touchBackstageSession(session.id, { loop: undefined });
-    return "Loop stopped.";
-  }
-  if (text.startsWith("/loop ")) {
-    const rest = text.slice("/loop ".length).trim();
-    const match = rest.match(/^(\d+)\s*(m|min|h|hr)?\s+([\s\S]+)$/);
-    if (!match) return "Usage: /loop <interval> <prompt> — e.g. /loop 30m check CI and fix failures";
-    let minutes = parseInt(match[1]);
-    if (match[2] === "h" || match[2] === "hr") minutes *= 60;
-    minutes = Math.max(5, minutes);
-    const prompt = match[3].trim();
-    touchBackstageSession(session.id, {
-      loop: { prompt, intervalMinutes: minutes, lastRunAt: new Date().toISOString(), setBy: user },
-    });
-    return `Loop set: every ${minutes}m — "${prompt}". First run in ${minutes}m; /loop stop to end it.`;
-  }
+	if (text === "/loop" || text === "/loop status") {
+		return session.loop
+			? `Loop active: every ${session.loop.intervalMinutes}m — "${session.loop.prompt}"`
+			: "No loop set. Use /loop <interval> <prompt> (e.g. /loop 30m check CI).";
+	}
+	if (text === "/loop stop" || text === "/loop off" || text === "/loop clear") {
+		touchBackstageSession(session.id, { loop: undefined });
+		return "Loop stopped.";
+	}
+	if (text.startsWith("/loop ")) {
+		const rest = text.slice("/loop ".length).trim();
+		const match = rest.match(/^(\d+)\s*(m|min|h|hr)?\s+([\s\S]+)$/);
+		if (!match)
+			return "Usage: /loop <interval> <prompt> — e.g. /loop 30m check CI and fix failures";
+		let minutes = parseInt(match[1]);
+		if (match[2] === "h" || match[2] === "hr") minutes *= 60;
+		minutes = Math.max(5, minutes);
+		const prompt = match[3].trim();
+		touchBackstageSession(session.id, {
+			loop: {
+				prompt,
+				intervalMinutes: minutes,
+				lastRunAt: new Date().toISOString(),
+				setBy: user,
+			},
+		});
+		return `Loop set: every ${minutes}m — "${prompt}". First run in ${minutes}m; /loop stop to end it.`;
+	}
 
-  return null;
+	return null;
 }
 
 // Loop ticker: fire due session loops (skips busy/archived sessions).
 // Guarded so a hot reload doesn't stack a second interval.
 if (!g.__backstageBooted) {
-  setInterval(() => {
-    for (const session of getCachedSessions()) {
-      const loop = session.loop;
-      if (!loop || session.archived || session.source !== "backstage") continue;
-      if (!session.claudeSessionId && !session.codexThreadId) continue;
-      if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) continue;
-      const last = loop.lastRunAt ? new Date(loop.lastRunAt).getTime() : 0;
-      if (Date.now() - last < loop.intervalMinutes * 60_000) continue;
-      touchBackstageSession(session.id, {
-        loop: { ...loop, lastRunAt: new Date().toISOString() },
-      });
-      console.log(`[loop] Firing loop prompt for ${session.id} (every ${loop.intervalMinutes}m)`);
-      void runSessionPromptAndDrain(session.id, loop.prompt, loop.setBy ? `${loop.setBy} (loop)` : "loop");
-    }
-  }, 60_000);
+	setInterval(() => {
+		for (const session of getCachedSessions()) {
+			const loop = session.loop;
+			if (!loop || session.archived || session.source !== "backstage") continue;
+			if (!session.claudeSessionId && !session.codexThreadId) continue;
+			if (
+				isAgentSessionBusy(
+					session.claudeSessionId,
+					session.codexThreadId,
+					session.id,
+				)
+			)
+				continue;
+			const last = loop.lastRunAt ? new Date(loop.lastRunAt).getTime() : 0;
+			if (Date.now() - last < loop.intervalMinutes * 60_000) continue;
+			touchBackstageSession(session.id, {
+				loop: { ...loop, lastRunAt: new Date().toISOString() },
+			});
+			console.log(
+				`[loop] Firing loop prompt for ${session.id} (every ${loop.intervalMinutes}m)`,
+			);
+			void runSessionPromptAndDrain(
+				session.id,
+				loop.prompt,
+				loop.setBy ? `${loop.setBy} (loop)` : "loop",
+			);
+		}
+	}, 60_000);
 }
 
 // Production frontend: build the SPA with code-splitting so the initial
@@ -1094,7 +1274,11 @@ const IS_DEV = process.env.BACKSTAGE_DEV === "1";
 const FRONTEND_DIST = `${import.meta.dir}/.frontend-dist`;
 const FRONTEND_SRC = `${import.meta.dir}/src/frontend`;
 
-type FrontendBundle = { indexHtml: string; gzip: Map<string, Blob>; version: string };
+type FrontendBundle = {
+	indexHtml: string;
+	gzip: Map<string, Blob>;
+	version: string;
+};
 
 // Build (or rebuild) the prod SPA bundle in-process. The result object on
 // globalThis is MUTATED in place (never reassigned) so the long-lived `frontend`
@@ -1103,68 +1287,82 @@ type FrontendBundle = { indexHtml: string; gzip: Map<string, Blob>; version: str
 // restart` that would interrupt every in-flight Claude run. `version` changes
 // whenever the entry or CSS hash changes, so clients know to refresh.
 async function buildFrontend(): Promise<string> {
-  const result = await Bun.build({
-    entrypoints: [`${FRONTEND_SRC}/App.tsx`],
-    outdir: FRONTEND_DIST,
-    minify: true,
-    splitting: true,
-    sourcemap: "none",
-    publicPath: "/backstage/",
-    naming: { entry: "[name]-[hash].[ext]", chunk: "[name]-[hash].[ext]", asset: "[name]-[hash].[ext]" },
-  });
-  if (!result.success) {
-    throw new AggregateError(result.logs, "frontend build failed");
-  }
-  // Bun's HTML-entry splitting mis-points the bootstrap <script> at a leaf
-  // chunk, so we build the JS entry and stitch index.html ourselves: keep the
-  // source shell (icons, splash, manifest links) and point it at the hashed
-  // entry + the extracted CSS.
-  const entry = result.outputs.find((o) => o.kind === "entry-point");
-  if (!entry) throw new Error("frontend build produced no entry point");
-  const entryName = entry.path.split("/").pop()!;
+	const result = await Bun.build({
+		entrypoints: [`${FRONTEND_SRC}/App.tsx`],
+		outdir: FRONTEND_DIST,
+		minify: true,
+		splitting: true,
+		sourcemap: "none",
+		publicPath: "/backstage/",
+		naming: {
+			entry: "[name]-[hash].[ext]",
+			chunk: "[name]-[hash].[ext]",
+			asset: "[name]-[hash].[ext]",
+		},
+	});
+	if (!result.success) {
+		throw new AggregateError(result.logs, "frontend build failed");
+	}
+	// Bun's HTML-entry splitting mis-points the bootstrap <script> at a leaf
+	// chunk, so we build the JS entry and stitch index.html ourselves: keep the
+	// source shell (icons, splash, manifest links) and point it at the hashed
+	// entry + the extracted CSS.
+	const entry = result.outputs.find((o) => o.kind === "entry-point");
+	if (!entry) throw new Error("frontend build produced no entry point");
+	const entryName = entry.path.split("/").pop()!;
 
-  // Bun 1.3.14's CSS minifier strips the space after var(...) and breaks the
-  // .panel-overlay / .sidebar-overlay inset (and a few color-mix percentages),
-  // which knocks out the mobile overlay layer. Bypass it: write the source CSS
-  // unmodified with a content-hashed name and serve it ourselves.
-  const cssSrc = await Bun.file(`${FRONTEND_SRC}/styles/global.css`).text();
-  const cssHash = Bun.hash(cssSrc).toString(36);
-  const cssName = `global-${cssHash}.css`;
-  await Bun.write(`${FRONTEND_DIST}/${cssName}`, cssSrc);
+	// Bun 1.3.14's CSS minifier strips the space after var(...) and breaks the
+	// .panel-overlay / .sidebar-overlay inset (and a few color-mix percentages),
+	// which knocks out the mobile overlay layer. Bypass it: write the source CSS
+	// unmodified with a content-hashed name and serve it ourselves.
+	const cssSrc = await Bun.file(`${FRONTEND_SRC}/styles/global.css`).text();
+	const cssHash = Bun.hash(cssSrc).toString(36);
+	const cssName = `global-${cssHash}.css`;
+	await Bun.write(`${FRONTEND_DIST}/${cssName}`, cssSrc);
 
-  let indexHtml = await Bun.file(`${FRONTEND_SRC}/index.html`).text();
-  indexHtml = indexHtml.replace(
-    '<script type="module" src="./App.tsx"></script>',
-    `<script type="module" crossorigin src="/backstage/${entryName}"></script>`
-  );
-  indexHtml = indexHtml.replace("</head>", `  <link rel="stylesheet" href="/backstage/${cssName}">\n</head>`);
-  const version = `${entryName}|${cssName}`;
+	let indexHtml = await Bun.file(`${FRONTEND_SRC}/index.html`).text();
+	indexHtml = indexHtml.replace(
+		'<script type="module" src="./App.tsx"></script>',
+		`<script type="module" crossorigin src="/backstage/${entryName}"></script>`,
+	);
+	indexHtml = indexHtml.replace(
+		"</head>",
+		`  <link rel="stylesheet" href="/backstage/${cssName}">\n</head>`,
+	);
+	const version = `${entryName}|${cssName}`;
 
-  const store: FrontendBundle = (g.__backstageFrontend ??= {
-    indexHtml: "",
-    gzip: new Map<string, Blob>(),
-    version: "",
-  });
-  store.indexHtml = indexHtml;
-  store.gzip.clear(); // stale gzipped blobs were keyed by the old hashed names
-  store.version = version;
-  console.log(`Frontend built: ${result.outputs.length} files → ${FRONTEND_DIST} (v=${version})`);
-  return version;
+	const store: FrontendBundle = (g.__backstageFrontend ??= {
+		indexHtml: "",
+		gzip: new Map<string, Blob>(),
+		version: "",
+	});
+	store.indexHtml = indexHtml;
+	store.gzip.clear(); // stale gzipped blobs were keyed by the old hashed names
+	store.version = version;
+	console.log(
+		`Frontend built: ${result.outputs.length} files → ${FRONTEND_DIST} (v=${version})`,
+	);
+	return version;
 }
 
 if (!IS_DEV && !g.__backstageFrontend) {
-  console.log("Building frontend (split + minified)…");
-  await buildFrontend();
+	console.log("Building frontend (split + minified)…");
+	await buildFrontend();
 }
 
-const frontend: FrontendBundle | null = IS_DEV ? null : (g.__backstageFrontend as FrontendBundle);
+const frontend: FrontendBundle | null = IS_DEV
+	? null
+	: (g.__backstageFrontend as FrontendBundle);
 
 // SPA entry: the HMR bundle in dev, the prebuilt index.html in prod. Reads
 // `frontend.indexHtml` fresh on each request so an in-process rebuild is served
 // immediately (the object is mutated, not replaced).
 const spaEntry = frontend
-  ? () => new Response(frontend.indexHtml, { headers: { "Content-Type": "text/html; charset=utf-8" } })
-  : homepage;
+	? () =>
+			new Response(frontend.indexHtml, {
+				headers: { "Content-Type": "text/html; charset=utf-8" },
+			})
+	: homepage;
 
 // Debounced in-process rebuild + client nudge. Triggered by the frontend
 // file-watch, a SIGUSR2 signal, or POST /backstage/api/rebuild-frontend — all of
@@ -1174,26 +1372,31 @@ const spaEntry = frontend
 let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
 let rebuildInFlight = false;
 function scheduleFrontendRebuild(reason: string, debounceMs = 300): void {
-  if (IS_DEV || !frontend) return;
-  if (rebuildTimer) clearTimeout(rebuildTimer);
-  rebuildTimer = setTimeout(async () => {
-    rebuildTimer = null;
-    if (rebuildInFlight) return scheduleFrontendRebuild(reason, 300); // coalesce
-    rebuildInFlight = true;
-    const before = frontend.version;
-    try {
-      const version = await buildFrontend();
-      if (version !== before) {
-        console.log(`[frontend] Rebuilt (${reason}); notifying clients (v=${version})`);
-        broadcastToAll({ type: "frontend_updated", version });
-      }
-    } catch (e) {
-      console.error(`[frontend] Rebuild failed (${reason}):`, e);
-      broadcastToAll({ type: "notice", message: `Frontend rebuild failed — see logs. (${e})` });
-    } finally {
-      rebuildInFlight = false;
-    }
-  }, debounceMs);
+	if (IS_DEV || !frontend) return;
+	if (rebuildTimer) clearTimeout(rebuildTimer);
+	rebuildTimer = setTimeout(async () => {
+		rebuildTimer = null;
+		if (rebuildInFlight) return scheduleFrontendRebuild(reason, 300); // coalesce
+		rebuildInFlight = true;
+		const before = frontend.version;
+		try {
+			const version = await buildFrontend();
+			if (version !== before) {
+				console.log(
+					`[frontend] Rebuilt (${reason}); notifying clients (v=${version})`,
+				);
+				broadcastToAll({ type: "frontend_updated", version });
+			}
+		} catch (e) {
+			console.error(`[frontend] Rebuild failed (${reason}):`, e);
+			broadcastToAll({
+				type: "notice",
+				message: `Frontend rebuild failed — see logs. (${e})`,
+			});
+		} finally {
+			rebuildInFlight = false;
+		}
+	}, debounceMs);
 }
 
 console.log(`Starting Backstage server on ${HOST}:${PORT}...`);
@@ -1202,1243 +1405,1669 @@ console.log(`Starting Backstage server on ${HOST}:${PORT}...`);
 // and in-flight runs survive a tweak; a fresh `bun run` just creates it once.
 // (Session/agent logic still hot-updates: the registry below is re-registered
 // on every reload, and per-message config is read fresh.)
-const server: import("bun").Server<WSClientData> = (g.__backstageServer ??= Bun.serve<WSClientData>({
-  port: PORT,
-  hostname: HOST,
-  // The plain-triage route waits for worktree+session boot (~15-60s);
-  // Bun's default 10s idleTimeout would drop the connection mid-wait
-  idleTimeout: 240,
-
-  routes: {
-    "/backstage": spaEntry,
-    "/backstage/": spaEntry,
-    "/backstage/index.html": spaEntry,
-    // Client-side routes must serve the SPA shell, not the raw file
-    "/backstage/new": spaEntry,
-    "/backstage/session/*": spaEntry,
-    "/backstage/automations": spaEntry,
-    "/backstage/wiki": spaEntry,
-    "/backstage/wiki/*": spaEntry,
-    "/backstage/connections": spaEntry,
-    "/backstage/archived": spaEntry,
-    "/backstage/reviews": spaEntry,
-    "/backstage/reviews/*": spaEntry,
-  },
-
-  async fetch(req) {
-    const url = new URL(req.url);
-    const path = url.pathname;
-
-    // Stream a local media file referenced by a `BACKSTAGE_VIDEO:` marker in a
-    // tool's output, so the session viewer can play it inline (tools can't return
-    // video blocks the way Read returns images). Path-scoped: absolute path under
-    // /tmp or /home/ubuntu, no traversal, known media extension. Range-enabled
-    // so the <video> scrubber can seek.
-    if (path === "/backstage/media" && req.method === "GET") {
-      const mediaPath = url.searchParams.get("path") || "";
-      const mediaTypes: Record<string, string> = {
-        ".mp4": "video/mp4",
-        ".webm": "video/webm",
-        ".mov": "video/quicktime",
-        ".png": "image/png",
-        ".jpg": "image/jpeg",
-        ".jpeg": "image/jpeg",
-        ".gif": "image/gif",
-        ".webp": "image/webp",
-      };
-      const ext = mediaPath.slice(mediaPath.lastIndexOf(".")).toLowerCase();
-      const scoped = mediaPath.startsWith("/tmp/") || mediaPath.startsWith("/home/ubuntu/");
-      if (!mediaPath.startsWith("/") || mediaPath.includes("..") || !scoped || !mediaTypes[ext]) {
-        return new Response("forbidden", { status: 403 });
-      }
-      const file = Bun.file(mediaPath);
-      if (!(await file.exists())) return new Response("not found", { status: 404 });
-
-      const type = mediaTypes[ext];
-      const size = file.size;
-      const range = req.headers.get("range");
-      const baseHeaders: Record<string, string> = {
-        "Content-Type": type,
-        "Accept-Ranges": "bytes",
-        "Cache-Control": "private, max-age=60",
-      };
-      if (range) {
-        const m = range.match(/bytes=(\d*)-(\d*)/);
-        let start = m && m[1] ? parseInt(m[1], 10) : 0;
-        let end = m && m[2] ? parseInt(m[2], 10) : size - 1;
-        if (Number.isNaN(start) || start < 0) start = 0;
-        if (Number.isNaN(end) || end >= size) end = size - 1;
-        if (start > end) {
-          return new Response("range not satisfiable", {
-            status: 416,
-            headers: { "Content-Range": `bytes */${size}` },
-          });
-        }
-        return new Response(file.slice(start, end + 1), {
-          status: 206,
-          headers: {
-            ...baseHeaders,
-            "Content-Range": `bytes ${start}-${end}/${size}`,
-            "Content-Length": String(end - start + 1),
-          },
-        });
-      }
-      return new Response(file, { headers: { ...baseHeaders, "Content-Length": String(size) } });
-    }
-
-    // App icons (KITT/red-M) — real PNGs so iOS home-screen and PWA installs
-    // pick them up; data-URI apple-touch-icons don't work on iOS. Short cache
-    // + must-revalidate so a refreshed design isn't pinned by a stale copy.
-    const iconFiles: Record<string, string> = {
-      "/backstage/apple-touch-icon.png": "apple-touch-icon.png", // 180×180
-      "/backstage/icon-192.png": "icon-192.png",
-      "/backstage/icon.png": "icon.png", // 512×512
-    };
-    if (iconFiles[path]) {
-      return new Response(Bun.file(`${import.meta.dir}/src/frontend/${iconFiles[path]}`), {
-        headers: { "Content-Type": "image/png", "Cache-Control": "public, max-age=3600, must-revalidate" },
-      });
-    }
-
-    // iOS PWA launch images (apple-touch-startup-image). One PNG per device
-    // resolution, generated by scripts/gen-splash.py. Filename is locked to the
-    // apple-splash-<w>-<h>.png pattern so the path can't escape the folder.
-    const splashMatch = path.match(/^\/backstage\/splash\/(apple-splash-\d+-\d+\.png)$/);
-    if (splashMatch) {
-      return new Response(Bun.file(`${import.meta.dir}/src/frontend/splash/${splashMatch[1]}`), {
-        headers: { "Content-Type": "image/png", "Cache-Control": "public, max-age=86400" },
-      });
-    }
-
-    // Built SPA assets (prod only). Content-hashed filenames → cache forever.
-    // Served gzipped (computed once, then memoised) since the JS is large.
-    const assetMatch = frontend && path.match(/^\/backstage\/([\w.-]+\.(?:js|css|map))$/);
-    if (assetMatch) {
-      const name = assetMatch[1];
-      const file = Bun.file(`${FRONTEND_DIST}/${name}`);
-      if (await file.exists()) {
-        const type = name.endsWith(".css")
-          ? "text/css"
-          : name.endsWith(".map")
-            ? "application/json"
-            : "text/javascript";
-        const headers: Record<string, string> = {
-          "Content-Type": `${type}; charset=utf-8`,
-          "Cache-Control": "public, max-age=31536000, immutable",
-        };
-        if ((req.headers.get("accept-encoding") || "").includes("gzip")) {
-          let gz = frontend.gzip.get(name);
-          if (!gz) {
-            gz = new Blob([Bun.gzipSync(new Uint8Array(await file.arrayBuffer()))]);
-            frontend.gzip.set(name, gz);
-          }
-          headers["Content-Encoding"] = "gzip";
-          headers["Vary"] = "Accept-Encoding";
-          return new Response(gz, { headers });
-        }
-        return new Response(file, { headers });
-      }
-    }
-    if (path === "/backstage/manifest.webmanifest") {
-      return Response.json(
-        {
-          name: "Michael",
-          short_name: "Michael",
-          start_url: "/backstage/",
-          display: "standalone",
-          background_color: "#0b0809",
-          theme_color: "#0b0809",
-          icons: [
-            { src: "/backstage/icon-192.png?v=3", sizes: "192x192", type: "image/png", purpose: "any" },
-            { src: "/backstage/icon.png?v=3", sizes: "512x512", type: "image/png", purpose: "any" },
-          ],
-        },
-        { headers: { "Content-Type": "application/manifest+json" } }
-      );
-    }
-
-    // Land the user in a Plain triage session for a thread. If one already
-    // exists for this thread, jump straight to it; otherwise start a fresh
-    // triage run with the same context the automation gets on thread_created.
-    // Linked from the Plain support cards.
-    const plainTriageMatch = path.match(/^\/backstage\/plain-triage\/([^/]+)$/);
-    if (plainTriageMatch && req.method === "GET") {
-      const threadId = decodeURIComponent(plainTriageMatch[1]);
-
-      const redirect = (to: string) =>
-        new Response(null, { status: 302, headers: { Location: to } });
-
-      // Reuse the most recent live (non-archived) session for this thread so
-      // the card links to ongoing work instead of spawning a duplicate run.
-      const existing = getCachedSessions()
-        .filter((s) => s.plainThreadId === threadId && !s.archived)
-        .sort(
-          (a, b) =>
-            new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime()
-        )[0];
-      if (existing) return redirect(`/backstage/session/${existing.id}`);
-
-      const automation = listAutomations().find(
-        (a) => a.eventKey === "plain:thread_created"
-      );
-      if (!automation) return redirect("/backstage/");
-
-      // Build the same payload shape the webhook event carries
-      let payload: Record<string, unknown> = { threadId };
-      try {
-        const { getThreadWithMessages } = await import("./src/agents/plain/api");
-        const thread = await getThreadWithMessages(threadId);
-        payload = {
-          threadId,
-          title: thread?.title || null,
-          previewText: thread?.previewText || thread?.description || null,
-          status: thread?.status || null,
-          customer: {
-            email: thread?.customer?.email?.email || null,
-            fullName: thread?.customer?.fullName || null,
-          },
-        };
-      } catch (e) {
-        console.error(`[plain-triage] Thread lookup failed for ${threadId}:`, e);
-      }
-
-      const sessionId = await new Promise<string | null>((resolve) => {
-        const timer = setTimeout(() => resolve(null), 120_000);
-        void runAutomation(
-          automation,
-          (id) => {
-            sessionsCache = null;
-            clearTimeout(timer);
-            resolve(id);
-          },
-          { trigger: "event", eventContext: JSON.stringify(payload, null, 2) }
-        );
-      });
-
-      return redirect(sessionId ? `/backstage/session/${sessionId}` : "/backstage/");
-    }
-
-    // Health check (includes agent health — Tailscale-only, not public).
-    // frontendVersion lets clients detect a frontend-only rebuild (no bootId
-    // change) and refresh.
-    if (path === "/backstage/api/health") {
-      const agentHealth: Record<string, unknown> = {};
-      for (const a of agents) {
-        agentHealth[a.name] = a.health();
-      }
-      return Response.json({
-        ok: true,
-        bootId: BOOT_ID,
-        frontendVersion: frontend?.version ?? null,
-        uptime: process.uptime(),
-        // In-flight runner runs this process is driving — a drain-aware deploy
-        // polls this to restart only when the service is idle (or near it), so a
-        // restart kills as few in-flight runs/background tasks as possible.
-        activeRuns: activeAgentRunCount(),
-        agents: agentHealth,
-      });
-    }
-
-    // Rebuild the frontend bundle in-process (no restart → live runs untouched).
-    // Drop-in replacement for `systemctl restart backstage` after a frontend/CSS
-    // change. Tailscale + team gated at the network layer like every route here.
-    if (path === "/backstage/api/rebuild-frontend" && req.method === "POST") {
-      if (IS_DEV || !frontend) {
-        return Response.json({ ok: false, error: "not available in dev mode" }, { status: 400 });
-      }
-      try {
-        const version = await buildFrontend();
-        broadcastToAll({ type: "frontend_updated", version });
-        return Response.json({ ok: true, version });
-      } catch (e) {
-        return Response.json({ ok: false, error: String(e) }, { status: 500 });
-      }
-    }
-
-    // List sessions
-    if (path === "/backstage/api/sessions" && req.method === "GET") {
-      // Enrich with live, in-process signals that aren't on the cached session
-      // objects: whether a run is blocked on a human question (pendingAsks) and
-      // how many prompts are queued behind it. Drives the sidebar/tab "needs
-      // input" highlight without a second round-trip.
-      const enriched = getCachedSessions().map((s) => ({
-        ...s,
-        waitingForInput: pendingAsks.has(s.id),
-        queuedCount: promptQueues.get(s.id)?.length || 0,
-      }));
-      return Response.json(enriched);
-    }
-
-    // Get transcript for a session
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/transcript$/) && req.method === "GET") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/transcript$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-      if (!session.transcriptPath) return Response.json([]);
-      return Response.json(parseTranscript(session.transcriptPath));
-    }
-
-    // Sub-agent (Task/Agent) conversation for a session. The agentId comes from
-    // a Task tool_result's `agentId` field in the parent transcript.
-    {
-      const m = path.match(/^\/backstage\/api\/sessions\/(.+)\/subagent\/([^/]+)$/);
-      if (m && req.method === "GET") {
-        const session = findSession(decodeURIComponent(m[1]));
-        if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-        if (!session.transcriptPath) return Response.json({ error: "No transcript" }, { status: 404 });
-        const sub = getSubagentTranscript(session.transcriptPath, decodeURIComponent(m[2]));
-        if (!sub) return Response.json({ error: "Sub-agent not found" }, { status: 404 });
-        return Response.json({ ...sub, sessionRunning: session.isRunning });
-      }
-    }
-
-    // Live git diff for a session's worktree (Changes tab)
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/diff$/) && req.method === "GET") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/diff$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-
-      // One diff per repo in the session: primary worktree + each attached repo.
-      // Each carries its project id so the panel can show a repo switcher and
-      // route per-line feedback to the right checkout.
-      const targets: Array<{ project: string; dir: string | null; primary: boolean }> = [
-        {
-          project: session.project || (session.worktreeDir ? projectForPath(session.worktreeDir).id : "tella-fusion"),
-          dir: session.worktreeDir,
-          primary: true,
-        },
-        ...(session.attachedRepos || []).map((r) => ({ project: r.project, dir: r.dir, primary: false })),
-      ];
-
-      const repos = await Promise.all(
-        targets.map(async (t) => {
-          let diff: SessionDiff = {
-            branch: null, baseRef: null, files: [], totalAdditions: 0, totalDeletions: 0, rawPatch: "",
-          };
-          if (t.dir && existsSync(t.dir)) {
-            try {
-              diff = await getSessionDiff(t.dir, getProject(t.project).defaultBranch);
-            } catch {}
-          }
-          return { project: t.project, dir: t.dir, primary: t.primary, diff };
-        })
-      );
-
-      return Response.json({ repos });
-    }
-
-    // PR details for a session's branch (PR tab). `?repo=<project>` targets an
-    // attached repo's PR; default/primary targets the session's own branch.
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr$/) && req.method === "GET") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-      const target = resolvePrTarget(session, url.searchParams.get("repo"));
-      if (!target) return Response.json(null);
-      return Response.json(await getPrDetails(target.branch, target.ghRepo));
-    }
-
-    // PR diff for inline review in the PR tab
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-diff$/) && req.method === "GET") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-diff$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-      const target = resolvePrTarget(session, url.searchParams.get("repo"));
-      if (!target) return Response.json(null);
-      return Response.json(await getPrDiff(target.branch, target.ghRepo));
-    }
-
-    // Local dev-server ("Preview") status for a session's worktree — which
-    // services (.ports.conf) are listening, so the header can link to the
-    // webapp and show/stop running processes.
-    {
-      const m = path.match(/^\/backstage\/api\/sessions\/(.+)\/preview$/);
-      if (m && req.method === "GET") {
-        const session = findSession(decodeURIComponent(m[1]));
-        if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-        if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
-          return Response.json({ hasPortsConf: false, webappPort: null, running: false, previewUrl: null, services: [] });
-        }
-        return Response.json(await getPreviewStatus(session.worktreeDir));
-      }
-    }
-
-    // Stop the session's dev server (scoped to its worktree's process group).
-    {
-      const m = path.match(/^\/backstage\/api\/sessions\/(.+)\/preview\/stop$/);
-      if (m && req.method === "POST") {
-        const session = findSession(decodeURIComponent(m[1]));
-        if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-        if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
-          return Response.json({ hasPortsConf: false, webappPort: null, running: false, previewUrl: null, services: [] });
-        }
-        return Response.json(await stopPreview(session.worktreeDir));
-      }
-    }
-
-    // Post a comment on the session's PR (inline when path+line present)
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-comment$/) && req.method === "POST") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-comment$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-
-      const body = await req.json().catch(() => null);
-      if (!body?.text?.trim()) return Response.json({ error: "Empty comment" }, { status: 400 });
-      const target = resolvePrTarget(session, body.repo);
-      if (!target) return Response.json({ error: "No branch/PR for that repo" }, { status: 400 });
-
-      const user = body.user || "Someone";
-      const result = await postPrComment(target.branch, {
-        body: `**${user}** via Michael:\n\n${body.text.trim()}`,
-        path: body.path,
-        line: body.line,
-        startLine: body.startLine,
-        side: body.side,
-        startSide: body.startSide,
-      }, target.ghRepo);
-      if ("error" in result) return Response.json(result, { status: 502 });
-      return Response.json(result);
-    }
-
-    // Submit a batched review (all pending inline comments + an event) on the PR.
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/) && req.method === "POST") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-
-      const body = await req.json().catch(() => null);
-      const target = resolvePrTarget(session, body?.repo);
-      if (!target) return Response.json({ error: "No branch/PR for that repo" }, { status: 400 });
-      const event =
-        body?.event === "APPROVE" || body?.event === "REQUEST_CHANGES" ? body.event : "COMMENT";
-      const comments = Array.isArray(body?.comments) ? body.comments : [];
-      if (!comments.length && !body?.summary?.trim()) {
-        return Response.json({ error: "Nothing to submit" }, { status: 400 });
-      }
-
-      const user = body?.user || "Someone";
-      const summary = body?.summary?.trim();
-      const reviewBody = summary
-        ? `**${user}** via Michael:\n\n${summary}`
-        : `Review by **${user}** via Michael.`;
-      const result = await submitPrReview(target.branch, {
-        event,
-        body: reviewBody,
-        comments: comments
-          .filter((c: any) => c?.text?.trim() && c?.path && c?.line)
-          .map((c: any) => ({
-            path: c.path,
-            line: c.line,
-            startLine: c.startLine,
-            side: c.side,
-            startSide: c.startSide,
-            body: `**${user}**: ${c.text.trim()}`,
-          })),
-      }, target.ghRepo);
-      if ("error" in result) return Response.json(result, { status: 502 });
-      sessionsCache = null; // a review can change reviewDecision in the list
-      return Response.json(result);
-    }
-
-    // Squash & merge the session's PR — human-triggered from the Reviews view.
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-merge$/) && req.method === "POST") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-merge$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-
-      const body = await req.json().catch(() => ({}));
-      const target = resolvePrTarget(session, body.repo);
-      if (!target) return Response.json({ error: "No branch/PR for that repo" }, { status: 400 });
-      const method = body.method === "merge" || body.method === "rebase" ? body.method : "squash";
-      try {
-        const result = await mergePr(target.branch, { method, deleteBranch: !!body.deleteBranch }, target.ghRepo);
-        if ("error" in result) return Response.json(result, { status: 502 });
-        sessionsCache = null; // refresh prState in the sessions list
-        return Response.json(result);
-      } catch (e: any) {
-        return Response.json({ error: e.message || String(e) }, { status: 500 });
-      }
-    }
-
-    // Bulk-archive idle sessions
-    if (path === "/backstage/api/sessions/archive-old" && req.method === "POST") {
-      const body = await req.json().catch(() => ({}));
-      const days = Math.max(1, parseInt(body.days) || 7);
-      const count = archiveOlderThan(getAllSessions(), days);
-      sessionsCache = null;
-      return Response.json({ archived: count });
-    }
-
-    // Archive / unarchive a single session
-    const archiveMatch = path.match(/^\/backstage\/api\/sessions\/(.+)\/archive$/);
-    if (archiveMatch && req.method === "POST") {
-      const sessionId = decodeURIComponent(archiveMatch[1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-      const body = await req.json().catch(() => ({}));
-      setArchived(sessionId, body.archived !== false);
-      sessionsCache = null;
-      return Response.json({ ok: true });
-    }
-
-    // Delete a session (+ optional worktree cleanup)
-    if (path.match(/^\/backstage\/api\/sessions\/(.+)$/) && req.method === "DELETE") {
-      const sessionId = decodeURIComponent(path.match(/^\/backstage\/api\/sessions\/(.+)$/)![1]);
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-
-      const cleanWorktree = url.searchParams.get("worktree") === "true";
-      try {
-        deleteSession(session);
-        if (cleanWorktree && session.worktreeDir && session.branch) {
-          await removeWorktree(session.branch, projectForPath(session.worktreeDir).id);
-        }
-        sessionsCache = null;
-        return Response.json({ ok: true });
-      } catch (e: any) {
-        return Response.json({ error: e.message }, { status: 500 });
-      }
-    }
-
-    // List worktrees (optionally for a specific project)
-    if (path === "/backstage/api/worktrees" && req.method === "GET") {
-      return Response.json(await listWorktrees(url.searchParams.get("project") || undefined));
-    }
-
-    // File-mention autocomplete ("@" in the composer). Searches the session's
-    // primary worktree plus any attached repos (cross-repo sessions), falling
-    // back to the default project repo for new-session composers with no session
-    // yet. Each hit carries `insert` (what lands in the textarea: a bare path for
-    // the primary repo, `<project>:path` for an attached one) and a `repo` label
-    // when more than one repo is in play.
-    if (path === "/backstage/api/files" && req.method === "GET") {
-      const q = url.searchParams.get("q") || "";
-      const sessionId = url.searchParams.get("session");
-      const repos: Array<{ project: string; dir: string; primary: boolean }> = [];
-      const session = sessionId ? findSession(sessionId) : undefined;
-      if (session?.worktreeDir && existsSync(session.worktreeDir)) {
-        repos.push({
-          project: session.project || projectForPath(session.worktreeDir).id,
-          dir: session.worktreeDir,
-          primary: true,
-        });
-        for (const r of session.attachedRepos || []) {
-          if (existsSync(r.dir)) repos.push({ project: r.project, dir: r.dir, primary: false });
-        }
-      }
-      if (!repos.length) {
-        const proj = getProject(url.searchParams.get("project") || undefined);
-        repos.push({ project: proj.id, dir: proj.repo, primary: true });
-      }
-      const multi = repos.length > 1;
-      const perRepo = multi ? Math.max(6, Math.floor(20 / repos.length)) : 20;
-      const out: Array<{ display: string; insert: string; repo?: string }> = [];
-      for (const r of repos) {
-        try {
-          for (const f of await searchRepoFiles(r.dir, q, perRepo)) {
-            out.push({
-              display: f,
-              insert: r.primary ? f : `${r.project}:${f}`,
-              repo: multi ? r.project : undefined,
-            });
-          }
-        } catch {}
-      }
-      return Response.json({ files: out.slice(0, 24) });
-    }
-
-    // Projects available to attach / start a session against.
-    if (path === "/backstage/api/projects" && req.method === "GET") {
-      return Response.json({
-        projects: Object.values(PROJECTS).map((p) => ({
-          id: p.id,
-          defaultBranch: p.defaultBranch,
-          sharedCheckout: !!p.sharedCheckout,
-        })),
-      });
-    }
-
-    // Attach a secondary repo to a session (cross-repo work): creates/reuses an
-    // isolated worktree and records it on the session.
-    const attachMatch = path.match(/^\/backstage\/api\/sessions\/(.+)\/attach-repo$/);
-    if (attachMatch && req.method === "POST") {
-      const sessionId = decodeURIComponent(attachMatch[1]);
-      const body = (await req.json().catch(() => ({}))) as { project?: string; branch?: string };
-      if (!body.project) return Response.json({ error: "project required" }, { status: 400 });
-      try {
-        const { attached, all } = await attachRepo(sessionId, body.project, body.branch);
-        return Response.json({ ok: true, attached, attachedRepos: all });
-      } catch (e: any) {
-        return Response.json({ error: e.message || String(e) }, { status: 400 });
-      }
-    }
-
-    // Detach a secondary repo (drops it from the session; leaves the worktree on
-    // disk so unmerged work isn't lost — clean it up via the worktrees sweep).
-    // POST, not DELETE, so it isn't swallowed by the generic DELETE /sessions/:id.
-    const detachMatch = path.match(/^\/backstage\/api\/sessions\/(.+)\/detach-repo$/);
-    if (detachMatch && req.method === "POST") {
-      const sessionId = decodeURIComponent(detachMatch[1]);
-      const body = (await req.json().catch(() => ({}))) as { project?: string };
-      const session = findSession(sessionId);
-      if (!session) return Response.json({ error: "Session not found" }, { status: 404 });
-      const all = (session.attachedRepos || []).filter((r) => r.project !== body.project);
-      touchBackstageSession(sessionId, { attachedRepos: all });
-      return Response.json({ ok: true, attachedRepos: all });
-    }
-
-    // ── Automations ──
-    if (path === "/backstage/api/automations" && req.method === "GET") {
-      const list = listAutomations().map((a) => ({
-        ...a,
-        isRunning: isAutomationRunning(a.id),
-      }));
-      return Response.json(list);
-    }
-
-    if (path === "/backstage/api/automations" && req.method === "POST") {
-      const body = await req.json().catch(() => null);
-      if (!body) return Response.json({ error: "Invalid JSON" }, { status: 400 });
-      const result = createAutomation(body);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    const autoRunMatch = path.match(/^\/backstage\/api\/automations\/([^/]+)\/run$/);
-    if (autoRunMatch && req.method === "POST") {
-      const automation = getAutomation(autoRunMatch[1]);
-      if (!automation) return Response.json({ error: "Not found" }, { status: 404 });
-      if (isAutomationRunning(automation.id)) {
-        return Response.json({ error: "Already running" }, { status: 409 });
-      }
-      // Fire and forget; session shows up in the list once it boots
-      void runAutomation(automation, () => {
-        sessionsCache = null;
-      });
-      return Response.json({ ok: true });
-    }
-
-    const autoMatch = path.match(/^\/backstage\/api\/automations\/([^/]+)$/);
-    if (autoMatch && req.method === "PUT") {
-      const body = await req.json().catch(() => null);
-      if (!body) return Response.json({ error: "Invalid JSON" }, { status: 400 });
-      const result = updateAutomation(autoMatch[1], body);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    if (autoMatch && req.method === "DELETE") {
-      return deleteAutomation(autoMatch[1])
-        ? Response.json({ ok: true })
-        : Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    // ── Actions (run a registered repo script behind a form) ──
-    if (path === "/backstage/api/actions" && req.method === "GET") {
-      return Response.json(listActions());
-    }
-
-    if (path === "/backstage/api/actions" && req.method === "POST") {
-      const body = await req.json().catch(() => null);
-      if (!body) return Response.json({ error: "Invalid JSON" }, { status: 400 });
-      const result = createAction(body);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    // Suggest inputs for a script being registered (parses $1..$9 / $VAR).
-    if (path === "/backstage/api/actions/introspect" && req.method === "POST") {
-      const body = (await req.json().catch(() => ({}))) as {
-        repo?: string;
-        scriptPath?: string;
-      };
-      const result = introspectScript(body.repo || "tella-fusion", String(body.scriptPath || ""));
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    const actionRunMatch = path.match(/^\/backstage\/api\/actions\/([^/]+)\/run$/);
-    if (actionRunMatch && req.method === "POST") {
-      const action = getAction(actionRunMatch[1]);
-      if (!action) return Response.json({ error: "Not found" }, { status: 404 });
-      const body = (await req.json().catch(() => ({}))) as {
-        values?: Record<string, unknown>;
-        user?: string;
-      };
-      const result = runAction(action, body.values || {}, body.user, () => {
-        sessionsCache = null;
-      });
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    const actionMatch = path.match(/^\/backstage\/api\/actions\/([^/]+)$/);
-    if (actionMatch && req.method === "GET") {
-      const action = getAction(actionMatch[1]);
-      return action
-        ? Response.json(action)
-        : Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    if (actionMatch && req.method === "DELETE") {
-      return deleteAction(actionMatch[1])
-        ? Response.json({ ok: true })
-        : Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    // ── Connections ──
-    if (path === "/backstage/api/connections" && req.method === "GET") {
-      const force = url.searchParams.get("refresh") === "1";
-      const mcpServers = await getConnections(force);
-      const agentHealth: Record<string, unknown> = {};
-      for (const a of agents) agentHealth[a.name] = a.health();
-      return Response.json({ mcpServers, agents: agentHealth });
-    }
-
-    if (path === "/backstage/api/connections/mcp" && req.method === "POST") {
-      const body = await req.json().catch(() => null);
-      if (!body) return Response.json({ error: "Invalid JSON" }, { status: 400 });
-      const result = addMcpServer(body);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    const mcpDelMatch = path.match(/^\/backstage\/api\/connections\/mcp\/([^/]+)$/);
-    if (mcpDelMatch && req.method === "DELETE") {
-      const result = removeMcpServer(decodeURIComponent(mcpDelMatch[1]));
-      if ("error" in result) return Response.json(result, { status: 404 });
-      return Response.json(result);
-    }
-
-    // ── Claude account pool (tokens are never sent back, only masked) ──
-    if (path === "/backstage/api/claude-accounts" && req.method === "GET") {
-      return Response.json({ accounts: listAccountsPublic() });
-    }
-
-    if (path === "/backstage/api/claude-accounts" && req.method === "POST") {
-      const body = await req.json().catch(() => null);
-      if (!body?.name || !body?.token) {
-        return Response.json({ error: "name and token are required" }, { status: 400 });
-      }
-      const result = await addAccount(body.name, body.token);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    if (path === "/backstage/api/claude-accounts/refresh" && req.method === "POST") {
-      await refreshAllUsage();
-      return Response.json({ accounts: listAccountsPublic() });
-    }
-
-    const accountDelMatch = path.match(/^\/backstage\/api\/claude-accounts\/([^/]+)$/);
-    if (accountDelMatch && req.method === "DELETE") {
-      return removeAccount(decodeURIComponent(accountDelMatch[1]))
-        ? Response.json({ ok: true })
-        : Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    // ── Models available to sessions ──
-    if (path === "/backstage/api/models" && req.method === "GET") {
-      return Response.json({ models: KNOWN_MODELS, default: getDefaultModel() });
-    }
-
-    // Set (or clear, with model:null) the default model new sessions run on.
-    if (path === "/backstage/api/models/default" && req.method === "PUT") {
-      const body = await req.json().catch(() => null);
-      if (!body || !("model" in body)) {
-        return Response.json({ error: "model is required (id, or null to clear)" }, { status: 400 });
-      }
-      try {
-        const next = setDefaultModel(body.model ?? null);
-        return Response.json({ default: next });
-      } catch (e: any) {
-        return Response.json({ error: e?.message || "Failed to set default model" }, { status: 400 });
-      }
-    }
-
-    // ── Per-user pinned tabs ──
-    // Keyed on the self-selected `user` name (team-internal, not auth). GET reads
-    // a user's pins; PUT replaces them wholesale (the frontend sends the full list
-    // on every toggle and on first-load localStorage migration).
-    if (path === "/backstage/api/pins" && req.method === "GET") {
-      const user = url.searchParams.get("user") || "Anonymous";
-      return Response.json({ pins: getUserPins(user) });
-    }
-
-    if (path === "/backstage/api/pins" && req.method === "PUT") {
-      const body = await req.json().catch(() => null);
-      if (!body || typeof body.user !== "string" || !Array.isArray(body.pins)) {
-        return Response.json({ error: "user (string) and pins (array) are required" }, { status: 400 });
-      }
-      return Response.json({ pins: setUserPins(body.user, body.pins) });
-    }
-
-    // ── Codex (OpenAI) account pool ──
-    if (path === "/backstage/api/codex-accounts" && req.method === "GET") {
-      return Response.json({ accounts: listCodexAccountsPublic() });
-    }
-
-    if (path === "/backstage/api/codex-accounts" && req.method === "POST") {
-      const body = await req.json().catch(() => null);
-      if (!body?.name || !body?.value || !["api_key", "home"].includes(body?.kind)) {
-        return Response.json(
-          { error: "name, kind (api_key|home) and value are required" },
-          { status: 400 }
-        );
-      }
-      const result = addCodexAccount(body.name, body.kind, body.value);
-      if ("error" in result) return Response.json(result, { status: 400 });
-      return Response.json(result);
-    }
-
-    const codexAccountDelMatch = path.match(/^\/backstage\/api\/codex-accounts\/([^/]+)$/);
-    if (codexAccountDelMatch && req.method === "DELETE") {
-      return removeCodexAccount(decodeURIComponent(codexAccountDelMatch[1]))
-        ? Response.json({ ok: true })
-        : Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    // ── Wiki ──
-    if (path === "/backstage/api/wiki/tree" && req.method === "GET") {
-      return Response.json(getWikiTree());
-    }
-
-    if (path === "/backstage/api/wiki/file" && req.method === "GET") {
-      const rel = url.searchParams.get("path") || "";
-      const file = getWikiFile(rel);
-      if (!file) return Response.json({ error: "Not found" }, { status: 404 });
-      return Response.json(file);
-    }
-
-    if (path === "/backstage/api/wiki/search" && req.method === "GET") {
-      const q = url.searchParams.get("q") || "";
-      return Response.json(searchWiki(q));
-    }
-
-    // WebSocket upgrade
-    if (path === "/backstage/ws") {
-      const upgraded = server.upgrade(req, {
-        data: { watchingSessionId: null, user: null },
-      });
-      if (!upgraded) {
-        return new Response("WebSocket upgrade failed", { status: 400 });
-      }
-      return undefined;
-    }
-
-    // 404
-    return Response.json({ error: "Not found" }, { status: 404 });
-  },
-
-  websocket: {
-    open(ws) {
-      allClients.add(ws);
-      console.log("WebSocket client connected");
-    },
-
-    async message(ws, message) {
-      let msg: any;
-      try {
-        msg = JSON.parse(String(message));
-      } catch {
-        ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
-        return;
-      }
-
-      switch (msg.type) {
-        case "watch": {
-          const sessionId = msg.sessionId;
-          const session = findSession(sessionId);
-          if (!session) {
-            ws.send(JSON.stringify({ type: "error", message: "Session not found" }));
-            return;
-          }
-
-          // Stop watching any previous session first
-          stopAllWatchesForClient(ws);
-          leaveSession(ws);
-
-          const data = ws.data;
-          data.watchingSessionId = sessionId;
-          if (msg.user) data.user = msg.user;
-          joinSession(ws, sessionId);
-
-          // Send the tail of the transcript for a fast initial render. A large
-          // (multi-MB) transcript would otherwise block the open for seconds;
-          // `truncated` tells the client to offer "load earlier history", which
-          // comes back as a `load_history` message below.
-          const { entries, truncated } = session.transcriptPath
-            ? parseTranscriptTail(session.transcriptPath)
-            : { entries: [], truncated: false };
-          ws.send(JSON.stringify({ type: "transcript_init", entries, truncated }));
-
-          // Start file watcher
-          if (session.transcriptPath) {
-            startWatching(session.transcriptPath, ws);
-          }
-
-          // Pending interactive question, if any
-          const pendingAsk = pendingAsks.get(sessionId);
-          if (pendingAsk) {
-            ws.send(
-              JSON.stringify({
-                type: "ask_question",
-                sessionId,
-                questionId: pendingAsk.questionId,
-                questions: pendingAsk.questions,
-              })
-            );
-          }
-
-          // Current message queue + steer receipts for this session
-          ws.send(
-            JSON.stringify({
-              type: "queue_update",
-              sessionId,
-              queued: promptQueues.get(sessionId) || [],
-              steered: steeredReceipts.get(sessionId) || [],
-            })
-          );
-
-          // Send running status
-          ws.send(
-            JSON.stringify({
-              type: "session_status",
-              isRunning:
-                session.isRunning ||
-                isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id),
-            })
-          );
-          break;
-        }
-
-        case "load_history": {
-          // "Load earlier history" button: the initial watch only sent the tail,
-          // so re-send the full transcript (cached by mtime in jsonl-parser).
-          const session = findSession(msg.sessionId);
-          if (!session?.transcriptPath) {
-            ws.send(JSON.stringify({ type: "transcript_init", entries: [], truncated: false }));
-            return;
-          }
-          const entries = parseTranscript(session.transcriptPath);
-          ws.send(JSON.stringify({ type: "transcript_init", entries, truncated: false }));
-          break;
-        }
-
-        case "prompt": {
-          const { sessionId, content, user } = msg;
-          const images = parseImageDataUrls(msg.images);
-          const session = findSession(sessionId);
-          if (!session) {
-            ws.send(JSON.stringify({ type: "error", message: "Session not found" }));
-            return;
-          }
-
-          // Slash commands are handled by backstage itself
-          const notice = handleSlashCommand(session, String(content || "").trim(), user);
-          if (notice !== null) {
-            ws.send(JSON.stringify({ type: "notice", message: notice }));
-            sessionsCache = null;
-            break;
-          }
-
-          // Busy → steer it into the running query (delivered at the next
-          // turn boundary, Claude-Code style). Falls back to the queue when
-          // the run isn't steerable: codex runs, runs owned by another
-          // process (Slack handler, CLI in tmux), or a run that's finishing.
-          if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) {
-            const attributed = user ? `[${user}] ${content}` : content;
-            if (steerAgentRun([session.claudeSessionId, session.codexThreadId, session.id], attributed)) {
-              // The message lands in the transcript when its turn starts. Until
-              // then a steer receipt is the durable visible record (survives
-              // reload/leave); kept out of promptQueues so the drain never
-              // re-delivers it, and cleared when the run finishes.
-              recordSteer(sessionId, { content, user });
-              broadcastToSession(sessionId, {
-                type: "notice",
-                message: `Message from ${user || "you"} folded into the run — Michael picks it up at the next stopping point.`,
-              });
-              break;
-            }
-            enqueuePrompt(sessionId, { content, user });
-            watchExternalRunAndDrain(sessionId);
-            break;
-          }
-
-          // Codex sessions start a fresh thread on first prompt; Claude needs
-          // a session id to resume.
-          if (providerFor(session.model) === "claude" && !session.claudeSessionId) {
-            ws.send(JSON.stringify({ type: "error", message: "No Claude session to resume" }));
-            return;
-          }
-
-          await runSessionPromptAndDrain(sessionId, content, user, images);
-          break;
-        }
-
-        case "interrupt_prompt": {
-          // Esc-style redirect: stop the current turn, keep the session, and
-          // continue right away with this message. Falls back to a normal
-          // prompt (steer/queue/run) when there's nothing to interrupt.
-          const { sessionId, content, user } = msg;
-          const session = findSession(sessionId);
-          if (!session) {
-            ws.send(JSON.stringify({ type: "error", message: "Session not found" }));
-            return;
-          }
-          const attributed = user ? `[${user}] ${content}` : content;
-          if (
-            isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id) &&
-            interruptAndSteerAgentRun(
-              [session.claudeSessionId, session.codexThreadId, session.id],
-              attributed
-            )
-          ) {
-            // Interrupt aborts the current turn and continues immediately, so
-            // the message lands in the transcript almost at once — no steer
-            // receipt ("folded in" would be wrong for an interrupt) and no system
-            // notice. The sender's optimistic bubble reconciles when its real
-            // turn appears; the SDK's "[Request interrupted by user]" marker is
-            // filtered out in jsonl-parser.
-            break;
-          }
-          // Not interruptible (external run, codex, or just finished): treat
-          // like a normal send so the message is never lost.
-          if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) {
-            enqueuePrompt(sessionId, { content, user });
-            watchExternalRunAndDrain(sessionId);
-            break;
-          }
-          await runSessionPromptAndDrain(sessionId, content, user);
-          break;
-        }
-
-        case "cancel": {
-          const data = ws.data;
-          if (data.watchingSessionId) {
-            const session = findSession(data.watchingSessionId);
-            if (session) {
-              cancelAgentRun(session.claudeSessionId, session.codexThreadId, session.id);
-            }
-            clearSteerReceipts(data.watchingSessionId);
-            const dropped = promptQueues.get(data.watchingSessionId)?.length || 0;
-            if (dropped > 0) {
-              promptQueues.delete(data.watchingSessionId);
-              persistQueues();
-              broadcastQueue(data.watchingSessionId);
-              broadcastToSession(data.watchingSessionId, {
-                type: "notice",
-                message: `Cancelled — ${dropped} queued message${dropped === 1 ? "" : "s"} dropped.`,
-              });
-            }
-          }
-          break;
-        }
-
-        case "answer_question": {
-          const { sessionId, questionId, answers } = msg;
-          const pending = pendingAsks.get(sessionId);
-          if (pending && pending.questionId === questionId) {
-            pending.resolve(answers && typeof answers === "object" ? answers : null);
-          }
-          break;
-        }
-
-        case "create_session": {
-          const { branch, prompt, user, mode } = msg;
-          const images = parseImageDataUrls(msg.images);
-
-          // Fork: branch a new session off an existing one, keeping the REAL
-          // engine conversation (via SDK forkSession), optionally from a chosen
-          // message. Inherits the source's mode/model/cwd. Claude-only.
-          const forkFrom = msg.forkFrom as { sourceId?: string; messageId?: string } | undefined;
-          const forkSource = forkFrom?.sourceId ? findSession(forkFrom.sourceId) : undefined;
-          if (forkFrom?.sourceId && !forkSource) {
-            ws.send(JSON.stringify({ type: "error", message: "Fork source session not found" }));
-            return;
-          }
-          const canFork =
-            !!forkSource &&
-            providerFor(forkSource.model) === "claude" &&
-            !!forkSource.claudeSessionId;
-          if (forkSource && !canFork) {
-            ws.send(JSON.stringify({ type: "error", message: "Fork is only supported for Claude sessions" }));
-            return;
-          }
-
-          const isAsk = forkSource ? forkSource.mode !== "code" : mode === "ask";
-          // Optional model pick from the UI; invalid input falls back to default.
-          // A fork inherits the source's model.
-          const model = forkSource
-            ? forkSource.model
-            : msg.model
-              ? resolveModel(String(msg.model))?.id
-              : undefined;
-          const isCodex = providerFor(model) === "codex";
-          // Which repo this session works in (tella-fusion by default).
-          const project = getProject(typeof msg.project === "string" ? msg.project : undefined);
-          try {
-            let wtPath: string;
-            if (forkSource) {
-              // Share the source's cwd so the fork sees the same code state.
-              wtPath = forkSource.worktreeDir || project.repo;
-            } else if (isAsk) {
-              // Ask sessions run read-only on the main checkout — no worktree
-              wtPath = project.repo;
-            } else if (project.sharedCheckout) {
-              // Backstage: code sessions edit the live main checkout on the
-              // default branch (hot-reloads in the running server). No worktree.
-              wtPath = project.repo;
-            } else {
-              // Check if worktree exists, create if needed
-              const worktrees = await listWorktrees(project.id);
-              wtPath = worktrees.find((w) => w.branch === branch)?.path || "";
-              if (!wtPath) {
-                wtPath = await createWorktree(branch, project.id);
-              }
-            }
-
-            const bksId = `bks-${randomUUIDv7()}`;
-            const title = prompt.trim().split("\n")[0].slice(0, 80);
-
-            ws.send(JSON.stringify({ type: "stream_start", sessionId: bksId }));
-
-            let engineSessionId = "";
-            let persisted = false;
-            const persist = () => {
-              const sessionData: BackstageSessionFile = {
-                id: bksId,
-                claudeSessionId: isCodex ? "" : engineSessionId,
-                ...(isCodex && engineSessionId ? { codexThreadId: engineSessionId } : {}),
-                ...(model ? { model } : {}),
-                branch: forkSource
-                  ? forkSource.branch || ""
-                  : isAsk
-                    ? ""
-                    : project.sharedCheckout
-                      ? project.defaultBranch
-                      : branch,
-                worktreeDir: wtPath,
-                project: projectForPath(wtPath).id,
-                createdBy: user || "Anonymous",
-                createdAt: new Date().toISOString(),
-                lastActivity: new Date().toISOString(),
-                title,
-                mode: isAsk ? "ask" : "code",
-              };
-              writeFileSync(
-                `${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`,
-                JSON.stringify(sessionData, null, 2)
-              );
-              sessionsCache = null;
-              persisted = true;
-            };
-
-            for await (const event of runAgent({
-              prompt,
-              cwd: wtPath,
-              mode: isAsk ? "ask" : "code",
-              model,
-              images,
-              // Fork: resume the source engine session into a new branch,
-              // optionally from a specific past message.
-              ...(canFork
-                ? {
-                    sessionId: forkSource!.claudeSessionId!,
-                    forkSession: true,
-                    resumeSessionAt: forkFrom?.messageId,
-                  }
-                : {}),
-              inProcessMcp: interactiveMcpServers(user, bksId),
-              confirmTools: STRIPE_CONFIRM_TOOLS,
-              aws: true, // interactive sessions keep AWS read access (via injected creds)
-              journal: { bksSessionId: bksId, kind: "create" },
-              onAskUser: makeAskHandler(bksId),
-            })) {
-              if (event.type === "init") {
-                engineSessionId = event.sessionId || "";
-                // Persist immediately so the session is visible/shareable while running
-                persist();
-                ws.send(JSON.stringify({ type: "session_created", id: bksId }));
-              }
-              if (event.type === "text_chunk") {
-                // Direct send for the creator (not in the room until they watch),
-                // room broadcast for everyone else — never both to the same socket
-                ws.send(JSON.stringify({ type: "stream_text", text: event.text }));
-                broadcastToSession(bksId, { type: "stream_text", text: event.text }, ws);
-              }
-              if (event.type === "tool_use") {
-                const entry = {
-                  id: event.toolUseId || crypto.randomUUID(),
-                  type: "tool_use" as const,
-                  content: `Using ${event.toolName}`,
-                  timestamp: new Date().toISOString(),
-                  toolName: event.toolName,
-                  toolInput: event.toolInput,
-                  toolUseId: event.toolUseId,
-                };
-                ws.send(JSON.stringify({ type: "stream_tool_use", entry }));
-                broadcastToSession(bksId, { type: "stream_tool_use", entry }, ws);
-              }
-              if (event.type === "tool_result") {
-                const entry = {
-                  id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
-                  type: "tool_result" as const,
-                  content: event.content || "",
-                  timestamp: new Date().toISOString(),
-                  toolUseId: event.toolUseId,
-                  ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
-                  ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
-                };
-                ws.send(JSON.stringify({ type: "stream_tool_result", entry }));
-                broadcastToSession(bksId, { type: "stream_tool_result", entry }, ws);
-              }
-              if (event.type === "done") {
-                engineSessionId = event.sessionId || engineSessionId;
-              }
-              if (event.type === "error") {
-                ws.send(JSON.stringify({ type: "error", message: event.content }));
-              }
-            }
-
-            if (!persisted) persist();
-            else
-              touchBackstageSession(
-                bksId,
-                isCodex ? { codexThreadId: engineSessionId } : { claudeSessionId: engineSessionId }
-              );
-
-            ws.send(JSON.stringify({ type: "stream_done" }));
-            broadcastToSession(bksId, { type: "stream_done" }, ws);
-            broadcastToSession(bksId, { type: "session_status", isRunning: false });
-            if (!(promptQueues.get(bksId)?.length)) onHumanAsksSessionIdle(bksId);
-          } catch (e: any) {
-            ws.send(JSON.stringify({ type: "error", message: e.message || String(e) }));
-          }
-          break;
-        }
-      }
-    },
-
-    close(ws) {
-      allClients.delete(ws);
-      stopAllWatchesForClient(ws);
-      leaveSession(ws);
-      console.log("WebSocket client disconnected");
-    },
-  },
-
-  // Dev mode (HMR + error overlay + browser-console streaming) only when
-  // explicitly asked for — the systemd service is production, and the overlay
-  // pops "Script error." boxes on iOS with no diagnostics behind them.
-  development:
-    process.env.BACKSTAGE_DEV === "1"
-      ? {
-          hmr: true,
-          console: true,
-        }
-      : false,
-}));
+const server: import("bun").Server<WSClientData> = (g.__backstageServer ??=
+	Bun.serve<WSClientData>({
+		port: PORT,
+		hostname: HOST,
+		// The plain-triage route waits for worktree+session boot (~15-60s);
+		// Bun's default 10s idleTimeout would drop the connection mid-wait
+		idleTimeout: 240,
+
+		routes: {
+			"/backstage": spaEntry,
+			"/backstage/": spaEntry,
+			"/backstage/index.html": spaEntry,
+			// Client-side routes must serve the SPA shell, not the raw file
+			"/backstage/new": spaEntry,
+			"/backstage/session/*": spaEntry,
+			"/backstage/automations": spaEntry,
+			"/backstage/wiki": spaEntry,
+			"/backstage/wiki/*": spaEntry,
+			"/backstage/connections": spaEntry,
+			"/backstage/archived": spaEntry,
+			"/backstage/reviews": spaEntry,
+			"/backstage/reviews/*": spaEntry,
+		},
+
+		async fetch(req) {
+			const url = new URL(req.url);
+			const path = url.pathname;
+
+			// Stream a local media file referenced by a `BACKSTAGE_VIDEO:` marker in a
+			// tool's output, so the session viewer can play it inline (tools can't return
+			// video blocks the way Read returns images). Path-scoped: absolute path under
+			// /tmp or /home/ubuntu, no traversal, known media extension. Range-enabled
+			// so the <video> scrubber can seek.
+			if (path === "/backstage/media" && req.method === "GET") {
+				const mediaPath = url.searchParams.get("path") || "";
+				const mediaTypes: Record<string, string> = {
+					".mp4": "video/mp4",
+					".webm": "video/webm",
+					".mov": "video/quicktime",
+					".png": "image/png",
+					".jpg": "image/jpeg",
+					".jpeg": "image/jpeg",
+					".gif": "image/gif",
+					".webp": "image/webp",
+				};
+				const ext = mediaPath.slice(mediaPath.lastIndexOf(".")).toLowerCase();
+				const scoped =
+					mediaPath.startsWith("/tmp/") ||
+					mediaPath.startsWith("/home/ubuntu/");
+				if (
+					!mediaPath.startsWith("/") ||
+					mediaPath.includes("..") ||
+					!scoped ||
+					!mediaTypes[ext]
+				) {
+					return new Response("forbidden", { status: 403 });
+				}
+				const file = Bun.file(mediaPath);
+				if (!(await file.exists()))
+					return new Response("not found", { status: 404 });
+
+				const type = mediaTypes[ext];
+				const size = file.size;
+				const range = req.headers.get("range");
+				const baseHeaders: Record<string, string> = {
+					"Content-Type": type,
+					"Accept-Ranges": "bytes",
+					"Cache-Control": "private, max-age=60",
+				};
+				if (range) {
+					const m = range.match(/bytes=(\d*)-(\d*)/);
+					let start = m && m[1] ? parseInt(m[1], 10) : 0;
+					let end = m && m[2] ? parseInt(m[2], 10) : size - 1;
+					if (Number.isNaN(start) || start < 0) start = 0;
+					if (Number.isNaN(end) || end >= size) end = size - 1;
+					if (start > end) {
+						return new Response("range not satisfiable", {
+							status: 416,
+							headers: { "Content-Range": `bytes */${size}` },
+						});
+					}
+					return new Response(file.slice(start, end + 1), {
+						status: 206,
+						headers: {
+							...baseHeaders,
+							"Content-Range": `bytes ${start}-${end}/${size}`,
+							"Content-Length": String(end - start + 1),
+						},
+					});
+				}
+				return new Response(file, {
+					headers: { ...baseHeaders, "Content-Length": String(size) },
+				});
+			}
+
+			// App icons (KITT/red-M) — real PNGs so iOS home-screen and PWA installs
+			// pick them up; data-URI apple-touch-icons don't work on iOS. Short cache
+			// + must-revalidate so a refreshed design isn't pinned by a stale copy.
+			const iconFiles: Record<string, string> = {
+				"/backstage/apple-touch-icon.png": "apple-touch-icon.png", // 180×180
+				"/backstage/icon-192.png": "icon-192.png",
+				"/backstage/icon.png": "icon.png", // 512×512
+			};
+			if (iconFiles[path]) {
+				return new Response(
+					Bun.file(`${import.meta.dir}/src/frontend/${iconFiles[path]}`),
+					{
+						headers: {
+							"Content-Type": "image/png",
+							"Cache-Control": "public, max-age=3600, must-revalidate",
+						},
+					},
+				);
+			}
+
+			// iOS PWA launch images (apple-touch-startup-image). One PNG per device
+			// resolution, generated by scripts/gen-splash.py. Filename is locked to the
+			// apple-splash-<w>-<h>.png pattern so the path can't escape the folder.
+			const splashMatch = path.match(
+				/^\/backstage\/splash\/(apple-splash-\d+-\d+\.png)$/,
+			);
+			if (splashMatch) {
+				return new Response(
+					Bun.file(`${import.meta.dir}/src/frontend/splash/${splashMatch[1]}`),
+					{
+						headers: {
+							"Content-Type": "image/png",
+							"Cache-Control": "public, max-age=86400",
+						},
+					},
+				);
+			}
+
+			// Built SPA assets (prod only). Content-hashed filenames → cache forever.
+			// Served gzipped (computed once, then memoised) since the JS is large.
+			const assetMatch =
+				frontend && path.match(/^\/backstage\/([\w.-]+\.(?:js|css|map))$/);
+			if (assetMatch) {
+				const name = assetMatch[1];
+				const file = Bun.file(`${FRONTEND_DIST}/${name}`);
+				if (await file.exists()) {
+					const type = name.endsWith(".css")
+						? "text/css"
+						: name.endsWith(".map")
+							? "application/json"
+							: "text/javascript";
+					const headers: Record<string, string> = {
+						"Content-Type": `${type}; charset=utf-8`,
+						"Cache-Control": "public, max-age=31536000, immutable",
+					};
+					if ((req.headers.get("accept-encoding") || "").includes("gzip")) {
+						let gz = frontend.gzip.get(name);
+						if (!gz) {
+							gz = new Blob([
+								Bun.gzipSync(new Uint8Array(await file.arrayBuffer())),
+							]);
+							frontend.gzip.set(name, gz);
+						}
+						headers["Content-Encoding"] = "gzip";
+						headers["Vary"] = "Accept-Encoding";
+						return new Response(gz, { headers });
+					}
+					return new Response(file, { headers });
+				}
+			}
+			if (path === "/backstage/manifest.webmanifest") {
+				return Response.json(
+					{
+						name: "Michael",
+						short_name: "Michael",
+						start_url: "/backstage/",
+						display: "standalone",
+						background_color: "#0b0809",
+						theme_color: "#0b0809",
+						icons: [
+							{
+								src: "/backstage/icon-192.png?v=3",
+								sizes: "192x192",
+								type: "image/png",
+								purpose: "any",
+							},
+							{
+								src: "/backstage/icon.png?v=3",
+								sizes: "512x512",
+								type: "image/png",
+								purpose: "any",
+							},
+						],
+					},
+					{ headers: { "Content-Type": "application/manifest+json" } },
+				);
+			}
+
+			// Land the user in a Plain triage session for a thread. If one already
+			// exists for this thread, jump straight to it; otherwise start a fresh
+			// triage run with the same context the automation gets on thread_created.
+			// Linked from the Plain support cards.
+			const plainTriageMatch = path.match(
+				/^\/backstage\/plain-triage\/([^/]+)$/,
+			);
+			if (plainTriageMatch && req.method === "GET") {
+				const threadId = decodeURIComponent(plainTriageMatch[1]);
+
+				const redirect = (to: string) =>
+					new Response(null, { status: 302, headers: { Location: to } });
+
+				// Reuse the most recent live (non-archived) session for this thread so
+				// the card links to ongoing work instead of spawning a duplicate run.
+				const existing = getCachedSessions()
+					.filter((s) => s.plainThreadId === threadId && !s.archived)
+					.sort(
+						(a, b) =>
+							new Date(b.lastActivity).getTime() -
+							new Date(a.lastActivity).getTime(),
+					)[0];
+				if (existing) return redirect(`/backstage/session/${existing.id}`);
+
+				const automation = listAutomations().find(
+					(a) => a.eventKey === "plain:thread_created",
+				);
+				if (!automation) return redirect("/backstage/");
+
+				// Build the same payload shape the webhook event carries
+				let payload: Record<string, unknown> = { threadId };
+				try {
+					const { getThreadWithMessages } = await import(
+						"./src/agents/plain/api"
+					);
+					const thread = await getThreadWithMessages(threadId);
+					payload = {
+						threadId,
+						title: thread?.title || null,
+						previewText: thread?.previewText || thread?.description || null,
+						status: thread?.status || null,
+						customer: {
+							email: thread?.customer?.email?.email || null,
+							fullName: thread?.customer?.fullName || null,
+						},
+					};
+				} catch (e) {
+					console.error(
+						`[plain-triage] Thread lookup failed for ${threadId}:`,
+						e,
+					);
+				}
+
+				const sessionId = await new Promise<string | null>((resolve) => {
+					const timer = setTimeout(() => resolve(null), 120_000);
+					void runAutomation(
+						automation,
+						(id) => {
+							sessionsCache = null;
+							clearTimeout(timer);
+							resolve(id);
+						},
+						{
+							trigger: "event",
+							eventContext: JSON.stringify(payload, null, 2),
+						},
+					);
+				});
+
+				return redirect(
+					sessionId ? `/backstage/session/${sessionId}` : "/backstage/",
+				);
+			}
+
+			// Health check (includes agent health — Tailscale-only, not public).
+			// frontendVersion lets clients detect a frontend-only rebuild (no bootId
+			// change) and refresh.
+			if (path === "/backstage/api/health") {
+				const agentHealth: Record<string, unknown> = {};
+				for (const a of agents) {
+					agentHealth[a.name] = a.health();
+				}
+				return Response.json({
+					ok: true,
+					bootId: BOOT_ID,
+					frontendVersion: frontend?.version ?? null,
+					uptime: process.uptime(),
+					// In-flight runner runs this process is driving — a drain-aware deploy
+					// polls this to restart only when the service is idle (or near it), so a
+					// restart kills as few in-flight runs/background tasks as possible.
+					activeRuns: activeAgentRunCount(),
+					agents: agentHealth,
+				});
+			}
+
+			// Rebuild the frontend bundle in-process (no restart → live runs untouched).
+			// Drop-in replacement for `systemctl restart backstage` after a frontend/CSS
+			// change. Tailscale + team gated at the network layer like every route here.
+			if (path === "/backstage/api/rebuild-frontend" && req.method === "POST") {
+				if (IS_DEV || !frontend) {
+					return Response.json(
+						{ ok: false, error: "not available in dev mode" },
+						{ status: 400 },
+					);
+				}
+				try {
+					const version = await buildFrontend();
+					broadcastToAll({ type: "frontend_updated", version });
+					return Response.json({ ok: true, version });
+				} catch (e) {
+					return Response.json(
+						{ ok: false, error: String(e) },
+						{ status: 500 },
+					);
+				}
+			}
+
+			// List sessions
+			if (path === "/backstage/api/sessions" && req.method === "GET") {
+				// Enrich with live, in-process signals that aren't on the cached session
+				// objects: whether a run is blocked on a human question (pendingAsks) and
+				// how many prompts are queued behind it. Drives the sidebar/tab "needs
+				// input" highlight without a second round-trip.
+				const enriched = getCachedSessions().map((s) => ({
+					...s,
+					waitingForInput: pendingAsks.has(s.id),
+					queuedCount: promptQueues.get(s.id)?.length || 0,
+				}));
+				return Response.json(enriched);
+			}
+
+			// Get transcript for a session
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/transcript$/) &&
+				req.method === "GET"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/transcript$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+				if (!session.transcriptPath) return Response.json([]);
+				return Response.json(parseTranscript(session.transcriptPath));
+			}
+
+			// Sub-agent (Task/Agent) conversation for a session. The agentId comes from
+			// a Task tool_result's `agentId` field in the parent transcript.
+			{
+				const m = path.match(
+					/^\/backstage\/api\/sessions\/(.+)\/subagent\/([^/]+)$/,
+				);
+				if (m && req.method === "GET") {
+					const session = findSession(decodeURIComponent(m[1]));
+					if (!session)
+						return Response.json(
+							{ error: "Session not found" },
+							{ status: 404 },
+						);
+					if (!session.transcriptPath)
+						return Response.json({ error: "No transcript" }, { status: 404 });
+					const sub = getSubagentTranscript(
+						session.transcriptPath,
+						decodeURIComponent(m[2]),
+					);
+					if (!sub)
+						return Response.json(
+							{ error: "Sub-agent not found" },
+							{ status: 404 },
+						);
+					return Response.json({ ...sub, sessionRunning: session.isRunning });
+				}
+			}
+
+			// Live git diff for a session's worktree (Changes tab)
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/diff$/) &&
+				req.method === "GET"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/diff$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+
+				// One diff per repo in the session: primary worktree + each attached repo.
+				// Each carries its project id so the panel can show a repo switcher and
+				// route per-line feedback to the right checkout.
+				const targets: Array<{
+					project: string;
+					dir: string | null;
+					primary: boolean;
+				}> = [
+					{
+						project:
+							session.project ||
+							(session.worktreeDir
+								? projectForPath(session.worktreeDir).id
+								: "tella-fusion"),
+						dir: session.worktreeDir,
+						primary: true,
+					},
+					...(session.attachedRepos || []).map((r) => ({
+						project: r.project,
+						dir: r.dir,
+						primary: false,
+					})),
+				];
+
+				const repos = await Promise.all(
+					targets.map(async (t) => {
+						let diff: SessionDiff = {
+							branch: null,
+							baseRef: null,
+							files: [],
+							totalAdditions: 0,
+							totalDeletions: 0,
+							rawPatch: "",
+						};
+						if (t.dir && existsSync(t.dir)) {
+							try {
+								diff = await getSessionDiff(
+									t.dir,
+									getProject(t.project).defaultBranch,
+								);
+							} catch {}
+						}
+						return { project: t.project, dir: t.dir, primary: t.primary, diff };
+					}),
+				);
+
+				return Response.json({ repos });
+			}
+
+			// PR details for a session's branch (PR tab). `?repo=<project>` targets an
+			// attached repo's PR; default/primary targets the session's own branch.
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/pr$/) &&
+				req.method === "GET"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/pr$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+				const target = resolvePrTarget(session, url.searchParams.get("repo"));
+				if (!target) return Response.json(null);
+				return Response.json(await getPrDetails(target.branch, target.ghRepo));
+			}
+
+			// PR diff for inline review in the PR tab
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-diff$/) &&
+				req.method === "GET"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-diff$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+				const target = resolvePrTarget(session, url.searchParams.get("repo"));
+				if (!target) return Response.json(null);
+				return Response.json(await getPrDiff(target.branch, target.ghRepo));
+			}
+
+			// Local dev-server ("Preview") status for a session's worktree — which
+			// services (.ports.conf) are listening, so the header can link to the
+			// webapp and show/stop running processes.
+			{
+				const m = path.match(/^\/backstage\/api\/sessions\/(.+)\/preview$/);
+				if (m && req.method === "GET") {
+					const session = findSession(decodeURIComponent(m[1]));
+					if (!session)
+						return Response.json(
+							{ error: "Session not found" },
+							{ status: 404 },
+						);
+					if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
+						return Response.json({
+							hasPortsConf: false,
+							webappPort: null,
+							running: false,
+							previewUrl: null,
+							services: [],
+						});
+					}
+					return Response.json(await getPreviewStatus(session.worktreeDir));
+				}
+			}
+
+			// Stop the session's dev server (scoped to its worktree's process group).
+			{
+				const m = path.match(
+					/^\/backstage\/api\/sessions\/(.+)\/preview\/stop$/,
+				);
+				if (m && req.method === "POST") {
+					const session = findSession(decodeURIComponent(m[1]));
+					if (!session)
+						return Response.json(
+							{ error: "Session not found" },
+							{ status: 404 },
+						);
+					if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
+						return Response.json({
+							hasPortsConf: false,
+							webappPort: null,
+							running: false,
+							previewUrl: null,
+							services: [],
+						});
+					}
+					return Response.json(await stopPreview(session.worktreeDir));
+				}
+			}
+
+			// Post a comment on the session's PR (inline when path+line present)
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-comment$/) &&
+				req.method === "POST"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-comment$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+
+				const body = await req.json().catch(() => null);
+				if (!body?.text?.trim())
+					return Response.json({ error: "Empty comment" }, { status: 400 });
+				const target = resolvePrTarget(session, body.repo);
+				if (!target)
+					return Response.json(
+						{ error: "No branch/PR for that repo" },
+						{ status: 400 },
+					);
+
+				const user = body.user || "Someone";
+				const result = await postPrComment(
+					target.branch,
+					{
+						body: `**${user}** via Michael:\n\n${body.text.trim()}`,
+						path: body.path,
+						line: body.line,
+						startLine: body.startLine,
+						side: body.side,
+						startSide: body.startSide,
+					},
+					target.ghRepo,
+				);
+				if ("error" in result) return Response.json(result, { status: 502 });
+				return Response.json(result);
+			}
+
+			// Submit a batched review (all pending inline comments + an event) on the PR.
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/) &&
+				req.method === "POST"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-review$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+
+				const body = await req.json().catch(() => null);
+				const target = resolvePrTarget(session, body?.repo);
+				if (!target)
+					return Response.json(
+						{ error: "No branch/PR for that repo" },
+						{ status: 400 },
+					);
+				const event =
+					body?.event === "APPROVE" || body?.event === "REQUEST_CHANGES"
+						? body.event
+						: "COMMENT";
+				const comments = Array.isArray(body?.comments) ? body.comments : [];
+				if (!comments.length && !body?.summary?.trim()) {
+					return Response.json({ error: "Nothing to submit" }, { status: 400 });
+				}
+
+				const user = body?.user || "Someone";
+				const summary = body?.summary?.trim();
+				const reviewBody = summary
+					? `**${user}** via Michael:\n\n${summary}`
+					: `Review by **${user}** via Michael.`;
+				const result = await submitPrReview(
+					target.branch,
+					{
+						event,
+						body: reviewBody,
+						comments: comments
+							.filter((c: any) => c?.text?.trim() && c?.path && c?.line)
+							.map((c: any) => ({
+								path: c.path,
+								line: c.line,
+								startLine: c.startLine,
+								side: c.side,
+								startSide: c.startSide,
+								body: `**${user}**: ${c.text.trim()}`,
+							})),
+					},
+					target.ghRepo,
+				);
+				if ("error" in result) return Response.json(result, { status: 502 });
+				sessionsCache = null; // a review can change reviewDecision in the list
+				return Response.json(result);
+			}
+
+			// Squash & merge the session's PR — human-triggered from the Reviews view.
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-merge$/) &&
+				req.method === "POST"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)\/pr-merge$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+
+				const body = await req.json().catch(() => ({}));
+				const target = resolvePrTarget(session, body.repo);
+				if (!target)
+					return Response.json(
+						{ error: "No branch/PR for that repo" },
+						{ status: 400 },
+					);
+				const method =
+					body.method === "merge" || body.method === "rebase"
+						? body.method
+						: "squash";
+				try {
+					const result = await mergePr(
+						target.branch,
+						{ method, deleteBranch: !!body.deleteBranch },
+						target.ghRepo,
+					);
+					if ("error" in result) return Response.json(result, { status: 502 });
+					sessionsCache = null; // refresh prState in the sessions list
+					return Response.json(result);
+				} catch (e: any) {
+					return Response.json(
+						{ error: e.message || String(e) },
+						{ status: 500 },
+					);
+				}
+			}
+
+			// Bulk-archive idle sessions
+			if (
+				path === "/backstage/api/sessions/archive-old" &&
+				req.method === "POST"
+			) {
+				const body = await req.json().catch(() => ({}));
+				const days = Math.max(1, parseInt(body.days) || 7);
+				const count = archiveOlderThan(getAllSessions(), days);
+				sessionsCache = null;
+				return Response.json({ archived: count });
+			}
+
+			// Archive / unarchive a single session
+			const archiveMatch = path.match(
+				/^\/backstage\/api\/sessions\/(.+)\/archive$/,
+			);
+			if (archiveMatch && req.method === "POST") {
+				const sessionId = decodeURIComponent(archiveMatch[1]);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+				const body = await req.json().catch(() => ({}));
+				setArchived(sessionId, body.archived !== false);
+				sessionsCache = null;
+				return Response.json({ ok: true });
+			}
+
+			// Delete a session (+ optional worktree cleanup)
+			if (
+				path.match(/^\/backstage\/api\/sessions\/(.+)$/) &&
+				req.method === "DELETE"
+			) {
+				const sessionId = decodeURIComponent(
+					path.match(/^\/backstage\/api\/sessions\/(.+)$/)![1],
+				);
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+
+				const cleanWorktree = url.searchParams.get("worktree") === "true";
+				try {
+					deleteSession(session);
+					if (cleanWorktree && session.worktreeDir && session.branch) {
+						await removeWorktree(
+							session.branch,
+							projectForPath(session.worktreeDir).id,
+						);
+					}
+					sessionsCache = null;
+					return Response.json({ ok: true });
+				} catch (e: any) {
+					return Response.json({ error: e.message }, { status: 500 });
+				}
+			}
+
+			// List worktrees (optionally for a specific project)
+			if (path === "/backstage/api/worktrees" && req.method === "GET") {
+				return Response.json(
+					await listWorktrees(url.searchParams.get("project") || undefined),
+				);
+			}
+
+			// File-mention autocomplete ("@" in the composer). Searches the session's
+			// primary worktree plus any attached repos (cross-repo sessions), falling
+			// back to the default project repo for new-session composers with no session
+			// yet. Each hit carries `insert` (what lands in the textarea: a bare path for
+			// the primary repo, `<project>:path` for an attached one) and a `repo` label
+			// when more than one repo is in play.
+			if (path === "/backstage/api/files" && req.method === "GET") {
+				const q = url.searchParams.get("q") || "";
+				const sessionId = url.searchParams.get("session");
+				const repos: Array<{ project: string; dir: string; primary: boolean }> =
+					[];
+				const session = sessionId ? findSession(sessionId) : undefined;
+				if (session?.worktreeDir && existsSync(session.worktreeDir)) {
+					repos.push({
+						project: session.project || projectForPath(session.worktreeDir).id,
+						dir: session.worktreeDir,
+						primary: true,
+					});
+					for (const r of session.attachedRepos || []) {
+						if (existsSync(r.dir))
+							repos.push({ project: r.project, dir: r.dir, primary: false });
+					}
+				}
+				if (!repos.length) {
+					const proj = getProject(url.searchParams.get("project") || undefined);
+					repos.push({ project: proj.id, dir: proj.repo, primary: true });
+				}
+				const multi = repos.length > 1;
+				const perRepo = multi ? Math.max(6, Math.floor(20 / repos.length)) : 20;
+				const out: Array<{ display: string; insert: string; repo?: string }> =
+					[];
+				for (const r of repos) {
+					try {
+						for (const f of await searchRepoFiles(r.dir, q, perRepo)) {
+							out.push({
+								display: f,
+								insert: r.primary ? f : `${r.project}:${f}`,
+								repo: multi ? r.project : undefined,
+							});
+						}
+					} catch {}
+				}
+				return Response.json({ files: out.slice(0, 24) });
+			}
+
+			// Projects available to attach / start a session against.
+			if (path === "/backstage/api/projects" && req.method === "GET") {
+				return Response.json({
+					projects: Object.values(PROJECTS).map((p) => ({
+						id: p.id,
+						defaultBranch: p.defaultBranch,
+						sharedCheckout: !!p.sharedCheckout,
+					})),
+				});
+			}
+
+			// Attach a secondary repo to a session (cross-repo work): creates/reuses an
+			// isolated worktree and records it on the session.
+			const attachMatch = path.match(
+				/^\/backstage\/api\/sessions\/(.+)\/attach-repo$/,
+			);
+			if (attachMatch && req.method === "POST") {
+				const sessionId = decodeURIComponent(attachMatch[1]);
+				const body = (await req.json().catch(() => ({}))) as {
+					project?: string;
+					branch?: string;
+				};
+				if (!body.project)
+					return Response.json({ error: "project required" }, { status: 400 });
+				try {
+					const { attached, all } = await attachRepo(
+						sessionId,
+						body.project,
+						body.branch,
+					);
+					return Response.json({ ok: true, attached, attachedRepos: all });
+				} catch (e: any) {
+					return Response.json(
+						{ error: e.message || String(e) },
+						{ status: 400 },
+					);
+				}
+			}
+
+			// Detach a secondary repo (drops it from the session; leaves the worktree on
+			// disk so unmerged work isn't lost — clean it up via the worktrees sweep).
+			// POST, not DELETE, so it isn't swallowed by the generic DELETE /sessions/:id.
+			const detachMatch = path.match(
+				/^\/backstage\/api\/sessions\/(.+)\/detach-repo$/,
+			);
+			if (detachMatch && req.method === "POST") {
+				const sessionId = decodeURIComponent(detachMatch[1]);
+				const body = (await req.json().catch(() => ({}))) as {
+					project?: string;
+				};
+				const session = findSession(sessionId);
+				if (!session)
+					return Response.json({ error: "Session not found" }, { status: 404 });
+				const all = (session.attachedRepos || []).filter(
+					(r) => r.project !== body.project,
+				);
+				touchBackstageSession(sessionId, { attachedRepos: all });
+				return Response.json({ ok: true, attachedRepos: all });
+			}
+
+			// ── Automations ──
+			if (path === "/backstage/api/automations" && req.method === "GET") {
+				const list = listAutomations().map((a) => ({
+					...a,
+					isRunning: isAutomationRunning(a.id),
+				}));
+				return Response.json(list);
+			}
+
+			if (path === "/backstage/api/automations" && req.method === "POST") {
+				const body = await req.json().catch(() => null);
+				if (!body)
+					return Response.json({ error: "Invalid JSON" }, { status: 400 });
+				const result = createAutomation(body);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			const autoRunMatch = path.match(
+				/^\/backstage\/api\/automations\/([^/]+)\/run$/,
+			);
+			if (autoRunMatch && req.method === "POST") {
+				const automation = getAutomation(autoRunMatch[1]);
+				if (!automation)
+					return Response.json({ error: "Not found" }, { status: 404 });
+				if (isAutomationRunning(automation.id)) {
+					return Response.json({ error: "Already running" }, { status: 409 });
+				}
+				// Fire and forget; session shows up in the list once it boots
+				void runAutomation(automation, () => {
+					sessionsCache = null;
+				});
+				return Response.json({ ok: true });
+			}
+
+			const autoMatch = path.match(/^\/backstage\/api\/automations\/([^/]+)$/);
+			if (autoMatch && req.method === "PUT") {
+				const body = await req.json().catch(() => null);
+				if (!body)
+					return Response.json({ error: "Invalid JSON" }, { status: 400 });
+				const result = updateAutomation(autoMatch[1], body);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			if (autoMatch && req.method === "DELETE") {
+				return deleteAutomation(autoMatch[1])
+					? Response.json({ ok: true })
+					: Response.json({ error: "Not found" }, { status: 404 });
+			}
+
+			// ── Actions (run a registered repo script behind a form) ──
+			if (path === "/backstage/api/actions" && req.method === "GET") {
+				return Response.json(listActions());
+			}
+
+			if (path === "/backstage/api/actions" && req.method === "POST") {
+				const body = await req.json().catch(() => null);
+				if (!body)
+					return Response.json({ error: "Invalid JSON" }, { status: 400 });
+				const result = createAction(body);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			// Suggest inputs for a script being registered (parses $1..$9 / $VAR).
+			if (
+				path === "/backstage/api/actions/introspect" &&
+				req.method === "POST"
+			) {
+				const body = (await req.json().catch(() => ({}))) as {
+					repo?: string;
+					scriptPath?: string;
+				};
+				const result = introspectScript(
+					body.repo || "tella-fusion",
+					String(body.scriptPath || ""),
+				);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			const actionRunMatch = path.match(
+				/^\/backstage\/api\/actions\/([^/]+)\/run$/,
+			);
+			if (actionRunMatch && req.method === "POST") {
+				const action = getAction(actionRunMatch[1]);
+				if (!action)
+					return Response.json({ error: "Not found" }, { status: 404 });
+				const body = (await req.json().catch(() => ({}))) as {
+					values?: Record<string, unknown>;
+					user?: string;
+				};
+				const result = runAction(action, body.values || {}, body.user, () => {
+					sessionsCache = null;
+				});
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			const actionMatch = path.match(/^\/backstage\/api\/actions\/([^/]+)$/);
+			if (actionMatch && req.method === "GET") {
+				const action = getAction(actionMatch[1]);
+				return action
+					? Response.json(action)
+					: Response.json({ error: "Not found" }, { status: 404 });
+			}
+
+			if (actionMatch && req.method === "DELETE") {
+				return deleteAction(actionMatch[1])
+					? Response.json({ ok: true })
+					: Response.json({ error: "Not found" }, { status: 404 });
+			}
+
+			// ── Connections ──
+			if (path === "/backstage/api/connections" && req.method === "GET") {
+				const force = url.searchParams.get("refresh") === "1";
+				const mcpServers = await getConnections(force);
+				const agentHealth: Record<string, unknown> = {};
+				for (const a of agents) agentHealth[a.name] = a.health();
+				return Response.json({ mcpServers, agents: agentHealth });
+			}
+
+			if (path === "/backstage/api/connections/mcp" && req.method === "POST") {
+				const body = await req.json().catch(() => null);
+				if (!body)
+					return Response.json({ error: "Invalid JSON" }, { status: 400 });
+				const result = addMcpServer(body);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			const mcpDelMatch = path.match(
+				/^\/backstage\/api\/connections\/mcp\/([^/]+)$/,
+			);
+			if (mcpDelMatch && req.method === "DELETE") {
+				const result = removeMcpServer(decodeURIComponent(mcpDelMatch[1]));
+				if ("error" in result) return Response.json(result, { status: 404 });
+				return Response.json(result);
+			}
+
+			// ── Claude account pool (tokens are never sent back, only masked) ──
+			if (path === "/backstage/api/claude-accounts" && req.method === "GET") {
+				return Response.json({ accounts: listAccountsPublic() });
+			}
+
+			if (path === "/backstage/api/claude-accounts" && req.method === "POST") {
+				const body = await req.json().catch(() => null);
+				if (!body?.name || !body?.token) {
+					return Response.json(
+						{ error: "name and token are required" },
+						{ status: 400 },
+					);
+				}
+				const result = await addAccount(body.name, body.token);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			if (
+				path === "/backstage/api/claude-accounts/refresh" &&
+				req.method === "POST"
+			) {
+				await refreshAllUsage();
+				return Response.json({ accounts: listAccountsPublic() });
+			}
+
+			const accountDelMatch = path.match(
+				/^\/backstage\/api\/claude-accounts\/([^/]+)$/,
+			);
+			if (accountDelMatch && req.method === "DELETE") {
+				return removeAccount(decodeURIComponent(accountDelMatch[1]))
+					? Response.json({ ok: true })
+					: Response.json({ error: "Not found" }, { status: 404 });
+			}
+
+			// ── Models available to sessions ──
+			if (path === "/backstage/api/models" && req.method === "GET") {
+				return Response.json({
+					models: KNOWN_MODELS,
+					default: getDefaultModel(),
+				});
+			}
+
+			// Set (or clear, with model:null) the default model new sessions run on.
+			if (path === "/backstage/api/models/default" && req.method === "PUT") {
+				const body = await req.json().catch(() => null);
+				if (!body || !("model" in body)) {
+					return Response.json(
+						{ error: "model is required (id, or null to clear)" },
+						{ status: 400 },
+					);
+				}
+				try {
+					const next = setDefaultModel(body.model ?? null);
+					return Response.json({ default: next });
+				} catch (e: any) {
+					return Response.json(
+						{ error: e?.message || "Failed to set default model" },
+						{ status: 400 },
+					);
+				}
+			}
+
+			// ── Per-user pinned tabs ──
+			// Keyed on the self-selected `user` name (team-internal, not auth). GET reads
+			// a user's pins; PUT replaces them wholesale (the frontend sends the full list
+			// on every toggle and on first-load localStorage migration).
+			if (path === "/backstage/api/pins" && req.method === "GET") {
+				const user = url.searchParams.get("user") || "Anonymous";
+				return Response.json({ pins: getUserPins(user) });
+			}
+
+			if (path === "/backstage/api/pins" && req.method === "PUT") {
+				const body = await req.json().catch(() => null);
+				if (
+					!body ||
+					typeof body.user !== "string" ||
+					!Array.isArray(body.pins)
+				) {
+					return Response.json(
+						{ error: "user (string) and pins (array) are required" },
+						{ status: 400 },
+					);
+				}
+				return Response.json({ pins: setUserPins(body.user, body.pins) });
+			}
+
+			// ── Per-user session tab colors ──
+			// Same per-user model as pins: GET reads a user's tab colors; PUT replaces
+			// the whole map (the frontend sends the full map on every color change).
+			if (path === "/backstage/api/tab-colors" && req.method === "GET") {
+				const user = url.searchParams.get("user") || "Anonymous";
+				return Response.json({ colors: getUserTabColors(user) });
+			}
+
+			if (path === "/backstage/api/tab-colors" && req.method === "PUT") {
+				const body = await req.json().catch(() => null);
+				if (
+					!body ||
+					typeof body.user !== "string" ||
+					typeof body.colors !== "object" ||
+					body.colors === null
+				) {
+					return Response.json(
+						{ error: "user (string) and colors (object) are required" },
+						{ status: 400 },
+					);
+				}
+				return Response.json({
+					colors: setUserTabColors(body.user, body.colors),
+				});
+			}
+
+			// ── Codex (OpenAI) account pool ──
+			if (path === "/backstage/api/codex-accounts" && req.method === "GET") {
+				return Response.json({ accounts: listCodexAccountsPublic() });
+			}
+
+			if (path === "/backstage/api/codex-accounts" && req.method === "POST") {
+				const body = await req.json().catch(() => null);
+				if (
+					!body?.name ||
+					!body?.value ||
+					!["api_key", "home"].includes(body?.kind)
+				) {
+					return Response.json(
+						{ error: "name, kind (api_key|home) and value are required" },
+						{ status: 400 },
+					);
+				}
+				const result = addCodexAccount(body.name, body.kind, body.value);
+				if ("error" in result) return Response.json(result, { status: 400 });
+				return Response.json(result);
+			}
+
+			const codexAccountDelMatch = path.match(
+				/^\/backstage\/api\/codex-accounts\/([^/]+)$/,
+			);
+			if (codexAccountDelMatch && req.method === "DELETE") {
+				return removeCodexAccount(decodeURIComponent(codexAccountDelMatch[1]))
+					? Response.json({ ok: true })
+					: Response.json({ error: "Not found" }, { status: 404 });
+			}
+
+			// ── Wiki ──
+			if (path === "/backstage/api/wiki/tree" && req.method === "GET") {
+				return Response.json(getWikiTree());
+			}
+
+			if (path === "/backstage/api/wiki/file" && req.method === "GET") {
+				const rel = url.searchParams.get("path") || "";
+				const file = getWikiFile(rel);
+				if (!file)
+					return Response.json({ error: "Not found" }, { status: 404 });
+				return Response.json(file);
+			}
+
+			if (path === "/backstage/api/wiki/search" && req.method === "GET") {
+				const q = url.searchParams.get("q") || "";
+				return Response.json(searchWiki(q));
+			}
+
+			// WebSocket upgrade
+			if (path === "/backstage/ws") {
+				const upgraded = server.upgrade(req, {
+					data: { watchingSessionId: null, user: null },
+				});
+				if (!upgraded) {
+					return new Response("WebSocket upgrade failed", { status: 400 });
+				}
+				return undefined;
+			}
+
+			// 404
+			return Response.json({ error: "Not found" }, { status: 404 });
+		},
+
+		websocket: {
+			open(ws) {
+				allClients.add(ws);
+				console.log("WebSocket client connected");
+			},
+
+			async message(ws, message) {
+				let msg: any;
+				try {
+					msg = JSON.parse(String(message));
+				} catch {
+					ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+					return;
+				}
+
+				switch (msg.type) {
+					case "watch": {
+						const sessionId = msg.sessionId;
+						const session = findSession(sessionId);
+						if (!session) {
+							ws.send(
+								JSON.stringify({ type: "error", message: "Session not found" }),
+							);
+							return;
+						}
+
+						// Stop watching any previous session first
+						stopAllWatchesForClient(ws);
+						leaveSession(ws);
+
+						const data = ws.data;
+						data.watchingSessionId = sessionId;
+						if (msg.user) data.user = msg.user;
+						joinSession(ws, sessionId);
+
+						// Send the tail of the transcript for a fast initial render. A large
+						// (multi-MB) transcript would otherwise block the open for seconds;
+						// `truncated` tells the client to offer "load earlier history", which
+						// comes back as a `load_history` message below.
+						const { entries, truncated } = session.transcriptPath
+							? parseTranscriptTail(session.transcriptPath)
+							: { entries: [], truncated: false };
+						ws.send(
+							JSON.stringify({ type: "transcript_init", entries, truncated }),
+						);
+
+						// Start file watcher
+						if (session.transcriptPath) {
+							startWatching(session.transcriptPath, ws);
+						}
+
+						// Pending interactive question, if any
+						const pendingAsk = pendingAsks.get(sessionId);
+						if (pendingAsk) {
+							ws.send(
+								JSON.stringify({
+									type: "ask_question",
+									sessionId,
+									questionId: pendingAsk.questionId,
+									questions: pendingAsk.questions,
+								}),
+							);
+						}
+
+						// Current message queue + steer receipts for this session
+						ws.send(
+							JSON.stringify({
+								type: "queue_update",
+								sessionId,
+								queued: promptQueues.get(sessionId) || [],
+								steered: steeredReceipts.get(sessionId) || [],
+							}),
+						);
+
+						// Send running status
+						ws.send(
+							JSON.stringify({
+								type: "session_status",
+								isRunning:
+									session.isRunning ||
+									isAgentSessionBusy(
+										session.claudeSessionId,
+										session.codexThreadId,
+										session.id,
+									),
+							}),
+						);
+						break;
+					}
+
+					case "load_history": {
+						// "Load earlier history" button: the initial watch only sent the tail,
+						// so re-send the full transcript (cached by mtime in jsonl-parser).
+						const session = findSession(msg.sessionId);
+						if (!session?.transcriptPath) {
+							ws.send(
+								JSON.stringify({
+									type: "transcript_init",
+									entries: [],
+									truncated: false,
+								}),
+							);
+							return;
+						}
+						const entries = parseTranscript(session.transcriptPath);
+						ws.send(
+							JSON.stringify({
+								type: "transcript_init",
+								entries,
+								truncated: false,
+							}),
+						);
+						break;
+					}
+
+					case "prompt": {
+						const { sessionId, content, user } = msg;
+						const images = parseImageDataUrls(msg.images);
+						const session = findSession(sessionId);
+						if (!session) {
+							ws.send(
+								JSON.stringify({ type: "error", message: "Session not found" }),
+							);
+							return;
+						}
+
+						// Slash commands are handled by backstage itself
+						const notice = handleSlashCommand(
+							session,
+							String(content || "").trim(),
+							user,
+						);
+						if (notice !== null) {
+							ws.send(JSON.stringify({ type: "notice", message: notice }));
+							sessionsCache = null;
+							break;
+						}
+
+						// Busy → steer it into the running query (delivered at the next
+						// turn boundary, Claude-Code style). Falls back to the queue when
+						// the run isn't steerable: codex runs, runs owned by another
+						// process (Slack handler, CLI in tmux), or a run that's finishing.
+						if (
+							isAgentSessionBusy(
+								session.claudeSessionId,
+								session.codexThreadId,
+								session.id,
+							)
+						) {
+							const attributed = user ? `[${user}] ${content}` : content;
+							if (
+								steerAgentRun(
+									[session.claudeSessionId, session.codexThreadId, session.id],
+									attributed,
+								)
+							) {
+								// The message lands in the transcript when its turn starts. Until
+								// then a steer receipt is the durable visible record (survives
+								// reload/leave); kept out of promptQueues so the drain never
+								// re-delivers it, and cleared when the run finishes.
+								recordSteer(sessionId, { content, user });
+								broadcastToSession(sessionId, {
+									type: "notice",
+									message: `Message from ${user || "you"} folded into the run — Michael picks it up at the next stopping point.`,
+								});
+								break;
+							}
+							enqueuePrompt(sessionId, { content, user });
+							watchExternalRunAndDrain(sessionId);
+							break;
+						}
+
+						// Codex sessions start a fresh thread on first prompt; Claude needs
+						// a session id to resume.
+						if (
+							providerFor(session.model) === "claude" &&
+							!session.claudeSessionId
+						) {
+							ws.send(
+								JSON.stringify({
+									type: "error",
+									message: "No Claude session to resume",
+								}),
+							);
+							return;
+						}
+
+						await runSessionPromptAndDrain(sessionId, content, user, images);
+						break;
+					}
+
+					case "interrupt_prompt": {
+						// Esc-style redirect: stop the current turn, keep the session, and
+						// continue right away with this message. Falls back to a normal
+						// prompt (steer/queue/run) when there's nothing to interrupt.
+						const { sessionId, content, user } = msg;
+						const session = findSession(sessionId);
+						if (!session) {
+							ws.send(
+								JSON.stringify({ type: "error", message: "Session not found" }),
+							);
+							return;
+						}
+						const attributed = user ? `[${user}] ${content}` : content;
+						if (
+							isAgentSessionBusy(
+								session.claudeSessionId,
+								session.codexThreadId,
+								session.id,
+							) &&
+							interruptAndSteerAgentRun(
+								[session.claudeSessionId, session.codexThreadId, session.id],
+								attributed,
+							)
+						) {
+							// Interrupt aborts the current turn and continues immediately, so
+							// the message lands in the transcript almost at once — no steer
+							// receipt ("folded in" would be wrong for an interrupt) and no system
+							// notice. The sender's optimistic bubble reconciles when its real
+							// turn appears; the SDK's "[Request interrupted by user]" marker is
+							// filtered out in jsonl-parser.
+							break;
+						}
+						// Not interruptible (external run, codex, or just finished): treat
+						// like a normal send so the message is never lost.
+						if (
+							isAgentSessionBusy(
+								session.claudeSessionId,
+								session.codexThreadId,
+								session.id,
+							)
+						) {
+							enqueuePrompt(sessionId, { content, user });
+							watchExternalRunAndDrain(sessionId);
+							break;
+						}
+						await runSessionPromptAndDrain(sessionId, content, user);
+						break;
+					}
+
+					case "cancel": {
+						const data = ws.data;
+						if (data.watchingSessionId) {
+							const session = findSession(data.watchingSessionId);
+							if (session) {
+								cancelAgentRun(
+									session.claudeSessionId,
+									session.codexThreadId,
+									session.id,
+								);
+							}
+							clearSteerReceipts(data.watchingSessionId);
+							const dropped =
+								promptQueues.get(data.watchingSessionId)?.length || 0;
+							if (dropped > 0) {
+								promptQueues.delete(data.watchingSessionId);
+								persistQueues();
+								broadcastQueue(data.watchingSessionId);
+								broadcastToSession(data.watchingSessionId, {
+									type: "notice",
+									message: `Cancelled — ${dropped} queued message${dropped === 1 ? "" : "s"} dropped.`,
+								});
+							}
+						}
+						break;
+					}
+
+					case "answer_question": {
+						const { sessionId, questionId, answers } = msg;
+						const pending = pendingAsks.get(sessionId);
+						if (pending && pending.questionId === questionId) {
+							pending.resolve(
+								answers && typeof answers === "object" ? answers : null,
+							);
+						}
+						break;
+					}
+
+					case "create_session": {
+						const { branch, prompt, user, mode } = msg;
+						const images = parseImageDataUrls(msg.images);
+
+						// Fork: branch a new session off an existing one, keeping the REAL
+						// engine conversation (via SDK forkSession), optionally from a chosen
+						// message. Inherits the source's mode/model/cwd. Claude-only.
+						const forkFrom = msg.forkFrom as
+							| { sourceId?: string; messageId?: string }
+							| undefined;
+						const forkSource = forkFrom?.sourceId
+							? findSession(forkFrom.sourceId)
+							: undefined;
+						if (forkFrom?.sourceId && !forkSource) {
+							ws.send(
+								JSON.stringify({
+									type: "error",
+									message: "Fork source session not found",
+								}),
+							);
+							return;
+						}
+						const canFork =
+							!!forkSource &&
+							providerFor(forkSource.model) === "claude" &&
+							!!forkSource.claudeSessionId;
+						if (forkSource && !canFork) {
+							ws.send(
+								JSON.stringify({
+									type: "error",
+									message: "Fork is only supported for Claude sessions",
+								}),
+							);
+							return;
+						}
+
+						const isAsk = forkSource
+							? forkSource.mode !== "code"
+							: mode === "ask";
+						// Optional model pick from the UI; invalid input falls back to default.
+						// A fork inherits the source's model.
+						const model = forkSource
+							? forkSource.model
+							: msg.model
+								? resolveModel(String(msg.model))?.id
+								: undefined;
+						const isCodex = providerFor(model) === "codex";
+						// Which repo this session works in (tella-fusion by default).
+						const project = getProject(
+							typeof msg.project === "string" ? msg.project : undefined,
+						);
+						try {
+							let wtPath: string;
+							if (forkSource) {
+								// Share the source's cwd so the fork sees the same code state.
+								wtPath = forkSource.worktreeDir || project.repo;
+							} else if (isAsk) {
+								// Ask sessions run read-only on the main checkout — no worktree
+								wtPath = project.repo;
+							} else if (project.sharedCheckout) {
+								// Backstage: code sessions edit the live main checkout on the
+								// default branch (hot-reloads in the running server). No worktree.
+								wtPath = project.repo;
+							} else {
+								// Check if worktree exists, create if needed
+								const worktrees = await listWorktrees(project.id);
+								wtPath = worktrees.find((w) => w.branch === branch)?.path || "";
+								if (!wtPath) {
+									wtPath = await createWorktree(branch, project.id);
+								}
+							}
+
+							const bksId = `bks-${randomUUIDv7()}`;
+							const title = prompt.trim().split("\n")[0].slice(0, 80);
+
+							ws.send(
+								JSON.stringify({ type: "stream_start", sessionId: bksId }),
+							);
+
+							let engineSessionId = "";
+							let persisted = false;
+							const persist = () => {
+								const sessionData: BackstageSessionFile = {
+									id: bksId,
+									claudeSessionId: isCodex ? "" : engineSessionId,
+									...(isCodex && engineSessionId
+										? { codexThreadId: engineSessionId }
+										: {}),
+									...(model ? { model } : {}),
+									branch: forkSource
+										? forkSource.branch || ""
+										: isAsk
+											? ""
+											: project.sharedCheckout
+												? project.defaultBranch
+												: branch,
+									worktreeDir: wtPath,
+									project: projectForPath(wtPath).id,
+									createdBy: user || "Anonymous",
+									createdAt: new Date().toISOString(),
+									lastActivity: new Date().toISOString(),
+									title,
+									mode: isAsk ? "ask" : "code",
+								};
+								writeFileSync(
+									`${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`,
+									JSON.stringify(sessionData, null, 2),
+								);
+								sessionsCache = null;
+								persisted = true;
+							};
+
+							for await (const event of runAgent({
+								prompt,
+								cwd: wtPath,
+								mode: isAsk ? "ask" : "code",
+								model,
+								images,
+								// Fork: resume the source engine session into a new branch,
+								// optionally from a specific past message.
+								...(canFork
+									? {
+											sessionId: forkSource!.claudeSessionId!,
+											forkSession: true,
+											resumeSessionAt: forkFrom?.messageId,
+										}
+									: {}),
+								inProcessMcp: interactiveMcpServers(user, bksId),
+								confirmTools: STRIPE_CONFIRM_TOOLS,
+								aws: true, // interactive sessions keep AWS read access (via injected creds)
+								journal: { bksSessionId: bksId, kind: "create" },
+								onAskUser: makeAskHandler(bksId),
+							})) {
+								if (event.type === "init") {
+									engineSessionId = event.sessionId || "";
+									// Persist immediately so the session is visible/shareable while running
+									persist();
+									ws.send(
+										JSON.stringify({ type: "session_created", id: bksId }),
+									);
+								}
+								if (event.type === "text_chunk") {
+									// Direct send for the creator (not in the room until they watch),
+									// room broadcast for everyone else — never both to the same socket
+									ws.send(
+										JSON.stringify({ type: "stream_text", text: event.text }),
+									);
+									broadcastToSession(
+										bksId,
+										{ type: "stream_text", text: event.text },
+										ws,
+									);
+								}
+								if (event.type === "tool_use") {
+									const entry = {
+										id: event.toolUseId || crypto.randomUUID(),
+										type: "tool_use" as const,
+										content: `Using ${event.toolName}`,
+										timestamp: new Date().toISOString(),
+										toolName: event.toolName,
+										toolInput: event.toolInput,
+										toolUseId: event.toolUseId,
+									};
+									ws.send(JSON.stringify({ type: "stream_tool_use", entry }));
+									broadcastToSession(
+										bksId,
+										{ type: "stream_tool_use", entry },
+										ws,
+									);
+								}
+								if (event.type === "tool_result") {
+									const entry = {
+										id: event.toolUseId
+											? `tr-${event.toolUseId}`
+											: crypto.randomUUID(),
+										type: "tool_result" as const,
+										content: event.content || "",
+										timestamp: new Date().toISOString(),
+										toolUseId: event.toolUseId,
+										...(event.images && event.images.length > 0
+											? { images: event.images }
+											: {}),
+										...(event.videos && event.videos.length > 0
+											? { videos: event.videos }
+											: {}),
+									};
+									ws.send(
+										JSON.stringify({ type: "stream_tool_result", entry }),
+									);
+									broadcastToSession(
+										bksId,
+										{ type: "stream_tool_result", entry },
+										ws,
+									);
+								}
+								if (event.type === "done") {
+									engineSessionId = event.sessionId || engineSessionId;
+								}
+								if (event.type === "error") {
+									ws.send(
+										JSON.stringify({ type: "error", message: event.content }),
+									);
+								}
+							}
+
+							if (!persisted) persist();
+							else
+								touchBackstageSession(
+									bksId,
+									isCodex
+										? { codexThreadId: engineSessionId }
+										: { claudeSessionId: engineSessionId },
+								);
+
+							ws.send(JSON.stringify({ type: "stream_done" }));
+							broadcastToSession(bksId, { type: "stream_done" }, ws);
+							broadcastToSession(bksId, {
+								type: "session_status",
+								isRunning: false,
+							});
+							if (!promptQueues.get(bksId)?.length)
+								onHumanAsksSessionIdle(bksId);
+						} catch (e: any) {
+							ws.send(
+								JSON.stringify({
+									type: "error",
+									message: e.message || String(e),
+								}),
+							);
+						}
+						break;
+					}
+				}
+			},
+
+			close(ws) {
+				allClients.delete(ws);
+				stopAllWatchesForClient(ws);
+				leaveSession(ws);
+				console.log("WebSocket client disconnected");
+			},
+		},
+
+		// Dev mode (HMR + error overlay + browser-console streaming) only when
+		// explicitly asked for — the systemd service is production, and the overlay
+		// pops "Script error." boxes on iOS with no diagnostics behind them.
+		development:
+			process.env.BACKSTAGE_DEV === "1"
+				? {
+						hmr: true,
+						console: true,
+					}
+				: false,
+	}));
 
 console.log(`Backstage running at http://${HOST}:${PORT}/backstage/`);
 
@@ -2447,265 +3076,326 @@ console.log(`Backstage running at http://${HOST}:${PORT}/backstage/`);
 // WebSocket handlers use, so a management session steers/answers/creates the
 // exact same way a human does in the web UI. See src/server/session-control.ts.
 registerSessionControl({
-  listSessions: () => getCachedSessions().map(buildSummary),
+	listSessions: () => getCachedSessions().map(buildSummary),
 
-  getSession: (id) => {
-    const s = findSession(id);
-    return s ? buildSummary(s) : undefined;
-  },
+	getSession: (id) => {
+		const s = findSession(id);
+		return s ? buildSummary(s) : undefined;
+	},
 
-  transcriptTail: (id, n) => {
-    const s = findSession(id);
-    if (!s?.transcriptPath) return [];
-    return parseTranscript(s.transcriptPath).slice(-Math.max(0, n));
-  },
+	transcriptTail: (id, n) => {
+		const s = findSession(id);
+		if (!s?.transcriptPath) return [];
+		return parseTranscript(s.transcriptPath).slice(-Math.max(0, n));
+	},
 
-  answerQuestion: (id, answers) => {
-    const pending = pendingAsks.get(id);
-    if (!pending) return false;
-    // resolve() clears the timeout, deletes the entry and unblocks makeAskHandler,
-    // which broadcasts ask_resolved and lets the run continue with these answers.
-    pending.resolve(answers && typeof answers === "object" ? answers : null);
-    return true;
-  },
+	answerQuestion: (id, answers) => {
+		const pending = pendingAsks.get(id);
+		if (!pending) return false;
+		// resolve() clears the timeout, deletes the entry and unblocks makeAskHandler,
+		// which broadcasts ask_resolved and lets the run continue with these answers.
+		pending.resolve(answers && typeof answers === "object" ? answers : null);
+		return true;
+	},
 
-  deliverToSession: async (id, content, user) => {
-    const session = findSession(id);
-    if (!session) return { status: "error" as const, message: "No session with that id." };
-    const attributed = user ? `[${user}] ${content}` : content;
+	deliverToSession: async (id, content, user) => {
+		const session = findSession(id);
+		if (!session)
+			return { status: "error" as const, message: "No session with that id." };
+		const attributed = user ? `[${user}] ${content}` : content;
 
-    if (isAgentSessionBusy(session.claudeSessionId, session.codexThreadId, session.id)) {
-      // Busy + owned here → fold into the running turn (delivered at the next
-      // stopping point). Otherwise queue and drain when the external run ends.
-      if (steerAgentRun([session.claudeSessionId, session.codexThreadId, session.id], attributed)) {
-        recordSteer(id, { content, user });
-        broadcastToSession(id, {
-          type: "notice",
-          message: `Message from ${user || "Michael"} folded into the run — picked up at the next stopping point.`,
-        });
-        return { status: "steered" as const, message: "Folded into the running turn." };
-      }
-      enqueuePrompt(id, { content, user });
-      watchExternalRunAndDrain(id);
-      return { status: "queued" as const, message: "Queued behind the current run." };
-    }
+		if (
+			isAgentSessionBusy(
+				session.claudeSessionId,
+				session.codexThreadId,
+				session.id,
+			)
+		) {
+			// Busy + owned here → fold into the running turn (delivered at the next
+			// stopping point). Otherwise queue and drain when the external run ends.
+			if (
+				steerAgentRun(
+					[session.claudeSessionId, session.codexThreadId, session.id],
+					attributed,
+				)
+			) {
+				recordSteer(id, { content, user });
+				broadcastToSession(id, {
+					type: "notice",
+					message: `Message from ${user || "Michael"} folded into the run — picked up at the next stopping point.`,
+				});
+				return {
+					status: "steered" as const,
+					message: "Folded into the running turn.",
+				};
+			}
+			enqueuePrompt(id, { content, user });
+			watchExternalRunAndDrain(id);
+			return {
+				status: "queued" as const,
+				message: "Queued behind the current run.",
+			};
+		}
 
-    if (providerFor(session.model) === "claude" && !session.claudeSessionId) {
-      return { status: "error" as const, message: "Session has no Claude session to resume yet." };
-    }
+		if (providerFor(session.model) === "claude" && !session.claudeSessionId) {
+			return {
+				status: "error" as const,
+				message: "Session has no Claude session to resume yet.",
+			};
+		}
 
-    // Idle → start a fresh turn in the background; don't block the tool call on
-    // the whole run finishing.
-    void runSessionPromptAndDrain(id, content, user).catch((e) =>
-      console.error(`[sessions-mcp] deliver to ${id} failed:`, e)
-    );
-    return { status: "started" as const, message: "Started a new turn on the session." };
-  },
+		// Idle → start a fresh turn in the background; don't block the tool call on
+		// the whole run finishing.
+		void runSessionPromptAndDrain(id, content, user).catch((e) =>
+			console.error(`[sessions-mcp] deliver to ${id} failed:`, e),
+		);
+		return {
+			status: "started" as const,
+			message: "Started a new turn on the session.",
+		};
+	},
 
-  cancelSession: (id) => {
-    const session = findSession(id);
-    if (!session) return false;
-    const cancelled = cancelAgentRun(session.claudeSessionId, session.codexThreadId, session.id);
-    clearSteerReceipts(id);
-    const dropped = promptQueues.get(id)?.length || 0;
-    if (dropped > 0) {
-      promptQueues.delete(id);
-      persistQueues();
-      broadcastQueue(id);
-    }
-    return cancelled;
-  },
+	cancelSession: (id) => {
+		const session = findSession(id);
+		if (!session) return false;
+		const cancelled = cancelAgentRun(
+			session.claudeSessionId,
+			session.codexThreadId,
+			session.id,
+		);
+		clearSteerReceipts(id);
+		const dropped = promptQueues.get(id)?.length || 0;
+		if (dropped > 0) {
+			promptQueues.delete(id);
+			persistQueues();
+			broadcastQueue(id);
+		}
+		return cancelled;
+	},
 
-  createSession: async ({ prompt, branch, mode, model: modelInput, user }) => {
-    const isAsk = mode !== "code";
-    const model = modelInput ? resolveModel(String(modelInput))?.id : undefined;
-    const isCodex = providerFor(model) === "codex";
+	createSession: async ({ prompt, branch, mode, model: modelInput, user }) => {
+		const isAsk = mode !== "code";
+		const model = modelInput ? resolveModel(String(modelInput))?.id : undefined;
+		const isCodex = providerFor(model) === "codex";
 
-    let wtPath: string;
-    if (isAsk) {
-      wtPath = `${HOME}/projects/tella-fusion`;
-    } else {
-      const worktrees = await listWorktrees();
-      wtPath = worktrees.find((w) => w.branch === branch)?.path || "";
-      if (!wtPath) wtPath = await createWorktree(branch!);
-    }
+		let wtPath: string;
+		if (isAsk) {
+			wtPath = `${HOME}/projects/tella-fusion`;
+		} else {
+			const worktrees = await listWorktrees();
+			wtPath = worktrees.find((w) => w.branch === branch)?.path || "";
+			if (!wtPath) wtPath = await createWorktree(branch!);
+		}
 
-    const bksId = `bks-${randomUUIDv7()}`;
-    const title = prompt.trim().split("\n")[0].slice(0, 80);
+		const bksId = `bks-${randomUUIDv7()}`;
+		const title = prompt.trim().split("\n")[0].slice(0, 80);
 
-    let engineSessionId = "";
-    let persisted = false;
-    const persist = () => {
-      const sessionData: BackstageSessionFile = {
-        id: bksId,
-        claudeSessionId: isCodex ? "" : engineSessionId,
-        ...(isCodex && engineSessionId ? { codexThreadId: engineSessionId } : {}),
-        ...(model ? { model } : {}),
-        branch: isAsk ? "" : branch || "",
-        worktreeDir: wtPath,
-        createdBy: user || "Michael",
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-        title,
-        mode: isAsk ? "ask" : "code",
-      };
-      writeFileSync(
-        `${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`,
-        JSON.stringify(sessionData, null, 2)
-      );
-      sessionsCache = null;
-      persisted = true;
-    };
+		let engineSessionId = "";
+		let persisted = false;
+		const persist = () => {
+			const sessionData: BackstageSessionFile = {
+				id: bksId,
+				claudeSessionId: isCodex ? "" : engineSessionId,
+				...(isCodex && engineSessionId
+					? { codexThreadId: engineSessionId }
+					: {}),
+				...(model ? { model } : {}),
+				branch: isAsk ? "" : branch || "",
+				worktreeDir: wtPath,
+				createdBy: user || "Michael",
+				createdAt: new Date().toISOString(),
+				lastActivity: new Date().toISOString(),
+				title,
+				mode: isAsk ? "ask" : "code",
+			};
+			writeFileSync(
+				`${BACKSTAGE_SESSIONS_DIR}/${bksId}.json`,
+				JSON.stringify(sessionData, null, 2),
+			);
+			sessionsCache = null;
+			persisted = true;
+		};
 
-    // Run in the background; watchers (web UI) see the live stream, the same as
-    // a UI-created session. The tool returns the id immediately.
-    void (async () => {
-      try {
-        for await (const event of runAgent({
-          prompt,
-          cwd: wtPath,
-          mode: isAsk ? "ask" : "code",
-          model,
-          inProcessMcp: interactiveMcpServers(user, bksId),
-          confirmTools: STRIPE_CONFIRM_TOOLS,
-          aws: true,
-          journal: { bksSessionId: bksId, kind: "create" },
-          onAskUser: makeAskHandler(bksId),
-        })) {
-          if (event.type === "init") {
-            engineSessionId = event.sessionId || "";
-            persist();
-          }
-          if (event.type === "text_chunk") {
-            broadcastToSession(bksId, { type: "stream_text", text: event.text });
-          }
-          if (event.type === "tool_use") {
-            broadcastToSession(bksId, {
-              type: "stream_tool_use",
-              entry: {
-                id: event.toolUseId || crypto.randomUUID(),
-                type: "tool_use",
-                content: `Using ${event.toolName}`,
-                timestamp: new Date().toISOString(),
-                toolName: event.toolName,
-                toolInput: event.toolInput,
-                toolUseId: event.toolUseId,
-              },
-            });
-          }
-          if (event.type === "tool_result") {
-            broadcastToSession(bksId, {
-              type: "stream_tool_result",
-              entry: {
-                id: event.toolUseId ? `tr-${event.toolUseId}` : crypto.randomUUID(),
-                type: "tool_result",
-                content: event.content || "",
-                timestamp: new Date().toISOString(),
-                toolUseId: event.toolUseId,
-                ...(event.images && event.images.length > 0 ? { images: event.images } : {}),
-                ...(event.videos && event.videos.length > 0 ? { videos: event.videos } : {}),
-              },
-            });
-          }
-          if (event.type === "done") {
-            engineSessionId = event.sessionId || engineSessionId;
-          }
-          if (event.type === "error") {
-            broadcastToSession(bksId, { type: "error", message: event.content });
-          }
-        }
-        if (!persisted) persist();
-        else
-          touchBackstageSession(
-            bksId,
-            isCodex ? { codexThreadId: engineSessionId } : { claudeSessionId: engineSessionId }
-          );
-        broadcastToSession(bksId, { type: "stream_done" });
-        broadcastToSession(bksId, { type: "session_status", isRunning: false });
-        if (!(promptQueues.get(bksId)?.length)) onHumanAsksSessionIdle(bksId);
-      } catch (e) {
-        console.error(`[sessions-mcp] create session ${bksId} failed:`, e);
-      }
-    })();
+		// Run in the background; watchers (web UI) see the live stream, the same as
+		// a UI-created session. The tool returns the id immediately.
+		void (async () => {
+			try {
+				for await (const event of runAgent({
+					prompt,
+					cwd: wtPath,
+					mode: isAsk ? "ask" : "code",
+					model,
+					inProcessMcp: interactiveMcpServers(user, bksId),
+					confirmTools: STRIPE_CONFIRM_TOOLS,
+					aws: true,
+					journal: { bksSessionId: bksId, kind: "create" },
+					onAskUser: makeAskHandler(bksId),
+				})) {
+					if (event.type === "init") {
+						engineSessionId = event.sessionId || "";
+						persist();
+					}
+					if (event.type === "text_chunk") {
+						broadcastToSession(bksId, {
+							type: "stream_text",
+							text: event.text,
+						});
+					}
+					if (event.type === "tool_use") {
+						broadcastToSession(bksId, {
+							type: "stream_tool_use",
+							entry: {
+								id: event.toolUseId || crypto.randomUUID(),
+								type: "tool_use",
+								content: `Using ${event.toolName}`,
+								timestamp: new Date().toISOString(),
+								toolName: event.toolName,
+								toolInput: event.toolInput,
+								toolUseId: event.toolUseId,
+							},
+						});
+					}
+					if (event.type === "tool_result") {
+						broadcastToSession(bksId, {
+							type: "stream_tool_result",
+							entry: {
+								id: event.toolUseId
+									? `tr-${event.toolUseId}`
+									: crypto.randomUUID(),
+								type: "tool_result",
+								content: event.content || "",
+								timestamp: new Date().toISOString(),
+								toolUseId: event.toolUseId,
+								...(event.images && event.images.length > 0
+									? { images: event.images }
+									: {}),
+								...(event.videos && event.videos.length > 0
+									? { videos: event.videos }
+									: {}),
+							},
+						});
+					}
+					if (event.type === "done") {
+						engineSessionId = event.sessionId || engineSessionId;
+					}
+					if (event.type === "error") {
+						broadcastToSession(bksId, {
+							type: "error",
+							message: event.content,
+						});
+					}
+				}
+				if (!persisted) persist();
+				else
+					touchBackstageSession(
+						bksId,
+						isCodex
+							? { codexThreadId: engineSessionId }
+							: { claudeSessionId: engineSessionId },
+					);
+				broadcastToSession(bksId, { type: "stream_done" });
+				broadcastToSession(bksId, { type: "session_status", isRunning: false });
+				if (!promptQueues.get(bksId)?.length) onHumanAsksSessionIdle(bksId);
+			} catch (e) {
+				console.error(`[sessions-mcp] create session ${bksId} failed:`, e);
+			}
+		})();
 
-    return { id: bksId };
-  },
+		return { id: bksId };
+	},
 });
 
 // --- Agent loading and webhook server ---
 
 async function loadAgents(): Promise<AgentModule[]> {
-  const agents: AgentModule[] = [];
+	const agents: AgentModule[] = [];
 
-  if (process.env.ENABLE_PLAIN_AGENT !== "false") {
-    try {
-      const { PlainAgent } = await import("./src/agents/plain/index");
-      agents.push(new PlainAgent());
-      console.log("[agents] Plain agent loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load plain agent:", e);
-    }
-  }
+	if (process.env.ENABLE_PLAIN_AGENT !== "false") {
+		try {
+			const { PlainAgent } = await import("./src/agents/plain/index");
+			agents.push(new PlainAgent());
+			console.log("[agents] Plain agent loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load plain agent:", e);
+		}
+	}
 
-  if (process.env.ENABLE_LINEAR_AGENT !== "false") {
-    try {
-      const { LinearAgent } = await import("./src/agents/linear/index");
-      agents.push(new LinearAgent());
-      console.log("[agents] Linear agent loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load linear agent:", e);
-    }
-  }
+	if (process.env.ENABLE_LINEAR_AGENT !== "false") {
+		try {
+			const { LinearAgent } = await import("./src/agents/linear/index");
+			agents.push(new LinearAgent());
+			console.log("[agents] Linear agent loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load linear agent:", e);
+		}
+	}
 
-  if (process.env.ENABLE_SLACK_AGENT !== "false") {
-    try {
-      const { SlackAgent } = await import("./src/agents/slack/index");
-      agents.push(new SlackAgent());
-      console.log("[agents] Slack agent loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load slack agent:", e);
-    }
-  }
+	if (process.env.ENABLE_SLACK_AGENT !== "false") {
+		try {
+			const { SlackAgent } = await import("./src/agents/slack/index");
+			agents.push(new SlackAgent());
+			console.log("[agents] Slack agent loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load slack agent:", e);
+		}
+	}
 
-  // Gated on the signing secret: without it every webhook fails verification, so
-  // there's no point exposing the route. Set STRIPE_WEBHOOK_SECRET to activate.
-  if (process.env.ENABLE_STRIPE_AGENT !== "false" && process.env.STRIPE_WEBHOOK_SECRET) {
-    try {
-      const { StripeAgent } = await import("./src/agents/stripe/index");
-      agents.push(new StripeAgent());
-      console.log("[agents] Stripe agent loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load stripe agent:", e);
-    }
-  }
+	// Gated on the signing secret: without it every webhook fails verification, so
+	// there's no point exposing the route. Set STRIPE_WEBHOOK_SECRET to activate.
+	if (
+		process.env.ENABLE_STRIPE_AGENT !== "false" &&
+		process.env.STRIPE_WEBHOOK_SECRET
+	) {
+		try {
+			const { StripeAgent } = await import("./src/agents/stripe/index");
+			agents.push(new StripeAgent());
+			console.log("[agents] Stripe agent loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load stripe agent:", e);
+		}
+	}
 
-  // Generic Grafana poller: drives every automation that carries a `grafanaPoll`
-  // config (export failures, upload-processing failures, and any future signal
-  // added as data). Gated on Grafana creds (the agent no-ops without them).
-  if (process.env.ENABLE_GRAFANA_POLLER !== "false") {
-    try {
-      const { GrafanaPollerAgent } = await import("./src/agents/grafana-poller/index");
-      agents.push(new GrafanaPollerAgent({ onSessionInvalidate: () => { sessionsCache = null; } }));
-      console.log("[agents] Grafana poller loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load grafana poller:", e);
-    }
-  }
+	// Generic Grafana poller: drives every automation that carries a `grafanaPoll`
+	// config (export failures, upload-processing failures, and any future signal
+	// added as data). Gated on Grafana creds (the agent no-ops without them).
+	if (process.env.ENABLE_GRAFANA_POLLER !== "false") {
+		try {
+			const { GrafanaPollerAgent } = await import(
+				"./src/agents/grafana-poller/index"
+			);
+			agents.push(
+				new GrafanaPollerAgent({
+					onSessionInvalidate: () => {
+						sessionsCache = null;
+					},
+				}),
+			);
+			console.log("[agents] Grafana poller loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load grafana poller:", e);
+		}
+	}
 
-  // GitHub PR agent: review / auto-fix / simplify on tella-fusion PRs. Receives
-  // PR events forwarded from the Slack agent's /github/webhook; owns lifecycle
-  // (seeds the disabled review automation, recovers interrupted fix loops).
-  if (process.env.ENABLE_GITHUB_AGENT !== "false") {
-    try {
-      const { GithubAgent } = await import("./src/agents/github/index");
-      agents.push(new GithubAgent({ onSessionInvalidate: () => { sessionsCache = null; } }));
-      console.log("[agents] GitHub agent loaded");
-    } catch (e) {
-      console.error("[agents] Failed to load github agent:", e);
-    }
-  }
+	// GitHub PR agent: review / auto-fix / simplify on tella-fusion PRs. Receives
+	// PR events forwarded from the Slack agent's /github/webhook; owns lifecycle
+	// (seeds the disabled review automation, recovers interrupted fix loops).
+	if (process.env.ENABLE_GITHUB_AGENT !== "false") {
+		try {
+			const { GithubAgent } = await import("./src/agents/github/index");
+			agents.push(
+				new GithubAgent({
+					onSessionInvalidate: () => {
+						sessionsCache = null;
+					},
+				}),
+			);
+			console.log("[agents] GitHub agent loaded");
+		} catch (e) {
+			console.error("[agents] Failed to load github agent:", e);
+		}
+	}
 
-  return agents;
+	return agents;
 }
 
 // One-time startup: agents, schedulers, recurring timers, and signal handlers.
@@ -2713,195 +3403,208 @@ async function loadAgents(): Promise<AgentModule[]> {
 // any of it — the already-running agents/timers keep going untouched (only a
 // real restart reloads their code, and that restart is now graceful, below).
 if (!g.__backstageBooted) {
-  // Start webhook server with enabled agents + automation webhook triggers
-  agents = await loadAgents();
-  g.__agents = agents;
-  const webhookServer = startWebhookServer(
-    agents,
-    getWebhookRoutes(() => {
-      sessionsCache = null;
-    })
-  );
-  void webhookServer;
+	// Start webhook server with enabled agents + automation webhook triggers
+	agents = await loadAgents();
+	g.__agents = agents;
+	const webhookServer = startWebhookServer(
+		agents,
+		getWebhookRoutes(() => {
+			sessionsCache = null;
+		}),
+	);
+	void webhookServer;
 
-  // Seed the make_*_editor.sh action family (create-if-absent, UI edits preserved).
-  try {
-    ensureSeedActions();
-  } catch (e) {
-    console.error("[actions] Failed to seed actions:", e);
-  }
+	// Seed the make_*_editor.sh action family (create-if-absent, UI edits preserved).
+	try {
+		ensureSeedActions();
+	} catch (e) {
+		console.error("[actions] Failed to seed actions:", e);
+	}
 
-  // Seed cron-scheduled "sweep" loops (Production Error Sweep, …) as automations
-  // before the scheduler starts. Create-if-absent, so UI edits are preserved.
-  try {
-    const { ensureSweepLoops } = await import("./src/agents/loops/sweep");
-    ensureSweepLoops();
-    const { ensureMonitors } = await import("./src/agents/loops/monitor");
-    ensureMonitors();
-    const { ensureSeoLoops } = await import("./src/agents/loops/seo");
-    ensureSeoLoops();
-    const { ensureStalePrMonitor } = await import("./src/agents/loops/stale-prs");
-    ensureStalePrMonitor();
-    const { ensureCronJobs } = await import("./src/agents/loops/cron-jobs");
-    ensureCronJobs();
-  } catch (e) {
-    console.error("[loops] Failed to seed sweep/monitor/seo/stale-pr/cron loops:", e);
-  }
+	// Seed cron-scheduled "sweep" loops (Production Error Sweep, …) as automations
+	// before the scheduler starts. Create-if-absent, so UI edits are preserved.
+	try {
+		const { ensureSweepLoops } = await import("./src/agents/loops/sweep");
+		ensureSweepLoops();
+		const { ensureMonitors } = await import("./src/agents/loops/monitor");
+		ensureMonitors();
+		const { ensureSeoLoops } = await import("./src/agents/loops/seo");
+		ensureSeoLoops();
+		const { ensureStalePrMonitor } = await import(
+			"./src/agents/loops/stale-prs"
+		);
+		ensureStalePrMonitor();
+		const { ensureCronJobs } = await import("./src/agents/loops/cron-jobs");
+		ensureCronJobs();
+	} catch (e) {
+		console.error(
+			"[loops] Failed to seed sweep/monitor/seo/stale-pr/cron loops:",
+			e,
+		);
+	}
 
-  // Cron-scheduled automations + internal event bus (agents → automations)
-  startScheduler(() => {
-    sessionsCache = null;
-  });
-  setEventSessionCallback(() => {
-    sessionsCache = null;
-  });
+	// Cron-scheduled automations + internal event bus (agents → automations)
+	startScheduler(() => {
+		sessionsCache = null;
+	});
+	setEventSessionCallback(() => {
+		sessionsCache = null;
+	});
 
-  // Archive triage sessions when their Plain ticket is done
-  startPlainArchiveSweep(() => {
-    sessionsCache = null;
-  });
+	// Archive triage sessions when their Plain ticket is done
+	startPlainArchiveSweep(() => {
+		sessionsCache = null;
+	});
 
-  // Poll per-account Claude usage (drives account picking + the Connections UI)
-  startUsagePoller();
+	// Poll per-account Claude usage (drives account picking + the Connections UI)
+	startUsagePoller();
 
-  // Resume Claude runs a previous process left in-flight (restart/crash), then
-  // wake any session that finished its turn during the shutdown drain (so the
-  // journal no longer held it). Together these wake every session that was
-  // active before the restart.
-  setTimeout(() => {
-    const resumedIds = resumeInterruptedRuns(
-      () => {
-        sessionsCache = null;
-      },
-      // Re-attach the AskUserQuestion handler so a run that was blocked on an
-      // ask (web UI or Slack escalation) can ask again after the restart instead
-      // of dead-ending headless. Automations stay headless by design.
-      (bksSessionId) => {
-        const session = findSession(bksSessionId);
-        if (!session || session.source !== "backstage" || session.automation) return undefined;
-        return makeAskHandler(bksSessionId);
-      },
-    );
-    if (resumedIds.length > 0) {
-      console.log(`[runner] Resumed ${resumedIds.length} interrupted run(s) from before restart`);
-      sessionsCache = null;
-    }
-    resumeDrainedSessions(new Set(resumedIds));
-    // Re-deliver messages that were queued/steered when the process went down.
-    restorePromptQueues();
-    // Restore human-in-the-loop asks: re-arm scheduled timers, and degrade any
-    // block asks that lost their held turn to async so late replies still land.
-    initHumanAsks();
-  }, 3000);
+	// Resume Claude runs a previous process left in-flight (restart/crash), then
+	// wake any session that finished its turn during the shutdown drain (so the
+	// journal no longer held it). Together these wake every session that was
+	// active before the restart.
+	setTimeout(() => {
+		const resumedIds = resumeInterruptedRuns(
+			() => {
+				sessionsCache = null;
+			},
+			// Re-attach the AskUserQuestion handler so a run that was blocked on an
+			// ask (web UI or Slack escalation) can ask again after the restart instead
+			// of dead-ending headless. Automations stay headless by design.
+			(bksSessionId) => {
+				const session = findSession(bksSessionId);
+				if (!session || session.source !== "backstage" || session.automation)
+					return undefined;
+				return makeAskHandler(bksSessionId);
+			},
+		);
+		if (resumedIds.length > 0) {
+			console.log(
+				`[runner] Resumed ${resumedIds.length} interrupted run(s) from before restart`,
+			);
+			sessionsCache = null;
+		}
+		resumeDrainedSessions(new Set(resumedIds));
+		// Re-deliver messages that were queued/steered when the process went down.
+		restorePromptQueues();
+		// Restore human-in-the-loop asks: re-arm scheduled timers, and degrade any
+		// block asks that lost their held turn to async so late replies still land.
+		initHumanAsks();
+	}, 3000);
 
-  // Ongoing hygiene (every 6h): archive sessions idle for more than a week,
-  // then remove worktrees of archived sessions idle >14 days with no WIP.
-  setInterval(
-    async () => {
-      const count = archiveOlderThan(getAllSessions(), 7);
-      if (count > 0) {
-        console.log(`[archive] Auto-archived ${count} session(s) idle >7 days`);
-        sessionsCache = null;
-      }
-      try {
-        const removed = await sweepArchivedWorktrees(getAllSessions(), 14);
-        if (removed.length > 0) {
-          console.log(
-            `[worktree-sweep] Removed ${removed.length} clean worktree(s): ${removed.join(", ")}`
-          );
-          sessionsCache = null;
-        }
-      } catch (e) {
-        console.error("[worktree-sweep] Sweep failed:", e);
-      }
-    },
-    6 * 60 * 60 * 1000
-  );
+	// Ongoing hygiene (every 6h): archive sessions idle for more than a week,
+	// then remove worktrees of archived sessions idle >14 days with no WIP.
+	setInterval(
+		async () => {
+			const count = archiveOlderThan(getAllSessions(), 7);
+			if (count > 0) {
+				console.log(`[archive] Auto-archived ${count} session(s) idle >7 days`);
+				sessionsCache = null;
+			}
+			try {
+				const removed = await sweepArchivedWorktrees(getAllSessions(), 14);
+				if (removed.length > 0) {
+					console.log(
+						`[worktree-sweep] Removed ${removed.length} clean worktree(s): ${removed.join(", ")}`,
+					);
+					sessionsCache = null;
+				}
+			} catch (e) {
+				console.error("[worktree-sweep] Sweep failed:", e);
+			}
+		},
+		6 * 60 * 60 * 1000,
+	);
 
-  // Run agent startup hooks
-  for (const agent of agents) {
-    try {
-      await agent.startup();
-      console.log(`[agents] ${agent.name} agent started`);
-    } catch (e) {
-      console.error(`[agents] ${agent.name} agent startup failed:`, e);
-    }
-  }
+	// Run agent startup hooks
+	for (const agent of agents) {
+		try {
+			await agent.startup();
+			console.log(`[agents] ${agent.name} agent started`);
+		} catch (e) {
+			console.error(`[agents] ${agent.name} agent startup failed:`, e);
+		}
+	}
 
-  // Graceful shutdown: stop taking new work, let in-flight runs reach a natural
-  // stopping point (bounded), then exit — instead of killing every run mid-turn.
-  // Anything still running after the drain window is picked up by the run
-  // journal on the next boot (resumeInterruptedRuns), so nothing is lost.
-  // 2-min default so in-flight runner runs have a real chance to finish their
-  // current turn before exit. Must stay below the unit's TimeoutStopSec (140s),
-  // or systemd SIGKILLs the process mid-drain.
-  const DRAIN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_DRAIN_MS || "120000");
-  let shuttingDown = false;
-  const gracefulShutdown = async (signal: string) => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log(`[shutdown] ${signal} — stopping intake and draining in-flight runs…`);
-    // Snapshot active sessions BEFORE the drain — the drain lets runs finish
-    // their turn and clear themselves from the journal, so this is the only
-    // record of sessions that should be woken on the next boot.
-    snapshotActiveSessions();
-    // Tell connected UIs we're going down so they can show a "restarting" modal
-    // and auto-refresh once the new instance is up (instead of silently queuing
-    // messages that would be lost). Brief pause to let the frames flush.
-    broadcastToAll({ type: "server_restarting" });
-    await new Promise((r) => setTimeout(r, 150));
-    // Stop agents from accepting new work (Slack socket, webhook intake, …).
-    for (const agent of agents) {
-      try {
-        await agent.shutdown();
-      } catch (e) {
-        console.error(`[shutdown] ${agent.name} shutdown error:`, e);
-      }
-    }
-    // Stop accepting new HTTP/WS connections; existing ones can finish.
-    try {
-      server.stop();
-    } catch {}
-    // Wait for runner-driven runs (web UI / automations / loops) to settle.
-    const deadline = Date.now() + DRAIN_TIMEOUT_MS;
-    let n = activeAgentRunCount();
-    while (n > 0 && Date.now() < deadline) {
-      console.log(`[shutdown] waiting on ${n} in-flight run(s)…`);
-      await new Promise((r) => setTimeout(r, 500));
-      n = activeAgentRunCount();
-    }
-    if (n > 0) {
-      console.log(
-        `[shutdown] ${n} run(s) still active after ${DRAIN_TIMEOUT_MS}ms — the journal will resume them on restart`
-      );
-    } else {
-      console.log("[shutdown] all in-flight runs drained cleanly");
-    }
-    process.exit(0);
-  };
-  process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
-  process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
+	// Graceful shutdown: stop taking new work, let in-flight runs reach a natural
+	// stopping point (bounded), then exit — instead of killing every run mid-turn.
+	// Anything still running after the drain window is picked up by the run
+	// journal on the next boot (resumeInterruptedRuns), so nothing is lost.
+	// 2-min default so in-flight runner runs have a real chance to finish their
+	// current turn before exit. Must stay below the unit's TimeoutStopSec (140s),
+	// or systemd SIGKILLs the process mid-drain.
+	const DRAIN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_DRAIN_MS || "120000");
+	let shuttingDown = false;
+	const gracefulShutdown = async (signal: string) => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		console.log(
+			`[shutdown] ${signal} — stopping intake and draining in-flight runs…`,
+		);
+		// Snapshot active sessions BEFORE the drain — the drain lets runs finish
+		// their turn and clear themselves from the journal, so this is the only
+		// record of sessions that should be woken on the next boot.
+		snapshotActiveSessions();
+		// Tell connected UIs we're going down so they can show a "restarting" modal
+		// and auto-refresh once the new instance is up (instead of silently queuing
+		// messages that would be lost). Brief pause to let the frames flush.
+		broadcastToAll({ type: "server_restarting" });
+		await new Promise((r) => setTimeout(r, 150));
+		// Stop agents from accepting new work (Slack socket, webhook intake, …).
+		for (const agent of agents) {
+			try {
+				await agent.shutdown();
+			} catch (e) {
+				console.error(`[shutdown] ${agent.name} shutdown error:`, e);
+			}
+		}
+		// Stop accepting new HTTP/WS connections; existing ones can finish.
+		try {
+			server.stop();
+		} catch {}
+		// Wait for runner-driven runs (web UI / automations / loops) to settle.
+		const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+		let n = activeAgentRunCount();
+		while (n > 0 && Date.now() < deadline) {
+			console.log(`[shutdown] waiting on ${n} in-flight run(s)…`);
+			await new Promise((r) => setTimeout(r, 500));
+			n = activeAgentRunCount();
+		}
+		if (n > 0) {
+			console.log(
+				`[shutdown] ${n} run(s) still active after ${DRAIN_TIMEOUT_MS}ms — the journal will resume them on restart`,
+			);
+		} else {
+			console.log("[shutdown] all in-flight runs drained cleanly");
+		}
+		process.exit(0);
+	};
+	process.on("SIGTERM", () => void gracefulShutdown("SIGTERM"));
+	process.on("SIGINT", () => void gracefulShutdown("SIGINT"));
 
-  // Frontend live-reload: rebuild the SPA bundle in-process when its source
-  // changes, so a CSS/frontend tweak no longer needs a `systemctl restart` that
-  // interrupts every running session. `kill -USR2 <pid>` forces it too (drop-in
-  // for restart in a deploy script). Guarded by __backstageBooted so a hot
-  // reload doesn't stack watchers/handlers. recursive watch needs Linux ≥ 6.x
-  // (we're on 6.17) — fine here.
-  if (!IS_DEV && frontend) {
-    try {
-      const watcher = watch(FRONTEND_SRC, { recursive: true }, (_evt, file) => {
-        if (file && /\.(tsx?|css|html)$/.test(file.toString())) {
-          scheduleFrontendRebuild(`watch:${file}`);
-        }
-      });
-      process.on("exit", () => watcher.close());
-      console.log(`[frontend] Watching ${FRONTEND_SRC} for live rebuilds`);
-    } catch (e) {
-      console.error("[frontend] Could not start file-watch (use SIGUSR2/endpoint to rebuild):", e);
-    }
-    process.on("SIGUSR2", () => scheduleFrontendRebuild("SIGUSR2", 0));
-  }
+	// Frontend live-reload: rebuild the SPA bundle in-process when its source
+	// changes, so a CSS/frontend tweak no longer needs a `systemctl restart` that
+	// interrupts every running session. `kill -USR2 <pid>` forces it too (drop-in
+	// for restart in a deploy script). Guarded by __backstageBooted so a hot
+	// reload doesn't stack watchers/handlers. recursive watch needs Linux ≥ 6.x
+	// (we're on 6.17) — fine here.
+	if (!IS_DEV && frontend) {
+		try {
+			const watcher = watch(FRONTEND_SRC, { recursive: true }, (_evt, file) => {
+				if (file && /\.(tsx?|css|html)$/.test(file.toString())) {
+					scheduleFrontendRebuild(`watch:${file}`);
+				}
+			});
+			process.on("exit", () => watcher.close());
+			console.log(`[frontend] Watching ${FRONTEND_SRC} for live rebuilds`);
+		} catch (e) {
+			console.error(
+				"[frontend] Could not start file-watch (use SIGUSR2/endpoint to rebuild):",
+				e,
+			);
+		}
+		process.on("SIGUSR2", () => scheduleFrontendRebuild("SIGUSR2", 0));
+	}
 
-  g.__backstageBooted = true;
+	g.__backstageBooted = true;
 }

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -20,333 +20,386 @@ import { useSidebarSwipe } from "./hooks/useSidebarSwipe";
 import { archiveSessionApi } from "./lib/api";
 import { pushRecent } from "./lib/recents";
 import { getPins, togglePin, onPinsChanged } from "./lib/pins";
+import {
+	getTabColors,
+	setTabColor,
+	onTabColorsChanged,
+} from "./lib/tab-colors";
 import type { UnifiedSession } from "./lib/types";
 import "./styles/global.css";
 
 type Route =
-  | { view: "home" }
-  | { view: "new"; prompt?: string }
-  | { view: "session"; id: string }
-  | { view: "reviews"; id?: string }
-  | { view: "automations" }
-  | { view: "actions" }
-  | { view: "wiki"; path: string | null }
-  | { view: "connections" }
-  | { view: "archived" };
+	| { view: "home" }
+	| { view: "new"; prompt?: string }
+	| { view: "session"; id: string }
+	| { view: "reviews"; id?: string }
+	| { view: "automations" }
+	| { view: "actions" }
+	| { view: "wiki"; path: string | null }
+	| { view: "connections" }
+	| { view: "archived" };
 
 function parseRoute(pathname: string): Route {
-  const sessionMatch = pathname.match(/^\/backstage\/session\/(.+)$/);
-  if (sessionMatch) return { view: "session", id: decodeURIComponent(sessionMatch[1]) };
-  if (pathname === "/backstage/new") return { view: "new" };
-  if (pathname === "/backstage/automations") return { view: "automations" };
-  if (pathname === "/backstage/actions") return { view: "actions" };
-  if (pathname === "/backstage/connections") return { view: "connections" };
-  if (pathname === "/backstage/archived") return { view: "archived" };
-  const reviewsMatch = pathname.match(/^\/backstage\/reviews(?:\/(.+))?$/);
-  if (reviewsMatch) return { view: "reviews", id: reviewsMatch[1] ? decodeURIComponent(reviewsMatch[1]) : undefined };
-  const wikiMatch = pathname.match(/^\/backstage\/wiki(?:\/(.*))?$/);
-  if (wikiMatch) return { view: "wiki", path: wikiMatch[1] ? decodeURIComponent(wikiMatch[1]) : null };
-  return { view: "home" };
+	const sessionMatch = pathname.match(/^\/backstage\/session\/(.+)$/);
+	if (sessionMatch)
+		return { view: "session", id: decodeURIComponent(sessionMatch[1]) };
+	if (pathname === "/backstage/new") return { view: "new" };
+	if (pathname === "/backstage/automations") return { view: "automations" };
+	if (pathname === "/backstage/actions") return { view: "actions" };
+	if (pathname === "/backstage/connections") return { view: "connections" };
+	if (pathname === "/backstage/archived") return { view: "archived" };
+	const reviewsMatch = pathname.match(/^\/backstage\/reviews(?:\/(.+))?$/);
+	if (reviewsMatch)
+		return {
+			view: "reviews",
+			id: reviewsMatch[1] ? decodeURIComponent(reviewsMatch[1]) : undefined,
+		};
+	const wikiMatch = pathname.match(/^\/backstage\/wiki(?:\/(.*))?$/);
+	if (wikiMatch)
+		return {
+			view: "wiki",
+			path: wikiMatch[1] ? decodeURIComponent(wikiMatch[1]) : null,
+		};
+	return { view: "home" };
 }
 
 function routePath(route: Route): string {
-  switch (route.view) {
-    case "session":
-      return `/backstage/session/${encodeURIComponent(route.id)}`;
-    case "new":
-      return route.prompt
-        ? `/backstage/new?prompt=${encodeURIComponent(route.prompt)}`
-        : "/backstage/new";
-    case "automations":
-      return "/backstage/automations";
-    case "actions":
-      return "/backstage/actions";
-    case "connections":
-      return "/backstage/connections";
-    case "archived":
-      return "/backstage/archived";
-    case "reviews":
-      return route.id ? `/backstage/reviews/${encodeURIComponent(route.id)}` : "/backstage/reviews";
-    case "wiki":
-      return route.path
-        ? `/backstage/wiki/${route.path.split("/").map(encodeURIComponent).join("/")}`
-        : "/backstage/wiki";
-    default:
-      return "/backstage/";
-  }
+	switch (route.view) {
+		case "session":
+			return `/backstage/session/${encodeURIComponent(route.id)}`;
+		case "new":
+			return route.prompt
+				? `/backstage/new?prompt=${encodeURIComponent(route.prompt)}`
+				: "/backstage/new";
+		case "automations":
+			return "/backstage/automations";
+		case "actions":
+			return "/backstage/actions";
+		case "connections":
+			return "/backstage/connections";
+		case "archived":
+			return "/backstage/archived";
+		case "reviews":
+			return route.id
+				? `/backstage/reviews/${encodeURIComponent(route.id)}`
+				: "/backstage/reviews";
+		case "wiki":
+			return route.path
+				? `/backstage/wiki/${route.path.split("/").map(encodeURIComponent).join("/")}`
+				: "/backstage/wiki";
+		default:
+			return "/backstage/";
+	}
 }
 
 function App() {
-  const { sessions, loading, refresh } = useSessions();
-  const { connected, send, addHandler } = useWebSocket();
-  // iOS evicts standalone PWAs from memory and relaunches them at the manifest
-  // start_url (/backstage/) — losing the session you had open. On a cold load
-  // that lands on home, restore the last session so it isn't dropped. This only
-  // runs on a fresh document load (never on in-app navigation, which uses
-  // pushState), so tapping the logo to go home still works.
-  const [route, setRoute] = useState<Route>(() => {
-    const parsed = parseRoute(location.pathname);
-    if (parsed.view === "home") {
-      const lastId = localStorage.getItem("michael-last-session");
-      if (lastId) {
-        const restored: Route = { view: "session", id: lastId };
-        history.replaceState(null, "", routePath(restored));
-        return restored;
-      }
-    }
-    return parsed;
-  });
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const sidebarRef = useRef<HTMLDivElement | null>(null);
-  // A session we've just navigated to that may not be in the polled list yet
-  // (create → navigate races the async refresh, and the file is only written
-  // once the run's `init` lands). While pending, the detail pane shows
-  // "Loading…" instead of flashing "Session not found".
-  const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
-  const pendingTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const [pins, setPins] = useState<string[]>(getPins);
+	const { sessions, loading, refresh } = useSessions();
+	const { connected, send, addHandler } = useWebSocket();
+	// iOS evicts standalone PWAs from memory and relaunches them at the manifest
+	// start_url (/backstage/) — losing the session you had open. On a cold load
+	// that lands on home, restore the last session so it isn't dropped. This only
+	// runs on a fresh document load (never on in-app navigation, which uses
+	// pushState), so tapping the logo to go home still works.
+	const [route, setRoute] = useState<Route>(() => {
+		const parsed = parseRoute(location.pathname);
+		if (parsed.view === "home") {
+			const lastId = localStorage.getItem("michael-last-session");
+			if (lastId) {
+				const restored: Route = { view: "session", id: lastId };
+				history.replaceState(null, "", routePath(restored));
+				return restored;
+			}
+		}
+		return parsed;
+	});
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+	const sidebarRef = useRef<HTMLDivElement | null>(null);
+	// A session we've just navigated to that may not be in the polled list yet
+	// (create → navigate races the async refresh, and the file is only written
+	// once the run's `init` lands). While pending, the detail pane shows
+	// "Loading…" instead of flashing "Session not found".
+	const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
+	const pendingTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+	const [pins, setPins] = useState<string[]>(getPins);
+	const [tabColors, setTabColors] =
+		useState<Record<string, string>>(getTabColors);
 
-  useEffect(() => onPinsChanged(() => setPins(getPins())), []);
+	useEffect(() => onPinsChanged(() => setPins(getPins())), []);
+	useEffect(() => onTabColorsChanged(() => setTabColors(getTabColors())), []);
 
-  useSidebarSwipe({ open: sidebarOpen, setOpen: setSidebarOpen, panelRef: sidebarRef });
+	useSidebarSwipe({
+		open: sidebarOpen,
+		setOpen: setSidebarOpen,
+		panelRef: sidebarRef,
+	});
 
-  function navigate(route: Route) {
-    history.pushState(null, "", routePath(route));
-    setRoute(route);
-    setSidebarOpen(false);
-  }
+	function navigate(route: Route) {
+		history.pushState(null, "", routePath(route));
+		setRoute(route);
+		setSidebarOpen(false);
+	}
 
-  useEffect(() => {
-    const onPop = () => setRoute(parseRoute(location.pathname));
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
+	useEffect(() => {
+		const onPop = () => setRoute(parseRoute(location.pathname));
+		window.addEventListener("popstate", onPop);
+		return () => window.removeEventListener("popstate", onPop);
+	}, []);
 
-  // Remember the last session so a cold relaunch can restore it (see above);
-  // clear it when the user deliberately goes home so we don't force them back in.
-  // Also feed the sidebar's "Recently opened" list.
-  useEffect(() => {
-    if (route.view === "session") {
-      localStorage.setItem("michael-last-session", route.id);
-      pushRecent(route.id);
-    } else if (route.view === "home") {
-      localStorage.removeItem("michael-last-session");
-    }
-  }, [route]);
+	// Remember the last session so a cold relaunch can restore it (see above);
+	// clear it when the user deliberately goes home so we don't force them back in.
+	// Also feed the sidebar's "Recently opened" list.
+	useEffect(() => {
+		if (route.view === "session") {
+			localStorage.setItem("michael-last-session", route.id);
+			pushRecent(route.id);
+		} else if (route.view === "home") {
+			localStorage.removeItem("michael-last-session");
+		}
+	}, [route]);
 
-  // Tear down the launch splash (rendered in index.html) once the app has mounted.
-  useEffect(() => {
-    const splash = document.getElementById("splash");
-    if (!splash) return;
-    splash.classList.add("splash-hide");
-    const t = setTimeout(() => splash.remove(), 400);
-    return () => clearTimeout(t);
-  }, []);
+	// Tear down the launch splash (rendered in index.html) once the app has mounted.
+	useEffect(() => {
+		const splash = document.getElementById("splash");
+		if (!splash) return;
+		splash.classList.add("splash-hide");
+		const t = setTimeout(() => splash.remove(), 400);
+		return () => clearTimeout(t);
+	}, []);
 
-  // When a session is created from the New Session form or Ask box, jump straight into it
-  useEffect(() => {
-    return addHandler((msg) => {
-      if (msg.type === "session_created") {
-        // Mark it pending so the viewer shows "Loading…" until the poll catches
-        // up; a fallback timeout clears it so a failed create can't stick.
-        setPendingSessionId(msg.id);
-        clearTimeout(pendingTimer.current);
-        pendingTimer.current = setTimeout(() => setPendingSessionId(null), 30000);
-        refresh();
-        navigate({ view: "session", id: msg.id });
-      }
-    });
-  }, [addHandler, refresh]);
+	// When a session is created from the New Session form or Ask box, jump straight into it
+	useEffect(() => {
+		return addHandler((msg) => {
+			if (msg.type === "session_created") {
+				// Mark it pending so the viewer shows "Loading…" until the poll catches
+				// up; a fallback timeout clears it so a failed create can't stick.
+				setPendingSessionId(msg.id);
+				clearTimeout(pendingTimer.current);
+				pendingTimer.current = setTimeout(
+					() => setPendingSessionId(null),
+					30000,
+				);
+				refresh();
+				navigate({ view: "session", id: msg.id });
+			}
+		});
+	}, [addHandler, refresh]);
 
-  // Clear the pending flag once the session shows up in the polled list.
-  useEffect(() => {
-    if (
-      pendingSessionId &&
-      sessions.some((s) => s.id === pendingSessionId || s.aliasIds?.includes(pendingSessionId))
-    ) {
-      setPendingSessionId(null);
-      clearTimeout(pendingTimer.current);
-    }
-  }, [sessions, pendingSessionId]);
+	// Clear the pending flag once the session shows up in the polled list.
+	useEffect(() => {
+		if (
+			pendingSessionId &&
+			sessions.some(
+				(s) =>
+					s.id === pendingSessionId || s.aliasIds?.includes(pendingSessionId),
+			)
+		) {
+			setPendingSessionId(null);
+			clearTimeout(pendingTimer.current);
+		}
+	}, [sessions, pendingSessionId]);
 
-  const currentSession: UnifiedSession | null =
-    route.view === "session"
-      ? sessions.find((s) => s.id === route.id || s.aliasIds?.includes(route.id)) || null
-      : null;
+	const currentSession: UnifiedSession | null =
+		route.view === "session"
+			? sessions.find(
+					(s) => s.id === route.id || s.aliasIds?.includes(route.id),
+				) || null
+			: null;
 
-  // Pinned sessions shown as tabs above the title (pin order preserved).
-  const pinnedTabs = pins
-    .map((id) => sessions.find((s) => s.id === id || s.aliasIds?.includes(id)))
-    .filter((s): s is UnifiedSession => Boolean(s));
+	// Pinned sessions shown as tabs above the title (pin order preserved).
+	const pinnedTabs = pins
+		.map((id) => sessions.find((s) => s.id === id || s.aliasIds?.includes(id)))
+		.filter((s): s is UnifiedSession => Boolean(s));
 
-  // The currently-open session always gets a tab, even when it isn't pinned —
-  // like Chrome, this transient tab lives only while its session is the active
-  // route and closes the moment you navigate away. Pinned tabs persist; the ☆
-  // on a transient tab promotes it to a pinned one.
-  const pinnedIds = new Set(pinnedTabs.map((s) => s.id));
-  const tabs =
-    currentSession && !pinnedIds.has(currentSession.id)
-      ? [...pinnedTabs, currentSession]
-      : pinnedTabs;
+	// The currently-open session always gets a tab, even when it isn't pinned —
+	// like Chrome, this transient tab lives only while its session is the active
+	// route and closes the moment you navigate away. Pinned tabs persist; the ☆
+	// on a transient tab promotes it to a pinned one.
+	const pinnedIds = new Set(pinnedTabs.map((s) => s.id));
+	const tabs =
+		currentSession && !pinnedIds.has(currentSession.id)
+			? [...pinnedTabs, currentSession]
+			: pinnedTabs;
 
-  const activeView =
-    route.view === "automations" ||
-    route.view === "actions" ||
-    route.view === "wiki" ||
-    route.view === "connections" ||
-    route.view === "reviews"
-      ? route.view
-      : ("sessions" as const);
+	const activeView =
+		route.view === "automations" ||
+		route.view === "actions" ||
+		route.view === "wiki" ||
+		route.view === "connections" ||
+		route.view === "reviews"
+			? route.view
+			: ("sessions" as const);
 
-  return (
-    <UserGate>
-      <RestartOverlay connected={connected} addHandler={addHandler} />
-      <UpdateToast addHandler={addHandler} />
-      <div className="app">
-        <header className="app-header">
-          <div className="app-header-left">
-            <button
-              className="hamburger"
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              aria-label="Toggle sidebar"
-            >
-              <span /><span /><span />
-            </button>
-            <a
-              className="app-title"
-              href="/backstage/"
-              onClick={(e) => {
-                e.preventDefault();
-                navigate({ view: "home" });
-              }}
-            >
-              <span className="app-logo">M</span>
-              <span className="app-title-text">Michael</span>
-            </a>
-          </div>
-          <div className="app-header-right">
-            <span className={`connection-dot ${connected ? "connected" : "disconnected"}`} />
-            <UserPicker />
-          </div>
-        </header>
+	return (
+		<UserGate>
+			<RestartOverlay connected={connected} addHandler={addHandler} />
+			<UpdateToast addHandler={addHandler} />
+			<div className="app">
+				<header className="app-header">
+					<div className="app-header-left">
+						<button
+							className="hamburger"
+							onClick={() => setSidebarOpen(!sidebarOpen)}
+							aria-label="Toggle sidebar"
+						>
+							<span />
+							<span />
+							<span />
+						</button>
+						<a
+							className="app-title"
+							href="/backstage/"
+							onClick={(e) => {
+								e.preventDefault();
+								navigate({ view: "home" });
+							}}
+						>
+							<span className="app-logo">M</span>
+							<span className="app-title-text">Michael</span>
+						</a>
+					</div>
+					<div className="app-header-right">
+						<span
+							className={`connection-dot ${connected ? "connected" : "disconnected"}`}
+						/>
+						<UserPicker />
+					</div>
+				</header>
 
-        <div className="app-body">
-          {/* Overlay to close sidebar on mobile */}
-          {sidebarOpen && (
-            <div className="sidebar-overlay" onClick={() => setSidebarOpen(false)} />
-          )}
+				<div className="app-body">
+					{/* Overlay to close sidebar on mobile */}
+					{sidebarOpen && (
+						<div
+							className="sidebar-overlay"
+							onClick={() => setSidebarOpen(false)}
+						/>
+					)}
 
-          <div ref={sidebarRef} className={`sidebar-container ${sidebarOpen ? "sidebar-open" : ""}`}>
-            <Sidebar
-              sessions={sessions}
-              selectedId={currentSession?.id || null}
-              activeView={activeView}
-              onNavigate={(view) =>
-                navigate(
-                  view === "sessions"
-                    ? { view: "home" }
-                    : view === "wiki"
-                      ? { view: "wiki", path: null }
-                      : { view }
-                )
-              }
-              onSelect={(s) => navigate({ view: "session", id: s.id })}
-              onNewSession={() => navigate({ view: "new" })}
-              onOpenArchived={() => navigate({ view: "archived" })}
-              onArchive={async (s) => {
-                try {
-                  await archiveSessionApi(s.id, true);
-                } catch (e) {
-                  console.error("Archive failed:", e);
-                }
-                refresh();
-              }}
-            />
-          </div>
+					<div
+						ref={sidebarRef}
+						className={`sidebar-container ${sidebarOpen ? "sidebar-open" : ""}`}
+					>
+						<Sidebar
+							sessions={sessions}
+							selectedId={currentSession?.id || null}
+							activeView={activeView}
+							onNavigate={(view) =>
+								navigate(
+									view === "sessions"
+										? { view: "home" }
+										: view === "wiki"
+											? { view: "wiki", path: null }
+											: { view },
+								)
+							}
+							onSelect={(s) => navigate({ view: "session", id: s.id })}
+							onNewSession={() => navigate({ view: "new" })}
+							onOpenArchived={() => navigate({ view: "archived" })}
+							onArchive={async (s) => {
+								try {
+									await archiveSessionApi(s.id, true);
+								} catch (e) {
+									console.error("Archive failed:", e);
+								}
+								refresh();
+							}}
+						/>
+					</div>
 
-          <main className="detail-pane">
-            <SessionTabs
-              tabs={tabs}
-              activeId={currentSession?.id || null}
-              pinnedIds={pinnedIds}
-              onSelect={(s) => navigate({ view: "session", id: s.id })}
-              onTogglePin={(id) => setPins(togglePin(id))}
-            />
-            {route.view === "new" ? (
-              <NewSession
-                onBack={() => navigate({ view: "home" })}
-                send={send}
-                addHandler={addHandler}
-                connected={connected}
-              />
-            ) : route.view === "automations" ? (
-              <Automations onOpenSession={(id) => navigate({ view: "session", id })} />
-            ) : route.view === "actions" ? (
-              <Actions onOpenSession={(id) => navigate({ view: "session", id })} />
-            ) : route.view === "connections" ? (
-              <Connections />
-            ) : route.view === "reviews" ? (
-              <Reviews
-                sessions={sessions}
-                selectedId={route.id ?? null}
-                onSelect={(id) => navigate({ view: "reviews", id })}
-                onOpenSession={(id) => navigate({ view: "session", id })}
-              />
-            ) : route.view === "archived" ? (
-              <Archived
-                sessions={sessions}
-                onSelect={(s) => navigate({ view: "session", id: s.id })}
-                onChanged={refresh}
-              />
-            ) : route.view === "wiki" ? (
-              <Wiki
-                docPath={route.path}
-                onNavigate={(path) => navigate({ view: "wiki", path })}
-              />
-            ) : route.view === "session" ? (
-              currentSession ? (
-                <SessionViewer
-                  key={currentSession.id}
-                  session={currentSession}
-                  onBack={() => navigate({ view: "home" })}
-                  send={send}
-                  addHandler={addHandler}
-                  connected={connected}
-                />
-              ) : (
-                <div className="detail-empty">
-                  <div className="detail-empty-inner">
-                    {(() => {
-                      const isLoading = loading || route.id === pendingSessionId;
-                      return (
-                        <>
-                          <div className="detail-empty-title">
-                            {isLoading ? "Loading session…" : "Session not found"}
-                          </div>
-                          <div className="detail-empty-sub">
-                            {isLoading ? "" : "It may have been deleted."}
-                          </div>
-                        </>
-                      );
-                    })()}
-                  </div>
-                </div>
-              )
-            ) : (
-              <Home
-                sessions={sessions}
-                loading={loading}
-                connected={connected}
-                send={send}
-                onSelect={(s) => navigate({ view: "session", id: s.id })}
-                onNewSession={(prompt) => navigate({ view: "new", prompt })}
-              />
-            )}
-          </main>
-        </div>
-      </div>
-    </UserGate>
-  );
+					<main className="detail-pane">
+						<SessionTabs
+							tabs={tabs}
+							activeId={currentSession?.id || null}
+							pinnedIds={pinnedIds}
+							colors={tabColors}
+							onSelect={(s) => navigate({ view: "session", id: s.id })}
+							onTogglePin={(id) => setPins(togglePin(id))}
+							onSetColor={(id, color) => setTabColors(setTabColor(id, color))}
+							onNewSession={() => navigate({ view: "new" })}
+						/>
+						{route.view === "new" ? (
+							<NewSession
+								onBack={() => navigate({ view: "home" })}
+								send={send}
+								addHandler={addHandler}
+								connected={connected}
+							/>
+						) : route.view === "automations" ? (
+							<Automations
+								onOpenSession={(id) => navigate({ view: "session", id })}
+							/>
+						) : route.view === "actions" ? (
+							<Actions
+								onOpenSession={(id) => navigate({ view: "session", id })}
+							/>
+						) : route.view === "connections" ? (
+							<Connections />
+						) : route.view === "reviews" ? (
+							<Reviews
+								sessions={sessions}
+								selectedId={route.id ?? null}
+								onSelect={(id) => navigate({ view: "reviews", id })}
+								onOpenSession={(id) => navigate({ view: "session", id })}
+							/>
+						) : route.view === "archived" ? (
+							<Archived
+								sessions={sessions}
+								onSelect={(s) => navigate({ view: "session", id: s.id })}
+								onChanged={refresh}
+							/>
+						) : route.view === "wiki" ? (
+							<Wiki
+								docPath={route.path}
+								onNavigate={(path) => navigate({ view: "wiki", path })}
+							/>
+						) : route.view === "session" ? (
+							currentSession ? (
+								<SessionViewer
+									key={currentSession.id}
+									session={currentSession}
+									onBack={() => navigate({ view: "home" })}
+									send={send}
+									addHandler={addHandler}
+									connected={connected}
+								/>
+							) : (
+								<div className="detail-empty">
+									<div className="detail-empty-inner">
+										{(() => {
+											const isLoading =
+												loading || route.id === pendingSessionId;
+											return (
+												<>
+													<div className="detail-empty-title">
+														{isLoading
+															? "Loading session…"
+															: "Session not found"}
+													</div>
+													<div className="detail-empty-sub">
+														{isLoading ? "" : "It may have been deleted."}
+													</div>
+												</>
+											);
+										})()}
+									</div>
+								</div>
+							)
+						) : (
+							<Home
+								sessions={sessions}
+								loading={loading}
+								connected={connected}
+								send={send}
+								onSelect={(s) => navigate({ view: "session", id: s.id })}
+								onNewSession={(prompt) => navigate({ view: "new", prompt })}
+							/>
+						)}
+					</main>
+				</div>
+			</div>
+		</UserGate>
+	);
 }
 
 const root = createRoot(document.getElementById("root")!);

--- a/src/frontend/components/SessionTabs.tsx
+++ b/src/frontend/components/SessionTabs.tsx
@@ -1,14 +1,24 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import type { UnifiedSession } from "../lib/types";
+import { TAB_COLORS, colorHex } from "../lib/tab-colors";
 
 interface Props {
-  tabs: UnifiedSession[];
-  activeId: string | null;
-  /** IDs of sessions that are pinned; the rest are transient (current route only). */
-  pinnedIds: Set<string>;
-  onSelect: (session: UnifiedSession) => void;
-  onTogglePin: (id: string) => void;
+	tabs: UnifiedSession[];
+	activeId: string | null;
+	/** IDs of sessions that are pinned; the rest are transient (current route only). */
+	pinnedIds: Set<string>;
+	/** Map of session id → swatch key for tabs the user has colored. */
+	colors: Record<string, string>;
+	onSelect: (session: UnifiedSession) => void;
+	onTogglePin: (id: string) => void;
+	/** Set a tab's color (swatch key), or clear it with `null`. */
+	onSetColor: (id: string, color: string | null) => void;
+	/** Jump to the New Session view (the reveal-on-hover "+" tab). */
+	onNewSession: () => void;
 }
+
+/** Open swatch menu: which session, and where to anchor it (viewport coords). */
+type Menu = { id: string; x: number; y: number };
 
 /**
  * Horizontal strip of session tabs above the session title, on every view.
@@ -16,48 +26,130 @@ interface Props {
  * header). The currently-open session also shows as a *transient* tab even when
  * unpinned: like Chrome, it closes as soon as you navigate away. Clicking the
  * ☆ on a transient tab promotes it to a pinned one; the ★ on a pinned tab
- * unpins (removing the tab).
+ * unpins (removing the tab). Hovering the strip also reveals a trailing "+"
+ * tab that jumps straight to the New Session view.
+ *
+ * Right-clicking a tab opens a swatch menu to color it (a per-user view
+ * preference, synced across devices like pins) — handy for telling a row of
+ * lookalike tabs apart at a glance.
  */
-export function SessionTabs({ tabs, activeId, pinnedIds, onSelect, onTogglePin }: Props) {
-  if (tabs.length === 0) return null;
+export function SessionTabs({
+	tabs,
+	activeId,
+	pinnedIds,
+	colors,
+	onSelect,
+	onTogglePin,
+	onSetColor,
+	onNewSession,
+}: Props) {
+	const [menu, setMenu] = useState<Menu | null>(null);
 
-  return (
-    <div className="session-tabs" role="tablist">
-      {tabs.map((s) => {
-        const pinned = pinnedIds.has(s.id);
-        const waiting = !!s.waitingForInput;
-        return (
-          <div
-            key={s.id}
-            role="tab"
-            aria-selected={s.id === activeId}
-            className={`session-tab ${s.id === activeId ? "session-tab-active" : ""} ${
-              pinned ? "" : "session-tab-transient"
-            } ${waiting ? "session-tab-waiting" : ""}`}
-            onClick={() => onSelect(s)}
-            title={waiting ? `${s.title} — waiting for your input` : s.title}
-          >
-            {waiting ? (
-              <span className="session-tab-dot session-tab-dot-waiting" />
-            ) : (
-              s.isRunning && <span className="session-tab-dot" />
-            )}
-            <span className="session-tab-title">{s.title}</span>
-            <span
-              className={`session-tab-pin ${pinned ? "session-tab-pin-on" : ""}`}
-              role="button"
-              aria-label={pinned ? "Unpin (remove tab)" : "Pin tab"}
-              title={pinned ? "Unpin" : "Pin tab"}
-              onClick={(e) => {
-                e.stopPropagation();
-                onTogglePin(s.id);
-              }}
-            >
-              {pinned ? "★" : "☆"}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
+	// Dismiss the swatch menu on any outside click, scroll, or Escape.
+	useEffect(() => {
+		if (!menu) return;
+		const close = () => setMenu(null);
+		const onKey = (e: KeyboardEvent) => e.key === "Escape" && setMenu(null);
+		window.addEventListener("click", close);
+		window.addEventListener("scroll", close, true);
+		window.addEventListener("keydown", onKey);
+		return () => {
+			window.removeEventListener("click", close);
+			window.removeEventListener("scroll", close, true);
+			window.removeEventListener("keydown", onKey);
+		};
+	}, [menu]);
+
+	if (tabs.length === 0) return null;
+
+	return (
+		<div className="session-tabs" role="tablist">
+			{tabs.map((s) => {
+				const pinned = pinnedIds.has(s.id);
+				const waiting = !!s.waitingForInput;
+				const hex = colorHex(colors[s.id]);
+				return (
+					<div
+						key={s.id}
+						role="tab"
+						aria-selected={s.id === activeId}
+						className={`session-tab ${s.id === activeId ? "session-tab-active" : ""} ${
+							pinned ? "" : "session-tab-transient"
+						} ${waiting ? "session-tab-waiting" : ""} ${hex ? "session-tab-colored" : ""}`}
+						style={
+							hex ? ({ "--tab-color": hex } as React.CSSProperties) : undefined
+						}
+						onClick={() => onSelect(s)}
+						onContextMenu={(e) => {
+							e.preventDefault();
+							setMenu({ id: s.id, x: e.clientX, y: e.clientY });
+						}}
+						title={waiting ? `${s.title} — waiting for your input` : s.title}
+					>
+						{waiting ? (
+							<span className="session-tab-dot session-tab-dot-waiting" />
+						) : (
+							s.isRunning && <span className="session-tab-dot" />
+						)}
+						<span className="session-tab-title">{s.title}</span>
+						<span
+							className={`session-tab-pin ${pinned ? "session-tab-pin-on" : ""}`}
+							role="button"
+							aria-label={pinned ? "Unpin (remove tab)" : "Pin tab"}
+							title={pinned ? "Unpin" : "Pin tab"}
+							onClick={(e) => {
+								e.stopPropagation();
+								onTogglePin(s.id);
+							}}
+						>
+							{pinned ? "★" : "☆"}
+						</span>
+					</div>
+				);
+			})}
+			<button
+				type="button"
+				className="session-tab session-tab-new"
+				aria-label="New session"
+				title="New session"
+				onClick={onNewSession}
+			>
+				+
+			</button>
+
+			{menu && (
+				<div
+					className="tab-color-menu"
+					style={{ left: menu.x, top: menu.y }}
+					// Keep clicks inside the menu from bubbling to the window-level closer.
+					onClick={(e) => e.stopPropagation()}
+				>
+					{TAB_COLORS.map((c) => (
+						<button
+							key={c.key}
+							type="button"
+							className={`tab-color-swatch ${colors[menu.id] === c.key ? "tab-color-swatch-on" : ""}`}
+							style={{ background: c.hex }}
+							aria-label={c.label}
+							title={c.label}
+							onClick={() => {
+								onSetColor(menu.id, c.key);
+								setMenu(null);
+							}}
+						/>
+					))}
+					<button
+						type="button"
+						className="tab-color-swatch tab-color-swatch-none"
+						aria-label="No color"
+						title="No color"
+						onClick={() => {
+							onSetColor(menu.id, null);
+							setMenu(null);
+						}}
+					/>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -3,69 +3,87 @@ import type { UnifiedSession } from "./types";
 const BASE = "/backstage/api";
 
 export async function fetchSessions(): Promise<UnifiedSession[]> {
-  const res = await fetch(`${BASE}/sessions`);
-  if (!res.ok) throw new Error(`Failed to fetch sessions: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/sessions`);
+	if (!res.ok) throw new Error(`Failed to fetch sessions: ${res.status}`);
+	return res.json();
 }
 
 export interface PreviewService {
-  name: string;
-  key: string;
-  port: number;
-  running: boolean;
-  pids: number[];
+	name: string;
+	key: string;
+	port: number;
+	running: boolean;
+	pids: number[];
 }
 
 export interface PreviewStatus {
-  hasPortsConf: boolean;
-  webappPort: number | null;
-  running: boolean;
-  previewUrl: string | null;
-  services: PreviewService[];
+	hasPortsConf: boolean;
+	webappPort: number | null;
+	running: boolean;
+	previewUrl: string | null;
+	services: PreviewService[];
 }
 
 export async function fetchPreview(sessionId: string): Promise<PreviewStatus> {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/preview`);
-  if (!res.ok) throw new Error(`Failed to fetch preview: ${res.status}`);
-  return res.json();
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/preview`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch preview: ${res.status}`);
+	return res.json();
 }
 
-export async function stopPreviewApi(sessionId: string): Promise<PreviewStatus> {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/preview/stop`, {
-    method: "POST",
-  });
-  if (!res.ok) throw new Error(`Failed to stop preview: ${res.status}`);
-  return res.json();
+export async function stopPreviewApi(
+	sessionId: string,
+): Promise<PreviewStatus> {
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/preview/stop`,
+		{
+			method: "POST",
+		},
+	);
+	if (!res.ok) throw new Error(`Failed to stop preview: ${res.status}`);
+	return res.json();
 }
 
 export async function fetchTranscript(sessionId: string) {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/transcript`);
-  if (!res.ok) throw new Error(`Failed to fetch transcript: ${res.status}`);
-  return res.json();
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/transcript`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch transcript: ${res.status}`);
+	return res.json();
 }
 
 export interface SubagentTranscript {
-  meta: { agentId: string; agentType?: string; description?: string; toolUseId?: string; spawnDepth?: number };
-  entries: import("./types").TranscriptEntry[];
-  sessionRunning: boolean;
+	meta: {
+		agentId: string;
+		agentType?: string;
+		description?: string;
+		toolUseId?: string;
+		spawnDepth?: number;
+	};
+	entries: import("./types").TranscriptEntry[];
+	sessionRunning: boolean;
 }
 
-export async function fetchSubagent(sessionId: string, agentId: string): Promise<SubagentTranscript> {
-  const res = await fetch(
-    `${BASE}/sessions/${encodeURIComponent(sessionId)}/subagent/${encodeURIComponent(agentId)}`
-  );
-  if (!res.ok) throw new Error(`Failed to fetch sub-agent: ${res.status}`);
-  return res.json();
+export async function fetchSubagent(
+	sessionId: string,
+	agentId: string,
+): Promise<SubagentTranscript> {
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/subagent/${encodeURIComponent(agentId)}`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch sub-agent: ${res.status}`);
+	return res.json();
 }
 
 /** A single "@"-mention suggestion. `insert` is what lands in the textarea. */
 export interface FileMention {
-  /** Repo-relative path, for display. */
-  display: string;
-  /** Text inserted after the "@": bare path (primary repo) or `project:path`. */
-  insert: string;
-  /** Repo label, set only when more than one repo is searched (cross-repo). */
-  repo?: string;
+	/** Repo-relative path, for display. */
+	display: string;
+	/** Text inserted after the "@": bare path (primary repo) or `project:path`. */
+	insert: string;
+	/** Repo label, set only when more than one repo is searched (cross-repo). */
+	repo?: string;
 }
 
 /**
@@ -74,228 +92,265 @@ export interface FileMention {
  * repo when there's no session).
  */
 export async function fetchFileMentions(
-  query: string,
-  sessionId?: string,
+	query: string,
+	sessionId?: string,
 ): Promise<FileMention[]> {
-  const params = new URLSearchParams({ q: query });
-  if (sessionId) params.set("session", sessionId);
-  const res = await fetch(`${BASE}/files?${params.toString()}`);
-  if (!res.ok) return [];
-  const data = await res.json();
-  return data.files ?? [];
+	const params = new URLSearchParams({ q: query });
+	if (sessionId) params.set("session", sessionId);
+	const res = await fetch(`${BASE}/files?${params.toString()}`);
+	if (!res.ok) return [];
+	const data = await res.json();
+	return data.files ?? [];
 }
 
 export interface ProjectInfo {
-  id: string;
-  defaultBranch: string;
-  sharedCheckout: boolean;
+	id: string;
+	defaultBranch: string;
+	sharedCheckout: boolean;
 }
 
 export async function fetchProjects(): Promise<ProjectInfo[]> {
-  const res = await fetch(`${BASE}/projects`);
-  if (!res.ok) return [];
-  const data = await res.json();
-  return data.projects ?? [];
+	const res = await fetch(`${BASE}/projects`);
+	if (!res.ok) return [];
+	const data = await res.json();
+	return data.projects ?? [];
 }
 
 export interface AttachedRepo {
-  project: string;
-  branch: string;
-  dir: string;
+	project: string;
+	branch: string;
+	dir: string;
 }
 
 export async function attachRepoApi(
-  sessionId: string,
-  project: string,
-  branch?: string,
+	sessionId: string,
+	project: string,
+	branch?: string,
 ): Promise<AttachedRepo[]> {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/attach-repo`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ project, ...(branch ? { branch } : {}) }),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body.attachedRepos as AttachedRepo[];
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/attach-repo`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ project, ...(branch ? { branch } : {}) }),
+		},
+	);
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body.attachedRepos as AttachedRepo[];
 }
 
-export async function detachRepoApi(sessionId: string, project: string): Promise<AttachedRepo[]> {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/detach-repo`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ project }),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body.attachedRepos as AttachedRepo[];
+export async function detachRepoApi(
+	sessionId: string,
+	project: string,
+): Promise<AttachedRepo[]> {
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/detach-repo`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ project }),
+		},
+	);
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body.attachedRepos as AttachedRepo[];
 }
 
 export async function fetchWorktrees(project?: string) {
-  const qs = project ? `?project=${encodeURIComponent(project)}` : "";
-  const res = await fetch(`${BASE}/worktrees${qs}`);
-  if (!res.ok) throw new Error(`Failed to fetch worktrees: ${res.status}`);
-  return res.json();
+	const qs = project ? `?project=${encodeURIComponent(project)}` : "";
+	const res = await fetch(`${BASE}/worktrees${qs}`);
+	if (!res.ok) throw new Error(`Failed to fetch worktrees: ${res.status}`);
+	return res.json();
 }
 
-export async function deleteSessionApi(sessionId: string, cleanWorktree: boolean): Promise<void> {
-  const params = cleanWorktree ? "?worktree=true" : "";
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}${params}`, {
-    method: "DELETE",
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.error || `Failed to delete: ${res.status}`);
-  }
+export async function deleteSessionApi(
+	sessionId: string,
+	cleanWorktree: boolean,
+): Promise<void> {
+	const params = cleanWorktree ? "?worktree=true" : "";
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}${params}`,
+		{
+			method: "DELETE",
+		},
+	);
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		throw new Error(body.error || `Failed to delete: ${res.status}`);
+	}
 }
 
 export async function fetchDiff(
-  sessionId: string,
+	sessionId: string,
 ): Promise<import("./types").SessionDiffResponse> {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/diff`);
-  if (!res.ok) throw new Error(`Failed to fetch diff: ${res.status}`);
-  return res.json();
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/diff`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch diff: ${res.status}`);
+	return res.json();
 }
 
 /** `repo` (a project id) targets an attached repo's PR; omit for the primary. */
 export async function fetchPr(sessionId: string, repo?: string) {
-  const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr${qs}`);
-  if (!res.ok) throw new Error(`Failed to fetch PR: ${res.status}`);
-  return res.json();
+	const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr${qs}`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch PR: ${res.status}`);
+	return res.json();
 }
 
 export async function fetchPrDiff(sessionId: string, repo?: string) {
-  const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-diff${qs}`);
-  if (!res.ok) throw new Error(`Failed to fetch PR diff: ${res.status}`);
-  return res.json();
+	const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-diff${qs}`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch PR diff: ${res.status}`);
+	return res.json();
 }
 
 export async function postPrCommentApi(
-  sessionId: string,
-  payload: {
-    text: string;
-    user: string;
-    path?: string;
-    line?: number;
-    startLine?: number;
-    side?: "RIGHT" | "LEFT";
-    repo?: string;
-  }
+	sessionId: string,
+	payload: {
+		text: string;
+		user: string;
+		path?: string;
+		line?: number;
+		startLine?: number;
+		side?: "RIGHT" | "LEFT";
+		repo?: string;
+	},
 ) {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-comment`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body as { ok: true; url?: string };
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-comment`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+		},
+	);
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body as { ok: true; url?: string };
 }
 
 export async function submitPrReviewApi(
-  sessionId: string,
-  payload: {
-    user: string;
-    event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
-    summary?: string;
-    repo?: string;
-    comments: Array<{
-      text: string;
-      path: string;
-      line: number;
-      startLine?: number;
-      side?: "RIGHT" | "LEFT";
-      startSide?: "RIGHT" | "LEFT";
-    }>;
-  }
+	sessionId: string,
+	payload: {
+		user: string;
+		event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+		summary?: string;
+		repo?: string;
+		comments: Array<{
+			text: string;
+			path: string;
+			line: number;
+			startLine?: number;
+			side?: "RIGHT" | "LEFT";
+			startSide?: "RIGHT" | "LEFT";
+		}>;
+	},
 ) {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-review`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body as { ok: true; url?: string };
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-review`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+		},
+	);
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body as { ok: true; url?: string };
 }
 
 export async function mergePrApi(
-  sessionId: string,
-  method: "squash" | "merge" | "rebase" = "squash",
-  repo?: string,
+	sessionId: string,
+	method: "squash" | "merge" | "rebase" = "squash",
+	repo?: string,
 ) {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-merge`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ method, ...(repo ? { repo } : {}) }),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body as { ok: true; url?: string };
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/pr-merge`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ method, ...(repo ? { repo } : {}) }),
+		},
+	);
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body as { ok: true; url?: string };
 }
 
 // ── Automations ──
 
 export interface ModelOption {
-  id: string;
-  provider: "claude" | "codex";
-  label: string;
-  aliases: string[];
+	id: string;
+	provider: "claude" | "codex";
+	label: string;
+	aliases: string[];
 }
 
-export async function fetchModels(): Promise<{ models: ModelOption[]; default: string }> {
-  const res = await fetch(`${BASE}/models`);
-  if (!res.ok) throw new Error(`Failed to fetch models: ${res.status}`);
-  return res.json();
+export async function fetchModels(): Promise<{
+	models: ModelOption[];
+	default: string;
+}> {
+	const res = await fetch(`${BASE}/models`);
+	if (!res.ok) throw new Error(`Failed to fetch models: ${res.status}`);
+	return res.json();
 }
 
 export async function fetchAutomations() {
-  const res = await fetch(`${BASE}/automations`);
-  if (!res.ok) throw new Error(`Failed to fetch automations: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/automations`);
+	if (!res.ok) throw new Error(`Failed to fetch automations: ${res.status}`);
+	return res.json();
 }
 
 export async function createAutomationApi(input: {
-  name: string;
-  prompt: string;
-  schedule: string;
-  mode: "ask" | "code";
-  createdBy: string;
-  eventKey?: string;
-  model?: string;
-  fallbackModel?: string;
+	name: string;
+	prompt: string;
+	schedule: string;
+	mode: "ask" | "code";
+	createdBy: string;
+	eventKey?: string;
+	model?: string;
+	fallbackModel?: string;
 }) {
-  const res = await fetch(`${BASE}/automations`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body;
+	const res = await fetch(`${BASE}/automations`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body;
 }
 
 export async function updateAutomationApi(id: string, patch: object) {
-  const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(patch),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body;
+	const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}`, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(patch),
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body;
 }
 
 export async function deleteAutomationApi(id: string) {
-  const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}`, { method: "DELETE" });
-  if (!res.ok) throw new Error(`Failed to delete: ${res.status}`);
+	const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}`, {
+		method: "DELETE",
+	});
+	if (!res.ok) throw new Error(`Failed to delete: ${res.status}`);
 }
 
 export async function runAutomationApi(id: string) {
-  const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}/run`, { method: "POST" });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	const res = await fetch(`${BASE}/automations/${encodeURIComponent(id)}/run`, {
+		method: "POST",
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
 }
 
 // ── Actions (run a registered repo script behind a form) ──
@@ -303,165 +358,202 @@ export async function runAutomationApi(id: string) {
 export type ActionInputType = "text" | "number" | "select" | "boolean";
 
 export interface ActionInput {
-  name: string;
-  label?: string;
-  type: ActionInputType;
-  required?: boolean;
-  default?: string;
-  options?: string[];
-  hint?: string;
+	name: string;
+	label?: string;
+	type: ActionInputType;
+	required?: boolean;
+	default?: string;
+	options?: string[];
+	hint?: string;
 }
 
 export interface Action {
-  id: string;
-  name: string;
-  description?: string;
-  repo: string;
-  scriptPath: string;
-  inputs: ActionInput[];
-  argMode: "positional" | "env";
-  confirm?: boolean;
-  model?: string;
-  seeded?: boolean;
-  createdBy: string;
-  createdAt: string;
-  lastRunAt?: string;
-  lastRunSessionId?: string;
+	id: string;
+	name: string;
+	description?: string;
+	repo: string;
+	scriptPath: string;
+	inputs: ActionInput[];
+	argMode: "positional" | "env";
+	confirm?: boolean;
+	model?: string;
+	seeded?: boolean;
+	createdBy: string;
+	createdAt: string;
+	lastRunAt?: string;
+	lastRunSessionId?: string;
 }
 
 export async function fetchActions(): Promise<Action[]> {
-  const res = await fetch(`${BASE}/actions`);
-  if (!res.ok) throw new Error(`Failed to fetch actions: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/actions`);
+	if (!res.ok) throw new Error(`Failed to fetch actions: ${res.status}`);
+	return res.json();
 }
 
 export async function createActionApi(input: {
-  name: string;
-  description?: string;
-  repo: string;
-  scriptPath: string;
-  inputs: ActionInput[];
-  argMode: "positional" | "env";
-  confirm?: boolean;
-  createdBy: string;
+	name: string;
+	description?: string;
+	repo: string;
+	scriptPath: string;
+	inputs: ActionInput[];
+	argMode: "positional" | "env";
+	confirm?: boolean;
+	createdBy: string;
 }): Promise<Action> {
-  const res = await fetch(`${BASE}/actions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body;
+	const res = await fetch(`${BASE}/actions`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body;
 }
 
 export async function deleteActionApi(id: string): Promise<void> {
-  const res = await fetch(`${BASE}/actions/${encodeURIComponent(id)}`, { method: "DELETE" });
-  if (!res.ok) throw new Error(`Failed to delete: ${res.status}`);
+	const res = await fetch(`${BASE}/actions/${encodeURIComponent(id)}`, {
+		method: "DELETE",
+	});
+	if (!res.ok) throw new Error(`Failed to delete: ${res.status}`);
 }
 
 export async function runActionApi(
-  id: string,
-  values: Record<string, unknown>,
-  user: string
+	id: string,
+	values: Record<string, unknown>,
+	user: string,
 ): Promise<{ sessionId: string }> {
-  const res = await fetch(`${BASE}/actions/${encodeURIComponent(id)}/run`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ values, user }),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body;
+	const res = await fetch(`${BASE}/actions/${encodeURIComponent(id)}/run`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ values, user }),
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body;
 }
 
 export async function introspectActionApi(
-  repo: string,
-  scriptPath: string
+	repo: string,
+	scriptPath: string,
 ): Promise<{ inputs: ActionInput[]; argMode: "positional" | "env" }> {
-  const res = await fetch(`${BASE}/actions/introspect`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ repo, scriptPath }),
-  });
-  const body = await res.json();
-  if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-  return body;
+	const res = await fetch(`${BASE}/actions/introspect`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ repo, scriptPath }),
+	});
+	const body = await res.json();
+	if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+	return body;
 }
 
 // ── Pins (per-user pinned tabs) ──
 
 export async function fetchPins(user: string): Promise<string[]> {
-  const res = await fetch(`${BASE}/pins?user=${encodeURIComponent(user)}`);
-  if (!res.ok) throw new Error(`Failed to fetch pins: ${res.status}`);
-  const body = await res.json();
-  return Array.isArray(body?.pins) ? body.pins : [];
+	const res = await fetch(`${BASE}/pins?user=${encodeURIComponent(user)}`);
+	if (!res.ok) throw new Error(`Failed to fetch pins: ${res.status}`);
+	const body = await res.json();
+	return Array.isArray(body?.pins) ? body.pins : [];
 }
 
-export async function savePinsApi(user: string, pins: string[]): Promise<string[]> {
-  const res = await fetch(`${BASE}/pins`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user, pins }),
-  });
-  if (!res.ok) throw new Error(`Failed to save pins: ${res.status}`);
-  const body = await res.json();
-  return Array.isArray(body?.pins) ? body.pins : pins;
+export async function savePinsApi(
+	user: string,
+	pins: string[],
+): Promise<string[]> {
+	const res = await fetch(`${BASE}/pins`, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ user, pins }),
+	});
+	if (!res.ok) throw new Error(`Failed to save pins: ${res.status}`);
+	const body = await res.json();
+	return Array.isArray(body?.pins) ? body.pins : pins;
+}
+
+// ── Tab colors (per-user session tab colors) ──
+
+export async function fetchTabColors(
+	user: string,
+): Promise<Record<string, string>> {
+	const res = await fetch(
+		`${BASE}/tab-colors?user=${encodeURIComponent(user)}`,
+	);
+	if (!res.ok) throw new Error(`Failed to fetch tab colors: ${res.status}`);
+	const body = await res.json();
+	return body?.colors && typeof body.colors === "object" ? body.colors : {};
+}
+
+export async function saveTabColorsApi(
+	user: string,
+	colors: Record<string, string>,
+): Promise<Record<string, string>> {
+	const res = await fetch(`${BASE}/tab-colors`, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ user, colors }),
+	});
+	if (!res.ok) throw new Error(`Failed to save tab colors: ${res.status}`);
+	const body = await res.json();
+	return body?.colors && typeof body.colors === "object" ? body.colors : colors;
 }
 
 // ── Wiki ──
 
 export async function fetchWikiTree() {
-  const res = await fetch(`${BASE}/wiki/tree`);
-  if (!res.ok) throw new Error(`Failed to fetch wiki tree: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/wiki/tree`);
+	if (!res.ok) throw new Error(`Failed to fetch wiki tree: ${res.status}`);
+	return res.json();
 }
 
 export async function fetchWikiFile(path: string) {
-  const res = await fetch(`${BASE}/wiki/file?path=${encodeURIComponent(path)}`);
-  if (!res.ok) throw new Error(`Failed to fetch doc: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/wiki/file?path=${encodeURIComponent(path)}`);
+	if (!res.ok) throw new Error(`Failed to fetch doc: ${res.status}`);
+	return res.json();
 }
 
 export async function searchWikiApi(q: string) {
-  const res = await fetch(`${BASE}/wiki/search?q=${encodeURIComponent(q)}`);
-  if (!res.ok) throw new Error(`Search failed: ${res.status}`);
-  return res.json();
+	const res = await fetch(`${BASE}/wiki/search?q=${encodeURIComponent(q)}`);
+	if (!res.ok) throw new Error(`Search failed: ${res.status}`);
+	return res.json();
 }
 
 export async function archiveSessionApi(sessionId: string, archived: boolean) {
-  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(sessionId)}/archive`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ archived }),
-  });
-  if (!res.ok) throw new Error(`Failed to update archive state: ${res.status}`);
+	const res = await fetch(
+		`${BASE}/sessions/${encodeURIComponent(sessionId)}/archive`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ archived }),
+		},
+	);
+	if (!res.ok) throw new Error(`Failed to update archive state: ${res.status}`);
 }
 
-export async function archiveOldApi(days: number): Promise<{ archived: number }> {
-  const res = await fetch(`${BASE}/sessions/archive-old`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ days }),
-  });
-  if (!res.ok) throw new Error(`Failed to archive: ${res.status}`);
-  return res.json();
+export async function archiveOldApi(
+	days: number,
+): Promise<{ archived: number }> {
+	const res = await fetch(`${BASE}/sessions/archive-old`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ days }),
+	});
+	if (!res.ok) throw new Error(`Failed to archive: ${res.status}`);
+	return res.json();
 }
 
 export function getWebSocketUrl(): string {
-  const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${location.host}/backstage/ws`;
+	const proto = location.protocol === "https:" ? "wss:" : "ws:";
+	return `${proto}//${location.host}/backstage/ws`;
 }
 
 export function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = now - then;
+	const now = Date.now();
+	const then = new Date(dateStr).getTime();
+	const diff = now - then;
 
-  if (diff < 0) return "just now";
-  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
-  return new Date(dateStr).toLocaleDateString();
+	if (diff < 0) return "just now";
+	if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+	if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+	if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+	if (diff < 604_800_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+	return new Date(dateStr).toLocaleDateString();
 }

--- a/src/frontend/lib/tab-colors.ts
+++ b/src/frontend/lib/tab-colors.ts
@@ -1,0 +1,79 @@
+// Per-user session tab colors, stored server-side (keyed on the UserPicker
+// name) so they follow you across devices — same model as pins.ts. The public
+// API stays synchronous (an in-memory cache) so callers don't await: the cache
+// is hydrated from the server on load and on user switch, and writes are
+// optimistic — update the cache + fire the change event immediately, then PUT.
+import { fetchTabColors, saveTabColorsApi } from "./api";
+import { getCurrentUser } from "../components/UserPicker";
+
+const CHANGE_EVENT = "michael-tab-colors-changed";
+const USER_CHANGE_EVENT = "michael-user-changed";
+
+/** The default swatch palette. Keys must stay in sync with server/tab-colors.ts. */
+export const TAB_COLORS: { key: string; label: string; hex: string }[] = [
+	{ key: "red", label: "Red", hex: "#f85149" },
+	{ key: "orange", label: "Orange", hex: "#db8a40" },
+	{ key: "yellow", label: "Yellow", hex: "#d29922" },
+	{ key: "green", label: "Green", hex: "#3fb950" },
+	{ key: "blue", label: "Blue", hex: "#4493f8" },
+	{ key: "purple", label: "Purple", hex: "#a371f7" },
+	{ key: "pink", label: "Pink", hex: "#db61a2" },
+];
+
+export function colorHex(key: string | undefined): string | null {
+	return TAB_COLORS.find((c) => c.key === key)?.hex ?? null;
+}
+
+let cache: Record<string, string> = {};
+let loadedFor: string | null = null;
+
+function emit() {
+	window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+async function load(user: string) {
+	loadedFor = user;
+	let colors: Record<string, string> = {};
+	try {
+		colors = await fetchTabColors(user);
+	} catch {
+		colors = {};
+	}
+	// A newer load() (user switched mid-flight) wins.
+	if (loadedFor !== user) return;
+	cache = colors;
+	emit();
+}
+
+void load(getCurrentUser());
+window.addEventListener(USER_CHANGE_EVENT, () => void load(getCurrentUser()));
+
+export function getTabColors(): Record<string, string> {
+	return cache;
+}
+
+export function getTabColor(id: string): string | undefined {
+	return cache[id];
+}
+
+/** Set (or, with `null`/unknown key, clear) a session's tab color. */
+export function setTabColor(
+	id: string,
+	color: string | null,
+): Record<string, string> {
+	const next = { ...cache };
+	if (color && TAB_COLORS.some((c) => c.key === color)) {
+		next[id] = color;
+	} else {
+		delete next[id];
+	}
+	cache = next;
+	emit();
+	void saveTabColorsApi(getCurrentUser(), next).catch(() => {});
+	return next;
+}
+
+export function onTabColorsChanged(handler: () => void): () => void {
+	window.addEventListener(CHANGE_EVENT, handler);
+	return () => window.removeEventListener(CHANGE_EVENT, handler);
+}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -4,594 +4,733 @@
    ───────────────────────────────────────────────────────────── */
 
 :root {
-  --bg: #0b0809;
-  --bg-raised: #130f11;
-  --bg-panel: #171215;
-  --bg-hover: #1f171a;
-  --bg-active: #271b1f;
-  --border: #2b2126;
-  --border-strong: #392b30;
-  --text: #ece7e8;
-  --text-dim: #a89ba0;
-  --text-faint: #6f6166;
-  --accent: #ff3b3b;
-  --accent-soft: rgba(255, 59, 59, 0.13);
-  --green: #3fb950;
-  --green-soft: rgba(63, 185, 80, 0.14);
-  --yellow: #d29922;
-  --red: #f85149;
-  --red-soft: rgba(248, 81, 73, 0.12);
-  --purple: #a371f7;
-  --mono: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
-  --radius: 8px;
-  /* Header height grows by the iOS status-bar inset when installed as a PWA
+	--bg: #0b0809;
+	--bg-raised: #130f11;
+	--bg-panel: #171215;
+	--bg-hover: #1f171a;
+	--bg-active: #271b1f;
+	--border: #2b2126;
+	--border-strong: #392b30;
+	--text: #ece7e8;
+	--text-dim: #a89ba0;
+	--text-faint: #6f6166;
+	--accent: #ff3b3b;
+	--accent-soft: rgba(255, 59, 59, 0.13);
+	--green: #3fb950;
+	--green-soft: rgba(63, 185, 80, 0.14);
+	--yellow: #d29922;
+	--red: #f85149;
+	--red-soft: rgba(248, 81, 73, 0.12);
+	--purple: #a371f7;
+	--mono: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+	--sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
+	--radius: 8px;
+	/* Header height grows by the iOS status-bar inset when installed as a PWA
      (black-translucent draws the webview under the clock/notch) */
-  --header-h: calc(52px + env(safe-area-inset-top, 0px));
+	--header-h: calc(52px + env(safe-area-inset-top, 0px));
 }
 
 * {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 html {
-  /* Drives light-dark() in embedded components (@pierre/trees) + native UI */
-  color-scheme: dark;
+	/* Drives light-dark() in embedded components (@pierre/trees) + native UI */
+	color-scheme: dark;
 }
 
-html, body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--sans);
-  font-size: 14px;
-  -webkit-font-smoothing: antialiased;
+html,
+body {
+	margin: 0;
+	padding: 0;
+	height: 100%;
+	background: var(--bg);
+	color: var(--text);
+	font-family: var(--sans);
+	font-size: 14px;
+	-webkit-font-smoothing: antialiased;
 }
 
 /* Lock the outer document to the viewport so only inner containers scroll.
    position: fixed stops iOS rubber-band/elastic overscroll of the whole page
    (header included); overscroll-behavior stops scroll-chaining to the body. */
 body {
-  position: fixed;
-  inset: 0;
-  overflow: hidden;
-  overscroll-behavior: none;
-  touch-action: pan-x pan-y;
+	position: fixed;
+	inset: 0;
+	overflow: hidden;
+	overscroll-behavior: none;
+	touch-action: pan-x pan-y;
 }
 
 #root {
-  height: 100vh;
-  height: 100dvh;
-  overflow: hidden;
+	height: 100vh;
+	height: 100dvh;
+	overflow: hidden;
 }
 
 button {
-  font-family: inherit;
-  cursor: pointer;
+	font-family: inherit;
+	cursor: pointer;
 }
 
-input, textarea, select {
-  font-family: inherit;
+input,
+textarea,
+select {
+	font-family: inherit;
 }
 
 a {
-  color: var(--accent);
+	color: var(--accent);
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+	width: 8px;
+	height: 8px;
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
-  border-radius: 4px;
+	background: var(--border-strong);
+	border-radius: 4px;
 }
 ::-webkit-scrollbar-track {
-  background: transparent;
+	background: transparent;
 }
 
 /* ── App chrome ──────────────────────────────────────────── */
 
 .app {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 }
 
 .app-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: env(safe-area-inset-top, 0px) 16px 0;
-  height: var(--header-h);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: env(safe-area-inset-top, 0px) 16px 0;
+	height: var(--header-h);
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-raised);
+	flex-shrink: 0;
 }
 
 .app-header-left {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
 }
 
 .app-title {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-  text-decoration: none;
-  letter-spacing: -0.01em;
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--text);
+	text-decoration: none;
+	letter-spacing: -0.01em;
 }
 
 /* KITT scanner: black tile, glowing red M, a red beam sweeping across it */
 .app-logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 7px;
-  background: radial-gradient(120% 120% at 50% 38%, #1c0405 0%, #0a0608 70%);
-  border: 1px solid rgba(255, 40, 40, 0.22);
-  color: #ff2a2a;
-  font-weight: 800;
-  font-size: 14px;
-  text-shadow: 0 0 6px rgba(255, 30, 30, 0.85), 0 0 2px rgba(255, 90, 90, 0.9);
-  position: relative;
-  overflow: hidden;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	border-radius: 7px;
+	background: radial-gradient(120% 120% at 50% 38%, #1c0405 0%, #0a0608 70%);
+	border: 1px solid rgba(255, 40, 40, 0.22);
+	color: #ff2a2a;
+	font-weight: 800;
+	font-size: 14px;
+	text-shadow:
+		0 0 6px rgba(255, 30, 30, 0.85),
+		0 0 2px rgba(255, 90, 90, 0.9);
+	position: relative;
+	overflow: hidden;
 }
 .app-logo::after {
-  content: "";
-  position: absolute;
-  top: -10%;
-  bottom: -10%;
-  width: 42%;
-  left: 0;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 30, 30, 0.85) 45%,
-    rgba(255, 120, 120, 0.95) 50%,
-    rgba(255, 30, 30, 0.85) 55%,
-    transparent
-  );
-  filter: blur(1px);
-  mix-blend-mode: screen;
-  pointer-events: none;
-  animation: kitt-scan 2.6s ease-in-out infinite alternate;
+	content: "";
+	position: absolute;
+	top: -10%;
+	bottom: -10%;
+	width: 42%;
+	left: 0;
+	background: linear-gradient(
+		90deg,
+		transparent,
+		rgba(255, 30, 30, 0.85) 45%,
+		rgba(255, 120, 120, 0.95) 50%,
+		rgba(255, 30, 30, 0.85) 55%,
+		transparent
+	);
+	filter: blur(1px);
+	mix-blend-mode: screen;
+	pointer-events: none;
+	animation: kitt-scan 2.6s ease-in-out infinite alternate;
 }
 @keyframes kitt-scan {
-  from { transform: translateX(-130%); }
-  to { transform: translateX(270%); }
+	from {
+		transform: translateX(-130%);
+	}
+	to {
+		transform: translateX(270%);
+	}
 }
 @media (prefers-reduced-motion: reduce) {
-  .app-logo::after { animation: none; opacity: 0.5; transform: translateX(80%); }
+	.app-logo::after {
+		animation: none;
+		opacity: 0.5;
+		transform: translateX(80%);
+	}
 }
 
 .sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 10px 8px 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	padding: 10px 8px 6px;
 }
 
 .sidebar-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  color: var(--text-dim);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 6px 8px;
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-radius: 6px;
+	color: var(--text-dim);
+	font-size: 13px;
+	font-weight: 500;
+	padding: 6px 8px;
 }
-.sidebar-nav-item:hover { color: var(--text); background: var(--bg-hover); }
-.sidebar-nav-item.active { color: var(--text); background: var(--bg-active); }
+.sidebar-nav-item:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+.sidebar-nav-item.active {
+	color: var(--text);
+	background: var(--bg-active);
+}
 
 .sidebar-nav-icon {
-  display: inline-flex;
-  color: var(--text-faint);
+	display: inline-flex;
+	color: var(--text-faint);
 }
 .sidebar-nav-item.active .sidebar-nav-icon,
-.sidebar-nav-item:hover .sidebar-nav-icon { color: var(--text-dim); }
+.sidebar-nav-item:hover .sidebar-nav-icon {
+	color: var(--text-dim);
+}
 
 .sidebar-section-label {
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--text-faint);
-  padding: 10px 14px 0;
-  border-top: 1px solid var(--border);
-  margin-top: 4px;
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	color: var(--text-faint);
+	padding: 10px 14px 0;
+	border-top: 1px solid var(--border);
+	margin-top: 4px;
 }
 
 .app-header-right {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 
 .connection-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
 }
-.connection-dot.connected { background: var(--green); }
-.connection-dot.disconnected { background: var(--red); }
+.connection-dot.connected {
+	background: var(--green);
+}
+.connection-dot.disconnected {
+	background: var(--red);
+}
 
 .user-picker {
-  background: var(--bg-panel);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 5px 8px;
-  font-size: 13px;
+	background: var(--bg-panel);
+	color: var(--text);
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	padding: 5px 8px;
+	font-size: 13px;
 }
 
 .app-body {
-  display: flex;
-  flex: 1;
-  min-height: 0;
+	display: flex;
+	flex: 1;
+	min-height: 0;
 }
 
 .hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  background: none;
-  border: none;
-  padding: 6px;
+	display: none;
+	flex-direction: column;
+	gap: 4px;
+	background: none;
+	border: none;
+	padding: 6px;
 }
 .hamburger span {
-  width: 18px;
-  height: 2px;
-  background: var(--text-dim);
-  border-radius: 1px;
+	width: 18px;
+	height: 2px;
+	background: var(--text-dim);
+	border-radius: 1px;
 }
 
 /* ── Sidebar ─────────────────────────────────────────────── */
 
 .sidebar-container {
-  width: 252px;
-  flex-shrink: 0;
-  border-right: 1px solid var(--border);
-  background: var(--bg-raised);
-  display: flex;
-  min-height: 0;
+	width: 252px;
+	flex-shrink: 0;
+	border-right: 1px solid var(--border);
+	background: var(--bg-raised);
+	display: flex;
+	min-height: 0;
 }
 
 .sidebar {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  min-height: 0;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	min-height: 0;
 }
 
 .sidebar-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 10px 8px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 10px 10px 8px;
 }
 
 .sidebar-search-wrap {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  background: var(--bg-panel);
-  border: 1px solid transparent;
-  border-radius: 7px;
-  padding: 0 8px;
-  min-width: 0;
-  transition: border-color 0.12s, background 0.12s;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	background: var(--bg-panel);
+	border: 1px solid transparent;
+	border-radius: 7px;
+	padding: 0 8px;
+	min-width: 0;
+	transition:
+		border-color 0.12s,
+		background 0.12s;
 }
 .sidebar-search-wrap:focus-within {
-  border-color: var(--border-strong);
-  background: var(--bg-hover);
+	border-color: var(--border-strong);
+	background: var(--bg-hover);
 }
 
 .sidebar-search-icon {
-  color: var(--text-faint);
-  flex-shrink: 0;
+	color: var(--text-faint);
+	flex-shrink: 0;
 }
 
 .sidebar-search {
-  flex: 1;
-  background: none;
-  border: none;
-  color: var(--text);
-  padding: 6px 0;
-  font-size: 12.5px;
-  outline: none;
-  min-width: 0;
+	flex: 1;
+	background: none;
+	border: none;
+	color: var(--text);
+	padding: 6px 0;
+	font-size: 12.5px;
+	outline: none;
+	min-width: 0;
 }
-.sidebar-search::placeholder { color: var(--text-faint); }
+.sidebar-search::placeholder {
+	color: var(--text-faint);
+}
 
 .sidebar-new-btn {
-  width: 26px;
-  height: 26px;
-  background: var(--bg-panel);
-  color: var(--text-dim);
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  font-size: 15px;
-  line-height: 1;
-  font-weight: 500;
-  flex-shrink: 0;
+	width: 26px;
+	height: 26px;
+	background: var(--bg-panel);
+	color: var(--text-dim);
+	border: 1px solid var(--border);
+	border-radius: 7px;
+	font-size: 15px;
+	line-height: 1;
+	font-weight: 500;
+	flex-shrink: 0;
 }
 .sidebar-new-btn:hover {
-  color: var(--text);
-  border-color: var(--border-strong);
-  background: var(--bg-hover);
+	color: var(--text);
+	border-color: var(--border-strong);
+	background: var(--bg-hover);
 }
 
 .sidebar-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 2px 6px 20px;
+	flex: 1;
+	overflow-y: auto;
+	padding: 2px 6px 20px;
 }
 
 .sidebar-archived-link {
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-top: 1px solid var(--border);
-  color: var(--text-faint);
-  font-size: 12px;
-  padding: 10px 8px;
-  margin-top: 8px;
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-top: 1px solid var(--border);
+	color: var(--text-faint);
+	font-size: 12px;
+	padding: 10px 8px;
+	margin-top: 8px;
 }
-.sidebar-archived-link:hover { color: var(--text); }
+.sidebar-archived-link:hover {
+	color: var(--text);
+}
 
 .sidebar-empty {
-  color: var(--text-faint);
-  text-align: center;
-  padding: 24px 0;
-  font-size: 13px;
+	color: var(--text-faint);
+	text-align: center;
+	padding: 24px 0;
+	font-size: 13px;
 }
 
 .sidebar-group {
-  margin-bottom: 2px;
+	margin-bottom: 2px;
 }
 
 .sidebar-group-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  background: none;
-  border: none;
-  border-radius: 5px;
-  color: var(--text-faint);
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 7px 6px 5px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	background: none;
+	border: none;
+	border-radius: 5px;
+	color: var(--text-faint);
+	font-size: 10.5px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	padding: 7px 6px 5px;
 }
-.sidebar-group-header:hover { color: var(--text-dim); }
+.sidebar-group-header:hover {
+	color: var(--text-dim);
+}
 
 .sidebar-group-chevron {
-  font-size: 8px;
-  width: 10px;
-  opacity: 0;
-  transition: opacity 0.12s;
-  text-align: right;
+	font-size: 8px;
+	width: 10px;
+	opacity: 0;
+	transition: opacity 0.12s;
+	text-align: right;
 }
-.sidebar-group-header:hover .sidebar-group-chevron { opacity: 1; }
+.sidebar-group-header:hover .sidebar-group-chevron {
+	opacity: 1;
+}
 
 .sidebar-group-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
 }
 
 .sidebar-group-name {
-  text-align: left;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+	text-align: left;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .sidebar-group-count {
-  margin-left: auto;
-  color: var(--text-faint);
-  font-weight: 500;
-  opacity: 0.7;
+	margin-left: auto;
+	color: var(--text-faint);
+	font-weight: 500;
+	opacity: 0.7;
 }
 
 .sidebar-item {
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  padding: 5px 8px 6px;
-  color: var(--text);
-  position: relative;
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-radius: 6px;
+	padding: 5px 8px 6px;
+	color: var(--text);
+	position: relative;
 }
 
 /* Archive × — hover-revealed on desktop, always visible on touch screens */
 .sidebar-item-x {
-  display: none;
-  position: absolute;
-  right: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 20px;
-  height: 20px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 5px;
-  font-size: 15px;
-  line-height: 1;
-  color: var(--text-faint);
+	display: none;
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 20px;
+	height: 20px;
+	align-items: center;
+	justify-content: center;
+	border-radius: 5px;
+	font-size: 15px;
+	line-height: 1;
+	color: var(--text-faint);
 }
-.sidebar-item:hover .sidebar-item-x { display: flex; }
-.sidebar-item-x:hover { color: var(--text); background: var(--bg-active); }
+.sidebar-item:hover .sidebar-item-x {
+	display: flex;
+}
+.sidebar-item-x:hover {
+	color: var(--text);
+	background: var(--bg-active);
+}
 @media (hover: none) {
-  .sidebar-item-x { display: flex; }
-  .sidebar-item { padding-right: 30px; }
+	.sidebar-item-x {
+		display: flex;
+	}
+	.sidebar-item {
+		padding-right: 30px;
+	}
 }
-.sidebar-item:hover { background: var(--bg-hover); }
+.sidebar-item:hover {
+	background: var(--bg-hover);
+}
 .sidebar-item-selected,
-.sidebar-item-selected:hover { background: var(--bg-active); }
+.sidebar-item-selected:hover {
+	background: var(--bg-active);
+}
 
 .sidebar-item-top {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
 }
 
 .sidebar-item-status {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
 }
 .sidebar-status-running {
-  background: var(--green);
-  animation: pulse 1.4s ease-in-out infinite;
+	background: var(--green);
+	animation: pulse 1.4s ease-in-out infinite;
 }
-.sidebar-status-recent { background: var(--yellow); }
+.sidebar-status-recent {
+	background: var(--yellow);
+}
 .sidebar-status-waiting {
-  background: var(--accent);
-  box-shadow: 0 0 6px var(--accent);
-  animation: pulse 1.2s ease-in-out infinite;
+	background: var(--accent);
+	box-shadow: 0 0 6px var(--accent);
+	animation: pulse 1.2s ease-in-out infinite;
 }
 
 /* A session blocked on an AskUserQuestion — draw the eye so it gets answered. */
-.sidebar-item-waiting { background: var(--accent-soft); }
-.sidebar-item-waiting:hover { background: var(--accent-soft); }
-.sidebar-item-waiting .sidebar-item-title { font-weight: 550; }
+.sidebar-item-waiting {
+	background: var(--accent-soft);
+}
+.sidebar-item-waiting:hover {
+	background: var(--accent-soft);
+}
+.sidebar-item-waiting .sidebar-item-title {
+	font-weight: 550;
+}
 
 .sidebar-item-title {
-  font-size: 12.5px;
-  font-weight: 450;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+	font-size: 12.5px;
+	font-weight: 450;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .sidebar-item-meta {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 1px;
-  font-size: 11px;
-  color: var(--text-faint);
-  white-space: nowrap;
-  overflow: hidden;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-top: 1px;
+	font-size: 11px;
+	color: var(--text-faint);
+	white-space: nowrap;
+	overflow: hidden;
 }
 
-.sidebar-meta-sep { opacity: 0.5; }
-.sidebar-meta-pr { color: var(--green); }
-.sidebar-meta-merged { color: var(--purple); }
-.sidebar-meta-closed { color: var(--red); }
-.sidebar-meta-linear { color: #7b86e8; }
+.sidebar-meta-sep {
+	opacity: 0.5;
+}
+.sidebar-meta-pr {
+	color: var(--green);
+}
+.sidebar-meta-merged {
+	color: var(--purple);
+}
+.sidebar-meta-closed {
+	color: var(--red);
+}
+.sidebar-meta-linear {
+	color: #7b86e8;
+}
 
 /* ── Detail pane / empty state ───────────────────────────── */
 
 .detail-pane {
-  flex: 1;
-  min-width: 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
 }
 
 /* Pinned sessions as tabs, above the session title (mobile + desktop) */
 .session-tabs {
-  display: flex;
-  align-items: stretch;
-  gap: 3px;
-  padding: 6px 8px 0;
-  background: var(--bg-raised);
-  border-bottom: 1px solid var(--border);
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  flex-shrink: 0;
-  scrollbar-width: none;
+	display: flex;
+	align-items: stretch;
+	gap: 3px;
+	padding: 6px 8px 0;
+	background: var(--bg-raised);
+	border-bottom: 1px solid var(--border);
+	overflow-x: auto;
+	overscroll-behavior-x: contain;
+	flex-shrink: 0;
+	scrollbar-width: none;
 }
-.session-tabs::-webkit-scrollbar { display: none; }
+.session-tabs::-webkit-scrollbar {
+	display: none;
+}
 
 .session-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  max-width: 200px;
-  padding: 7px 10px;
-  border: 1px solid transparent;
-  border-bottom: none;
-  border-radius: 8px 8px 0 0;
-  background: var(--bg-panel);
-  color: var(--text-dim);
-  font-size: 12.5px;
-  cursor: pointer;
-  white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+	max-width: 200px;
+	padding: 7px 10px;
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: 8px 8px 0 0;
+	background: var(--bg-panel);
+	color: var(--text-dim);
+	font-size: 12.5px;
+	cursor: pointer;
+	white-space: nowrap;
 }
-.session-tab:hover { color: var(--text); background: var(--bg-hover); }
+.session-tab:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
 .session-tab-active {
-  color: var(--text);
-  background: var(--bg);
-  border-color: var(--border);
+	color: var(--text);
+	background: var(--bg);
+	border-color: var(--border);
 }
 
 .session-tab-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 150px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 150px;
 }
 
 .session-tab-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--green);
-  flex-shrink: 0;
-  animation: pulse 1.4s ease-in-out infinite;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--green);
+	flex-shrink: 0;
+	animation: pulse 1.4s ease-in-out infinite;
 }
 /* Tab is blocked on an AskUserQuestion — match the sidebar's "needs you" accent. */
 .session-tab-dot-waiting {
-  background: var(--accent);
-  box-shadow: 0 0 6px var(--accent);
-  animation: pulse 1.2s ease-in-out infinite;
+	background: var(--accent);
+	box-shadow: 0 0 6px var(--accent);
+	animation: pulse 1.2s ease-in-out infinite;
 }
 .session-tab-waiting {
-  color: var(--text);
-  border-color: var(--accent);
-  background: var(--accent-soft);
+	color: var(--text);
+	border-color: var(--accent);
+	background: var(--accent-soft);
 }
-.session-tab-waiting:hover { background: var(--accent-soft); }
+.session-tab-waiting:hover {
+	background: var(--accent-soft);
+}
 
 /* A transient tab (the current session when it isn't pinned) reads as
    provisional: dashed top edge, like a Chrome tab that hasn't been pinned. */
 .session-tab-transient {
-  /* Dash only the visible edges — `border-style: dashed` would re-enable the
+	/* Dash only the visible edges — `border-style: dashed` would re-enable the
      bottom border (reset to the 3px default width by `border-bottom: none`),
      making transient tabs 3px taller than solid ones and the strip jumpy. */
-  border-top-style: dashed;
-  border-left-style: dashed;
-  border-right-style: dashed;
+	border-top-style: dashed;
+	border-left-style: dashed;
+	border-right-style: dashed;
+}
+
+/* A user-colored tab: a colored top edge plus a faint tint of the chosen
+   swatch (`--tab-color`, set inline). Lets a row of lookalike tabs be told
+   apart at a glance. The active colored tab leans into the tint a touch more.
+   The waiting accent (border-color) still wins over the colored border. */
+.session-tab-colored {
+	border-top-color: var(--tab-color);
+	border-top-width: 2px;
+	background: color-mix(in srgb, var(--tab-color) 12%, var(--bg-panel));
+}
+.session-tab-colored:hover {
+	background: color-mix(in srgb, var(--tab-color) 18%, var(--bg-panel));
+}
+.session-tab-colored.session-tab-active {
+	background: color-mix(in srgb, var(--tab-color) 16%, var(--bg));
+	border-color: var(--border);
+	border-top-color: var(--tab-color);
+}
+/* Keep the dashed top edge readable on a transient colored tab. */
+.session-tab-colored.session-tab-transient {
+	border-top-style: dashed;
+}
+
+/* Right-click swatch menu — a floating row of color chips anchored at the
+   cursor. Fixed-position so it escapes the tab strip's overflow clipping. */
+.tab-color-menu {
+	position: fixed;
+	z-index: 1000;
+	display: flex;
+	gap: 6px;
+	padding: 7px 8px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+.tab-color-swatch {
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	padding: 0;
+	cursor: pointer;
+	transition: transform 0.1s ease;
+}
+.tab-color-swatch:hover {
+	transform: scale(1.18);
+}
+.tab-color-swatch-on {
+	box-shadow:
+		0 0 0 2px var(--bg-panel),
+		0 0 0 3px var(--text);
+}
+/* The "no color" chip: an empty ring with a diagonal strike. */
+.tab-color-swatch-none {
+	background: var(--bg-active);
+	position: relative;
+}
+.tab-color-swatch-none::after {
+	content: "";
+	position: absolute;
+	inset: 3px;
+	border-top: 1.5px solid var(--text-faint);
+	transform: rotate(45deg);
+	transform-origin: center;
 }
 
 /* Pin control: ★ on a pinned tab unpins (removes it); ☆ on a transient tab
@@ -599,1666 +738,2066 @@ a {
    desktop. The ☆ stays visible on transient tabs so the pin affordance is
    discoverable. */
 .session-tab-pin {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--text-dim);
-  flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	border-radius: 4px;
+	font-size: 11px;
+	line-height: 1;
+	color: var(--text-dim);
+	flex-shrink: 0;
 }
-.session-tab-pin-on { color: var(--yellow); }
-.session-tab-pin:hover { background: var(--bg-active); color: #e3b341; }
+.session-tab-pin-on {
+	color: var(--yellow);
+}
+.session-tab-pin:hover {
+	background: var(--bg-active);
+	color: #e3b341;
+}
 
 @media (hover: hover) and (pointer: fine) {
-  .session-tab-pin {
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.12s ease;
-  }
-  .session-tab:hover .session-tab-pin,
-  .session-tab-active .session-tab-pin {
-    opacity: 1;
-    pointer-events: auto;
-  }
+	.session-tab-pin {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.12s ease;
+	}
+	.session-tab:hover .session-tab-pin,
+	.session-tab-active .session-tab-pin {
+		opacity: 1;
+		pointer-events: auto;
+	}
+}
+
+/* Trailing "+" tab — quick jump to the New Session view. Reset the <button>
+   chrome to match the tab look, then reveal on hover of the strip (desktop);
+   always shown on touch where there's nothing to hover. */
+.session-tab-new {
+	padding: 7px 12px;
+	font-size: 15px;
+	line-height: 1;
+	font-family: inherit;
+}
+.session-tab-new:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+
+@media (hover: hover) and (pointer: fine) {
+	.session-tab-new {
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.12s ease;
+	}
+	.session-tabs:hover .session-tab-new {
+		opacity: 1;
+		pointer-events: auto;
+	}
 }
 
 .detail-empty {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
-.detail-empty-inner { text-align: center; }
+.detail-empty-inner {
+	text-align: center;
+}
 
 .detail-empty-logo {
-  width: 56px;
-  height: 56px;
-  margin: 0 auto 14px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #ff5a5a, #b00000);
-  color: #fff;
-  font-size: 30px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	width: 56px;
+	height: 56px;
+	margin: 0 auto 14px;
+	border-radius: 16px;
+	background: linear-gradient(135deg, #ff5a5a, #b00000);
+	color: #fff;
+	font-size: 30px;
+	font-weight: 700;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .detail-empty-title {
-  font-size: 19px;
-  font-weight: 600;
+	font-size: 19px;
+	font-weight: 600;
 }
 
 .detail-empty-sub {
-  color: var(--text-dim);
-  margin-top: 6px;
-  font-size: 13.5px;
+	color: var(--text-dim);
+	margin-top: 6px;
+	font-size: 13.5px;
 }
 
 .btn-new-session {
-  margin-top: 18px;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  padding: 9px 18px;
-  font-size: 13.5px;
-  font-weight: 500;
+	margin-top: 18px;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 7px;
+	padding: 9px 18px;
+	font-size: 13.5px;
+	font-weight: 500;
 }
-.btn-new-session:hover { filter: brightness(1.1); }
+.btn-new-session:hover {
+	filter: brightness(1.1);
+}
 
-.loading, .empty {
-  color: var(--text-faint);
-  text-align: center;
-  padding: 40px 0;
+.loading,
+.empty {
+	color: var(--text-faint);
+	text-align: center;
+	padding: 40px 0;
 }
 
 /* ── Session viewer layout ───────────────────────────────── */
 
 .session-viewer {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  min-height: 0;
-  position: relative;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	position: relative;
 }
 
 .viewer-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
-  flex-shrink: 0;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 16px;
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-raised);
+	flex-shrink: 0;
+	min-width: 0;
 }
 
 .viewer-title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-  font-weight: 500;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+	font-weight: 500;
 }
 
 .source-chip {
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 2px 8px;
-  border-radius: 99px;
-  flex-shrink: 0;
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	padding: 2px 8px;
+	border-radius: 99px;
+	flex-shrink: 0;
 }
-.source-slack { background: rgba(74, 21, 75, 0.55); color: #d9a8db; }
-.source-linear { background: rgba(94, 106, 210, 0.25); color: #9da6ee; }
-.source-backstage { background: rgba(13, 148, 136, 0.22); color: #5eead4; }
-.source-cli { background: var(--bg-active); color: var(--text-dim); }
-.source-ask { background: rgba(210, 153, 34, 0.18); color: #e3b341; }
+.source-slack {
+	background: rgba(74, 21, 75, 0.55);
+	color: #d9a8db;
+}
+.source-linear {
+	background: rgba(94, 106, 210, 0.25);
+	color: #9da6ee;
+}
+.source-backstage {
+	background: rgba(13, 148, 136, 0.22);
+	color: #5eead4;
+}
+.source-cli {
+	background: var(--bg-active);
+	color: var(--text-dim);
+}
+.source-ask {
+	background: rgba(210, 153, 34, 0.18);
+	color: #e3b341;
+}
 
 .viewer-branch {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  font-size: 14px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+	font-size: 14px;
 }
 
 .viewer-started-by {
-  color: var(--text-faint);
-  font-size: 12.5px;
-  flex-shrink: 0;
+	color: var(--text-faint);
+	font-size: 12.5px;
+	flex-shrink: 0;
 }
 
 .working-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: var(--green-soft);
-  color: var(--green);
-  font-size: 12px;
-  font-weight: 600;
-  padding: 3px 10px;
-  border-radius: 99px;
-  flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: var(--green-soft);
+	color: var(--green);
+	font-size: 12px;
+	font-weight: 600;
+	padding: 3px 10px;
+	border-radius: 99px;
+	flex-shrink: 0;
 }
 
 .working-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--green);
-  animation: pulse 1.4s ease-in-out infinite;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--green);
+	animation: pulse 1.4s ease-in-out infinite;
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.35;
+	}
 }
 
 .viewer-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
 }
 
 /* presence avatars */
 .presence {
-  display: flex;
-  align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 .presence-avatar {
-  position: relative;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--bg-active);
-  border: 1px solid var(--border-strong);
-  color: var(--text-dim);
-  font-size: 11px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: -6px;
+	position: relative;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	background: var(--bg-active);
+	border: 1px solid var(--border-strong);
+	color: var(--text-dim);
+	font-size: 11px;
+	font-weight: 700;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: -6px;
 }
-.presence-avatar:first-child { margin-left: 0; }
+.presence-avatar:first-child {
+	margin-left: 0;
+}
 .presence-me {
-  background: var(--accent-soft);
-  border-color: var(--accent);
-  color: var(--accent);
+	background: var(--accent-soft);
+	border-color: var(--accent);
+	color: var(--accent);
 }
 .presence-count {
-  position: absolute;
-  bottom: -3px;
-  right: -3px;
-  background: var(--accent);
-  color: #fff;
-  font-size: 8.5px;
-  border-radius: 99px;
-  padding: 0 3px;
-  line-height: 1.3;
+	position: absolute;
+	bottom: -3px;
+	right: -3px;
+	background: var(--accent);
+	color: #fff;
+	font-size: 8.5px;
+	border-radius: 99px;
+	padding: 0 3px;
+	line-height: 1.3;
 }
 
 .session-link {
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-  padding: 3px 9px;
-  border-radius: 5px;
-  border: 1px solid var(--border-strong);
-  color: var(--text-dim);
+	font-size: 12px;
+	font-weight: 600;
+	text-decoration: none;
+	padding: 3px 9px;
+	border-radius: 5px;
+	border: 1px solid var(--border-strong);
+	color: var(--text-dim);
 }
-.session-link-pr { color: var(--green); border-color: rgba(63, 185, 80, 0.4); }
-.session-link-pr-merged { color: var(--purple); border-color: rgba(163, 113, 247, 0.4); }
-.session-link-pr-closed { color: var(--red); border-color: rgba(248, 81, 73, 0.4); }
-.session-link-linear { color: #7b86e8; border-color: rgba(94, 106, 210, 0.5); }
-.session-link-plain { color: #5eead4; border-color: rgba(13, 148, 136, 0.5); }
+.session-link-pr {
+	color: var(--green);
+	border-color: rgba(63, 185, 80, 0.4);
+}
+.session-link-pr-merged {
+	color: var(--purple);
+	border-color: rgba(163, 113, 247, 0.4);
+}
+.session-link-pr-closed {
+	color: var(--red);
+	border-color: rgba(248, 81, 73, 0.4);
+}
+.session-link-linear {
+	color: #7b86e8;
+	border-color: rgba(94, 106, 210, 0.5);
+}
+.session-link-plain {
+	color: #5eead4;
+	border-color: rgba(13, 148, 136, 0.5);
+}
 
 .btn-panel-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-dim);
-  padding: 3px 10px;
-  font-size: 12px;
-  white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-dim);
+	padding: 3px 10px;
+	font-size: 12px;
+	white-space: nowrap;
 }
-.btn-panel-toggle-icon { font-size: 13px; line-height: 1; }
+.btn-panel-toggle-icon {
+	font-size: 13px;
+	line-height: 1;
+}
 /* PR button label stays visible everywhere (incl. mobile, where the generic
    .btn-panel-toggle-label is hidden) — the PR number is the point of it. */
-.btn-pr-label { font-size: 12px; line-height: 1; }
+.btn-pr-label {
+	font-size: 12px;
+	line-height: 1;
+}
 .btn-panel-toggle.active,
 .btn-panel-toggle:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-  background: var(--accent-soft);
+	color: var(--accent);
+	border-color: var(--accent);
+	background: var(--accent-soft);
 }
 
 .btn-viewer-delete {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-faint);
-  padding: 3px 10px;
-  font-size: 12px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-faint);
+	padding: 3px 10px;
+	font-size: 12px;
 }
 
 /* Preview (local dev server) control */
-.preview-wrap { position: relative; display: inline-flex; align-items: stretch; }
-.preview-open {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-right: none;
-  border-radius: 5px 0 0 5px;
-  color: var(--text-dim);
-  padding: 3px 10px;
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-  white-space: nowrap;
+.preview-wrap {
+	position: relative;
+	display: inline-flex;
+	align-items: stretch;
 }
-.preview-open.running { color: var(--green); border-color: rgba(63, 185, 80, 0.4); }
-.preview-open.running:hover { background: rgba(63, 185, 80, 0.12); }
-.preview-open:disabled { color: var(--text-faint); cursor: default; }
+.preview-open {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-right: none;
+	border-radius: 5px 0 0 5px;
+	color: var(--text-dim);
+	padding: 3px 10px;
+	font-size: 12px;
+	font-weight: 600;
+	text-decoration: none;
+	white-space: nowrap;
+}
+.preview-open.running {
+	color: var(--green);
+	border-color: rgba(63, 185, 80, 0.4);
+}
+.preview-open.running:hover {
+	background: rgba(63, 185, 80, 0.12);
+}
+.preview-open:disabled {
+	color: var(--text-faint);
+	cursor: default;
+}
 .preview-caret {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 0 5px 5px 0;
-  color: var(--text-dim);
-  padding: 3px 7px;
-  font-size: 11px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 0 5px 5px 0;
+	color: var(--text-dim);
+	padding: 3px 7px;
+	font-size: 11px;
 }
 .preview-caret.active,
-.preview-caret:hover { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+.preview-caret:hover {
+	color: var(--accent);
+	border-color: var(--accent);
+	background: var(--accent-soft);
+}
 
 .preview-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--green);
-  flex-shrink: 0;
-  box-shadow: 0 0 0 2px rgba(63, 185, 80, 0.18);
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--green);
+	flex-shrink: 0;
+	box-shadow: 0 0 0 2px rgba(63, 185, 80, 0.18);
 }
-.preview-dot.off { background: var(--text-faint); box-shadow: none; }
+.preview-dot.off {
+	background: var(--text-faint);
+	box-shadow: none;
+}
 
 .preview-popover {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 50;
-  min-width: 240px;
-  background: var(--bg-elevated, var(--bg-active));
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  padding: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+	position: absolute;
+	top: calc(100% + 6px);
+	right: 0;
+	z-index: 50;
+	min-width: 240px;
+	background: var(--bg-elevated, var(--bg-active));
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	padding: 10px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 .preview-popover-title {
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-faint);
-  margin-bottom: 8px;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-faint);
+	margin-bottom: 8px;
 }
-.preview-empty { font-size: 12px; color: var(--text-faint); padding: 4px 0; }
-.preview-services { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 5px; }
-.preview-services li { display: flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-dim); }
-.preview-svc-name { font-weight: 600; }
-.preview-svc-port { color: var(--text-faint); }
-.preview-svc-state { margin-left: auto; font-size: 11px; color: var(--text-faint); }
-.preview-svc-state.on { color: var(--green); }
+.preview-empty {
+	font-size: 12px;
+	color: var(--text-faint);
+	padding: 4px 0;
+}
+.preview-services {
+	list-style: none;
+	margin: 0 0 8px;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+.preview-services li {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	color: var(--text-dim);
+}
+.preview-svc-name {
+	font-weight: 600;
+}
+.preview-svc-port {
+	color: var(--text-faint);
+}
+.preview-svc-state {
+	margin-left: auto;
+	font-size: 11px;
+	color: var(--text-faint);
+}
+.preview-svc-state.on {
+	color: var(--green);
+}
 .preview-stop {
-  width: 100%;
-  background: none;
-  border: 1px solid rgba(248, 81, 73, 0.4);
-  border-radius: 5px;
-  color: var(--red);
-  padding: 5px 10px;
-  font-size: 12px;
-  font-weight: 600;
+	width: 100%;
+	background: none;
+	border: 1px solid rgba(248, 81, 73, 0.4);
+	border-radius: 5px;
+	color: var(--red);
+	padding: 5px 10px;
+	font-size: 12px;
+	font-weight: 600;
 }
-.preview-stop:hover:not(:disabled) { background: rgba(248, 81, 73, 0.12); }
-.preview-stop:disabled { opacity: 0.45; cursor: default; }
-.preview-hint { font-size: 10.5px; color: var(--text-faint); margin-top: 6px; text-align: center; }
+.preview-stop:hover:not(:disabled) {
+	background: rgba(248, 81, 73, 0.12);
+}
+.preview-stop:disabled {
+	opacity: 0.45;
+	cursor: default;
+}
+.preview-hint {
+	font-size: 10.5px;
+	color: var(--text-faint);
+	margin-top: 6px;
+	text-align: center;
+}
 
 .btn-viewer-share {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-dim);
-  padding: 3px 10px;
-  font-size: 12px;
-  white-space: nowrap;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-dim);
+	padding: 3px 10px;
+	font-size: 12px;
+	white-space: nowrap;
 }
-.btn-viewer-share:hover { color: var(--text); border-color: var(--text-faint); }
-.btn-viewer-share-done { color: var(--green); border-color: var(--green); }
+.btn-viewer-share:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
+.btn-viewer-share-done {
+	color: var(--green);
+	border-color: var(--green);
+}
 
 .btn-viewer-pin {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-dim);
-  padding: 3px 9px;
-  font-size: 13px;
-  line-height: 1;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-dim);
+	padding: 3px 9px;
+	font-size: 13px;
+	line-height: 1;
 }
-.btn-viewer-pin:hover { color: var(--text); border-color: var(--text-faint); }
-.btn-viewer-pin.active { color: var(--yellow); border-color: var(--yellow); }
+.btn-viewer-pin:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
+.btn-viewer-pin.active {
+	color: var(--yellow);
+	border-color: var(--yellow);
+}
 .btn-viewer-delete:hover {
-  color: var(--red);
-  border-color: var(--red);
-  background: var(--red-soft);
+	color: var(--red);
+	border-color: var(--red);
+	background: var(--red-soft);
 }
 
 .viewer-delete-confirm {
-  display: flex;
-  gap: 6px;
+	display: flex;
+	gap: 6px;
 }
 
-.btn-delete-wt, .btn-delete-only, .btn-delete-cancel {
-  border-radius: 5px;
-  padding: 3px 10px;
-  font-size: 12px;
-  border: 1px solid var(--border-strong);
-  background: none;
-  color: var(--text-dim);
+.btn-delete-wt,
+.btn-delete-only,
+.btn-delete-cancel {
+	border-radius: 5px;
+	padding: 3px 10px;
+	font-size: 12px;
+	border: 1px solid var(--border-strong);
+	background: none;
+	color: var(--text-dim);
 }
-.btn-delete-wt { color: var(--red); border-color: var(--red); }
-.btn-delete-only { color: var(--yellow); border-color: var(--yellow); }
-.btn-delete-cancel:hover { color: var(--text); }
+.btn-delete-wt {
+	color: var(--red);
+	border-color: var(--red);
+}
+.btn-delete-only {
+	color: var(--yellow);
+	border-color: var(--yellow);
+}
+.btn-delete-cancel:hover {
+	color: var(--text);
+}
 
 /* split layout: chat + workspace panel */
 .viewer-split {
-  display: flex;
-  flex: 1;
-  min-height: 0;
+	display: flex;
+	flex: 1;
+	min-height: 0;
 }
 
 .viewer-chat {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	min-height: 0;
 }
 
 .viewer-panel {
-  width: 44%;
-  max-width: 720px;
-  min-width: 320px;
-  border-left: 1px solid var(--border);
-  background: var(--bg-raised);
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+	width: 44%;
+	max-width: 720px;
+	min-width: 320px;
+	border-left: 1px solid var(--border);
+	background: var(--bg-raised);
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 
 .panel-tabs {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 8px 10px 0;
+	border-bottom: 1px solid var(--border);
 }
 
 .panel-tab {
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 6px 12px 8px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	color: var(--text-dim);
+	font-size: 13px;
+	font-weight: 500;
+	padding: 6px 12px 8px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
 }
-.panel-tab:hover { color: var(--text); }
+.panel-tab:hover {
+	color: var(--text);
+}
 .panel-tab.active {
-  color: var(--text);
-  border-bottom-color: var(--accent);
+	color: var(--text);
+	border-bottom-color: var(--accent);
 }
 
 .panel-tab-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
 }
-.pr-dot-open { background: var(--green); }
-.pr-dot-merged { background: var(--purple); }
-.pr-dot-closed { background: var(--red); }
+.pr-dot-open {
+	background: var(--green);
+}
+.pr-dot-merged {
+	background: var(--purple);
+}
+.pr-dot-closed {
+	background: var(--red);
+}
 
 .panel-close {
-  background: none;
-  border: none;
-  color: var(--text-faint);
-  font-size: 13px;
-  padding: 4px 8px 8px;
-  margin-left: 6px;
+	background: none;
+	border: none;
+	color: var(--text-faint);
+	font-size: 13px;
+	padding: 4px 8px 8px;
+	margin-left: 6px;
 }
-.panel-close:hover { color: var(--text); }
+.panel-close:hover {
+	color: var(--text);
+}
 
 .panel-overlay {
-  display: none;
+	display: none;
 }
 
 .panel-branch {
-  margin-left: auto;
-  color: var(--text-faint);
-  font-family: var(--mono);
-  font-size: 11.5px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 45%;
-  padding-bottom: 6px;
+	margin-left: auto;
+	color: var(--text-faint);
+	font-family: var(--mono);
+	font-size: 11.5px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 45%;
+	padding-bottom: 6px;
 }
 
 .panel-body {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
 }
 
 .panel-placeholder {
-  color: var(--text-faint);
-  text-align: center;
-  padding: 48px 16px;
-  font-size: 13px;
+	color: var(--text-faint);
+	text-align: center;
+	padding: 48px 16px;
+	font-size: 13px;
 }
-.panel-error { color: var(--red); }
+.panel-error {
+	color: var(--red);
+}
 
 /* ── Sub-agent sidebar ───────────────────────────────────── */
 
 /* A Task/Agent tool block that can open its sub-agent conversation. */
 .tool-open-subagent {
-  margin-left: auto;
-  background: var(--accent-soft);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--accent);
-  font-size: 11.5px;
-  font-weight: 500;
-  padding: 2px 8px;
-  white-space: nowrap;
+	margin-left: auto;
+	background: var(--accent-soft);
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	color: var(--accent);
+	font-size: 11.5px;
+	font-weight: 500;
+	padding: 2px 8px;
+	white-space: nowrap;
 }
-.tool-open-subagent:hover { border-color: var(--accent); }
+.tool-open-subagent:hover {
+	border-color: var(--accent);
+}
 /* Keep the ✓ tight to the open button rather than pushed to the far edge. */
-.tool-agent .tool-summary { margin-right: 4px; }
+.tool-agent .tool-summary {
+	margin-right: 4px;
+}
 
 .subagent-head {
-  padding: 8px 10px 10px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
+	padding: 8px 10px 10px;
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-raised);
 }
 .subagent-head-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 .subagent-chip {
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--accent);
-  background: var(--accent-soft);
-  border-radius: 5px;
-  padding: 2px 6px;
-  white-space: nowrap;
+	font-size: 10.5px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--accent);
+	background: var(--accent-soft);
+	border-radius: 5px;
+	padding: 2px 6px;
+	white-space: nowrap;
 }
 .subagent-title {
-  font-weight: 600;
-  font-size: 13.5px;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-weight: 600;
+	font-size: 13.5px;
+	color: var(--text);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .subagent-live-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--green);
-  flex-shrink: 0;
-  animation: pulse 1.6s ease-in-out infinite;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--green);
+	flex-shrink: 0;
+	animation: pulse 1.6s ease-in-out infinite;
 }
-.subagent-head-top .panel-close { margin-left: auto; }
+.subagent-head-top .panel-close {
+	margin-left: auto;
+}
 .subagent-back {
-  margin-top: 8px;
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 12px;
-  padding: 0;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	margin-top: 8px;
+	background: none;
+	border: none;
+	color: var(--text-dim);
+	font-size: 12px;
+	padding: 0;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
-.subagent-back:hover { color: var(--text); }
+.subagent-back:hover {
+	color: var(--text);
+}
 .subagent-desc {
-  margin-top: 6px;
-  color: var(--text-dim);
-  font-size: 12px;
-  line-height: 1.4;
+	margin-top: 6px;
+	color: var(--text-dim);
+	font-size: 12px;
+	line-height: 1.4;
 }
-.subagent-body { padding: 12px 14px; }
+.subagent-body {
+	padding: 12px 14px;
+}
 .subagent-messages {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 /* ── Diff panel ──────────────────────────────────────────── */
 
 .diff-panel {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 
 .diff-summary {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border);
-  font-size: 12.5px;
-  position: sticky;
-  top: 0;
-  background: var(--bg-raised);
-  z-index: 1;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 10px 14px;
+	border-bottom: 1px solid var(--border);
+	font-size: 12.5px;
+	position: sticky;
+	top: 0;
+	background: var(--bg-raised);
+	z-index: 1;
 }
 
-.diff-summary-files { color: var(--text-dim); }
+.diff-summary-files {
+	color: var(--text-dim);
+}
 
 /* Per-repo tabs in a multi-repo session's PR panel */
 .pr-repo-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-  overflow-x: auto;
+	display: flex;
+	gap: 4px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--border);
+	overflow-x: auto;
 }
 .pr-repo-tab {
-  font-size: 12px;
-  white-space: nowrap;
-  color: var(--text-dim);
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 7px;
-  padding: 3px 10px;
-  cursor: pointer;
+	font-size: 12px;
+	white-space: nowrap;
+	color: var(--text-dim);
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 7px;
+	padding: 3px 10px;
+	cursor: pointer;
 }
-.pr-repo-tab:hover { color: var(--text); }
+.pr-repo-tab:hover {
+	color: var(--text);
+}
 .pr-repo-tab-active {
-  color: var(--text);
-  background: var(--bg-panel);
-  border-color: var(--border);
+	color: var(--text);
+	background: var(--bg-panel);
+	border-color: var(--border);
 }
 
 /* Per-repo tabs in a multi-repo session's diff */
 .diff-repo-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
-  overflow-x: auto;
-  position: sticky;
-  top: 0;
-  z-index: 2;
+	display: flex;
+	gap: 4px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-raised);
+	overflow-x: auto;
+	position: sticky;
+	top: 0;
+	z-index: 2;
 }
 .diff-repo-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  white-space: nowrap;
-  color: var(--text-dim);
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 7px;
-  padding: 3px 9px;
-  cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	white-space: nowrap;
+	color: var(--text-dim);
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 7px;
+	padding: 3px 9px;
+	cursor: pointer;
 }
-.diff-repo-tab:hover { color: var(--text); }
+.diff-repo-tab:hover {
+	color: var(--text);
+}
 .diff-repo-tab-active {
-  color: var(--text);
-  background: var(--bg-panel);
-  border-color: var(--border);
+	color: var(--text);
+	background: var(--bg-panel);
+	border-color: var(--border);
 }
 .diff-repo-tab-count {
-  font-size: 10.5px;
-  color: var(--text-faint);
-  background: color-mix(in srgb, var(--text-faint) 20%, transparent);
-  border-radius: 999px;
-  padding: 0 5px;
+	font-size: 10.5px;
+	color: var(--text-faint);
+	background: color-mix(in srgb, var(--text-faint) 20%, transparent);
+	border-radius: 999px;
+	padding: 0 5px;
 }
 
-.diff-add { color: var(--green); font-weight: 600; }
-.diff-del { color: var(--red); font-weight: 600; }
+.diff-add {
+	color: var(--green);
+	font-weight: 600;
+}
+.diff-del {
+	color: var(--red);
+	font-weight: 600;
+}
 
 .btn-icon {
-  margin-left: auto;
-  background: none;
-  border: none;
-  color: var(--text-faint);
-  font-size: 14px;
-  padding: 2px 6px;
-  border-radius: 4px;
+	margin-left: auto;
+	background: none;
+	border: none;
+	color: var(--text-faint);
+	font-size: 14px;
+	padding: 2px 6px;
+	border-radius: 4px;
 }
-.btn-icon:hover { color: var(--text); background: var(--bg-hover); }
+.btn-icon:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
 
 .diff-truncated {
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  color: var(--yellow);
-  background: rgba(210, 153, 34, 0.15);
-  border-radius: 4px;
-  padding: 1px 7px;
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	color: var(--yellow);
+	background: rgba(210, 153, 34, 0.15);
+	border-radius: 4px;
+	padding: 1px 7px;
 }
 
 .diff-render {
-  padding: 10px 10px 28px;
+	padding: 10px 10px 28px;
 }
-.diff-render [class*="pierre"] { max-width: 100%; }
+.diff-render [class*="pierre"] {
+	max-width: 100%;
+}
 
-.commentable-diff { display: flex; flex-direction: column; gap: 10px; }
+.commentable-diff {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
 
 .diff-comment-form {
-  background: var(--bg-panel);
-  border: 1px solid var(--accent);
-  border-radius: 8px;
-  padding: 10px;
-  margin: 6px 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-family: var(--sans);
+	background: var(--bg-panel);
+	border: 1px solid var(--accent);
+	border-radius: 8px;
+	padding: 10px;
+	margin: 6px 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	font-family: var(--sans);
 }
 
 .diff-comment-target {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-faint);
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-faint);
 }
 
 .diff-comment-input {
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 6px;
-  color: var(--text);
-  padding: 8px 10px;
-  font-size: 13px;
-  font-family: var(--sans);
-  line-height: 1.45;
-  resize: vertical;
-  outline: none;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 6px;
+	color: var(--text);
+	padding: 8px 10px;
+	font-size: 13px;
+	font-family: var(--sans);
+	line-height: 1.45;
+	resize: vertical;
+	outline: none;
 }
-.diff-comment-input:focus { border-color: var(--accent); }
+.diff-comment-input:focus {
+	border-color: var(--accent);
+}
 
 .diff-comment-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
 }
-.diff-comment-actions .btn-send { padding: 6px 14px; font-size: 12.5px; }
+.diff-comment-actions .btn-send {
+	padding: 6px 14px;
+	font-size: 12.5px;
+}
 
 .diff-comment-error {
-  color: var(--red);
-  font-size: 12px;
+	color: var(--red);
+	font-size: 12px;
 }
 
 .diff-comment-disabled {
-  color: var(--text-faint);
-  font-size: 12.5px;
+	color: var(--text-faint);
+	font-size: 12.5px;
 }
 
 .diff-comment-confirmation {
-  background: var(--green-soft);
-  color: var(--green);
-  border-radius: 6px;
-  padding: 6px 12px;
-  font-size: 12.5px;
-  font-weight: 600;
+	background: var(--green-soft);
+	color: var(--green);
+	border-radius: 6px;
+	padding: 6px 12px;
+	font-size: 12.5px;
+	font-weight: 600;
 }
 
 .diff-comment-hint {
-  color: var(--text-faint);
-  font-size: 11.5px;
-  text-align: center;
-  padding-bottom: 8px;
+	color: var(--text-faint);
+	font-size: 11.5px;
+	text-align: center;
+	padding-bottom: 8px;
 }
 
 /* A saved-but-not-yet-submitted inline comment, shown in-place on the diff. */
 .diff-pending-comment {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-left: 3px solid var(--accent);
-  border-radius: 8px;
-  padding: 9px 10px;
-  margin: 6px 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-family: var(--sans);
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-left: 3px solid var(--accent);
+	border-radius: 8px;
+	padding: 9px 10px;
+	margin: 6px 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-family: var(--sans);
 }
 .diff-pending-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
 }
 .diff-pending-remove {
-  background: none;
-  border: none;
-  color: var(--text-faint);
-  font-size: 11.5px;
-  padding: 2px 4px;
-  cursor: pointer;
+	background: none;
+	border: none;
+	color: var(--text-faint);
+	font-size: 11.5px;
+	padding: 2px 4px;
+	cursor: pointer;
 }
-.diff-pending-remove:hover { color: var(--red); }
+.diff-pending-remove:hover {
+	color: var(--red);
+}
 .diff-pending-text {
-  font-size: 13px;
-  line-height: 1.45;
-  color: var(--text);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+	font-size: 13px;
+	line-height: 1.45;
+	color: var(--text);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 }
 
 /* Floating "you have pending comments" bar — sticks to the bottom of whichever
    container scrolls the diff (the split drawer's diff pane, or the panel body). */
 .pr-review-bar {
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
-  margin-top: 10px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.35);
-  padding: 10px 12px;
-  padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	position: sticky;
+	bottom: 0;
+	z-index: 5;
+	margin-top: 10px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.35);
+	padding: 10px 12px;
+	padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 .pr-review-bar-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
 }
 .pr-review-count {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text);
 }
 .pr-review-toggle {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  padding: 7px 14px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 7px;
+	padding: 7px 14px;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
 }
-.pr-review-toggle:hover { filter: brightness(1.1); }
+.pr-review-toggle:hover {
+	filter: brightness(1.1);
+}
 .pr-review-form {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 9px;
+	border-top: 1px solid var(--border);
+	padding-top: 10px;
 }
 .pr-review-summary {
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text);
-  padding: 8px 10px;
-  font-size: 13px;
-  font-family: var(--sans);
-  line-height: 1.45;
-  resize: vertical;
-  outline: none;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text);
+	padding: 8px 10px;
+	font-size: 13px;
+	font-family: var(--sans);
+	line-height: 1.45;
+	resize: vertical;
+	outline: none;
 }
-.pr-review-summary:focus { border-color: var(--accent); }
+.pr-review-summary:focus {
+	border-color: var(--accent);
+}
 .pr-review-events {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
 }
 .pr-review-event {
-  flex: 1 1 auto;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text-dim);
-  padding: 7px 10px;
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
+	flex: 1 1 auto;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text-dim);
+	padding: 7px 10px;
+	font-size: 12.5px;
+	font-weight: 500;
+	cursor: pointer;
+	white-space: nowrap;
 }
-.pr-review-event:hover { color: var(--text); }
+.pr-review-event:hover {
+	color: var(--text);
+}
 .pr-review-event.active {
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
-  border-color: var(--accent);
-  color: var(--text);
+	background: color-mix(in srgb, var(--accent) 16%, transparent);
+	border-color: var(--accent);
+	color: var(--text);
 }
 .pr-review-submit {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  padding: 9px 12px;
-  font-size: 13.5px;
-  font-weight: 600;
-  cursor: pointer;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 7px;
+	padding: 9px 12px;
+	font-size: 13.5px;
+	font-weight: 600;
+	cursor: pointer;
 }
-.pr-review-submit:disabled { opacity: 0.5; cursor: default; }
-.pr-review-submit:not(:disabled):hover { filter: brightness(1.1); }
+.pr-review-submit:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+.pr-review-submit:not(:disabled):hover {
+	filter: brightness(1.1);
+}
 
-.pr-diff-section { display: flex; flex-direction: column; gap: 8px; }
+.pr-diff-section {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
 
 .pr-comment-link {
-  margin-left: 8px;
-  color: var(--accent);
-  text-decoration: none;
-  text-transform: none;
-  letter-spacing: 0;
-  font-weight: 500;
+	margin-left: 8px;
+	color: var(--accent);
+	text-decoration: none;
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: 500;
 }
 
 .diff-files {
-  padding: 8px 10px 24px;
+	padding: 8px 10px 24px;
 }
 
 .diff-file {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  margin-bottom: 8px;
-  overflow: hidden;
-  background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	margin-bottom: 8px;
+	overflow: hidden;
+	background: var(--bg-panel);
 }
 
 .diff-file-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: none;
-  border: none;
-  padding: 8px 10px;
-  color: var(--text);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	background: none;
+	border: none;
+	padding: 8px 10px;
+	color: var(--text);
+	min-width: 0;
 }
-.diff-file-header:hover { background: var(--bg-hover); }
+.diff-file-header:hover {
+	background: var(--bg-hover);
+}
 
 .diff-status {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
+	font-family: var(--mono);
+	font-size: 11px;
+	font-weight: 700;
+	width: 18px;
+	height: 18px;
+	border-radius: 4px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
 }
-.diff-status-added, .diff-status-untracked { background: var(--green-soft); color: var(--green); }
-.diff-status-modified { background: rgba(210, 153, 34, 0.15); color: var(--yellow); }
-.diff-status-deleted { background: var(--red-soft); color: var(--red); }
-.diff-status-renamed { background: var(--accent-soft); color: var(--accent); }
+.diff-status-added,
+.diff-status-untracked {
+	background: var(--green-soft);
+	color: var(--green);
+}
+.diff-status-modified {
+	background: rgba(210, 153, 34, 0.15);
+	color: var(--yellow);
+}
+.diff-status-deleted {
+	background: var(--red-soft);
+	color: var(--red);
+}
+.diff-status-renamed {
+	background: var(--accent-soft);
+	color: var(--accent);
+}
 
 .diff-file-path {
-  font-family: var(--mono);
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
-  text-align: left;
+	font-family: var(--mono);
+	font-size: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+	flex: 1;
+	text-align: left;
 }
 
 .diff-file-stats {
-  display: flex;
-  gap: 6px;
-  font-size: 11.5px;
-  flex-shrink: 0;
+	display: flex;
+	gap: 6px;
+	font-size: 11.5px;
+	flex-shrink: 0;
 }
 
 .diff-chevron {
-  color: var(--text-faint);
-  font-size: 10px;
-  flex-shrink: 0;
+	color: var(--text-faint);
+	font-size: 10px;
+	flex-shrink: 0;
 }
 
 .diff-patch {
-  margin: 0;
-  border-top: 1px solid var(--border);
-  font-family: var(--mono);
-  font-size: 11.5px;
-  line-height: 1.55;
-  overflow-x: auto;
-  max-height: 480px;
-  overflow-y: auto;
+	margin: 0;
+	border-top: 1px solid var(--border);
+	font-family: var(--mono);
+	font-size: 11.5px;
+	line-height: 1.55;
+	overflow-x: auto;
+	max-height: 480px;
+	overflow-y: auto;
 }
 
 .diff-line {
-  padding: 0 10px;
-  white-space: pre;
+	padding: 0 10px;
+	white-space: pre;
 }
-.diff-line-add { background: rgba(63, 185, 80, 0.13); color: #7ee787; }
-.diff-line-del { background: rgba(248, 81, 73, 0.12); color: #ffa198; }
+.diff-line-add {
+	background: rgba(63, 185, 80, 0.13);
+	color: #7ee787;
+}
+.diff-line-del {
+	background: rgba(248, 81, 73, 0.12);
+	color: #ffa198;
+}
 .diff-line-hunk {
-  background: var(--accent-soft);
-  color: var(--text-dim);
-  padding: 2px 10px;
+	background: var(--accent-soft);
+	color: var(--text-dim);
+	padding: 2px 10px;
 }
 
 /* ── PR panel ────────────────────────────────────────────── */
 
 .pr-panel {
-  padding: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	padding: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 /* The info region (header, checks, body, actions) keeps the vertical rhythm
    whether or not it's beside the diff. */
 .pr-panel-info {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	min-width: 0;
 }
 
 /* Split layout (Reviews drawer): metadata/checks/actions on the left, the
    code diff filling the rest — each scrolls on its own. */
 .pr-panel-split {
-  flex-direction: row;
-  align-items: stretch;
-  height: 100%;
-  padding: 0;
-  gap: 0;
+	flex-direction: row;
+	align-items: stretch;
+	height: 100%;
+	padding: 0;
+	gap: 0;
 }
 .pr-panel-split .pr-panel-info {
-  width: 384px;
-  flex-shrink: 0;
-  overflow-y: auto;
-  padding: 18px;
-  border-right: 1px solid var(--border);
+	width: 384px;
+	flex-shrink: 0;
+	overflow-y: auto;
+	padding: 18px;
+	border-right: 1px solid var(--border);
 }
 .pr-panel-split .pr-panel-diff {
-  flex: 1;
-  min-width: 0;
-  overflow-y: auto;
-  padding: 18px 20px;
-  background: var(--bg);
+	flex: 1;
+	min-width: 0;
+	overflow-y: auto;
+	padding: 18px 20px;
+	background: var(--bg);
 }
-.pr-panel-split .pr-diff-section { margin-top: 0; }
+.pr-panel-split .pr-diff-section {
+	margin-top: 0;
+}
 
 .pr-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .pr-pill {
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 3px 10px;
-  border-radius: 99px;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 3px 10px;
+	border-radius: 99px;
 }
-.pr-pill-open { background: var(--green-soft); color: var(--green); }
-.pr-pill-merged { background: rgba(163, 113, 247, 0.16); color: var(--purple); }
-.pr-pill-closed { background: var(--red-soft); color: var(--red); }
-.pr-pill-draft { background: var(--bg-active); color: var(--text-dim); }
+.pr-pill-open {
+	background: var(--green-soft);
+	color: var(--green);
+}
+.pr-pill-merged {
+	background: rgba(163, 113, 247, 0.16);
+	color: var(--purple);
+}
+.pr-pill-closed {
+	background: var(--red-soft);
+	color: var(--red);
+}
+.pr-pill-draft {
+	background: var(--bg-active);
+	color: var(--text-dim);
+}
 
 .pr-number {
-  color: var(--text-dim);
-  text-decoration: none;
-  font-size: 13px;
+	color: var(--text-dim);
+	text-decoration: none;
+	font-size: 13px;
 }
-.pr-number:hover { color: var(--accent); }
+.pr-number:hover {
+	color: var(--accent);
+}
 
 .pr-title {
-  font-size: 15.5px;
-  font-weight: 600;
-  color: var(--text);
-  text-decoration: none;
-  line-height: 1.35;
+	font-size: 15.5px;
+	font-weight: 600;
+	color: var(--text);
+	text-decoration: none;
+	line-height: 1.35;
 }
-.pr-title:hover { color: var(--accent); }
+.pr-title:hover {
+	color: var(--accent);
+}
 
 .pr-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 14px;
-  font-size: 12.5px;
-  color: var(--text-dim);
-  align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 14px;
+	font-size: 12.5px;
+	color: var(--text-dim);
+	align-items: center;
 }
 
 .pr-branch {
-  font-family: var(--mono);
-  font-size: 11.5px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  padding: 2px 8px;
-  border-radius: 5px;
+	font-family: var(--mono);
+	font-size: 11.5px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	padding: 2px 8px;
+	border-radius: 5px;
 }
 
-.pr-review { text-transform: capitalize; font-weight: 600; }
-.pr-review-approved { color: var(--green); }
-.pr-review-changes_requested { color: var(--red); }
-.pr-review-review_required { color: var(--yellow); }
+.pr-review {
+	text-transform: capitalize;
+	font-weight: 600;
+}
+.pr-review-approved {
+	color: var(--green);
+}
+.pr-review-changes_requested {
+	color: var(--red);
+}
+.pr-review-review_required {
+	color: var(--yellow);
+}
 
 .pr-checks {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
-  overflow: hidden;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: var(--bg-panel);
+	overflow: hidden;
 }
 
 .pr-checks-title {
-  font-size: 11.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-faint);
-  padding: 8px 12px 6px;
+	font-size: 11.5px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-faint);
+	padding: 8px 12px 6px;
 }
 
 .pr-checks-summary {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  background: none;
-  border: none;
-  padding: 10px 12px;
-  cursor: pointer;
-  color: var(--text);
-  font: inherit;
-  text-align: left;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	background: none;
+	border: none;
+	padding: 10px 12px;
+	cursor: pointer;
+	color: var(--text);
+	font: inherit;
+	text-align: left;
 }
-.pr-checks-summary:hover { background: var(--bg-hover); }
+.pr-checks-summary:hover {
+	background: var(--bg-hover);
+}
 .pr-checks-status {
-  font-size: 13px;
-  font-weight: 600;
+	font-size: 13px;
+	font-weight: 600;
 }
-.pr-checks-status.pr-sum-pass { color: var(--green); }
-.pr-checks-status.pr-sum-fail { color: var(--red); }
-.pr-checks-status.pr-sum-pending { color: var(--yellow); }
+.pr-checks-status.pr-sum-pass {
+	color: var(--green);
+}
+.pr-checks-status.pr-sum-fail {
+	color: var(--red);
+}
+.pr-checks-status.pr-sum-pending {
+	color: var(--yellow);
+}
 .pr-checks-counts {
-  display: flex;
-  gap: 10px;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
+	display: flex;
+	gap: 10px;
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
 }
-.check-success-text { color: var(--green); }
-.check-failure-text { color: var(--red); }
-.check-pending-text { color: var(--yellow); }
+.check-success-text {
+	color: var(--green);
+}
+.check-failure-text {
+	color: var(--red);
+}
+.check-pending-text {
+	color: var(--yellow);
+}
 .pr-checks-chevron {
-  margin-left: auto;
-  color: var(--text-faint);
-  font-size: 11px;
+	margin-left: auto;
+	color: var(--text-faint);
+	font-size: 11px;
 }
 
 .pr-check {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  text-decoration: none;
-  color: var(--text);
-  font-size: 12.5px;
-  border-top: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	text-decoration: none;
+	color: var(--text);
+	font-size: 12.5px;
+	border-top: 1px solid var(--border);
 }
-.pr-check:hover { background: var(--bg-hover); }
+.pr-check:hover {
+	background: var(--bg-hover);
+}
 
 .pr-check-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
 }
-.check-success { background: var(--green); }
-.check-failure { background: var(--red); }
-.check-pending { background: var(--yellow); animation: pulse 1.4s infinite; }
-.check-neutral { background: var(--text-faint); }
+.check-success {
+	background: var(--green);
+}
+.check-failure {
+	background: var(--red);
+}
+.check-pending {
+	background: var(--yellow);
+	animation: pulse 1.4s infinite;
+}
+.check-neutral {
+	background: var(--text-faint);
+}
 
 .pr-check-name {
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .pr-check-state {
-  color: var(--text-faint);
-  font-size: 11.5px;
+	color: var(--text-faint);
+	font-size: 11.5px;
 }
 
 .pr-body {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: var(--bg-panel);
 }
 
 .pr-body-text {
-  margin: 0;
-  padding: 4px 12px 12px;
-  font-family: var(--sans);
-  font-size: 12.5px;
-  color: var(--text-dim);
-  white-space: pre-wrap;
-  word-break: break-word;
-  max-height: 280px;
-  overflow-y: auto;
+	margin: 0;
+	padding: 4px 12px 12px;
+	font-family: var(--sans);
+	font-size: 12.5px;
+	color: var(--text-dim);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 280px;
+	overflow-y: auto;
 }
 
 .btn-open-pr {
-  display: block;
-  text-align: center;
-  background: var(--accent);
-  color: #fff;
-  text-decoration: none;
-  border-radius: 7px;
-  padding: 9px;
-  font-size: 13px;
-  font-weight: 500;
+	display: block;
+	text-align: center;
+	background: var(--accent);
+	color: #fff;
+	text-decoration: none;
+	border-radius: 7px;
+	padding: 9px;
+	font-size: 13px;
+	font-weight: 500;
 }
-.btn-open-pr:hover { filter: brightness(1.1); }
+.btn-open-pr:hover {
+	filter: brightness(1.1);
+}
 
 /* PR action row (Open on GitHub / Squash & merge / Open session) */
 .pr-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: stretch;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: stretch;
 }
-.pr-actions .btn-open-pr { flex: 1; min-width: 150px; }
+.pr-actions .btn-open-pr {
+	flex: 1;
+	min-width: 150px;
+}
 
 .btn-merge-pr {
-  flex: 1;
-  min-width: 150px;
-  text-align: center;
-  background: #238636;
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  padding: 9px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
+	flex: 1;
+	min-width: 150px;
+	text-align: center;
+	background: #238636;
+	color: #fff;
+	border: none;
+	border-radius: 7px;
+	padding: 9px;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
 }
-.btn-merge-pr:hover:not(:disabled) { background: #2ea043; }
-.btn-merge-pr:disabled { opacity: 0.6; cursor: default; }
-.btn-merge-confirm { background: #cf222e; }
-.btn-merge-confirm:hover:not(:disabled) { background: #e5484d; }
+.btn-merge-pr:hover:not(:disabled) {
+	background: #2ea043;
+}
+.btn-merge-pr:disabled {
+	opacity: 0.6;
+	cursor: default;
+}
+.btn-merge-confirm {
+	background: #cf222e;
+}
+.btn-merge-confirm:hover:not(:disabled) {
+	background: #e5484d;
+}
 
 .btn-open-session {
-  background: var(--bg-active);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  padding: 9px 14px;
-  font-size: 13px;
-  cursor: pointer;
+	background: var(--bg-active);
+	color: var(--text);
+	border: 1px solid var(--border);
+	border-radius: 7px;
+	padding: 9px 14px;
+	font-size: 13px;
+	cursor: pointer;
 }
-.btn-open-session:hover { background: var(--bg-hover); }
+.btn-open-session:hover {
+	background: var(--bg-hover);
+}
 
 .pr-merge-error {
-  color: var(--red);
-  font-size: 12.5px;
-  background: var(--red-soft);
-  border-radius: 6px;
-  padding: 8px 10px;
+	color: var(--red);
+	font-size: 12.5px;
+	background: var(--red-soft);
+	border-radius: 6px;
+	padding: 8px 10px;
 }
 
 /* ── Reviews view ────────────────────────────────────────── */
 
 .sidebar-nav-count {
-  margin-left: auto;
-  background: var(--accent);
-  color: #fff;
-  font-size: 10.5px;
-  font-weight: 600;
-  border-radius: 99px;
-  padding: 1px 7px;
-  line-height: 1.5;
+	margin-left: auto;
+	background: var(--accent);
+	color: #fff;
+	font-size: 10.5px;
+	font-weight: 600;
+	border-radius: 99px;
+	padding: 1px 7px;
+	line-height: 1.5;
 }
 
 .reviews {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  position: relative;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	position: relative;
 }
 .reviews-main {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
 }
 
 /* ── Header + filter tabs ───────────────────────────────── */
 .reviews-header {
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  background: var(--bg);
-  padding: 16px 22px 0;
-  border-bottom: 1px solid var(--border);
+	position: sticky;
+	top: 0;
+	z-index: 3;
+	background: var(--bg);
+	padding: 16px 22px 0;
+	border-bottom: 1px solid var(--border);
 }
 .reviews-header-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 12px;
 }
 .reviews-title {
-  font-size: 18px;
-  font-weight: 650;
-  letter-spacing: -0.01em;
-  margin: 0;
+	font-size: 18px;
+	font-weight: 650;
+	letter-spacing: -0.01em;
+	margin: 0;
 }
 .reviews-search {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  padding: 6px 10px;
-  width: 240px;
-  color: var(--text-faint);
-  transition: border-color 0.12s, background 0.12s;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	background: var(--bg-raised);
+	border: 1px solid var(--border);
+	border-radius: 7px;
+	padding: 6px 10px;
+	width: 240px;
+	color: var(--text-faint);
+	transition:
+		border-color 0.12s,
+		background 0.12s;
 }
 .reviews-search:focus-within {
-  border-color: var(--border-strong);
-  background: var(--bg-panel);
+	border-color: var(--border-strong);
+	background: var(--bg-panel);
 }
 .reviews-search input {
-  flex: 1;
-  min-width: 0;
-  background: none;
-  border: none;
-  outline: none;
-  color: var(--text);
-  font-size: 13px;
+	flex: 1;
+	min-width: 0;
+	background: none;
+	border: none;
+	outline: none;
+	color: var(--text);
+	font-size: 13px;
 }
-.reviews-search input::placeholder { color: var(--text-faint); }
+.reviews-search input::placeholder {
+	color: var(--text-faint);
+}
 
 .reviews-tabs {
-  display: flex;
-  gap: 2px;
+	display: flex;
+	gap: 2px;
 }
 .reviews-tab {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  padding: 8px 13px 11px;
-  margin-bottom: -1px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-dim);
-  cursor: pointer;
-  transition: color 0.12s;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	padding: 8px 13px 11px;
+	margin-bottom: -1px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text-dim);
+	cursor: pointer;
+	transition: color 0.12s;
 }
-.reviews-tab:hover { color: var(--text); }
+.reviews-tab:hover {
+	color: var(--text);
+}
 .reviews-tab.active {
-  color: var(--text);
-  border-bottom-color: var(--accent);
+	color: var(--text);
+	border-bottom-color: var(--accent);
 }
 .reviews-tab-count {
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--text-dim);
-  background: var(--bg-active);
-  border-radius: 99px;
-  padding: 1px 7px;
-  min-width: 20px;
-  text-align: center;
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--text-dim);
+	background: var(--bg-active);
+	border-radius: 99px;
+	padding: 1px 7px;
+	min-width: 20px;
+	text-align: center;
 }
 .reviews-tab.active .reviews-tab-count {
-  background: var(--accent-soft);
-  color: var(--accent);
+	background: var(--accent-soft);
+	color: var(--accent);
 }
 
 /* ── Table ──────────────────────────────────────────────── */
 .reviews-table {
-  display: flex;
-  flex-direction: column;
+	display: flex;
+	flex-direction: column;
 }
 .reviews-row {
-  display: grid;
-  grid-template-columns:
-    92px minmax(0, 1fr) 156px 132px 116px 132px 78px;
-  align-items: center;
-  gap: 14px;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  padding: 11px 22px;
-  cursor: pointer;
-  color: var(--text);
-  font: inherit;
+	display: grid;
+	grid-template-columns: 92px minmax(0, 1fr) 156px 132px 116px 132px 78px;
+	align-items: center;
+	gap: 14px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-bottom: 1px solid var(--border);
+	padding: 11px 22px;
+	cursor: pointer;
+	color: var(--text);
+	font: inherit;
 }
-.reviews-row:hover { background: var(--bg-hover); }
+.reviews-row:hover {
+	background: var(--bg-hover);
+}
 .reviews-row.active {
-  background: var(--bg-active);
-  box-shadow: inset 2px 0 0 var(--accent);
+	background: var(--bg-active);
+	box-shadow: inset 2px 0 0 var(--accent);
 }
 .reviews-row-head {
-  position: sticky;
-  top: 95px;
-  z-index: 2;
-  background: var(--bg);
-  cursor: default;
-  padding-top: 9px;
-  padding-bottom: 9px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
+	position: sticky;
+	top: 95px;
+	z-index: 2;
+	background: var(--bg);
+	cursor: default;
+	padding-top: 9px;
+	padding-bottom: 9px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
 }
-.reviews-row-head:hover { background: var(--bg); }
+.reviews-row-head:hover {
+	background: var(--bg);
+}
 
 /* Columns */
 .rv-c-state {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 12.5px;
-  font-weight: 500;
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12.5px;
+	font-weight: 500;
 }
-.rv-state-label { white-space: nowrap; }
-.rv-state-open { color: var(--green); }
-.rv-state-draft { color: var(--text-dim); }
-.rv-state-merged { color: var(--purple); }
-.rv-state-closed { color: var(--red); }
+.rv-state-label {
+	white-space: nowrap;
+}
+.rv-state-open {
+	color: var(--green);
+}
+.rv-state-draft {
+	color: var(--text-dim);
+}
+.rv-state-merged {
+	color: var(--purple);
+}
+.rv-state-closed {
+	color: var(--red);
+}
 
 .rv-c-title {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	min-width: 0;
 }
 .rv-title-line {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  min-width: 0;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	min-width: 0;
 }
 .rv-title-text {
-  font-size: 14px;
-  font-weight: 550;
-  line-height: 1.3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-size: 14px;
+	font-weight: 550;
+	line-height: 1.3;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .rv-num {
-  font-size: 12.5px;
-  color: var(--text-faint);
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
+	font-size: 12.5px;
+	color: var(--text-faint);
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
 }
 .rv-sub-line {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 12px;
-  color: var(--text-faint);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	font-size: 12px;
+	color: var(--text-faint);
+	min-width: 0;
 }
 .rv-branch {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 100%;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-family: var(--mono);
+	font-size: 11.5px;
+	color: var(--text-dim);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 100%;
 }
-.rv-branch svg { flex-shrink: 0; opacity: 0.7; }
+.rv-branch svg {
+	flex-shrink: 0;
+	opacity: 0.7;
+}
 .rv-linear {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--text-dim);
-  background: var(--bg-active);
-  border-radius: 5px;
-  padding: 1px 6px;
+	flex-shrink: 0;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	color: var(--text-dim);
+	background: var(--bg-active);
+	border-radius: 5px;
+	padding: 1px 6px;
 }
 .rv-running {
-  flex-shrink: 0;
-  font-size: 11px;
-  color: var(--green);
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--green);
 }
 
 /* Checks */
 .rv-checks {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 12.5px;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12.5px;
 }
 .rv-checks-empty,
-.rv-dim { color: var(--text-faint); font-size: 12.5px; }
+.rv-dim {
+	color: var(--text-faint);
+	font-size: 12.5px;
+}
 .rv-check-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 99px;
-  flex-shrink: 0;
+	width: 8px;
+	height: 8px;
+	border-radius: 99px;
+	flex-shrink: 0;
 }
-.rv-check-dot-pass { background: var(--green); }
-.rv-check-dot-fail { background: var(--red); }
+.rv-check-dot-pass {
+	background: var(--green);
+}
+.rv-check-dot-fail {
+	background: var(--red);
+}
 .rv-check-dot-pending {
-  background: #d9a23a;
-  animation: rv-pulse 1.4s ease-in-out infinite;
+	background: #d9a23a;
+	animation: rv-pulse 1.4s ease-in-out infinite;
 }
-@keyframes rv-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
-.rv-checks-pass .rv-checks-label { color: var(--green); }
-.rv-checks-fail .rv-checks-label { color: var(--red); }
-.rv-checks-pending .rv-checks-label { color: #d9a23a; }
-.rv-checks-label { white-space: nowrap; }
+@keyframes rv-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.35;
+	}
+}
+.rv-checks-pass .rv-checks-label {
+	color: var(--green);
+}
+.rv-checks-fail .rv-checks-label {
+	color: var(--red);
+}
+.rv-checks-pending .rv-checks-label {
+	color: #d9a23a;
+}
+.rv-checks-label {
+	white-space: nowrap;
+}
 .rv-checks-bar {
-  display: inline-flex;
-  width: 46px;
-  height: 4px;
-  border-radius: 99px;
-  overflow: hidden;
-  background: var(--bg-active);
-  flex-shrink: 0;
+	display: inline-flex;
+	width: 46px;
+	height: 4px;
+	border-radius: 99px;
+	overflow: hidden;
+	background: var(--bg-active);
+	flex-shrink: 0;
 }
-.rv-bar-seg { height: 100%; }
-.rv-bar-pass { background: var(--green); }
-.rv-bar-fail { background: var(--red); }
-.rv-bar-pending { background: #d9a23a; }
+.rv-bar-seg {
+	height: 100%;
+}
+.rv-bar-pass {
+	background: var(--green);
+}
+.rv-bar-fail {
+	background: var(--red);
+}
+.rv-bar-pending {
+	background: #d9a23a;
+}
 
 /* Review decision */
 .rv-review {
-  font-size: 12px;
-  font-weight: 550;
-  white-space: nowrap;
+	font-size: 12px;
+	font-weight: 550;
+	white-space: nowrap;
 }
-.rv-review-approved { color: var(--green); }
-.rv-review-changes { color: #d9a23a; }
-.rv-review-pending { color: var(--text-faint); }
+.rv-review-approved {
+	color: var(--green);
+}
+.rv-review-changes {
+	color: #d9a23a;
+}
+.rv-review-pending {
+	color: var(--text-faint);
+}
 
 /* Changes / diffstat */
 .rv-changes {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 4px;
+	display: inline-flex;
+	flex-direction: column;
+	gap: 4px;
 }
 .rv-diffstat {
-  display: inline-flex;
-  gap: 7px;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  font-family: var(--mono);
+	display: inline-flex;
+	gap: 7px;
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+	font-family: var(--mono);
 }
-.rv-add { color: var(--green); }
-.rv-del { color: var(--red); }
-.rv-diffsquares { display: inline-flex; gap: 2px; }
-.rv-sq { width: 8px; height: 8px; border-radius: 2px; }
-.rv-sq-add { background: var(--green); }
-.rv-sq-del { background: var(--red); }
-.rv-sq-none { background: var(--border-strong); }
+.rv-add {
+	color: var(--green);
+}
+.rv-del {
+	color: var(--red);
+}
+.rv-diffsquares {
+	display: inline-flex;
+	gap: 2px;
+}
+.rv-sq {
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
+}
+.rv-sq-add {
+	background: var(--green);
+}
+.rv-sq-del {
+	background: var(--red);
+}
+.rv-sq-none {
+	background: var(--border-strong);
+}
 
 /* Author */
 .rv-c-author {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
 }
 .rv-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 99px;
-  flex-shrink: 0;
-  background: var(--bg-active);
+	width: 22px;
+	height: 22px;
+	border-radius: 99px;
+	flex-shrink: 0;
+	background: var(--bg-active);
 }
 .rv-author-name {
-  font-size: 12.5px;
-  color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-size: 12.5px;
+	color: var(--text-dim);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .rv-c-updated {
-  font-size: 12.5px;
-  color: var(--text-faint);
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
+	font-size: 12.5px;
+	color: var(--text-faint);
+	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
 }
 
 .reviews-empty {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 /* ── Detail drawer ──────────────────────────────────────── */
 .reviews-drawer {
-  flex: 1 1 auto;
-  min-width: 0;
-  border-left: 1px solid var(--border);
-  background: var(--bg-panel);
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+	flex: 1 1 auto;
+	min-width: 0;
+	border-left: 1px solid var(--border);
+	background: var(--bg-panel);
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 .reviews-drawer-head {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--border);
+	flex-shrink: 0;
 }
 .reviews-drawer-close {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	background: none;
+	border: none;
+	color: var(--text-dim);
+	cursor: pointer;
+	flex-shrink: 0;
 }
-.reviews-drawer-close:hover { background: var(--bg-hover); color: var(--text); }
+.reviews-drawer-close:hover {
+	background: var(--bg-hover);
+	color: var(--text);
+}
 .reviews-drawer-back {
-  display: none;
-  align-items: center;
-  gap: 7px;
-  background: none;
-  border: none;
-  padding: 4px 6px;
-  margin: -4px 0 -4px -2px;
-  font: inherit;
-  font-size: 14px;
-  font-weight: 550;
-  color: var(--text);
-  cursor: pointer;
+	display: none;
+	align-items: center;
+	gap: 7px;
+	background: none;
+	border: none;
+	padding: 4px 6px;
+	margin: -4px 0 -4px -2px;
+	font: inherit;
+	font-size: 14px;
+	font-weight: 550;
+	color: var(--text);
+	cursor: pointer;
 }
-.reviews-drawer-back svg { color: var(--text-dim); }
+.reviews-drawer-back svg {
+	color: var(--text-dim);
+}
 .reviews-drawer-title {
-  font-size: 13.5px;
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	font-size: 13.5px;
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 .reviews-drawer-body {
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
 }
 
 /* When a PR is open the list collapses to a compact rail (GitHub split view):
    the diff is the hero, the list just keeps you oriented. */
 .reviews-has-detail .reviews-main {
-  flex: 0 0 360px;
-  border-right: 1px solid var(--border);
+	flex: 0 0 360px;
+	border-right: 1px solid var(--border);
 }
-.reviews-has-detail .reviews-search { display: none; }
-.reviews-has-detail .reviews-header { padding: 14px 16px 0; }
-.reviews-has-detail .reviews-title { font-size: 16px; }
-.reviews-has-detail .reviews-tabs { overflow-x: auto; }
+.reviews-has-detail .reviews-search {
+	display: none;
+}
+.reviews-has-detail .reviews-header {
+	padding: 14px 16px 0;
+}
+.reviews-has-detail .reviews-title {
+	font-size: 16px;
+}
+.reviews-has-detail .reviews-tabs {
+	overflow-x: auto;
+}
 .reviews-has-detail .reviews-row {
-  grid-template-columns: 22px minmax(0, 1fr) auto;
-  gap: 10px;
-  padding: 10px 16px;
+	grid-template-columns: 22px minmax(0, 1fr) auto;
+	gap: 10px;
+	padding: 10px 16px;
 }
 .reviews-has-detail .reviews-row-head,
 .reviews-has-detail .rv-state-label,
@@ -2267,13 +2806,20 @@ a {
 .reviews-has-detail .rv-c-author,
 .reviews-has-detail .rv-c-changes,
 .reviews-has-detail .rv-c-updated {
-  display: none;
+	display: none;
 }
-.reviews-has-detail .rv-checks-label { font-size: 12px; }
+.reviews-has-detail .rv-checks-label {
+	font-size: 12px;
+}
 
 @media (max-width: 1180px) {
-  .reviews-row { grid-template-columns: 88px minmax(0, 1fr) 150px 118px 78px; }
-  .rv-c-review, .rv-c-author { display: none; }
+	.reviews-row {
+		grid-template-columns: 88px minmax(0, 1fr) 150px 118px 78px;
+	}
+	.rv-c-review,
+	.rv-c-author {
+		display: none;
+	}
 }
 
 /* ── Mobile: card rows + nested full-screen detail ──────────
@@ -2282,2522 +2828,3026 @@ a {
    author · time), and opening a PR pushes a full-screen detail view with a
    back affordance — a nested master→detail flow instead of a squished split. */
 @media (max-width: 720px) {
-  .reviews-table .reviews-row.reviews-row-head { display: none; }
-  .reviews-table .reviews-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    row-gap: 9px;
-    column-gap: 12px;
-    padding: 14px 16px;
-  }
-  .reviews-row .rv-c-state { order: 1; }
-  .reviews-row .rv-c-title {
-    order: 2;
-    flex: 1 1 calc(100% - 90px);
-    min-width: 0;
-  }
-  /* second line: every remaining signal, re-shown and reflowed */
-  .reviews-row .rv-c-checks { order: 3; display: inline-flex; }
-  .reviews-row .rv-c-changes { order: 4; display: inline-flex; flex-direction: row; align-items: center; gap: 8px; }
-  .reviews-row .rv-c-review { order: 5; display: inline-flex; }
-  .reviews-row .rv-c-author { order: 6; display: inline-flex; }
-  .reviews-row .rv-c-updated { order: 7; margin-left: auto; }
-  .rv-checks-bar { display: none; }
+	.reviews-table .reviews-row.reviews-row-head {
+		display: none;
+	}
+	.reviews-table .reviews-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		row-gap: 9px;
+		column-gap: 12px;
+		padding: 14px 16px;
+	}
+	.reviews-row .rv-c-state {
+		order: 1;
+	}
+	.reviews-row .rv-c-title {
+		order: 2;
+		flex: 1 1 calc(100% - 90px);
+		min-width: 0;
+	}
+	/* second line: every remaining signal, re-shown and reflowed */
+	.reviews-row .rv-c-checks {
+		order: 3;
+		display: inline-flex;
+	}
+	.reviews-row .rv-c-changes {
+		order: 4;
+		display: inline-flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 8px;
+	}
+	.reviews-row .rv-c-review {
+		order: 5;
+		display: inline-flex;
+	}
+	.reviews-row .rv-c-author {
+		order: 6;
+		display: inline-flex;
+	}
+	.reviews-row .rv-c-updated {
+		order: 7;
+		margin-left: auto;
+	}
+	.rv-checks-bar {
+		display: none;
+	}
 
-  /* the list and detail are separate screens, not a split */
-  .reviews-has-detail .reviews-main { display: none; }
-  .reviews-has-detail .reviews-drawer {
-    position: absolute;
-    inset: 0;
-    z-index: 20;
-    border-left: none;
-  }
-  .reviews-drawer-close, .reviews-has-detail .reviews-drawer-title { display: none; }
-  .reviews-drawer-back { display: inline-flex; }
-  .reviews-drawer-body { overflow-y: auto; }
+	/* the list and detail are separate screens, not a split */
+	.reviews-has-detail .reviews-main {
+		display: none;
+	}
+	.reviews-has-detail .reviews-drawer {
+		position: absolute;
+		inset: 0;
+		z-index: 20;
+		border-left: none;
+	}
+	.reviews-drawer-close,
+	.reviews-has-detail .reviews-drawer-title {
+		display: none;
+	}
+	.reviews-drawer-back {
+		display: inline-flex;
+	}
+	.reviews-drawer-body {
+		overflow-y: auto;
+	}
 
-  /* the PrPanel split stacks: info, then the diff below */
-  .pr-panel-split { flex-direction: column; height: auto; }
-  .pr-panel-split .pr-panel-info {
-    width: auto;
-    flex-shrink: 1;
-    overflow-y: visible;
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
-  .pr-panel-split .pr-panel-diff { overflow-y: visible; }
+	/* the PrPanel split stacks: info, then the diff below */
+	.pr-panel-split {
+		flex-direction: column;
+		height: auto;
+	}
+	.pr-panel-split .pr-panel-info {
+		width: auto;
+		flex-shrink: 1;
+		overflow-y: visible;
+		border-right: none;
+		border-bottom: 1px solid var(--border);
+	}
+	.pr-panel-split .pr-panel-diff {
+		overflow-y: visible;
+	}
 }
 
 /* ── Messages ────────────────────────────────────────────── */
 
 /* Holds the scroll area plus the floating "Jump to latest" pill. */
 .viewer-messages-region {
-  position: relative;
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
+	position: relative;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
 }
 
 .viewer-messages {
-  flex: 1;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 18px 20px 10px;
-  min-height: 0;
-  /* Keep the reader's place when content loads/expands above them (principle 12):
+	flex: 1;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	padding: 18px 20px 10px;
+	min-height: 0;
+	/* Keep the reader's place when content loads/expands above them (principle 12):
      the browser anchors scroll to on-screen content instead of jumping. */
-  overflow-anchor: auto;
+	overflow-anchor: auto;
 }
 
 /* The streaming tail is excluded from anchoring so a glued-to-bottom follow
    isn't fought by the anchor as tokens append. */
-.msg-streaming { overflow-anchor: none; }
+.msg-streaming {
+	overflow-anchor: none;
+}
 
 /* "Load earlier history" — shown when the initial view is only the tail of a
    large transcript. Excluded from scroll anchoring so the click-to-expand keeps
    the reader's place via the content below it. */
 .load-history {
-  display: flex;
-  justify-content: center;
-  padding: 4px 0 14px;
-  overflow-anchor: none;
+	display: flex;
+	justify-content: center;
+	padding: 4px 0 14px;
+	overflow-anchor: none;
 }
 .load-history-btn {
-  font: inherit;
-  font-size: 12px;
-  color: var(--text-dim);
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 5px 14px;
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+	font: inherit;
+	font-size: 12px;
+	color: var(--text-dim);
+	background: var(--bg-raised);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 5px 14px;
+	cursor: pointer;
+	transition:
+		background 0.12s,
+		color 0.12s;
 }
 .load-history-btn:hover:not(:disabled) {
-  background: var(--bg-hover);
-  color: var(--text);
+	background: var(--bg-hover);
+	color: var(--text);
 }
-.load-history-btn:disabled { opacity: 0.6; cursor: default; }
+.load-history-btn:disabled {
+	opacity: 0.6;
+	cursor: default;
+}
 
 /* Bottom spacer that lets the latest turn reach the top of the viewport. Height is
    set imperatively by the scroll hook; no transition so it tracks streaming exactly. */
 .turn-spacer {
-  flex-shrink: 0;
-  height: 0;
-  pointer-events: none;
-  overflow-anchor: none;
+	flex-shrink: 0;
+	height: 0;
+	pointer-events: none;
+	overflow-anchor: none;
 }
 
 /* Make it easy to return to the latest reply (principles 8 & 9). Floats just
    above the composer; appears only when the reader has scrolled away. */
 .jump-latest {
-  position: absolute;
-  left: 50%;
-  bottom: 14px;
-  transform: translateX(-50%);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 7px 14px;
-  font-size: 12.5px;
-  font-weight: 600;
-  color: var(--text);
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 99px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-  cursor: pointer;
-  z-index: 5;
-  animation: jump-rise 0.18s ease-out;
+	position: absolute;
+	left: 50%;
+	bottom: 14px;
+	transform: translateX(-50%);
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 7px 14px;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: var(--text);
+	background: var(--bg-raised);
+	border: 1px solid var(--border);
+	border-radius: 99px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+	cursor: pointer;
+	z-index: 5;
+	animation: jump-rise 0.18s ease-out;
 }
-.jump-latest:hover { border-color: var(--accent); }
-.jump-latest-arrow { font-size: 14px; line-height: 1; }
+.jump-latest:hover {
+	border-color: var(--accent);
+}
+.jump-latest-arrow {
+	font-size: 14px;
+	line-height: 1;
+}
 /* Content arrived out of view — draw the eye with the accent. */
 .jump-latest-new {
-  border-color: var(--accent);
-  color: var(--accent);
+	border-color: var(--accent);
+	color: var(--accent);
 }
-.jump-latest-new .jump-latest-arrow { animation: pulse 1s ease-in-out infinite; }
+.jump-latest-new .jump-latest-arrow {
+	animation: pulse 1s ease-in-out infinite;
+}
 
 @keyframes jump-rise {
-  from { opacity: 0; transform: translate(-50%, 6px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
+	from {
+		opacity: 0;
+		transform: translate(-50%, 6px);
+	}
+	to {
+		opacity: 1;
+		transform: translate(-50%, 0);
+	}
 }
 
 .msg {
-  margin-bottom: 18px;
-  max-width: 860px;
-  margin-left: auto;
-  margin-right: auto;
+	margin-bottom: 18px;
+	max-width: 860px;
+	margin-left: auto;
+	margin-right: auto;
 }
 
-.msg-user { margin-top: 22px; }
+.msg-user {
+	margin-top: 22px;
+}
 
 .msg-label {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 10.5px;
-  font-weight: 600;
-  margin-bottom: 5px;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--text-faint);
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 10.5px;
+	font-weight: 600;
+	margin-bottom: 5px;
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	color: var(--text-faint);
 }
 .msg-label::before {
-  content: "";
-  width: 7px;
-  height: 7px;
-  flex-shrink: 0;
+	content: "";
+	width: 7px;
+	height: 7px;
+	flex-shrink: 0;
 }
 .msg-label-user::before {
-  border-radius: 2px;
-  background: #5b7cfa;
-  opacity: 0.9;
+	border-radius: 2px;
+	background: #5b7cfa;
+	opacity: 0.9;
 }
 .msg-label-assistant::before {
-  border-radius: 50%;
-  background: linear-gradient(135deg, #ff5a5a, #b00000);
+	border-radius: 50%;
+	background: linear-gradient(135deg, #ff5a5a, #b00000);
 }
 
 .msg-body {
-  line-height: 1.65;
-  font-size: 14px;
-  word-break: break-word;
+	line-height: 1.65;
+	font-size: 14px;
+	word-break: break-word;
 }
 
 .msg-body-user {
-  display: inline-block;
-  max-width: 100%;
-  background: rgba(91, 124, 250, 0.12);
-  border: 1px solid rgba(91, 124, 250, 0.28);
-  border-radius: 12px;
-  border-top-left-radius: 4px;
-  padding: 9px 14px;
-  color: var(--text);
+	display: inline-block;
+	max-width: 100%;
+	background: rgba(91, 124, 250, 0.12);
+	border: 1px solid rgba(91, 124, 250, 0.28);
+	border-radius: 12px;
+	border-top-left-radius: 4px;
+	padding: 9px 14px;
+	color: var(--text);
 }
 
-.msg-body-assistant { color: var(--text); }
+.msg-body-assistant {
+	color: var(--text);
+}
 
 /* Human-in-the-loop: a teammate's reply routed back into the session. Distinct
    from the driver's own blue "You" bubbles — a warm teal, to read as someone
    else stepping in. */
-.msg-human { margin-top: 22px; }
-.msg-label-human { color: #1f9e8a; }
+.msg-human {
+	margin-top: 22px;
+}
+.msg-label-human {
+	color: #1f9e8a;
+}
 .msg-label-human::before {
-  border-radius: 50%;
-  background: linear-gradient(135deg, #28d3b4, #0f8f7a);
+	border-radius: 50%;
+	background: linear-gradient(135deg, #28d3b4, #0f8f7a);
 }
 .msg-body-human {
-  display: inline-block;
-  max-width: 100%;
-  background: rgba(31, 158, 138, 0.12);
-  border: 1px solid rgba(31, 158, 138, 0.3);
-  border-radius: 12px;
-  border-top-left-radius: 4px;
-  padding: 9px 14px;
-  color: var(--text);
+	display: inline-block;
+	max-width: 100%;
+	background: rgba(31, 158, 138, 0.12);
+	border: 1px solid rgba(31, 158, 138, 0.3);
+	border-radius: 12px;
+	border-top-left-radius: 4px;
+	padding: 9px 14px;
+	color: var(--text);
 }
 
 .msg-streaming .msg-body-assistant::after {
-  content: "";
-  display: inline-block;
-  width: 7px;
-  height: 14px;
-  margin-left: 3px;
-  vertical-align: -2px;
-  border-radius: 2px;
-  background: var(--accent);
-  animation: pulse 1s ease-in-out infinite;
+	content: "";
+	display: inline-block;
+	width: 7px;
+	height: 14px;
+	margin-left: 3px;
+	vertical-align: -2px;
+	border-radius: 2px;
+	background: var(--accent);
+	animation: pulse 1s ease-in-out infinite;
 }
 
 .msg-system {
-  text-align: center;
-  /* `auto` left/right keeps this in the same centered column as user/assistant
+	text-align: center;
+	/* `auto` left/right keeps this in the same centered column as user/assistant
      bubbles — a bare `0` here pins it to the left edge and the pill reads
      off-center against the conversation. */
-  margin: 12px auto;
+	margin: 12px auto;
 }
 .msg-system-text {
-  display: inline-block;
-  max-width: min(560px, 100%);
-  color: var(--text-faint);
-  font-size: 11.5px;
-  line-height: 1.45;
-  text-align: center;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 6px 14px;
+	display: inline-block;
+	max-width: min(560px, 100%);
+	color: var(--text-faint);
+	font-size: 11.5px;
+	line-height: 1.45;
+	text-align: center;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 6px 14px;
 }
 
 /* Restart overlay (covers the UI while the server redeploys) */
 .update-toast {
-  position: fixed;
-  left: 50%;
-  bottom: 22px;
-  transform: translateX(-50%);
-  z-index: 9000;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  max-width: calc(100vw - 32px);
-  padding: 10px 12px 10px 16px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 12px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
-  animation: toast-rise 0.22s ease-out;
+	position: fixed;
+	left: 50%;
+	bottom: 22px;
+	transform: translateX(-50%);
+	z-index: 9000;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	max-width: calc(100vw - 32px);
+	padding: 10px 12px 10px 16px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 12px;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+	animation: toast-rise 0.22s ease-out;
 }
 @keyframes toast-rise {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(-50%) translateY(0);
+	}
 }
 .update-toast-text {
-  font-size: 13px;
-  color: var(--text);
+	font-size: 13px;
+	color: var(--text);
 }
 .update-toast-refresh {
-  font-size: 13px;
-  font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 8px;
-  border: none;
-  background: var(--accent);
-  color: #fff;
-  cursor: pointer;
+	font-size: 13px;
+	font-weight: 600;
+	padding: 6px 12px;
+	border-radius: 8px;
+	border: none;
+	background: var(--accent);
+	color: #fff;
+	cursor: pointer;
 }
-.update-toast-refresh:hover { filter: brightness(1.08); }
+.update-toast-refresh:hover {
+	filter: brightness(1.08);
+}
 .update-toast-dismiss {
-  font-size: 13px;
-  line-height: 1;
-  padding: 4px 6px;
-  border: none;
-  background: transparent;
-  color: var(--text-dim);
-  cursor: pointer;
+	font-size: 13px;
+	line-height: 1;
+	padding: 4px 6px;
+	border: none;
+	background: transparent;
+	color: var(--text-dim);
+	cursor: pointer;
 }
-.update-toast-dismiss:hover { color: var(--text); }
+.update-toast-dismiss:hover {
+	color: var(--text);
+}
 @media (max-width: 520px) {
-  .update-toast { bottom: 14px; }
+	.update-toast {
+		bottom: 14px;
+	}
 }
 
 .restart-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 10000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  background: rgba(7, 5, 6, 0.82);
-  backdrop-filter: blur(4px);
+	position: fixed;
+	inset: 0;
+	z-index: 10000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: rgba(7, 5, 6, 0.82);
+	backdrop-filter: blur(4px);
 }
 .restart-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: 14px;
-  max-width: 340px;
-  padding: 28px 26px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 14px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 14px;
+	max-width: 340px;
+	padding: 28px 26px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 14px;
 }
 .restart-spinner {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 2.5px solid var(--border-strong);
-  border-top-color: var(--accent);
-  animation: spin 0.8s linear infinite;
+	width: 30px;
+	height: 30px;
+	border-radius: 50%;
+	border: 2.5px solid var(--border-strong);
+	border-top-color: var(--accent);
+	animation: spin 0.8s linear infinite;
 }
 .restart-spinner-done {
-  border-color: var(--green);
-  border-top-color: var(--green);
-  animation: none;
+	border-color: var(--green);
+	border-top-color: var(--green);
+	animation: none;
 }
 @keyframes spin {
-  to { transform: rotate(360deg); }
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 /* Covers the session view while a delete (optionally + worktree) is in flight —
    worktree cleanup can take a few seconds, so show clear progress instead of a
    view that looks frozen. Stays up through the redirect to Home. */
 .session-delete-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 30;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--bg) 72%, transparent);
-  backdrop-filter: blur(2px);
+	position: absolute;
+	inset: 0;
+	z-index: 30;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix(in srgb, var(--bg) 72%, transparent);
+	backdrop-filter: blur(2px);
 }
 .session-delete-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
-  padding: 26px 32px;
-  border-radius: 12px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 14px;
+	padding: 26px 32px;
+	border-radius: 12px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
 }
 .session-delete-label {
-  font-size: 13px;
-  color: var(--text-dim);
+	font-size: 13px;
+	color: var(--text-dim);
 }
 .restart-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--text);
 }
 .restart-sub {
-  font-size: 12.5px;
-  line-height: 1.5;
-  color: var(--text-dim);
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--text-dim);
 }
 
 /* markdown content */
-.markdown p { margin: 0 0 6px; }
+.markdown p {
+	margin: 0 0 6px;
+}
 
-.markdown a { color: var(--accent); text-decoration: none; }
-.markdown a:hover { text-decoration: underline; }
+.markdown a {
+	color: var(--accent);
+	text-decoration: none;
+}
+.markdown a:hover {
+	text-decoration: underline;
+}
 
-.markdown strong { font-weight: 600; color: var(--text); }
+.markdown strong {
+	font-weight: 600;
+	color: var(--text);
+}
 
 .markdown pre {
-  background: #0c0c10;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
-  margin: 2px 0 8px;
-  overflow-x: auto;
-  font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.55;
+	background: #0c0c10;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 10px 12px;
+	margin: 2px 0 8px;
+	overflow-x: auto;
+	font-family: var(--mono);
+	font-size: 12px;
+	line-height: 1.55;
 }
 
 .markdown code {
-  font-family: var(--mono);
-  font-size: 0.9em;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 4px;
-  padding: 1.5px 5px;
-  color: #dde1f0;
+	font-family: var(--mono);
+	font-size: 0.9em;
+	background: rgba(255, 255, 255, 0.06);
+	border-radius: 4px;
+	padding: 1.5px 5px;
+	color: #dde1f0;
 }
 .markdown pre code {
-  background: none;
-  padding: 0;
-  font-size: 12px;
-  color: inherit;
+	background: none;
+	padding: 0;
+	font-size: 12px;
+	color: inherit;
 }
 
-.markdown ul, .markdown ol { margin: 0 0 6px; padding-left: 20px; }
-.markdown li { margin: 2.5px 0; }
-.markdown li > ul, .markdown li > ol { margin: 2px 0 0; }
-
-.markdown h1, .markdown h2, .markdown h3, .markdown h4 {
-  margin: 6px 0 1px;
-  line-height: 1.3;
-  font-weight: 600;
-  color: var(--text);
+.markdown ul,
+.markdown ol {
+	margin: 0 0 6px;
+	padding-left: 20px;
 }
-.markdown h1 { font-size: 15.5px; }
-.markdown h2 { font-size: 14.5px; }
-.markdown h3, .markdown h4 { font-size: 13.5px; }
+.markdown li {
+	margin: 2.5px 0;
+}
+.markdown li > ul,
+.markdown li > ol {
+	margin: 2px 0 0;
+}
 
-.markdown > :first-child { margin-top: 0; }
-.markdown > :last-child { margin-bottom: 0; }
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4 {
+	margin: 6px 0 1px;
+	line-height: 1.3;
+	font-weight: 600;
+	color: var(--text);
+}
+.markdown h1 {
+	font-size: 15.5px;
+}
+.markdown h2 {
+	font-size: 14.5px;
+}
+.markdown h3,
+.markdown h4 {
+	font-size: 13.5px;
+}
+
+.markdown > :first-child {
+	margin-top: 0;
+}
+.markdown > :last-child {
+	margin-bottom: 0;
+}
 
 .markdown blockquote {
-  margin: 2px 0 8px;
-  padding: 3px 12px;
-  border-left: 2px solid rgba(255, 59, 59, 0.4);
-  color: var(--text-dim);
+	margin: 2px 0 8px;
+	padding: 3px 12px;
+	border-left: 2px solid rgba(255, 59, 59, 0.4);
+	color: var(--text-dim);
 }
 
 .markdown table {
-  border-collapse: collapse;
-  margin: 2px 0 10px;
-  font-size: 12.5px;
-  display: block;
-  overflow-x: auto;
-  max-width: 100%;
+	border-collapse: collapse;
+	margin: 2px 0 10px;
+	font-size: 12.5px;
+	display: block;
+	overflow-x: auto;
+	max-width: 100%;
 }
 .markdown th {
-  text-align: left;
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
-  border-bottom: 1px solid var(--border-strong);
-  padding: 4px 16px 5px 0;
+	text-align: left;
+	font-size: 10.5px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
+	border-bottom: 1px solid var(--border-strong);
+	padding: 4px 16px 5px 0;
 }
 .markdown td {
-  border-bottom: 1px solid var(--border);
-  padding: 6px 16px 6px 0;
-  vertical-align: top;
+	border-bottom: 1px solid var(--border);
+	padding: 6px 16px 6px 0;
+	vertical-align: top;
 }
-.markdown tr:last-child td { border-bottom: none; }
+.markdown tr:last-child td {
+	border-bottom: none;
+}
 
 .markdown hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 12px 0;
+	border: none;
+	border-top: 1px solid var(--border);
+	margin: 12px 0;
 }
 
 /* ── Home dashboard ──────────────────────────────────────── */
 
 .home {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
 }
 
 .home-inner {
-  max-width: 760px;
-  margin: 0 auto;
-  padding: 40px 24px 60px;
+	max-width: 760px;
+	margin: 0 auto;
+	padding: 40px 24px 60px;
 }
 
 .home-hero {
-  margin-bottom: 36px;
+	margin-bottom: 36px;
 }
 
 .home-greeting {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  margin-bottom: 16px;
-  text-align: center;
+	font-size: 22px;
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	margin-bottom: 16px;
+	text-align: center;
 }
 
 .ask-box {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 14px;
-  padding: 12px;
-  transition: border-color 0.15s;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 14px;
+	padding: 12px;
+	transition: border-color 0.15s;
 }
-.ask-box:focus-within { border-color: var(--accent); }
+.ask-box:focus-within {
+	border-color: var(--accent);
+}
 
 .ask-input {
-  width: 100%;
-  background: none;
-  border: none;
-  color: var(--text);
-  font-size: 14.5px;
-  line-height: 1.5;
-  resize: none;
-  outline: none;
-  padding: 2px 4px 8px;
+	width: 100%;
+	background: none;
+	border: none;
+	color: var(--text);
+	font-size: 14.5px;
+	line-height: 1.5;
+	resize: none;
+	outline: none;
+	padding: 2px 4px 8px;
 }
-.ask-input::placeholder { color: var(--text-faint); }
+.ask-input::placeholder {
+	color: var(--text-faint);
+}
 
 .ask-actions {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
+	display: flex;
+	justify-content: space-between;
+	gap: 10px;
 }
-
 
 .btn-task {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text-dim);
-  padding: 7px 14px;
-  font-size: 13px;
-  font-weight: 500;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text-dim);
+	padding: 7px 14px;
+	font-size: 13px;
+	font-weight: 500;
 }
-.btn-task:hover { color: var(--text); border-color: var(--text-faint); }
+.btn-task:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
 
 .btn-ask {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 7px;
-  padding: 7px 22px;
-  font-size: 13px;
-  font-weight: 600;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 7px;
+	padding: 7px 22px;
+	font-size: 13px;
+	font-weight: 600;
 }
-.btn-ask:disabled { opacity: 0.4; cursor: default; }
-.btn-ask:not(:disabled):hover { filter: brightness(1.1); }
+.btn-ask:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.btn-ask:not(:disabled):hover {
+	filter: brightness(1.1);
+}
 
 .ask-suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 7px;
-  margin-top: 12px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 7px;
+	margin-top: 12px;
 }
 
 .ask-suggestion {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 99px;
-  color: var(--text-dim);
-  font-size: 12px;
-  padding: 5px 12px;
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 99px;
+	color: var(--text-dim);
+	font-size: 12px;
+	padding: 5px 12px;
+	max-width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .ask-suggestion:hover {
-  color: var(--text);
-  border-color: var(--border-strong);
-  background: var(--bg-hover);
+	color: var(--text);
+	border-color: var(--border-strong);
+	background: var(--bg-hover);
 }
 
 .ask-suggestion-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
 }
 
-.home-section { margin-bottom: 26px; }
+.home-section {
+	margin-bottom: 26px;
+}
 
 .home-section-title {
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
-  margin-bottom: 8px;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
+	margin-bottom: 8px;
 }
 
 .home-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .home-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  width: 100%;
-  text-align: left;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 11px 14px;
-  color: var(--text);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	width: 100%;
+	text-align: left;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	padding: 11px 14px;
+	color: var(--text);
+	min-width: 0;
 }
-.home-row:hover { border-color: var(--border-strong); background: var(--bg-hover); }
+.home-row:hover {
+	border-color: var(--border-strong);
+	background: var(--bg-hover);
+}
 
 .home-row-main {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 .home-row-title {
-  font-size: 13.5px;
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	font-size: 13.5px;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .home-row-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 11.5px;
-  color: var(--text-faint);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-size: 11.5px;
+	color: var(--text-faint);
+	min-width: 0;
 }
 
 .home-row-branch {
-  font-family: var(--mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	font-family: var(--mono);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .home-empty {
-  color: var(--text-faint);
-  font-size: 13px;
-  padding: 14px 4px;
+	color: var(--text-faint);
+	font-size: 13px;
+	padding: 14px 4px;
 }
 
 .status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 700;
-  padding: 3px 10px;
-  border-radius: 99px;
-  flex-shrink: 0;
-  min-width: 70px;
-  justify-content: center;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11px;
+	font-weight: 700;
+	padding: 3px 10px;
+	border-radius: 99px;
+	flex-shrink: 0;
+	min-width: 70px;
+	justify-content: center;
 }
-.status-green { background: var(--green-soft); color: var(--green); }
-.status-blue { background: var(--accent-soft); color: var(--accent); }
-.status-purple { background: rgba(163, 113, 247, 0.16); color: var(--purple); }
-.status-red { background: var(--red-soft); color: var(--red); }
-.status-yellow { background: rgba(210, 153, 34, 0.15); color: var(--yellow); }
-.status-gray { background: var(--bg-active); color: var(--text-faint); }
+.status-green {
+	background: var(--green-soft);
+	color: var(--green);
+}
+.status-blue {
+	background: var(--accent-soft);
+	color: var(--accent);
+}
+.status-purple {
+	background: rgba(163, 113, 247, 0.16);
+	color: var(--purple);
+}
+.status-red {
+	background: var(--red-soft);
+	color: var(--red);
+}
+.status-yellow {
+	background: rgba(210, 153, 34, 0.15);
+	color: var(--yellow);
+}
+.status-gray {
+	background: var(--bg-active);
+	color: var(--text-faint);
+}
 
 .pin-btn {
-  color: var(--text-faint);
-  font-size: 15px;
-  padding: 4px 6px;
-  border-radius: 5px;
-  flex-shrink: 0;
+	color: var(--text-faint);
+	font-size: 15px;
+	padding: 4px 6px;
+	border-radius: 5px;
+	flex-shrink: 0;
 }
-.pin-btn:hover { color: var(--yellow); background: var(--bg-active); }
-.pin-active { color: var(--yellow); }
+.pin-btn:hover {
+	color: var(--yellow);
+	background: var(--bg-active);
+}
+.pin-active {
+	color: var(--yellow);
+}
 
 /* ── Work blocks (Devin-style "Worked for Xs") ───────────── */
 
 .work-block {
-  max-width: 860px;
-  margin: 0 auto 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-raised);
-  overflow: hidden;
+	max-width: 860px;
+	margin: 0 auto 12px;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: var(--bg-raised);
+	overflow: hidden;
 }
 
-.work-block-live { border-color: rgba(63, 185, 80, 0.35); }
+.work-block-live {
+	border-color: rgba(63, 185, 80, 0.35);
+}
 
 .work-block-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: none;
-  border: none;
-  padding: 8px 12px;
-  color: var(--text-dim);
-  font-size: 12.5px;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	background: none;
+	border: none;
+	padding: 8px 12px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	min-width: 0;
 }
-.work-block-header:hover { background: var(--bg-hover); }
+.work-block-header:hover {
+	background: var(--bg-hover);
+}
 
-.work-block-chevron { font-size: 9px; flex-shrink: 0; }
+.work-block-chevron {
+	font-size: 9px;
+	flex-shrink: 0;
+}
 
 .work-block-title {
-  font-weight: 600;
-  color: var(--text-dim);
-  flex-shrink: 0;
+	font-weight: 600;
+	color: var(--text-dim);
+	flex-shrink: 0;
 }
 
 .work-block-steps {
-  color: var(--text-faint);
-  flex-shrink: 0;
+	color: var(--text-faint);
+	flex-shrink: 0;
 }
 
 .work-block-preview {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-faint);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-faint);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .work-block-spinner {
-  width: 10px;
-  height: 10px;
-  margin-left: auto;
-  flex-shrink: 0;
-  border: 2px solid var(--green-soft);
-  border-top-color: var(--green);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+	width: 10px;
+	height: 10px;
+	margin-left: auto;
+	flex-shrink: 0;
+	border: 2px solid var(--green-soft);
+	border-top-color: var(--green);
+	border-radius: 50%;
+	animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 .work-block-body {
-  border-top: 1px solid var(--border);
-  padding: 8px 10px;
+	border-top: 1px solid var(--border);
+	padding: 8px 10px;
 }
-.work-block-body .tool { margin-bottom: 4px; }
-.work-block-body .tool:last-child { margin-bottom: 0; }
+.work-block-body .tool {
+	margin-bottom: 4px;
+}
+.work-block-body .tool:last-child {
+	margin-bottom: 0;
+}
 
 /* ── Spin-off menu ───────────────────────────────────────── */
 
-.spinoff { position: relative; }
+.spinoff {
+	position: relative;
+}
 
 .spinoff-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 50;
-  width: 320px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
-  overflow: hidden;
+	position: absolute;
+	top: calc(100% + 6px);
+	right: 0;
+	z-index: 50;
+	width: 320px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+	overflow: hidden;
 }
 
 .spinoff-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  padding: 10px 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-bottom: 1px solid var(--border);
+	padding: 10px 14px;
 }
-.spinoff-item:last-child { border-bottom: none; }
-.spinoff-item:hover { background: var(--bg-hover); }
+.spinoff-item:last-child {
+	border-bottom: none;
+}
+.spinoff-item:hover {
+	background: var(--bg-hover);
+}
 
 .spinoff-item-title {
-  color: var(--text);
-  font-size: 13px;
-  font-weight: 600;
+	color: var(--text);
+	font-size: 13px;
+	font-weight: 600;
 }
 .spinoff-item-sub {
-  color: var(--text-faint);
-  font-size: 11.5px;
-  line-height: 1.4;
+	color: var(--text-faint);
+	font-size: 11.5px;
+	line-height: 1.4;
 }
 
 .spinoff-form {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 50;
-  width: 380px;
-  max-width: 90vw;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
-  padding: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	position: absolute;
+	top: calc(100% + 6px);
+	right: 0;
+	z-index: 50;
+	width: 380px;
+	max-width: 90vw;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+	padding: 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .spinoff-form-title {
-  font-weight: 600;
-  font-size: 13.5px;
+	font-weight: 600;
+	font-size: 13.5px;
 }
 
 .spinoff-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-dim);
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--text-dim);
 }
 
 .spinoff-form input,
 .spinoff-form textarea {
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text);
-  padding: 7px 10px;
-  font-size: 13px;
-  outline: none;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text);
+	padding: 7px 10px;
+	font-size: 13px;
+	outline: none;
 }
 .spinoff-form input:focus,
-.spinoff-form textarea:focus { border-color: var(--accent); }
-.spinoff-form textarea { resize: vertical; line-height: 1.45; }
+.spinoff-form textarea:focus {
+	border-color: var(--accent);
+}
+.spinoff-form textarea {
+	resize: vertical;
+	line-height: 1.45;
+}
 
 .spinoff-form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
 }
 
 .spinoff-note {
-  color: var(--text-faint);
-  font-size: 11.5px;
+	color: var(--text-faint);
+	font-size: 11.5px;
 }
 
 /* automation webhook row */
 .automation-webhook {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid var(--border);
+	min-width: 0;
 }
 
 .automation-webhook-label {
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-faint);
-  flex-shrink: 0;
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--text-faint);
+	flex-shrink: 0;
 }
 
 .automation-webhook-url {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-dim);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+	flex: 1;
 }
 
 /* ── Terminal panel ──────────────────────────────────────── */
 
 .terminal {
-  height: 100%;
-  overflow-y: auto;
-  padding: 12px 14px 24px;
-  font-family: var(--mono);
-  font-size: 11.5px;
-  line-height: 1.55;
-  background: #08080a;
+	height: 100%;
+	overflow-y: auto;
+	padding: 12px 14px 24px;
+	font-family: var(--mono);
+	font-size: 11.5px;
+	line-height: 1.55;
+	background: #08080a;
 }
 
-.terminal-entry { margin-bottom: 12px; }
+.terminal-entry {
+	margin-bottom: 12px;
+}
 
 .terminal-cmd {
-  color: var(--text);
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-weight: 600;
+	color: var(--text);
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-weight: 600;
 }
 
-.terminal-prompt { color: var(--green); }
+.terminal-prompt {
+	color: var(--green);
+}
 
 .terminal-output {
-  margin: 4px 0 0;
-  color: var(--text-dim);
-  white-space: pre-wrap;
-  word-break: break-word;
-  max-height: 360px;
-  overflow-y: auto;
+	margin: 4px 0 0;
+	color: var(--text-dim);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 360px;
+	overflow-y: auto;
 }
 
 .terminal-running {
-  color: var(--yellow);
-  margin-top: 4px;
-  animation: pulse 1.4s infinite;
+	color: var(--yellow);
+	margin-top: 4px;
+	animation: pulse 1.4s infinite;
 }
 
 /* ── Tool calls ──────────────────────────────────────────── */
 
 .tool {
-  max-width: 860px;
-  margin-bottom: 6px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--bg-panel);
-  overflow: hidden;
+	max-width: 860px;
+	margin-bottom: 6px;
+	border: 1px solid var(--border);
+	border-radius: 7px;
+	background: var(--bg-panel);
+	overflow: hidden;
 }
 
 .tool-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  cursor: pointer;
-  font-size: 12.5px;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px;
+	cursor: pointer;
+	font-size: 12.5px;
+	min-width: 0;
 }
-.tool-header:hover { background: var(--bg-hover); }
+.tool-header:hover {
+	background: var(--bg-hover);
+}
 
-.tool-icon { color: var(--text-faint); font-size: 9px; flex-shrink: 0; }
+.tool-icon {
+	color: var(--text-faint);
+	font-size: 9px;
+	flex-shrink: 0;
+}
 
 .tool-name {
-  font-weight: 600;
-  color: var(--purple);
-  font-size: 12px;
-  flex-shrink: 0;
+	font-weight: 600;
+	color: var(--purple);
+	font-size: 12px;
+	flex-shrink: 0;
 }
 
 .tool-summary {
-  color: var(--text-dim);
-  font-family: var(--mono);
-  font-size: 11.5px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
+	color: var(--text-dim);
+	font-family: var(--mono);
+	font-size: 11.5px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+	flex: 1;
 }
 
-.tool-ok { color: var(--green); font-size: 11px; flex-shrink: 0; }
+.tool-ok {
+	color: var(--green);
+	font-size: 11px;
+	flex-shrink: 0;
+}
 
 .tool-detail {
-  border-top: 1px solid var(--border);
-  padding: 10px;
+	border-top: 1px solid var(--border);
+	padding: 10px;
 }
 
 .tool-pre {
-  margin: 0;
-  font-family: var(--mono);
-  font-size: 11.5px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--text-dim);
-  max-height: 320px;
-  overflow-y: auto;
+	margin: 0;
+	font-family: var(--mono);
+	font-size: 11.5px;
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--text-dim);
+	max-height: 320px;
+	overflow-y: auto;
 }
 
 /* Shiki-highlighted variant: keep .tool-pre's box, strip shiki's own chrome */
 .tool-pre-code pre.shiki {
-  margin: 0;
-  padding: 0;
-  background: transparent !important;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  white-space: pre-wrap;
-  word-break: break-word;
+	margin: 0;
+	padding: 0;
+	background: transparent !important;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	white-space: pre-wrap;
+	word-break: break-word;
 }
 .tool-pre-code pre.shiki code {
-  font-family: inherit;
-  font-size: inherit;
+	font-family: inherit;
+	font-size: inherit;
 }
 .shiki-gutter {
-  color: var(--text-faint);
-  user-select: none;
+	color: var(--text-faint);
+	user-select: none;
 }
 
 .tool-result-divider {
-  margin: 10px 0 6px;
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
+	margin: 10px 0 6px;
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
 }
 
 /* ── Input area ──────────────────────────────────────────── */
 
 .viewer-input {
-  border-top: 1px solid var(--border);
-  padding: 12px 20px 14px;
-  background: var(--bg-raised);
-  flex-shrink: 0;
+	border-top: 1px solid var(--border);
+	padding: 12px 20px 14px;
+	background: var(--bg-raised);
+	flex-shrink: 0;
 }
 
 .viewer-input-row {
-  display: flex;
-  gap: 10px;
-  align-items: flex-end;
-  max-width: 860px;
-  margin: 0 auto;
+	display: flex;
+	gap: 10px;
+	align-items: flex-end;
+	max-width: 860px;
+	margin: 0 auto;
 }
 
 .prompt-input {
-  flex: 1;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  color: var(--text);
-  padding: 10px 14px;
-  font-size: 13.5px;
-  line-height: 1.5;
-  resize: vertical;
-  min-height: 44px;
-  outline: none;
+	flex: 1;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	color: var(--text);
+	padding: 10px 14px;
+	font-size: 13.5px;
+	line-height: 1.5;
+	resize: vertical;
+	min-height: 44px;
+	outline: none;
 }
-.prompt-input:focus { border-color: var(--accent); }
-.prompt-input::placeholder { color: var(--text-faint); }
+.prompt-input:focus {
+	border-color: var(--accent);
+}
+.prompt-input::placeholder {
+	color: var(--text-faint);
+}
 
 .btn-send {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 10px 18px;
-  font-size: 13.5px;
-  font-weight: 500;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 8px;
+	padding: 10px 18px;
+	font-size: 13.5px;
+	font-weight: 500;
 }
-.btn-send:disabled { opacity: 0.4; cursor: default; }
-.btn-send:not(:disabled):hover { filter: brightness(1.1); }
+.btn-send:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.btn-send:not(:disabled):hover {
+	filter: brightness(1.1);
+}
 
 /* ── Composer (shared chat input — Claude/Codex style) ─────────────── */
 
 .composer-wrap {
-  max-width: 860px;
-  margin: 0 auto;
-  width: 100%;
+	max-width: 860px;
+	margin: 0 auto;
+	width: 100%;
 }
 
 .composer {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 16px;
-  padding: 12px 12px 8px 14px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 16px;
+	padding: 12px 12px 8px 14px;
+	transition:
+		border-color 0.15s,
+		box-shadow 0.15s;
 }
 .composer:focus-within {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+	border-color: var(--accent);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
 }
-.composer-disabled { opacity: 0.6; }
+.composer-disabled {
+	opacity: 0.6;
+}
 
 .composer-textarea {
-  display: block;
-  width: 100%;
-  background: none;
-  border: none;
-  outline: none;
-  resize: none;
-  color: var(--text);
-  font-size: 13.5px;
-  line-height: 1.55;
-  min-height: 22px;
-  max-height: 220px;
-  padding: 0;
-  font-family: inherit;
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	outline: none;
+	resize: none;
+	color: var(--text);
+	font-size: 13.5px;
+	line-height: 1.55;
+	min-height: 22px;
+	max-height: 220px;
+	padding: 0;
+	font-family: inherit;
 }
-.composer-textarea::placeholder { color: var(--text-faint); }
+.composer-textarea::placeholder {
+	color: var(--text-faint);
+}
 
 /* Cross-repo bar (primary + attached repos) above a code session */
 .repobar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 16px;
+	border-bottom: 1px solid var(--border);
 }
 .repobar-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11.5px;
-  font-weight: 500;
-  color: var(--text-dim);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 2px 9px;
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11.5px;
+	font-weight: 500;
+	color: var(--text-dim);
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 2px 9px;
 }
 .repobar-chip-primary {
-  color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+	color: var(--accent);
+	border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 .repobar-detach {
-  background: none;
-  border: none;
-  color: var(--text-faint);
-  cursor: pointer;
-  font-size: 13px;
-  line-height: 1;
-  padding: 0 0 0 2px;
+	background: none;
+	border: none;
+	color: var(--text-faint);
+	cursor: pointer;
+	font-size: 13px;
+	line-height: 1;
+	padding: 0 0 0 2px;
 }
-.repobar-detach:hover { color: var(--text); }
-.repobar-add-wrap { position: relative; display: inline-flex; }
+.repobar-detach:hover {
+	color: var(--text);
+}
+.repobar-add-wrap {
+	position: relative;
+	display: inline-flex;
+}
 .repobar-add {
-  font-size: 11.5px;
-  color: var(--text-dim);
-  background: none;
-  border: 1px dashed var(--border-strong);
-  border-radius: 999px;
-  padding: 2px 9px;
-  cursor: pointer;
+	font-size: 11.5px;
+	color: var(--text-dim);
+	background: none;
+	border: 1px dashed var(--border-strong);
+	border-radius: 999px;
+	padding: 2px 9px;
+	cursor: pointer;
 }
-.repobar-add:hover { color: var(--text); border-color: var(--text-faint); }
+.repobar-add:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
 .repobar-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  min-width: 160px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 9px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-  padding: 4px;
-  z-index: 30;
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	min-width: 160px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 9px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+	padding: 4px;
+	z-index: 30;
 }
 .repobar-menu-item {
-  display: block;
-  width: 100%;
-  text-align: left;
-  font-size: 12px;
-  color: var(--text);
-  background: none;
-  border: none;
-  border-radius: 6px;
-  padding: 6px 8px;
-  cursor: pointer;
+	display: block;
+	width: 100%;
+	text-align: left;
+	font-size: 12px;
+	color: var(--text);
+	background: none;
+	border: none;
+	border-radius: 6px;
+	padding: 6px 8px;
+	cursor: pointer;
 }
-.repobar-menu-item:hover { background: color-mix(in srgb, var(--accent) 14%, transparent); }
-.repobar-menu-empty { font-size: 11.5px; color: var(--text-faint); padding: 6px 8px; }
-.repobar-error { font-size: 11px; color: var(--danger, #e5484d); }
+.repobar-menu-item:hover {
+	background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.repobar-menu-empty {
+	font-size: 11.5px;
+	color: var(--text-faint);
+	padding: 6px 8px;
+}
+.repobar-error {
+	font-size: 11px;
+	color: var(--danger, #e5484d);
+}
 
 /* "@"-mention file autocomplete */
-.composer-input-wrap { position: relative; }
+.composer-input-wrap {
+	position: relative;
+}
 .mention-popup {
-  position: absolute;
-  left: 0;
-  bottom: calc(100% + 6px);
-  width: min(520px, 100%);
-  max-height: 240px;
-  overflow-y: auto;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 10px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
-  padding: 4px;
-  z-index: 40;
+	position: absolute;
+	left: 0;
+	bottom: calc(100% + 6px);
+	width: min(520px, 100%);
+	max-height: 240px;
+	overflow-y: auto;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+	padding: 4px;
+	z-index: 40;
+}
+/* Flip below the input when there isn't room above (centered home composer). */
+.mention-popup-down {
+	bottom: auto;
+	top: calc(100% + 6px);
 }
 .mention-item {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 6px 9px;
-  border-radius: 7px;
-  cursor: pointer;
-  font-size: 12.5px;
-  line-height: 1.3;
-  white-space: nowrap;
-  overflow: hidden;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	padding: 6px 9px;
+	border-radius: 7px;
+	cursor: pointer;
+	font-size: 12.5px;
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
 }
-.mention-item-active { background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.mention-item-active {
+	background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
 .mention-repo {
-  flex-shrink: 0;
-  font-size: 10.5px;
-  font-weight: 600;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  border-radius: 5px;
-  padding: 1px 5px;
-  align-self: center;
+	flex-shrink: 0;
+	font-size: 10.5px;
+	font-weight: 600;
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 14%, transparent);
+	border-radius: 5px;
+	padding: 1px 5px;
+	align-self: center;
 }
-.mention-base { color: var(--text); font-weight: 500; flex-shrink: 0; }
+.mention-base {
+	color: var(--text);
+	font-weight: 500;
+	flex-shrink: 0;
+}
 .mention-dir {
-  color: var(--text-faint);
-  font-size: 11.5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  direction: rtl;
-  text-align: left;
+	color: var(--text-faint);
+	font-size: 11.5px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	direction: rtl;
+	text-align: left;
 }
 
 .composer-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 10px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 10px;
 }
-.composer-spacer { flex: 1; }
+.composer-spacer {
+	flex: 1;
+}
 
 .composer-model {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  position: relative;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px 9px 3px 9px;
-  color: var(--text-dim);
-  font-size: 12px;
-  max-width: 240px;
-  transition: border-color 0.15s, color 0.15s;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	position: relative;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 3px 9px 3px 9px;
+	color: var(--text-dim);
+	font-size: 12px;
+	max-width: 240px;
+	transition:
+		border-color 0.15s,
+		color 0.15s;
 }
-.composer-model:hover { border-color: var(--text-faint); color: var(--text); }
+.composer-model:hover {
+	border-color: var(--text-faint);
+	color: var(--text);
+}
 .composer-model select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: none;
-  border: none;
-  outline: none;
-  color: inherit;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  max-width: 180px;
-  text-overflow: ellipsis;
-  padding-right: 2px;
+	appearance: none;
+	-webkit-appearance: none;
+	background: none;
+	border: none;
+	outline: none;
+	color: inherit;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	max-width: 180px;
+	text-overflow: ellipsis;
+	padding-right: 2px;
 }
-.composer-model select:disabled { cursor: default; opacity: 0.7; }
+.composer-model select:disabled {
+	cursor: default;
+	opacity: 0.7;
+}
 .composer-model-chevron {
-  font-size: 9px;
-  color: var(--text-faint);
-  pointer-events: none;
+	font-size: 9px;
+	color: var(--text-faint);
+	pointer-events: none;
 }
 .composer-model-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex-shrink: 0;
 }
-.dot-claude { background: #d97757; }
-.dot-codex { background: #19c37d; }
+.dot-claude {
+	background: #d97757;
+}
+.dot-codex {
+	background: #19c37d;
+}
 
 .composer-send {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  font-size: 15px;
-  font-weight: 600;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: filter 0.15s, transform 0.1s;
+	width: 30px;
+	height: 30px;
+	border-radius: 50%;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	transition:
+		filter 0.15s,
+		transform 0.1s;
 }
-.composer-send:disabled { opacity: 0.35; cursor: default; }
-.composer-send:not(:disabled):hover { filter: brightness(1.12); transform: scale(1.05); }
-.composer-send-queue { background: var(--bg-raised); color: var(--text-dim); border: 1px solid var(--border-strong); }
-.composer-send-interrupt { background: var(--red-soft); color: var(--red); border: 1px solid var(--red); }
+.composer-send:disabled {
+	opacity: 0.35;
+	cursor: default;
+}
+.composer-send:not(:disabled):hover {
+	filter: brightness(1.12);
+	transform: scale(1.05);
+}
+.composer-send-queue {
+	background: var(--bg-raised);
+	color: var(--text-dim);
+	border: 1px solid var(--border-strong);
+}
+.composer-send-interrupt {
+	background: var(--red-soft);
+	color: var(--red);
+	border: 1px solid var(--red);
+}
 
 .composer-hint {
-  color: var(--text-faint);
-  font-size: 11px;
-  text-align: center;
-  margin-top: 7px;
+	color: var(--text-faint);
+	font-size: 11px;
+	text-align: center;
+	margin-top: 7px;
 }
 
-.chip-fallback { opacity: 0.65; }
+.chip-fallback {
+	opacity: 0.65;
+}
 
 /* Model pill in the session header */
 .model-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  border-radius: 999px;
-  padding: 2px 9px;
-  font-size: 11px;
-  font-weight: 500;
-  border: 1px solid var(--border-strong);
-  color: var(--text-dim);
-  white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	border-radius: 999px;
+	padding: 2px 9px;
+	font-size: 11px;
+	font-weight: 500;
+	border: 1px solid var(--border-strong);
+	color: var(--text-dim);
+	white-space: nowrap;
 }
 .model-pill::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
+	content: "";
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
 }
-.model-pill-claude::before { background: #d97757; }
-.model-pill-codex::before { background: #19c37d; }
+.model-pill-claude::before {
+	background: #d97757;
+}
+.model-pill-codex::before {
+	background: #19c37d;
+}
 
 .prompt-hint {
-  color: var(--text-faint);
-  font-size: 11px;
-  margin-top: 5px;
+	color: var(--text-faint);
+	font-size: 11px;
+	margin-top: 5px;
 }
 
 .input-busy {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--text-dim);
-  font-size: 13px;
-  max-width: 860px;
-  margin: 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: var(--text-dim);
+	font-size: 13px;
+	max-width: 860px;
+	margin: 0 auto;
 }
 
 .pulse-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--green);
-  animation: pulse 1.4s infinite;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--green);
+	animation: pulse 1.4s infinite;
 }
 
 .btn-cancel {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 7px;
-  color: var(--text-faint);
-  padding: 5px 12px;
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 7px;
+	color: var(--text-faint);
+	padding: 5px 12px;
+	font-size: 12.5px;
+	font-weight: 500;
+	cursor: pointer;
+	transition:
+		color 0.12s ease,
+		background 0.12s ease,
+		border-color 0.12s ease;
 }
 .btn-cancel-icon {
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
-  background: currentColor;
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
+	background: currentColor;
 }
 .btn-cancel:hover {
-  color: var(--red);
-  background: var(--red-soft);
-  border-color: var(--red-soft);
+	color: var(--red);
+	background: var(--red-soft);
+	border-color: var(--red-soft);
 }
 
 .input-disabled {
-  color: var(--text-faint);
-  font-size: 13px;
-  max-width: 860px;
-  margin: 0 auto;
+	color: var(--text-faint);
+	font-size: 13px;
+	max-width: 860px;
+	margin: 0 auto;
 }
 
 /* ── New session form ────────────────────────────────────── */
 
 .new-session {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  /* The form can outgrow the viewport (especially on phones, where the keyboard
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	/* The form can outgrow the viewport (especially on phones, where the keyboard
      shrinks it further) — let it scroll so the Start button is always reachable. */
-  min-height: 0;
-  overflow-y: auto;
+	min-height: 0;
+	overflow-y: auto;
 }
 
 .btn-back {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 13px;
-  padding: 4px 8px;
-  border-radius: 5px;
+	background: none;
+	border: none;
+	color: var(--text-dim);
+	font-size: 13px;
+	padding: 4px 8px;
+	border-radius: 5px;
 }
-.btn-back:hover { color: var(--text); background: var(--bg-hover); }
+.btn-back:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
 
 .new-session-form {
-  max-width: 560px;
-  width: 100%;
-  margin: 32px auto;
-  padding: 0 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+	max-width: 560px;
+	width: 100%;
+	margin: 32px auto;
+	padding: 0 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
 }
 
 .new-session-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-dim);
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text-dim);
 }
 
 .new-session-form select,
 .new-session-form input,
 .new-session-form textarea {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  color: var(--text);
-  padding: 10px 12px;
-  font-size: 13.5px;
-  outline: none;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	color: var(--text);
+	padding: 10px 12px;
+	font-size: 13.5px;
+	outline: none;
 }
 .new-session-form select:focus,
 .new-session-form input:focus,
-.new-session-form textarea:focus { border-color: var(--accent); }
+.new-session-form textarea:focus {
+	border-color: var(--accent);
+}
 
 .new-session-form textarea {
-  resize: vertical;
-  line-height: 1.5;
-  width: 100%;
-  box-sizing: border-box;
+	resize: vertical;
+	line-height: 1.5;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .btn-create {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 11px;
-  font-size: 14px;
-  font-weight: 500;
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 8px;
+	padding: 11px;
+	font-size: 14px;
+	font-weight: 500;
 }
-.btn-create:disabled { opacity: 0.4; cursor: default; }
-.btn-create:not(:disabled):hover { filter: brightness(1.1); }
+.btn-create:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.btn-create:not(:disabled):hover {
+	filter: brightness(1.1);
+}
 
 .form-error {
-  background: var(--red-soft);
-  border: 1px solid rgba(248, 81, 73, 0.4);
-  color: var(--red);
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-size: 13px;
+	background: var(--red-soft);
+	border: 1px solid rgba(248, 81, 73, 0.4);
+	color: var(--red);
+	border-radius: 8px;
+	padding: 10px 12px;
+	font-size: 13px;
 }
 
 .create-note {
-  color: var(--text-faint);
-  font-size: 12.5px;
-  text-align: center;
+	color: var(--text-faint);
+	font-size: 12.5px;
+	text-align: center;
 }
 
 /* ── Automations ─────────────────────────────────────────── */
 
 .automations {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-  padding: 28px 24px 60px;
-  max-width: 860px;
-  width: 100%;
-  margin: 0 auto;
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
+	padding: 28px 24px 60px;
+	max-width: 860px;
+	width: 100%;
+	margin: 0 auto;
 }
 
 .page-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 22px;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 22px;
 }
 
 .page-title {
-  margin: 0;
-  font-size: 19px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+	margin: 0;
+	font-size: 19px;
+	font-weight: 600;
+	letter-spacing: -0.01em;
 }
 
 .page-sub {
-  color: var(--text-faint);
-  font-size: 12.5px;
-  margin-top: 4px;
+	color: var(--text-faint);
+	font-size: 12.5px;
+	margin-top: 4px;
 }
 
 .automations-empty {
-  text-align: center;
-  color: var(--text-dim);
-  padding: 48px 16px;
+	text-align: center;
+	color: var(--text-dim);
+	padding: 48px 16px;
 }
-.automations-empty p { margin: 0 0 8px; }
-.automations-empty-sub { color: var(--text-faint); font-size: 13px; }
+.automations-empty p {
+	margin: 0 0 8px;
+}
+.automations-empty-sub {
+	color: var(--text-faint);
+	font-size: 13px;
+}
 
 .automation-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .automation-card {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 14px 16px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 14px 16px;
 }
-.automation-disabled { opacity: 0.55; }
+.automation-disabled {
+	opacity: 0.55;
+}
 
 .automation-top {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
 }
 
 .automation-name {
-  font-weight: 600;
-  font-size: 14px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	font-weight: 600;
+	font-size: 14px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .automation-actions {
-  margin-left: auto;
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
+	margin-left: auto;
+	display: flex;
+	gap: 6px;
+	flex-shrink: 0;
 }
 
 .btn-small {
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-dim);
-  padding: 3px 10px;
-  font-size: 12px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-dim);
+	padding: 3px 10px;
+	font-size: 12px;
 }
-.btn-small:hover { color: var(--text); border-color: var(--text-faint); }
-.btn-small:disabled { opacity: 0.4; cursor: default; }
-.btn-small-danger:hover { color: var(--red); border-color: var(--red); }
+.btn-small:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
+.btn-small:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+.btn-small-danger:hover {
+	color: var(--red);
+	border-color: var(--red);
+}
 
 .auto-toggle {
-  width: 34px;
-  height: 19px;
-  border-radius: 99px;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-active);
-  position: relative;
-  flex-shrink: 0;
-  padding: 0;
-  transition: background 0.15s;
+	width: 34px;
+	height: 19px;
+	border-radius: 99px;
+	border: 1px solid var(--border-strong);
+	background: var(--bg-active);
+	position: relative;
+	flex-shrink: 0;
+	padding: 0;
+	transition: background 0.15s;
 }
 .auto-toggle-knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 13px;
-  height: 13px;
-  border-radius: 50%;
-  background: var(--text-faint);
-  transition: transform 0.15s, background 0.15s;
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 13px;
+	height: 13px;
+	border-radius: 50%;
+	background: var(--text-faint);
+	transition:
+		transform 0.15s,
+		background 0.15s;
 }
-.auto-toggle-on { background: var(--green-soft); border-color: var(--green); }
+.auto-toggle-on {
+	background: var(--green-soft);
+	border-color: var(--green);
+}
 .auto-toggle-on .auto-toggle-knob {
-  transform: translateX(15px);
-  background: var(--green);
+	transform: translateX(15px);
+	background: var(--green);
 }
 
 .automation-prompt {
-  color: var(--text-dim);
-  font-size: 13px;
-  line-height: 1.5;
-  margin: 9px 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+	color: var(--text-dim);
+	font-size: 13px;
+	line-height: 1.5;
+	margin: 9px 0;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 
 .automation-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px 14px;
-  font-size: 12px;
-  color: var(--text-faint);
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px 14px;
+	font-size: 12px;
+	color: var(--text-faint);
 }
 
 .automation-cron {
-  font-family: var(--mono);
-  background: var(--bg-active);
-  border-radius: 4px;
-  padding: 1px 7px;
-  font-size: 11px;
+	font-family: var(--mono);
+	background: var(--bg-active);
+	border-radius: 4px;
+	padding: 1px 7px;
+	font-size: 11px;
 }
 
-.auto-status-ok { color: var(--green); }
-.auto-status-err { color: var(--red); }
+.auto-status-ok {
+	color: var(--green);
+}
+.auto-status-err {
+	color: var(--red);
+}
 
 .automation-session-link {
-  color: var(--accent);
-  text-decoration: none;
-  cursor: pointer;
+	color: var(--accent);
+	text-decoration: none;
+	cursor: pointer;
 }
-.automation-session-link:hover { text-decoration: underline; }
+.automation-session-link:hover {
+	text-decoration: underline;
+}
 
-.automation-by { margin-left: auto; }
+.automation-by {
+	margin-left: auto;
+}
 
 .automation-form {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 12px;
-  padding: 18px;
-  margin-bottom: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 12px;
+	padding: 18px;
+	margin-bottom: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
 }
 
 .automation-form-title {
-  font-weight: 600;
-  font-size: 14.5px;
+	font-weight: 600;
+	font-size: 14.5px;
 }
 
 .automation-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--text-dim);
-  flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--text-dim);
+	flex: 1;
 }
 
 .automation-form input,
 .automation-form textarea,
 .automation-form select {
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text);
-  padding: 8px 11px;
-  font-size: 13.5px;
-  outline: none;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text);
+	padding: 8px 11px;
+	font-size: 13.5px;
+	outline: none;
 }
 .automation-form input:focus,
 .automation-form textarea:focus,
-.automation-form select:focus { border-color: var(--accent); }
-.automation-form textarea { resize: vertical; line-height: 1.5; }
+.automation-form select:focus {
+	border-color: var(--accent);
+}
+.automation-form textarea {
+	resize: vertical;
+	line-height: 1.5;
+}
 
-.mono-input { font-family: var(--mono); }
+.mono-input {
+	font-family: var(--mono);
+}
 
 .automation-form-row {
-  display: flex;
-  gap: 14px;
+	display: flex;
+	gap: 14px;
 }
 
 .automation-form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
 }
 
 /* ── Connections ─────────────────────────────────────────── */
 
 .connections {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-  padding: 28px 24px 60px;
-  max-width: 920px;
-  width: 100%;
-  margin: 0 auto;
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
+	padding: 28px 24px 60px;
+	max-width: 920px;
+	width: 100%;
+	margin: 0 auto;
 }
 
 .conn-section-title {
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
-  margin: 22px 0 10px;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
+	margin: 22px 0 10px;
 }
 
 .conn-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 10px;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 10px;
 }
 
 .conn-card {
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 14px;
-  min-width: 0;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 14px;
+	min-width: 0;
 }
 
 .conn-card-top {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 8px;
 }
 
 .conn-logo {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 13px;
-  color: #fff;
-  background: var(--bg-active);
-  flex-shrink: 0;
+	width: 28px;
+	height: 28px;
+	border-radius: 8px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 700;
+	font-size: 13px;
+	color: #fff;
+	background: var(--bg-active);
+	flex-shrink: 0;
 }
-.conn-logo-slack { background: #4A154B; }
-.conn-logo-linear { background: #5E6AD2; }
-.conn-logo-plain { background: #0D9488; }
-.conn-logo-sentry { background: #584774; }
-.conn-logo-workos { background: #6363F1; }
-.conn-logo-tinybird { background: #27F795; color: #08080a; }
+.conn-logo-slack {
+	background: #4a154b;
+}
+.conn-logo-linear {
+	background: #5e6ad2;
+}
+.conn-logo-plain {
+	background: #0d9488;
+}
+.conn-logo-sentry {
+	background: #584774;
+}
+.conn-logo-workos {
+	background: #6363f1;
+}
+.conn-logo-tinybird {
+	background: #27f795;
+	color: #08080a;
+}
 
 .conn-name {
-  font-weight: 600;
-  font-size: 14px;
-  text-transform: capitalize;
-  flex: 1;
-  min-width: 0;
+	font-weight: 600;
+	font-size: 14px;
+	text-transform: capitalize;
+	flex: 1;
+	min-width: 0;
 }
 
 .conn-blurb {
-  color: var(--text-dim);
-  font-size: 12.5px;
-  line-height: 1.45;
-  margin-bottom: 8px;
+	color: var(--text-dim);
+	font-size: 12.5px;
+	line-height: 1.45;
+	margin-bottom: 8px;
 }
 
 .conn-detail {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11.5px;
-  color: var(--text-faint);
-  min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 11.5px;
+	color: var(--text-faint);
+	min-width: 0;
 }
 
 .conn-transport {
-  font-family: var(--mono);
-  background: var(--bg-active);
-  border-radius: 4px;
-  padding: 1px 6px;
-  flex-shrink: 0;
+	font-family: var(--mono);
+	background: var(--bg-active);
+	border-radius: 4px;
+	padding: 1px 6px;
+	flex-shrink: 0;
 }
 
 .conn-target {
-  font-family: var(--mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+	font-family: var(--mono);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .conn-error {
-  margin-top: 8px;
-  color: var(--red);
-  font-size: 11.5px;
-  font-family: var(--mono);
+	margin-top: 8px;
+	color: var(--red);
+	font-size: 11.5px;
+	font-family: var(--mono);
 }
 
 .conn-remove {
-  margin-top: 10px;
-  background: none;
-  border: 1px solid var(--border-strong);
-  border-radius: 5px;
-  color: var(--text-faint);
-  padding: 2px 9px;
-  font-size: 11.5px;
+	margin-top: 10px;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 5px;
+	color: var(--text-faint);
+	padding: 2px 9px;
+	font-size: 11.5px;
 }
-.conn-remove:hover { color: var(--red); border-color: var(--red); }
+.conn-remove:hover {
+	color: var(--red);
+	border-color: var(--red);
+}
 
 .conn-footnote {
-  margin-top: 24px;
-  color: var(--text-faint);
-  font-size: 12.5px;
+	margin-top: 24px;
+	color: var(--text-faint);
+	font-size: 12.5px;
 }
 .conn-footnote code {
-  font-family: var(--mono);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
+	font-family: var(--mono);
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	padding: 1px 5px;
 }
 
 /* MCP tool chip in transcripts */
 .tool-mcp-chip {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: rgba(163, 113, 247, 0.16);
-  color: var(--purple);
-  border-radius: 4px;
-  padding: 1px 6px;
-  flex-shrink: 0;
+	font-size: 10px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	background: rgba(163, 113, 247, 0.16);
+	color: var(--purple);
+	border-radius: 4px;
+	padding: 1px 6px;
+	flex-shrink: 0;
 }
 
 /* ── Wiki ────────────────────────────────────────────────── */
 
 .wiki {
-  flex: 1;
-  display: flex;
-  min-height: 0;
+	flex: 1;
+	display: flex;
+	min-height: 0;
 }
 
 .wiki-nav {
-  width: 300px;
-  flex-shrink: 0;
-  border-right: 1px solid var(--border);
-  background: var(--bg-raised);
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+	width: 300px;
+	flex-shrink: 0;
+	border-right: 1px solid var(--border);
+	background: var(--bg-raised);
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 
 .wiki-search-wrap {
-  padding: 12px;
-  border-bottom: 1px solid var(--border);
+	padding: 12px;
+	border-bottom: 1px solid var(--border);
 }
 
 .wiki-search {
-  width: 100%;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text);
-  padding: 7px 10px;
-  font-size: 13px;
-  outline: none;
+	width: 100%;
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	color: var(--text);
+	padding: 7px 10px;
+	font-size: 13px;
+	outline: none;
 }
-.wiki-search:focus { border-color: var(--accent); }
-.wiki-search::placeholder { color: var(--text-faint); }
-
-.wiki-tree, .wiki-results {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px 6px 24px;
+.wiki-search:focus {
+	border-color: var(--accent);
+}
+.wiki-search::placeholder {
+	color: var(--text-faint);
 }
 
-.wiki-tree { padding: 6px 4px 16px; }
+.wiki-tree,
+.wiki-results {
+	flex: 1;
+	overflow-y: auto;
+	padding: 8px 6px 24px;
+}
+
+.wiki-tree {
+	padding: 6px 4px 16px;
+}
 
 .wiki-filetree {
-  display: block;
-  height: 100%;
-  /* The tree's shadow styles use light-dark(); force the dark arm —
+	display: block;
+	height: 100%;
+	/* The tree's shadow styles use light-dark(); force the dark arm —
      the app is dark-only regardless of OS preference */
-  color-scheme: dark;
+	color-scheme: dark;
 }
 
-.wiki-dir, .wiki-file {
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 5px;
-  color: var(--text-dim);
-  font-size: 13px;
-  padding: 5px 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.wiki-dir,
+.wiki-file {
+	display: block;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-radius: 5px;
+	color: var(--text-dim);
+	font-size: 13px;
+	padding: 5px 8px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
-.wiki-dir { font-weight: 600; color: var(--text); }
-.wiki-dir:hover, .wiki-file:hover { background: var(--bg-hover); }
+.wiki-dir {
+	font-weight: 600;
+	color: var(--text);
+}
+.wiki-dir:hover,
+.wiki-file:hover {
+	background: var(--bg-hover);
+}
 .wiki-file-selected,
-.wiki-file-selected:hover { background: var(--accent-soft); color: var(--text); }
+.wiki-file-selected:hover {
+	background: var(--accent-soft);
+	color: var(--text);
+}
 
 .wiki-chevron {
-  display: inline-block;
-  width: 13px;
-  font-size: 9px;
-  color: var(--text-faint);
+	display: inline-block;
+	width: 13px;
+	font-size: 9px;
+	color: var(--text-faint);
 }
 
 .wiki-empty {
-  color: var(--text-faint);
-  text-align: center;
-  padding: 24px 0;
-  font-size: 13px;
+	color: var(--text-faint);
+	text-align: center;
+	padding: 24px 0;
+	font-size: 13px;
 }
 
 .wiki-result {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  padding: 8px 10px;
-  min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	border-radius: 6px;
+	padding: 8px 10px;
+	min-width: 0;
 }
-.wiki-result:hover { background: var(--bg-hover); }
+.wiki-result:hover {
+	background: var(--bg-hover);
+}
 
 .wiki-result-title {
-  color: var(--text);
-  font-size: 13px;
-  font-weight: 600;
+	color: var(--text);
+	font-size: 13px;
+	font-weight: 600;
 }
 .wiki-result-snippet {
-  color: var(--text-dim);
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	color: var(--text-dim);
+	font-size: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .wiki-result-path {
-  color: var(--text-faint);
-  font-size: 11px;
-  font-family: var(--mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	color: var(--text-faint);
+	font-size: 11px;
+	font-family: var(--mono);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .wiki-content {
-  flex: 1;
-  overflow-y: auto;
-  min-width: 0;
-  padding: 24px 32px 80px;
+	flex: 1;
+	overflow-y: auto;
+	min-width: 0;
+	padding: 24px 32px 80px;
 }
 
 .wiki-nav-toggle {
-  display: none;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 6px;
-  color: var(--text-dim);
-  padding: 6px 12px;
-  font-size: 13px;
-  margin-bottom: 14px;
+	display: none;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 6px;
+	color: var(--text-dim);
+	padding: 6px 12px;
+	font-size: 13px;
+	margin-bottom: 14px;
 }
 
 .wiki-doc-path {
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--text-faint);
-  margin-bottom: 16px;
+	font-family: var(--mono);
+	font-size: 11.5px;
+	color: var(--text-faint);
+	margin-bottom: 16px;
 }
 
 .wiki-doc {
-  max-width: 780px;
-  font-size: 14px;
-  line-height: 1.65;
+	max-width: 780px;
+	font-size: 14px;
+	line-height: 1.65;
 }
-.wiki-doc h1 { font-size: 22px; margin: 0 0 14px; }
-.wiki-doc h2 { font-size: 17px; margin: 22px 0 10px; }
-.wiki-doc h3 { font-size: 15px; margin: 18px 0 8px; }
-.wiki-doc img { max-width: 100%; border-radius: 8px; }
-.wiki-doc a { color: var(--accent); }
+.wiki-doc h1 {
+	font-size: 22px;
+	margin: 0 0 14px;
+}
+.wiki-doc h2 {
+	font-size: 17px;
+	margin: 22px 0 10px;
+}
+.wiki-doc h3 {
+	font-size: 15px;
+	margin: 18px 0 8px;
+}
+.wiki-doc img {
+	max-width: 100%;
+	border-radius: 8px;
+}
+.wiki-doc a {
+	color: var(--accent);
+}
 
 .wiki-welcome {
-  max-width: 560px;
-  margin: 60px auto;
-  text-align: center;
-  color: var(--text-dim);
+	max-width: 560px;
+	margin: 60px auto;
+	text-align: center;
+	color: var(--text-dim);
 }
-.wiki-welcome h2 { color: var(--text); margin-bottom: 12px; }
+.wiki-welcome h2 {
+	color: var(--text);
+	margin-bottom: 12px;
+}
 .wiki-welcome code {
-  font-family: var(--mono);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
-  font-size: 12.5px;
+	font-family: var(--mono);
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	padding: 1px 5px;
+	font-size: 12.5px;
 }
-.wiki-welcome-hint { font-size: 13px; color: var(--text-faint); }
+.wiki-welcome-hint {
+	font-size: 13px;
+	color: var(--text-faint);
+}
 
 /* ── User gate ───────────────────────────────────────────── */
 
 .user-gate-overlay {
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg);
+	height: 100vh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--bg);
 }
 
 .user-gate-card {
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 32px;
-  text-align: center;
-  width: 380px;
-  max-width: calc(100vw - 32px);
+	background: var(--bg-raised);
+	border: 1px solid var(--border);
+	border-radius: 14px;
+	padding: 32px;
+	text-align: center;
+	width: 380px;
+	max-width: calc(100vw - 32px);
 }
 
 .user-gate-card h2 {
-  margin: 0 0 20px;
-  font-size: 17px;
+	margin: 0 0 20px;
+	font-size: 17px;
 }
 
 .user-gate-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 10px;
 }
 
 .user-gate-btn {
-  background: var(--bg-panel);
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  color: var(--text);
-  padding: 12px;
-  font-size: 14px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	color: var(--text);
+	padding: 12px;
+	font-size: 14px;
 }
 .user-gate-btn:hover {
-  border-color: var(--accent);
-  background: var(--accent-soft);
+	border-color: var(--accent);
+	background: var(--accent-soft);
 }
 
 /* ── Responsive ──────────────────────────────────────────── */
 
 @media (max-width: 920px) {
-  .viewer-panel {
-    position: fixed;
-    top: var(--header-h);
-    right: 0;
-    bottom: 0;
-    width: min(480px, 94vw);
-    min-width: 0;
-    max-width: none;
-    z-index: 30;
-    box-shadow: -12px 0 32px rgba(0, 0, 0, 0.5);
-  }
+	.viewer-panel {
+		position: fixed;
+		top: var(--header-h);
+		right: 0;
+		bottom: 0;
+		width: min(480px, 94vw);
+		min-width: 0;
+		max-width: none;
+		z-index: 30;
+		box-shadow: -12px 0 32px rgba(0, 0, 0, 0.5);
+	}
 
-  .panel-overlay {
-    display: block;
-    position: fixed;
-    inset: var(--header-h) 0 0 0;
-    background: rgba(0, 0, 0, 0.45);
-    z-index: 25;
-  }
+	.panel-overlay {
+		display: block;
+		position: fixed;
+		inset: var(--header-h) 0 0 0;
+		background: rgba(0, 0, 0, 0.45);
+		z-index: 25;
+	}
 
-  .panel-close { display: block; }
+	.panel-close {
+		display: block;
+	}
 
-  .wiki-nav {
-    position: fixed;
-    top: var(--header-h);
-    left: 0;
-    bottom: 0;
-    z-index: 30;
-    width: min(320px, 88vw);
-    transform: translateX(-100%);
-    transition: transform 0.18s ease;
-    box-shadow: 12px 0 32px rgba(0, 0, 0, 0.5);
-  }
-  .wiki-nav-open { transform: translateX(0); }
-  .wiki-nav-toggle { display: inline-block; }
-  .wiki-content { padding: 16px 16px 60px; }
+	.wiki-nav {
+		position: fixed;
+		top: var(--header-h);
+		left: 0;
+		bottom: 0;
+		z-index: 30;
+		width: min(320px, 88vw);
+		transform: translateX(-100%);
+		transition: transform 0.18s ease;
+		box-shadow: 12px 0 32px rgba(0, 0, 0, 0.5);
+	}
+	.wiki-nav-open {
+		transform: translateX(0);
+	}
+	.wiki-nav-toggle {
+		display: inline-block;
+	}
+	.wiki-content {
+		padding: 16px 16px 60px;
+	}
 }
 
 @media (max-width: 720px) {
-  .hamburger { display: flex; }
+	.hamburger {
+		display: flex;
+	}
 
-  .sidebar-container {
-    position: fixed;
-    top: var(--header-h);
-    left: 0;
-    bottom: 0;
-    z-index: 40;
-    transform: translateX(-100%);
-    transition: transform 0.18s ease;
-    width: min(300px, 85vw);
-  }
-  .sidebar-container.sidebar-open { transform: translateX(0); }
+	.sidebar-container {
+		position: fixed;
+		top: var(--header-h);
+		left: 0;
+		bottom: 0;
+		z-index: 40;
+		transform: translateX(-100%);
+		transition: transform 0.18s ease;
+		width: min(300px, 85vw);
+	}
+	.sidebar-container.sidebar-open {
+		transform: translateX(0);
+	}
 
-  .sidebar-overlay {
-    position: fixed;
-    inset: var(--header-h) 0 0 0;
-    background: rgba(0, 0, 0, 0.55);
-    z-index: 35;
-  }
+	.sidebar-overlay {
+		position: fixed;
+		inset: var(--header-h) 0 0 0;
+		background: rgba(0, 0, 0, 0.55);
+		z-index: 35;
+	}
 
-  .app-header { padding: env(safe-area-inset-top, 0px) 10px 0; }
+	.app-header {
+		padding: env(safe-area-inset-top, 0px) 10px 0;
+	}
 
-  /* Two-line header on phones: title row first (single line, so it always
+	/* Two-line header on phones: title row first (single line, so it always
      shows), a compact actions row right-aligned beneath it. */
-  .viewer-header {
-    padding: 7px 10px;
-    gap: 6px;
-    flex-wrap: wrap;
-    row-gap: 6px;
-  }
-  .viewer-title { gap: 7px; flex: 1 1 100%; min-width: 0; }
-  .viewer-started-by { display: none; }
-  .viewer-branch {
-    font-size: 13px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  /* The model pill duplicates the composer's model selector — drop it from the
+	.viewer-header {
+		padding: 7px 10px;
+		gap: 6px;
+		flex-wrap: wrap;
+		row-gap: 6px;
+	}
+	.viewer-title {
+		gap: 7px;
+		flex: 1 1 100%;
+		min-width: 0;
+	}
+	.viewer-started-by {
+		display: none;
+	}
+	.viewer-branch {
+		font-size: 13px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	/* The model pill duplicates the composer's model selector — drop it from the
      title row on phones so the title gets the full width (less truncation). */
-  .viewer-title .model-pill { display: none; }
+	.viewer-title .model-pill {
+		display: none;
+	}
 
-  .viewer-header-actions {
-    width: 100%;
-    justify-content: flex-end;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-  }
-  /* Compact, comfortably-tappable controls that stay on one row */
-  .viewer-header-actions button,
-  .viewer-header-actions .session-link {
-    font-size: 11px;
-    padding: 5px 9px;
-    min-height: 30px;
-  }
-  /* Icon-only workspace toggle on phones — the label is kept on desktop */
-  .btn-panel-toggle-label { display: none; }
-  /* Make the Workspace toggle the one standout control — it's how you reach the
+	.viewer-header-actions {
+		width: 100%;
+		justify-content: flex-end;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+	/* Compact, comfortably-tappable controls that stay on one row */
+	.viewer-header-actions button,
+	.viewer-header-actions .session-link {
+		font-size: 11px;
+		padding: 5px 9px;
+		min-height: 30px;
+	}
+	/* Icon-only workspace toggle on phones — the label is kept on desktop */
+	.btn-panel-toggle-label {
+		display: none;
+	}
+	/* Make the Workspace toggle the one standout control — it's how you reach the
      diff / terminal / PR on a phone. (Scoped to .btn-workspace so the Spin-off
      trigger, which shares .btn-panel-toggle, stays neutral.) */
-  .viewer-header-actions .btn-workspace {
-    order: 2;
-    color: var(--accent);
-    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
-    padding: 5px 11px;
-    font-size: 15px;
-  }
-  .viewer-header-actions .btn-workspace.active {
-    background: var(--accent);
-    color: #fff;
-    border-color: var(--accent);
-  }
-  .working-pill { padding: 3px 8px; font-size: 11px; }
+	.viewer-header-actions .btn-workspace {
+		order: 2;
+		color: var(--accent);
+		border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+		background: color-mix(in srgb, var(--accent) 12%, transparent);
+		padding: 5px 11px;
+		font-size: 15px;
+	}
+	.viewer-header-actions .btn-workspace.active {
+		background: var(--accent);
+		color: #fff;
+		border-color: var(--accent);
+	}
+	.working-pill {
+		padding: 3px 8px;
+		font-size: 11px;
+	}
 
-  /* The keyboard-shortcut hint is irrelevant on touch and eats vertical space
+	/* The keyboard-shortcut hint is irrelevant on touch and eats vertical space
      right where the keyboard appears — hide it. */
-  .composer-hint,
-  .prompt-hint { display: none; }
+	.composer-hint,
+	.prompt-hint {
+		display: none;
+	}
 
-  .viewer-messages { padding: 12px 12px 8px; }
+	.viewer-messages {
+		padding: 12px 12px 8px;
+	}
 
-  .viewer-input {
-    padding: 8px 10px;
-    /* The hint is the bottom-most (non-interactive) element, so it can sit
+	.viewer-input {
+		padding: 8px 10px;
+		/* The hint is the bottom-most (non-interactive) element, so it can sit
        right next to the home indicator — drop almost all of the safe-area
        inset to keep the gap tight (~8px) on home-indicator iPhones. */
-    padding-bottom: max(8px, calc(env(safe-area-inset-bottom, 0px) - 26px));
-  }
+		padding-bottom: max(8px, calc(env(safe-area-inset-bottom, 0px) - 26px));
+	}
 
-  /* 16px stops iOS Safari from zooming into focused inputs */
-  .prompt-input,
-  .sidebar-search,
-  .ask-input,
-  .new-session-form select,
-  .new-session-form input,
-  .new-session-form textarea {
-    font-size: 16px;
-  }
+	/* 16px stops iOS Safari from zooming into focused inputs */
+	.prompt-input,
+	.sidebar-search,
+	.ask-input,
+	.new-session-form select,
+	.new-session-form input,
+	.new-session-form textarea {
+		font-size: 16px;
+	}
 
-  .home-inner { padding: 24px 14px 48px; }
-  .home-greeting { font-size: 18px; }
-  .home-row { padding: 10px 10px; gap: 8px; }
-  .status-pill { min-width: 0; padding: 3px 8px; }
+	.home-inner {
+		padding: 24px 14px 48px;
+	}
+	.home-greeting {
+		font-size: 18px;
+	}
+	.home-row {
+		padding: 10px 10px;
+		gap: 8px;
+	}
+	.status-pill {
+		min-width: 0;
+		padding: 3px 8px;
+	}
 
+	.automations {
+		padding: 18px 14px 48px;
+	}
+	.connections {
+		padding: 18px 14px 48px;
+	}
+	.page-header {
+		flex-direction: column;
+		gap: 10px;
+	}
+	.automation-form-row {
+		flex-direction: column;
+		gap: 14px;
+	}
+	.automation-by {
+		display: none;
+	}
+	.automation-form input,
+	.automation-form textarea,
+	.automation-form select,
+	.wiki-search {
+		font-size: 16px;
+	}
 
+	.btn-send {
+		padding: 10px 14px;
+	}
+	.prompt-hint {
+		display: none;
+	}
 
-  .automations { padding: 18px 14px 48px; }
-  .connections { padding: 18px 14px 48px; }
-  .page-header { flex-direction: column; gap: 10px; }
-  .automation-form-row { flex-direction: column; gap: 14px; }
-  .automation-by { display: none; }
-  .automation-form input,
-  .automation-form textarea,
-  .automation-form select,
-  .wiki-search { font-size: 16px; }
+	/* Keep the home Ask toolbar on one tidy row */
+	.btn-task {
+		white-space: nowrap;
+	}
+	.composer-toolbar {
+		gap: 6px;
+	}
 
-  .btn-send { padding: 10px 14px; }
-  .prompt-hint { display: none; }
-
-  /* Keep the home Ask toolbar on one tidy row */
-  .btn-task { white-space: nowrap; }
-  .composer-toolbar { gap: 6px; }
-
-  /* Automation cards: the single top row (toggle · name · chips · buttons)
+	/* Automation cards: the single top row (toggle · name · chips · buttons)
      starves the title of width on phones — wrap it instead. Title gets the
      first line, chips flow after, actions drop to their own row. */
-  .automation-top { flex-wrap: wrap; row-gap: 8px; }
-  .automation-name {
-    flex: 1 1 60%;
-    min-width: 0;
-    white-space: normal;
-    overflow-wrap: anywhere;
-  }
-  .automation-actions { margin-left: 0; width: 100%; }
+	.automation-top {
+		flex-wrap: wrap;
+		row-gap: 8px;
+	}
+	.automation-name {
+		flex: 1 1 60%;
+		min-width: 0;
+		white-space: normal;
+		overflow-wrap: anywhere;
+	}
+	.automation-actions {
+		margin-left: 0;
+		width: 100%;
+	}
 
-  .msg-body { font-size: 14px; }
+	.msg-body {
+		font-size: 14px;
+	}
 
-  .diff-patch { font-size: 10.5px; }
-  .diff-files { padding: 6px 6px 20px; }
+	.diff-patch {
+		font-size: 10.5px;
+	}
+	.diff-files {
+		padding: 6px 6px 20px;
+	}
 
-  .pr-panel { padding: 10px; }
+	.pr-panel {
+		padding: 10px;
+	}
 
-  .new-session-form {
-    margin: 16px auto;
-    /* Clear the home indicator / nav so the Start button isn't flush to the edge. */
-    padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
-  }
+	.new-session-form {
+		margin: 16px auto;
+		/* Clear the home indicator / nav so the Start button isn't flush to the edge. */
+		padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
+	}
 
-  .user-gate-card { padding: 22px; }
+	.user-gate-card {
+		padding: 22px;
+	}
 }
 
-.automation-event { color: #e3b341; }
+.automation-event {
+	color: #e3b341;
+}
 
 .session-banners {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 7px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding: 7px 16px;
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-raised);
 }
 
 .session-banner {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-dim);
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 99px;
-  padding: 3px 12px;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	color: var(--text-dim);
+	background: var(--bg-panel);
+	border: 1px solid var(--border);
+	border-radius: 99px;
+	padding: 3px 12px;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* ── AskUserQuestion card ────────────────────────────────── */
 
 .ask-card {
-  max-width: 860px;
-  margin: 4px auto 16px;
-  background: var(--bg-panel);
-  border: 1px solid rgba(255, 59, 59, 0.4);
-  border-radius: 12px;
-  padding: 14px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	max-width: 860px;
+	margin: 4px auto 16px;
+	background: var(--bg-panel);
+	border: 1px solid rgba(255, 59, 59, 0.4);
+	border-radius: 12px;
+	padding: 14px 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .ask-card-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--accent);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--accent);
 }
 
 .ask-card-header {
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-faint);
-  margin-bottom: 3px;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
+	margin-bottom: 3px;
 }
 
 .ask-card-text {
-  font-size: 13.5px;
-  margin-bottom: 8px;
+	font-size: 13.5px;
+	margin-bottom: 8px;
 }
 
 .ask-card-options {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-bottom: 8px;
 }
 
 .ask-card-option {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  text-align: left;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 8px;
-  padding: 8px 12px;
-  color: var(--text);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	text-align: left;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 8px;
+	padding: 8px 12px;
+	color: var(--text);
 }
-.ask-card-option:hover { border-color: var(--text-faint); }
+.ask-card-option:hover {
+	border-color: var(--text-faint);
+}
 .ask-card-option.active {
-  border-color: var(--accent);
-  background: var(--accent-soft);
+	border-color: var(--accent);
+	background: var(--accent-soft);
 }
 
-.ask-card-option-label { font-size: 13px; font-weight: 600; }
-.ask-card-option-desc { font-size: 11.5px; color: var(--text-dim); }
+.ask-card-option-label {
+	font-size: 13px;
+	font-weight: 600;
+}
+.ask-card-option-desc {
+	font-size: 11.5px;
+	color: var(--text-dim);
+}
 
 .ask-card-other {
-  width: 100%;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 7px;
-  color: var(--text);
-  padding: 7px 10px;
-  font-size: 12.5px;
-  outline: none;
+	width: 100%;
+	background: var(--bg-raised);
+	border: 1px solid var(--border-strong);
+	border-radius: 7px;
+	color: var(--text);
+	padding: 7px 10px;
+	font-size: 12.5px;
+	outline: none;
 }
-.ask-card-other:focus { border-color: var(--accent); }
+.ask-card-other:focus {
+	border-color: var(--accent);
+}
 
-.ask-card-actions { display: flex; justify-content: flex-end; }
+.ask-card-actions {
+	display: flex;
+	justify-content: flex-end;
+}
 
-.msg-queued { opacity: 0.55; }
+.msg-queued {
+	opacity: 0.55;
+}
 
 /* Optimistic just-sent bubble: present but visibly not-yet-confirmed */
-.msg-sending { opacity: 0.6; }
-.msg-sending .msg-label-user { animation: sendingPulse 1.2s ease-in-out infinite; }
-@keyframes sendingPulse { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+.msg-sending {
+	opacity: 0.6;
+}
+.msg-sending .msg-label-user {
+	animation: sendingPulse 1.2s ease-in-out infinite;
+}
+@keyframes sendingPulse {
+	0%,
+	100% {
+		opacity: 0.55;
+	}
+	50% {
+		opacity: 1;
+	}
+}
 
 /* Inline images: markdown images, pasted images, and Read-of-image results */
 .msg-images,
 .tool-result-images {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 6px;
 }
-.md-image-link { display: inline-block; line-height: 0; }
+.md-image-link {
+	display: inline-block;
+	line-height: 0;
+}
 .md-image,
 .markdown img {
-  max-width: 100%;
-  max-height: 360px;
-  height: auto;
-  border-radius: 8px;
-  border: 1px solid rgba(127, 127, 127, 0.25);
-  margin: 6px 0;
-  display: block;
+	max-width: 100%;
+	max-height: 360px;
+	height: auto;
+	border-radius: 8px;
+	border: 1px solid rgba(127, 127, 127, 0.25);
+	margin: 6px 0;
+	display: block;
 }
 .tool-result-videos {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 6px;
 }
 .md-video {
-  max-width: 100%;
-  max-height: 480px;
-  border-radius: 8px;
-  border: 1px solid rgba(127, 127, 127, 0.25);
-  margin: 6px 0;
-  display: block;
-  background: #000;
+	max-width: 100%;
+	max-height: 480px;
+	border-radius: 8px;
+	border: 1px solid rgba(127, 127, 127, 0.25);
+	margin: 6px 0;
+	display: block;
+	background: #000;
 }
 
 /* Composer image attachments (pasted/dropped screenshots) */
 .composer-images {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 8px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 8px;
 }
 .composer-image-thumb {
-  position: relative;
-  line-height: 0;
+	position: relative;
+	line-height: 0;
 }
 .composer-image-thumb img {
-  height: 56px;
-  width: auto;
-  max-width: 120px;
-  object-fit: cover;
-  border-radius: 8px;
-  border: 1px solid var(--border-strong);
+	height: 56px;
+	width: auto;
+	max-width: 120px;
+	object-fit: cover;
+	border-radius: 8px;
+	border: 1px solid var(--border-strong);
 }
 .composer-image-remove {
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: none;
-  background: var(--text);
-  color: var(--bg-panel);
-  font-size: 13px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
+	position: absolute;
+	top: -6px;
+	right: -6px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	border: none;
+	background: var(--text);
+	color: var(--bg-panel);
+	font-size: 13px;
+	line-height: 1;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
 }
 
 /* "Fork from here" affordance on assistant messages */
 .msg-fork-btn {
-  margin-left: 8px;
-  border: none;
-  background: none;
-  color: var(--text-dim);
-  font-size: 11px;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s, color 0.12s;
+	margin-left: 8px;
+	border: none;
+	background: none;
+	color: var(--text-dim);
+	font-size: 11px;
+	cursor: pointer;
+	opacity: 0;
+	transition:
+		opacity 0.12s,
+		color 0.12s;
 }
-.msg-assistant:hover .msg-fork-btn { opacity: 1; }
-.msg-fork-btn:hover { color: var(--accent); }
+.msg-assistant:hover .msg-fork-btn {
+	opacity: 1;
+}
+.msg-fork-btn:hover {
+	color: var(--accent);
+}
 
 /* Fork mode banner above the composer */
 .fork-banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 7px 12px;
-  margin-bottom: 8px;
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
-  font-size: 12.5px;
-  color: var(--text);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 7px 12px;
+	margin-bottom: 8px;
+	border-radius: 10px;
+	background: color-mix(in srgb, var(--accent) 12%, transparent);
+	border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+	font-size: 12.5px;
+	color: var(--text);
 }
 .fork-banner-cancel {
-  border: none;
-  background: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  font-size: 12px;
+	border: none;
+	background: none;
+	color: var(--text-dim);
+	cursor: pointer;
+	font-size: 12px;
 }
-.fork-banner-cancel:hover { color: var(--text); }
+.fork-banner-cancel:hover {
+	color: var(--text);
+}
 
 .queue-count {
-  font-size: 11.5px;
-  color: var(--accent);
-  font-weight: 600;
+	font-size: 11.5px;
+	color: var(--accent);
+	font-weight: 600;
 }
 
 /* ── Claude account pool (Connections page) ── */
-.conn-logo-claude { background: #D97757; }
+.conn-logo-claude {
+	background: #d97757;
+}
 
 .acct-usage-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-  font-size: 11.5px;
-  color: var(--text-dim);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 8px;
+	font-size: 11.5px;
+	color: var(--text-dim);
 }
 
 .acct-usage-label {
-  width: 18px;
-  flex-shrink: 0;
-  color: var(--text-faint);
+	width: 18px;
+	flex-shrink: 0;
+	color: var(--text-faint);
 }
 
 .acct-usage-bar {
-  flex: 1;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--bg-active);
-  overflow: hidden;
-  min-width: 40px;
+	flex: 1;
+	height: 6px;
+	border-radius: 3px;
+	background: var(--bg-active);
+	overflow: hidden;
+	min-width: 40px;
 }
 
 .acct-usage-fill {
-  height: 100%;
-  border-radius: 3px;
-  transition: width 0.3s ease;
+	height: 100%;
+	border-radius: 3px;
+	transition: width 0.3s ease;
 }
-.acct-usage-green { background: #34d399; }
-.acct-usage-yellow { background: #fbbf24; }
-.acct-usage-red { background: #f87171; }
-.acct-usage-gray { background: var(--border); }
+.acct-usage-green {
+	background: #34d399;
+}
+.acct-usage-yellow {
+	background: #fbbf24;
+}
+.acct-usage-red {
+	background: #f87171;
+}
+.acct-usage-gray {
+	background: var(--border);
+}
 
 .acct-usage-pct {
-  width: 34px;
-  text-align: right;
-  flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
+	width: 34px;
+	text-align: right;
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
 }
 
 .acct-usage-reset {
-  color: var(--text-faint);
-  white-space: nowrap;
-  flex-shrink: 0;
+	color: var(--text-faint);
+	white-space: nowrap;
+	flex-shrink: 0;
 }

--- a/src/server/tab-colors.ts
+++ b/src/server/tab-colors.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-user session tab colors. Like pins.ts, each user (the self-selected
+ * `backstage-user` name from the UserPicker — not an auth identity) gets one
+ * JSON file `~/.backstage-tab-colors/<user>.json` of shape
+ * `{ colors: { [sessionId]: colorKey } }`, where `colorKey` is one of the
+ * named swatches in the frontend palette (see lib/tab-colors.ts). Colors are
+ * a per-user view preference, so they live next to pins and sync across devices.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+const HOME = process.env.HOME || "/home/ubuntu";
+const COLORS_DIR = `${HOME}/.backstage-tab-colors`;
+
+/** Allowed swatch keys — keep in sync with TAB_COLORS in lib/tab-colors.ts. */
+const ALLOWED = new Set([
+	"red",
+	"orange",
+	"yellow",
+	"green",
+	"blue",
+	"purple",
+	"pink",
+]);
+
+/** Map a free-form user name to a safe filename; empty/odd input → Anonymous. */
+function sanitizeUser(user: string): string {
+	const cleaned = (user || "")
+		.trim()
+		.replace(/[^A-Za-z0-9_-]/g, "_")
+		.slice(0, 64);
+	return cleaned || "Anonymous";
+}
+
+function fileFor(user: string): string {
+	return `${COLORS_DIR}/${sanitizeUser(user)}.json`;
+}
+
+export type TabColors = Record<string, string>;
+
+export function getTabColors(user: string): TabColors {
+	try {
+		const f = fileFor(user);
+		if (!existsSync(f)) return {};
+		const raw = JSON.parse(readFileSync(f, "utf8"));
+		return clean(raw?.colors);
+	} catch {
+		return {};
+	}
+}
+
+/** Keep only string-id → allowed-color entries. */
+function clean(input: unknown): TabColors {
+	const out: TabColors = {};
+	if (input && typeof input === "object") {
+		for (const [id, color] of Object.entries(
+			input as Record<string, unknown>,
+		)) {
+			if (
+				typeof id === "string" &&
+				typeof color === "string" &&
+				ALLOWED.has(color)
+			) {
+				out[id] = color;
+			}
+		}
+	}
+	return out;
+}
+
+/** Replace a user's tab colors (validated). Returns the stored map. */
+export function setTabColors(user: string, colors: unknown): TabColors {
+	const cleaned = clean(colors);
+	try {
+		if (!existsSync(COLORS_DIR)) mkdirSync(COLORS_DIR, { recursive: true });
+		writeFileSync(fileFor(user), JSON.stringify({ colors: cleaned }, null, 2));
+	} catch {}
+	return cleaned;
+}


### PR DESCRIPTION
Right-click a session tab to open a swatch menu and color it from a default palette. Colors are a per-user view preference, stored server-side and synced across devices exactly like pins — useful for telling a row of lookalike tabs apart at a glance.

## What's new
- **Right-click any session tab** → floating swatch menu (red / orange / yellow / green / blue / purple / pink, plus a "no color" chip). Dismisses on outside-click, scroll, or Escape.
- Colored tabs get a colored top edge + a faint tint of the chosen swatch (`--tab-color`).

## Implementation (mirrors the pins pattern)
- `src/server/tab-colors.ts` — per-user `~/.backstage-tab-colors/<user>.json` store, validated against the allowed swatch keys. `GET`/`PUT /backstage/api/tab-colors` routes in `backstage.ts`.
- `src/frontend/lib/tab-colors.ts` — synchronous in-memory cache hydrated from the server, optimistic writes, `TAB_COLORS` palette (mirror of `lib/pins.ts`, minus the legacy localStorage migration).
- `SessionTabs.tsx` — `onContextMenu` opens the menu; new `colors`/`onSetColor` props wired through `App.tsx`.

## Operational note
The new backend route lives in the `Bun.serve` `fetch` closure, which is captured once via `??=`, so **it needs a `systemctl restart` (or the deploy-on-merge) to go live** — it won't hot-reload. The frontend changes hot-rebuild as usual. Until the route is live the feature degrades gracefully (fetch throws → cache stays empty → no colors shown, nothing breaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)