### PR TITLE
oneshot: log the account name on the error path too

### DIFF
--- a/src/server/opencode-oneshot.ts
+++ b/src/server/opencode-oneshot.ts
@@ -265,6 +265,10 @@ export async function opencodeOneShot(
         status: limited ? "usage_limit" : "error",
         error: message.slice(0, 500),
         duration_ms: Date.now() - startedAt,
+        // Name the account on the error path too, not just on success (line ~228):
+        // a wedged account that broke every one-shot for hours was only
+        // identifiable by correlating with the last ok row — logged 2026-07-14.
+        ...(account ? { account: account.name } : {}),
       });
       return null;
     }


### PR DESCRIPTION
## What

The one-shot audit emits the `account` name on the **success** path (`opencode-oneshot.ts` ~L228) but not on the **error / usage_limit** path (~L261). Add the same `...(account ? { account: account.name } : {})` spread to the failure audit.

## Why

On 2026-07-14 a single wedged / subscription-broken Claude account broke *every* title/branch/router one-shot for ~4.5h (titles rendered the raw prompt). Because the error audit rows didn't name the account, it could only be identified by hand-correlating with the last `status:ok` row before the wedge — a papercut logged by Kent that day. Naming the account on the error path makes a wedged account directly greppable from the audit log.

`account` is already in scope at that catch block (it's used for the rotate/sideline logic just above), so this is a one-line, no-risk change.

## Verify

`bunx tsc --noEmit` — no new errors (the sole error, `deploy/oc-web-proxy.ts:44`, is pre-existing and unrelated).

Found by the nightly Dreaming reflection over 2026-07-14's audit digest.

Created by [this Michael session](https://os.tella.dev/session/bks-019f6409-ff50-7000-999d-7dcd76afb644)