### PR TITLE
Redesign Settings → Default model as a grouped radio list

### DIFF
--- a/src/frontend/components/Connections.tsx
+++ b/src/frontend/components/Connections.tsx
@@ -310,8 +310,11 @@ export function DefaultModel() {
     load();
   }, [load]);
 
+  // Optimistic: highlight the clicked row immediately, revert if the save fails.
   async function handleChange(id: string) {
-    if (id === current) return;
+    if (id === current || saving) return;
+    const prev = current;
+    setCurrent(id);
     setSaving(true);
     setError(null);
     try {
@@ -325,48 +328,52 @@ export function DefaultModel() {
       setCurrent(body.default);
     } catch (e: any) {
       setError(e.message);
+      setCurrent(prev);
     }
     setSaving(false);
   }
 
-  const claudeModels = (models || []).filter((m) => m.provider === "claude");
-  const codexModels = (models || []).filter((m) => m.provider === "codex");
+  const groups = [
+    { label: "Claude", items: (models || []).filter((m) => m.provider === "claude") },
+    { label: "Codex", items: (models || []).filter((m) => m.provider === "codex") },
+  ].filter((g) => g.items.length > 0);
 
   return (
     <>
       {error && (
         <div className="form-error" onClick={() => setError(null)}>{error}</div>
       )}
-      <div className="conn-card" style={{ maxWidth: 460 }}>
-        <div className="conn-blurb">
-          New sessions and agent runs (Slack, Linear, Plain, automations without their own model)
-          start on this model. Per-session overrides still win. Applies to the next run — no restart.
-        </div>
-        <div className="conn-detail" style={{ alignItems: "center", gap: 10 }}>
-          <select
-            value={current}
-            disabled={!models || saving}
-            onChange={(e) => handleChange(e.target.value)}
-            aria-label="Default model"
-            style={{ flex: 1, minWidth: 0 }}
-          >
-            {claudeModels.length > 0 && (
-              <optgroup label="Claude">
-                {claudeModels.map((m) => (
-                  <option key={m.id} value={m.id}>{m.label}</option>
-                ))}
-              </optgroup>
-            )}
-            {codexModels.length > 0 && (
-              <optgroup label="Codex">
-                {codexModels.map((m) => (
-                  <option key={m.id} value={m.id}>{m.label}</option>
-                ))}
-              </optgroup>
-            )}
-          </select>
-          {saving && <span className="conn-target">Saving…</span>}
-        </div>
+      <div className="setting-card model-picker" role="radiogroup" aria-label="Default model">
+        {!models && <div className="model-picker-empty">Loading models…</div>}
+        {models && groups.length === 0 && (
+          <div className="model-picker-empty">No models available.</div>
+        )}
+        {groups.map((g) => (
+          <div className="model-group" key={g.label}>
+            <div className="model-group-label">{g.label}</div>
+            {g.items.map((m) => {
+              const active = m.id === current;
+              return (
+                <button
+                  key={m.id}
+                  role="radio"
+                  aria-checked={active}
+                  className={`model-row ${active ? "active" : ""}`}
+                  onClick={() => handleChange(m.id)}
+                >
+                  <span className="model-row-radio" aria-hidden="true" />
+                  <span className="model-row-name">{m.label}</span>
+                  {m.aliases[0] && <span className="model-row-alias">{m.aliases[0]}</span>}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="settings-hint">
+        New sessions and agent runs (Slack, Linear, Plain, automations without their own model)
+        start on this model. Per-session overrides still win. Applies to the next run — no
+        restart needed.
       </div>
     </>
   );

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -9386,6 +9386,75 @@ button.preview-open:not(:disabled):hover {
 	gap: 8px;
 }
 
+/* Default-model picker: provider-grouped radio rows inside a setting card */
+.model-picker {
+	padding: 6px;
+}
+.model-picker-empty {
+	padding: 12px 10px;
+	font-size: 13px;
+	color: var(--text-faint);
+}
+.model-group + .model-group {
+	margin-top: 6px;
+	padding-top: 6px;
+	border-top: 1px solid var(--border);
+}
+.model-group-label {
+	font-size: 10.5px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--text-faint);
+	padding: 8px 10px 4px;
+}
+.model-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--text);
+	font-size: 13.5px;
+	font-family: inherit;
+	padding: 8px 10px;
+	border-radius: 8px;
+}
+.model-row:hover {
+	background: var(--bg-hover);
+}
+.model-row-radio {
+	width: 15px;
+	height: 15px;
+	flex-shrink: 0;
+	border-radius: 50%;
+	border: 1.5px solid var(--border-strong);
+	transition: border 0.12s ease;
+}
+.model-row.active .model-row-radio {
+	border: 5px solid var(--accent);
+}
+.model-row-name {
+	flex: 1;
+	min-width: 0;
+	font-weight: 500;
+}
+.model-row.active .model-row-name {
+	font-weight: 600;
+}
+.model-row-alias {
+	font-family: var(--mono);
+	font-size: 11px;
+	color: var(--text-faint);
+	background: var(--bg-active);
+	border-radius: 4px;
+	padding: 1px 6px;
+	flex-shrink: 0;
+}
+
 /* Toggle switch */
 .ui-switch {
 	width: 38px;


### PR DESCRIPTION
The Default model panel was a beige card with a paragraph of explainer text and a native `<select>` — it didn't match the rest of the settings surface.

**Now:**
- A `setting-card` radio list, models grouped under **Claude** / **Codex** provider labels (same idiom as the account switcher / theme cards).
- One row per model: radio indicator, model name, and its `/model` alias as a mono chip (`fable`, `opus`, `codex`, …) — doubles as documentation for the Slack command.
- Selection is optimistic: the row highlights immediately and reverts if the save fails (error banner unchanged).
- The long explainer moved to a `settings-hint` below the card instead of dominating it.

No API or behavior changes — still `GET /api/models` + `PUT /api/models/default`.

Verified with `tsc` (no new errors; only pre-existing unrelated ones) and a rendered mock against the real stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1f42-7ce0-7000-a483-a4d6fadae8ad)