### PR TITLE
Mobile: chevron-only back button (drop the word 'Back')

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -785,7 +785,6 @@ function App() {
 										strokeLinejoin="round"
 									/>
 								</svg>
-								<span>Back</span>
 							</button>
 						) : (
 							brand


### PR DESCRIPTION
On mobile, the top-bar back button showed a chevron **and** the word "Back". Next to the centered iOS-style page title that eats horizontal space, so this shows just the chevron.

The whole `.app-header` bar is mobile-only (hidden on desktop), so no responsive gating is needed — the word is simply removed. `aria-label="Back to sidebar"` stays, so it's still accessible.

`bun run typecheck` passes.

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f2723-35fb-7000-b9ad-b2ab02649e48)