### PR TITLE
os1: Review view-tab is opt-in (open from the sidebar), not default-on

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -709,8 +709,12 @@ function App() {
 	// Whether the current session's Review pane is foregrounded (the top tab
 	// strip's Review view-tab). Reset to chat whenever the open session changes.
 	const [reviewActive, setReviewActive] = useState(false);
-	// Sessions whose Review view-tab was dismissed (×); onOpenReview re-adds it.
-	const [reviewClosed, setReviewClosed] = useState<Set<string>>(() => new Set());
+	// Sessions whose Review view-tab is open (opened from the sidebar); empty by default.
+	const [reviewOpen, setReviewOpen] = useState<Set<string>>(() => new Set());
+	// One-shot: the session whose Review tab should foreground once it lands, set
+	// when opening Review from the sidebar. Survives the session-change reset
+	// below (a pulse consumed by the effect next to it), then cleared.
+	const [pendingReviewOpen, setPendingReviewOpen] = useState<string | null>(null);
 
 	// Set for the render right after opening a workspace from the sidebar, so the
 	// session it lands on autofocuses its composer (you picked the workspace to
@@ -980,12 +984,21 @@ function App() {
 	useEffect(() => {
 		setReviewActive(false);
 	}, [currentSession?.id]);
+	// ...unless we just opened Review for that session from the sidebar: once it
+	// lands (this render or the one after navigation), foreground Review and
+	// consume the pulse. Runs after the reset effect above, so it wins.
+	useEffect(() => {
+		if (pendingReviewOpen && pendingReviewOpen === currentSession?.id) {
+			setReviewActive(true);
+			setPendingReviewOpen(null);
+		}
+	}, [currentSession?.id, pendingReviewOpen]);
 	// The current code session's Review pane, surfaced as a leftmost view-tab in
 	// the top strip (siblings share the worktree/PR, so one Review tab suffices).
 	const currentHasWorkspace =
 		!!currentSession && Boolean(currentSession.worktreeDir || currentSession.branch);
 	const reviewViewTabs: ViewTab[] =
-		currentSession && currentHasWorkspace && !reviewClosed.has(currentSession.id)
+		currentSession && currentHasWorkspace && reviewOpen.has(currentSession.id)
 			? [
 					{
 						id: `review:${currentSession.id}`,
@@ -1005,21 +1018,33 @@ function App() {
 	function openReview() {
 		if (!currentSession) return;
 		const id = currentSession.id;
-		setReviewClosed((prev) => {
-			if (!prev.has(id)) return prev;
-			const next = new Set(prev);
-			next.delete(id);
-			return next;
+		setReviewOpen((prev) => {
+			if (prev.has(id)) return prev;
+			return new Set(prev).add(id);
 		});
 		setReviewActive(true);
 	}
 	function closeReviewTab() {
 		if (currentSession) {
 			const id = currentSession.id;
-			setReviewClosed((prev) => new Set(prev).add(id));
+			setReviewOpen((prev) => {
+				if (!prev.has(id)) return prev;
+				const next = new Set(prev);
+				next.delete(id);
+				return next;
+			});
 		}
 		setReviewActive(false);
 	}
+	// Open a session's Review tab from the sidebar: select it and foreground its
+	// Review once it lands (pendingReviewOpen survives the session-change reset).
+	const openReviewForSession = React.useCallback((session: UnifiedSession) => {
+		setReviewOpen((prev) =>
+			prev.has(session.id) ? prev : new Set(prev).add(session.id),
+		);
+		setPendingReviewOpen(session.id);
+		navigate({ view: "session", id: session.id });
+	}, []);
 	currentSessionRef.current = currentSession;
 
 	// Mark the open session read up to its latest activity — both when it's first
@@ -1597,6 +1622,7 @@ function App() {
 							reportsActive={route.view === "reports"}
 							onOpenReports={() => navigate({ view: "reports" })}
 							onSelect={(s) => navigate({ view: "session", id: s.id })}
+							onOpenReview={openReviewForSession}
 							onOpenPr={(repo, branch) =>
 								navigate({ view: "pr", repo, branch })
 							}

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -205,6 +205,8 @@ interface Props {
 	/** Open automation-produced recurring reports. */
 	onOpenReports: () => void;
 	onSelect: (session: UnifiedSession) => void;
+	/** Foreground a session's Review view-tab (from a chat row's context menu). */
+	onOpenReview: (session: UnifiedSession) => void;
 	/** Open the session-less PR preview for a PR row with no chat behind it. */
 	onOpenPr: (repo: string, branch: string) => void;
 	/** The PR preview currently open (highlights its row), or null. */
@@ -792,6 +794,7 @@ export function Sidebar({
 	reportsActive,
 	onOpenReports,
 	onSelect,
+	onOpenReview,
 	onOpenPr,
 	selectedPr = null,
 	onOpenSupportThread,
@@ -3118,6 +3121,15 @@ export function Sidebar({
 								copyToClipboard(absoluteLink(chatPath(first)), () =>
 									onToast?.("Link copied"),
 								),
+						});
+					// A chat that owns a worktree/branch (and thus a PR/diff) can open
+					// its Review tab here — it's off by default in the viewer.
+					if (first && (first.worktreeDir || first.branch))
+						entries.push({
+							kind: "item",
+							icon: <IconEye size={20} />,
+							label: "Open review",
+							onClick: () => onOpenReview(first),
 						});
 					// Archive is the removal action here (a chat/workspace is finished
 					// by archiving, never inferred-deleted). A chatless workspace has


### PR DESCRIPTION
## What

Follow-up to #58. That PR moved the inner `Chat | Review` toggle into the
Conductor-style top tab strip as a "view-tab", but left Review **shown by
default** on every code session (it rendered unless the user dismissed it via a
`reviewClosed` Set). This flips the model to **opt-in**: Review is absent until
you explicitly open it, and it's openable from the sidebar.

## Changes

**`src/frontend/App.tsx`**
- Replaced the `reviewClosed` Set with a `reviewOpen` Set (default empty). The
  Review view-tab is built only when `currentSession && currentHasWorkspace &&
  reviewOpen.has(currentSession.id)`.
- `openReview()` adds the current session to `reviewOpen` + activates review;
  `closeReviewTab()` removes it + deactivates. The "reset review-active on
  session change" effect is unchanged.
- New `openReviewForSession(session)` (used by the sidebar): selects the session
  and foregrounds its Review. It uses a `pendingReviewOpen` one-shot that
  survives the session-change reset effect (a second effect consumes the pulse
  once the session lands, so it wins over the reset), mirroring the existing
  `focusComposerOnOpen` pulse pattern.

**`src/frontend/components/Sidebar.tsx`**
- Extended the existing chat/workspace row context menu with an **"Open review"**
  item (`IconEye`), shown only on chat rows that own a worktree/branch. It calls
  a new `onOpenReview(session)` prop, threaded from `App.tsx`.

The in-viewer PR/review triggers (`onOpenReview` in `SessionViewer`) still open
Review through the same `openReview` path — not regressed.

## Verification

- `bunx tsc --noEmit`: clean except the 4 pre-existing unrelated errors in
  `deploy/oc-web-proxy.ts` and `src/server/claude-accounts.test.ts`. The four
  touched-area files (App.tsx, Sidebar.tsx, SessionTabs.tsx, SessionViewer.tsx)
  are error-free.
- `bun build src/frontend/App.tsx --outdir /tmp/rev-build --target browser`:
  succeeds, exit 0 (bundled 1439 modules, no JSX/import errors).

Started by Kent de Bruin in [this Michael session](https://os.tella.dev/session/bks-019f6afa-c006-7000-ada2-8d2a24c86c7e)
