### PR TITLE
Add Dub Links MCP server to backstage

### DIFF
--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -28,6 +28,13 @@
     "circle": {
       "type": "http",
       "url": "https://app.circle.so/api/mcp"
+    },
+    "dub": {
+      "type": "http",
+      "url": "https://mcp.dub.sh/mcp/dub-links",
+      "headers": {
+        "Mcp-Dub-Token": "<your-dub-api-key>"
+      }
     }
   }
 }

--- a/src/server/draft-automation.ts
+++ b/src/server/draft-automation.ts
@@ -44,7 +44,7 @@ Rules:
 - prompt: the full instructions for each run, written to the agent in second person. Be specific: what to look at, what to produce, what NOT to do. Each run is a fresh session with no memory — the prompt must be self-contained. 3-8 sentences, use numbered steps when there's a sequence.
 - schedule: 5-field cron in UTC (the server runs UTC; 9am Amsterdam ≈ 7-8 UTC, 9am PT = 16 UTC). "" if the automation is event- or webhook-triggered rather than time-based.
 - mode: "ask" = read-only investigation/reporting. "code" = the run gets a git worktree and can edit code and open PRs. Pick "code" only if the description involves changing code.
-- mcpServers: least privilege — ONLY servers the runs genuinely need, from this list: ${mcpNames.join(", ")}. Use [] when the task only needs the repo and gh CLI. Rough guide: plain = support tickets, workos = user/org accounts, stripe = billing, sentry = errors, grafana = logs/metrics, tinybird = product analytics, linear = issues, slack = team chat.
+- mcpServers: least privilege — ONLY servers the runs genuinely need, from this list: ${mcpNames.join(", ")}. Use [] when the task only needs the repo and gh CLI. Rough guide: plain = support tickets, workos = user/org accounts, stripe = billing, sentry = errors, grafana = logs/metrics, tinybird = product analytics, linear = issues, slack = team chat, dub = short links / click analytics.
 - eventKey: null unless the description says "when/whenever X happens" and X matches one of: ${KNOWN_EVENT_KEYS.join(", ")}. When eventKey is set, schedule is usually "".
 - Runs that touch support tickets must never reply to the customer — they leave internal notes with a suggested reply, written in English.
 


### PR DESCRIPTION
Johnny asked to add [Dub's MCP](https://dub.co/docs/mcp-server) to backstage.

## What this does
Adds the **Dub Links MCP server** (`https://mcp.dub.sh/mcp/dub-links`) so Michael's sessions can manage short links (create/update/bulk) and pull click / lead / sale analytics for `links.tella.com` — the same links the `email-link` skill creates.

## Live config (already applied on the VPS)
The runtime `mcp-config.json` is gitignored (holds live secrets), so the operational change was applied directly there:
```json
"dub": {
  "type": "http",
  "url": "https://mcp.dub.sh/mcp/dub-links",
  "headers": { "Mcp-Dub-Token": "<DUB_API_KEY>" }
}
```
Verified: `initialize` + `tools/list` succeed against the endpoint with our existing `DUB_API_KEY`, and backstage's connection checker reports `dub` as **connected**. The file-watcher picks it up automatically, so new sessions see it without a restart.

## This PR (the reviewable/tracked part)
- `mcp-config.example.json` — documents the `dub` entry with a placeholder token, following the `type: http` + `headers` pattern used by stripe/linear/incident.
- `draft-automation.ts` — adds `dub = short links / click analytics` to the least-privilege server guide so automations can scope to it.

## Auth
Dub Links MCP authenticates with a standard Dub API key via the `Mcp-Dub-Token` header — reusing the webapp's `DUB_API_KEY`, no new credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)