### PR TITLE
os1: unify Chat/Review into one Conductor-style tab strip

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -27,7 +27,7 @@ import { PreviewWait, matchPreviewWaitRoute } from "./components/PreviewWait";
 import { SettingsMenu } from "./components/SettingsMenu";
 import { TitleBar } from "./components/TitleBar";
 import { Settings, type SettingsSectionKey } from "./components/Settings";
-import { SessionTabs } from "./components/SessionTabs";
+import { SessionTabs, type ViewTab } from "./components/SessionTabs";
 import { RestartOverlay } from "./components/RestartOverlay";
 import { MediaLightboxHost } from "./components/MediaLightbox";
 import { UpdatePill } from "./components/UpdatePill";
@@ -706,6 +706,11 @@ function App() {
 	// open SessionViewer to clear its composer and scroll to the live edge. With no
 	// session open there's nothing to stay in, so it falls back to the palette.
 	const [newChatSeq, setNewChatSeq] = useState(0);
+	// Whether the current session's Review pane is foregrounded (the top tab
+	// strip's Review view-tab). Reset to chat whenever the open session changes.
+	const [reviewActive, setReviewActive] = useState(false);
+	// Sessions whose Review view-tab was dismissed (×); onOpenReview re-adds it.
+	const [reviewClosed, setReviewClosed] = useState<Set<string>>(() => new Set());
 
 	// Set for the render right after opening a workspace from the sidebar, so the
 	// session it lands on autofocuses its composer (you picked the workspace to
@@ -971,6 +976,50 @@ function App() {
 	// The open chat, read by the mount-once tab-shortcut handler (⌘⌥C / ⌘W —
 	// see the effect next to closeChat below).
 	const currentSessionRef = useRef<UnifiedSession | null>(null);
+	// Opening a different session always starts on its chat, never a stale Review.
+	useEffect(() => {
+		setReviewActive(false);
+	}, [currentSession?.id]);
+	// The current code session's Review pane, surfaced as a leftmost view-tab in
+	// the top strip (siblings share the worktree/PR, so one Review tab suffices).
+	const currentHasWorkspace =
+		!!currentSession && Boolean(currentSession.worktreeDir || currentSession.branch);
+	const reviewViewTabs: ViewTab[] =
+		currentSession && currentHasWorkspace && !reviewClosed.has(currentSession.id)
+			? [
+					{
+						id: `review:${currentSession.id}`,
+						label: "Review",
+						active: reviewActive,
+						dotClass: currentSession.prState
+							? currentSession.prState === "OPEN" &&
+								currentSession.prMergeable === "CONFLICTING"
+								? "pr-dot-conflict"
+								: `pr-dot-${currentSession.prState.toLowerCase()}`
+							: null,
+					},
+				]
+			: [];
+	// Foreground/dismiss the Review view-tab; onOpenReview re-adds a dismissed
+	// one (fired by the PR status chip / "open PR" affordances in SessionViewer).
+	function openReview() {
+		if (!currentSession) return;
+		const id = currentSession.id;
+		setReviewClosed((prev) => {
+			if (!prev.has(id)) return prev;
+			const next = new Set(prev);
+			next.delete(id);
+			return next;
+		});
+		setReviewActive(true);
+	}
+	function closeReviewTab() {
+		if (currentSession) {
+			const id = currentSession.id;
+			setReviewClosed((prev) => new Set(prev).add(id));
+		}
+		setReviewActive(false);
+	}
 	currentSessionRef.current = currentSession;
 
 	// Mark the open session read up to its latest activity — both when it's first
@@ -1739,10 +1788,16 @@ function App() {
 						<SessionTabs
 							tabs={projectChats}
 							archived={archivedChats}
-							activeId={currentSession?.id || null}
+							activeId={reviewActive ? null : currentSession?.id || null}
 							colors={tabColors}
-							onSelect={(s) => navigate({ view: "session", id: s.id })}
+							onSelect={(s) => {
+								setReviewActive(false);
+								navigate({ view: "session", id: s.id });
+							}}
 							onSetColor={(key, color) => setTabColors(setTabColor(key, color))}
+							viewTabs={reviewViewTabs}
+							onSelectView={() => setReviewActive(true)}
+							onCloseView={closeReviewTab}
 							onNewChat={handleNewChat}
 							onRename={async (id, title) => {
 								try {
@@ -1883,6 +1938,8 @@ function App() {
 										})
 									}
 									workspaceChats={projectChats}
+									showReview={reviewActive}
+									onOpenReview={openReview}
 									allSessions={sessions}
 									allProjects={projects}
 									onNewChat={handleNewChat}

--- a/src/frontend/components/SessionTabs.tsx
+++ b/src/frontend/components/SessionTabs.tsx
@@ -23,6 +23,18 @@ import { useIsPhone } from "../hooks/useIsPhone";
  * button starts a new chat in this workspace sharing its worktree;
  * right-clicking + offers the other modes (stacked worktree / ask).
  */
+/** A non-chat pane (Review, …) surfaced as a leftmost tab in the strip. */
+export type ViewTab = {
+	/** Stable id, e.g. `review:<sessionId>`. */
+	id: string;
+	/** Tab label ("Review"). */
+	label: string;
+	/** Whether this pane is the foregrounded tab. */
+	active: boolean;
+	/** Optional status-dot class (e.g. PR state) shown before the label. */
+	dotClass?: string | null;
+};
+
 interface Props {
 	/** Sibling chats in the current workspace, in display order. */
 	tabs: UnifiedSession[];
@@ -34,6 +46,17 @@ interface Props {
 	colors: Record<string, string>;
 	onSelect: (session: UnifiedSession) => void;
 	onSetColor: (key: string, color: string | null) => void;
+	/**
+	 * Non-chat "view" tabs (currently just Review) pinned to the LEFT of the
+	 * chat tabs. Each is bound to a session; selecting one foregrounds that
+	 * pane, its × dismisses it. Generalized so more panes (diff, terminal, …)
+	 * can drop in later.
+	 */
+	viewTabs: ViewTab[];
+	/** Foreground a view tab (show its pane). */
+	onSelectView: (id: string) => void;
+	/** Dismiss a view tab from the strip. */
+	onCloseView: (id: string) => void;
 	/**
 	 * Start a new chat in this workspace. share = reuse the workspace worktree
 	 * (the + button's plain-click default), stack = new worktree branched off it,
@@ -66,6 +89,9 @@ export function SessionTabs({
 	colors,
 	onSelect,
 	onSetColor,
+	viewTabs,
+	onSelectView,
+	onCloseView,
 	onNewChat,
 	onRename,
 	onClose,
@@ -105,9 +131,11 @@ export function SessionTabs({
 		};
 	}, [newMenu]);
 
-	// One chat (or a standalone chat) → no tab strip. The lone workspace's
-	// "+ New tab" button lives next to the session title in the header instead.
-	if (tabs.length <= 1) return null;
+	// One chat and no view tabs → no strip. The lone workspace's "+ New tab"
+	// button lives next to the session title in the header instead. But once a
+	// non-chat pane (Review) is open, the strip appears so it has somewhere to
+	// live — a lone code chat then reads as [Review][chat].
+	if (tabs.length <= 1 && viewTabs.length === 0) return null;
 
 	// New-tab "+" — plain-click shares the workspace worktree; right-click offers
 	// the stacked/ask modes.
@@ -167,6 +195,32 @@ export function SessionTabs({
 	return (
 		<div className="session-tabs" role="tablist">
 			<div className="session-tabs-scroll">
+				{/* Non-chat panes (Review, …) ride at the FRONT of the strip. */}
+				{viewTabs.map((v) => (
+					<div
+						key={v.id}
+						role="tab"
+						aria-selected={v.active}
+						className={`session-tab session-tab-view ${v.active ? "session-tab-active" : ""}`}
+						onClick={() => onSelectView(v.id)}
+						title={v.label}
+					>
+						{v.dotClass && <span className={`panel-tab-dot ${v.dotClass}`} />}
+						<span className="session-tab-title">{v.label}</span>
+						<button
+							type="button"
+							className="session-tab-close"
+							aria-label={`Close ${v.label}`}
+							title={`Close ${v.label}`}
+							onClick={(e) => {
+								e.stopPropagation();
+								onCloseView(v.id);
+							}}
+						>
+							×
+						</button>
+					</div>
+				))}
 				{tabs.map((session) => {
 					const key = session.id;
 					const waiting = !!session.waitingForInput;

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -189,6 +189,14 @@ interface Props {
 		id: string,
 		req: { to: string; by: string; at: string; accepted?: { by: string; at: string } } | null,
 	) => void;
+	/**
+	 * Whether the Review pane is foregrounded — driven by the top tab strip's
+	 * Review view-tab (App state), replacing the old inline Chat|Review toggle.
+	 * When false, the chat transcript shows.
+	 */
+	showReview?: boolean;
+	/** Open/foreground this session's Review view-tab (PR/review triggers). */
+	onOpenReview?: () => void;
 }
 
 type PanelTab =
@@ -301,6 +309,8 @@ export function SessionViewer({
 	onOpenSession,
 	onRunningChange,
 	onReviewChange,
+	showReview = false,
+	onOpenReview,
 }: Props) {
 	const [entries, setEntries] = useState<TranscriptEntry[]>([]);
 	// No transcript file yet (a fresh chat that hasn't run) → nothing to load;
@@ -454,11 +464,11 @@ export function SessionViewer({
 		setPanelTab(tab);
 		localStorage.setItem("michael-panel-tab", tab);
 	}
-	// Main chat-area view: the transcript+composer ("chat") or a full-width
-	// PR review ("review") that takes over the whole chat column so the code
-	// diff gets the full width. Only reachable on a code session (hasWorkspace);
-	// the effect below drops back to "chat" whenever there is no workspace.
-	const [mainView, setMainView] = useState<"chat" | "review">("chat");
+	// Main chat-area view: the transcript+composer vs. the full-width PR review
+	// that takes over the whole chat column. Which one shows is now owned by App
+	// (the top tab strip's Review view-tab) and passed in as `showReview`; the
+	// open triggers call onOpenReview. Only meaningful on a code session
+	// (hasWorkspace) — App only offers the Review tab there.
 	// Bumped by the ⋯ menu's "New side chat" — tells the SideChatsPanel to
 	// create (and open) a fresh side chat as soon as it shows. The panel calls
 	// onCreateConsumed to reset it to 0, so tab remounts don't re-create.
@@ -715,11 +725,6 @@ export function SessionViewer({
 		)
 			setPanelTab("info");
 	}, [workflowsLoaded, panelTab, workflowRuns.length, hasWorkspace]);
-
-	// A session with no code workspace has no Review — never sit on it.
-	useEffect(() => {
-		if (!hasWorkspace && mainView !== "chat") setMainView("chat");
-	}, [hasWorkspace, mainView]);
 
 	// Ask→code promotion: creates a worktree and flips the chat to code mode.
 	// The 5s session poll picks up the mode change and re-renders with the full
@@ -2729,34 +2734,7 @@ export function SessionViewer({
 
 			<div className="viewer-split">
 				<div className="viewer-chat">
-					{hasWorkspace && (
-						<div className="main-view-switch" role="tablist">
-							<button
-								type="button"
-								role="tab"
-								aria-selected={mainView === "chat"}
-								className={`main-view-tab ${mainView === "chat" ? "active" : ""}`}
-								onClick={() => setMainView("chat")}
-							>
-								Chat
-							</button>
-							<button
-								type="button"
-								role="tab"
-								aria-selected={mainView === "review"}
-								className={`main-view-tab ${mainView === "review" ? "active" : ""}`}
-								onClick={() => setMainView("review")}
-							>
-								Review
-								{session.prState && (
-									<span
-										className={`panel-tab-dot ${session.prState === "OPEN" && session.prMergeable === "CONFLICTING" ? "pr-dot-conflict" : `pr-dot-${session.prState.toLowerCase()}`}`}
-									/>
-								)}
-							</button>
-						</div>
-					)}
-					{mainView === "review" && hasWorkspace ? (
+					{showReview && hasWorkspace ? (
 						<div className="viewer-review-main">
 							<PrPanel
 								sessionId={session.id}
@@ -3175,7 +3153,7 @@ export function SessionViewer({
 								repo={session.repo || undefined}
 								archived={session.archived}
 								send={connected ? send : undefined}
-								onOpenPrTab={() => setMainView("review")}
+								onOpenPrTab={() => onOpenReview?.()}
 								running={isRunningLive}
 								refreshTick={gitRefreshTick}
 								// Globe (staging deploy) rides inside the strip, left of the
@@ -3296,7 +3274,7 @@ export function SessionViewer({
 									reviewRequestSessionId={effectiveReview?.ownerId}
 									onReviewChange={onReviewChange}
 									send={connected ? send : undefined}
-									onOpenTab={(tab) => (tab === "pr" ? setMainView("review") : selectPanelTab(tab))}
+									onOpenTab={(tab) => (tab === "pr" ? onOpenReview?.() : selectPanelTab(tab))}
 									onAddToInput={(text) =>
 										setComposerPrefill((p) => ({
 											seq: (p?.seq ?? 0) + 1,

--- a/src/frontend/styles/global.css
+++ b/src/frontend/styles/global.css
@@ -16307,45 +16307,12 @@ html[data-theme="light"] .pixel-spinner .pixel {
 
 
 /* ------------------------------------------------------------------ *
- * Main chat-area Chat/Review switch + full-width review host.
- * The PR review moves out of the cramped right panel: a segmented control
- * at the top of the chat column swaps the transcript+composer for a
- * full-width PrPanel (its .pr-panel-split rail + diff then get the whole
- * main area). The switch mirrors the .panel-tab pill look so both tab
- * strips read as one family; only shown on code sessions.
+ * Full-width review host for the chat column.
+ * The PR review moves out of the cramped right panel: selecting the top tab
+ * strip's Review view-tab swaps the transcript+composer for a full-width
+ * PrPanel (its .pr-panel-split rail + diff get the whole main area). Only
+ * offered on code sessions.
  * ------------------------------------------------------------------ */
-.main-view-switch {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-	flex-shrink: 0;
-	padding: 10px 16px 4px;
-}
-.main-view-tab {
-	background: none;
-	border: none;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	font-size: 13px;
-	font-weight: 500;
-	padding: 5px 14px;
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	cursor: pointer;
-	transition:
-		background 0.14s ease,
-		color 0.14s ease;
-}
-.main-view-tab:hover {
-	color: var(--text);
-	background: var(--bg-hover);
-}
-.main-view-tab.active {
-	color: var(--text);
-	background: var(--bg-active);
-}
-
 /* Full-width review host: a flex child of .viewer-chat that stretches, so
    the PrPanel (its .pr-panel-split is height:100%) fills the whole column. */
 .viewer-review-main {
@@ -16384,8 +16351,3 @@ html[data-theme="light"] .pixel-spinner .pixel {
 	border-color: var(--text-faint);
 }
 
-@media (max-width: 720px) {
-	.main-view-switch {
-		padding: 8px 12px 4px;
-	}
-}


### PR DESCRIPTION
## What

Collapses the two stacked tab bars into one. Today a code session shows a top **SessionTabs** strip (workspace sibling chats) *and* a second inline `Chat | Review` toggle inside the session. This makes **Review a leftmost "view-tab" in the top strip** — opened and closed there like a Conductor pane — so there's a single tab bar.

Before → after:
- Lone code chat: `[Chat | Review]` inner bar → top strip `[Review] [chat]`
- Multi-chat workspace: two bars → one strip `[Review] [nvm] [New chat] +`

## How

- **`SessionTabs.tsx`** — new generic `viewTabs: ViewTab[]` rendered *before* the chat tabs, each with select / close (`×` on hover) / active state + an optional PR-state dot. The strip now renders when there are ≥2 chats **or** any view-tab (so a lone code chat still gets a strip once Review is present).
- **`SessionViewer.tsx`** — dropped the local `mainView` state, the `.main-view-switch` bar, and the guard effect. The Review pane is now driven by a `showReview` prop; the existing PR/review triggers (`onOpenPrTab`, the right-panel `onOpenTab("pr")`) route up via `onOpenReview`.
- **`App.tsx`** — lifted the state: `reviewActive` (is the current session's Review foregrounded) + `reviewClosed` (sessions where the `×` dismissed it). Resets to chat on session change; builds the single Review view-tab for the current code session; wires select/close/open. A chat-tab click clears review; the `×` dismisses it; the PR-status/review affordances reopen it.
- **`global.css`** — removed the now-dead `.main-view-switch` / `.main-view-tab` rules (kept `.viewer-review-main` + `.workspace-info-review-btn`, still used).

## Design decisions (stated for review)

- **Generic view-tabs, Review only shipped.** The strip holds arbitrary non-chat panes; diff/terminal/PR-preview/etc. can drop in later with no rework. Only Review is wired now.
- **One Review tab, bound to the current session.** Shared siblings resolve to the same worktree/PR, so per-sibling Review tabs would just be clutter. Switching to a sibling starts on its chat.
- **Reopen after close** is via the existing PR-status chip / review affordances inside the session (there's no `+view` picker yet). Easy to add a manual reopen if you want one.

## Verification

`tsc --noEmit` clean for the three changed files (the 4 repo-wide errors are pre-existing, in `deploy/oc-web-proxy.ts` + `claude-accounts.test.ts`). Frontend bundle builds clean (1440 modules). Not yet visually verified in a running instance — backstage UI has no easy headless-screenshot path; best eyeballed once it's on `master` (bun --hot) or a manual dev instance.

Created by [this Michael session](https://os.tella.dev/session/bks-019f6afa-c006-7000-ada2-8d2a24c86c7e)