### PR TITLE
Track seo-sweep PRs in #proj-seo (announce on open, ✅ on merge)

### DIFF
--- a/src/agents/github/constants.ts
+++ b/src/agents/github/constants.ts
@@ -45,6 +45,8 @@ export const DOCS_SYNC_AUTOMATION_NAME = "docs-sync";
 export const DOCS_SYNC_BRANCH_PREFIX = "auto-docs-sync-";
 /** #proj-help-center — where docs-sync announces the PRs it opens. */
 export const DOCS_SYNC_SLACK_CHANNEL = "C09BAFFK8F8";
+/** #proj-seo — where every seo-sweep PR is announced (opened) and ticked ✅ (merged). */
+export const SEO_SLACK_CHANNEL = "C0BE3E5JGTH";
 
 /**
  * PR trigger labels. Canonical names are the generic os-* ones; the legacy

--- a/src/agents/github/seo-notify.ts
+++ b/src/agents/github/seo-notify.ts
@@ -1,0 +1,60 @@
+/**
+ * SEO tracking in #proj-seo: announce each `seo-sweep` PR when it opens, then
+ * tick that announcement with ✅ when the PR merges — so the channel is a single
+ * at-a-glance log of proposed vs landed SEO work.
+ *
+ * Mirrors docs-sync-notify: the announcement is a normal bot message that links
+ * the PR, and the merge check-off finds it again by that `/pull/<n>` link (no
+ * stored `ts`). Both halves are best-effort and never throw into the webhook.
+ */
+import { sendSlackMessage, addReaction, fetchChannelHistory } from "../slack/slack-api";
+import { SEO_SLACK_CHANNEL } from "./constants";
+
+const MERGED_REACTION = "white_check_mark";
+/** Recent messages to scan when locating a PR's announcement. */
+const HISTORY_LIMIT = 200;
+
+/** True when `text` links the given PR (matches the `/pull/<n>` URL, not a
+ *  longer number that merely starts with it, e.g. #4433 vs #44330). */
+function linksPr(text: string, prNumber: number): boolean {
+  return new RegExp(`/pull/${prNumber}(?!\\d)`).test(text);
+}
+
+/**
+ * Announce a newly-opened seo-sweep PR in #proj-seo so Johnny can track it.
+ * Idempotent: if an announcement for this PR is already in the channel (e.g. the
+ * `opened` and `labeled` webhooks both fired), it posts nothing.
+ */
+export async function announceSeoPr(
+  prNumber: number,
+  title: string,
+  htmlUrl: string,
+): Promise<void> {
+  const url = htmlUrl || `https://github.com/tellahq/tella-fusion/pull/${prNumber}`;
+  const history = await fetchChannelHistory(SEO_SLACK_CHANNEL, HISTORY_LIMIT);
+  if (history.some((m) => m.isBot && linksPr(m.text, prNumber))) return;
+
+  await sendSlackMessage(
+    SEO_SLACK_CHANNEL,
+    `:mag: *New SEO PR* — ${title}\n${url}\nI'll add a ✅ here once it's merged.`,
+  );
+  console.log(`[github] announced seo-sweep PR #${prNumber} in #proj-seo`);
+}
+
+/**
+ * Add a ✅ to the #proj-seo announcement for a just-merged seo-sweep PR. Scans
+ * recent channel history for the message that links this PR and reacts to it.
+ */
+export async function markSeoPrMerged(prNumber: number): Promise<void> {
+  const history = await fetchChannelHistory(SEO_SLACK_CHANNEL, HISTORY_LIMIT);
+  const message = history.find((m) => m.isBot && linksPr(m.text, prNumber));
+  if (!message) {
+    console.log(
+      `[github] seo-sweep PR #${prNumber} merged, but no announcement found in #proj-seo to check off`,
+    );
+    return;
+  }
+
+  await addReaction(SEO_SLACK_CHANNEL, message.ts, MERGED_REACTION);
+  console.log(`[github] checked off #proj-seo announcement for merged PR #${prNumber}`);
+}

