### PR TITLE
docs-sync: fire on bot-authored feature PRs (skip only auto-docs-sync branches)

### DIFF
--- a/src/agents/github/constants.ts
+++ b/src/agents/github/constants.ts
@@ -9,6 +9,8 @@ export const REVIEW_AUTOMATION_NAME = "github-pr-review";
 export const PR_MERGED_EVENT_KEY = "github:pr_merged";
 /** Name of the seeded docs-sync automation (fires on PR merge). */
 export const DOCS_SYNC_AUTOMATION_NAME = "docs-sync";
+/** Branch prefix for docs-sync's own PRs — skipped on merge so it can't loop. */
+export const DOCS_SYNC_BRANCH_PREFIX = "auto-docs-sync-";
 
 export const LABEL_REVIEW = "michael-review";
 export const LABEL_AUTOFIX = "michael-auto-fix";

--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -11,6 +11,7 @@ import { GITHUB_REPO, BOT_LOGIN } from "./github-rest";
 import {
   PR_EVENT_KEY,
   PR_MERGED_EVENT_KEY,
+  DOCS_SYNC_BRANCH_PREFIX,
   REVIEW_AUTOMATION_NAME,
   LABEL_REVIEW,
   LABEL_AUTOFIX,
@@ -114,13 +115,16 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
         recordMergedSeoPr(pr.number, pr.merged_at || new Date().toISOString());
       }
       // Docs-sync: review the merged PR for user-facing changes and update the
-      // Mintlify docs. Skip PRs authored by our bot account — that includes the
-      // docs-sync automation's own PRs, so this can never loop on itself.
-      if (pr.user?.login !== BOT_LOGIN) {
+      // Mintlify docs. Skip only the docs-sync automation's OWN PRs (they land on
+      // `auto-docs-sync-*` branches) so it can never loop on itself. Do NOT skip by
+      // author: tella-butler authors most real feature PRs (co-recording, camera
+      // backgrounds, onboarding, …), and those are exactly the merges that need docs.
+      const headRef = pr.head?.ref || "";
+      if (!headRef.startsWith(DOCS_SYNC_BRANCH_PREFIX)) {
         const payload = JSON.stringify({
           prNumber: pr.number,
           title: pr.title || `PR #${pr.number}`,
-          headRef: pr.head?.ref || "",
+          headRef,
           author: pr.user?.login || "",
         });
         const fired = fireAutomationsForEvent(PR_MERGED_EVENT_KEY, payload);


### PR DESCRIPTION
## Why

Johnny asked why the docs-sync automation hasn't opened any docs PRs. It **is** enabled and firing on merges — but a loop-safety guard is swallowing the majority of merges.

The merge handler skipped every PR authored by `tella-butler`:

```ts
if (pr.user?.login !== BOT_LOGIN) { …fire docs-sync… }
```

The intent was "don't loop on docs-sync's own PRs." But `tella-butler` authors **~60% of recent tella-fusion merges** (18 of the last 30 — co-recording, camera backgrounds, onboarding, media page, …), because Backstage/Michael open feature PRs as that account. So the guard silently dropped exactly the doc-worthy merges. Only **one** docs-sync PR ever fired ([tella-fusion#4411](https://github.com/tellahq/tella-fusion/pull/4411)).

## Fix

Key the loop guard on the docs-sync **branch prefix** (`auto-docs-sync-*`) instead of the author. Docs-sync's own PRs still land on that branch, so it can't loop on itself — but bot-authored *feature* PRs now correctly trigger a docs review.

- `constants.ts`: add `DOCS_SYNC_BRANCH_PREFIX = "auto-docs-sync-"`
- `webhook.ts`: skip on `headRef.startsWith(DOCS_SYNC_BRANCH_PREFIX)` rather than `pr.user.login === BOT_LOGIN`

`BOT_LOGIN` is still used elsewhere (the `senderIsBot` review guard), so its import stays.

## Note

Needs a backstage restart to take effect (the running process predates this change). After that, the next non-docs-sync merge — human or bot — will fire docs-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)