### PR TITLE
Repo chips in the session top bar, in front of the workspace title

### DIFF
--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -751,9 +751,10 @@ export function SessionViewer({
 		return () => ro.disconnect();
 	}, [topbarEl]);
 	// Collapse before the inline row can overrun: the title's non-shrinkable
-	// floor (source chip + model pill + Working pill) plus all six action buttons
-	// needs ~820px, so below that the secondary actions move into the ⋯ menu.
-	const compactHeader = headerW > 0 && headerW < 820;
+	// floor (source chip + repo chips + model pill + Working pill) plus all six
+	// action buttons needs ~900px, so below that the secondary actions move into
+	// the ⋯ menu.
+	const compactHeader = headerW > 0 && headerW < 900;
 
 	const [overflowOpen, setOverflowOpen] = useState(false);
 	const overflowRef = useRef<HTMLDivElement>(null);
@@ -897,6 +898,16 @@ export function SessionViewer({
 						<span className={`source-chip source-${session.source}`}>
 							{session.source}
 						</span>
+					)}
+					{/* Repo chips ride in the header in front of the workspace title —
+					    the top bar reads "repo · workspace", no separate repo row. */}
+					{session.worktreeDir && !isAsk && (
+						<RepoBar
+							sessionId={session.id}
+							primaryRepo={session.repo || "tella-fusion"}
+							branch={session.branch}
+							initialAttached={session.attachedRepos || []}
+						/>
 					)}
 					{renameDraft !== null ? (
 						<input
@@ -1070,15 +1081,6 @@ export function SessionViewer({
 				);
 				return topbarEl ? createPortal(header, topbarEl) : header;
 			})()}
-
-			{session.worktreeDir && !isAsk && (
-				<RepoBar
-					sessionId={session.id}
-					primaryRepo={session.repo || "tella-fusion"}
-					branch={session.branch}
-					initialAttached={session.attachedRepos || []}
-				/>
-			)}
 
 			{(session.goal || session.loop) && (
 				<div className="session-banners">

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -5537,14 +5537,14 @@ button.preview-open:not(:disabled):hover {
 	color: var(--text-faint);
 }
 
-/* Cross-repo bar (primary + attached repos) above a code session */
+/* Cross-repo chips (primary + attached repos), inline in the viewer header in
+   front of the workspace title. Chips keep their width — the title next to
+   them is what truncates. */
 .repobar {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
 	gap: 6px;
-	padding: 8px 16px;
-	border-bottom: 1px solid var(--border);
+	flex-shrink: 0;
 }
 .repobar-chip {
 	display: inline-flex;
@@ -6869,6 +6869,11 @@ button.preview-open:not(:disabled):hover {
 	/* The model pill duplicates the composer's model selector — drop it from the
      title row on phones so the title gets the full width (less truncation). */
 	.viewer-title .model-pill {
+		display: none;
+	}
+	/* Repo chips stay on phones, but the attach button is desktop furniture —
+	   drop it so the title keeps its width. */
+	.viewer-title .repobar-add-wrap {
 		display: none;
 	}
 


### PR DESCRIPTION
The repo chips (primary repo + attached repos + `+ repo` attach button + fresh-session repo switcher) used to render as a separate `RepoBar` row under the session header. Now they render inline in the session top bar, in front of the workspace title — the top bar reads **repo · workspace title** and the separate repo row is gone, so the repo isn't displayed twice.

- `SessionViewer`: `RepoBar` moved into `viewer-title` (after the source chip, before the title), standalone row removed; compact-header collapse threshold bumped 820 → 900px for the extra chip width.
- CSS: `.repobar` loses its row padding/border and becomes a non-shrinking inline flex group (the title next to it is what truncates); on phones the `+ repo` button is hidden (chips stay) so the title keeps its width.

All RepoBar behavior (attach, detach, switch primary on fresh sessions) is unchanged — only where it renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f1f83-80ca-7000-b72d-af417208a856)