### PR TITLE
Sidebar: move user into the Michael menu, reuse the space for a collapse toggle

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -12,7 +12,7 @@ import { Notes, type NotesSelection } from "./components/Notes";
 import { Connections } from "./components/Connections";
 import { Archived } from "./components/Archived";
 import { Reviews } from "./components/Reviews";
-import { UserPicker, UserGate, getCurrentUser } from "./components/UserPicker";
+import { UserGate, getCurrentUser } from "./components/UserPicker";
 import { SettingsMenu } from "./components/SettingsMenu";
 import { Settings } from "./components/Settings";
 import { SessionTabs } from "./components/SessionTabs";
@@ -163,6 +163,19 @@ function App() {
 	// that (see the `.mobile-detail` CSS and the back button below). It's inert on
 	// desktop, where the sidebar + detail are a static split.
 	const detailPaneRef = useRef<HTMLElement | null>(null);
+	// Desktop-only: collapse the left sidebar entirely (persisted per browser). On
+	// mobile the page-stack (mobileDetail) governs the sidebar instead; this hides
+	// the static desktop column and swaps in a floating re-open control.
+	const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(
+		() => localStorage.getItem("michael-sidebar-collapsed") === "1",
+	);
+	function toggleSidebarCollapsed() {
+		setSidebarCollapsed((v) => {
+			const next = !v;
+			localStorage.setItem("michael-sidebar-collapsed", next ? "1" : "0");
+			return next;
+		});
+	}
 	// The top bar above the tab strip. The session viewer portals its header
 	// (session name + actions, incl. the workspace-panel toggle) into this slot so
 	// the layout reads name-on-top / tabs-below; other views render a plain title.
@@ -474,9 +487,9 @@ function App() {
 				: route.view
 			: ("sessions" as const);
 
-	// Brand (Michael + settings chevron) and the connection/user controls. Shared
-	// between the mobile top bar and the desktop sidebar's brand row, so they read
-	// identically in both layouts.
+	// Brand: the Michael title + its dropdown (the "Michael menu"), which now carries
+	// the account switcher and connection status that used to sit as a separate chip.
+	// Shared between the mobile top bar and the desktop sidebar's brand row.
 	const brand = (
 		<div className="app-brand">
 			<a
@@ -490,16 +503,36 @@ function App() {
 				<span className="app-logo">M</span>
 				<span className="app-title-text">Michael</span>
 			</a>
-			<SettingsMenu onOpenSettings={() => navigate({ view: "settings" })} />
+			<SettingsMenu
+				onOpenSettings={() => navigate({ view: "settings" })}
+				connected={connected}
+			/>
 		</div>
 	);
-	const userControls = (
-		<div className="app-header-right">
-			<span
-				className={`connection-dot ${connected ? "connected" : "disconnected"}`}
+
+	// The "toggle left sidebar" panel glyph — a framed rectangle with a divider
+	// marking the collapsible left column. Reused by the brand-row collapse button
+	// and the floating re-open control.
+	const panelIcon = (
+		<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+			<rect
+				x="1.75"
+				y="2.75"
+				width="12.5"
+				height="10.5"
+				rx="2"
+				stroke="currentColor"
+				strokeWidth="1.4"
 			/>
-			<UserPicker />
-		</div>
+			<line
+				x1="6.25"
+				y1="2.75"
+				x2="6.25"
+				y2="13.25"
+				stroke="currentColor"
+				strokeWidth="1.4"
+			/>
+		</svg>
 	);
 
 	return (
@@ -534,24 +567,35 @@ function App() {
 							brand
 						)}
 					</div>
-					{userControls}
 				</header>
 
 				{route.view === "settings" ? (
 					<Settings onBack={() => navigate({ view: "home" })} />
 				) : (
-				<div className={`app-body ${mobileDetail ? "mobile-detail" : "mobile-root"}`}>
+				<div
+					className={`app-body ${mobileDetail ? "mobile-detail" : "mobile-root"}${
+						sidebarCollapsed ? " sidebar-collapsed" : ""
+					}`}
+				>
 					<div
 						className="sidebar-container"
 						style={
 							{ "--sidebar-w": `${sidebarWidth}px` } as React.CSSProperties
 						}
 					>
-						{/* Desktop brand row: Michael left, user right (hidden on mobile,
-						    where the top bar carries these instead). */}
+						{/* Desktop brand row: Michael menu on the left, the collapse toggle
+						    on the right (hidden on mobile, where the top bar carries the
+						    brand instead). */}
 						<div className="sidebar-brand">
 							{brand}
-							{userControls}
+							<button
+								className="sidebar-toggle-btn"
+								onClick={toggleSidebarCollapsed}
+								aria-label="Hide sidebar"
+								title="Toggle left sidebar"
+							>
+								{panelIcon}
+							</button>
 						</div>
 						<Sidebar
 							sessions={sessions}
@@ -660,6 +704,17 @@ function App() {
 					</div>
 
 					<main className="detail-pane" ref={detailPaneRef}>
+						{/* Floating re-open control, shown only while the desktop sidebar
+						    is collapsed (CSS-gated). Mirrors the brand-row toggle so the
+						    sidebar can always be brought back. */}
+						<button
+							className="sidebar-reopen"
+							onClick={toggleSidebarCollapsed}
+							aria-label="Show sidebar"
+							title="Toggle left sidebar"
+						>
+							{panelIcon}
+						</button>
 						{/* Top bar: session name + actions (portaled in by SessionViewer)
 						    on session routes, a plain title otherwise. Sits above the tab
 						    strip so the session identity reads first, tabs below it. */}

--- a/src/frontend/components/SettingsMenu.tsx
+++ b/src/frontend/components/SettingsMenu.tsx
@@ -1,12 +1,21 @@
 import React, { useEffect, useRef, useState } from "react";
+import { TEAM, setCurrentUser, useCurrentUser } from "./UserPicker";
 
-// The dropdown behind the "Michael" title in the top bar. It's a small menu whose
-// one entry opens the full Settings page (theme, notifications, …). Appearance and
-// other preferences live in Settings now, not inline here.
+// The dropdown behind the "Michael" title in the top bar — the "Michael menu". It
+// holds the account switcher (who you're acting as), the live connection status,
+// and an entry into the full Settings page (theme, notifications, …). Appearance
+// and other preferences live in Settings now, not inline here.
 
-export function SettingsMenu({ onOpenSettings }: { onOpenSettings?: () => void }) {
+export function SettingsMenu({
+	onOpenSettings,
+	connected,
+}: {
+	onOpenSettings?: () => void;
+	connected?: boolean;
+}) {
 	const [open, setOpen] = useState(false);
 	const ref = useRef<HTMLDivElement | null>(null);
+	const currentUser = useCurrentUser();
 
 	// Dismiss on outside click / Escape while open.
 	useEffect(() => {
@@ -48,6 +57,60 @@ export function SettingsMenu({ onOpenSettings }: { onOpenSettings?: () => void }
 			</button>
 			{open && (
 				<div className="settings-dropdown" role="menu">
+					<div className="settings-section">
+						<div className="settings-section-label">Acting as</div>
+						<div className="settings-user-list">
+							{TEAM.map((name) => (
+								<button
+									key={name}
+									className={`settings-user-item${
+										name === currentUser ? " active" : ""
+									}`}
+									role="menuitemradio"
+									aria-checked={name === currentUser}
+									onClick={() => {
+									setCurrentUser(name);
+									setOpen(false);
+								}}
+								>
+									<span className="settings-user-avatar">
+										{name.charAt(0).toUpperCase()}
+									</span>
+									<span className="settings-user-name">{name}</span>
+									{name === currentUser && (
+										<svg
+											className="settings-user-check"
+											width="13"
+											height="13"
+											viewBox="0 0 16 16"
+											fill="none"
+										>
+											<path
+												d="M3.5 8.5l3 3 6-7"
+												stroke="currentColor"
+												strokeWidth="1.6"
+												strokeLinecap="round"
+												strokeLinejoin="round"
+											/>
+										</svg>
+									)}
+								</button>
+							))}
+						</div>
+					</div>
+
+					<div className="settings-section">
+						<div className="settings-status-row">
+							<span
+								className={`connection-dot ${
+									connected ? "connected" : "disconnected"
+								}`}
+							/>
+							{connected ? "Connected" : "Reconnecting…"}
+						</div>
+					</div>
+
+					<div className="settings-section">
 					<button
 						className="settings-menu-item"
 						role="menuitem"
@@ -67,6 +130,7 @@ export function SettingsMenu({ onOpenSettings }: { onOpenSettings?: () => void }
 						</svg>
 						Settings
 					</button>
+					</div>
 				</div>
 			)}
 		</div>

--- a/src/frontend/components/UserPicker.tsx
+++ b/src/frontend/components/UserPicker.tsx
@@ -13,6 +13,11 @@ export function getCurrentUser(): string {
   return localStorage.getItem(KEY) || "Anonymous";
 }
 
+/** Switch the current user (used by the Michael dropdown's account switcher). */
+export function setCurrentUser(name: string) {
+  setStoredUser(name);
+}
+
 /** Reactive current user — updates when the picker (or another tab) changes it. */
 export function useCurrentUser(): string {
   const [user, setUser] = useState(getCurrentUser);
@@ -28,34 +33,6 @@ export function useCurrentUser(): string {
   }, []);
 
   return user;
-}
-
-export function UserPicker() {
-  const user = useCurrentUser();
-
-  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    setStoredUser(e.target.value);
-  }
-
-  return (
-    <div className="user-picker">
-      <span className="user-picker-val">{user}</span>
-      <span className="user-picker-caret">▾</span>
-      <select
-        className="user-picker-select"
-        value={user}
-        onChange={handleChange}
-        aria-label="Current user"
-      >
-        {!TEAM.includes(user) && <option value={user}>{user}</option>}
-        {TEAM.map((name) => (
-          <option key={name} value={name}>
-            {name}
-          </option>
-        ))}
-      </select>
-    </div>
-  );
 }
 
 export function UserGate({ children }: { children: React.ReactNode }) {

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -405,12 +405,6 @@ a {
 	margin-top: 4px;
 }
 
-.app-header-right {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-}
-
 .connection-dot {
 	width: 8px;
 	height: 8px;
@@ -421,44 +415,6 @@ a {
 }
 .connection-dot.disconnected {
 	background: var(--red);
-}
-
-.user-picker {
-	position: relative;
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	padding: 4px 9px;
-	border: 1px solid var(--border-strong);
-	border-radius: 999px;
-	background: var(--bg-raised);
-	color: var(--text-dim);
-	font-size: 12.5px;
-	cursor: pointer;
-	transition: border-color 0.12s, color 0.12s;
-}
-.user-picker:hover {
-	color: var(--text);
-	border-color: var(--text-faint);
-}
-.user-picker-val {
-	font-weight: 500;
-	color: var(--text);
-}
-.user-picker-caret {
-	font-size: 8px;
-	color: var(--text-faint);
-}
-.user-picker-select {
-	position: absolute;
-	inset: 0;
-	width: 100%;
-	height: 100%;
-	opacity: 0;
-	cursor: pointer;
-	appearance: none;
-	-webkit-appearance: none;
-	border: none;
 }
 
 .app-body {
@@ -495,7 +451,8 @@ a {
 	min-height: 0;
 }
 
-/* Brand row at the top of the desktop sidebar: Michael left, user right. */
+/* Brand row at the top of the desktop sidebar: Michael menu left, collapse
+   toggle right. */
 .sidebar-brand {
 	display: flex;
 	align-items: center;
@@ -505,6 +462,41 @@ a {
 	border-bottom: 1px solid var(--border);
 	flex-shrink: 0;
 	min-width: 0;
+}
+
+/* Collapse toggle sitting where the user chip used to be. The floating re-open
+   control (.sidebar-reopen) shares its look so the affordance reads the same
+   whether the sidebar is open or hidden. */
+.sidebar-toggle-btn,
+.sidebar-reopen {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	flex-shrink: 0;
+	padding: 0;
+	background: none;
+	border: none;
+	border-radius: 7px;
+	color: var(--text-faint);
+	cursor: pointer;
+	transition: color 0.12s, background 0.12s;
+}
+.sidebar-toggle-btn:hover,
+.sidebar-reopen:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+
+/* The re-open control is mounted in the detail pane but only shows while the
+   desktop sidebar is collapsed (see the sidebar-collapsed rules below). */
+.sidebar-reopen {
+	position: absolute;
+	top: 11px;
+	left: 12px;
+	z-index: 20;
+	display: none;
 }
 
 /* Drag handle on the sidebar's right edge — a hover/active hairline over a
@@ -1369,6 +1361,29 @@ body.resizing-x {
 	min-height: 0;
 	display: flex;
 	flex-direction: column;
+	/* Anchor for the floating .sidebar-reopen control when the sidebar collapses. */
+	position: relative;
+}
+
+/* ── Collapsed desktop sidebar ──────────────────────────────
+   Hide the static left column entirely and reveal the floating re-open control.
+   Scoped to desktop; on mobile the page-stack (mobile-root/mobile-detail) owns
+   the sidebar and this class is inert. */
+@media (min-width: 721px) {
+	.app-body.sidebar-collapsed .sidebar-container {
+		display: none;
+	}
+	.app-body.sidebar-collapsed .sidebar-reopen {
+		display: inline-flex;
+	}
+	/* Clear the floating control so it never sits on top of the topbar title or
+	   the session header's first row. */
+	.app-body.sidebar-collapsed .detail-topbar-title {
+		padding-left: 52px;
+	}
+	.app-body.sidebar-collapsed .viewer-header {
+		padding-left: 52px;
+	}
 }
 
 /* Top bar above the tab strip. On session routes the SessionViewer portals its
@@ -8691,6 +8706,72 @@ button.preview-open:not(:disabled):hover {
 }
 .settings-menu-item:hover {
 	background: var(--bg-hover);
+}
+
+/* Account switcher inside the Michael menu — one row per teammate, the active
+   one checked. Replaces the old header user-picker chip. */
+.settings-user-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+.settings-user-item {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--text);
+	font-size: 13px;
+	font-family: inherit;
+	padding: 6px 8px;
+	border-radius: 7px;
+}
+.settings-user-item:hover {
+	background: var(--bg-hover);
+}
+.settings-user-item.active {
+	color: var(--text);
+}
+.settings-user-avatar {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	flex-shrink: 0;
+	border-radius: 50%;
+	background: var(--bg-active);
+	color: var(--text-dim);
+	font-size: 11px;
+	font-weight: 600;
+}
+.settings-user-item.active .settings-user-avatar {
+	background: var(--accent);
+	color: #fff;
+}
+.settings-user-name {
+	flex: 1;
+	min-width: 0;
+	font-weight: 500;
+}
+.settings-user-check {
+	color: var(--accent);
+	flex-shrink: 0;
+}
+
+/* Connection status line in the Michael menu (the dot that used to sit inline
+   in the header, now labelled). */
+.settings-status-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 2px 8px;
+	font-size: 12px;
+	color: var(--text-dim);
 }
 
 /* Theme picker — three preview cards (System / Light / Dark) */


### PR DESCRIPTION
## What

Reworks the desktop sidebar's brand row per the request: **move the user into the Michael dropdown, and use that freed space to open/close the left sidebar.**

Before, the brand row had `[Michael ▾]` on the left and a separate user-picker chip (+ connection dot) on the right.

## Changes

- **Michael menu (`SettingsMenu`)** now carries:
  - an **"Acting as"** account switcher — one row per teammate, the current user checked
  - a **labelled connection-status** row (replacing the bare header dot)
  - the existing **Settings** entry
- **Brand row right slot** is now a **panel-glyph collapse toggle**. A matching **floating re-open control** shows in the detail pane while the sidebar is hidden, so it can always be brought back. Collapse state is desktop-only and persisted per browser (`michael-sidebar-collapsed`).
- **Mobile is untouched** — the hamburger drawer still governs the sidebar there; the collapse class is inert below 721px.
- **Dead code removed**: the `UserPicker` component and its CSS (`.user-picker*`, `.app-header-right`) are gone now that the header chip is retired. The user store helpers (`getCurrentUser` / `useCurrentUser` / new `setCurrentUser`) and `UserGate` stay.

## Notes

- Isolated in a fresh worktree off `origin/master`, so unrelated in-progress work in the main checkout is not swept in.
- `tsc --noEmit` shows only pre-existing, unrelated errors (missing generated `mcp-config.json`, etc.); none in the touched files.

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1dd4-84d7-7000-b062-4813531bcb44)