### PR TITLE
github-review: don't resume the engine session across re-reviews (fix 'Prompt is too long')

### DIFF
--- a/src/agents/github/review.ts
+++ b/src/agents/github/review.ts
@@ -146,7 +146,16 @@ export async function runReview(
       model: config.model,
       branch: pr.headRef,
       title: `Review · PR #${pr.number} ${details.title}`.slice(0, 100),
-      resume: isUpdate,
+      // Each review is self-contained: the CURRENT full diff is inlined (capped)
+      // and a fresh full assessment is posted (superseding the prior comment), so
+      // we do NOT resume the prior engine session. Resuming accumulated the whole
+      // transcript across every push, and on actively-updated PRs the context grew
+      // past the engine's 1M-token limit — the run then hard-failed with "Prompt is
+      // too long" and could not be compacted (a single over-limit exchange has
+      // nothing to drop). See the 2026-07-11 dream: 12 such failures, all
+      // github-review, e.g. PR #4638 (15 errors / 0 turns). `isUpdate` still drives
+      // the "re-review the current diff" prompt framing above.
+      resume: false,
       onSessionCreated,
     });
 


### PR DESCRIPTION
## What
Re-reviews of a PR stopped resuming the prior per-PR engine session. `src/agents/github/review.ts` now passes `resume: false` (was `resume: isUpdate`).

## Why
Every push to a PR re-runs the review and, on an update, resumed the same engine session — so the whole prior transcript (each review's file reads + a freshly-inlined full diff) accumulated. On actively-updated PRs the context grew past the engine's **1M-token limit** and the run **hard-failed** with `Prompt is too long`. It can't be compacted: a single over-limit exchange has nothing to drop, so the review just fails every attempt.

The 2026-07-11 nightly audit surfaced this as the largest github-review failure mode after account-pool exhaustion:
- **12** `Prompt is too long` errors, **all** github-review.
- Sample: PR #4638's review logged **15 errors / 0 turns / \$0** — stuck, never produced a review.

## Why this is safe
Each review is already self-contained: the **current full diff** is inlined (200k-char cap in `diffBlock`) and a **fresh full assessment** is posted, superseding the prior review comment. So a fresh engine session per review has everything it needs and reviews correctly — with bounded context.

**Tradeoff (for the reviewer to weigh at merge):** a re-review no longer remembers what it flagged on the previous commit, so it may repeat a finding or re-read a few files (marginally more tokens per run). That's strictly better than the current outcome, where reviews on busy PRs fail outright. The `isUpdate` header still frames the run as re-reviewing the current diff.

`bunx tsc --noEmit` passes.

Created by [this Michael session](https://os.tella.dev/session/bks-019f5497-206e-7000-95ad-a27ae5c44cdd)