--- a/src/agents/github/webhook.ts
+++ b/src/agents/github/webhook.ts
@@ -132,6 +132,12 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
         void fireSimplify(ref, requestedBy);
       } else if (labelMatches(label, LABEL_ADVERSARIAL)) {
         void fireAdversarial(ref, requestedBy);
+      } else if (isDefaultRepo && label === SEO_LABEL) {
+        // A human tagged an existing PR as seo-sweep — track it in #proj-seo too.
+        const { announceSeoPr } = await import("./seo-notify");
+        void announceSeoPr(pr.number, pr.title || `PR #${pr.number}`, pr.html_url || "").catch((e) =>
+          console.error(`[github] announceSeoPr failed for #${pr.number}:`, e),
+        );
       }
       return;
     }
@@ -152,6 +158,11 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
       if ((pr.labels || []).some((l) => l.name === SEO_LABEL)) {
         const { recordMergedSeoPr } = await import("../loops/seo");
         recordMergedSeoPr(pr.number, pr.merged_at || new Date().toISOString());
+        // Tick the #proj-seo announcement done so the channel shows landed vs open.
+        const { markSeoPrMerged } = await import("./seo-notify");
+        void markSeoPrMerged(pr.number).catch((e) =>
+          console.error(`[github] markSeoPrMerged failed for #${pr.number}:`, e),
+        );
       }
       // Docs-sync: review the merged PR for user-facing changes and update the
       // Mintlify docs. Skip only the docs-sync automation's OWN PRs (they land on
@@ -177,6 +188,22 @@ export async function handleGithubPrEvent(event: string, payload: any): Promise<
         if (fired) console.log(`[github] PR #${pr.number} merged → fired ${fired} docs-sync automation(s)`);
       }
       return;
+    }
+
+    // ── seo-sweep PR opened → announce in #proj-seo so it can be tracked ──
+    // The sweep opens as the bot with the `seo-sweep` label already applied, so
+    // this fires for our own PRs (a human labelling an existing PR is handled in
+    // the `labeled` block above). announceSeoPr is idempotent, so the two paths
+    // can't double-post. Falls through so a normal review still runs below.
+    if (
+      isDefaultRepo &&
+      (action === "opened" || action === "reopened" || action === "ready_for_review") &&
+      (pr.labels || []).some((l) => l.name === SEO_LABEL)
+    ) {
+      const { announceSeoPr } = await import("./seo-notify");
+      void announceSeoPr(pr.number, pr.title || `PR #${pr.number}`, pr.html_url || "").catch((e) =>
+        console.error(`[github] announceSeoPr failed for #${pr.number}:`, e),
+      );
     }
 
     // ── Open / update actions → review when opted in and non-draft ──

--- a/src/agents/loops/seo.ts
+++ b/src/agents/loops/seo.ts
@@ -12,6 +12,11 @@
  *      to the learnings file. The sweep reads that file each run, so the loop gets
  *      better over time.
  *
+ * Tracking: every seo-sweep PR is announced in #proj-seo when it opens and ✅'d
+ * there when it merges (github/seo-notify.ts, wired from the PR webhook), so the
+ * channel is a running log of proposed vs landed SEO work. The validation loop
+ * posts its measured outcomes to the same channel.
+ *
  * Feedback state lives on the box (decoupled from repo PR churn):
  *   ~/.opensession-seo/pending.jsonl  — merged seo-sweep PRs awaiting validation
  *   ~/.opensession-seo/learnings.md   — measured outcomes; the sweep's memory
@@ -93,6 +98,8 @@ The PR body MUST contain this machine-readable block so the post-merge validator
 
 Then a human summary: what changed, the Ahrefs rationale (positions/volumes), and the next candidate move.
 
