### PR TITLE
Show in the chat how long the agent has been working

### DIFF
--- a/src/frontend/components/Elapsed.tsx
+++ b/src/frontend/components/Elapsed.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * Self-ticking "how long has this been going" label (CLI-spinner style).
+ * Isolated so the once-a-second tick re-renders only this span, not the
+ * component that embeds it.
+ */
+export function Elapsed({
+	since,
+	className,
+}: {
+	since: number;
+	className?: string;
+}) {
+	const [, bump] = useState(0);
+	useEffect(() => {
+		const id = setInterval(() => bump((n) => n + 1), 1000);
+		return () => clearInterval(id);
+	}, []);
+
+	const label = formatElapsed(Date.now() - since);
+	if (label === null) return null;
+	return <span className={className ?? "elapsed-time"}>{label}</span>;
+}
+
+export function formatElapsed(ms: number): string | null {
+	if (!isFinite(ms)) return null;
+	const secs = Math.max(0, Math.floor(ms / 1000));
+	if (secs < 60) return `${secs}s`;
+	const mins = Math.floor(secs / 60);
+	if (mins < 60) return `${mins}m ${secs % 60}s`;
+	const hours = Math.floor(mins / 60);
+	return `${hours}h ${mins % 60}m`;
+}

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -38,6 +38,7 @@ import { PreviewButton } from "./PreviewButton";
 import { SpinOffMenu } from "./SpinOffMenu";
 import { IconSidebarRight } from "./icons";
 import { Tooltip } from "./Tooltip";
+import { Elapsed } from "./Elapsed";
 import { isPinned, togglePin, onPinsChanged } from "../lib/pins";
 import { useChatScroll } from "../hooks/useChatScroll";
 
@@ -258,6 +259,26 @@ export function SessionViewer({
 		: "";
 	const panelAvailable = hasWorkspace || hasPlain;
 	const isBusy = isRunningLive || isStreaming;
+
+	// Anchor for the "how long has Michael been working" ticker: the current
+	// turn's user message (server truth, so it survives reopening a session
+	// mid-run), the optimistic just-sent bubble, or — for turns with no user
+	// entry — when this client saw the run begin.
+	const busyStartRef = useRef(Date.now());
+	useEffect(() => {
+		if (isBusy) busyStartRef.current = Date.now();
+	}, [isBusy]);
+	const turnStartedAt = useMemo(() => {
+		if (!isBusy) return null;
+		let t = 0;
+		for (const e of entries) {
+			if (e.type !== "user") continue;
+			const ts = new Date(e.timestamp).getTime();
+			if (isFinite(ts) && ts > t) t = ts;
+		}
+		for (const p of pending) if (p.sentAt > t) t = p.sentAt;
+		return t || busyStartRef.current;
+	}, [isBusy, entries, pending]);
 
 	// Ctrl+R focuses the composer (overrides browser reload while in a session)
 	const composerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -1245,6 +1266,12 @@ export function SessionViewer({
 										{streamBy && streamBy !== me
 											? `${streamBy} is driving — Michael is working…`
 											: "Michael is working…"}
+										{turnStartedAt !== null && (
+											<Elapsed
+												since={turnStartedAt}
+												className="busy-elapsed"
+											/>
+										)}
 										{(queued.length > 0 || visibleSteered.length > 0) && (
 											<span className="queue-count">
 												{visibleSteered.length > 0 &&

--- a/src/frontend/components/WorkBlock.tsx
+++ b/src/frontend/components/WorkBlock.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import type { TranscriptEntry } from "../lib/types";
 import { ToolCallBlock, parseMcpTool } from "./ToolCallBlock";
+import { Elapsed } from "./Elapsed";
 
 interface Props {
   items: TranscriptEntry[]; // tool_use entries, in order
@@ -27,14 +28,26 @@ export function WorkBlock({ items, toolResults, live, onOpenSubagent }: Props) {
 
   const duration = blockDuration(items, toolResults);
   const last = items[items.length - 1];
+  // While live, tick against the wall clock from the block's first step so the
+  // header reads like the CLI spinner ("Working for 9m 7s") instead of only
+  // advancing when a new tool result lands.
+  const startMs = items.length > 0 ? new Date(items[0].timestamp).getTime() : NaN;
 
   return (
     <div className={`work-block ${live ? "work-block-live" : ""}`}>
       <button className="work-block-header" onClick={() => setExpanded(!expanded)}>
         <span className="work-block-chevron">{expanded ? "▾" : "▸"}</span>
         <span className="work-block-title">
-          {live ? "Working" : "Worked"}
-          {duration ? ` for ${duration}` : ""}
+          {live && isFinite(startMs) ? (
+            <>
+              Working for <Elapsed since={startMs} className="work-block-elapsed" />
+            </>
+          ) : (
+            <>
+              {live ? "Working" : "Worked"}
+              {duration ? ` for ${duration}` : ""}
+            </>
+          )}
         </span>
         <span className="work-block-steps">
           {items.length} step{items.length === 1 ? "" : "s"}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -5120,6 +5120,15 @@ button.preview-open:not(:disabled):hover {
 	flex-shrink: 0;
 }
 
+/* Live tickers ("Working for 9m 7s"); tabular digits so they don't jitter. */
+.work-block-elapsed,
+.busy-elapsed {
+	font-variant-numeric: tabular-nums;
+}
+.busy-elapsed {
+	color: var(--text-faint);
+}
+
 .work-block-preview {
 	font-family: var(--mono);
 	font-size: 11px;


### PR DESCRIPTION
The terminal spinner shows elapsed time ("9m, 7.3s") while Claude works; the Backstage chat had no equivalent — you couldn't tell how long Michael had been at it.

Now:

- The busy bar above the composer reads **"Michael is working… 9m 7s"**, ticking once a second.
- The live work block header ticks **"Working for 9m 7s"** against the wall clock, instead of only advancing when a new tool result lands. Finished blocks keep the existing static "Worked for …".

Implementation notes:

- The timer anchors on the current turn's user message timestamp (server truth, so it's correct when you open a session mid-run), falling back to the optimistic just-sent bubble, or to when the client saw the run begin (e.g. automation turns).
- The once-a-second tick lives in a small isolated `Elapsed` component, so it re-renders one span per second rather than the whole `SessionViewer`/transcript. Tabular numerals so the digits don't jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1f6c-e013-7000-af99-bce31f53023a)