### PR TITLE
Navigate only visible sidebar items with command arrows

### DIFF
--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -1836,9 +1836,10 @@ export function Sidebar({
 		return () => window.removeEventListener("keydown", onKeyDown);
 	}, [wsRowOrder, selectedId, onArchiveWorkspace]);
 
-	// ⌘↓/⌘↑ cycle the open session through the sidebar's workspace rows in
-	// visual order (down = next row), wrapping at the ends. Chatless rows are
-	// skipped — same candidate set as the archive-with-next handlers above.
+	// ⌘↓/⌘↑ cycle through the sidebar's rendered items in visual order (down =
+	// next row), wrapping at the ends. Reading the DOM here is intentional: each
+	// section owns its filtering and collapsed state, so rendered buttons are the
+	// single source of truth for what keyboard navigation can reach.
 	// Deliberately fires while the composer is focused (unlike the archive
 	// chords): jumping workspaces without leaving the keyboard is the point,
 	// and that costs the textarea its ⌘-arrow caret-to-start/end moves. Alt is
@@ -1860,13 +1861,17 @@ export function Sidebar({
 				)
 			)
 				return;
-			const candidates = wsRowOrder.filter((r) => r.chats.length > 0);
+			const candidates = Array.from(
+				document.querySelectorAll<HTMLButtonElement>(
+					".sidebar-workspace button.sidebar-item",
+				),
+			);
 			if (candidates.length === 0) return;
-			const idx = candidates.findIndex((r) =>
-				r.chats.some((c) => c.id === selectedId),
+			const idx = candidates.findIndex((item) =>
+				item.classList.contains("sidebar-item-selected"),
 			);
 			const dir = e.key === "ArrowDown" ? 1 : -1;
-			// No open session in the list (e.g. Home): enter from the edge.
+			// No selected sidebar item (e.g. Home): enter from the edge.
 			const next =
 				idx < 0
 					? dir === 1
@@ -1876,12 +1881,12 @@ export function Sidebar({
 			if (!next) return;
 			e.preventDefault();
 			closeWsHover();
-			if (next.workspace) onOpenProject(next.workspace.id);
-			else if (next.chats[0]) onSelect(next.chats[0]);
+			next.scrollIntoView({ block: "nearest" });
+			next.click();
 		}
 		window.addEventListener("keydown", onKeyDown);
 		return () => window.removeEventListener("keydown", onKeyDown);
-	}, [wsRowOrder, selectedId, onOpenProject, onSelect]);
+	}, []);
 
 	// ── Workspace hover card ────────────────────────────────────────────────
 	// One card for the whole list (only one row can be dwelled on at a time).


### PR DESCRIPTION
## Summary
- derive command-arrow navigation from the rendered sidebar rows
- skip sessions hidden by collapsed sections
- continue through pull request, support, note, and automation rows
- scroll each keyboard-selected row into view

## Verification
- `bun test src/frontend/lib/review-queue.test.ts src/frontend/lib/sidebar-filter.test.ts` (10 pass)
- `git diff --check`
- verified the live hot-reload bundle contains the rendered-row selector
- repository-wide typecheck remains blocked by the pre-existing `deploy/oc-web-proxy.ts(44,34)` error

Started by Michiel Westerbeek in [this Michael session](https://os.tella.dev/session/bks-019f8133-ae94-7000-a81d-46c0a19f0d94)