### PR TITLE
Docs-sync as a backstage automation (on PR merge)

### DIFF
--- a/src/agents/github/constants.ts
+++ b/src/agents/github/constants.ts
@@ -5,6 +5,11 @@ export const PR_EVENT_KEY = "github:pull_request";
 /** Name of the seeded (disabled-by-default) review automation. */
 export const REVIEW_AUTOMATION_NAME = "github-pr-review";
 
+/** Internal event key published when a PR is merged into tella-fusion. */
+export const PR_MERGED_EVENT_KEY = "github:pr_merged";
+/** Name of the seeded docs-sync automation (fires on PR merge). */
+export const DOCS_SYNC_AUTOMATION_NAME = "docs-sync";
+
 export const LABEL_REVIEW = "michael-review";
 export const LABEL_AUTOFIX = "michael-auto-fix";
 export const LABEL_SIMPLIFY = "michael-simplify";

--- a/src/agents/github/index.ts
+++ b/src/agents/github/index.ts
@@ -14,8 +14,13 @@ import {
   saveAutomation,
 } from "../../server/automations";
 import { githubConfigured } from "./github-rest";
-import { PR_EVENT_KEY, REVIEW_AUTOMATION_NAME } from "./constants";
-import { DEFAULT_REVIEW_PROMPT } from "./prompts";
+import {
+  PR_EVENT_KEY,
+  REVIEW_AUTOMATION_NAME,
+  PR_MERGED_EVENT_KEY,
+  DOCS_SYNC_AUTOMATION_NAME,
+} from "./constants";
+import { DEFAULT_REVIEW_PROMPT, DOCS_SYNC_PROMPT } from "./prompts";
 import { setGithubSessionInvalidate, resolveReviewConfig } from "./webhook";
 import { listPrStates, activeCodeLoops, clearPendingMention } from "./state";
 import type { PrRef } from "./review";
@@ -42,6 +47,32 @@ function ensureReviewAutomation(): void {
   // Seed it OFF — start label-only; flip on in the Automations UI to review every non-draft PR.
   saveAutomation({ ...created, enabled: false });
   console.log(`[github] Seeded review automation "${REVIEW_AUTOMATION_NAME}" (disabled)`);
+}
+
+/**
+ * Seed the docs-sync automation if it doesn't exist yet. Keyed on eventKey.
+ * Code mode: each merged PR runs a headless session in a fresh worktree that
+ * updates the Mintlify docs and opens a PR. Seeded ENABLED — this is the live
+ * replacement for the old Mintlify-hosted docs-sync workflow. Toggle it in the
+ * Automations UI.
+ */
+function ensureDocsSyncAutomation(): void {
+  const existing = listAutomations().find((a) => a.eventKey === PR_MERGED_EVENT_KEY);
+  if (existing) return;
+  const created = createAutomation({
+    name: DOCS_SYNC_AUTOMATION_NAME,
+    prompt: DOCS_SYNC_PROMPT,
+    schedule: "",
+    mode: "code",
+    createdBy: "Michael (github agent)",
+    eventKey: PR_MERGED_EVENT_KEY,
+    model: "claude-opus-4-8",
+  });
+  if ("error" in created) {
+    console.error(`[github] Failed to seed docs-sync automation:`, created.error);
+    return;
+  }
+  console.log(`[github] Seeded docs-sync automation "${DOCS_SYNC_AUTOMATION_NAME}" (enabled)`);
 }
 
 /** Re-enter auto-fix loops that a restart interrupted. */
@@ -171,6 +202,7 @@ export class GithubAgent implements AgentModule {
     }
     if (this.onSessionInvalidate) setGithubSessionInvalidate(this.onSessionInvalidate);
     ensureReviewAutomation();
+    ensureDocsSyncAutomation();
     await recoverFixLoops();
     await recoverOneShots();
     await recoverMentions();

