### PR TITLE
Add ⌘K session-search command palette

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { Sidebar } from "./components/Sidebar";
 import { SessionViewer } from "./components/SessionViewer";
 import { NewSession } from "./components/NewSession";
+import { SessionSearch } from "./components/SessionSearch";
 import { Home } from "./components/Home";
 import { Automations } from "./components/Automations";
 import { Goals } from "./components/Goals";
@@ -246,6 +247,12 @@ function App() {
 		setPalette({ open: true, prompt });
 		setSidebarOpen(false);
 	}, []);
+
+	// The ⌘K session-search command palette. Like the new-session palette it's an
+	// overlay driven by its own state so it can open over any view.
+	const [searchOpen, setSearchOpen] = useState(false);
+	const searchOpenRef = useRef(searchOpen);
+	searchOpenRef.current = searchOpen;
 	const closePalette = React.useCallback(() => {
 		setPalette({ open: false });
 		// A deep link left the URL on /backstage/new — return home on close.
@@ -259,16 +266,26 @@ function App() {
 		return () => window.removeEventListener("popstate", onPop);
 	}, []);
 
-	// ⌘K / ⌘N toggles the palette; Esc closes it.
+	// ⌘K toggles the session-search palette; ⌘N the new-session palette. Esc
+	// closes whichever is open (search's own input also handles Esc, but this
+	// covers the case where focus has left it).
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
 			const k = e.key.toLowerCase();
-			if ((e.metaKey || e.ctrlKey) && (k === "k" || k === "n")) {
+			if ((e.metaKey || e.ctrlKey) && k === "k") {
+				e.preventDefault();
+				setSearchOpen((o) => !o);
+				return;
+			}
+			if ((e.metaKey || e.ctrlKey) && k === "n") {
 				e.preventDefault();
 				paletteOpenRef.current ? closePalette() : openPalette();
 				return;
 			}
-			if (e.key === "Escape" && paletteOpenRef.current) closePalette();
+			if (e.key === "Escape") {
+				if (searchOpenRef.current) setSearchOpen(false);
+				else if (paletteOpenRef.current) closePalette();
+			}
 		};
 		window.addEventListener("keydown", onKey);
 		return () => window.removeEventListener("keydown", onKey);
@@ -673,7 +690,19 @@ function App() {
 					<div className="right-panel-slot" ref={setRightPanelEl} />
 				</div>
 
-				{/* ⌘K new-session palette — overlays every view. */}
+				{/* ⌘K session-search palette — overlays every view. */}
+				{searchOpen && (
+					<SessionSearch
+						sessions={sessions}
+						onSelect={(id) => {
+							setSearchOpen(false);
+							navigate({ view: "session", id });
+						}}
+						onClose={() => setSearchOpen(false)}
+					/>
+				)}
+
+				{/* ⌘N new-session palette — overlays every view. */}
 				{palette.open && (
 					<NewSession
 						onBack={closePalette}

--- a/src/frontend/components/SessionSearch.tsx
+++ b/src/frontend/components/SessionSearch.tsx
@@ -1,0 +1,340 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { UnifiedSession } from "../lib/types";
+import { relativeTime } from "../lib/api";
+
+interface Props {
+	sessions: UnifiedSession[];
+	/** Open a session by id (also closes the palette). */
+	onSelect: (id: string) => void;
+	onClose: () => void;
+}
+
+const DEFAULT_PROJECT = "tella-fusion";
+
+function sessionRepo(s: UnifiedSession): string {
+	return s.project || DEFAULT_PROJECT;
+}
+
+// The status buckets a session can fall into, mirroring the sidebar's triage
+// order: a blocked question first, then live activity, then PR lifecycle.
+type Status = "needsinput" | "running" | "review" | "merged" | "done";
+
+const STATUS_META: Record<Status, { label: string; dotClass: string }> = {
+	needsinput: { label: "Needs input", dotClass: "ss-dot-accent" },
+	running: { label: "Running", dotClass: "ss-dot-green" },
+	review: { label: "In review", dotClass: "ss-dot-yellow" },
+	merged: { label: "Merged", dotClass: "ss-dot-purple" },
+	done: { label: "Done", dotClass: "ss-dot-dim" },
+};
+
+const STATUS_ORDER: Status[] = [
+	"needsinput",
+	"running",
+	"review",
+	"merged",
+	"done",
+];
+
+function sessionStatus(s: UnifiedSession): Status {
+	if (s.waitingForInput) return "needsinput";
+	if (s.isRunning) return "running";
+	if (s.prState === "OPEN") return "review";
+	if (s.prState === "MERGED") return "merged";
+	return "done";
+}
+
+// The searchable haystack for a session — title plus every field a person might
+// recall it by (branch, owner, automation, repo, Linear id).
+function haystack(s: UnifiedSession): string {
+	return [
+		s.title,
+		s.branch,
+		s.startedBy,
+		s.automation,
+		sessionRepo(s),
+		s.linearIssue?.identifier,
+		s.linearIssue?.title,
+	]
+		.filter(Boolean)
+		.join(" ")
+		.toLowerCase();
+}
+
+// A compact styled dropdown built on a native <select> (an invisible select is
+// stacked over the pill so we get a real OS menu for free — same trick as the
+// new-session palette).
+function FilterPill({
+	label,
+	value,
+	options,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	options: Array<{ value: string; label: string }>;
+	onChange: (v: string) => void;
+}) {
+	const active = value !== "all";
+	const current = options.find((o) => o.value === value);
+	return (
+		<div className={`ss-pill${active ? " ss-pill-active" : ""}`}>
+			<span className="ss-pill-key">{label}</span>
+			<span className="ss-pill-val">{current?.label ?? value}</span>
+			<span className="ss-pill-caret">▾</span>
+			<select
+				className="ss-pill-select"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				aria-label={label}
+			>
+				{options.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}
+
+export function SessionSearch({ sessions, onSelect, onClose }: Props) {
+	const [query, setQuery] = useState("");
+	const [person, setPerson] = useState("all");
+	const [repo, setRepo] = useState("all");
+	const [status, setStatus] = useState<Status | "all">("all");
+	const [active, setActive] = useState(0);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	// Only live (non-archived) sessions are searchable here.
+	const pool = useMemo(
+		() => sessions.filter((s) => !s.archived),
+		[sessions],
+	);
+
+	// Filter option lists are built off the full pool (not the filtered set) so
+	// they don't churn as you narrow things down.
+	const personOptions = useMemo(() => {
+		const seen = new Map<string, string>(); // lowercased → first-seen spelling
+		for (const s of pool) {
+			if (s.automation || !s.startedBy) continue;
+			const k = s.startedBy.toLowerCase();
+			if (!seen.has(k)) seen.set(k, s.startedBy);
+		}
+		return [
+			{ value: "all", label: "Anyone" },
+			...Array.from(seen.entries())
+				.sort((a, b) => a[1].localeCompare(b[1]))
+				.map(([k, label]) => ({ value: k, label })),
+		];
+	}, [pool]);
+
+	const repoOptions = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const s of pool) {
+			const p = sessionRepo(s);
+			counts.set(p, (counts.get(p) || 0) + 1);
+		}
+		return [
+			{ value: "all", label: "Any repo" },
+			...Array.from(counts.entries())
+				.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+				.map(([p]) => ({ value: p, label: p })),
+		];
+	}, [pool]);
+
+	const statusOptions = useMemo(
+		() => [
+			{ value: "all", label: "Any status" },
+			...STATUS_ORDER.map((k) => ({ value: k, label: STATUS_META[k].label })),
+		],
+		[],
+	);
+
+	const results = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		const terms = q.split(/\s+/).filter(Boolean);
+		let out = pool.filter((s) => {
+			if (person !== "all" && (s.startedBy || "").toLowerCase() !== person)
+				return false;
+			if (repo !== "all" && sessionRepo(s) !== repo) return false;
+			if (status !== "all" && sessionStatus(s) !== status) return false;
+			if (terms.length === 0) return true;
+			const hay = haystack(s);
+			return terms.every((t) => hay.includes(t));
+		});
+		// Most-recently-active first — the same order the sidebar defaults to.
+		out = out.sort(
+			(a, b) =>
+				new Date(b.lastActivity).getTime() -
+				new Date(a.lastActivity).getTime(),
+		);
+		return out.slice(0, 100);
+	}, [pool, query, person, repo, status]);
+
+	// Clamp the active row whenever the result set changes.
+	useEffect(() => {
+		setActive((i) => Math.min(i, Math.max(0, results.length - 1)));
+	}, [results.length]);
+
+	// Keep the highlighted row scrolled into view during keyboard nav.
+	useEffect(() => {
+		const el = listRef.current?.querySelector<HTMLElement>(
+			`[data-idx="${active}"]`,
+		);
+		el?.scrollIntoView({ block: "nearest" });
+	}, [active]);
+
+	function onKeyDown(e: React.KeyboardEvent) {
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setActive((i) => Math.min(i + 1, results.length - 1));
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setActive((i) => Math.max(i - 1, 0));
+		} else if (e.key === "Enter") {
+			e.preventDefault();
+			const s = results[active];
+			if (s) onSelect(s.id);
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			onClose();
+		}
+	}
+
+	const hasFilter =
+		person !== "all" || repo !== "all" || status !== "all";
+
+	return (
+		<div
+			className="palette-backdrop"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div
+				className="palette-card ss-card"
+				role="dialog"
+				aria-label="Search sessions"
+				onKeyDown={onKeyDown}
+			>
+				<div className="ss-search-row">
+					<svg
+						className="ss-search-icon"
+						width="16"
+						height="16"
+						viewBox="0 0 16 16"
+						fill="none"
+						aria-hidden="true"
+					>
+						<circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.5" />
+						<path
+							d="M14 14L10.7 10.7"
+							stroke="currentColor"
+							strokeWidth="1.5"
+							strokeLinecap="round"
+						/>
+					</svg>
+					<input
+						ref={inputRef}
+						className="ss-search-input"
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						placeholder="Search all sessions…"
+						spellCheck={false}
+					/>
+					<kbd className="ss-kbd">esc</kbd>
+				</div>
+
+				<div className="ss-filters">
+					<FilterPill
+						label="Person"
+						value={person}
+						options={personOptions}
+						onChange={setPerson}
+					/>
+					<FilterPill
+						label="Repo"
+						value={repo}
+						options={repoOptions}
+						onChange={setRepo}
+					/>
+					<FilterPill
+						label="Status"
+						value={status}
+						options={statusOptions}
+						onChange={(v) => setStatus(v as Status | "all")}
+					/>
+					{hasFilter && (
+						<button
+							className="ss-clear"
+							onClick={() => {
+								setPerson("all");
+								setRepo("all");
+								setStatus("all");
+							}}
+						>
+							Clear
+						</button>
+					)}
+				</div>
+
+				<div className="ss-results" ref={listRef}>
+					{results.length === 0 && (
+						<div className="ss-empty">No matching sessions</div>
+					)}
+					{results.map((s, i) => {
+						const st = sessionStatus(s);
+						const meta = STATUS_META[st];
+						return (
+							<button
+								key={s.id}
+								data-idx={i}
+								className={`ss-item${i === active ? " ss-item-active" : ""}`}
+								onMouseMove={() => setActive(i)}
+								onClick={() => onSelect(s.id)}
+							>
+								<span className={`ss-item-dot ${meta.dotClass}`} />
+								<span className="ss-item-main">
+									<span className="ss-item-title">{s.title}</span>
+									<span className="ss-item-meta">
+										{s.automation ? (
+											<span className="ss-tag ss-tag-auto">{s.automation}</span>
+										) : (
+											s.startedBy && <span>{s.startedBy}</span>
+										)}
+										<span className="ss-item-repo">{sessionRepo(s)}</span>
+										{s.branch && (
+											<span className="ss-item-branch">{s.branch}</span>
+										)}
+										<span className="ss-item-time">
+											{relativeTime(s.lastActivity)}
+										</span>
+									</span>
+								</span>
+								<span className="ss-item-status">{meta.label}</span>
+							</button>
+						);
+					})}
+				</div>
+
+				<div className="ss-hint">
+					<span>
+						<kbd className="ss-kbd">↑</kbd>
+						<kbd className="ss-kbd">↓</kbd> navigate
+					</span>
+					<span>
+						<kbd className="ss-kbd">↵</kbd> open
+					</span>
+					<span className="ss-hint-count">
+						{results.length} session{results.length === 1 ? "" : "s"}
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -7694,3 +7694,226 @@ button.preview-open:not(:disabled):hover {
 	.palette-footer { flex-wrap: wrap; }
 	.palette-switch { order: 2; }
 }
+
+/* ── ⌘K session search palette ─────────────────────────────────────────── */
+.ss-card {
+	max-height: 76vh;
+}
+
+.ss-search-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 14px 16px;
+	border-bottom: 1px solid var(--border);
+}
+.ss-search-icon {
+	color: var(--text-faint);
+	flex-shrink: 0;
+}
+.ss-search-input {
+	flex: 1;
+	border: none;
+	background: none;
+	outline: none;
+	color: var(--text);
+	font-family: var(--sans);
+	font-size: 16px;
+	line-height: 1.4;
+}
+.ss-search-input::placeholder {
+	color: var(--text-faint);
+}
+
+.ss-filters {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	padding: 10px 14px;
+	border-bottom: 1px solid var(--border);
+	flex-wrap: wrap;
+}
+.ss-pill {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 4px 9px;
+	border: 1px solid var(--border-strong);
+	border-radius: 999px;
+	background: var(--bg-raised);
+	font-size: 12.5px;
+	color: var(--text-dim);
+	cursor: pointer;
+	transition: border-color 0.12s, color 0.12s;
+}
+.ss-pill:hover {
+	color: var(--text);
+	border-color: var(--text-faint);
+}
+.ss-pill-active {
+	border-color: var(--accent);
+	color: var(--text);
+}
+.ss-pill-key {
+	color: var(--text-faint);
+	font-weight: 500;
+}
+.ss-pill-active .ss-pill-key {
+	color: var(--accent);
+}
+.ss-pill-val {
+	font-weight: 500;
+}
+.ss-pill-caret {
+	font-size: 8px;
+	color: var(--text-faint);
+}
+.ss-pill-select {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	cursor: pointer;
+	appearance: none;
+	-webkit-appearance: none;
+	border: none;
+}
+.ss-clear {
+	margin-left: auto;
+	border: none;
+	background: none;
+	color: var(--text-faint);
+	font-size: 12.5px;
+	cursor: pointer;
+	padding: 4px 6px;
+	border-radius: 6px;
+}
+.ss-clear:hover {
+	color: var(--text);
+	background: var(--bg-raised);
+}
+
+.ss-results {
+	overflow-y: auto;
+	padding: 6px;
+	flex: 1;
+	min-height: 0;
+}
+.ss-empty {
+	padding: 28px 16px;
+	text-align: center;
+	color: var(--text-faint);
+	font-size: 13px;
+}
+.ss-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 8px 10px;
+	border: none;
+	background: none;
+	border-radius: 9px;
+	cursor: pointer;
+	text-align: left;
+	color: var(--text);
+}
+.ss-item-active {
+	background: var(--bg-raised);
+}
+.ss-item-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+.ss-dot-accent { background: var(--accent); }
+.ss-dot-green { background: var(--green); }
+.ss-dot-yellow { background: var(--yellow); }
+.ss-dot-purple { background: var(--purple); }
+.ss-dot-dim { background: var(--text-faint); }
+
+.ss-item-main {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1;
+}
+.ss-item-title {
+	font-size: 13.5px;
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.ss-item-meta {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 11.5px;
+	color: var(--text-faint);
+	overflow: hidden;
+	white-space: nowrap;
+}
+.ss-item-repo {
+	color: var(--text-dim);
+}
+.ss-item-branch {
+	font-family: var(--mono, monospace);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 220px;
+}
+.ss-item-time {
+	margin-left: auto;
+	flex-shrink: 0;
+}
+.ss-tag {
+	padding: 1px 6px;
+	border-radius: 5px;
+	font-size: 11px;
+}
+.ss-tag-auto {
+	background: rgba(210, 153, 34, 0.16);
+	color: #d29922;
+}
+.ss-item-status {
+	font-size: 11.5px;
+	color: var(--text-faint);
+	flex-shrink: 0;
+}
+
+.ss-hint {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 8px 14px;
+	border-top: 1px solid var(--border);
+	font-size: 11.5px;
+	color: var(--text-faint);
+}
+.ss-hint-count {
+	margin-left: auto;
+}
+.ss-kbd {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 16px;
+	padding: 1px 4px;
+	margin: 0 1px;
+	border: 1px solid var(--border-strong);
+	border-radius: 4px;
+	background: var(--bg-raised);
+	font-family: var(--sans);
+	font-size: 10.5px;
+	color: var(--text-dim);
+}
+
+@media (max-width: 560px) {
+	.ss-item-branch { display: none; }
+	.ss-item-status { display: none; }
+}


### PR DESCRIPTION
## What

Adds a **⌘K command palette to search across all sessions**, with filter controls at the top.

- **⌘K** → opens the new session-search palette (fleet-wide search).
- **⌘N** → still opens the new-session palette. Previously ⌘K *and* ⌘N both opened new-session; ⌘K is now search.
- **Esc** closes whichever palette is open.

## Search & filters

- Fuzzy-ish substring search over **title, branch, owner, automation, repo, and Linear id** (all query terms must match).
- Three filter pills: **Person**, **Repo**, **Status** (Needs input / Running / In review / Merged / Done). Options are built from the live session pool, so they reflect what's actually there.
- Results are **most-recently-active first**, capped at 100, and fully keyboard-navigable (↑/↓ to move, ↵ to open, Esc to close). Each row shows a status dot, title, owner/automation, repo, branch and last-active time.

## Implementation notes

- New `SessionSearch.tsx` component; wired into `App.tsx`'s global keydown + overlay layer alongside the existing new-session palette.
- Reuses the existing `.palette-backdrop` / `.palette-card` shell and the invisible-`<select>`-over-a-styled-pill trick, so there's no new popover machinery. All new styling lives in a self-contained `.ss-*` block in `global.css`.
- Scoped to non-archived sessions.

Isolated to 3 files (`App.tsx`, `SessionSearch.tsx`, `global.css`). No new TypeScript errors introduced (the two pre-existing `send`-prop errors on `SessionViewer`/`NewSession` are on `master` already and untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)