### PR TITLE
Center the session name in the mobile top bar (iOS-sheet style)

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -509,6 +509,12 @@ function App() {
 									? "New session"
 									: "";
 
+	// iOS-sheet style: on a mobile session page the session name sits centered in
+	// the top bar, next to the Back chevron. Other pushed views keep their plain
+	// left-aligned .detail-topbar-title, so this is session-only.
+	const mobileHeaderTitle: string =
+		route.view === "session" ? currentSession?.title ?? "" : "";
+
 	const activeView =
 		route.view === "automations" ||
 		route.view === "goals" ||
@@ -600,6 +606,11 @@ function App() {
 							brand
 						)}
 					</div>
+					{mobileDetail && mobileHeaderTitle && (
+						<span className="app-header-title" title={mobileHeaderTitle}>
+							{mobileHeaderTitle}
+						</span>
+					)}
 				</header>
 
 				{route.view === "settings" ? (

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -6810,6 +6810,27 @@ button.preview-open:not(:disabled):hover {
 	.app-header {
 		display: flex;
 		padding: env(safe-area-inset-top, 0px) 10px 0;
+		position: relative;
+	}
+	/* iOS-sheet nav bar: the page title is centered across the whole bar (not
+	   after the Back chevron). Symmetric side insets keep it honestly centered
+	   while clearing the Back button; it truncates rather than pushing layout.
+	   Non-interactive so taps fall through to Back / the actions below. */
+	.app-header-title {
+		position: absolute;
+		left: 62px;
+		right: 62px;
+		top: 50%;
+		transform: translateY(-50%);
+		text-align: center;
+		font-size: 15px;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		color: var(--text);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		pointer-events: none;
 	}
 	.sidebar-brand {
 		display: none;
@@ -6826,23 +6847,10 @@ button.preview-open:not(:disabled):hover {
 		flex-wrap: wrap;
 		row-gap: 6px;
 	}
+	/* The session title now lives centered in the top bar (.app-header-title),
+	   so the in-header title row is redundant on phones — drop it and let the
+	   header be just the compact actions row. */
 	.viewer-title {
-		gap: 7px;
-		flex: 1 1 100%;
-		min-width: 0;
-	}
-	.viewer-started-by {
-		display: none;
-	}
-	.viewer-branch {
-		font-size: 14px;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-	/* The model pill duplicates the composer's model selector — drop it from the
-     title row on phones so the title gets the full width (less truncation). */
-	.viewer-title .model-pill {
 		display: none;
 	}
 


### PR DESCRIPTION
On mobile the session name sat in a second header row *below* the Back chevron, which felt disconnected. This moves it up next to Back and centers it across the top bar like an iOS sheet nav bar.

### What changed
- Render the session title centered in the mobile `.app-header`, next to the Back chevron. It's absolutely positioned with symmetric side insets so it stays honestly centered on the bar and clears the Back button, truncating with an ellipsis rather than pushing the layout.
- Drop the now-redundant in-header title row (`.viewer-title`) on phones, so the header below is just the compact actions row.
- Session-only: other pushed views keep their existing left-aligned `.detail-topbar-title`.

Desktop is unaffected — `.app-header` is `display:none` above 720px, so the centered title only appears on mobile.

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1efb-ef7c-7000-b8b8-b2bb1b0c4b6f)