### PR TITLE
Collapse "Acting as" into a submenu

### DIFF
--- a/src/frontend/components/SettingsMenu.tsx
+++ b/src/frontend/components/SettingsMenu.tsx
@@ -14,6 +14,7 @@ export function SettingsMenu({
 	connected?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
+	const [actingOpen, setActingOpen] = useState(false);
 	const ref = useRef<HTMLDivElement | null>(null);
 	const currentUser = useCurrentUser();
 
@@ -33,6 +34,11 @@ export function SettingsMenu({
 			document.removeEventListener("mousedown", onDown);
 			document.removeEventListener("keydown", onKey);
 		};
+	}, [open]);
+
+	// Collapse the acting-as submenu whenever the whole menu closes.
+	useEffect(() => {
+		if (!open) setActingOpen(false);
 	}, [open]);
 
 	return (
@@ -57,46 +63,87 @@ export function SettingsMenu({
 			</button>
 			{open && (
 				<div className="settings-dropdown" role="menu">
-					<div className="settings-section">
-						<div className="settings-section-label">Acting as</div>
-						<div className="settings-user-list">
-							{TEAM.map((name) => (
-								<button
-									key={name}
-									className={`settings-user-item${
-										name === currentUser ? " active" : ""
-									}`}
-									role="menuitemradio"
-									aria-checked={name === currentUser}
-									onClick={() => {
-									setCurrentUser(name);
-									setOpen(false);
-								}}
-								>
-									<span className="settings-user-avatar">
-										{name.charAt(0).toUpperCase()}
-									</span>
-									<span className="settings-user-name">{name}</span>
-									{name === currentUser && (
-										<svg
-											className="settings-user-check"
-											width="13"
-											height="13"
-											viewBox="0 0 16 16"
-											fill="none"
+					<div
+						className="settings-section settings-submenu"
+						onMouseEnter={() => setActingOpen(true)}
+						onMouseLeave={() => setActingOpen(false)}
+					>
+						<button
+							className={`settings-menu-item settings-submenu-trigger${
+								actingOpen ? " active" : ""
+							}`}
+							role="menuitem"
+							aria-haspopup="menu"
+							aria-expanded={actingOpen}
+							onClick={() => setActingOpen((v) => !v)}
+						>
+							<span className="settings-user-avatar active">
+								{currentUser.charAt(0).toUpperCase()}
+							</span>
+							<span className="settings-submenu-label">
+								<span className="settings-submenu-title">Acting as</span>
+								<span className="settings-submenu-value">{currentUser}</span>
+							</span>
+							<svg
+								className="settings-submenu-chevron"
+								width="10"
+								height="10"
+								viewBox="0 0 10 10"
+								aria-hidden="true"
+							>
+								<path
+									d="M3.5 2L6.5 5L3.5 8"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="1.5"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								/>
+							</svg>
+						</button>
+						{actingOpen && (
+							<div className="settings-submenu-panel" role="menu">
+								<div className="settings-user-list">
+									{TEAM.map((name) => (
+										<button
+											key={name}
+											className={`settings-user-item${
+												name === currentUser ? " active" : ""
+											}`}
+											role="menuitemradio"
+											aria-checked={name === currentUser}
+											onClick={() => {
+											setCurrentUser(name);
+											setActingOpen(false);
+											setOpen(false);
+										}}
 										>
-											<path
-												d="M3.5 8.5l3 3 6-7"
-												stroke="currentColor"
-												strokeWidth="1.6"
-												strokeLinecap="round"
-												strokeLinejoin="round"
-											/>
-										</svg>
-									)}
-								</button>
-							))}
-						</div>
+											<span className="settings-user-avatar">
+												{name.charAt(0).toUpperCase()}
+											</span>
+											<span className="settings-user-name">{name}</span>
+											{name === currentUser && (
+												<svg
+													className="settings-user-check"
+													width="13"
+													height="13"
+													viewBox="0 0 16 16"
+													fill="none"
+												>
+													<path
+														d="M3.5 8.5l3 3 6-7"
+														stroke="currentColor"
+														strokeWidth="1.6"
+														strokeLinecap="round"
+														strokeLinejoin="round"
+													/>
+												</svg>
+											)}
+										</button>
+									))}
+								</div>
+							</div>
+						)}
 					</div>
 
 					<div className="settings-section">

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -8924,8 +8924,56 @@ button.preview-open:not(:disabled):hover {
 	background: var(--bg-hover);
 }
 
-/* Account switcher inside the Michael menu — one row per teammate, the active
-   one checked. Replaces the old header user-picker chip. */
+/* Account switcher inside the Michael menu — collapsed to a single "Acting as"
+   row that opens a flyout submenu with one row per teammate. */
+.settings-submenu {
+	position: relative;
+}
+.settings-submenu-trigger {
+	margin-bottom: 0;
+}
+.settings-submenu-label {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+	line-height: 1.25;
+}
+.settings-submenu-title {
+	font-weight: 500;
+}
+.settings-submenu-value {
+	font-size: 11px;
+	color: var(--text-dim);
+}
+.settings-submenu-chevron {
+	flex-shrink: 0;
+	color: var(--text-faint);
+}
+.settings-submenu-trigger.active .settings-submenu-chevron {
+	color: var(--text);
+}
+.settings-submenu-panel {
+	position: absolute;
+	top: -12px;
+	left: calc(100% + 6px);
+	z-index: 210;
+	min-width: 200px;
+	background: var(--bg-panel);
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32);
+	padding: 8px;
+}
+/* Transparent bridge over the gap so moving from trigger to panel doesn't close it. */
+.settings-submenu-panel::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: -8px;
+	width: 8px;
+	height: 100%;
+}
 .settings-user-list {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## What

The Michael menu (behind the top-bar title) showed the full "Acting as" teammate list inline, which took up most of the dropdown. This collapses it into a single **Acting as** row that displays the current user and reveals the teammate list in a flyout submenu on hover/click.

## Details

- `SettingsMenu.tsx`: the inline user list is now a `settings-submenu` trigger row (avatar + "Acting as" + current user + chevron) that opens a `settings-submenu-panel` flyout containing the same teammate list. Submenu collapses when the menu closes or a teammate is picked.
- `global.css`: styles for the trigger row and flyout panel, plus a transparent hover bridge over the gap so moving the pointer from the trigger to the panel doesn't dismiss it.

Only my two hunks were committed; the shared checkout's other in-progress edits were left untouched.

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1e1a-f26c-7000-9a61-8aa1163d3220)