### PR TITLE
Sidebar PR rows open the PR's auto-created workspace when sessionless

### DIFF
--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -609,7 +609,8 @@ export function Sidebar({
 
 	// One sidebar row per open PR of the focus person. `session` is the most
 	// recently active session on that PR (the click target); a sessionless PR
-	// opens on GitHub instead.
+	// opens its auto-created workspace when one exists (PRs opened outside
+	// Backstage, e.g. from Conductor), and GitHub otherwise.
 	interface PrRow {
 		url: string;
 		number?: number;
@@ -618,6 +619,7 @@ export function Sidebar({
 		updatedAt: string;
 		repo: string;
 		session: UnifiedSession | null;
+		workspaceId: string | null;
 	}
 
 	// Open PRs for the focus person (the Person filter, defaulting to you;
@@ -667,6 +669,7 @@ export function Sidebar({
 				updatedAt: pr.updatedAt,
 				repo: pr.repo,
 				session,
+				workspaceId: pr.workspaceId || null,
 			});
 		}
 
@@ -689,6 +692,7 @@ export function Sidebar({
 				updatedAt: s.prUpdatedAt || s.lastActivity,
 				repo: sessionRepo(s),
 				session: s,
+				workspaceId: s.projectId || null,
 			});
 		}
 
@@ -1892,11 +1896,18 @@ export function Sidebar({
 											}`}
 											onClick={() => {
 												if (r.session) onSelect(r.session);
+												else if (r.workspaceId) onOpenProject(r.workspaceId);
 												else window.open(r.url, "_blank", "noopener");
 											}}
 											title={`${r.number ? `#${r.number} ` : ""}${r.title} — ${
 												r.repo
-											}${r.session ? "" : " (no session — opens on GitHub)"}`}
+											}${
+												r.session
+													? ""
+													: r.workspaceId
+														? " (opens its workspace)"
+														: " (no session — opens on GitHub)"
+											}`}
 										>
 											{filter.repo === "all" && <RepoTile name={r.repo} />}
 											<span className="text-faint text-[11px] max-[720px]:text-[13px] tabular-nums shrink-0">

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -89,9 +89,11 @@ export interface OpenPr {
 	/** Web user-picker key ("kent"), or null when the author isn't a teammate. */
 	person: string | null;
 	updatedAt: string;
+	/** The PR's auto-created workspace (`ghpr-<n>`), when one exists. */
+	workspaceId: string | null;
 }
 
-/** Every open PR in the repo, attributed to teammates by GitHub author. */
+/** Every open PR across the covered repos, attributed by GitHub author. */
 export async function fetchOpenPrs(): Promise<OpenPr[]> {
 	const data = await request<{ prs: OpenPr[] }>("/open-prs", {
 		label: "Failed to fetch open PRs",

--- a/src/server/sessions.ts
+++ b/src/server/sessions.ts
@@ -6,6 +6,7 @@ import {
 	githubLoginToPersonKey,
 } from "./shared/user-mappings";
 import { isArchivedId } from "./archive";
+import { listWorkspaces } from "./workspaces";
 import { getTitleOverride } from "./title-overrides";
 import { getGeneratedTitle } from "./generated-titles";
 import { findCodexRollout } from "./codex-accounts";
@@ -481,9 +482,21 @@ export interface OpenPrEntry {
 	/** Web user-picker key ("kent"), or null when the author isn't a teammate. */
 	person: string | null;
 	updatedAt: string;
+	/** The PR's auto-created workspace (`ghpr-<n>`), when one exists. */
+	workspaceId: string | null;
 }
 
 export function getOpenPrs(): OpenPrEntry[] {
+	// PR-backed workspaces, keyed per repo + PR number, so a sessionless PR row
+	// can still open the workspace the PR automations already created for it.
+	// The ghpr key carries no repo, and workspaces predating the repo field are
+	// tella-fusion's (its automations created them all), so absent repo = fusion.
+	const wsByPr = new Map<string, string>();
+	for (const w of listWorkspaces()) {
+		const num = w.prNumber ?? Number(/^ghpr-(\d+)$/.exec(w.key || "")?.[1]);
+		if (num) wsByPr.set(`${w.repo || "tella-fusion"}#${num}`, w.id);
+	}
+
 	const out: OpenPrEntry[] = [];
 	for (const [repoId, byBranch] of getPrsByRepo()) {
 		for (const [branch, pr] of byBranch) {
@@ -499,6 +512,7 @@ export function getOpenPrs(): OpenPrEntry[] {
 				author: pr.author,
 				person: githubLoginToPersonKey(pr.author),
 				updatedAt: pr.updatedAt,
+				workspaceId: wsByPr.get(`${repoId}#${pr.number}`) || null,
 			});
 		}
 	}


### PR DESCRIPTION
## Why

Kent: *"there is only one open PR [shown for me], which is not true — I have many open PRs on GitHub, on tella-fusion and backstage… it can pick up your workspace, which is already generated based on that PR, even if you use another tool like Conductor."*

Most of this is already fixed and live: the sidebar's Open PRs section attributes every open PR to its teammate via each user's GitHub login in `user-mappings.ts`, and since `dbb324a2` (deployed with today's restart) the PR cache covers tellahq/backstage alongside tella-fusion, keyed per-repo. Kent's ~15 fusion PRs now show under his name.

The remaining gap this PR closes: a PR authored **outside Backstage** (Conductor, plain git) has no session, so its row jumped straight to GitHub — even when the PR automations had already created its `ghpr-<n>` workspace grouping the review/fix chats.

## What

- `/api/open-prs` entries now carry `workspaceId`: the PR's auto-created workspace, matched by the workspace's `prNumber`/`ghpr-<n>` key **plus repo** (the key carries no repo; workspaces predating the repo field count as tella-fusion, whose automations created them all).
- Sidebar Open PR rows click through session → PR workspace → GitHub, and the hover hint says which. Session-derived rows carry the session's own workspace.

## Validation

`bunx tsc --noEmit` — no errors in the touched files (remaining errors are pre-existing missing-module noise also on master). Rebased on master after `dbb324a2` landed the multi-repo cache in parallel; this PR is now only the workspace-linking delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f2228-221f-7000-8751-2e393b83aabb)