### PR TITLE
Open transcript images in a browsable lightbox

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -19,6 +19,7 @@ import { Settings } from "./components/Settings";
 import { SessionTabs } from "./components/SessionTabs";
 import { RestartOverlay } from "./components/RestartOverlay";
 import { UpdateToast } from "./components/UpdateToast";
+import { ImageLightbox } from "./components/ImageLightbox";
 import { useSessions } from "./hooks/useSessions";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useBackSwipe } from "./hooks/useBackSwipe";
@@ -1135,5 +1136,6 @@ const root = createRoot(document.getElementById("root")!);
 root.render(
 	<TooltipProvider>
 		<App />
+		<ImageLightbox />
 	</TooltipProvider>,
 );

--- a/src/frontend/components/ImageLightbox.tsx
+++ b/src/frontend/components/ImageLightbox.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+interface LightboxState {
+	images: string[];
+	index: number;
+}
+
+/**
+ * Fullscreen viewer for inline transcript images. Mounted once at the app
+ * root: a capture-phase document click handler hijacks clicks on any
+ * `img.md-image` — message attachments, markdown images, tool-result
+ * screenshots — and opens it in an overlay with prev/next browsing across
+ * the clicked image's group, instead of the old dead-end `data:` new-tab
+ * navigation (which browsers block anyway).
+ */
+export function ImageLightbox() {
+	const [state, setState] = useState<LightboxState | null>(null);
+
+	useEffect(() => {
+		const onClick = (e: MouseEvent) => {
+			if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
+				return;
+			const target = e.target as Element | null;
+			const img = target?.closest?.("img.md-image");
+			if (!(img instanceof HTMLImageElement)) return;
+			e.preventDefault();
+			e.stopPropagation();
+
+			// Browse within the clicked image's own group (one message's
+			// attachments, one markdown body, one tool result) — not every
+			// image in the transcript.
+			const group =
+				img.closest(".msg-images, .tool-result-images, .markdown") ??
+				document.body;
+			const siblings = Array.from(
+				group.querySelectorAll<HTMLImageElement>("img.md-image"),
+			);
+			setState({
+				images: siblings.map((el) => el.currentSrc || el.src),
+				index: Math.max(0, siblings.indexOf(img)),
+			});
+		};
+		document.addEventListener("click", onClick, true);
+		return () => document.removeEventListener("click", onClick, true);
+	}, []);
+
+	const close = useCallback(() => setState(null), []);
+	const step = useCallback((delta: number) => {
+		setState(
+			(s) =>
+				s && { ...s, index: (s.index + delta + s.images.length) % s.images.length },
+		);
+	}, []);
+
+	const open = state !== null;
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				e.stopPropagation();
+				close();
+			} else if (e.key === "ArrowLeft") {
+				e.preventDefault();
+				step(-1);
+			} else if (e.key === "ArrowRight") {
+				e.preventDefault();
+				step(1);
+			}
+		};
+		window.addEventListener("keydown", onKey, true);
+		return () => window.removeEventListener("keydown", onKey, true);
+	}, [open, close, step]);
+
+	if (!state) return null;
+	const { images, index } = state;
+	const many = images.length > 1;
+
+	return (
+		<div className="lightbox" onClick={close} role="dialog" aria-modal="true">
+			<button
+				type="button"
+				className="lightbox-close"
+				onClick={close}
+				title="Close (Esc)"
+			>
+				×
+			</button>
+			{many && (
+				<button
+					type="button"
+					className="lightbox-nav lightbox-prev"
+					onClick={(e) => {
+						e.stopPropagation();
+						step(-1);
+					}}
+					title="Previous (←)"
+				>
+					‹
+				</button>
+			)}
+			<img
+				className="lightbox-img"
+				src={images[index]}
+				alt=""
+				onClick={(e) => e.stopPropagation()}
+			/>
+			{many && (
+				<button
+					type="button"
+					className="lightbox-nav lightbox-next"
+					onClick={(e) => {
+						e.stopPropagation();
+						step(1);
+					}}
+					title="Next (→)"
+				>
+					›
+				</button>
+			)}
+			{many && (
+				<div className="lightbox-counter">
+					{index + 1} / {images.length}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -7576,6 +7576,97 @@ html[data-theme="light"] .tool-code-surface {
 	border: 1px solid rgba(127, 127, 127, 0.25);
 	margin: 6px 0;
 	display: block;
+	cursor: zoom-in;
+}
+
+/* Fullscreen lightbox for inline transcript images */
+.lightbox {
+	position: fixed;
+	inset: 0;
+	z-index: 9500;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.82);
+	backdrop-filter: blur(2px);
+	animation: lightbox-fade 0.15s ease-out;
+}
+@keyframes lightbox-fade {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+.lightbox-img {
+	max-width: calc(100vw - 128px);
+	max-height: calc(100vh - 64px);
+	border-radius: 10px;
+	box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+}
+.lightbox-close,
+.lightbox-nav {
+	position: fixed;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border: none;
+	border-radius: 50%;
+	background: rgba(255, 255, 255, 0.12);
+	color: #fff;
+	cursor: pointer;
+	transition: background 0.12s ease;
+}
+.lightbox-close:hover,
+.lightbox-nav:hover {
+	background: rgba(255, 255, 255, 0.24);
+}
+.lightbox-close {
+	top: 14px;
+	right: 14px;
+	width: 36px;
+	height: 36px;
+	font-size: 22px;
+	line-height: 1;
+}
+.lightbox-nav {
+	top: 50%;
+	transform: translateY(-50%);
+	width: 44px;
+	height: 44px;
+	font-size: 30px;
+	line-height: 1;
+	padding: 0 0 4px;
+}
+.lightbox-prev {
+	left: 14px;
+}
+.lightbox-next {
+	right: 14px;
+}
+.lightbox-counter {
+	position: fixed;
+	bottom: 16px;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: 12.5px;
+	font-variant-numeric: tabular-nums;
+	color: rgba(255, 255, 255, 0.85);
+	background: rgba(0, 0, 0, 0.45);
+	padding: 4px 10px;
+	border-radius: 999px;
+}
+@media (max-width: 700px) {
+	.lightbox-img {
+		max-width: calc(100vw - 20px);
+		max-height: calc(100vh - 110px);
+	}
+	.lightbox-nav {
+		top: auto;
+		bottom: 52px;
+		transform: none;
+	}
 }
 .tool-result-videos {
 	display: flex;


### PR DESCRIPTION
Clicking inline images in a session transcript (message attachments, markdown images, tool-result screenshots) previously opened the raw `data:` URL in a new tab — which modern browsers block, so the thumbnails were effectively dead ends.

This adds a fullscreen lightbox, mounted once at the app root, that intercepts clicks on any `img.md-image` via a capture-phase document handler:

- Opens the clicked image centered on a dark backdrop
- Prev/next chevrons + ← / → keys browse through the clicked image's group (one message's attachments, one markdown body, or one tool result), with wrap-around and a `2 / 4` counter
- Escape, the × button, or clicking the backdrop closes it
- Thumbnails get a `zoom-in` cursor

Verified in headless Chrome with a bundled harness: click on thumb 2 opens at 2/4, three ArrowRights wrap to 1/4, Escape restores the page pixel-identically. `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f2215-438e-7000-be28-d9c27a192caa)