+You do NOT need to post to Slack yourself — backstage auto-announces every \`${SEO_LABEL}\` PR in #proj-seo when it opens and adds a ✅ there when it merges, so the channel tracks proposed vs landed SEO work automatically.
+
 ## 7. If there's nothing safe to ship
 Post your measurement + recommendation as the session summary and open NO PR. Consistency beats forcing a change.`;
 
@@ -114,7 +121,7 @@ Permissions note: this is read-only with respect to the tella-fusion codebase/gi
 Classify each PR: IMPROVED / FLAT / REGRESSED, with the actual numbers. Append a dated entry to \`${LEARNINGS_FILE}\` (create it if absent) with: the date, PR #, the KIND of change (metadata / internal-links / content refresh / schema …), the target keywords + pages, the measured before→after, the verdict, and a one-line ACTIONABLE takeaway for the daily sweep (e.g. "internal links from /recorder lifted 'screen recorder' #12→#7 — do more of this"; or "metadata-only tweak on /chrome moved nothing in 3wks — deprioritize"). Be concrete — this file steers future runs.
 
 ## 4. Report + clean up
-- Post ONE concise summary to Slack channel \`C0AFQ7PV057\` (#michael-tinker) via the Slack MCP \`conversations_add_message\`: start with "📈 Michael SEO validation:" then, per PR: #<n> '<title>' — <verdict> (<key numbers>); takeaway: <…>. Cover all PRs validated this run in the one message.
+- Post ONE concise summary to Slack channel \`C0BE3E5JGTH\` (#proj-seo — the SEO tracking channel) via the Slack MCP \`conversations_add_message\`: start with "📈 Michael SEO validation:" then, per PR: #<n> '<title>' — <verdict> (<key numbers>); takeaway: <…>. Cover all PRs validated this run in the one message.
 - Remove each validated PR's line from \`${PENDING_FILE}\` (rewrite the file without those lines so it isn't re-validated).`;
 
 interface SeoLoopSeed {


### PR DESCRIPTION
Johnny asked to keep SEO work trackable in one place (#proj-seo) and have merged SEO PRs auto-checked off.

## What this does
- **Announce on open:** every \`seo-sweep\` PR is posted to **#proj-seo** when it opens — a bot message linking the PR. This is the message that gets the ✅. Mirrors how docs-sync announces its PRs in #proj-help-center.
- **✅ on merge:** when a \`seo-sweep\` PR merges, backstage finds that announcement (by its \`/pull/<n>\` link) and adds a ✅ — so the channel shows proposed vs landed at a glance. This lives in the PR webhook (`markSeoPrMerged`, mirroring `markDocsSyncPrMerged`) because the sweep session is long gone by merge time — a prompt alone cannot react later.
- **Validation → same channel:** the daily SEO Validation summary now posts to #proj-seo instead of #michael-tinker, so proposed / landed / measured-outcome SEO signal all land together.

## How
- New `src/agents/github/seo-notify.ts`: `announceSeoPr` (idempotent — skips if the PR is already announced) + `markSeoPrMerged`. Both best-effort, never throw into the webhook. No stored state — the message is relocated by its `/pull/<n>` link, same trick as docs-sync.
- `webhook.ts`: announce on `opened`/`reopened`/`ready_for_review` (and on a human applying the `seo-sweep` label), ✅ on merge — both gated on the `seo-sweep` label + default repo.
- `constants.ts`: `SEO_SLACK_CHANNEL`.
- `seo.ts`: validation posts to #proj-seo; sweep prompt notes announcements are automatic.

The Michael bot has been added to #proj-seo (it was not a member).

## Notes
- `tsc --noEmit` is clean for these files (the one pre-existing error in `deploy/oc-web-proxy.ts` is on master already, untouched here).
- Takes effect on the next backstage deploy. In the meantime I have updated the live SEO Validation automation to post to #proj-seo so that half is already live.

Started by Johnny Lin in [this Michael session](https://os.tella.dev/session/slack-C0AFQ7PV057-1784566174.722439)