### PR TITLE
Redesign chat composer: stowed-away toolbar, plus/goal icons, preview chips

### DIFF
--- a/src/frontend/components/Composer.tsx
+++ b/src/frontend/components/Composer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { ModelOption, FileMention } from "../lib/api";
 import { splitAttachments, imageFilesFromPaste, type FileAttachment } from "../lib/images";
 import { ImageThumbs } from "./ImageThumbs";
@@ -30,7 +30,18 @@ interface Props {
    * interrupting (the main send button interrupts immediately when busy).
    */
   onSteerSend?: () => void;
+  /**
+   * When set, renders a goal button in the toolbar (◎). Wired by the session
+   * viewer to prefix the draft with "/goal", the command that pins a goal.
+   */
+  onGoal?: () => void;
   hint?: string;
+  /**
+   * Faint shortcut label tucked into the input's top-right corner (e.g.
+   * "⌃R to focus"). Shown only while the field is empty and unfocused so it
+   * never competes with what you're typing.
+   */
+  focusHint?: string;
   autoFocus?: boolean;
   /** Exposes the textarea so parents can focus it (e.g. keyboard shortcuts). */
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
@@ -59,11 +70,53 @@ function modelShortLabel(id: string, models: ModelOption[]): string {
   return m ? m.label : id;
 }
 
+/** Inline icon: a 16px glyph that inherits color from its button. */
+function Icon({ path, fill }: { path: string; fill?: boolean }) {
+  return (
+    <svg
+      className="composer-icon"
+      viewBox="0 0 24 24"
+      fill={fill ? "currentColor" : "none"}
+      stroke={fill ? "none" : "currentColor"}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={path} />
+    </svg>
+  );
+}
+
+const PLUS = "M12 5v14M5 12h14";
+const ARROW_UP = "M12 19V5M6 11l6-6 6 6";
+const BOLT = "M13 2 4 14h6l-1 8 9-12h-6l1-8z";
+const FOLD_IN = "M12 4v10m0 0 4-4m-4 4-4-4M5 20h14";
+
+/** Concentric-ring target — the "goal" glyph. */
+function GoalIcon() {
+  return (
+    <svg
+      className="composer-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="12" r="4.5" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 /**
  * Shared chat composer (Claude/Codex-style): rounded container with an
- * auto-growing textarea and a bottom toolbar carrying the model pill and a
- * circular send button. Enter sends, Shift+Enter newlines. With `mentionFetch`,
- * typing "@" opens a file-path autocomplete (arrows to move, Enter/Tab to pick).
+ * auto-growing textarea and a bottom toolbar carrying the model pill, ghost
+ * icon actions (goal, attach), and the send button. Enter sends, Shift+Enter
+ * newlines. With `mentionFetch`, typing "@" opens a file-path autocomplete
+ * (arrows to move, Enter/Tab to pick).
  */
 export function Composer({
   value,
@@ -82,7 +135,9 @@ export function Composer({
   modelTitle,
   leftExtra,
   onSteerSend,
+  onGoal,
   hint,
+  focusHint,
   autoFocus,
   textareaRef: externalRef,
   images,
@@ -94,6 +149,7 @@ export function Composer({
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalRef ?? internalRef;
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [focused, setFocused] = useState(false);
   const imgs = images || [];
   const fls = files || [];
   // Any attachment affordance (paste/drop/pick + thumbnails) is enabled when the
@@ -164,6 +220,9 @@ export function Composer({
         <FileChips files={fls} onRemove={removeFile} disabled={disabled} />
         <div className="composer-input-wrap" ref={mentions.inputWrapRef}>
           {mentions.popup}
+          {focusHint && !focused && !value && (
+            <span className="composer-focus-hint">{focusHint}</span>
+          )}
           <textarea
             ref={textareaRef}
             className="composer-textarea"
@@ -177,7 +236,9 @@ export function Composer({
             onKeyDown={handleKeyDown}
             onKeyUp={mentions.sync}
             onClick={mentions.sync}
+            onFocus={() => setFocused(true)}
             onBlur={() => {
+              setFocused(false);
               // Let a click on a suggestion (mousedown) win the race first.
               setTimeout(mentions.close, 120);
             }}
@@ -207,17 +268,29 @@ export function Composer({
             </select>
             <span className="composer-model-chevron">▾</span>
           </div>
+          {onGoal && (
+            <button
+              type="button"
+              className="composer-tool-btn"
+              onClick={onGoal}
+              disabled={disabled}
+              title="Pin a goal (/goal)"
+              aria-label="Pin a goal"
+            >
+              <GoalIcon />
+            </button>
+          )}
           {canAttach && (
             <>
               <button
                 type="button"
-                className="composer-attach-btn"
+                className="composer-tool-btn"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={disabled}
-                title={onFilesChange ? "Attach a file" : "Attach an image"}
-                aria-label={onFilesChange ? "Attach a file" : "Attach an image"}
+                title={onFilesChange ? "Add files or images" : "Add images"}
+                aria-label={onFilesChange ? "Add files or images" : "Add images"}
               >
-                📎
+                <Icon path={PLUS} />
               </button>
               <input
                 ref={fileInputRef}
@@ -241,8 +314,9 @@ export function Composer({
               onClick={onSteerSend}
               disabled={disabled || sendDisabled}
               title="Fold in at Michael's next stopping point — don't interrupt the current turn"
+              aria-label="Queue message"
             >
-              +
+              <Icon path={FOLD_IN} />
             </button>
           )}
           <button
@@ -253,8 +327,9 @@ export function Composer({
               sendTitle ||
               (busy ? "Send now — interrupts the current turn and redirects Michael (Enter)" : "Send (Enter)")
             }
+            aria-label="Send"
           >
-            {busy ? "⚡" : "↑"}
+            <Icon path={busy ? BOLT : ARROW_UP} fill={busy} />
           </button>
         </div>
       </div>

--- a/src/frontend/components/FileChips.tsx
+++ b/src/frontend/components/FileChips.tsx
@@ -7,26 +7,63 @@ interface Props {
   disabled?: boolean;
 }
 
-/** Removable chip row for non-image file attachments (staged to disk server-side). */
+/** File-type category → chip accent color (drives the icon badge tint). */
+type Category = "code" | "doc" | "data" | "media" | "archive" | "file";
+
+const EXT_CATEGORY: Record<string, Category> = {
+  // code
+  ts: "code", tsx: "code", js: "code", jsx: "code", res: "code", rs: "code",
+  py: "code", go: "code", rb: "code", java: "code", c: "code", h: "code",
+  cpp: "code", css: "code", html: "code", sh: "code", sql: "code",
+  // docs
+  md: "doc", mdx: "doc", txt: "doc", pdf: "doc", doc: "doc", docx: "doc", rtf: "doc",
+  // structured data
+  json: "data", yaml: "data", yml: "data", toml: "data", csv: "data", xml: "data",
+  // media
+  png: "media", jpg: "media", jpeg: "media", gif: "media", webp: "media", svg: "media",
+  mp4: "media", mov: "media", webm: "media", mp3: "media", wav: "media",
+  // archives
+  zip: "archive", tar: "archive", gz: "archive", rar: "archive", "7z": "archive",
+};
+
+function categoryFor(name: string): Category {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_CATEGORY[ext] ?? "file";
+}
+
+function extLabel(name: string): string {
+  const ext = name.includes(".") ? name.split(".").pop()! : "";
+  return ext.slice(0, 4).toUpperCase();
+}
+
+/**
+ * Removable chip row for non-image file attachments (staged to disk
+ * server-side). Each chip leads with a small type-colored badge (the file's
+ * extension) so it reads at a glance, mirroring the file previews in the input.
+ */
 export function FileChips({ files, onRemove, disabled }: Props) {
   if (files.length === 0) return null;
   return (
     <div className="composer-files">
-      {files.map((f, i) => (
-        <div key={i} className="composer-file-chip" title={f.name}>
-          <span className="composer-file-icon">📎</span>
-          <span className="composer-file-name">{f.name}</span>
-          <button
-            type="button"
-            className="composer-file-remove"
-            onClick={() => onRemove(i)}
-            disabled={disabled}
-            title="Remove file"
-          >
-            ×
-          </button>
-        </div>
-      ))}
+      {files.map((f, i) => {
+        const cat = categoryFor(f.name);
+        return (
+          <div key={i} className={`composer-file-chip cat-${cat}`} title={f.name}>
+            <span className="composer-file-badge">{extLabel(f.name) || "•"}</span>
+            <span className="composer-file-name">{f.name}</span>
+            <button
+              type="button"
+              className="composer-file-remove"
+              onClick={() => onRemove(i)}
+              disabled={disabled}
+              title="Remove file"
+              aria-label={`Remove ${f.name}`}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -1045,7 +1045,14 @@ export function SessionViewer({
 											: "Switch the model for this session"
 									}
 									mentionFetch={(q) => fetchFileMentions(q, session.id)}
+									onGoal={() => {
+										setInput((prev) =>
+											prev.trimStart().startsWith("/goal") ? prev : `/goal ${prev}`,
+										);
+										composerRef.current?.focus();
+									}}
 									hint="Enter to send · Shift+Enter for newline · @ to mention a file · /goal pins a goal · /loop runs on an interval"
+									focusHint="⌃R to focus"
 									textareaRef={composerRef}
 								/>
 							</>

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -4570,6 +4570,16 @@ body.resizing-x {
 .composer-input-wrap {
 	position: relative;
 }
+.composer-focus-hint {
+	position: absolute;
+	top: 1px;
+	right: 2px;
+	font-size: 11px;
+	color: var(--text-faint);
+	opacity: 0.7;
+	pointer-events: none;
+	user-select: none;
+}
 .mention-popup {
 	position: absolute;
 	left: 0;
@@ -4643,18 +4653,20 @@ body.resizing-x {
 	align-items: center;
 	gap: 6px;
 	position: relative;
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	padding: 3px 9px 3px 9px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	padding: 3px 7px;
 	color: var(--text-dim);
 	font-size: 12px;
 	max-width: 240px;
 	transition:
 		border-color 0.15s,
+		background 0.15s,
 		color 0.15s;
 }
 .composer-model:hover {
-	border-color: var(--text-faint);
+	border-color: var(--border);
+	background: var(--bg-hover);
 	color: var(--text);
 }
 .composer-model select {
@@ -4693,15 +4705,46 @@ body.resizing-x {
 	background: #19c37d;
 }
 
+.composer-icon {
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
+}
+
+/* Ghost icon actions in the toolbar (goal, add-attachment) — tucked away
+   until hovered, matching the "stowed away" toolbar. */
+.composer-tool-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	border: none;
+	border-radius: 8px;
+	background: none;
+	color: var(--text-faint);
+	cursor: pointer;
+	flex-shrink: 0;
+	transition:
+		background 0.15s,
+		color 0.15s;
+}
+.composer-tool-btn:hover:not(:disabled) {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+.composer-tool-btn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
 .composer-send {
 	width: 30px;
 	height: 30px;
-	border-radius: 50%;
+	border-radius: 8px;
 	background: var(--accent);
 	color: #fff;
 	border: none;
-	font-size: 15px;
-	font-weight: 600;
 	line-height: 1;
 	display: inline-flex;
 	align-items: center;
@@ -5763,6 +5806,7 @@ body.resizing-x {
 	/* The keyboard-shortcut hint is irrelevant on touch and eats vertical space
      right where the keyboard appears — hide it. */
 	.composer-hint,
+	.composer-focus-hint,
 	.prompt-hint {
 		display: none;
 	}
@@ -6127,32 +6171,6 @@ body.resizing-x {
 	cursor: default;
 }
 
-/* Round attach button in the in-session composer toolbar */
-.composer-attach-btn {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	background: none;
-	color: var(--text-dim);
-	font-size: 14px;
-	line-height: 1;
-	cursor: pointer;
-	flex-shrink: 0;
-}
-.composer-attach-btn:hover:not(:disabled) {
-	color: var(--text);
-	border-color: var(--border-strong);
-	background: var(--bg-hover);
-}
-.composer-attach-btn:disabled {
-	opacity: 0.5;
-	cursor: default;
-}
-
 /* Non-image file attachments: chip row (filename + remove) */
 .composer-files {
 	display: flex;
@@ -6163,17 +6181,48 @@ body.resizing-x {
 .composer-file-chip {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	gap: 7px;
 	max-width: 220px;
-	padding: 4px 8px;
+	padding: 4px 9px 4px 4px;
 	border: 1px solid var(--border-strong);
-	border-radius: 7px;
-	background: var(--bg-hover);
+	border-radius: 8px;
+	background: var(--bg-panel);
 	font-size: 12px;
 	color: var(--text);
 }
-.composer-file-icon {
+/* File-type badge: a small tinted square carrying the extension, colored by
+   category so the chip reads at a glance (a lightweight file preview). */
+.composer-file-badge {
 	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 5px;
+	font-size: 8.5px;
+	font-weight: 700;
+	letter-spacing: 0.02em;
+	color: var(--chip-accent, var(--text-dim));
+	background: color-mix(in srgb, var(--chip-accent, var(--text-dim)) 16%, transparent);
+}
+.composer-file-chip.cat-code {
+	--chip-accent: #4f8cff;
+}
+.composer-file-chip.cat-doc {
+	--chip-accent: #e5484d;
+}
+.composer-file-chip.cat-data {
+	--chip-accent: #e0a020;
+}
+.composer-file-chip.cat-media {
+	--chip-accent: #19c37d;
+}
+.composer-file-chip.cat-archive {
+	--chip-accent: #a06be0;
+}
+.composer-file-chip.cat-file {
+	--chip-accent: var(--text-dim);
 }
 .composer-file-name {
 	overflow: hidden;


### PR DESCRIPTION
Redesigns the shared session **Composer** to match the reference design Michiel shared — a cleaner, more "stowed away" chat input.

## What changed
- **Icons, not emoji.** Send (↑), interrupt (⚡), fold-in queue, attach (+), and goal (◎) are now crisp inline SVGs that inherit color.
- **Plus to add stuff.** The bordered 📎 attach button becomes a ghost `+` button.
- **Goal button (◎).** New optional toolbar button that prefixes the draft with `/goal` (the command that pins a goal). Wired only in `SessionViewer`, where `/goal` applies.
- **Squared send button** (rounded square instead of a circle); toolbar icon actions are ghost buttons that surface on hover.
- **Minimal model selector** — borderless until hover.
- **Focus hint.** A faint `⌃R to focus` tucked into the input's top-right, shown only while the field is empty and unfocused (hidden on touch). *(Note: Backstage focuses the composer with **Ctrl+R**, not ⌘L as in the reference screenshot.)*
- **File chips with a preview badge.** Each non-image chip leads with a type-colored extension badge (code/doc/data/media/archive), a lightweight file preview.
- Deletes the now-unused `.composer-attach-btn` styles.

## Scope / safety
- Branched off `origin/master` in an isolated worktree, so it does **not** entangle the in-progress sidebar work sitting uncommitted on `master`.
- `bunx tsc --noEmit` is clean for all touched files (the 21 remaining errors are pre-existing: missing `@codemirror/*`/`yjs` deps + unrelated files).
- `Composer.tsx` and `FileChips.tsx` bundle cleanly via `bun build`.

## Preview
Rendered from the real `global.css` (dark + light), across idle / with-attachments / busy states — see the images in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)