### PR TITLE
Bump Meridian to remove stale MultiEdit deny rule

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@opencode-ai/sdk": "^1.17.15",
         "@pierre/diffs": "1.2.8",
         "@pierre/trees": "^1.0.0-beta.4",
-        "@rynfar/meridian": "1.45.0",
+        "@rynfar/meridian": "1.45.4",
         "@rynfar/meridian-plugin-opencode-scrub": "0.2.0",
         "@team-plain/typescript-sdk": "^5.12.1",
         "@xterm/addon-fit": "^0.11.0",
@@ -49,6 +49,9 @@
         "typescript": "^5.7.0",
       },
     },
+  },
+  "overrides": {
+    "@rynfar/meridian": "1.45.4",
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.104", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw=="],
@@ -395,7 +398,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
-    "@rynfar/meridian": ["@rynfar/meridian@1.45.0", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-040GdZkVDkzceWnsnu8Y13M/kwyv5wqj/GOI/1jh0AgcbPihl/NnQIIV92RDw4aTBE8Y87HG9BhZWfHMYSH6SQ=="],
+    "@rynfar/meridian": ["@rynfar/meridian@1.45.4", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.117", "@anthropic-ai/claude-code": "^2.1.198", "jsonc-parser": "^3.3.1", "libsql": "^0.5.29" }, "bin": { "meridian": "dist/cli.js", "claude-max-proxy": "dist/cli.js" } }, "sha512-UsWSvJvueZp4fV9L8gDJKSmk234RHaFTiKKXSN2uUnmxiC97bpmZBNPALpHPLGNzkgFR6/lU3xYB1YTc6z0w4Q=="],
 
     "@rynfar/meridian-plugin-opencode-scrub": ["@rynfar/meridian-plugin-opencode-scrub@0.2.0", "", { "peerDependencies": { "@rynfar/meridian": "*" }, "optionalPeers": ["@rynfar/meridian"] }, "sha512-RaXNkIwPB2NmicdNvDmYLKbLz5KsnAlNt3XfuejstPpMZBbogxhi6JSsU3k6nHGj/yoYmbpLYMGD4Bv4v30Tvg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@opencode-ai/sdk": "^1.17.15",
     "@pierre/diffs": "1.2.8",
     "@pierre/trees": "^1.0.0-beta.4",
-    "@rynfar/meridian": "1.45.0",
+    "@rynfar/meridian": "1.45.4",
     "@rynfar/meridian-plugin-opencode-scrub": "0.2.0",
     "@team-plain/typescript-sdk": "^5.12.1",
     "@xterm/addon-fit": "^0.11.0",
@@ -51,5 +51,8 @@
     "@types/web-push": "^3.6.4",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "@rynfar/meridian": "1.45.4"
   }
 }

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -465,7 +465,7 @@ export function opencodeRunPolicy(opts: {
 // ── Meridian bridge (opencode/anthropic/* default path) ──────────────────────
 //
 // VERSION PINNING (package.json): opencode-with-claude 1.6.14 +
-// @rynfar/meridian 1.45.0 + @rynfar/meridian-plugin-opencode-scrub 0.2.0 are
+// @rynfar/meridian 1.45.4 + @rynfar/meridian-plugin-opencode-scrub 0.2.0 are
 // pinned EXACT. These versions chase Anthropic's third-party billing-gate
 // behavior (the scrub plugin exists to keep turns on flat subscription quota);
 // bump deliberately after watching the repos' releases, and re-run


### PR DESCRIPTION
## Summary
- Bumps the pinned @rynfar/meridian package from 1.45.0 to 1.45.4.
- Adds a package override so opencode-with-claude resolves to the same fixed Meridian version instead of keeping a nested 1.45.0 copy.
- Updates the Meridian version-pinning comment in opencode-runner.ts.

## Why
The audit warning came from Meridian's bundled BLOCKED_BUILTIN_TOOLS list, which included the legacy Claude Code tool name MultiEdit. Meridian 1.45.4 no longer includes MultiEdit, while preserving the existing deny intent for real built-in tools like Edit.

## Verification
- bunx tsc --noEmit
- grep confirmed no MultiEdit remains in node_modules/@rynfar/meridian or node_modules/opencode-with-claude
- grep confirmed no stale @rynfar/meridian@1.45.0 remains in bun.lock

Spawned by Michael's nightly Dreaming reflection.

Created by [this Michael session](https://os.tella.dev/session/bks-019f59c1-7cc2-7000-ad14-94a2b0144f2b)