### PR TITLE
Export/upload investigators: reply in Slack thread via slack_reply_to_thread

### DIFF
--- a/src/agents/export/prompt.ts
+++ b/src/agents/export/prompt.ts
@@ -63,7 +63,7 @@ When you do open a PR: work on a branch in this worktree, make the minimal chang
 
 ## Step 6 — Report to Slack (always)
 
-Post a concise summary to the Slack control card thread for this investigation — channel \`slackChannelId\` and \`thread_ts\` = \`slackThreadTs\` from the triggering payload — using the Slack MCP \`slack_post_message\` (pass \`channel_id\` and \`thread_ts\`). Prefix it so it's clearly from you, Michael. Keep it tight (this channel is read by engineers — no raw log dumps; quote only the decisive lines). Include:
+Post a concise summary to the Slack control card thread for this investigation — channel \`slackChannelId\` and \`thread_ts\` = \`slackThreadTs\` from the triggering payload — using the Slack MCP \`slack_reply_to_thread\` (pass \`channel_id\`, \`thread_ts\`, and \`text\`). Do NOT use \`slack_post_message\` for this — its schema has no \`thread_ts\`, so it can't reply in the control-card thread; \`slack_reply_to_thread\` is the tool that threads. Prefix it so it's clearly from you, Michael. Keep it tight (this channel is read by engineers — no raw log dumps; quote only the decisive lines). Include:
 - The story (\`story_id\`, name if known) and a one-line failure classification (e.g. "SIGABRT in <fn>", "raw-MP4 source — needs re-upload", "NVENC OOM on 4K").
 - The proven root cause, citing the decisive log line / activity failure / layer.
 - How many attempts / which dimensions failed, and whether this looks isolated to this story or systemic.

--- a/src/agents/upload/prompt.ts
+++ b/src/agents/upload/prompt.ts
@@ -63,7 +63,7 @@ When you do open a PR: work on a branch in this worktree, make the minimal chang
 
 ## Step 6 — Report to Slack (always)
 
-Post a concise summary to the Slack control card thread for this investigation — channel \`slackChannelId\` and \`thread_ts\` = \`slackThreadTs\` from the triggering payload — using the Slack MCP \`slack_post_message\` (pass \`channel_id\` and \`thread_ts\`). Prefix it so it's clearly from you, Michael. Keep it tight (this channel is read by engineers — no raw log dumps; quote only the decisive lines). Include:
+Post a concise summary to the Slack control card thread for this investigation — channel \`slackChannelId\` and \`thread_ts\` = \`slackThreadTs\` from the triggering payload — using the Slack MCP \`slack_reply_to_thread\` (pass \`channel_id\`, \`thread_ts\`, and \`text\`). Do NOT use \`slack_post_message\` for this — its schema has no \`thread_ts\`, so it can't reply in the control-card thread; \`slack_reply_to_thread\` is the tool that threads. Prefix it so it's clearly from you, Michael. Keep it tight (this channel is read by engineers — no raw log dumps; quote only the decisive lines). Include:
 - The upload (\`streaming_upload_id\`, user email if known) and a one-line failure classification (e.g. "convert_to_hls crash on cover-art mjpeg stream", "incomplete upload — 3/12 parts in S3", "ffprobe: missing moov atom").
 - The proven root cause, citing the decisive log line / failed activity / missing segment.
 - Whether this looks isolated to this upload or systemic (cross-check with \`summarize_user_uploads\` and whether other users are hitting the same shape).


### PR DESCRIPTION
## What
The **Export failure investigation** and **Upload failure investigation** automation prompts (`src/agents/export/prompt.ts`, `src/agents/upload/prompt.ts`, Step 6) told the agent to post its summary into the Slack control-card thread using `slack_post_message` and to *pass `channel_id` and `thread_ts`*.

The slack MCP's `slack_post_message` schema only accepts `channel_id` + `text` — there is no `thread_ts` parameter — so the threaded reply couldn't work. Two independent automation runs logged this as a papercut on 2026-07-21.

## Fix
Point both prompts at `slack_reply_to_thread` (the deployed `mcp-server-slack` ships it: `channel_id`, `thread_ts`, `text`), and spell out the gotcha inline so the mistake doesn't recur.

## Note (live records)
These are code-seeded automations — merging this updates the seed, **not** the live automation records in `~/.opensession-automations`. To apply to the running automations, PUT the updated prompt to each via `/backstage/api/automations/:id` (export = `auto-019efe4c-0e27-7000-8d2f-5861e1e60c6a`; upload = its sibling). Flagging for a human — I did not touch live config.

## Verification
`bunx tsc --noEmit` clean; diff is the two prompt lines only.

Surfaced by the nightly Dreaming reflection (2026-07-21 digest).

Started by Michiel Westerbeek in [this Michael session](https://os.tella.dev/session/bks-019f8816-7b96-7000-903a-eba4cc9874e9)