### PR TITLE
ask-mode bash: allow read-only git plumbing + date reads

### DIFF
--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -772,9 +772,18 @@ const ASK_BASH_PERMISSIONS: Record<string, "allow" | "deny"> = {
   "find *": "allow", "head *": "allow", "tail *": "allow", "wc *": "allow",
   "tree*": "allow", "file *": "allow", "stat *": "allow", "du *": "allow",
   "df*": "allow", "which *": "allow", "pwd": "allow", "echo *": "allow",
+  // Read-only clock reads (timestamp math in digests/triage). Only the read
+  // forms — bare "date */date -s" (setting the clock) needs root and is not
+  // allowed here; these globs cover `date +%s`, `date -u`, `date -d '…'`.
+  "date": "allow", "date +*": "allow", "date -u*": "allow",
+  "date -d*": "allow", "date -r*": "allow",
   "git status*": "allow", "git log*": "allow", "git diff*": "allow",
   "git show*": "allow", "git branch*": "allow", "git blame*": "allow",
   "git grep*": "allow", "git ls-files*": "allow",
+  // git plumbing reads: rev-parse just prints resolved revs/paths (no mutation),
+  // and review agents routinely chain `… && git rev-parse HEAD` — opencode
+  // evaluates each sub-command, so an unlisted rev-parse denied the whole line.
+  "git rev-parse*": "allow", "git cat-file*": "allow", "git describe*": "allow",
   // Read-only GitHub inspection (PR-backlog digests, review triage). Only the
   // non-mutating `gh pr` read verbs — NOT bare "gh *" (that would allow
   // pr create/merge/close/comment) and NOT "gh api *" (which can -X POST/PATCH


### PR DESCRIPTION
## What

Ask-mode runs (github-review, prompt reviews, read-only automations) share `ASK_BASH_PERMISSIONS` — a deny-by-default bash allowlist of read-only inspection commands. On 2026-07-18 the audit digest showed **8 bash denials** (the day's single largest tool-error group), and every one was a genuinely read-only command that simply wasn't listed:

- `git log --oneline -8 && git status --short --branch && git rev-parse HEAD` (a github-review run) — opencode evaluates each sub-command of a compound line, so the whole chain was denied purely because `git rev-parse` isn't allowlisted.
- `date +%s`, `date -u`, `date -d '24 hours ago' +%s` (a read-only automation doing timestamp math).

## Change

Added to the ask-mode allowlist:
- `git rev-parse*`, `git cat-file*`, `git describe*` — pure git plumbing reads, no mutation.
- `date`, `date +*`, `date -u*`, `date -d*`, `date -r*` — the read forms only. Setting the clock (`date -s`) needs root and stays unlisted.

Write/exec-capable commands seen in the same denial set (`sed -n` — has `w`; `awk` — has `system()`/`print >`; `apply_patch`/`python3 <<` writes) were intentionally left denied.

## Verify

`bunx tsc --noEmit` clean for this file (one pre-existing unrelated error in `deploy/oc-web-proxy.ts`).

Created by [this Michael session](https://os.tella.dev/session/bks-019f78a3-83db-7000-b99e-2fabda4a0a64)