### PR TITLE
docs-sync: check off Slack announcement when a docs PR merges

### DIFF
--- a/src/agents/github/constants.ts
+++ b/src/agents/github/constants.ts
@@ -11,6 +11,8 @@ export const PR_MERGED_EVENT_KEY = "github:pr_merged";
 export const DOCS_SYNC_AUTOMATION_NAME = "docs-sync";
 /** Branch prefix for docs-sync's own PRs — skipped on merge so it can't loop. */
 export const DOCS_SYNC_BRANCH_PREFIX = "auto-docs-sync-";
+/** #proj-help-center — where docs-sync announces the PRs it opens. */
+export const DOCS_SYNC_SLACK_CHANNEL = "C09BAFFK8F8";
 
 export const LABEL_REVIEW = "michael-review";
 export const LABEL_AUTOFIX = "michael-auto-fix";

--- a/src/agents/github/docs-sync-notify.ts
+++ b/src/agents/github/docs-sync-notify.ts
@@ -1,0 +1,36 @@
+/**
+ * When a docs-sync PR is merged, tick the Slack announcement it posted in
+ * #proj-help-center — mirroring how Mintlify's integration marked its own docs
+ * PRs done. docs-sync's runner posts that announcement via the LLM (free-form,
+ * so backstage never captured its `ts`), so we can't look the message up by a
+ * stored id. Instead we find it at merge time by the PR URL it links, then add
+ * a ✅ reaction. Best-effort: if the message isn't found we just log and move on.
+ */
+import { fetchChannelHistory, addReaction } from "../slack/slack-api";
+import { DOCS_SYNC_SLACK_CHANNEL } from "./constants";
+
+const MERGED_REACTION = "white_check_mark";
+
+/** True when `text` links the given PR (matches the `/pull/<n>` URL, not a
+ *  longer number that merely starts with it, e.g. #4433 vs #44330). */
+function linksPr(text: string, prNumber: number): boolean {
+  return new RegExp(`/pull/${prNumber}(?!\\d)`).test(text);
+}
+
+/**
+ * Add a ✅ to the docs-sync announcement for a just-merged docs PR. Scans recent
+ * history of the docs channel for the message that links this PR and reacts to it.
+ */
+export async function markDocsSyncPrMerged(prNumber: number): Promise<void> {
+  const history = await fetchChannelHistory(DOCS_SYNC_SLACK_CHANNEL, 200);
+  const message = history.find((m) => m.isBot && linksPr(m.text, prNumber));
+  if (!message) {
+    console.log(
+      `[github] docs-sync PR #${prNumber} merged, but no announcement found in #proj-help-center to check off`,
+    );
+    return;
+  }
+
+  await addReaction(DOCS_SYNC_SLACK_CHANNEL, message.ts, MERGED_REACTION);
+  console.log(`[github] Checked off docs-sync announcement for merged PR #${prNumber}`);
+}

--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -120,7 +120,14 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
       // author: tella-butler authors most real feature PRs (co-recording, camera
       // backgrounds, onboarding, …), and those are exactly the merges that need docs.
       const headRef = pr.head?.ref || "";
-      if (!headRef.startsWith(DOCS_SYNC_BRANCH_PREFIX)) {
+      if (headRef.startsWith(DOCS_SYNC_BRANCH_PREFIX)) {
+        // A docs-sync PR itself was merged — don't re-fire docs-sync (loop), but
+        // tick its Slack announcement done, like Mintlify used to.
+        const { markDocsSyncPrMerged } = await import("./docs-sync-notify");
+        void markDocsSyncPrMerged(pr.number).catch((e) =>
+          console.error(`[github] markDocsSyncPrMerged failed for #${pr.number}:`, e),
+        );
+      } else {
         const payload = JSON.stringify({
           prNumber: pr.number,
           title: pr.title || `PR #${pr.number}`,


### PR DESCRIPTION
Johnny asked: when we merge a docs-sync PR, add a checkmark to the Slack message in #proj-help-center — like Mintlify used to.

## What it does

When a docs-sync PR (an `auto-docs-sync-*` branch) is merged into tella-fusion, the merge webhook now adds a :white_check_mark: reaction to the announcement docs-sync posted in #proj-help-center for that PR.

## How

The docs-sync runner posts its "Opened a docs-sync PR for #X … <PR url>" message free-form via the LLM, so backstage never captured the message `ts`. Rather than restructure that, we look the message up at merge time: scan recent history of the docs channel for the bot message that links the merged PR (`/pull/<n>`, boundary-matched so #4433 ≠ #44330) and react to it. Best-effort — if no announcement is found (e.g. the run decided no docs were needed and posted nothing), we just log.

## Changes

- `webhook.ts` — in the merge branch, `auto-docs-sync-*` PRs now route to `markDocsSyncPrMerged` instead of being silently skipped. Non-docs-sync merges still fire docs-sync as before (no behavior change there).
- `docs-sync-notify.ts` (new) — `markDocsSyncPrMerged`, reusing the existing `fetchChannelHistory` + `addReaction` Slack helpers.
- `constants.ts` — `DOCS_SYNC_SLACK_CHANNEL` (#proj-help-center).

Needs one backstage restart to pick up the webhook change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)