### PR TITLE
workflow_status: spill oversized result to a scratch file instead of hard-truncating

### DIFF
--- a/src/agents/slack/workflow-tools.ts
+++ b/src/agents/slack/workflow-tools.ts
@@ -18,6 +18,7 @@
  */
 
 import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { z } from "zod";
 import { startWorkflow, cancelWorkflow } from "../../server/workflow-runner";
 import {
@@ -258,10 +259,34 @@ export function createWorkflowsMcpServer(ctx: WorkflowsToolContext) {
 					} catch {
 						result = String(run.result);
 					}
-					if (result.length > 20_000)
-						result = result.slice(0, 20_000) + "\n… (truncated)";
 					lines.push("Result:");
-					lines.push(result);
+					if (result.length > 20_000) {
+						// Spill the full value to a scratch file so it isn't lost to
+						// the tool-output cap. /tmp/opencode/** is readable by the
+						// Read tool in BOTH shell and ask-mode runs (see
+						// ASK_EXTERNAL_DIR_PERMISSIONS in opencode-runner.ts), so the
+						// agent can read the untruncated result instead of replaying
+						// the whole workflow with a compacted return shape (the
+						// "resume_workflow just to reshape the return" papercut).
+						let spillPath = "";
+						try {
+							const dir = "/tmp/opencode/workflow-results";
+							mkdirSync(dir, { recursive: true });
+							spillPath = `${dir}/${run.runId}.txt`;
+							writeFileSync(spillPath, result);
+						} catch {
+							spillPath = "";
+						}
+						lines.push(
+							result.slice(0, 20_000) + "\n… (truncated at 20,000 chars)",
+						);
+						if (spillPath)
+							lines.push(
+								`Full result (${result.length} chars) written to ${spillPath} — Read that file for the complete value instead of re-running the workflow.`,
+							);
+					} else {
+						lines.push(result);
+					}
 				}
 				return text(lines.join("\n"));
 			},


### PR DESCRIPTION
## What

`workflow_status` truncated a workflow's return value at 20,000 chars with no paging and no file fallback. In an ask-mode run (no shell), the full synthesis was then unrecoverable — the agent had to `resume_workflow` with a byte-identical script whose *only* change was a compacted return shape, just to squeeze the output under the cap.

The **Morning support digest** automation logged this as a papercut on 2026-07-19.

## Fix

When the result exceeds 20k chars, write the **full** value to `/tmp/opencode/workflow-results/<runId>.txt` and surface the path in the tool output (alongside the existing truncated preview). That directory is already readable by the Read tool in **both** shell and ask-mode runs (`ASK_EXTERNAL_DIR_PERMISSIONS` allows `/tmp/opencode/**`), so the agent reads the untruncated result directly instead of replaying the whole workflow.

Small, self-contained change in `src/agents/slack/workflow-tools.ts` (+ a `node:fs` import). `bunx tsc --noEmit` clean (only the pre-existing unrelated `deploy/oc-web-proxy.ts` error remains).

🌙 Surfaced by the nightly Dreaming reflection from the 2026-07-19 audit digest.

Created by [this Michael session](https://os.tella.dev/session/bks-019f7dc9-f02e-7000-afe6-02f456620ec7)