### PR TITLE
Composer: make the queue button outline read as a solid ring

### DIFF
--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -6919,7 +6919,7 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 .composer-send-queue-main {
 	background: var(--bg-raised);
 	color: var(--accent);
-	border: 1px solid var(--accent-soft);
+	border: 2px solid var(--accent);
 }
 .composer-send-interrupt {
 	background: var(--red-soft);


### PR DESCRIPTION
The queued-send button (the arrow-down-right shown while a turn is busy) used a `1px` border in `--accent-soft` — a ~10%-opacity accent hairline. Next to the solid-red stop button it read as faint and made the circle look **smaller** than the stop, even though both are the same `.composer-send` box (identical 32px desktop / 40px mobile).

This bumps it to a `2px solid var(--accent)` ring, so:
- the outline is easy to read (no more barely-visible hairline), and
- the button carries the same visual weight as the stop button beside it.

Stop and queue are already the same box size at every breakpoint, so no size changes were needed — the perceived difference was entirely the faint border.

**Before → after** (busy/queue state, red stop + outlined queue):
- before: faint 10%-opacity 1px red ring
- after: crisp 2px solid red ring

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f3709-653b-7000-a8a2-8ba80f8d7bdc)