### PR TITLE
fix(github-review): stop redundant PR-diff webfetches + floor review model to opus

### DIFF
--- a/src/agents/github/mention.ts
+++ b/src/agents/github/mention.ts
@@ -19,7 +19,7 @@ import {
   clearPendingMention,
 } from "./state";
 import { runGithubAgent, authorForLogin, finalSummary, sessionUrl } from "./run";
-import { buildMentionPrompt, buildFollowupMentionPrompt } from "./prompts";
+import { buildMentionPrompt, buildFollowupMentionPrompt, REVIEW_DEFAULT_MODEL } from "./prompts";
 import { triggerPrAction } from "./trigger";
 import {
   postIssueComment,
@@ -177,7 +177,7 @@ export async function runConversationalMention(
       return;
     }
     headRef = details.headRefName;
-    const model = listAutomations().find((a) => a.eventKey === PR_EVENT_KEY)?.model;
+    const model = listAutomations().find((a) => a.eventKey === PR_EVENT_KEY)?.model || REVIEW_DEFAULT_MODEL;
     const link = `[📺 open session](${sessionUrl(prNumber, "mention")})`;
 
     const st = getOrInitPrState(prNumber, headRef);
@@ -276,7 +276,7 @@ async function runFollowupMention(
     `${REPLY_MARKER}\n🔄 On it — PR #${prNumber} is ${stateLabel}, so I'm starting a fresh follow-up branch off \`${baseRef}\` for @${args.author}'s request… · ${link}`,
   );
 
-  const model = listAutomations().find((a) => a.eventKey === PR_EVENT_KEY)?.model;
+  const model = listAutomations().find((a) => a.eventKey === PR_EVENT_KEY)?.model || REVIEW_DEFAULT_MODEL;
   const worktreeDir = await createWorktreeForFollowup(branch, baseRef);
   console.log(
     `[github] Follow-up mention on ${stateLabel} PR #${prNumber} from @${args.author} → branch ${branch}`,

--- a/src/agents/github/prompts.ts
+++ b/src/agents/github/prompts.ts
@@ -41,6 +41,15 @@ How to review well:
 - Do NOT edit files, run interactive tools, ask questions, or post anything yourself — the system posts your review.`;
 
 /**
+ * Default model for PR reviews and PR mentions when the seeded `github-pr-review`
+ * automation doesn't pin one. Michiel's directive (2026-07-10): reviews must run
+ * on opus or fable, never sonnet — cost is not a concern on the subscription pool.
+ * Opus is the designated reviewer/critic model (see CLAUDE.md model routing).
+ * A human can still override per-run by setting the automation's `model`.
+ */
+export const REVIEW_DEFAULT_MODEL = "claude-opus-4-8";
+
+/**
  * Docs-sync automation prompt (code mode). Fires once per merged tella-fusion PR.
  * The run starts in a fresh worktree on a dedicated `auto-docs-sync-*` branch off
  * main; the merged PR's changes are already in the checkout. The triggering event
@@ -137,6 +146,9 @@ export function diffBlock(patch: string): string {
     "## The diff",
     "",
     "The PR's diff is inlined below (this run has no shell — do not try to run `gh` or `git`).",
+    "The COMPLETE diff is already here: do NOT webfetch the PR's `.diff` URL,",
+    "`patch-diff.githubusercontent.com`, or any `api.github.com/…/pulls/…` URL to fetch it —",
+    "those 404 on fork/closed PRs, this ask-mode run has no need for them, and everything is below.",
     "Your checkout is at the BASE branch: the PR's changes are NOT applied to the files on",
     "disk. Use the diff for what changed and Read/Grep on the checkout for surrounding context.",
     "",

--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -19,7 +19,7 @@ import {
   LABEL_ADVERSARIAL,
 } from "./constants";
 import { runReview, type PrRef, type ReviewConfig } from "./review";
-import { DEFAULT_REVIEW_PROMPT } from "./prompts";
+import { DEFAULT_REVIEW_PROMPT, REVIEW_DEFAULT_MODEL } from "./prompts";
 import { SEO_LABEL } from "../loops/seo";
 
 let onSessionInvalidate: (() => void) | undefined;
@@ -58,7 +58,7 @@ export function resolveReviewConfig(): { autoEnabled: boolean; config: ReviewCon
     autoEnabled: !!automation?.enabled,
     config: {
       prompt: automation?.prompt || DEFAULT_REVIEW_PROMPT,
-      model: automation?.model,
+      model: automation?.model || REVIEW_DEFAULT_MODEL,
     },
   };
 }


### PR DESCRIPTION
## Why

From the nightly **Dreaming** retro on the 2026-07-09 audit digest. `github-review` was the single priciest run bucket (~\$286 across 37 reviews) yet leaked work:

- **~15 webfetch 404s** — reviewers fetching the PR `.diff`, `patch-diff.githubusercontent.com`, and `api.github.com/…/pulls/…` URLs, which 404 on fork/closed PRs. The complete diff is *already inlined* into the review prompt by `diffBlock()` (ask-mode runs have no shell), so those fetches are redundant *and* fail.
- **Reviews sometimes fell back to sonnet.** The seeded `github-pr-review` automation pins no model, so an unset model fell through to the global fallback. Per Michiel's directive (2026-07-10): reviews should run on **opus or fable, never sonnet** — cost is not a concern on the subscription pool.

## What changed

- `prompts.ts` `diffBlock()`: explicitly tells the reviewer the complete diff is inlined and **not** to webfetch the PR `.diff` / `patch-diff` / `api.github.com` pulls URLs.
- `prompts.ts`: new `REVIEW_DEFAULT_MODEL = "claude-opus-4-8"` (opus is the designated reviewer/critic model per CLAUDE.md).
- `webhook.ts` `resolveReviewConfig()` and both model resolutions in `mention.ts` now floor to `REVIEW_DEFAULT_MODEL` when the automation doesn't pin one — so reviews never silently fall to sonnet. A human can still override via the automation's `model`.

Fable is a one-line swap (`REVIEW_DEFAULT_MODEL`) if preferred over opus.

## Verification

`bunx tsc --noEmit` passes (exit 0). No behavior change for reviews where the automation already pins a model.

Created by [this Michael session](https://michael.taila5d766.ts.net/opensession/session/bks-019f4b16-757a-7000-a97f-8f0896ac0e17)