### PR TITLE
Review: move to a full-width tab in the main area

### DIFF
--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -436,7 +436,7 @@ export function SessionViewer({
 		// "workflows" isn't meaningfully restorable (runs seed async, so the tab
 		// starts hidden and the body would flash PrPanel) — it, and any stored
 		// tab that no longer exists, maps back to Info.
-		const restorable: PanelTab[] = ["info", "changes", "terminal", "pr", "chat", "plain", "sidechats"];
+		const restorable: PanelTab[] = ["info", "changes", "terminal", "chat", "plain", "sidechats"];
 		const tab: PanelTab | null = restorable.includes(stored as PanelTab)
 			? (stored as PanelTab)
 			: stored
@@ -454,6 +454,11 @@ export function SessionViewer({
 		setPanelTab(tab);
 		localStorage.setItem("michael-panel-tab", tab);
 	}
+	// Main chat-area view: the transcript+composer ("chat") or a full-width
+	// PR review ("review") that takes over the whole chat column so the code
+	// diff gets the full width. Only reachable on a code session (hasWorkspace);
+	// the effect below drops back to "chat" whenever there is no workspace.
+	const [mainView, setMainView] = useState<"chat" | "review">("chat");
 	// Bumped by the ⋯ menu's "New side chat" — tells the SideChatsPanel to
 	// create (and open) a fresh side chat as soon as it shows. The panel calls
 	// onCreateConsumed to reset it to 0, so tab remounts don't re-create.
@@ -710,6 +715,11 @@ export function SessionViewer({
 		)
 			setPanelTab("info");
 	}, [workflowsLoaded, panelTab, workflowRuns.length, hasWorkspace]);
+
+	// A session with no code workspace has no Review — never sit on it.
+	useEffect(() => {
+		if (!hasWorkspace && mainView !== "chat") setMainView("chat");
+	}, [hasWorkspace, mainView]);
 
 	// Ask→code promotion: creates a worktree and flips the chat to code mode.
 	// The 5s session poll picks up the mode change and re-renders with the full
@@ -2719,6 +2729,62 @@ export function SessionViewer({
 
 			<div className="viewer-split">
 				<div className="viewer-chat">
+					{hasWorkspace && (
+						<div className="main-view-switch" role="tablist">
+							<button
+								type="button"
+								role="tab"
+								aria-selected={mainView === "chat"}
+								className={`main-view-tab ${mainView === "chat" ? "active" : ""}`}
+								onClick={() => setMainView("chat")}
+							>
+								Chat
+							</button>
+							<button
+								type="button"
+								role="tab"
+								aria-selected={mainView === "review"}
+								className={`main-view-tab ${mainView === "review" ? "active" : ""}`}
+								onClick={() => setMainView("review")}
+							>
+								Review
+								{session.prState && (
+									<span
+										className={`panel-tab-dot ${session.prState === "OPEN" && session.prMergeable === "CONFLICTING" ? "pr-dot-conflict" : `pr-dot-${session.prState.toLowerCase()}`}`}
+									/>
+								)}
+							</button>
+						</div>
+					)}
+					{mainView === "review" && hasWorkspace ? (
+						<div className="viewer-review-main">
+							<PrPanel
+								sessionId={session.id}
+								send={send}
+								split
+								onAddToInput={(text) =>
+									setComposerPrefill((p) => ({
+										seq: (p?.seq ?? 0) + 1,
+										text,
+									}))
+								}
+								repos={[
+									{
+										repo: session.repo || "tella-fusion",
+										primary: true,
+									},
+									...(session.attachedRepos || []).map((r) => ({
+										repo: r.repo,
+										primary: false,
+									})),
+								]}
+								linkedPrs={session.linkedPrs}
+								linkable
+								walkthrough={session.walkthrough}
+							/>
+						</div>
+					) : (
+					<>
 					<div className="viewer-messages-region">
 						<div
 							className="viewer-messages"
@@ -3036,6 +3102,8 @@ export function SessionViewer({
 							</>
 						)}
 					</div>
+					</>
+					)}
 				</div>
 
 				{/* Right region: a sub-agent conversation takes precedence over the
@@ -3107,7 +3175,7 @@ export function SessionViewer({
 								repo={session.repo || undefined}
 								archived={session.archived}
 								send={connected ? send : undefined}
-								onOpenPrTab={() => setPanelTab("pr")}
+								onOpenPrTab={() => setMainView("review")}
 								running={isRunningLive}
 								refreshTick={gitRefreshTick}
 								// Globe (staging deploy) rides inside the strip, left of the
@@ -3154,17 +3222,6 @@ export function SessionViewer({
 										onClick={() => selectPanelTab("terminal")}
 									>
 										Terminal
-									</button>
-									<button
-										className={`panel-tab ${panelTab === "pr" ? "active" : ""}`}
-										onClick={() => selectPanelTab("pr")}
-									>
-										Review
-										{session.prState && (
-											<span
-												className={`panel-tab-dot ${session.prState === "OPEN" && session.prMergeable === "CONFLICTING" ? "pr-dot-conflict" : `pr-dot-${session.prState.toLowerCase()}`}`}
-											/>
-										)}
 									</button>
 									<button
 										className={`panel-tab ${panelTab === "chat" ? "active" : ""}`}
@@ -3239,7 +3296,7 @@ export function SessionViewer({
 									reviewRequestSessionId={effectiveReview?.ownerId}
 									onReviewChange={onReviewChange}
 									send={connected ? send : undefined}
-									onOpenTab={(tab) => selectPanelTab(tab)}
+									onOpenTab={(tab) => (tab === "pr" ? setMainView("review") : selectPanelTab(tab))}
 									onAddToInput={(text) =>
 										setComposerPrefill((p) => ({
 											seq: (p?.seq ?? 0) + 1,
@@ -3283,8 +3340,7 @@ export function SessionViewer({
 								/>
 							) : waitingForWorkspace &&
 							  (panelTab === "changes" ||
-									panelTab === "terminal" ||
-									panelTab === "pr") ? (
+									panelTab === "terminal") ? (
 								// These tabs all read the worktree — hold them behind the
 								// waiting state until the create run finishes preparing it.
 								<WorkspaceWaiting detail="Waiting for the workspace to be ready." />
@@ -3314,32 +3370,7 @@ export function SessionViewer({
 									onOpenSession={(id) => onOpenSession?.(id)}
 									variant="panel"
 								/>
-							) : (
-								<PrPanel
-									sessionId={session.id}
-									send={send}
-									split
-									onAddToInput={(text) =>
-										setComposerPrefill((p) => ({
-											seq: (p?.seq ?? 0) + 1,
-											text,
-										}))
-									}
-									repos={[
-										{
-											repo: session.repo || "tella-fusion",
-											primary: true,
-										},
-										...(session.attachedRepos || []).map((r) => ({
-											repo: r.repo,
-											primary: false,
-										})),
-									]}
-									linkedPrs={session.linkedPrs}
-									linkable
-									walkthrough={session.walkthrough}
-								/>
-							)}
+							) : null}
 						</div>
 					</div>
 				) : null}

--- a/src/frontend/components/WorkspaceInfo.tsx
+++ b/src/frontend/components/WorkspaceInfo.tsx
@@ -1414,6 +1414,17 @@ export function WorkspaceInfo({
 				/>
 					<SandboxBadge sandbox={sandbox} />
 				</div>
+				{repo && (
+					<button
+						type="button"
+						className="workspace-info-review-btn"
+						onClick={() => onOpenTab?.("pr")}
+						title="Open the full-width review"
+					>
+						<IconPullRequest />
+						Review changes
+					</button>
+				)}
 				{pr?.number && repo === "tella-fusion" && (
 					<PrAgentActions
 							sessionId={sessionId}

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -16304,3 +16304,88 @@ html[data-theme="light"] .pixel-spinner .pixel {
   animation-name: pixel-snake-trail;
   animation-delay: 1066ms;
 }
+
+
+/* ------------------------------------------------------------------ *
+ * Main chat-area Chat/Review switch + full-width review host.
+ * The PR review moves out of the cramped right panel: a segmented control
+ * at the top of the chat column swaps the transcript+composer for a
+ * full-width PrPanel (its .pr-panel-split rail + diff then get the whole
+ * main area). The switch mirrors the .panel-tab pill look so both tab
+ * strips read as one family; only shown on code sessions.
+ * ------------------------------------------------------------------ */
+.main-view-switch {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+	padding: 10px 16px 4px;
+}
+.main-view-tab {
+	background: none;
+	border: none;
+	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
+	color: var(--text-dim);
+	font-size: 13px;
+	font-weight: 500;
+	padding: 5px 14px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	cursor: pointer;
+	transition:
+		background 0.14s ease,
+		color 0.14s ease;
+}
+.main-view-tab:hover {
+	color: var(--text);
+	background: var(--bg-hover);
+}
+.main-view-tab.active {
+	color: var(--text);
+	background: var(--bg-active);
+}
+
+/* Full-width review host: a flex child of .viewer-chat that stretches, so
+   the PrPanel (its .pr-panel-split is height:100%) fills the whole column. */
+.viewer-review-main {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+.viewer-review-main > .pr-panel {
+	flex: 1;
+	min-height: 0;
+}
+
+/* Prominent Review button in the Info panel head. */
+.workspace-info-review-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	width: 100%;
+	margin-top: 10px;
+	padding: 9px 12px;
+	border: 1px solid var(--border);
+	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
+	background: var(--bg-active);
+	color: var(--text);
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+	transition:
+		background 0.14s ease,
+		border-color 0.14s ease;
+}
+.workspace-info-review-btn:hover {
+	background: var(--bg-hover);
+	border-color: var(--text-faint);
+}
+
+@media (max-width: 720px) {
+	.main-view-switch {
+		padding: 8px 12px 4px;
+	}
+}


### PR DESCRIPTION
## What

Moves the PR **Review** out of the cramped right-hand panel and makes it open as a **full-width view in the main chat area**, so the review's info sidebar (Status/Reviewers/Checks/Files/Comments) becomes a left rail and the code diff gets the whole main area to expand.

## How it works

- **`SessionViewer.tsx`** — new local state `const [mainView, setMainView] = useState<"chat" | "review">("chat")`. A small **Chat / Review** segmented switch renders at the top of `.viewer-chat` (only when `hasWorkspace`; the Review tab carries the PR-state dot). When `mainView === "review"`, the transcript (`viewer-messages-region`) + composer (`viewer-input`) are replaced by a full-width `<PrPanel … split />` (same props the old right-panel `pr` tab passed) inside a `.viewer-review-main` host — the existing `.pr-panel-split` internal layout (info rail + `flex:1` diff) then fills the whole column with **no PrPanel changes**. An effect drops back to `"chat"` whenever the session has no workspace.
- **Info-panel affordances now open the main-area review** — the cleanest wiring is at the boundary: `WorkspaceInfo`'s `onOpenTab` is intercepted so `"pr"` → `setMainView("review")` (everything else still goes to `selectPanelTab`); `PrStatusBar`'s `onOpenPrTab` routes to review too. Added a prominent full-width **"Review changes"** button in the `WorkspaceInfo` head (gated on the session having a repo) for an obvious entry point.
- **Retired the right-panel `pr` tab** — removed its tab button, its `panel-body` render branch (now `null`, and unreachable since `"pr"` can no longer be selected), the `waitingForWorkspace` `panelTab === "pr"` case, and `"pr"` from the `restorable` tab list (a stale `"pr"` in localStorage now maps to Info). The `PanelTab` type keeps `"pr"` since `WorkspaceInfo` still speaks it across the `onOpenTab` boundary.
- **`global.css`** — `.main-view-switch` / `.main-view-tab` (mirrors the `.panel-tab` pill look via the same tokens so both tab strips read as one family), `.viewer-review-main` (full-width flex host so the `height:100%` `.pr-panel-split` fills it), `.workspace-info-review-btn`, and a mobile padding tweak.

## Design calls made

- Placed the switch as a lightweight segmented control at the top of `viewer-chat` (not a second full tab strip) so it doesn't compete with the workspace `SessionTabs` strip.
- The right-hand Info/Changes/Terminal panel is untouched and can stay open alongside the review — Review simply takes over the main chat column.
- Used bespoke CSS classes keyed on the existing design tokens (`--text-dim`, `--bg-hover`, `--bg-active`, `--border`) rather than raw colors, matching the surrounding `.panel-tab` styling.

## Verification

- `bun run tsc --noEmit` — **no type errors in the edited files** (`SessionViewer.tsx`, `WorkspaceInfo.tsx`). The only tsc errors are pre-existing and in untouched files (`deploy/oc-web-proxy.ts`, `src/server/claude-accounts.test.ts`). tsc passing on `SessionViewer` confirms the injected JSX fragment/ternary is balanced.
- Grepped the file to confirm no dead `panelTab === "pr"` / `setPanelTab("pr")` / `selectPanelTab("pr")` remain — only the intended `setMainView("review")` wiring.

Started by Kent de Bruin in [this Michael session](https://os.tella.dev/session/bks-019f6a66-3050-7000-8a75-62b01975d237)
