### PR TITLE
Fix command-arrow sidebar selector

### DIFF
--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -1863,7 +1863,7 @@ export function Sidebar({
 				return;
 			const candidates = Array.from(
 				document.querySelectorAll<HTMLButtonElement>(
-					".sidebar-workspace button.sidebar-item",
+					".sidebar-list button.sidebar-item",
 				),
 			);
 			if (candidates.length === 0) return;


### PR DESCRIPTION
## Summary
- scope command-arrow navigation to the actual `.sidebar-list` container
- restore keyboard navigation while retaining rendered-only candidate selection

## Root cause
PR #64 queried `.sidebar-workspace`, which contains the workspace header rather than the rendered rows. The selector returned zero candidates and the handler exited without navigating.

## Verification
- hard-reloaded the live app through CDP
- confirmed 129 visible `.sidebar-list button.sidebar-item` candidates
- dispatched Meta+ArrowDown and observed the selected index move from 1 to 2 and the route change to the next session
- `git diff --check`

Started by Michiel Westerbeek in [this Michael session](https://os.tella.dev/session/bks-019f8133-ae94-7000-a81d-46c0a19f0d94)