### PR TITLE
Mobile: change repo from the ⋯ menu + show 'repo · model' under the title

### DIFF
--- a/src/frontend/components/RepoSwitchMenu.tsx
+++ b/src/frontend/components/RepoSwitchMenu.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import {
+	fetchRepos,
+	fetchRepoSwitchable,
+	switchPrimaryRepoApi,
+	type RepoInfo,
+} from "../lib/api";
+import { RepoTile } from "./RepoTile";
+import { IconCheck } from "./icons";
+
+interface Props {
+	sessionId: string;
+	primaryRepo: string;
+	branch: string | null;
+	onSwitched?: () => void;
+}
+
+/**
+ * Repo switcher as flat menu rows for the phone ⋯ menu. On phones the inline
+ * header RepoBar is CSS-hidden (the centered top-bar title replaces the title
+ * row), so this is the only way to repoint a session at another repo. Switch
+ * only — attach/detach stay on the desktop RepoBar. Same guarantees as RepoBar:
+ * the old worktree (branch, commits, edits) is left on disk, and a switch that
+ * would abandon in-progress work is confirmed first.
+ */
+export function RepoSwitchMenu({ sessionId, primaryRepo, branch, onSwitched }: Props) {
+	const [repos, setRepos] = useState<RepoInfo[]>([]);
+	const [switchable, setSwitchable] = useState(true);
+	const [hasWork, setHasWork] = useState(false);
+	const [busy, setBusy] = useState<string | null>(null);
+
+	useEffect(() => {
+		fetchRepos().then(setRepos).catch(() => {});
+		fetchRepoSwitchable(sessionId)
+			.then(({ switchable, hasWork }) => {
+				setSwitchable(switchable);
+				setHasWork(hasWork);
+			})
+			.catch(() => {});
+	}, [sessionId]);
+
+	// Ask sessions read the shared checkout — there's no primary repo to switch.
+	if (!switchable) return null;
+
+	async function switchPrimary(repo: string) {
+		if (repo === primaryRepo || busy) return;
+		if (
+			hasWork &&
+			!window.confirm(
+				`Switch this workspace from ${primaryRepo} to ${repo}?\n\n` +
+					`Your current changes stay in the ${primaryRepo} worktree${
+						branch ? ` (branch ${branch})` : ""
+					} — they won't move to ${repo}. You can reopen them from that branch.`,
+			)
+		)
+			return;
+
+		setBusy(repo);
+		try {
+			await switchPrimaryRepoApi(sessionId, repo, hasWork);
+			onSwitched?.();
+		} catch (e: any) {
+			window.alert(e.message || String(e));
+		} finally {
+			setBusy(null);
+		}
+	}
+
+	return (
+		<div className="viewer-repo-menu">
+			<span className="viewer-repo-menu-label">Repo</span>
+			{repos.map((r) => (
+				<button
+					key={r.id}
+					type="button"
+					className={`btn-viewer-repo ${r.id === primaryRepo ? "current" : ""}`}
+					onClick={() => switchPrimary(r.id)}
+					disabled={!!busy || r.id === primaryRepo}
+				>
+					<RepoTile name={r.id} />
+					<span className="btn-viewer-repo-name">
+						{busy === r.id ? "Switching…" : r.id}
+					</span>
+					{r.id === primaryRepo && <IconCheck size={18} className="btn-viewer-repo-check" />}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -38,6 +38,7 @@ import type { FileAttachment } from "../lib/images";
 import { loadDraft, saveDraft, clearDraft } from "../lib/drafts";
 import { DiffPanel } from "./DiffPanel";
 import { RepoBar } from "./RepoBar";
+import { RepoSwitchMenu } from "./RepoSwitchMenu";
 import { AskCard } from "./AskCard";
 import { PrPanel } from "./PrPanel";
 import { PrStatusBar } from "./PrStatusBar";
@@ -1618,6 +1619,17 @@ export function SessionViewer({
 						New chat in workspace
 					</button>
 				);
+				// Switch the primary repo from the ⋯ menu — phone-only, since the
+				// inline header RepoBar is hidden on phones. Skipped for ask
+				// sessions (no primary repo) and sessions without a worktree.
+				const repoAction = isPhone && session.worktreeDir && !isAsk && (
+					<RepoSwitchMenu
+						sessionId={session.id}
+						primaryRepo={session.repo || "tella-fusion"}
+						branch={session.branch}
+						onSwitched={() => setOverflowOpen(false)}
+					/>
+				);
 				// Star (pin) and Spin off live in the ⋯ menu at every width,
 				// alongside Delete — occasional actions, not header chrome.
 				const overflowActions = (
@@ -1862,6 +1874,7 @@ export function SessionViewer({
 								{isPhone && secondaryActions}
 								{(compactHeader || isPhone) && collapsibleActions}
 								{newChatAction}
+								{repoAction}
 								{overflowActions}
 								{archiveAction}
 								{deleteAction}
@@ -1920,47 +1933,68 @@ export function SessionViewer({
 						: header;
 			})()}
 
-			{/* Compact model switcher under the mobile top-bar title. The composer's
-			    model pill is hidden on phones (keeps the input clean), so this small
-			    label — the session's model — doubles as a tap target: a native
-			    <select> overlays it and opens the OS picker. Backstage sessions only;
-			    Slack/Linear-owned sessions set their model from the owning thread. */}
-			{isPhone && headerModelEl && models.length > 0 &&
+			{/* Line under the mobile top-bar title: `repo · model`. The repo is the
+			    read-only session context (switch it from the ⋯ menu, where the
+			    inline header RepoBar folds on phones); the model is a tap target —
+			    the composer's model pill is hidden on phones, so this small label
+			    doubles as one: a native <select> overlays it and opens the OS
+			    picker. Backstage sessions only; Slack/Linear-owned sessions set
+			    their model from the owning thread. */}
+			{isPhone &&
+				headerModelEl &&
+				(models.length > 0 || (session.worktreeDir && !isAsk)) &&
 				createPortal(
-					<span
-						className="header-model-select"
-						title={
-							session.source !== "backstage"
-								? "Set the model from the owning agent (/model in the Slack thread)"
-								: "Switch the model for this session"
-						}
-					>
-						<span className="header-model-label">
-							{models.find((m) => m.id === effectiveModel)?.label ||
-								prettyModel(effectiveModel)}
-						</span>
-						<IconChevronDown className="header-model-chevron" size={14} />
-						{session.source === "backstage" && (
-							<select
-								className="palette-select-overlay"
-								value={model}
-								onChange={(e) => handleModelChange(e.target.value)}
-								aria-label="Model"
+					<>
+						{session.worktreeDir && !isAsk && (
+							<span
+								className="header-repo-label"
+								title="Repo for this session — change it from the ⋯ menu"
 							>
-								<option value="">
-									{models.find((m) => m.id === defaultModel)?.label ||
-										prettyModel(defaultModel)}
-								</option>
-								{models
-									.filter((m) => m.id !== defaultModel)
-									.map((m) => (
-										<option key={m.id} value={m.id}>
-											{m.label}
-										</option>
-									))}
-							</select>
+								{session.repo || "tella-fusion"}
+							</span>
 						)}
-					</span>,
+						{session.worktreeDir && !isAsk && models.length > 0 && (
+							<span className="header-model-sep" aria-hidden="true">
+								·
+							</span>
+						)}
+						{models.length > 0 && (
+							<span
+								className="header-model-select"
+								title={
+									session.source !== "backstage"
+										? "Set the model from the owning agent (/model in the Slack thread)"
+										: "Switch the model for this session"
+								}
+							>
+								<span className="header-model-label">
+									{models.find((m) => m.id === effectiveModel)?.label ||
+										prettyModel(effectiveModel)}
+								</span>
+								<IconChevronDown className="header-model-chevron" size={14} />
+								{session.source === "backstage" && (
+									<select
+										className="palette-select-overlay"
+										value={model}
+										onChange={(e) => handleModelChange(e.target.value)}
+										aria-label="Model"
+									>
+										<option value="">
+											{models.find((m) => m.id === defaultModel)?.label ||
+												prettyModel(defaultModel)}
+										</option>
+										{models
+											.filter((m) => m.id !== defaultModel)
+											.map((m) => (
+												<option key={m.id} value={m.id}>
+													{m.label}
+												</option>
+											))}
+									</select>
+								)}
+							</span>
+						)}
+					</>,
 					headerModelEl,
 				)}
 

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -2458,6 +2458,7 @@ body.resizing-x {
 .viewer-overflow-menu > .preview-wrap,
 .viewer-overflow-menu > .spinoff,
 .viewer-overflow-menu > .spinoff > .btn-panel-toggle,
+.viewer-overflow-menu > .viewer-repo-menu,
 .viewer-overflow-menu > .viewer-delete-confirm {
 	width: 100%;
 }
@@ -2697,6 +2698,59 @@ body.resizing-x {
 .btn-viewer-newchat:hover {
 	color: var(--text);
 	background: var(--bg-hover);
+}
+
+/* Repo switcher block in the phone ⋯ menu (RepoSwitchMenu). A small group
+   label over one tappable row per repo; the current repo reads as a disabled,
+   checked row. Rows mirror the archive/newchat look — icon + label, neutral
+   until hover. */
+.viewer-repo-menu {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.viewer-repo-menu-label {
+	padding: 2px 4px 0;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--text-faint);
+}
+.btn-viewer-repo {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	white-space: nowrap;
+	background: none;
+	border: 1px solid var(--border-strong);
+	border-radius: 10px;
+	color: var(--text-faint);
+	padding: 5px 12px;
+	font-size: 13px;
+	text-align: left;
+}
+.btn-viewer-repo:hover:not(:disabled) {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+.btn-viewer-repo-name {
+	min-width: 0;
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+/* Current repo: a non-interactive checked row, so the switch list still shows
+   where you are. */
+.btn-viewer-repo.current {
+	color: var(--text);
+	opacity: 1;
+	cursor: default;
+}
+.btn-viewer-repo-check {
+	flex-shrink: 0;
+	color: var(--text-dim);
 }
 
 /* Preview (local dev server) control — a segmented split button:
@@ -8473,20 +8527,37 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
-	/* Small centered model line under the title — the composer's model pill is
-	   hidden on phones, so this is where a session's model surfaces. It doubles
+	/* Small centered `repo · model` line under the title. The composer's model
+	   pill is hidden on phones, so this is where a session's model surfaces; the
+	   repo prefix names the codebase this session targets. The model half doubles
 	   as a tap-to-switch control (see .header-model-select), so re-enable pointer
 	   events that the pointer-events:none title wrapper turns off. */
 	.app-header-model {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 5px;
 		max-width: 100%;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		min-width: 0;
 		font-size: 11px;
 		font-weight: 500;
 		line-height: 1.1;
 		color: var(--text-dim);
 		pointer-events: auto;
+	}
+	/* Repo half of the subtitle — read-only context (switch it from the ⋯ menu).
+	   Truncates first so the model label stays legible on narrow phones. */
+	.header-repo-label {
+		flex-shrink: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--text-faint);
+	}
+	.header-model-sep {
+		flex-shrink: 0;
+		color: var(--text-faint);
 	}
 	/* Model line as a tap target: a compact label + chevron with a full-bleed
 	   transparent native <select> over it (opens the OS picker). Kept tiny to


### PR DESCRIPTION
## What & why

On mobile there was no way to change a session's repo: on phones the whole header title row (which carries the inline \`RepoBar\`) is CSS-hidden — the centered top-bar title replaces it — so the repo switcher never rendered.

This adds repo switching to the phone **⋯ overflow menu**, and surfaces the current repo in the subtitle under the title as **\`repo · model\`**.

## Changes

- **New \`RepoSwitchMenu\`** (phone-only, in the ⋯ menu): a small "Repo" group with one tappable row per repo; the current repo shows as a checked, disabled row. Switching reuses the existing \`POST /sessions/:id/switch-primary-repo\` API and the same *confirm-when-there's-work* guard as the desktop \`RepoBar\` (the old worktree is left on disk, nothing is lost). Switch only — attach/detach stay on the desktop \`RepoBar\`. Hidden for ask sessions (no primary repo to switch).
- **Subtitle line** under the mobile top-bar title becomes \`repo · model\`. The repo is read-only context; the model stays the tap-to-switch control it already was (native \`<select>\` over the label).

## Notes

- No backend changes — all repo endpoints already exist.
- \`bunx tsc --noEmit\` adds **0 new errors** (baseline on \`master\` is 5 pre-existing errors in untouched files: \`App.tsx\`, \`connections.ts\`).
- Not visually smoke-tested against a running instance to avoid spinning up a second backstage against the live session store; the change is additive and follows the existing model-pill / overflow-menu patterns.

🤖 Created by [this Michael session](https://michael.taila5d766.ts.net/backstage/session/bks-019f37d9-2810-7000-947b-f227d0a6ac13)