--- a/src/agents/github/prompts.ts
+++ b/src/agents/github/prompts.ts
@@ -40,6 +40,73 @@ How to review well:
 - Be high-signal: a few well-justified findings beat a long list of nits. Don't invent issues, don't praise, don't restate what the code does. If it's clean, say so briefly and approve.
 - Do NOT edit files, run interactive tools, ask questions, or post anything yourself — the system posts your review.`;
 
+/**
+ * Docs-sync automation prompt (code mode). Fires once per merged tella-fusion PR.
+ * The run starts in a fresh worktree on a dedicated `auto-docs-sync-*` branch off
+ * main; the merged PR's changes are already in the checkout. The triggering event
+ * JSON (with `prNumber`) is appended to this prompt by the automation runner.
+ */
+export const DOCS_SYNC_PROMPT = `You are Michael, Tella's engineering assistant. A pull request was just merged into \`tellahq/tella-fusion\`. Review its diff and update the Mintlify docs to reflect any user-facing changes.
+
+Read the "Triggering event" section at the end of this prompt for the merged PR's number. Then run \`gh pr diff <PR_NUMBER> --repo tellahq/tella-fusion\` (and \`gh pr view <PR_NUMBER>\` for the title/description) to see what changed. Read related files in the checkout for context — you have the full repo.
+
+Identify any changes that affect user-facing features, APIs, or behavior that should be reflected in the documentation. Do not include internally flagged features that aren't available to everyone yet.
+
+## Documentation location
+
+All docs live in \`packages/core/webapp/docs/\`. The navigation structure is defined in \`packages/core/webapp/docs/docs.json\`.
+
+The docs are organized into these tabs:
+
+- **Introduction** — \`introduction/\` (welcome, plans, FAQ, tutorials, glossary)
+- **Help Center** — \`help/\` (recording, editing, sharing, managing, integrations, troubleshooting, FAQ)
+- **API Reference** — \`authentication.mdx\`, \`embed-api.mdx\`, and OpenAPI-generated pages
+
+## Format to follow
+
+Every \`.mdx\` file starts with YAML frontmatter:
+
+\`\`\`mdx
+---
+title: "Page title"
+description: "One sentence summary for SEO (50–160 characters)"
+---
+\`\`\`
+
+Content conventions:
+
+- Write in second person ("you") with a direct, concise tone
+- Use \`##\` for top-level sections, \`####\` for substeps
+- Numbered lists for sequential steps, bullet lists for options or notes
+- Embed Tella videos with an \`<iframe>\` when a walkthrough exists
+- Use Mintlify components where appropriate: \`<Card>\`, \`<CardGroup>\`, \`<Note>\`, \`<Warning>\`, \`<Tip>\`
+- Keep paragraphs short — one to three sentences max
+
+## What to update
+
+- **New features**: Create a new \`.mdx\` page and add it to \`docs.json\` navigation in the appropriate group
+- **Changed behavior**: Update the existing page that covers the affected feature
+- **Removed features**: Remove the page and its \`docs.json\` entry, or add a note if the feature is deprecated but still visible
+- **API changes**: Update \`authentication.mdx\` or \`embed-api.mdx\` as needed. For public API changes, update schemas in \`src/app/api/public/v1/\` — do NOT edit \`docs/openapi.json\` directly
+
+## What to skip
+
+- Internal refactors, dependency updates, or CI/CD changes with no user-facing impact
+- Changes to \`AGENTS.md\`, \`CLAUDE.md\`, or other developer-only files
+- Backend-only performance improvements
+
+## Important
+
+- Match the style and structure of existing docs pages
+- Do not change content meaning when fixing style
+
+## Opening the PR
+
+You are already on a dedicated \`auto-docs-sync-*\` branch — do not create another.
+
+- If the merged PR needs documentation changes: make the edits, then commit with \`git add\` on the specific paths (never \`git add .\`), push the current branch with \`git push -u origin HEAD\`, and open a PR with \`gh pr create --repo tellahq/tella-fusion --title "Docs sync for #<PR_NUMBER>" --body "<summary of what you updated and why, referencing #<PR_NUMBER>>"\`.
+- If no documentation changes are needed: do nothing — make no commits and open no PR. End your turn with a one-line explanation of why the merged PR needed no docs update.`;
+
 /** Hidden machine-readable contract the review agent must satisfy at the end of its turn. */
 const REVIEW_OUTPUT_CONTRACT = `
 ## Output format (required)

--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -6,10 +6,11 @@
  * Defensive: never throws into the Slack handler; all behaviors are fired
  * fire-and-forget (GitHub's 10s webhook timeout).
  */
-import { listAutomations } from "../../server/automations";
+import { listAutomations, fireAutomationsForEvent } from "../../server/automations";
 import { GITHUB_REPO, BOT_LOGIN } from "./github-rest";
 import {
   PR_EVENT_KEY,
+  PR_MERGED_EVENT_KEY,
   REVIEW_AUTOMATION_NAME,
   LABEL_REVIEW,
   LABEL_AUTOFIX,
@@ -106,11 +107,24 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
       return;
     }
 
-    // ── Merge → queue seo-sweep PRs for later Ahrefs validation ──
+    // ── Merge → queue seo-sweep PRs + fire docs-sync ──
     if (action === "closed" && pr.merged) {
       if ((pr.labels || []).some((l) => l.name === SEO_LABEL)) {
         const { recordMergedSeoPr } = await import("../loops/seo");
         recordMergedSeoPr(pr.number, pr.merged_at || new Date().toISOString());
+      }
+      // Docs-sync: review the merged PR for user-facing changes and update the
+      // Mintlify docs. Skip PRs authored by our bot account — that includes the
+      // docs-sync automation's own PRs, so this can never loop on itself.
+      if (pr.user?.login !== BOT_LOGIN) {
+        const payload = JSON.stringify({
+          prNumber: pr.number,
+          title: pr.title || `PR #${pr.number}`,
+          headRef: pr.head?.ref || "",
+          author: pr.user?.login || "",
+        });
+        const fired = fireAutomationsForEvent(PR_MERGED_EVENT_KEY, payload);
+        if (fired) console.log(`[github] PR #${pr.number} merged → fired ${fired} docs-sync automation(s)`);
       }
       return;
     }


