### PR TITLE
Allow read-only sed -n / git merge-base,rev-parse / gh run in ask-mode bash

### DIFF
--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -702,17 +702,26 @@ const ASK_BASH_PERMISSIONS: Record<string, "allow" | "deny"> = {
   "*": "deny",
   "cat *": "allow", "ls*": "allow", "rg *": "allow", "grep *": "allow",
   "find *": "allow", "head *": "allow", "tail *": "allow", "wc *": "allow",
+  // sed -n: read-only line-range printing ("show me lines N-M"), on par with
+  // head/tail/cat for paging a file — the canonical read command review agents
+  // reach for (7 denials on 2026-07-16). Only the -n form; bare "sed *" (incl.
+  // in-place "sed -i") stays denied.
+  "sed -n *": "allow",
   "tree*": "allow", "file *": "allow", "stat *": "allow", "du *": "allow",
   "df*": "allow", "which *": "allow", "pwd": "allow", "echo *": "allow",
   "git status*": "allow", "git log*": "allow", "git diff*": "allow",
   "git show*": "allow", "git branch*": "allow", "git blame*": "allow",
   "git grep*": "allow", "git ls-files*": "allow",
+  "git merge-base*": "allow", "git rev-parse*": "allow",
   // Read-only GitHub inspection (PR-backlog digests, review triage). Only the
   // non-mutating `gh pr` read verbs — NOT bare "gh *" (that would allow
   // pr create/merge/close/comment) and NOT "gh api *" (which can -X POST/PATCH
   // any endpoint). These four only ever read.
   "gh pr list*": "allow", "gh pr view*": "allow",
   "gh pr checks*": "allow", "gh pr status*": "allow",
+  // Read-only CI-run inspection (review agents check a PR's Actions runs).
+  // Only the read verbs — bare "gh run *" would allow rerun/cancel/delete.
+  "gh run view*": "allow", "gh run list*": "allow", "gh run watch*": "allow",
   // jq: a pure read-only JSON filter (no file writes, no shell-out, no code
   // exec — its language is sandboxed data transformation), so it's on par with
   // grep/wc for the allowlist. Lets ask-mode runs process `gh --json` / API


### PR DESCRIPTION
## What
Adds a few genuinely read-only verbs to `ASK_BASH_PERMISSIONS` (the ask-mode bash allowlist used by github-review and other unattended ask runs) in `src/server/opencode-runner.ts`:
- `sed -n *` — read-only line-range printing ("show me lines N–M"), on par with the already-allowed `head`/`tail`/`cat`. Only the `-n` form; bare `sed *` / in-place `sed -i` stay denied.
- `git merge-base*`, `git rev-parse*` — read-only ref/ancestor resolution reviewers need to find a diff base.
- `gh run view*`, `gh run list*`, `gh run watch*` — read-only CI-run inspection. Bare `gh run *` (rerun/cancel/delete) stays denied.

## Why
Last night's Dreaming retro found **42 denied bash calls** on 2026-07-16 (top tool-error group, mostly `github-review`). Correlating each denied `tool_use_id` against its command in the audit log, the largest *legitimately read-only* buckets were exactly these: `sed -n` (7), `git merge-base`/`rev-parse` (3), `gh run view/list` (4). They were simply missing from the allowlist, so review agents burned turns retrying denied inspection commands.

Left deliberately denied: `cd <worktree> && <cmd>` compounds (9 denials). Allowing `cd *` would let `cd x && rm -rf` slip past the catch-all deny (last-match-wins), so that one needs a prompt-side fix (review cwd is already the worktree — don't `cd`) or compound-command splitting, tracked separately.

## Risk
Low — only adds allow-rules for read-only verbs to a Record literal; typechecks clean (the sole `tsc` error is pre-existing in `deploy/oc-web-proxy.ts`, unrelated). Runner-internals change, so it needs a real `systemctl restart` to take effect (noted for the human merging).

Created by [this Michael session](https://os.tella.dev/session/bks-019f6e56-e0a1-7000-82b6-260581b2c713)