### PR DESCRIPTION
Moves the last Mintlify-hosted workflow off Mintlify's infra and into backstage, per Michiel. Instead of a GitHub Action (the earlier direction in tella-fusion #4376), docs-sync now runs as a **code-mode backstage automation** triggered when a PR merges into `tella-fusion`.

## How it works

1. The GitHub PR webhook (already forwarded from the Slack agent) gains a new publish in its existing merge branch: on `closed && merged` it fires a `github:pr_merged` internal event with the PR number/title/branch/author.
2. A seeded **`docs-sync`** automation (code mode, `eventKey: github:pr_merged`) subscribes to that event. Each merge spins up a worktree off `main`, and the agent runs the docs-update prompt: read the merged PR diff (`gh pr diff`), update the Mintlify docs under `packages/core/webapp/docs/`, and open a PR — or do nothing if there's no user-facing change.

This reuses the existing automation + worktree machinery (the same path cron/code automations use) and mirrors the seeded review automation, so it shows up in the Automations UI and can be toggled/edited there.

## Changes

| File | Change |
| --- | --- |
| `constants.ts` | `PR_MERGED_EVENT_KEY` + `DOCS_SYNC_AUTOMATION_NAME` |
| `prompts.ts` | `DOCS_SYNC_PROMPT` — the docs-update spec (Johnny's prompt), adapted for a code-mode run that opens a PR |
| `webhook.ts` | fire the merge event; **skip PRs authored by the bot account** so docs-sync can't loop on its own merged PRs |
| `index.ts` | seed the `docs-sync` automation (enabled) on startup |

## Notes / decisions

- **Seeded enabled** — this is the live replacement for the Mintlify workflow, so it's on by default. Flip it off in the Automations UI if you'd rather gate it.
- **Loop prevention**: the automation opens PRs from the bot account on `auto-docs-sync-*` branches; the merge handler skips any PR whose author is the bot, so merging a docs-sync PR won't spawn another.
- **Model**: `claude-opus-4-8`, matching the review automation.
- Requires one backstage restart to seed the automation and pick up the webhook change (per backstage's usual deploy).
- Companion change: tella-fusion #4376 is being reduced to just removing `.mintlify/workflows/docs-sync.md` (dropping the GitHub Action approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)