### PR TITLE
Add fixed macOS execution node provider

### DIFF
--- a/docs/self-hosting-sandboxes.md
+++ b/docs/self-hosting-sandboxes.md
@@ -85,7 +85,7 @@ to `provider: "local"` (today's host behavior). Env override for the path:
 ```jsonc
 {
   // Which SandboxProvider new opted-in sessions get.
-  // "local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm"
+  // "local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos"
   "provider": "docker",
 
   // ── Docker provider ────────────────────────────────────────────────
@@ -198,6 +198,15 @@ to `provider: "local"` (today's host behavior). Env override for the path:
     "suspendedDurationSeconds": 3600, // only used with idleSuspendSeconds
     "logGroup": "/aws/lambda/microvms/opensession"
   },
+  "macos": {
+    // Fixed Tailscale-reachable Mac. SSH remains host-key checked and uses
+    // BatchMode; put the private key path here, never key material itself.
+    "host": "mac-mini.your-tailnet.ts.net",
+    "user": "opensession",     // optional; SSH config default when omitted
+    "port": 22,                 // optional
+    "identityFile": "/home/ubuntu/.ssh/opensession-mac", // optional
+    "remoteHome": "/Users/opensession"
+  },
 
   // How remote sandboxes authenticate `git clone` (they can't mount host
   // creds). "none" = public clone; "https-token" injects the token into the
@@ -226,7 +235,7 @@ to `provider: "local"` (today's host behavior). Env override for the path:
 
 ## Public dial-back ingress (remote providers)
 
-Remote sandboxes (Daytona/E2B/Box/Modal/Lambda MicroVMs) run on remote compute and must dial back
+Remote sandboxes (Daytona/E2B/Box/Modal/Lambda MicroVMs/macOS) run on remote compute and must dial back
 to backstage's `/opensession/run-ws/<hostId>` and `/opensession/rpc-ws`
 WebSocket routes from the **public internet**. The main server binds the
 tailnet and carries the whole app — never expose it. Instead,
@@ -481,6 +490,113 @@ in `deploy/sandbox/lambda-microvm/`.
 - To certify: `bun run deploy/sandbox/conformance.ts lambda-microvm` after the
   image and IAM resources exist.
 
+### Fixed macOS node (first functional provider)
+
+The `macos` provider runs the existing remote run host on one pre-provisioned
+Apple Silicon Mac. Backstage reaches it over noninteractive SSH, but each agent
+host is started as a unique Aqua `LaunchAgent` in `gui/$UID`. It therefore
+survives the SSH connection and runs in the logged-in desktop session, with the
+existing run-ws/rpc-ws, MCP proxy, steering, cancel, and restart-reattach
+machinery unchanged.
+
+**Provision the Mac once:**
+
+1. Create a dedicated **standard** local user (for example `opensession`), log
+   that user into the desktop, and keep the desktop logged in and unlocked
+   while the node is enabled. Do not run the node as an administrator.
+2. Join the Mac to the same Tailscale network as Backstage. Enable Remote Login
+   for only the dedicated user and restrict SSH to the Mac's Tailscale address
+   in the host firewall. Put Backstage's dedicated public key in that user's
+   `~/.ssh/authorized_keys`; keep the private key only on the Backstage host.
+3. Install full Xcode and select it with `sudo xcode-select -s
+   /Applications/Xcode.app/Contents/Developer`. Open Xcode once to accept its
+   license and finish first-launch components. Verify the Xcode command-line
+   tools expose Python 3 with `/usr/bin/python3 --version`; descriptor-confined
+   artifact imports use it on the Mac.
+4. As the dedicated user, install Bun, Claude Code, and the pinned OpenCode
+   version, then clone and install the Backstage runner at the configured SHA:
+
+   ```sh
+   curl -fsSL https://bun.sh/install | bash
+   curl -fsSL https://claude.ai/install.sh | bash
+   ~/.bun/bin/bun add -g opencode-ai@1.17.15
+   mkdir -p ~/.claude && test -s ~/.claude/settings.json || printf '{}\n' > ~/.claude/settings.json
+   mkdir -p ~/projects
+   git clone https://github.com/tellahq/backstage.git ~/projects/tella-backstage
+   git -C ~/projects/tella-backstage checkout --detach <runnerSha>
+   cd ~/projects/tella-backstage && ~/.bun/bin/bun install --frozen-lockfile
+   ```
+
+5. Set `runnerSha` in `~/.opensession-sandbox.json` to the same commit and set
+   `callbackBaseUrl` to a Tailscale-reachable Backstage WebSocket base. The
+   provider refuses non-Darwin, non-arm64, missing Xcode/Aqua, missing tools,
+   an OpenCode pin mismatch, or a runner SHA mismatch before cloning a session
+   workspace. The Linux Backstage host must also expose `/usr/bin/python3` for
+   descriptor-confined local artifact writes.
+6. Grant only the TCC permissions needed by the intended repo-local visual
+   tooling (typically Screen Recording, Accessibility, and Automation). TCC
+   prompts must be accepted interactively in the dedicated user's desktop;
+   validate the exact binaries/wrappers the scripts execute before unattended
+   use.
+
+Each child session gets an isolated clone under
+`~/.opensession-workspaces/<session>/<repo>` on the Mac. The Linux parent's
+`cwd` is never reused, attached repos are refused, private-repo clone auth uses
+the existing scoped `cloneCredential`, and deleting the session deletes that
+remote clone. The node must not hold release signing keys, App Store Connect
+credentials, production cloud credentials, or a developer's general-purpose
+SSH/GitHub credentials. Remote agent launches receive only the same per-run
+Claude/OpenAI account slices and MCP policy already used by other remote
+providers.
+
+This first provider has one fixed node and no visual-job scheduler. All runs
+serialize on a durable, node-wide **foreground lease** (a lockdir under
+`~/.opensession-node/foreground-lease` on the Mac — not merely per-session
+locking): a second session's run is refused with a clear "node is busy" error
+instead of silently contending for the desktop, keyboard, and screen. A lease
+whose owner is no longer running is reclaimed automatically after a short
+stale window. The lease, the run's remote spec/run directory, per-run
+credential seed material (the scoped Claude/OpenAI account files and the
+OpenAI seed dir), and the matching LaunchAgent plists/host logs are all
+removed when a run ends normally, on cancellation, on session `destroy()`,
+and when a later run reclaims a stale lease.
+
+Lease acquisition, LaunchAgent publication, and teardown are serialized across
+Backstage processes by an OS-backed `flock` on the Mac. Its detached holder
+is renewed while a launch is staging and expires after five minutes if the
+controlling process disappears; teardown does not release the foreground lease
+or credential files until launchd and the recorded run-host PID both confirm
+the previous host is gone.
+
+**Trust boundary: this is a single-user, single-machine node — it is NOT a
+multi-tenant sandbox.** Every session that runs here shares one Unix account
+on one dedicated Mac. Per-run cleanup removes scoped credentials and run-host
+state, but a later run still executes as the SAME account and can read
+another session's persisted worktree under
+`~/.opensession-workspaces/<session>/<repo>` if it chooses to — nothing
+enforces per-session filesystem isolation the way a container or VM does for
+the other providers. Only enable `macos` for deployments with exactly one
+trusted OpenSession user (or a group of users who already trust each other's
+session output), and keep the dedicated machine free of any secret,
+credential, or data that user should not incidentally be able to reach from a
+differently-authored session on the same node. Isolating untrusted sessions
+from each other requires a separate macOS user, VM, or node per tenant — not
+this provider as shipped.
+
+Artifact transfer uses the `import_remote_asset` tool on the
+`opensession-assets` MCP server: give it a path relative to the session's
+remote workspace root (for example a screenshot or recording a repo-local
+script wrote under `.build/opensession/artifacts/`) and Backstage fetches the
+file over the same noninteractive SSH transport. The transfer streams into a
+descriptor-confined local writer, is capped at 500 MB, and is size- and
+SHA-256-verified before atomic publication in the session's assets folder. No
+Linux SSH credential or reverse connection is ever exposed to the remote
+child. Imported video files (`.mp4`/`.webm`/`.mov`) print a
+`BACKSTAGE_VIDEO:` marker so the session viewer plays them inline; images
+appear in the Assets tab immediately. The Shell tab intentionally reports
+unavailable for macOS sessions until the provider has a remote PTY; it never
+falls back to an unrelated Linux host shell.
+
 ## Licensing notes
 
 - **Daytona** is AGPL-3.0. OpenSession consumes it **over its API** (via the
@@ -491,6 +607,7 @@ in `deploy/sandbox/lambda-microvm/`.
 - **E2B**: the JS SDK is MIT; the self-host infra repo is Apache-2.0.
 - **Modal**: the official `modal` TypeScript SDK is Apache-2.0.
 - **AWS Lambda MicroVMs**: the AWS SDK client is Apache-2.0.
+- **macOS**: uses the system OpenSSH client and launchd; no provider SDK.
 - **Docker provider**: plain `docker` CLI against your own daemon; nothing
   vendored.
 - Core imports adapter SDKs only inside `src/server/sandbox/adapters/` —

--- a/src/agents/slack/assets-tools.test.ts
+++ b/src/agents/slack/assets-tools.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { formatImportedAssetMessage, isVideoAssetPath } from "./assets-tools";
+
+describe("isVideoAssetPath", () => {
+	test("recognizes common video extensions", () => {
+		expect(isVideoAssetPath("demo.mp4")).toBe(true);
+		expect(isVideoAssetPath("clip.WEBM")).toBe(true);
+		expect(isVideoAssetPath("/abs/path/recording.mov")).toBe(true);
+	});
+
+	test("does not treat images or other files as video", () => {
+		expect(isVideoAssetPath("screenshot.png")).toBe(false);
+		expect(isVideoAssetPath("report.html")).toBe(false);
+		expect(isVideoAssetPath("no-extension")).toBe(false);
+	});
+});
+
+describe("formatImportedAssetMessage (import_remote_asset output)", () => {
+	test("prints a BACKSTAGE_VIDEO marker with the local absolute path for video imports", () => {
+		const msg = formatImportedAssetMessage({
+			remoteAbsPath: "/Users/runner/ws/.build/opensession/artifacts/demo.mp4",
+			localRelPath: "demo.mp4",
+			localAbsPath: "/home/ubuntu/.opensession-assets/bks-1/demo.mp4",
+			size: 1234,
+		});
+		expect(msg).toContain(
+			"Imported /Users/runner/ws/.build/opensession/artifacts/demo.mp4",
+		);
+		expect(msg).toContain("demo.mp4");
+		expect(msg).toContain("BACKSTAGE_VIDEO: /home/ubuntu/.opensession-assets/bks-1/demo.mp4");
+		// jsonl-parser.ts's VIDEO_MARKER requires the marker on its own line,
+		// with no trailing text after the path.
+		const markerLine = msg.split("\n").find((l) => l.startsWith("BACKSTAGE_VIDEO:"));
+		expect(markerLine).toBe("BACKSTAGE_VIDEO: /home/ubuntu/.opensession-assets/bks-1/demo.mp4");
+	});
+
+	test("omits the video marker for non-video imports (e.g. images)", () => {
+		const msg = formatImportedAssetMessage({
+			remoteAbsPath: "/Users/runner/ws/screenshot.png",
+			localRelPath: "screenshot.png",
+			localAbsPath: "/home/ubuntu/.opensession-assets/bks-1/screenshot.png",
+			size: 42,
+		});
+		expect(msg).not.toContain("BACKSTAGE_VIDEO");
+		expect(msg).toContain("visible in this session's Assets tab now");
+	});
+});

--- a/src/agents/slack/assets-tools.ts
+++ b/src/agents/slack/assets-tools.ts
@@ -34,12 +34,60 @@ function text(s: string) {
 }
 
 function fmtSize(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
-export function createAssetsMcpServer(ctx: { sessionId: string }) {
+const VIDEO_ASSET_EXTENSIONS = new Set([".mp4", ".webm", ".mov"]);
+
+/** Whether an asset path's extension warrants a `BACKSTAGE_VIDEO:` marker so
+ *  the session viewer plays it inline (see jsonl-parser.ts's VIDEO_MARKER). */
+export function isVideoAssetPath(path: string): boolean {
+	const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+	return VIDEO_ASSET_EXTENSIONS.has(ext);
+}
+
+/** The import_remote_asset success message — a plain function so the
+ *  BACKSTAGE_VIDEO marker logic is testable without invoking the MCP tool
+ *  handler (matches the sessions-tools.ts pattern of extracting a pure
+ *  helper out of the tool()-wrapped closure). */
+export function formatImportedAssetMessage(input: {
+	remoteAbsPath: string;
+	localRelPath: string;
+	localAbsPath: string;
+	size: number;
+}): string {
+	const lines = [
+		`Imported ${input.remoteAbsPath} (${fmtSize(input.size)}) → ${input.localRelPath}.`,
+		"It's visible in this session's Assets tab now.",
+	];
+	if (isVideoAssetPath(input.localAbsPath)) {
+		lines.push(`BACKSTAGE_VIDEO: ${input.localAbsPath}`);
+	}
+	return lines.join("\n");
+}
+
+export interface ImportedRemoteAsset {
+	size: number;
+	remoteAbsPath: string;
+	localAbsPath: string;
+	localRelPath: string;
+}
+
+export function createAssetsMcpServer(ctx: {
+	sessionId: string;
+	/** Resolves the session's active macOS execution-node sandbox and fetches
+	 *  one file from its remote workspace into the local assets folder.
+	 *  Undefined in contexts where no sandbox lookup is wired (e.g. tests) —
+	 *  the tool reports that plainly rather than throwing. Wired from
+	 *  interactive-mcp.ts, which owns the session/sandbox lookup so this
+	 *  module stays free of sandbox-specific imports. */
+	importRemoteAsset?: (input: {
+		remotePath: string;
+		destPath: string;
+	}) => Promise<ImportedRemoteAsset>;
+}) {
   const tools = [
     tool(
       "write_asset",
@@ -112,22 +160,52 @@ export function createAssetsMcpServer(ctx: { sessionId: string }) {
         }
       }
     ),
-    tool(
-      "delete_asset",
-      "Delete a file (or a whole subfolder) from this session's assets folder.",
-      {
-        path: z.string().describe("Relative path inside the assets folder."),
-      },
-      async (args: { path: string }) => {
-        try {
-          deleteAsset(ctx.sessionId, args.path);
-          return text(`Deleted ${args.path}.`);
-        } catch (e: any) {
-          return text(`Couldn't delete ${args.path}: ${e?.message || String(e)}`);
-        }
-      }
-    ),
-  ];
+		tool(
+			"delete_asset",
+			"Delete a file (or a whole subfolder) from this session's assets folder.",
+			{
+				path: z.string().describe("Relative path inside the assets folder."),
+			},
+			async (args: { path: string }) => {
+				try {
+					deleteAsset(ctx.sessionId, args.path);
+					return text(`Deleted ${args.path}.`);
+				} catch (e: any) {
+					return text(`Couldn't delete ${args.path}: ${e?.message || String(e)}`);
+				}
+			}
+		),
+		tool(
+			"import_remote_asset",
+			"Import a file from this session's remote macOS execution-node workspace into the local Assets folder — the artifact-transfer counterpart to write_asset for sessions running on the `macos` sandbox provider (e.g. screenshots/video written under `.build/opensession/artifacts/` by a repo-local script). Give a path RELATIVE to the session's remote workspace root; the file is fetched over the existing SSH control transport and written directly into this session's local assets folder as raw bytes (binary-safe, no base64 round trip). Only available for sessions actively running on the macos sandbox — local/non-macos sessions and paths outside the remote workspace are rejected. Imported videos (.mp4/.webm/.mov) additionally print a BACKSTAGE_VIDEO marker so the session viewer plays them inline; images appear in the Assets tab immediately.",
+			{
+				remotePath: z
+					.string()
+					.describe(
+						"Path to the file, relative to the session's remote workspace root on the Mac (no leading /, no ..), e.g. '.build/opensession/artifacts/demo.mp4'."
+					),
+				destPath: z
+					.string()
+					.optional()
+					.describe(
+						"Destination path inside the local assets folder. Defaults to the remote file's basename."
+					),
+			},
+			async (args: { remotePath: string; destPath?: string }) => {
+				if (!ctx.importRemoteAsset) {
+					return text("import_remote_asset is unavailable in this context.");
+				}
+				const destPath =
+					args.destPath?.trim() || args.remotePath.split("/").filter(Boolean).pop() || "asset";
+				try {
+					const result = await ctx.importRemoteAsset({ remotePath: args.remotePath, destPath });
+					return text(formatImportedAssetMessage(result));
+				} catch (e: any) {
+					return text(`Couldn't import ${args.remotePath}: ${e?.message || String(e)}`);
+				}
+			}
+		),
+	];
 
   return createSdkMcpServer({ name: "opensession-assets", version: "1.0.0", tools });
 }

--- a/src/agents/slack/sessions-tools.ts
+++ b/src/agents/slack/sessions-tools.ts
@@ -257,7 +257,7 @@ export interface SpawnTaskArgs {
   model?: string;
   mode?: "ask" | "code";
   /** true = config default provider; or an explicit configured provider id. */
-  sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm";
+  sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos";
 }
 
 export type SpawnTaskResult =
@@ -548,7 +548,7 @@ export function createSessionsMcpServer(ctx: SessionsToolContext) {
             .optional()
             .describe("Create an unrelated standalone session instead of a child of the current session."),
           sandbox: z
-            .union([z.boolean(), z.enum(["docker", "daytona", "e2b", "box", "modal", "lambda-microvm"])])
+            .union([z.boolean(), z.enum(["docker", "daytona", "e2b", "box", "modal", "lambda-microvm", "macos"])])
             .optional()
             .describe("Run the session in an isolated sandbox: true = the server's default provider, or an explicit provider id (must be configured server-side, else the create fails with a clear error). Omit for a host run."),
         },
@@ -562,7 +562,7 @@ export function createSessionsMcpServer(ctx: SessionsToolContext) {
           parentSessionId?: string;
           reportBack?: boolean;
           standalone?: boolean;
-          sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm";
+          sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos";
         }) => {
           if (!args.prompt?.trim()) return text("Need a prompt to start a session.");
           if (args.mode === "code" && !args.branch?.trim()) {
@@ -652,7 +652,7 @@ export function createSessionsMcpServer(ctx: SessionsToolContext) {
           branch: z.string().optional().describe("Branch for code mode when the child can't share this session's worktree (standalone or different repo)."),
           model: z.string().optional().describe("Optional model id (e.g. 'gpt-5.5' for a Codex worker, or a Claude model id)."),
           mode: z.enum(["ask", "code"]).optional().describe("'code' (default) can edit files / open PRs; 'ask' is read-only."),
-          sandbox: z.union([z.boolean(), z.enum(["docker", "daytona", "e2b", "box", "modal", "lambda-microvm"])]).optional().describe("Run the child in an isolated sandbox: true = the server's default provider, or an explicit configured provider id."),
+          sandbox: z.union([z.boolean(), z.enum(["docker", "daytona", "e2b", "box", "modal", "lambda-microvm", "macos"])]).optional().describe("Run the child in an isolated sandbox: true = the server's default provider, or an explicit configured provider id."),
         },
         async (args: SpawnTaskArgs) => {
           const res = await spawnTaskImpl(args, ctx);

--- a/src/frontend/components/NewSession.tsx
+++ b/src/frontend/components/NewSession.tsx
@@ -179,7 +179,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
   const showSandboxPicker =
     !!sandboxStatus?.enabled && !sandboxStatus.killSwitch && sandboxChoices.length > 0;
   const sandboxLabel = (id: string) =>
-    id === "" ? "Host" : id === "docker" ? "Docker" : id === "daytona" ? "Daytona" : id === "e2b" ? "E2B" : id === "box" ? "Box" : id === "modal" ? "Modal" : id === "lambda-microvm" ? "AWS Lambda MicroVM" : id;
+    id === "" ? "Host" : id === "docker" ? "Docker" : id === "daytona" ? "Daytona" : id === "e2b" ? "E2B" : id === "box" ? "Box" : id === "modal" ? "Modal" : id === "lambda-microvm" ? "AWS Lambda MicroVM" : id === "macos" ? "macOS" : id;
 
   // Model × environment capability check, driven entirely by the server's
   // matrix (status.modelFamilies — the same source resolveRequestedSandbox
@@ -196,9 +196,9 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
   );
   const sandboxModelWarning = (() => {
     if (!sandboxProvider || !modelFamily) return null;
-    if (modelFamily.environments[sandboxProvider as "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm"]) return null;
+    if (modelFamily.environments[sandboxProvider as "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos"]) return null;
     const supported = (Object.keys(modelFamily.environments) as Array<
-      "local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm"
+      "local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos"
     >)
       .filter(
         (e) =>

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -1382,7 +1382,7 @@ export interface SandboxModelFamilyInfo {
 	id: string;
 	label: string;
 	match: { provider: "claude" | "codex" | "opencode"; idPrefix?: string };
-	environments: Record<"local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm", boolean>;
+	environments: Record<"local" | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos", boolean>;
 	hint?: string;
 }
 
@@ -1392,7 +1392,7 @@ export interface SandboxStatusInfo {
 	enabled: boolean;
 	defaultProvider: string;
 	providers: Array<{
-		id: "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm";
+		id: "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos";
 		configured: boolean;
 		note?: string;
 	}>;

--- a/src/server/agent-runner.ts
+++ b/src/server/agent-runner.ts
@@ -542,7 +542,13 @@ export function resumeInterruptedRuns(
   reposNoteFor?: (bksSessionId: string) => string | undefined,
   onEvent?: (bksSessionId: string, event: StreamEvent) => void,
 ): string[] {
-  const interrupted = takeInterruptedRuns();
+  const interrupted = takeInterruptedRuns(
+    (run) =>
+      run.sandboxProvider === "macos" &&
+      !run.kind?.startsWith("github-") &&
+      !run.kind?.startsWith("slack") &&
+      !run.kind?.startsWith("workflow"),
+  );
   const resumed: string[] = [];
 
   for (const run of interrupted) {
@@ -577,7 +583,8 @@ export function resumeInterruptedRuns(
         run.sandboxProvider === "e2b" ||
         run.sandboxProvider === "box" ||
         run.sandboxProvider === "modal" ||
-        run.sandboxProvider === "lambda-microvm")
+        run.sandboxProvider === "lambda-microvm" ||
+        run.sandboxProvider === "macos")
     ) {
       const isDocker = run.sandboxProvider === "docker";
       if (run.bksSessionId) resumed.push(run.bksSessionId);
@@ -586,9 +593,25 @@ export function resumeInterruptedRuns(
           const resume = isDocker
             ? (await import("./sandbox/docker")).resumeDockerSandboxRun
             : (await import("./sandbox/adapters/bootstrap")).resumeRemoteSandboxRun;
-          const events = await resume(run, {
-            onAskUser: run.bksSessionId ? askHandlerFor?.(run.bksSessionId) : undefined,
-          });
+          const events = await (async () => {
+            for (let attempt = 0; ; attempt++) {
+              try {
+                return await resume(run, {
+                  onAskUser: run.bksSessionId ? askHandlerFor?.(run.bksSessionId) : undefined,
+                });
+              } catch (error) {
+                const lockContended =
+                  run.sandboxProvider === "macos" &&
+                  error instanceof Error &&
+                  error.message.includes("being mutated by another process");
+                if (!lockContended || attempt >= 10) throw error;
+                console.warn(
+                  `[runner] macOS resume for ${run.runKey} is waiting for a stale mutation lock`,
+                );
+                await Bun.sleep(30_000);
+              }
+            }
+          })();
           if (!events) {
             console.warn(
               `[runner] Sandbox ${run.sandboxId} for interrupted run ${run.runKey} is gone — the session's next prompt recreates it`

--- a/src/server/interactive-mcp.ts
+++ b/src/server/interactive-mcp.ts
@@ -35,6 +35,8 @@ import { automationRunMcpForSession, selfImproveMcpForSession } from "./automati
 import { findSession, touchBackstageSession } from "./session-cache";
 import { attachRepo, linkPr, sessionRepoIds, switchPrimaryRepo } from "./session-repos";
 import { makeAskHandler } from "./asks";
+import { assetsDirFor, importAssetStream, MAX_IMPORT_BYTES } from "./session-assets";
+import { fetchMacosAsset } from "./sandbox/adapters/macos";
 
 /** The session's primary repo id, for the papercuts toggle (undefined =
  *  chat-only session, which logs under no repo and is always enabled). */
@@ -177,7 +179,38 @@ export function interactiveMcpServers(
 					}),
 					// Per-session scratch assets (previewed in the Assets tab).
 					// Works in Ask mode — writes land outside the checkout.
-					"opensession-assets": createAssetsMcpServer({ sessionId }),
+					"opensession-assets": createAssetsMcpServer({
+						sessionId,
+						// import_remote_asset: only wired to a purpose for macOS
+						// execution-node sessions (session.sandbox.provider ===
+						// "macos") — the session/sandbox lookup lives here so
+						// assets-tools.ts stays free of sandbox-specific imports,
+						// matching the closure pattern used by opensession-repos
+						// and opensession-preview above.
+						importRemoteAsset: async ({ remotePath, destPath }) => {
+							const s = findSession(sessionId);
+							if (!s?.sandbox || s.sandbox.provider !== "macos" || !s.sandbox.sandboxId) {
+								throw new Error(
+									"import_remote_asset only works on sessions actively running on the macos execution-node sandbox",
+								);
+							}
+							const fetched = await fetchMacosAsset({
+								sandboxId: s.sandbox.sandboxId,
+								sessionId,
+								remotePath,
+								maxBytes: MAX_IMPORT_BYTES,
+								consume: (chunks, expected) =>
+									importAssetStream(sessionId, destPath, chunks, expected),
+							});
+							const asset = fetched.value;
+							return {
+								size: asset.size,
+								remoteAbsPath: fetched.remoteAbsPath,
+								localAbsPath: `${assetsDirFor(sessionId)}/${asset.path}`,
+								localRelPath: asset.path,
+							};
+						},
+					}),
 					// The user's Desk todo list — add/list/complete/drop/update.
 					// Interactive-only like the siblings (the automation branch below
 					// fails closed): untrusted ticket text must not write to a

--- a/src/server/preview.ts
+++ b/src/server/preview.ts
@@ -685,9 +685,13 @@ export async function getSandboxPreviewStatus(
     starting: !webapp?.running && isStarting(worktreeDir),
     previewUrl,
     bootable:
-      !!webapp?.running ||
-      (await resolvePreviewBoot(worktreeDir, repoForPath(worktreeDir), sandboxExists(sandbox))) !=
-        null,
+      sandbox.provider !== "macos" &&
+      (!!webapp?.running ||
+        (await resolvePreviewBoot(
+          worktreeDir,
+          repoForPath(worktreeDir),
+          sandboxExists(sandbox),
+        )) != null),
     services,
   };
 }

--- a/src/server/routes/preview.ts
+++ b/src/server/routes/preview.ts
@@ -39,6 +39,11 @@ export async function handlePreviewRoutes(
 				return Response.json(
 					await getSandboxPreviewStatus(sbx, session.worktreeDir!),
 				);
+			if (session.sandbox?.workspace === "volume")
+				return Response.json(
+					{ error: "Remote session workspace is unavailable" },
+					{ status: 503 },
+				);
 			if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
 				return Response.json({
 					hasPortsConf: false,
@@ -68,6 +73,11 @@ export async function handlePreviewRoutes(
 			const sbx = session.worktreeDir
 				? await activeSandboxFor(session)
 				: null;
+			if (!sbx && session.sandbox?.workspace === "volume")
+				return Response.json(
+					{ error: "Remote session workspace is unavailable" },
+					{ status: 503 },
+				);
 			if (!session.worktreeDir || (!existsSync(session.worktreeDir) && !sbx))
 				return Response.json(
 					{ error: "Session has no worktree" },
@@ -123,6 +133,11 @@ export async function handlePreviewRoutes(
 				return Response.json(
 					await startSandboxPreview(sbx, session.worktreeDir!),
 				);
+			if (session.sandbox?.workspace === "volume")
+				return Response.json(
+					{ error: "Remote session workspace is unavailable" },
+					{ status: 503 },
+				);
 			if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
 				return Response.json({
 					hasPortsConf: false,
@@ -157,6 +172,11 @@ export async function handlePreviewRoutes(
 			if (sbx)
 				return Response.json(
 					await stopSandboxPreview(sbx, session.worktreeDir!),
+				);
+			if (session.sandbox?.workspace === "volume")
+				return Response.json(
+					{ error: "Remote session workspace is unavailable" },
+					{ status: 503 },
 				);
 			if (!session.worktreeDir || !existsSync(session.worktreeDir)) {
 				return Response.json({

--- a/src/server/routes/session-git.test.ts
+++ b/src/server/routes/session-git.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { WorkspaceExec } from "../sandbox";
+import {
+	__materializeMacosBaseImageForTest,
+	isMissingMacosAssetError,
+} from "./session-git";
+
+function fakeExec(exitCode = 0) {
+	const calls: string[][] = [];
+	const exec = (async (command: string[]) => {
+		calls.push(command);
+		return { exitCode, stdout: "", stderr: "" };
+	}) as WorkspaceExec;
+	return { calls, exec };
+}
+
+describe("remote worktree images", () => {
+	test("removes a temporary base image when materialization fails", async () => {
+		const { calls, exec } = fakeExec(1);
+
+		const result = await __materializeMacosBaseImageForTest(exec, "base:image.png", async () => {
+			throw new Error("reader should not run");
+		});
+
+		expect(result).toBeNull();
+		expect(calls).toHaveLength(2);
+		expect(calls[1].slice(0, 4)).toEqual(["rm", "-f", "--", calls[0][5]]);
+	});
+
+	test("removes a temporary base image when streaming fails", async () => {
+		const { calls, exec } = fakeExec();
+
+		await expect(
+			__materializeMacosBaseImageForTest(exec, "base:image.png", async () => {
+				throw new Error("stream failed");
+			}),
+		).rejects.toThrow("stream failed");
+		expect(calls).toHaveLength(2);
+		expect(calls[1].slice(0, 4)).toEqual(["rm", "-f", "--", calls[0][5]]);
+	});
+
+	test("recognizes a missing remote asset for a 404 response", () => {
+		expect(
+			isMissingMacosAssetError(
+				new Error("remote asset not found in the session workspace: image.png"),
+			),
+		).toBe(true);
+		expect(isMissingMacosAssetError(new Error("ssh transport failed"))).toBe(false);
+	});
+});

--- a/src/server/routes/session-git.ts
+++ b/src/server/routes/session-git.ts
@@ -11,12 +11,73 @@ import type { DiffGroupFile } from "../diff-groups";
 import { type SessionDiff, discardSessionFile, getSessionDiff } from "../git-diff";
 import { getGitStatus, gitPull, gitPush } from "../git-status";
 import { imageContentType, imageHeaders } from "../image-mime";
-import { hasRemoteWorkspace, workspaceExecFor } from "../sandbox";
+import { hasRemoteWorkspace, workspaceExecFor, type WorkspaceExec } from "../sandbox";
+import { fetchMacosAsset } from "../sandbox/adapters/macos";
 import { findSession } from "../session-cache";
 import { getRepo, repoForPath } from "../worktree";
 import { $ } from "bun";
+import { createHash, randomUUID } from "crypto";
 import { existsSync } from "fs";
 import { resolve } from "path";
+
+const MAX_REMOTE_IMAGE_BYTES = 50 * 1024 * 1024;
+
+async function readMacosWorkspaceImage(
+	sandboxId: string,
+	sessionId: string,
+	remotePath: string,
+): Promise<ArrayBuffer> {
+	const result = await fetchMacosAsset({
+		sandboxId,
+		sessionId,
+		remotePath,
+		maxBytes: MAX_REMOTE_IMAGE_BYTES,
+		consume: async (chunks, expected) => {
+			const buffers: Buffer[] = [];
+			const hash = createHash("sha256");
+			let size = 0;
+			for await (const chunk of chunks) {
+				const buffer = Buffer.from(chunk);
+				buffers.push(buffer);
+				hash.update(buffer);
+				size += buffer.byteLength;
+			}
+			if (size !== expected.size || hash.digest("hex") !== expected.sha256) {
+				throw new Error("remote worktree image failed its integrity check");
+			}
+			return Uint8Array.from(Buffer.concat(buffers, size)).buffer;
+		},
+	});
+	return result.value;
+}
+
+async function materializeMacosBaseImage(
+	exec: WorkspaceExec,
+	revision: string,
+	read: (temporary: string) => Promise<ArrayBuffer>,
+): Promise<ArrayBuffer | null> {
+	const temporary = `.git/.opensession-image-${randomUUID()}`;
+	try {
+		const materialized = await exec([
+			"sh",
+			"-c",
+			'git show "$1" > "$2"',
+			"opensession-image",
+			revision,
+			temporary,
+		]);
+		if (materialized.exitCode !== 0) return null;
+		return await read(temporary);
+	} finally {
+		await exec(["rm", "-f", "--", temporary]);
+	}
+}
+
+export const __materializeMacosBaseImageForTest = materializeMacosBaseImage;
+
+export function isMissingMacosAssetError(error: unknown): boolean {
+	return error instanceof Error && error.message.includes("remote asset not found");
+}
 
 function isDiffGroupFile(file: unknown): file is DiffGroupFile {
 	if (typeof file !== "object" || file === null) return false;
@@ -263,14 +324,51 @@ export async function handleSessionGitRoutes(
 		const dir = isPrimary
 			? session.worktreeDir
 			: (session.attachedRepos || []).find((r) => r.repo === repoId)?.dir;
-		if (!dir || !existsSync(dir)) return new Response("No worktree", { status: 404 });
+		const remote = isPrimary && hasRemoteWorkspace(session);
+		if (!dir || (!existsSync(dir) && !remote))
+			return new Response("No worktree", { status: 404 });
 		// Keep reads inside the worktree — the path comes from the client.
 		const abs = resolve(dir, filePath);
 		if (abs !== dir && !abs.startsWith(`${dir}/`))
 			return new Response("Bad path", { status: 400 });
 		try {
+			const exec = remote ? await workspaceExecFor(session, dir) : null;
+			const macosSandboxId =
+				session.sandbox?.provider === "macos" ? session.sandbox.sandboxId : undefined;
 			if (url.searchParams.get("side") === "base") {
 				const repoConf = getRepo(repoId || primaryRepo);
+				if (exec) {
+					const mergeBase = await exec([
+						"git",
+						"merge-base",
+						"HEAD",
+						`origin/${repoConf.defaultBranch}`,
+					]);
+					if (mergeBase.exitCode !== 0)
+						return new Response("Not in base", { status: 404 });
+					const revision = `${mergeBase.stdout.trim()}:${filePath}`;
+					if (macosSandboxId) {
+						const bytes = await materializeMacosBaseImage(exec, revision, (temporary) =>
+							readMacosWorkspaceImage(macosSandboxId, sessionId, temporary),
+						);
+						if (!bytes) return new Response("Not in base", { status: 404 });
+						return new Response(bytes, {
+							headers: imageHeaders(contentType, "private, max-age=300"),
+						});
+					}
+					const image = await exec([
+						"sh",
+						"-c",
+						'tmp=$(mktemp) || exit; trap \'rm -f "$tmp"\' EXIT; git show "$1" > "$tmp" || exit; base64 < "$tmp"',
+						"opensession-image",
+						revision,
+					]);
+					if (image.exitCode !== 0)
+						return new Response("Not in base", { status: 404 });
+					return new Response(Buffer.from(image.stdout.replace(/\s/g, ""), "base64"), {
+						headers: imageHeaders(contentType, "private, max-age=300"),
+					});
+				}
 				const base = (
 					await $`git -C ${dir} merge-base HEAD origin/${repoConf.defaultBranch}`
 						.quiet()
@@ -285,6 +383,32 @@ export async function handleSessionGitRoutes(
 					return new Response("Not in base", { status: 404 });
 				return new Response(bytes, {
 					headers: imageHeaders(contentType, "private, max-age=300"),
+				});
+			}
+			if (exec) {
+				if (macosSandboxId) {
+					try {
+						return new Response(
+							await readMacosWorkspaceImage(macosSandboxId, sessionId, filePath),
+							{ headers: imageHeaders(contentType, "no-cache") },
+						);
+					} catch (error) {
+						if (isMissingMacosAssetError(error)) {
+							return new Response("Not found", { status: 404 });
+						}
+						throw error;
+					}
+				}
+				const image = await exec([
+					"sh",
+					"-c",
+					'base64 < "$1"',
+					"opensession-image",
+					filePath,
+				]);
+				if (image.exitCode !== 0) return new Response("Not found", { status: 404 });
+				return new Response(Buffer.from(image.stdout.replace(/\s/g, ""), "base64"), {
+					headers: imageHeaders(contentType, "no-cache"),
 				});
 			}
 			const f = Bun.file(abs);

--- a/src/server/run-journal.ts
+++ b/src/server/run-journal.ts
@@ -4,7 +4,17 @@
  * agent-runner.resumeInterruptedRuns resumes on boot. All engines journal
  * through these functions.
  */
-import { existsSync, readFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { randomUUID } from "crypto";
+import { dirname } from "path";
 import { OPENSESSION_CHATS_DIR } from "./paths";
 import { envAlias } from "./rename-compat";
 import { transitionRunState } from "./run-state";
@@ -71,19 +81,73 @@ function readRunJournal(): Record<string, ActiveRunRecord> {
   }
 }
 
-function writeRunJournal(journal: Record<string, ActiveRunRecord>): void {
+function writeRunJournal(journal: Record<string, ActiveRunRecord>): boolean {
   try {
     writeJsonAtomic(ACTIVE_RUNS_PATH, journal);
+    return true;
   } catch (e) {
     console.error("[runner] Failed to write run journal:", e);
+    return false;
   }
 }
 
+const journalLockWait = new Int32Array(new SharedArrayBuffer(4));
+
+function withRunJournalLock<T>(action: () => T): T {
+  const lockPath = `${ACTIVE_RUNS_PATH}.lock`;
+  const ownerPath = `${lockPath}/owner`;
+  const owner = `${process.pid}-${randomUUID()}`;
+  mkdirSync(dirname(ACTIVE_RUNS_PATH), { recursive: true });
+  const deadline = Date.now() + 5_000;
+  while (true) {
+    try {
+      mkdirSync(lockPath);
+      try {
+        writeFileSync(ownerPath, owner, { flag: "wx" });
+      } catch (error) {
+        rmSync(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 30_000) {
+          const stalePath = `${lockPath}.stale-${owner}`;
+          renameSync(lockPath, stalePath);
+          rmSync(stalePath, { recursive: true, force: true });
+          continue;
+        }
+      } catch {}
+      if (Date.now() >= deadline) throw new Error("timed out acquiring run journal lock");
+      Atomics.wait(journalLockWait, 0, 0, 10);
+    }
+  }
+  try {
+    return action();
+  } finally {
+    releaseRunJournalLock(lockPath, owner);
+  }
+}
+
+function releaseRunJournalLock(lockPath: string, owner: string): void {
+  try {
+    if (readFileSync(`${lockPath}/owner`, "utf8") === owner) {
+      rmSync(lockPath, { recursive: true, force: true });
+    }
+  } catch {}
+}
+
+export const __releaseRunJournalLockForTest = releaseRunJournalLock;
+
 export function journalSet(record: ActiveRunRecord): void {
-  const journal = readRunJournal();
-  const rejournal = record.runKey in journal;
-  journal[record.runKey] = record;
-  writeRunJournal(journal);
+  const rejournal = withRunJournalLock(() => {
+    const journal = readRunJournal();
+    const replacing = record.runKey in journal;
+    journal[record.runKey] = record;
+    if (!writeRunJournal(journal)) throw new Error(`failed to journal run ${record.runKey}`);
+    return replacing;
+  });
   // A fallback hop re-journals the same runKey mid-run — that's the running
   // self-edge, not a new registration, so keep the event but tag it.
   if (record.bksSessionId)
@@ -95,11 +159,31 @@ export function journalSet(record: ActiveRunRecord): void {
 }
 
 export function journalClear(runKey: string): void {
-  const journal = readRunJournal();
-  if (runKey in journal) {
+  withRunJournalLock(() => {
+    const journal = readRunJournal();
+    if (!(runKey in journal)) return;
     delete journal[runKey];
-    writeRunJournal(journal);
-  }
+    if (!writeRunJournal(journal)) throw new Error(`failed to clear journaled run ${runKey}`);
+  });
+}
+
+/** Atomically hand recovery ownership from an interrupted run to its
+ * replacement, so a crash can never leave both records recoverable. */
+export function journalReplace(oldRunKey: string, record: ActiveRunRecord): void {
+  withRunJournalLock(() => {
+    const journal = readRunJournal();
+    delete journal[oldRunKey];
+    journal[record.runKey] = record;
+    if (!writeRunJournal(journal)) {
+      throw new Error(`failed to journal replacement run ${record.runKey}`);
+    }
+  });
+  if (record.bksSessionId)
+    transitionRunState(record.bksSessionId, "run_registered", {
+      run_key: record.runKey,
+      kind: record.kind,
+      rejournal: true,
+    });
 }
 
 /** Snapshot of the runs currently journaled as in-flight (does not clear). */
@@ -127,13 +211,52 @@ function isRunActiveInProcess(runKey: string): boolean {
   return false;
 }
 
-/** Drain interrupted runs left by a previous process (clears the journal). */
-export function takeInterruptedRuns(): ActiveRunRecord[] {
-  const journal = readRunJournal();
-  const entries = Object.values(journal).filter(
-    (r) => !isRunActiveInProcess(r.runKey)
-  );
-  if (entries.length > 0) writeRunJournal({});
+/** Drain interrupted runs left by a previous process. Records selected by
+ * retain stay journaled until their asynchronous recovery explicitly clears
+ * them, so a transient recovery failure remains retryable after restart. */
+export function takeInterruptedRuns(
+  retain?: (record: ActiveRunRecord) => boolean,
+): ActiveRunRecord[] {
+  const entries = withRunJournalLock(() => {
+    const journal = readRunJournal();
+    const candidates = Object.values(journal).filter(
+      (r) => !isRunActiveInProcess(r.runKey)
+    );
+    const retained = new Set(
+      candidates.filter((record) => retain?.(record)).map((record) => record.runKey),
+    );
+    // Older builds could crash between journaling a macOS replacement and
+    // clearing its predecessor. A fixed node permits only one foreground run
+    // per session, so recover only the newest record from such a legacy pair.
+    const newestMacRun = new Map<string, ActiveRunRecord>();
+    for (const record of candidates) {
+      if (
+        !retained.has(record.runKey) ||
+        record.sandboxProvider !== "macos" ||
+        !record.sandboxId ||
+        !record.bksSessionId
+      ) continue;
+      const key = `${record.sandboxId}\0${record.bksSessionId}`;
+      const current = newestMacRun.get(key);
+      if (!current || record.startedAt >= current.startedAt) newestMacRun.set(key, record);
+    }
+    const superseded = new Set<string>();
+    for (const record of candidates) {
+      if (record.sandboxProvider !== "macos" || !record.sandboxId || !record.bksSessionId) continue;
+      const newest = newestMacRun.get(`${record.sandboxId}\0${record.bksSessionId}`);
+      if (newest && newest.runKey !== record.runKey) superseded.add(record.runKey);
+    }
+    const recoverable = candidates.filter((record) => !superseded.has(record.runKey));
+    if (recoverable.length > 0) {
+      for (const record of candidates) {
+        if (superseded.has(record.runKey) || !retained.has(record.runKey)) {
+          delete journal[record.runKey];
+        }
+      }
+      if (!writeRunJournal(journal)) throw new Error("failed to drain interrupted run journal");
+    }
+    return recoverable;
+  });
   for (const r of entries) {
     if (r.bksSessionId)
       transitionRunState(r.bksSessionId, "boot_journal_found", {

--- a/src/server/sandbox/adapters/bootstrap.ts
+++ b/src/server/sandbox/adapters/bootstrap.ts
@@ -9,9 +9,9 @@
  *    in-sandbox — bun, the backstage repo bundle (config `runnerBundleUrl`
  *    tarball, or a git clone of `runnerRepoUrl`/this checkout's origin at
  *    `runnerSha`), `bun install`, and the Claude Code CLI — all under
- *    /home/ubuntu so the runner's hardcoded absolute paths (claude CLI, repo
- *    bundle, HOST_ENTRY) resolve exactly like they do on the host and in the
- *    docker image (path parity is the contract; see deploy/sandbox/README.md).
+ *    /home/ubuntu so existing Linux providers retain path parity with the host
+ *    and docker image. Pre-provisioned hosts pass `RemoteRuntimePaths` instead
+ *    and verify their payload rather than invoking this Linux installer.
  *    COLD-START COST: several minutes on the first ensure of a fresh sandbox
  *    (bun install pulls the full dep tree incl. the ~223MB vendored codex
  *    binary). The fast path — Daytona snapshots / E2B custom templates with
@@ -51,10 +51,16 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, unlinkSync } from "fs";
-import { dirname } from "path";
+import { basename, dirname } from "path";
 import { OPENSESSION_CHATS_DIR } from "../../paths";
 import { envAlias, stateDir } from "../../rename-compat";
-import { journalSet, journalClear, type ActiveRunRecord } from "../../run-journal";
+import {
+  activeRunRecords,
+  journalSet,
+  journalClear,
+  journalReplace,
+  type ActiveRunRecord,
+} from "../../run-journal";
 import type { StreamEvent } from "../../run-events";
 import { RESUME_CONTINUATION_PROMPT } from "../../agent-runner";
 import { accountsForRemoteUpload } from "../../claude-accounts";
@@ -84,7 +90,6 @@ import { writeJsonAtomic } from "../../shared/atomic-write";
 import { HostHandle, type HandleCallbacks, type HostLauncher } from "../../host-client";
 import {
   HOST_SPEC_NAME,
-  HOST_ENTRY,
   REPO_ROOT,
   type RunHostSpec,
 } from "../../../runner-host/protocol";
@@ -100,25 +105,66 @@ import type {
   SandboxStatus,
 } from "../provider";
 
-/** Absolute paths INSIDE the sandbox — kept byte-identical to the host/docker
- *  layout so the runner's hardcoded paths resolve (do not "tidy" these). */
-export const REMOTE_HOME = "/home/ubuntu";
-export const REMOTE_BUN = `${REMOTE_HOME}/.bun/bin/bun`;
-export const REMOTE_CLAUDE = `${REMOTE_HOME}/.local/bin/claude`;
-export const REMOTE_OPENCODE = `${REMOTE_HOME}/.bun/bin/opencode`;
+const RUNS_BASE = `${OPENSESSION_CHATS_DIR}/sandbox-runs`;
+
+/** Absolute paths inside a remote execution node. The Linux defaults remain
+ * byte-identical for the API-backed providers; fixed hosts such as macOS pass
+ * their own path object rather than pretending the remote home is /home/ubuntu. */
+export interface RemoteRuntimePaths {
+  home: string;
+  bun: string;
+  claude: string;
+  opencode: string;
+  runnerRepo: string;
+  hostEntry: string;
+  openaiSeedDir: string;
+  path: string;
+  warmBase: string;
+  runsBase: string;
+}
+
+export function remoteRuntimePaths(
+  home = "/home/ubuntu",
+  runnerRepo = `${home}/projects/tella-backstage`,
+  path = `${home}/.bun/bin:${home}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`,
+  runsBase = `${home}/.opensession-chats/sandbox-runs`,
+): RemoteRuntimePaths {
+  return {
+    home,
+    bun: `${home}/.bun/bin/bun`,
+    claude: `${home}/.local/bin/claude`,
+    opencode: `${home}/.bun/bin/opencode`,
+    runnerRepo,
+    hostEntry: `${runnerRepo}/src/runner-host/host.ts`,
+    openaiSeedDir: `${home}/.opensession-openai-seeds`,
+    path,
+    warmBase: `${home}/.bks-warm`,
+    runsBase,
+  };
+}
+
+export const DEFAULT_REMOTE_RUNTIME = remoteRuntimePaths(
+  "/home/ubuntu",
+  "/home/ubuntu/projects/tella-backstage",
+  "/home/ubuntu/.bun/bin:/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  RUNS_BASE,
+);
+export const REMOTE_HOME = DEFAULT_REMOTE_RUNTIME.home;
+export const REMOTE_BUN = DEFAULT_REMOTE_RUNTIME.bun;
+export const REMOTE_CLAUDE = DEFAULT_REMOTE_RUNTIME.claude;
+export const REMOTE_OPENCODE = DEFAULT_REMOTE_RUNTIME.opencode;
 /** Same pin as deploy/sandbox/Dockerfile's OPENCODE_VERSION (host runs this
  *  too) — bump BOTH together. Part of bootstrapSignature, so a bump
  *  invalidates existing sandboxes/prewarms and re-bootstraps them. */
 export const REMOTE_OPENCODE_VERSION = "1.17.15";
-export const REMOTE_REPO = REPO_ROOT; // /home/ubuntu/projects/tella-backstage
+export const REMOTE_REPO = DEFAULT_REMOTE_RUNTIME.runnerRepo;
 const BOOTSTRAP_MARKER = `${REMOTE_HOME}/.bks-bootstrapped`;
 /** Where per-launch openai seed material lands in-sandbox — threaded to the
  *  run host via the OPENSESSION_OPENAI_SEED_DIR env (openaiRemoteSeedDir()),
  *  never derived independently on the two sides. */
-export const REMOTE_OPENAI_SEED_DIR = `${REMOTE_HOME}/.opensession-openai-seeds`;
-const REMOTE_PATH = `${REMOTE_HOME}/.bun/bin:${REMOTE_HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`;
+export const REMOTE_OPENAI_SEED_DIR = DEFAULT_REMOTE_RUNTIME.openaiSeedDir;
+const REMOTE_PATH = DEFAULT_REMOTE_RUNTIME.path;
 
-const RUNS_BASE = `${OPENSESSION_CHATS_DIR}/sandbox-runs`;
 const STATE_DIR = `${OPENSESSION_CHATS_DIR}/sandboxes`;
 
 // ── The wire each adapter implements ─────────────────────────────────────────
@@ -127,6 +173,8 @@ export interface RemoteExecOpts {
   cwd?: string;
   env?: Record<string, string>;
   timeoutMs?: number;
+  /** Provider-native detached-launch identifier (macOS LaunchAgent label). */
+  launchId?: string;
 }
 
 export interface RemoteDriver {
@@ -181,7 +229,7 @@ export interface RemoteSandboxState {
   lastActivityAt: string;
 }
 
-function sanitizeName(s: string): string {
+export function sanitizeName(s: string): string {
   return s.replace(/[^a-zA-Z0-9_.-]+/g, "-").replace(/^[^a-zA-Z0-9]+/, "");
 }
 
@@ -334,8 +382,8 @@ export async function remoteCloneUrl(repo: {
 export async function assertDialbackReachable(
   driver: RemoteDriver,
   label: string,
+  wsBase = remoteSandboxCallbackBaseUrl(),
 ): Promise<void> {
-  const wsBase = remoteSandboxCallbackBaseUrl();
   const httpBase = wsBase.replace(/^ws(s?):\/\//, "http$1://");
   const probe = await driver.exec(
     `command -v curl >/dev/null 2>&1 || { echo __BKS_NO_CURL__; exit 0; }; ` +
@@ -564,8 +612,9 @@ export async function warmRemoteWorkspace(
   driver: RemoteDriver,
   repo: { id: string; repo: string; ghRepo?: string; defaultBranch: string; depsInstall?: string },
   label: string,
+  runtime: RemoteRuntimePaths = DEFAULT_REMOTE_RUNTIME,
 ): Promise<void> {
-  const dir = `${REMOTE_WARM_BASE}/${sanitizeName(repo.id)}`;
+  const dir = `${runtime.warmBase}/${sanitizeName(repo.id)}`;
   const log = (msg: string) => console.log(`[sandbox:${label}] warm workspace: ${msg}`);
   const has = await driver.exec(`test -d ${shellQuoteWord(dir)}/.git`);
   if (has.exitCode !== 0) {
@@ -583,10 +632,10 @@ export async function warmRemoteWorkspace(
   // Deps: same convention as worktree.ts's installWorktreeDeps, expressed
   // in-sandbox (config depsInstall → tella-fusion webapp install → root
   // install when a package.json exists).
-  const bunEnv = `HOME=${REMOTE_HOME} PATH=${shellQuoteWord(REMOTE_PATH)}`;
+  const bunEnv = `HOME=${shellQuoteWord(runtime.home)} PATH=${shellQuoteWord(runtime.path)}`;
   const deps = repo.depsInstall
     ? `cd ${shellQuoteWord(dir)} && ${bunEnv} sh -c ${shellQuoteWord(repo.depsInstall)}`
-    : `cd ${shellQuoteWord(dir)} && ${bunEnv} sh -c 'if [ -f packages/core/webapp/package.json ]; then cd packages/core/webapp && ${REMOTE_BUN} install; elif [ -f package.json ]; then ${REMOTE_BUN} install; fi'`;
+    : `cd ${shellQuoteWord(dir)} && ${bunEnv} sh -c 'if [ -f packages/core/webapp/package.json ]; then cd packages/core/webapp && ${shellQuoteWord(runtime.bun)} install; elif [ -f package.json ]; then ${shellQuoteWord(runtime.bun)} install; fi'`;
   log("installing deps…");
   const r = await driver.exec(deps, { timeoutMs: 900_000 });
   if (r.exitCode !== 0) {
@@ -603,12 +652,13 @@ export async function setupRemoteWorkspace(
   branch: string,
   defaultBranch: string,
   repoId?: string,
+  runtime: RemoteRuntimePaths = DEFAULT_REMOTE_RUNTIME,
 ): Promise<void> {
   let cloned = await driver.exec(`test -d ${shellQuoteWord(cwd)}/.git`);
   if (cloned.exitCode !== 0 && repoId) {
     // Adopt a prewarmed clone (warmRemoteWorkspace) when one is waiting —
     // the mv is instant and carries node_modules with it.
-    const warmDir = `${REMOTE_WARM_BASE}/${sanitizeName(repoId)}`;
+    const warmDir = `${runtime.warmBase}/${sanitizeName(repoId)}`;
     const adopted = await driver.exec(
       `test -d ${shellQuoteWord(warmDir)}/.git && mkdir -p ${shellQuoteWord(dirname(cwd))} && mv ${shellQuoteWord(warmDir)} ${shellQuoteWord(cwd)}`,
     );
@@ -673,6 +723,14 @@ function sessionRunsDir(sessionId: string): string {
   return `${RUNS_BASE}/${sanitizeName(sessionId)}`;
 }
 
+function remoteRunDir(
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  hostDir: string,
+): string {
+  return `${runtime.runsBase}/${sanitizeName(sessionId)}/${sanitizeName(basename(hostDir))}`;
+}
+
 function readJsonSafe<T>(path: string): T | null {
   try {
     if (!existsSync(path)) return null;
@@ -683,32 +741,55 @@ function readJsonSafe<T>(path: string): T | null {
 }
 
 /**
- * HostLauncher over a RemoteDriver. Run-dir paths are identical host-side and
- * in-sandbox: spec.json exists in BOTH (host mirror feeds restart-resume;
- * the in-sandbox copy feeds HOST_ENTRY), meta/journal/log are sandbox-only.
+ * HostLauncher over a RemoteDriver. The Linux providers retain path parity;
+ * fixed remote hosts can use a different run base. spec.json exists in BOTH
+ * locations (host mirror feeds restart-resume); meta/journal/log are remote.
  */
-export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): HostLauncher {
+export function makeRemoteLauncher(
+  driver: RemoteDriver,
+  sessionId: string,
+  runtime: RemoteRuntimePaths = DEFAULT_REMOTE_RUNTIME,
+  callbackBaseUrl: () => string = remoteSandboxCallbackBaseUrl,
+): HostLauncher {
   return {
     async alive(dir) {
-      const meta = await driver.exec(`cat ${shellQuoteWord(`${dir}/meta.json`)} 2>/dev/null`);
-      if (meta.exitCode !== 0) return false;
+      const remoteDir = remoteRunDir(runtime, sessionId, dir);
+      const meta = await driver.exec(`cat ${shellQuoteWord(`${remoteDir}/meta.json`)} 2>/dev/null`);
+      if (meta.exitCode !== 0) {
+        if (meta.exitCode === 1) return false;
+        throw new Error(
+          `remote run metadata probe failed (${meta.exitCode}): ${(meta.stderr || meta.stdout).trim().slice(0, 500)}`,
+        );
+      }
       let pid = 0;
       try {
         pid = Number(JSON.parse(meta.stdout)?.pid) || 0;
       } catch {}
       if (!pid) return false;
-      return (await driver.exec(`kill -0 ${pid}`)).exitCode === 0;
+      const spec = `${remoteDir}/${HOST_SPEC_NAME}`;
+      const probe = await driver.exec(
+        `command=$(ps -p ${pid} -o command= 2>/dev/null || true); ` +
+          `if kill -0 ${pid} 2>/dev/null; then ` +
+          `case "$command" in *${shellQuoteWord(runtime.hostEntry)}*${shellQuoteWord(spec)}*) exit 0;; esac; fi; ` +
+          `exit 1`,
+      );
+      if (probe.exitCode === 0) return true;
+      if (probe.exitCode === 1) return false;
+      throw new Error(
+        `remote run liveness probe failed (${probe.exitCode}): ${(probe.stderr || probe.stdout).trim().slice(0, 500)}`,
+      );
     },
     newRunDir: (hostId) => `${sessionRunsDir(sessionId)}/${sanitizeName(hostId)}`,
     connector: (_dir, spec) => (spec.wsToken ? runWsConnector(spec.hostId) : undefined),
     async writeSpec(dir, spec) {
       mkdirSync(dir, { recursive: true });
       writeJsonAtomic(`${dir}/${HOST_SPEC_NAME}`, spec); // host mirror (resume)
-      const mk = await driver.exec(`mkdir -p ${shellQuoteWord(dir)}`);
+      const remoteDir = remoteRunDir(runtime, sessionId, dir);
+      const mk = await driver.exec(`mkdir -p ${shellQuoteWord(remoteDir)}`);
       if (mk.exitCode !== 0) {
         throw new Error(`remote run dir create failed: ${mk.stderr.trim().slice(0, 300)}`);
       }
-      await driver.writeFile(`${dir}/${HOST_SPEC_NAME}`, JSON.stringify(spec));
+      await driver.writeFile(`${remoteDir}/${HOST_SPEC_NAME}`, JSON.stringify(spec));
     },
     async launch(hostId, dir) {
       const spec = readJsonSafe<RunHostSpec>(`${dir}/${HOST_SPEC_NAME}`);
@@ -721,6 +802,7 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
       const mark = (step: string) =>
         console.log(`[sandbox-remote] launch ${hostId.slice(0, 11)}: ${step} (+${Date.now() - t0}ms)`);
       await driver.ensureStarted();
+      const remoteDir = remoteRunDir(runtime, sessionId, dir);
       mark("sandbox started");
       // Scoped Claude account upload — only what THIS run may use (pinned
       // account, else pool + the run user's own personal accounts; see the
@@ -728,10 +810,10 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
       // a previously-uploaded wider file never lingers.
       const accounts = accountsForRemoteUpload(spec.user, spec.accountId);
       await driver.writeFile(
-        `${REMOTE_HOME}/.backstage-claude-accounts.json`,
+        `${runtime.home}/.backstage-claude-accounts.json`,
         JSON.stringify({ accounts }, null, 2) + "\n",
       );
-      await driver.exec(`chmod 600 ${REMOTE_HOME}/.backstage-claude-accounts.json`);
+      await driver.exec(`chmod 600 ${shellQuoteWord(`${runtime.home}/.backstage-claude-accounts.json`)}`);
       // OpenCode bridge config: read IN-SANDBOX by the runner's opencode
       // dispatch (bridge mode, turn timeout). docker gets it as an ro mount;
       // without it every opencode/anthropic/* run in a remote sandbox dies
@@ -750,10 +832,10 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
         stateDir("opencode.json");
       if (existsSync(ocCfgSrc)) {
         await driver.writeFile(
-          `${REMOTE_HOME}/.backstage-opencode.json`,
+          `${runtime.home}/.backstage-opencode.json`,
           readFileSync(ocCfgSrc, "utf-8"),
         );
-        await driver.exec(`chmod 600 ${REMOTE_HOME}/.backstage-opencode.json`);
+        await driver.exec(`chmod 600 ${shellQuoteWord(`${runtime.home}/.backstage-opencode.json`)}`);
       }
       // OpenAI/ChatGPT-subscription material for opencode/openai/* dispatched
       // IN-SANDBOX. The raw CODEX_HOME/auth.json is NEVER uploaded — its
@@ -779,7 +861,7 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
           `[sandbox-remote] openai seed for ${maskOpenaiAccount(account)} skipped: ${reason}`,
         );
       }
-      const codexStorePath = `${REMOTE_HOME}/.backstage-codex-accounts.json`;
+      const codexStorePath = `${runtime.home}/.backstage-codex-accounts.json`;
       if (openaiUpload.accounts.length) {
         await driver.writeFile(
           codexStorePath,
@@ -787,12 +869,12 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
         );
         // Fresh seed dir per launch — stale per-account seeds never linger.
         await driver.exec(
-          `chmod 600 ${codexStorePath} && rm -rf ${shellQuoteWord(REMOTE_OPENAI_SEED_DIR)}`,
+          `chmod 600 ${shellQuoteWord(codexStorePath)} && rm -rf ${shellQuoteWord(runtime.openaiSeedDir)}`,
         );
         for (const seed of openaiUpload.seeds) {
-          const seedPath = openaiSeedAuthPath(REMOTE_OPENAI_SEED_DIR, seed.accountId);
+          const seedPath = openaiSeedAuthPath(runtime.openaiSeedDir, seed.accountId);
           await driver.exec(
-            `mkdir -p ${shellQuoteWord(dirname(seedPath))} && chmod 700 ${shellQuoteWord(REMOTE_OPENAI_SEED_DIR)} ${shellQuoteWord(dirname(seedPath))}`,
+            `mkdir -p ${shellQuoteWord(dirname(seedPath))} && chmod 700 ${shellQuoteWord(runtime.openaiSeedDir)} ${shellQuoteWord(dirname(seedPath))}`,
           );
           await driver.writeFile(seedPath, seed.content);
           await driver.exec(`chmod 600 ${shellQuoteWord(seedPath)}`);
@@ -810,35 +892,37 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
         });
       } else {
         await driver.exec(
-          `rm -f ${codexStorePath} && rm -rf ${shellQuoteWord(REMOTE_OPENAI_SEED_DIR)}`,
+          `rm -f ${shellQuoteWord(codexStorePath)} && rm -rf ${shellQuoteWord(runtime.openaiSeedDir)}`,
         );
       }
       mark("accounts uploaded");
       // Remote sandboxes dial back over the public ingress when it's enabled
       // (publicIngress.publicBaseUrl), else the plain callbackBaseUrl. Docker
       // stays on sandboxCallbackBaseUrl — its bridge path never leaves the box.
-      const base = remoteSandboxCallbackBaseUrl();
+      const base = callbackBaseUrl();
       registerRunWsHost(hostId, spec.wsToken);
       try {
         const env: Record<string, string> = {
-          HOME: REMOTE_HOME,
-          PATH: REMOTE_PATH,
+          HOME: runtime.home,
+          PATH: runtime.path,
           NODE_ENV: "production",
           // Deterministic opencode resolution (bootstrap installed it here) —
           // don't depend on PATH probing inside the run host.
           // New env names primary; deprecated aliases ride along so a
           // pinned/older remote runner bundle keeps working.
-          OPENSESSION_OPENCODE_BIN: REMOTE_OPENCODE,
-          BACKSTAGE_OPENCODE_BIN: REMOTE_OPENCODE,
-          OPENSESSION_RUN_JOURNAL: `${dir}/journal.json`,
-          BACKSTAGE_RUN_JOURNAL: `${dir}/journal.json`,
+          OPENSESSION_OPENCODE_BIN: runtime.opencode,
+          BACKSTAGE_OPENCODE_BIN: runtime.opencode,
+          OPENSESSION_CLAUDE_BIN: runtime.claude,
+          BACKSTAGE_CLAUDE_BIN: runtime.claude,
+          OPENSESSION_RUN_JOURNAL: `${remoteDir}/journal.json`,
+          BACKSTAGE_RUN_JOURNAL: `${remoteDir}/journal.json`,
           // Where bindOpenaiAccount finds the uploaded rotation-proof openai
           // seeds (only set when something was uploaded this launch). Old
           // alias rides along like the other env pairs.
           ...(openaiUpload.accounts.length
             ? {
-                OPENSESSION_OPENAI_SEED_DIR: REMOTE_OPENAI_SEED_DIR,
-                BACKSTAGE_OPENAI_SEED_DIR: REMOTE_OPENAI_SEED_DIR,
+                OPENSESSION_OPENAI_SEED_DIR: runtime.openaiSeedDir,
+                BACKSTAGE_OPENAI_SEED_DIR: runtime.openaiSeedDir,
               }
             : {}),
           // Dial-back on the primary prefix — the ingress/main serve accept
@@ -862,7 +946,8 @@ export function makeRemoteLauncher(driver: RemoteDriver, sessionId: string): Hos
         // (connectWithWait) anyway — after the bound, proceed and let that
         // decide.
         const bg = driver.execBackground(
-          `${envPrefix(env)}${REMOTE_BUN} run ${HOST_ENTRY} ${dir}/${HOST_SPEC_NAME} >> ${dir}/host.log 2>&1`,
+          `${envPrefix(env)}${shellQuoteWord(runtime.bun)} run ${shellQuoteWord(runtime.hostEntry)} ${shellQuoteWord(`${remoteDir}/${HOST_SPEC_NAME}`)} >> ${shellQuoteWord(`${remoteDir}/host.log`)} 2>&1`,
+          { env, launchId: hostId },
         );
         const bgTimeout = new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 30_000));
         const raced = await Promise.race([bg.then(() => "ok" as const), bgTimeout]);
@@ -1014,6 +1099,7 @@ async function* withRunJournal(
   events: AsyncGenerator<StreamEvent>,
   record: ActiveRunRecord,
   touch: () => void,
+  cleanup?: () => Promise<void>,
 ): AsyncGenerator<StreamEvent> {
   journalSet(record);
   touch();
@@ -1026,8 +1112,42 @@ async function* withRunJournal(
       yield ev;
     }
   } finally {
-    journalClear(record.runKey);
+    let cleaned = true;
+    try {
+      await cleanupRemoteRunWithRetry(record, cleanup);
+    } catch (cleanupError) {
+      cleaned = false;
+      console.warn(
+        `[sandbox-remote] cleanup for journaled run ${record.runKey} failed; retaining it for restart recovery:`,
+        cleanupError,
+      );
+    }
+    if (cleaned) journalClear(record.runKey);
     touch();
+  }
+}
+
+export async function cleanupRemoteRunWithRetry(
+  record: ActiveRunRecord,
+  cleanup?: () => Promise<void>,
+  retryDelayMs = 30_000,
+): Promise<void> {
+  if (!cleanup) return;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await cleanup();
+      return;
+    } catch (error) {
+      const lockContended =
+        record.sandboxProvider === "macos" &&
+        error instanceof Error &&
+        error.message.includes("being mutated by another process");
+      if (!lockContended || attempt >= 10) throw error;
+      console.warn(
+        `[sandbox-remote] cleanup for ${record.runKey} is waiting for a stale macOS mutation lock`,
+      );
+      await Bun.sleep(retryDelayMs);
+    }
   }
 }
 
@@ -1039,6 +1159,13 @@ export interface RemoteSandboxParts {
   sessionId: string;
   cwd: string;
   driver: RemoteDriver;
+  runtime?: RemoteRuntimePaths;
+  callbackBaseUrl?: () => string;
+  /** Optional fixed-node lifecycle hooks. API-backed providers omit these. */
+  beforeRun?(spec: RunHostSpec): Promise<void>;
+  afterLaunch?(spec: RunHostSpec): Promise<void>;
+  afterRun?(spec: RunHostSpec): Promise<void>;
+  recoverStaleRun?(sessionId: string, runId: string): Promise<void>;
   ports(): Promise<PortMap>;
   status(): Promise<SandboxStatus>;
   /** Activity ping (state file + provider-native keepalive, e.g. E2B's
@@ -1047,10 +1174,25 @@ export interface RemoteSandboxParts {
 }
 
 /** Internal accessor resume uses to reach a handle's driver/launcher. */
-const remoteParts = new WeakMap<object, { driver: RemoteDriver; launcher: HostLauncher }>();
+const remoteParts = new WeakMap<
+  object,
+  {
+    driver: RemoteDriver;
+    launcher: HostLauncher;
+    remoteRunDir(dir: string): string;
+    afterRun?: RemoteSandboxParts["afterRun"];
+    recoverStaleRun?: RemoteSandboxParts["recoverStaleRun"];
+  }
+>();
 
 export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
-  const launcher = makeRemoteLauncher(parts.driver, parts.sessionId);
+  const runtime = parts.runtime || DEFAULT_REMOTE_RUNTIME;
+  const launcher = makeRemoteLauncher(
+    parts.driver,
+    parts.sessionId,
+    runtime,
+    parts.callbackBaseUrl,
+  );
   const touch = () => {
     try {
       void parts.touchActivity();
@@ -1076,13 +1218,24 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
       spec.wsToken ??= crypto.randomUUID(); // remote runs are always WS
       const record = recordForSpec(spec, parts.sandboxId, parts.providerId);
       let handle: HostHandle | undefined;
+      let acquired = false;
       const t0 = Date.now();
       const mark = (step: string) =>
         console.log(`[sandbox-remote] launch ${spec.hostId.slice(0, 11)}: ${step} (+${Date.now() - t0}ms)`);
+      // The fixed macOS node can outlive this process. Journal before touching
+      // its lease so crashes during acquisition/spec write/launch are recoverable.
+      journalSet(record);
+      touch();
       try {
-        await launcher.writeSpec!(dir, spec);
-        mark("spec written");
-        await launcher.launch(spec.hostId, dir);
+        await parts.beforeRun?.(spec);
+        acquired = true;
+        try {
+          await launcher.writeSpec!(dir, spec);
+          mark("spec written");
+          await launcher.launch(spec.hostId, dir);
+        } finally {
+          await parts.afterLaunch?.(spec);
+        }
         handle = new HostHandle(dir, spec, callbacks, launcher);
         await handle.connectWithWait(45_000);
         mark("host attached");
@@ -1093,13 +1246,28 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         try {
           rmSync(dir, { recursive: true, force: true });
         } catch {}
+        let cleaned = !acquired;
+        if (acquired) {
+          try {
+            await parts.afterRun?.(spec);
+            cleaned = true;
+          } catch (cleanupError) {
+            console.warn(
+              `[sandbox-remote] launch cleanup for ${spec.hostId} failed; retaining its journal entry:`,
+              cleanupError,
+            );
+          }
+        }
+        if (cleaned) journalClear(record.runKey);
+        touch();
         throw e;
       }
       const ocRef: OcSessionRef = { id: spec.engineSessionId || "" };
-      const gen = withRunJournal(
+      const events = withRunJournal(
         withOpencodeTranscriptMirror(handle.events(), spec, ocRef),
         record,
         touch,
+        async () => parts.afterRun?.(spec),
       );
       // Steers fold into the running turn in-sandbox, so they never come back
       // as dial-back user frames — mirror DELIVERED steers into the current
@@ -1113,7 +1281,7 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         return delivered;
       };
       return {
-        events: () => gen,
+        events: () => events,
         steerable: providerFor(spec.model) !== "codex",
         steer: (text) => mirrorSteer(text, hostSteer(spec.bksSessionId, text)),
         interruptSteer: (text) =>
@@ -1148,7 +1316,13 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
     ports: () => parts.ports(),
     status: () => parts.status(),
   };
-  remoteParts.set(sandboxHandle, { driver: parts.driver, launcher });
+  remoteParts.set(sandboxHandle, {
+    driver: parts.driver,
+    launcher,
+    remoteRunDir: (dir) => remoteRunDir(runtime, parts.sessionId, dir),
+    afterRun: parts.afterRun,
+    recoverStaleRun: parts.recoverStaleRun,
+  });
   return sandboxHandle;
 }
 
@@ -1166,21 +1340,44 @@ export async function resumeRemoteSandboxRun(
   try {
     sandbox = await getSandboxProvider(run.sandboxProvider).get(run.sandboxId);
   } catch (e) {
-    console.warn(`[sandbox-remote] resume: provider.get(${run.sandboxId}) failed:`, e);
+    throw new Error(`sandbox provider failed while recovering ${run.sandboxId}`, { cause: e });
   }
-  if (!sandbox) return null;
+  if (!sandbox) {
+    journalClear(run.runKey);
+    return null;
+  }
   const parts = remoteParts.get(sandbox);
-  if (!parts) return null;
-  const { driver, launcher } = parts;
+  if (!parts) throw new Error(`sandbox ${run.sandboxId} has no remote recovery state`);
+  const {
+    driver,
+    launcher,
+    remoteRunDir: toRemoteRunDir,
+    afterRun,
+    recoverStaleRun,
+  } = parts;
+  const finishRemoteRun = async (spec: RunHostSpec) => {
+    try {
+      await cleanupRemoteRunWithRetry(run, afterRun ? () => afterRun(spec) : undefined);
+      journalClear(run.runKey);
+    } catch (cleanupError) {
+      console.warn(
+        `[sandbox-remote] resumed run cleanup for ${spec.hostId} failed; retaining its journal entry:`,
+        cleanupError,
+      );
+    }
+  };
   // Remote providers may preserve processes while suspended. Wake the sandbox
   // before checking meta/aliveness so restart recovery never duplicates a run.
   await driver.ensureStarted();
 
   const oldDir = launcher.newRunDir(run.runKey);
+  const oldRemoteDir = toRemoteRunDir(oldDir);
   const oldSpec = readJsonSafe<RunHostSpec>(`${oldDir}/${HOST_SPEC_NAME}`);
   if (oldSpec?.wsToken) {
     // Ended while we were down? meta.json lives in-sandbox only.
-    const meta = await driver.exec(`cat ${shellQuoteWord(`${oldDir}/meta.json`)} 2>/dev/null`);
+    const meta = await driver.exec(
+      `cat ${shellQuoteWord(`${oldRemoteDir}/meta.json`)} 2>/dev/null`,
+    );
     let done: StreamEvent | undefined;
     try {
       done = meta.exitCode === 0 ? JSON.parse(meta.stdout)?.done : undefined;
@@ -1191,7 +1388,11 @@ export async function resumeRemoteSandboxRun(
       } catch {}
       const terminal = done;
       return (async function* () {
-        yield terminal;
+        try {
+          yield terminal;
+        } finally {
+          await finishRemoteRun(oldSpec);
+        }
       })();
     }
     if (await launcher.alive(oldDir, null)) {
@@ -1208,11 +1409,13 @@ export async function resumeRemoteSandboxRun(
         handle.abandon();
         throw e;
       }
-      return withRunJournal(
+      const events = withRunJournal(
         withOpencodeTranscriptMirror(handle.events(), oldSpec),
         { ...run, startedAt: run.startedAt },
         () => {},
+        async () => afterRun?.(oldSpec),
       );
+      return events;
     }
   }
 
@@ -1220,6 +1423,7 @@ export async function resumeRemoteSandboxRun(
   // same sandbox so the engine session's in-sandbox state is reused.
   const prompt = run.claudeSessionId ? RESUME_CONTINUATION_PROMPT : run.prompt;
   if (!prompt) return null;
+  await recoverStaleRun?.(run.bksSessionId, run.runKey);
   const rpcToken = oldSpec?.proxyMcpServers?.length ? crypto.randomUUID() : undefined;
   if (rpcToken) registerRunToken(rpcToken, { sessionId: run.bksSessionId, user: run.user });
   const spec: RunHostSpec = {
@@ -1250,5 +1454,19 @@ export async function resumeRemoteSandboxRun(
     if (oldDir && existsSync(oldDir)) rmSync(oldDir, { recursive: true, force: true });
   } catch {}
   console.log(`[sandbox-remote] relaunching interrupted run ${run.runKey} in ${run.sandboxId} as ${spec.hostId}`);
-  return sandbox.launchRun(spec, { onAskUser: cb.onAskUser }).events();
+  if (!sandbox.launchRunEager) return null;
+  const replacement = recordForSpec(spec, run.sandboxId, run.sandboxProvider as SandboxProviderId);
+  journalReplace(run.runKey, replacement);
+  try {
+    const relaunched = await sandbox.launchRunEager(spec, { onAskUser: cb.onAskUser });
+    return relaunched.events();
+  } catch (error) {
+    // launchRunEager retains the replacement record when remote cleanup is
+    // incomplete. Restore the interrupted record only when it cleared the
+    // replacement after a clean failed launch.
+    if (!activeRunRecords().some((record) => record.runKey === replacement.runKey)) {
+      journalSet(run);
+    }
+    throw error;
+  }
 }

--- a/src/server/sandbox/adapters/macos.test.ts
+++ b/src/server/sandbox/adapters/macos.test.ts
@@ -1,0 +1,795 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { getSandboxProvider } from "../index";
+import {
+  cleanupRemoteRunWithRetry,
+  makeRemoteLauncher,
+  remoteRuntimePaths,
+  shellQuoteWord,
+  type RemoteDriver,
+} from "./bootstrap";
+import type { ExecResult } from "../provider";
+import {
+  acquireMacosLease,
+  acquireMacosMutationLock,
+  buildLaunchAgentPlist,
+  buildSshArgs,
+  createMacosSshDriver,
+  launchAgentCleanupCommand,
+  macosCleanupCommand,
+  pipeMacosRemoteFile,
+  readCappedStreamText,
+  releaseMacosMutationLock,
+  resolveMacosWorkspacePath,
+  statMacosRemotePath,
+  verifyMacosReadiness,
+  type MacosRemoteProcess,
+  type SshRunner,
+} from "./macos";
+
+describe("capped SSH output", () => {
+  test("fails explicitly instead of returning truncated stdout", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("12345"));
+        controller.close();
+      },
+    });
+
+    await expect(readCappedStreamText(stream, 4, true)).rejects.toThrow(
+      "remote command stdout exceeds the 4-byte capture cap",
+    );
+  });
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("macOS runtime paths", () => {
+  test("keeps existing Linux defaults byte-identical", () => {
+    expect(remoteRuntimePaths()).toEqual({
+      home: "/home/ubuntu",
+      bun: "/home/ubuntu/.bun/bin/bun",
+      claude: "/home/ubuntu/.local/bin/claude",
+      opencode: "/home/ubuntu/.bun/bin/opencode",
+      runnerRepo: "/home/ubuntu/projects/tella-backstage",
+      hostEntry: "/home/ubuntu/projects/tella-backstage/src/runner-host/host.ts",
+      openaiSeedDir: "/home/ubuntu/.opensession-openai-seeds",
+      path: "/home/ubuntu/.bun/bin:/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      warmBase: "/home/ubuntu/.bks-warm",
+      runsBase: "/home/ubuntu/.opensession-chats/sandbox-runs",
+    });
+  });
+
+  test("derives every runner path from a macOS home", () => {
+    const paths = remoteRuntimePaths(
+      "/Users/runner",
+      "/Users/runner/src/backstage",
+      "/Users/runner/.bun/bin:/opt/homebrew/bin:/usr/bin:/bin",
+    );
+    expect(paths.hostEntry).toBe("/Users/runner/src/backstage/src/runner-host/host.ts");
+    expect(paths.runsBase).toBe("/Users/runner/.opensession-chats/sandbox-runs");
+    expect(paths.path).toContain("/opt/homebrew/bin");
+  });
+});
+
+describe("remote run recovery", () => {
+  test("binds liveness to the runner entrypoint and exact run spec", async () => {
+    const calls: string[] = [];
+    const runtime = remoteRuntimePaths("/Users/runner", "/Users/runner/backstage");
+    const driver: RemoteDriver = {
+      async exec(command) {
+        calls.push(command);
+        if (command.includes("meta.json")) {
+          return { exitCode: 0, stdout: JSON.stringify({ pid: 4242 }), stderr: "" };
+        }
+        return { exitCode: 1, stdout: "", stderr: "" };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    };
+
+    const launcher = makeRemoteLauncher(driver, "bks-recovery", runtime);
+    expect(await launcher.alive("/tmp/rh-one", null)).toBe(false);
+    expect(calls[1]).toContain(runtime.hostEntry);
+    expect(calls[1]).toContain(
+      "/Users/runner/.opensession-chats/sandbox-runs/bks-recovery/rh-one/spec.json",
+    );
+  });
+
+  test("retries macOS cleanup while another process holds the mutation lock", async () => {
+    let attempts = 0;
+    await cleanupRemoteRunWithRetry(
+      {
+        runKey: "rh-cleanup",
+        cwd: "/tmp/worktree",
+        sandboxProvider: "macos",
+        startedAt: new Date().toISOString(),
+      },
+      async () => {
+        attempts++;
+        if (attempts < 3) throw new Error("node is being mutated by another process");
+      },
+      0,
+    );
+    expect(attempts).toBe(3);
+  });
+});
+
+describe("macOS SSH transport", () => {
+  test("constructs a noninteractive argv-safe SSH invocation", () => {
+    const argv = buildSshArgs(
+      {
+        host: "mac-mini.tailnet.ts.net",
+        user: "opensession",
+        port: 2222,
+        identityFile: "/home/ubuntu/.ssh/mac node",
+        remoteHome: "/Users/opensession",
+      },
+      "printf '%s' \"hello world\"",
+    );
+    expect(argv.slice(0, 8)).toEqual([
+      "ssh",
+      "-T",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ClearAllForwardings=yes",
+      "-o",
+      "ConnectTimeout=10",
+    ]);
+    expect(argv).toContain("opensession@mac-mini.tailnet.ts.net");
+    expect(argv).toContain("/home/ubuntu/.ssh/mac node");
+    expect(argv.at(-1)).toBe(`/bin/sh -lc 'printf '\\''%s'\\'' "hello world"'`);
+  });
+
+  test("writes and bootstraps a unique Aqua LaunchAgent", async () => {
+    const calls: Array<{ argv: string[]; input?: string }> = [];
+    const runner: SshRunner = async (argv, options) => {
+      calls.push({ argv, input: options?.input });
+      const command = argv.at(-1) || "";
+      if (command.includes("id -u")) return { exitCode: 0, stdout: "501\n", stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const driver = createMacosSshDriver(
+      {
+        host: "mac-mini.tailnet.ts.net",
+        user: "opensession",
+        remoteHome: "/Users/opensession",
+      },
+      "bks-test/session",
+      runner,
+    );
+
+    await driver.execBackground("bun run screenshot.ts", {
+      env: { HOME: "/Users/opensession", DISPLAY_NAME: "A&B" },
+    });
+
+    const write = calls.find((call) => call.input?.includes("<key>Label</key>"));
+    expect(write).toBeDefined();
+    expect(write!.input).toContain("com.tella.opensession.bks-test-session.");
+    expect(write!.input).toContain("<string>Aqua</string>");
+    expect(write!.input).toContain("<string>A&amp;B</string>");
+    expect(write!.input).toContain("launchctl bootout gui/501/");
+    const bootstrap = calls.find((call) => call.argv.at(-1)?.includes("launchctl bootstrap gui/501"));
+    expect(bootstrap).toBeDefined();
+    expect(bootstrap!.argv.at(-1)).toContain("Library/LaunchAgents/com.tella.opensession.bks-test-session.");
+  });
+
+  test("fails clearly when the Aqua launchd domain is unavailable", async () => {
+    const driver = createMacosSshDriver(
+      { host: "mac", remoteHome: "/Users/runner" },
+      "bks-test",
+      async () => ({ exitCode: 1, stdout: "", stderr: "no domain" }),
+    );
+    expect(driver.ensureStarted()).rejects.toThrow("no active gui/$UID launchd domain");
+  });
+});
+
+describe("LaunchAgent and readiness helpers", () => {
+  test("plist escapes command, paths, and environment", () => {
+    const plist = buildLaunchAgentPlist({
+      label: "com.tella.opensession.test",
+      command: "printf '<done>'",
+      stdoutPath: "/tmp/a&b.log",
+      stderrPath: "/tmp/error.log",
+      environment: { TOKEN: 'a&b"c' },
+    });
+    expect(plist).toContain("printf &apos;&lt;done&gt;&apos;");
+    expect(plist).toContain("/tmp/a&amp;b.log");
+    expect(plist).toContain("a&amp;b&quot;c");
+  });
+
+  test("cleanup is scoped to one session label", () => {
+    const command = launchAgentCleanupCommand("bks-123/unsafe", true);
+    expect(command).toContain("com.tella.opensession.bks-123-unsafe.*.plist");
+    expect(command).toContain("launchctl bootout");
+  });
+
+  test("readiness verifies Darwin arm64, Xcode, Aqua, tools, and runner SHA", async () => {
+    const commands: string[] = [];
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const driver: RemoteDriver = {
+      async exec(command) {
+        commands.push(command);
+        if (command === "uname -s && uname -m") {
+          return { exitCode: 0, stdout: "Darwin\narm64\n", stderr: "" };
+        }
+        if (command.includes("opencode") && command.includes("--version")) {
+          return { exitCode: 0, stdout: "1.17.15\n", stderr: "" };
+        }
+        if (command.includes("rev-parse HEAD")) {
+          return { exitCode: 0, stdout: "abc123\n", stderr: "" };
+        }
+        return { exitCode: 0, stdout: "ok\n", stderr: "" };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    };
+    await verifyMacosReadiness(driver, runtime, "abc123");
+    expect(commands.some((command) => command.includes("xcodebuild -version"))).toBe(true);
+    expect(commands.some((command) => command.includes("/dev/console"))).toBe(true);
+    expect(commands.some((command) => command.includes(runtime.hostEntry))).toBe(true);
+  });
+
+  test("provider registry exposes macos", () => {
+    expect(getSandboxProvider("macos").id).toBe("macos");
+  });
+});
+
+/** Fake driver that returns scripted responses in call order, so lease tests
+ *  can walk acquireMacosLease's exact decision tree (tryAcquire →
+ *  macosLeaseActive → cleanup → tryAcquire again) without a real Mac. */
+function sequenceDriver(results: ExecResult[]): { driver: RemoteDriver; calls: string[] } {
+  const calls: string[] = [];
+  let i = 0;
+  const driver: RemoteDriver = {
+    async exec(cmd) {
+      calls.push(cmd);
+      const r = results[i++];
+      if (!r) throw new Error(`test driver ran out of scripted responses at call ${i}: ${cmd.slice(0, 160)}`);
+      return r;
+    },
+    async execBackground() {},
+    async writeFile() {},
+    async ensureStarted() {},
+  };
+  return { driver, calls };
+}
+
+function localShellDriver(): RemoteDriver {
+  return {
+    async exec(command) {
+      const proc = Bun.spawn(["/bin/sh", "-lc", command], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      return { exitCode, stdout, stderr };
+    },
+    async execBackground() {},
+    async writeFile() {},
+    async ensureStarted() {},
+  };
+}
+
+describe("acquireMacosLease (node-wide foreground lease)", () => {
+  test("acquires an uncontended lease while holding the distributed mutation lock", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" }, // mutation lock
+      { exitCode: 0, stdout: "", stderr: "" }, // tryAcquire
+      { exitCode: 0, stdout: "", stderr: "" }, // release mutation lock
+    ]);
+    await acquireMacosLease(driver, runtime, "bks-1", "run-1");
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toContain("foreground-mutation.lock");
+    expect(calls[0]).toContain("fcntl.LOCK_EX | fcntl.LOCK_NB");
+    expect(calls[1]).toContain("/Users/runner/.opensession-node/foreground-lease");
+    expect(calls[1]).toContain('"sessionId":"bks-1"');
+    expect(calls[1]).toContain('"runId":"run-1"');
+    expect(calls[1]).toContain('mv "$owner_tmp"');
+    expect(calls[1]).toContain("exit 72");
+  });
+
+  test("the Python mutation holder acquires and releases a real OS lock", async () => {
+    const home = mkdtempSync(join(tmpdir(), "macos-mutation-lock-"));
+    temporaryDirectories.push(home);
+    const runtime = remoteRuntimePaths(home);
+    const driver = localShellDriver();
+
+    await acquireMacosLease(driver, runtime, "bks-1", "run-1");
+    expect(existsSync(join(home, ".opensession-node", "foreground-mutation-owner.json"))).toBe(
+      false,
+    );
+    expect(existsSync(join(home, ".opensession-node", "foreground-lease", "owner.json"))).toBe(
+      true,
+    );
+  });
+
+  test("renews the OS lock beyond its original TTL", async () => {
+    const home = mkdtempSync(join(tmpdir(), "macos-mutation-heartbeat-"));
+    temporaryDirectories.push(home);
+    const runtime = remoteRuntimePaths(home);
+    const driver = localShellDriver();
+    const lock = await acquireMacosMutationLock(driver, runtime, {
+      ttlSeconds: 1,
+      heartbeatMs: 100,
+    });
+    try {
+      await Bun.sleep(1_300);
+      await expect(
+        acquireMacosMutationLock(driver, runtime, { ttlSeconds: 1, heartbeatMs: 100 }),
+      ).rejects.toThrow("being mutated by another process");
+    } finally {
+      await releaseMacosMutationLock(driver, runtime, lock);
+    }
+
+    const next = await acquireMacosMutationLock(driver, runtime, {
+      ttlSeconds: 1,
+      heartbeatMs: 100,
+    });
+    await releaseMacosMutationLock(driver, runtime, next);
+  });
+
+  test("rejects a contended lease still inside the stale window without an active-process check", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:00:00Z");
+    const owner = {
+      sessionId: "bks-other",
+      runId: "run-other",
+      acquiredAt: new Date(now.getTime() - 1_000).toISOString(),
+    };
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /busy with bks-other/,
+    );
+    // Fresh lease: short-circuits on age, never probes whether the owner is
+    // actually alive and never touches its files.
+    expect(calls).toHaveLength(3);
+  });
+
+  test("rejects a stale-timed lease whose owner process is still alive", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const owner = {
+      sessionId: "bks-other",
+      runId: "run-other",
+      acquiredAt: new Date(now.getTime() - 10 * 60_000).toISOString(),
+    };
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" }, // mutation lock
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // tryAcquire
+      { exitCode: 0, stdout: "", stderr: "" }, // macosLeaseActive: alive
+      { exitCode: 0, stdout: "", stderr: "" }, // release mutation lock
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /busy with bks-other/,
+    );
+    expect(calls).toHaveLength(4);
+    expect(calls[2]).toContain("plutil -extract pid");
+    expect(calls[2]).toContain("ps -p");
+    expect(calls[2]).toContain("spec.json");
+  });
+
+  test("reclaims a stale dead lease, cleaning up the previous owner before retrying", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const owner = {
+      sessionId: "bks-other",
+      runId: "run-other",
+      acquiredAt: new Date(now.getTime() - 10 * 60_000).toISOString(),
+    };
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" }, // mutation lock
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // tryAcquire #1: contended
+      { exitCode: 1, stdout: "", stderr: "" }, // macosLeaseActive: dead
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // re-read under lock
+      { exitCode: 1, stdout: "", stderr: "" }, // owner still dead under lock
+      { exitCode: 0, stdout: "", stderr: "" }, // cleanupMacosRun for the stale owner
+      { exitCode: 0, stdout: "", stderr: "" }, // tryAcquire #2: succeeds
+      { exitCode: 0, stdout: "", stderr: "" }, // release mutation lock
+    ]);
+    await acquireMacosLease(driver, runtime, "bks-1", "run-1", now);
+    expect(calls).toHaveLength(8);
+    // Cleanup is scoped to the STALE owner's session/run, not the new claimant.
+    expect(calls[5]).toContain("for plist in");
+    expect(calls[5]).toContain("bks-other");
+    expect(calls[5]).not.toContain("bks-1");
+    // The retried acquire claims the lease for the NEW run.
+    expect(calls[6]).toContain('"sessionId":"bks-1"');
+  });
+
+  test("surfaces a concurrent-claim race as a clear retry error", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const owner = {
+      sessionId: "bks-other",
+      runId: "run-other",
+      acquiredAt: new Date(now.getTime() - 10 * 60_000).toISOString(),
+    };
+    const { driver } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" }, // mutation lock
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // tryAcquire #1: contended
+      { exitCode: 1, stdout: "", stderr: "" }, // macosLeaseActive: dead
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // re-read under lock
+      { exitCode: 1, stdout: "", stderr: "" }, // owner still dead
+      { exitCode: 0, stdout: "", stderr: "" }, // cleanup
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" }, // tryAcquire #2: someone else won
+      { exitCode: 0, stdout: "", stderr: "" }, // release mutation lock
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /claimed concurrently/,
+    );
+  });
+
+  test("treats a just-created lease without owner.json as initializing", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 74, stdout: "__INITIALIZING__\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1")).rejects.toThrow(
+      /still initializing/,
+    );
+    expect(calls).toHaveLength(3);
+  });
+
+  test("does not report success when owner publication fails", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 72, stdout: "", stderr: "owner write failed" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1")).rejects.toThrow(
+      /foreground lease failed.*owner write failed/s,
+    );
+    expect(calls).toHaveLength(3);
+  });
+
+  test("never deletes an owner replaced before stale reclamation", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const stale = {
+      sessionId: "bks-stale",
+      runId: "run-stale",
+      acquiredAt: new Date(now.getTime() - 10 * 60_000).toISOString(),
+    };
+    const replacement = { ...stale, sessionId: "bks-new", runId: "run-new" };
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" }, // mutation lock
+      { exitCode: 73, stdout: JSON.stringify(stale), stderr: "" },
+      { exitCode: 1, stdout: "", stderr: "" },
+      { exitCode: 73, stdout: JSON.stringify(replacement), stderr: "" }, // changed owner
+      { exitCode: 0, stdout: "", stderr: "" }, // release mutation lock
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /changed while reclaiming/,
+    );
+    expect(calls.some((call) => call.includes(".backstage-claude-accounts.json"))).toBe(false);
+  });
+
+  test("backs off when another process holds the mutation lock", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 1, stdout: "", stderr: "" }, // another process holds mutation lock
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /being mutated/,
+    );
+    // The OS-backed nonblocking flock is never deleted or stolen by a waiter.
+    expect(calls).toHaveLength(1);
+    expect(calls.every((c) => !c.includes(".backstage-claude-accounts.json"))).toBe(true);
+    expect(calls[0]).toContain("fcntl.LOCK_EX | fcntl.LOCK_NB");
+    expect(calls[0]).toContain(" 300");
+  });
+
+  test("treats a transport failure during liveness probing as unknown", async () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const now = new Date("2026-07-21T12:10:00Z");
+    const owner = {
+      sessionId: "bks-other",
+      runId: "run-other",
+      acquiredAt: new Date(now.getTime() - 10 * 60_000).toISOString(),
+    };
+    const { driver, calls } = sequenceDriver([
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 73, stdout: JSON.stringify(owner), stderr: "" },
+      { exitCode: 255, stdout: "", stderr: "connection lost" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ]);
+    await expect(acquireMacosLease(driver, runtime, "bks-1", "run-1", now)).rejects.toThrow(
+      /liveness probe failed \(255\).*connection lost/s,
+    );
+    expect(calls).toHaveLength(4);
+  });
+});
+
+describe("macosCleanupCommand (run/session teardown)", () => {
+  test("removing a specific run also removes its workspace and credential material", () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const runDir = `${runtime.runsBase}/bks-1`;
+    const workspace = "/Users/runner/.opensession-workspaces/bks-1/tella-fusion";
+    const command = macosCleanupCommand(runtime, "bks-1", "run-1", workspace);
+    expect(command).toContain(`rm -rf ${shellQuoteWord(runDir)}`);
+    expect(command).toContain(`rm -rf ${shellQuoteWord(workspace)}`);
+    expect(command).toContain(".backstage-claude-accounts.json");
+    expect(command).toContain(".backstage-codex-accounts.json");
+    expect(command).toContain(".opensession-openai-seeds");
+    expect(command).toContain("foreground-lease");
+    expect(command).toContain('[ "$owner_run" = run-1 ]');
+    expect(command).toContain("for plist in");
+    expect(command.indexOf('if ! { [ "$owner_run" = run-1 ]')).toBeLessThan(
+      command.indexOf("for plist in"),
+    );
+    expect(command).toContain("launchctl print");
+    expect(command).toContain('case "$command" in *"$run_dir/spec.json"*');
+    expect(command).toContain("exit 76");
+    expect(spawnSync("/bin/sh", ["-n"], { input: command }).status).toBe(0);
+    // Workspace and global resources are released only after the owned run's
+    // launchd job and recorded PID are both confirmed gone.
+    expect(command.indexOf(`rm -rf ${shellQuoteWord(workspace)}`)).toBeGreaterThan(
+      command.indexOf('if ! { [ "$owner_run" = run-1 ]'),
+    );
+    expect(command.indexOf(`rm -rf ${shellQuoteWord(workspace)}`)).toBeGreaterThan(
+      command.indexOf("exit 76"),
+    );
+  });
+
+  test("session destroy cleans its artifacts without disturbing another lease owner", () => {
+    const runtime = remoteRuntimePaths("/Users/runner");
+    const command = macosCleanupCommand(runtime, "bks-1");
+    // Session-wide match: no comparison against owner_run, unlike the
+    // per-run case above (`[ "$owner_run" = run-1 ] && ...`).
+    expect(command).toContain('if [ -z "$owner_session" ] || [ "$owner_session" = bks-1 ]; then');
+    expect(command).not.toContain('"$owner_run" =');
+    // Session-owned agents are removed before consulting the global lease.
+    expect(command.indexOf("for plist in")).toBeLessThan(command.indexOf("owner_session=$("));
+    // No workspace argument: the caller supplies the checkout separately.
+    expect(command).not.toContain("rm -rf /Users/runner/.opensession-workspaces");
+  });
+});
+
+describe("resolveMacosWorkspacePath (import_remote_asset path confinement)", () => {
+  test("confines a relative path to the session's remote workspace root", () => {
+    expect(resolveMacosWorkspacePath("/Users/runner/ws", "artifacts/demo.mp4")).toBe(
+      "/Users/runner/ws/artifacts/demo.mp4",
+    );
+    expect(resolveMacosWorkspacePath("/Users/runner/ws", "./demo.png")).toBe(
+      "/Users/runner/ws/demo.png",
+    );
+  });
+
+  test("rejects absolute paths and traversal out of the workspace", () => {
+    expect(() => resolveMacosWorkspacePath("/Users/runner/ws", "/etc/passwd")).toThrow();
+    expect(() => resolveMacosWorkspacePath("/Users/runner/ws", "../secrets")).toThrow();
+    expect(() => resolveMacosWorkspacePath("/Users/runner/ws", "artifacts/../../secrets")).toThrow();
+    expect(() => resolveMacosWorkspacePath("/Users/runner/ws", "")).toThrow();
+  });
+});
+
+describe("statMacosRemotePath (import_remote_asset stat + checksum)", () => {
+  test("parses a regular file's size and sha256", async () => {
+    const sha = "a".repeat(64);
+    const driver: RemoteDriver = {
+      async exec() {
+        return { exitCode: 0, stdout: `12345\n${sha}\n`, stderr: "" };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    };
+    expect(await statMacosRemotePath(driver, "/Users/runner/ws", "/Users/runner/ws/demo.mp4")).toEqual({
+      kind: "file",
+      size: 12345,
+      sha256: sha,
+    });
+  });
+
+  test("reports directories and missing paths distinctly from files", async () => {
+    const respond = (stdout: string): RemoteDriver => ({
+      async exec() {
+        return { exitCode: 0, stdout, stderr: "" };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    });
+    expect((await statMacosRemotePath(respond("DIR\n"), "/workspace", "/workspace/x")).kind).toBe("dir");
+    expect((await statMacosRemotePath(respond("MISSING\n"), "/workspace", "/workspace/x")).kind).toBe("missing");
+  });
+
+  test("requires a valid checksum and a descriptor-confined remote command", async () => {
+    let command = "";
+    const driver: RemoteDriver = {
+      async exec(cmd) {
+        command = cmd;
+        return { exitCode: 0, stdout: "12\nnot-a-sha\n", stderr: "" };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    };
+    await expect(
+      statMacosRemotePath(driver, "/Users/runner/ws", "/Users/runner/ws/artifacts/demo.mp4"),
+    ).rejects.toThrow(/invalid sha256/);
+    expect(command).toContain("os.O_NOFOLLOW");
+    expect(command).toContain("dir_fd=current");
+    expect(command).toContain("os.fstat(target)");
+    expect(command).toContain("hashlib.sha256()");
+    expect(command).toContain("artifacts/demo.mp4 stat");
+  });
+
+  test("opens every path component without following symlinks", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "macos-asset-workspace-"));
+    const outside = mkdtempSync(join(tmpdir(), "macos-asset-outside-"));
+    temporaryDirectories.push(workspace, outside);
+    mkdirSync(join(workspace, "artifacts"));
+    writeFileSync(join(workspace, "artifacts", "demo.bin"), "descriptor confined");
+    writeFileSync(join(outside, "secret.bin"), "secret");
+    symlinkSync(outside, join(workspace, "linked"), "dir");
+    const driver: RemoteDriver = {
+      async exec(command) {
+        const result = spawnSync("/bin/sh", ["-c", command], { encoding: "utf8" });
+        return {
+          exitCode: result.status ?? 1,
+          stdout: result.stdout || "",
+          stderr: result.stderr || result.error?.message || "",
+        };
+      },
+      async execBackground() {},
+      async writeFile() {},
+      async ensureStarted() {},
+    };
+
+    const info = await statMacosRemotePath(
+      driver,
+      workspace,
+      join(workspace, "artifacts", "demo.bin"),
+    );
+    expect(info.kind).toBe("file");
+    expect(info.size).toBe(19);
+    expect(info.sha256).toMatch(/^[0-9a-f]{64}$/);
+    await expect(
+      statMacosRemotePath(driver, workspace, join(workspace, "linked", "secret.bin")),
+    ).rejects.toThrow(/cannot open confined remote asset/);
+  });
+});
+
+/** Build a fake SSH subprocess that yields the given chunks on stdout, so
+ *  pipeMacosRemoteFile can be exercised without a real SSH connection. */
+function fakeRemoteProcess(
+  chunks: Uint8Array[],
+  exitCode = 0,
+  stderrText = "",
+): MacosRemoteProcess {
+  return {
+    stdout: new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stderrText));
+        controller.close();
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+    kill() {},
+  };
+}
+
+describe("pipeMacosRemoteFile (binary transfer over SSH)", () => {
+  const config = { host: "mac-mini.tailnet.ts.net", remoteHome: "/Users/runner" };
+
+  test("preserves arbitrary binary bytes across the SSH round trip", async () => {
+    // Non-UTF8-safe bytes (0x00, 0xFF, lone continuation bytes) that a text
+    // decode would corrupt — proves the transport never touches a JS string.
+    const payload = new Uint8Array([0, 1, 2, 255, 254, 253, 128, 10, 13, 0]);
+    let argv: string[] = [];
+    const buf = await pipeMacosRemoteFile(
+      config,
+      "/Users/runner/ws",
+      "/Users/runner/ws/artifact.bin",
+      1024,
+      async (chunks) => {
+        const received: Buffer[] = [];
+        for await (const chunk of chunks) received.push(Buffer.from(chunk));
+        return Buffer.concat(received);
+      },
+      (spawnArgv) => {
+        argv = spawnArgv;
+        return fakeRemoteProcess([payload.slice(0, 5), payload.slice(5)]);
+      },
+    );
+    expect(new Uint8Array(buf)).toEqual(payload);
+    expect(argv.at(-1)).toContain("os.O_NOFOLLOW");
+    expect(argv.at(-1)).toContain("artifact.bin read");
+  });
+
+  test("enforces the size cap mid-stream", async () => {
+    const big = new Uint8Array(2048).fill(7);
+    await expect(
+      pipeMacosRemoteFile(
+        config,
+        "/Users/runner/ws",
+        "/Users/runner/ws/big.bin",
+        1024,
+        async (chunks) => {
+          for await (const _chunk of chunks) {
+            // Drain the stream; the transfer cap must stop it first.
+          }
+        },
+        () => fakeRemoteProcess([big]),
+      ),
+    ).rejects.toThrow(/exceeds the 1024-byte import cap/);
+  });
+
+  test("surfaces a nonzero ssh exit as a clear error", async () => {
+    await expect(
+      pipeMacosRemoteFile(
+        config,
+        "/Users/runner/ws",
+        "/Users/runner/ws/missing.bin",
+        1024,
+        async (chunks) => {
+          for await (const _chunk of chunks) {
+            // Drain so the SSH exit status becomes the reported error.
+          }
+        },
+        () => fakeRemoteProcess([], 1, "cat: No such file or directory"),
+      ),
+    ).rejects.toThrow(/ssh exit 1.*No such file or directory/s);
+  });
+
+  test("kills and reaps ssh when the consumer fails", async () => {
+    let killed = false;
+    let resolveExit!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const process = fakeRemoteProcess([new Uint8Array([1, 2, 3])]);
+    process.exited = exited;
+    process.kill = () => {
+      killed = true;
+      resolveExit(143);
+    };
+
+    await expect(
+      pipeMacosRemoteFile(
+        config,
+        "/Users/runner/ws",
+        "/Users/runner/ws/artifact.bin",
+        1024,
+        async () => {
+          throw new Error("destination failed");
+        },
+        () => process,
+      ),
+    ).rejects.toThrow("destination failed");
+    expect(killed).toBe(true);
+  });
+});

--- a/src/server/sandbox/adapters/macos.ts
+++ b/src/server/sandbox/adapters/macos.ts
@@ -1,0 +1,1332 @@
+/** Fixed macOS execution node over SSH.
+ *
+ * The node is provisioned ahead of time and stays logged into an Aqua session.
+ * Backstage uses SSH only as a control transport: each agent run itself is a
+ * per-run LaunchAgent in gui/$UID, so it survives the SSH connection and can
+ * later use Xcode and TCC-approved GUI automation from the console session.
+ */
+
+import { dirname } from "path";
+import { REPO_ROOT } from "../../../runner-host/protocol";
+import { getRepo } from "../../worktree";
+import {
+  sandboxCallbackBaseUrl,
+  sandboxConfig,
+  type SandboxMacosConfig,
+} from "../config";
+import type {
+  ExecResult,
+  PortMap,
+  Sandbox,
+  SandboxProvider,
+  SandboxSessionSpec,
+  SandboxStatus,
+} from "../provider";
+import {
+  REMOTE_OPENCODE_VERSION,
+  assertDialbackReachable,
+  findRemoteStateBySession,
+  makeRemoteSandbox,
+  readRemoteState,
+  remoteCloneUrl,
+  remoteRuntimePaths,
+  removeRemoteState,
+  sanitizeName,
+  setupRemoteWorkspace,
+  shellQuoteWord,
+  touchRemoteState,
+  withRemoteEnsureLock,
+  writeRemoteState,
+  type RemoteDriver,
+  type RemoteExecOpts,
+  type RemoteRuntimePaths,
+} from "./bootstrap";
+
+export interface MacosSshConfig {
+  host: string;
+  user?: string;
+  port?: number;
+  identityFile?: string;
+  remoteHome: string;
+}
+
+interface SshRunOptions {
+  input?: string;
+  timeoutMs?: number;
+}
+
+export type SshRunner = (argv: string[], options?: SshRunOptions) => Promise<ExecResult>;
+
+function validateSshConfig(raw: SandboxMacosConfig | undefined): MacosSshConfig {
+  const host = raw?.host?.trim();
+  const remoteHome = raw?.remoteHome?.trim();
+  if (!host || host.startsWith("-") || /\s/.test(host)) {
+    throw new Error(
+      'macos sandbox provider is not configured — set {"macos":{"host":"mac.example.ts.net","remoteHome":"/Users/opensession"}} in ~/.opensession-sandbox.json',
+    );
+  }
+  if (!remoteHome?.startsWith("/") || remoteHome.includes("\0")) {
+    throw new Error("macos.remoteHome must be an absolute path on the Mac");
+  }
+  if (raw?.user && !/^[A-Za-z0-9._-]+$/.test(raw.user)) {
+    throw new Error("macos.user contains unsupported SSH username characters");
+  }
+  return {
+    host,
+    remoteHome,
+    user: raw?.user,
+    port: raw?.port,
+    identityFile: raw?.identityFile,
+  };
+}
+
+export function buildSshArgs(config: MacosSshConfig, remoteCommand: string): string[] {
+  const target = config.user ? `${config.user}@${config.host}` : config.host;
+  return [
+    "ssh",
+    "-T",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ClearAllForwardings=yes",
+    "-o",
+    "ConnectTimeout=10",
+    ...(config.port ? ["-p", String(config.port)] : []),
+    ...(config.identityFile
+      ? ["-o", "IdentitiesOnly=yes", "-i", config.identityFile]
+      : []),
+    "--",
+    target,
+    `/bin/sh -lc ${shellQuoteWord(remoteCommand)}`,
+  ];
+}
+
+async function defaultSshRunner(
+  argv: string[],
+  options: SshRunOptions = {},
+): Promise<ExecResult> {
+  const proc = Bun.spawn(argv, {
+    stdin: options.input === undefined ? "ignore" : "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = readCappedStreamText(proc.stdout, 4 * 1024 * 1024, true);
+  const stderr = readCappedStreamText(proc.stderr, 64 * 1024);
+  void stdout.catch(() => {});
+  void stderr.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill();
+      } catch {}
+      resolve();
+    }, options.timeoutMs ?? 120_000);
+  });
+  (timer as { unref?: () => void }).unref?.();
+  try {
+    if (options.input !== undefined) {
+      proc.stdin!.write(options.input);
+      proc.stdin!.end();
+    }
+    await Promise.race([proc.exited.then(() => undefined), timeout]);
+    const exitCode = await proc.exited;
+    return {
+      exitCode: timedOut ? 124 : exitCode,
+      stdout: await stdout,
+      stderr: await stderr,
+    };
+  } catch (error) {
+    try {
+      proc.kill();
+    } catch {}
+    await proc.exited.catch(() => 1);
+    await Promise.allSettled([stdout, stderr]);
+    throw error;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function commandWithOptions(cmd: string, opts?: RemoteExecOpts): string {
+  const cd = opts?.cwd ? `cd -- ${shellQuoteWord(opts.cwd)} && ` : "";
+  const env = Object.entries(opts?.env || {}).map(([key, value]) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`invalid remote environment key ${JSON.stringify(key)}`);
+    }
+    return `${key}=${shellQuoteWord(value)}`;
+  });
+  return `${cd}${env.length ? `env ${env.join(" ")} ` : ""}${cmd}`;
+}
+
+function xml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+export interface LaunchAgentPlistSpec {
+  label: string;
+  command: string;
+  stdoutPath: string;
+  stderrPath: string;
+  environment?: Record<string, string>;
+}
+
+export function buildLaunchAgentPlist(spec: LaunchAgentPlistSpec): string {
+  const environment = Object.entries(spec.environment || {})
+    .map(([key, value]) => `      <key>${xml(key)}</key>\n      <string>${xml(value)}</string>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>${xml(spec.label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/sh</string>
+      <string>-lc</string>
+      <string>${xml(spec.command)}</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+${environment}
+    </dict>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>${xml(spec.stdoutPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${xml(spec.stderrPath)}</string>
+  </dict>
+</plist>
+`;
+}
+
+export function launchAgentCleanupCommand(sessionId: string, force: boolean): string {
+  const prefix = `com.tella.opensession.${sanitizeName(sessionId)}`;
+  const action = force
+    ? 'launchctl bootout "gui/$uid/$label" >/dev/null 2>&1 || true; rm -f "$plist"'
+    : 'launchctl print "gui/$uid/$label" 2>/dev/null | grep -q "state = running" || { launchctl bootout "gui/$uid/$label" >/dev/null 2>&1 || true; rm -f "$plist"; }';
+  return (
+    `uid=$(id -u); for plist in "$HOME/Library/LaunchAgents"/${prefix}.*.plist; do ` +
+    `[ -e "$plist" ] || continue; ` +
+    `label=$(/usr/libexec/PlistBuddy -c 'Print :Label' "$plist" 2>/dev/null || true); ` +
+    `[ -n "$label" ] || { rm -f "$plist"; continue; }; ${action}; done`
+  );
+}
+
+const LEASE_STALE_AFTER_MS = 5 * 60_000;
+const LEASE_INITIALIZING_GRACE_SECONDS = 30;
+const MUTATION_LOCK_TTL_SECONDS = 300;
+const MUTATION_LOCK_HEARTBEAT_MS = 30_000;
+
+interface MacosLeaseOwner {
+  sessionId: string;
+  runId: string;
+  acquiredAt: string;
+}
+
+function leaseDir(runtime: RemoteRuntimePaths): string {
+  return `${runtime.home}/.opensession-node/foreground-lease`;
+}
+
+function mutationLockPath(runtime: RemoteRuntimePaths): string {
+  return `${runtime.home}/.opensession-node/foreground-mutation.lock`;
+}
+
+function mutationOwnerPath(runtime: RemoteRuntimePaths): string {
+  return `${runtime.home}/.opensession-node/foreground-mutation-owner.json`;
+}
+
+const MUTATION_LOCK_ACQUIRE_SCRIPT = `
+import fcntl, json, os, signal, sys, time
+lock_path, owner_path, token, ttl_raw = sys.argv[1:5]
+ttl = int(ttl_raw)
+expiry_grace = min(1.0, max(0.25, ttl * 0.1))
+os.makedirs(os.path.dirname(lock_path), mode=0o700, exist_ok=True)
+fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+try:
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    os.close(fd)
+    sys.exit(75)
+pid = os.fork()
+if pid:
+    os.close(fd)
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        try:
+            with open(owner_path, "r", encoding="utf-8") as handle:
+                owner = json.load(handle)
+            if owner.get("token") == token and owner.get("pid") == pid:
+                sys.exit(0)
+        except (OSError, ValueError):
+            pass
+        time.sleep(0.02)
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        pass
+    sys.exit(76)
+os.setsid()
+devnull = os.open(os.devnull, os.O_RDWR)
+for stream_fd in (0, 1, 2):
+    os.dup2(devnull, stream_fd)
+os.close(devnull)
+stopping = [False]
+def stop(_signum, _frame):
+    stopping[0] = True
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+temporary = owner_path + "." + token + ".tmp"
+payload = {"token": token, "pid": os.getpid(), "expiresAt": time.time() + ttl}
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, separators=(",", ":"))
+    handle.flush()
+    os.fsync(handle.fileno())
+os.replace(temporary, owner_path)
+while not stopping[0]:
+    try:
+        with open(owner_path, "r", encoding="utf-8") as handle:
+            owner = json.load(handle)
+            if owner.get("token") != token or time.time() >= owner.get("expiresAt", 0) + expiry_grace:
+                break
+    except (OSError, TypeError, ValueError):
+        break
+    time.sleep(0.1)
+try:
+    with open(owner_path, "r", encoding="utf-8") as handle:
+        owns_file = json.load(handle).get("token") == token
+    if owns_file:
+        os.unlink(owner_path)
+except (OSError, ValueError):
+    pass
+os.close(fd)
+os._exit(0)
+`;
+
+const MUTATION_LOCK_REFRESH_SCRIPT = `
+import json, os, sys, time
+owner_path, token, ttl_raw = sys.argv[1:4]
+ttl = int(ttl_raw)
+try:
+    with open(owner_path, "r", encoding="utf-8") as handle:
+        owner = json.load(handle)
+except (OSError, ValueError):
+    sys.exit(76)
+if owner.get("token") != token:
+    sys.exit(77)
+owner["expiresAt"] = time.time() + ttl
+temporary = owner_path + "." + token + ".refresh.tmp"
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(owner, handle, separators=(",", ":"))
+    handle.flush()
+    os.fsync(handle.fileno())
+os.replace(temporary, owner_path)
+`;
+
+const MUTATION_LOCK_RELEASE_SCRIPT = `
+import fcntl, json, os, sys
+lock_path, owner_path, token = sys.argv[1:4]
+try:
+    with open(owner_path, "r", encoding="utf-8") as handle:
+        owner = json.load(handle)
+except (OSError, ValueError):
+    sys.exit(0)
+if owner.get("token") != token:
+    sys.exit(77)
+try:
+    os.unlink(owner_path)
+except FileNotFoundError:
+    pass
+fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+fcntl.flock(fd, fcntl.LOCK_EX)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+`;
+
+function sessionRunDir(runtime: RemoteRuntimePaths, sessionId: string): string {
+  return `${runtime.runsBase}/${sanitizeName(sessionId)}`;
+}
+
+function launchAgentPrefix(sessionId: string, runId?: string): string {
+  return ["com.tella.opensession", sanitizeName(sessionId), runId && sanitizeName(runId)]
+    .filter(Boolean)
+    .join(".");
+}
+
+export function macosCleanupCommand(
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  runId?: string,
+  workspace?: string,
+): string {
+  const lease = leaseDir(runtime);
+  const owner = `${lease}/owner.json`;
+  // A session can respawn its run-host under a new host id while retaining the
+  // same foreground lease, so cleanup is session-wide for transient agents and
+  // logs. The lease itself still uses runId to avoid releasing a newer owner.
+  const prefix = launchAgentPrefix(sessionId);
+  const logs = `${runtime.home}/Library/Logs/OpenSession`;
+  const runRoot = sessionRunDir(runtime, sessionId);
+  const runMatch = runId
+    ? `[ "$owner_run" = ${shellQuoteWord(runId)} ] && [ "$owner_session" = ${shellQuoteWord(sessionId)} ]`
+    : `[ -z "$owner_session" ] || [ "$owner_session" = ${shellQuoteWord(sessionId)} ]`;
+  const sessionCleanup =
+    `uid=$(id -u); cleanup_failed=0; ` +
+    `for plist in "$HOME/Library/LaunchAgents"/${prefix}.*.plist; do ` +
+    `[ -e "$plist" ] || continue; ` +
+    `label=$(/usr/libexec/PlistBuddy -c 'Print :Label' "$plist" 2>/dev/null || true); ` +
+    `if [ -n "$label" ]; then launchctl bootout "gui/$uid/$label" >/dev/null 2>&1 || true; ` +
+    `if launchctl print "gui/$uid/$label" >/dev/null 2>&1; then cleanup_failed=1; continue; fi; fi; ` +
+    `rm -f "$plist"; done; ` +
+    `for meta in ${shellQuoteWord(`${runRoot}/`)}*/meta.json; do [ -e "$meta" ] || continue; ` +
+    `pid=$(/usr/bin/plutil -extract pid raw -o - "$meta" 2>/dev/null || true); ` +
+    `[ -n "$pid" ] || continue; run_dir="\${meta%/meta.json}"; host_active=0; attempt=0; ` +
+    `while [ "$attempt" -lt 50 ]; do attempt=$((attempt + 1)); ` +
+    `command=$(ps -p "$pid" -o command= 2>/dev/null || true); ` +
+    `if kill -0 "$pid" 2>/dev/null; then case "$command" in *"$run_dir/spec.json"*) host_active=1; sleep 0.1; continue;; esac; fi; ` +
+    `host_active=0; break; done; [ "$host_active" -eq 0 ] || cleanup_failed=1; done; ` +
+    `if [ "$cleanup_failed" -ne 0 ]; then echo 'macos run host survived launchctl bootout' >&2; exit 76; fi; ` +
+    `${workspace ? `rm -rf ${shellQuoteWord(workspace)}; ` : ""}` +
+    `rm -rf ${shellQuoteWord(runRoot)}; ` +
+    `rm -f ${shellQuoteWord(`${logs}/${prefix}.`)}*.stdout.log ${shellQuoteWord(`${logs}/${prefix}.`)}*.stderr.log; `;
+  const ownerRead =
+    `owner_session=$(/usr/bin/plutil -extract sessionId raw -o - ${shellQuoteWord(owner)} 2>/dev/null || true); ` +
+    `owner_run=$(/usr/bin/plutil -extract runId raw -o - ${shellQuoteWord(owner)} 2>/dev/null || true); `;
+  return (
+    (runId
+      ? `${ownerRead}if ! { ${runMatch}; }; then exit 0; fi; ${sessionCleanup}`
+      : `${sessionCleanup}${ownerRead}`) +
+    `if ${runMatch}; then ` +
+    `rm -f ${shellQuoteWord(`${runtime.home}/.backstage-claude-accounts.json`)} ` +
+    `${shellQuoteWord(`${runtime.home}/.backstage-codex-accounts.json`)}; ` +
+    `rm -rf ${shellQuoteWord(runtime.openaiSeedDir)} ${shellQuoteWord(lease)}; ` +
+    `fi`
+  );
+}
+
+const macosNodeMutationChains: Map<string, Promise<unknown>> =
+  ((globalThis as any).__macosNodeMutationChains ??= new Map());
+
+function withMacosNodeMutation<T>(runtime: RemoteRuntimePaths, fn: () => Promise<T>): Promise<T> {
+  const key = runtime.home;
+  const previous = macosNodeMutationChains.get(key) ?? Promise.resolve();
+  const run = previous.then(fn, fn);
+  const tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  macosNodeMutationChains.set(key, tail);
+  void tail.finally(() => {
+    if (macosNodeMutationChains.get(key) === tail) macosNodeMutationChains.delete(key);
+  });
+  return run;
+}
+
+export interface MacosMutationLock {
+  token: string;
+  heartbeat: ReturnType<typeof setInterval>;
+  refreshInFlight: Promise<void> | null;
+}
+
+async function refreshMacosMutationLock(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  token: string,
+  ttlSeconds: number,
+): Promise<void> {
+  const result = await driver.exec(
+    `/usr/bin/python3 -c ${shellQuoteWord(MUTATION_LOCK_REFRESH_SCRIPT)} ` +
+      `${shellQuoteWord(mutationOwnerPath(runtime))} ${shellQuoteWord(token)} ${ttlSeconds}`,
+    { timeoutMs: 10_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error("macos execution node mutation lock heartbeat was rejected");
+  }
+}
+
+export async function acquireMacosMutationLock(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  options: { ttlSeconds?: number; heartbeatMs?: number } = {},
+): Promise<MacosMutationLock> {
+  const ttlSeconds = options.ttlSeconds ?? MUTATION_LOCK_TTL_SECONDS;
+  const heartbeatMs = options.heartbeatMs ?? MUTATION_LOCK_HEARTBEAT_MS;
+  const token = crypto.randomUUID();
+  const result = await driver.exec(
+    `/usr/bin/python3 -c ${shellQuoteWord(MUTATION_LOCK_ACQUIRE_SCRIPT)} ` +
+      `${shellQuoteWord(mutationLockPath(runtime))} ` +
+      `${shellQuoteWord(mutationOwnerPath(runtime))} ` +
+      `${shellQuoteWord(token)} ${ttlSeconds}`,
+    { timeoutMs: 10_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error("macos execution node is being mutated by another process; retry the run");
+  }
+  const lock: MacosMutationLock = {
+    token,
+    heartbeat: undefined as unknown as ReturnType<typeof setInterval>,
+    refreshInFlight: null,
+  };
+  lock.heartbeat = setInterval(() => {
+    if (lock.refreshInFlight) return;
+    lock.refreshInFlight = refreshMacosMutationLock(driver, runtime, token, ttlSeconds)
+      .catch((error) => {
+        console.warn("[sandbox:macos] mutation lock heartbeat failed:", error);
+      })
+      .finally(() => {
+        lock.refreshInFlight = null;
+      });
+  }, heartbeatMs);
+  lock.heartbeat.unref?.();
+  return lock;
+}
+
+export async function releaseMacosMutationLock(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  lock: MacosMutationLock,
+): Promise<void> {
+  clearInterval(lock.heartbeat);
+  await lock.refreshInFlight;
+  const result = await driver.exec(
+    `/usr/bin/python3 -c ${shellQuoteWord(MUTATION_LOCK_RELEASE_SCRIPT)} ` +
+      `${shellQuoteWord(mutationLockPath(runtime))} ` +
+      `${shellQuoteWord(mutationOwnerPath(runtime))} ${shellQuoteWord(lock.token)}`,
+    { timeoutMs: 20_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error("macos execution node mutation lock could not be released");
+  }
+}
+
+async function withMacosRemoteMutation<T>(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const lock = await acquireMacosMutationLock(driver, runtime);
+  try {
+    return await fn();
+  } finally {
+    await releaseMacosMutationLock(driver, runtime, lock);
+  }
+}
+
+async function cleanupMacosRunInner(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  runId?: string,
+  workspace?: string,
+  mutationHeld = false,
+): Promise<void> {
+  const cleanup = async () => {
+    const result = await driver.exec(
+      macosCleanupCommand(runtime, sessionId, runId, workspace),
+      { timeoutMs: 30_000 },
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `macos cleanup failed for ${sessionId}: ${(result.stderr || result.stdout).trim().slice(0, 500)}`,
+      );
+    }
+  };
+  if (mutationHeld) return cleanup();
+  return withMacosRemoteMutation(driver, runtime, cleanup);
+}
+
+async function cleanupMacosRun(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  runId?: string,
+  workspace?: string,
+): Promise<void> {
+  return withMacosNodeMutation(runtime, () =>
+    cleanupMacosRunInner(driver, runtime, sessionId, runId, workspace),
+  );
+}
+
+async function macosLeaseActive(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  owner: MacosLeaseOwner,
+): Promise<boolean> {
+  const meta = `${sessionRunDir(runtime, owner.sessionId)}/${sanitizeName(owner.runId)}/meta.json`;
+  const spec = `${sessionRunDir(runtime, owner.sessionId)}/${sanitizeName(owner.runId)}/spec.json`;
+  const prefix = launchAgentPrefix(owner.sessionId, owner.runId);
+  const result = await driver.exec(
+    `pid=$(/usr/bin/plutil -extract pid raw -o - ${shellQuoteWord(meta)} 2>/dev/null || true); ` +
+      `command=$([ -n "$pid" ] && ps -p "$pid" -o command= 2>/dev/null || true); ` +
+      `if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then ` +
+      `case "$command" in *${shellQuoteWord(runtime.hostEntry)}*${shellQuoteWord(spec)}*) exit 0;; esac; fi; ` +
+      `uid=$(id -u); for plist in "$HOME/Library/LaunchAgents"/${prefix}.*.plist; do ` +
+      `[ -e "$plist" ] || continue; ` +
+      `label=$(/usr/libexec/PlistBuddy -c 'Print :Label' "$plist" 2>/dev/null || true); ` +
+      `[ -n "$label" ] && launchctl print "gui/$uid/$label" 2>/dev/null | grep -q "state = running" && exit 0; ` +
+      `done; exit 1`,
+    { timeoutMs: 20_000 },
+  );
+  if (result.exitCode === 0) return true;
+  if (result.exitCode === 1) return false;
+  throw new Error(
+    `macos liveness probe failed (${result.exitCode}): ${(result.stderr || result.stdout).trim().slice(0, 500)}`,
+  );
+}
+
+async function acquireMacosLeaseInner(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  runId: string,
+  now = new Date(),
+  mutationHeld = false,
+): Promise<void> {
+  const lease = leaseDir(runtime);
+  const owner: MacosLeaseOwner = { sessionId, runId, acquiredAt: now.toISOString() };
+  const tryAcquire = () =>
+    driver.exec(
+      `mkdir -p ${shellQuoteWord(dirname(lease))}; ` +
+        `if mkdir ${shellQuoteWord(lease)} 2>/dev/null; then ` +
+        `owner_tmp=${shellQuoteWord(`${lease}/owner.json.tmp`)}.$$; ` +
+        `if printf '%s' ${shellQuoteWord(JSON.stringify(owner))} > "$owner_tmp" && ` +
+        `mv "$owner_tmp" ${shellQuoteWord(`${lease}/owner.json`)} && ` +
+        `[ "$(cat ${shellQuoteWord(`${lease}/owner.json`)} 2>/dev/null)" = ${shellQuoteWord(JSON.stringify(owner))} ]; then exit 0; fi; ` +
+        `rm -f "$owner_tmp"; exit 72; ` +
+        `fi; ` +
+        `if [ ! -f ${shellQuoteWord(`${lease}/owner.json`)} ]; then ` +
+        `lease_mtime=$(stat -f%m -- ${shellQuoteWord(lease)} 2>/dev/null || echo 0); now_s=$(date +%s); ` +
+        `if [ "$lease_mtime" -gt 0 ] && [ $((now_s-lease_mtime)) -lt ${LEASE_INITIALIZING_GRACE_SECONDS} ]; then ` +
+        `echo __INITIALIZING__; exit 74; fi; echo __STALE_MISSING__; exit 73; fi; ` +
+        `cat ${shellQuoteWord(`${lease}/owner.json`)}; exit 73`,
+      { timeoutMs: 20_000 },
+    );
+
+  const acquire = async () => {
+    let acquired = await tryAcquire();
+    if (acquired.exitCode === 0) return;
+    if (acquired.exitCode === 74) {
+      throw new Error("macos execution node foreground lease is still initializing; retry the run");
+    }
+    if (acquired.exitCode !== 73) {
+      throw new Error(
+        `macos foreground lease failed: ${(acquired.stderr || acquired.stdout).trim().slice(0, 500)}`,
+      );
+    }
+
+    let current: MacosLeaseOwner | null = null;
+    try {
+      current = JSON.parse(acquired.stdout) as MacosLeaseOwner;
+    } catch {}
+    const age = current ? now.getTime() - Date.parse(current.acquiredAt) : Infinity;
+    if (
+      current &&
+      (age < LEASE_STALE_AFTER_MS || (await macosLeaseActive(driver, runtime, current)))
+    ) {
+      throw new Error(
+        `macos execution node is busy with ${current.sessionId} (${current.runId}); ` +
+          "the MVP serializes all runs on this fixed Aqua desktop",
+      );
+    }
+
+    // Re-read while holding the distributed mutation lock. This also defends
+    // against an older Backstage process that does not lock its fast path.
+    const rechecked = await tryAcquire();
+    if (rechecked.exitCode === 0) return;
+    if (rechecked.exitCode === 74) {
+      throw new Error("macos execution node foreground lease is still initializing; retry the run");
+    }
+    if (rechecked.exitCode !== 73 || rechecked.stdout.trim() !== acquired.stdout.trim()) {
+      throw new Error("macos execution node foreground lease changed while reclaiming; retry the run");
+    }
+
+    if (current?.sessionId) {
+      if (await macosLeaseActive(driver, runtime, current)) {
+        throw new Error(
+          `macos execution node is busy with ${current.sessionId} (${current.runId}); ` +
+            "the MVP serializes all runs on this fixed Aqua desktop",
+        );
+      }
+      await cleanupMacosRunInner(driver, runtime, current.sessionId, current.runId, undefined, true);
+    } else {
+      await driver.exec(`rm -rf ${shellQuoteWord(lease)}`);
+    }
+    acquired = await tryAcquire();
+    if (acquired.exitCode !== 0) {
+      throw new Error("macos execution node foreground lease was claimed concurrently; retry the run");
+    }
+  };
+  if (mutationHeld) return acquire();
+  return withMacosRemoteMutation(driver, runtime, acquire);
+}
+
+export function acquireMacosLease(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  sessionId: string,
+  runId: string,
+  now = new Date(),
+): Promise<void> {
+  return withMacosNodeMutation(runtime, () =>
+    acquireMacosLeaseInner(driver, runtime, sessionId, runId, now),
+  );
+}
+
+export function createMacosSshDriver(
+  config: MacosSshConfig,
+  sessionId: string,
+  runner: SshRunner = defaultSshRunner,
+): RemoteDriver {
+  const run = (command: string, options?: SshRunOptions) =>
+    runner(buildSshArgs(config, command), options);
+  const exec = (cmd: string, opts?: RemoteExecOpts) =>
+    run(commandWithOptions(cmd, opts), { timeoutMs: opts?.timeoutMs });
+
+  return {
+    exec,
+
+    async writeFile(path, content) {
+      const result = await run(
+        `umask 077; mkdir -p ${shellQuoteWord(dirname(path))} && cat > ${shellQuoteWord(path)}`,
+        { input: content },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(`macos SSH file write failed for ${path}: ${(result.stderr || result.stdout).trim()}`);
+      }
+    },
+
+    async ensureStarted() {
+      const result = await run(
+        'uid=$(id -u); launchctl print "gui/$uid" >/dev/null 2>&1',
+        { timeoutMs: 20_000 },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(
+          "macos execution node has no active gui/$UID launchd domain; log the dedicated user into an unlocked Aqua desktop before starting a run",
+        );
+      }
+    },
+
+    async execBackground(cmd, opts) {
+      await this.ensureStarted();
+      const uidResult = await exec("id -u", { timeoutMs: 20_000 });
+      if (uidResult.exitCode !== 0 || !/^\d+$/.test(uidResult.stdout.trim())) {
+        throw new Error(`macos execution node could not resolve its Aqua uid: ${uidResult.stderr.trim()}`);
+      }
+      const uid = uidResult.stdout.trim();
+      const suffix = crypto.randomUUID().replaceAll("-", "");
+      const launchId = sanitizeName(opts?.launchId || "run");
+      const label = `${launchAgentPrefix(sessionId, launchId)}.${suffix}`;
+      const launchAgents = `${config.remoteHome}/Library/LaunchAgents`;
+      const logs = `${config.remoteHome}/Library/Logs/OpenSession`;
+      const plistPath = `${launchAgents}/${label}.plist`;
+      const stdoutPath = `${logs}/${label}.stdout.log`;
+      const stderrPath = `${logs}/${label}.stderr.log`;
+      const cleanup =
+        `__bks_status=$?; rm -f ${shellQuoteWord(plistPath)}; ` +
+        `launchctl bootout gui/${uid}/${shellQuoteWord(label)} >/dev/null 2>&1 || true; ` +
+        `exit $__bks_status`;
+      const plist = buildLaunchAgentPlist({
+        label,
+        command: `${commandWithOptions(cmd, opts)}; ${cleanup}`,
+        stdoutPath,
+        stderrPath,
+        environment: opts?.env,
+      });
+      await this.writeFile(plistPath, plist);
+      const started = await exec(
+        `mkdir -p ${shellQuoteWord(logs)} && chmod 600 ${shellQuoteWord(plistPath)} && ` +
+          `launchctl print gui/${uid} >/dev/null 2>&1 && ` +
+          `launchctl bootstrap gui/${uid} ${shellQuoteWord(plistPath)}`,
+        { timeoutMs: 30_000 },
+      );
+      if (started.exitCode !== 0) {
+        await exec(`rm -f ${shellQuoteWord(plistPath)}`);
+        throw new Error(
+          `macos LaunchAgent ${label} failed to bootstrap in gui/${uid}: ` +
+            `${(started.stderr || started.stdout).trim().slice(0, 500)}`,
+        );
+      }
+    },
+  };
+}
+
+function need(result: ExecResult, message: string): void {
+  if (result.exitCode !== 0) {
+    const detail = (result.stderr || result.stdout).trim().slice(0, 400);
+    throw new Error(`macos execution node is not ready: ${message}${detail ? ` (${detail})` : ""}`);
+  }
+}
+
+export async function verifyMacosReadiness(
+  driver: RemoteDriver,
+  runtime: RemoteRuntimePaths,
+  expectedRunnerSha: string,
+): Promise<void> {
+  const platform = await driver.exec("uname -s && uname -m");
+  need(platform, "could not inspect platform");
+  const [os, arch] = platform.stdout.trim().split(/\s+/);
+  if (os !== "Darwin" || arch !== "arm64") {
+    throw new Error(`macos execution node requires Darwin arm64; found ${os || "unknown"} ${arch || "unknown"}`);
+  }
+  need(
+    await driver.exec(
+      'uid=$(id -u); [ "$(stat -f %Su /dev/console)" = "$(id -un)" ] && launchctl print "gui/$uid" >/dev/null 2>&1',
+    ),
+    "the SSH user must be the logged-in Aqua console user",
+  );
+  need(await driver.exec("xcode-select -p >/dev/null && xcodebuild -version"), "full Xcode is unavailable");
+  need(await driver.exec("test -x /usr/bin/python3 && /usr/bin/python3 --version"), "Python 3 is unavailable");
+  need(await driver.exec(`test -x ${shellQuoteWord(runtime.bun)} && ${shellQuoteWord(runtime.bun)} --version`), "Bun is unavailable at the configured remote home");
+  need(await driver.exec(`test -x ${shellQuoteWord(runtime.claude)} && ${shellQuoteWord(runtime.claude)} --version`), "Claude CLI is unavailable at the configured remote home");
+  const opencode = await driver.exec(
+    `test -x ${shellQuoteWord(runtime.opencode)} && ${shellQuoteWord(runtime.opencode)} --version`,
+  );
+  need(opencode, "OpenCode is unavailable at the configured remote home");
+  if (opencode.stdout.trim() !== REMOTE_OPENCODE_VERSION) {
+    throw new Error(
+      `macos execution node OpenCode version mismatch: got ${opencode.stdout.trim() || "unknown"}, want ${REMOTE_OPENCODE_VERSION}`,
+    );
+  }
+  need(
+    await driver.exec(`test -f ${shellQuoteWord(runtime.hostEntry)}`),
+    `runner host is missing at ${runtime.hostEntry}`,
+  );
+  need(
+    await driver.exec(
+      `test -d ${shellQuoteWord(`${runtime.runnerRepo}/node_modules`)} && test -s ${shellQuoteWord(`${runtime.home}/.claude/settings.json`)}`,
+    ),
+    "runner dependencies or ~/.claude/settings.json are missing; finish Mac provisioning",
+  );
+  const head = await driver.exec(`git -C ${shellQuoteWord(runtime.runnerRepo)} rev-parse HEAD`);
+  need(head, `runner checkout is not a git repository at ${runtime.runnerRepo}`);
+  if (head.stdout.trim() !== expectedRunnerSha) {
+    throw new Error(
+      `macos execution node runner SHA mismatch: got ${head.stdout.trim() || "unknown"}, want ${expectedRunnerSha}; update the provisioned runner checkout before selecting macos`,
+    );
+  }
+}
+
+async function localRunnerSha(): Promise<string> {
+  const ref = sandboxConfig().runnerSha || "HEAD";
+  const proc = Bun.spawn(["git", "-C", REPO_ROOT, "rev-parse", `${ref}^{commit}`], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  if (exitCode !== 0 || !stdout.trim()) {
+    throw new Error(
+      `could not resolve Backstage runner ref ${ref}; set runnerSha to a commit available in ${REPO_ROOT}`,
+    );
+  }
+  return stdout.trim();
+}
+
+function macosRuntime(config: MacosSshConfig): RemoteRuntimePaths {
+  return remoteRuntimePaths(
+    config.remoteHome,
+    `${config.remoteHome}/projects/tella-backstage`,
+    `${config.remoteHome}/.bun/bin:${config.remoteHome}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`,
+  );
+}
+
+export class MacosProvider implements SandboxProvider {
+  readonly id = "macos" as const;
+
+  ensure(spec: SandboxSessionSpec): Promise<Sandbox> {
+    return withRemoteEnsureLock(this.id, spec.sessionId, () => this.ensureInner(spec));
+  }
+
+  private async ensureInner(spec: SandboxSessionSpec): Promise<Sandbox> {
+    if (spec.attachedDirs?.length) {
+      throw new Error("attached repos are not supported on the macos execution node — detach them or use docker/local");
+    }
+    const config = validateSshConfig(sandboxConfig().macos);
+    const runtime = macosRuntime(config);
+    const previous = findRemoteStateBySession(this.id, spec.sessionId);
+    const repo = getRepo(spec.repo || previous?.repoId);
+    const branch = spec.branch || previous?.branch || repo.defaultBranch;
+    // Never reuse spec.cwd: that is the Linux parent's path. Every child gets
+    // a clone rooted under the Mac user's home, isolated by session id.
+    const cwd =
+      previous?.cwd ||
+      `${config.remoteHome}/.opensession-workspaces/${sanitizeName(spec.sessionId)}/${sanitizeName(repo.id)}`;
+    const sandboxId = previous?.sandboxId || `macos-${sanitizeName(spec.sessionId)}`;
+    const driver = createMacosSshDriver(config, spec.sessionId);
+
+    await driver.ensureStarted();
+    await verifyMacosReadiness(driver, runtime, await localRunnerSha());
+    await assertDialbackReachable(driver, "macos", sandboxCallbackBaseUrl());
+    await setupRemoteWorkspace(
+      driver,
+      cwd,
+      await remoteCloneUrl(repo),
+      branch,
+      repo.defaultBranch,
+      undefined,
+      runtime,
+    );
+    writeRemoteState({
+      sandboxId,
+      provider: this.id,
+      sessionId: spec.sessionId,
+      cwd,
+      repoId: repo.id,
+      branch,
+      createdAt: previous?.createdAt || new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+    });
+    return this.makeHandle(sandboxId, spec.sessionId, cwd, driver, runtime);
+  }
+
+  private makeHandle(
+    sandboxId: string,
+    sessionId: string,
+    cwd: string,
+    driver: RemoteDriver,
+    runtime: RemoteRuntimePaths,
+  ): Sandbox {
+    const providerId = this.id;
+    const launchLocks = new Map<string, MacosMutationLock>();
+    return makeRemoteSandbox({
+      providerId,
+      sandboxId,
+      sessionId,
+      cwd,
+      driver,
+      runtime,
+      callbackBaseUrl: sandboxCallbackBaseUrl,
+      beforeRun: async (spec) => {
+        const lock = await acquireMacosMutationLock(driver, runtime);
+        try {
+          await acquireMacosLeaseInner(
+            driver,
+            runtime,
+            sessionId,
+            spec.hostId,
+            new Date(),
+            true,
+          );
+          launchLocks.set(spec.hostId, lock);
+        } catch (error) {
+          await releaseMacosMutationLock(driver, runtime, lock);
+          throw error;
+        }
+      },
+      afterLaunch: async (spec) => {
+        const lock = launchLocks.get(spec.hostId);
+        if (!lock) return;
+        launchLocks.delete(spec.hostId);
+        await releaseMacosMutationLock(driver, runtime, lock);
+      },
+      afterRun: (spec) =>
+        cleanupMacosRun(driver, runtime, sessionId, spec.hostId),
+      recoverStaleRun: (_sessionId, runId) =>
+        cleanupMacosRun(driver, runtime, sessionId, runId),
+      async ports(): Promise<PortMap> {
+        return {};
+      },
+      async status(): Promise<SandboxStatus> {
+        const status = await driver.exec("true", { timeoutMs: 15_000 });
+        return status.exitCode === 0 ? "running" : "gone";
+      },
+      touchActivity: () => touchRemoteState(providerId, sandboxId),
+    });
+  }
+
+  async get(sandboxId: string): Promise<Sandbox | null> {
+    const state = readRemoteState(this.id, sandboxId);
+    if (!state) return null;
+    const config = validateSshConfig(sandboxConfig().macos);
+    const runtime = macosRuntime(config);
+    const driver = createMacosSshDriver(config, state.sessionId);
+    await driver.ensureStarted();
+    await verifyMacosReadiness(driver, runtime, await localRunnerSha());
+    return this.makeHandle(sandboxId, state.sessionId, state.cwd, driver, runtime);
+  }
+
+  async destroy(sandboxId: string): Promise<void> {
+    const state = readRemoteState(this.id, sandboxId);
+    if (!state) {
+      removeRemoteState(this.id, sandboxId);
+      return;
+    }
+    try {
+      const config = validateSshConfig(sandboxConfig().macos);
+      const runtime = macosRuntime(config);
+      const driver = createMacosSshDriver(config, state.sessionId);
+      await cleanupMacosRun(
+        driver,
+        runtime,
+        state.sessionId,
+        undefined,
+        state.cwd,
+      );
+    } catch (error) {
+      console.warn(
+        `[sandbox:macos] destroy(${sandboxId}) remote cleanup failed; retaining state for retry:`,
+        error,
+      );
+      throw error;
+    }
+    removeRemoteState(this.id, sandboxId);
+  }
+}
+
+// ── Remote asset import (opensession-assets' import_remote_asset tool) ───────
+//
+// A remote child session can only hand us a path relative to ITS workspace —
+// no Linux SSH credential or reverse connection reaches it. Backstage
+// resolves the session's sandbox state server-side, confines the path to the
+// remote workspace root, stats + checksums before transfer, and reads the
+// bytes over the same noninteractive SSH transport every other macos
+// operation uses. The MVP buffers the whole file in the Backstage process
+// (capped by the caller's maxBytes, session-assets.ts's MAX_IMPORT_BYTES) —
+// writing to disk is session-assets.ts's job (importAsset), not this
+// adapter's, so macos.ts stays free of "assets" concept knowledge.
+
+export interface MacosRemoteStat {
+  kind: "file" | "dir" | "missing";
+  size: number;
+  sha256?: string;
+}
+
+const REMOTE_ASSET_OPEN_SCRIPT = `
+import hashlib
+import os
+import stat
+import sys
+
+root, relative, mode = sys.argv[1:4]
+parts = relative.split("/")
+if not relative or any(part in ("", ".", "..") for part in parts):
+    print("invalid workspace-relative asset path", file=sys.stderr)
+    sys.exit(80)
+
+flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+dir_flags = flags | os.O_DIRECTORY
+fds = []
+try:
+    current = os.open(root, dir_flags)
+    fds.append(current)
+    for part in parts[:-1]:
+        current = os.open(part, dir_flags, dir_fd=current)
+        fds.append(current)
+    try:
+        target = os.open(parts[-1], flags, dir_fd=current)
+    except FileNotFoundError:
+        if mode == "stat":
+            print("MISSING")
+            sys.exit(0)
+        raise
+    fds.append(target)
+    info = os.fstat(target)
+    if stat.S_ISDIR(info.st_mode):
+        if mode == "stat":
+            print("DIR")
+            sys.exit(0)
+        print("remote asset is a directory", file=sys.stderr)
+        sys.exit(82)
+    if not stat.S_ISREG(info.st_mode):
+        print("remote asset is not a regular file", file=sys.stderr)
+        sys.exit(82)
+    if mode == "stat":
+        digest = hashlib.sha256()
+        while True:
+            chunk = os.read(target, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+        print(info.st_size)
+        print(digest.hexdigest())
+    elif mode == "read":
+        while True:
+            chunk = os.read(target, 1024 * 1024)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                written = os.write(1, view)
+                view = view[written:]
+    else:
+        print("invalid asset operation", file=sys.stderr)
+        sys.exit(80)
+except OSError as error:
+    print("cannot open confined remote asset: %s" % error, file=sys.stderr)
+    sys.exit(82)
+finally:
+    for fd in reversed(fds):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+`;
+
+function remoteAssetCommand(
+  remoteWorkspace: string,
+  absPath: string,
+  mode: "stat" | "read",
+): string {
+  const prefix = `${remoteWorkspace}/`;
+  if (!absPath.startsWith(prefix)) {
+    throw new Error("macos asset path escapes the workspace");
+  }
+  const relative = absPath.slice(prefix.length);
+  if (!relative || relative.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error("macos asset path must name a file inside the workspace");
+  }
+  return `/usr/bin/python3 -c ${shellQuoteWord(REMOTE_ASSET_OPEN_SCRIPT)} ${shellQuoteWord(remoteWorkspace)} ${shellQuoteWord(relative)} ${mode}`;
+}
+
+/** Stat + checksum a remote path through one descriptor-rooted open. */
+export async function statMacosRemotePath(
+  driver: RemoteDriver,
+  remoteWorkspace: string,
+  absPath: string,
+): Promise<MacosRemoteStat> {
+  const result = await driver.exec(
+    remoteAssetCommand(remoteWorkspace, absPath, "stat"),
+    { timeoutMs: 30_000 },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `macos asset stat failed: ${(result.stderr || result.stdout).trim().slice(0, 300)}`,
+    );
+  }
+  const out = result.stdout.trim();
+  if (out === "DIR") return { kind: "dir", size: 0 };
+  if (out === "MISSING" || !out) return { kind: "missing", size: 0 };
+  const [sizeLine, shaLine] = out.split("\n");
+  const size = Number((sizeLine || "").trim());
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(`macos asset stat returned an unexpected size: ${JSON.stringify(sizeLine)}`);
+  }
+  const sha256 = shaLine?.trim() || "";
+  if (!/^[0-9a-fA-F]{64}$/.test(sha256)) {
+    throw new Error(`macos asset stat returned an invalid sha256: ${JSON.stringify(shaLine)}`);
+  }
+  return { kind: "file", size, sha256: sha256.toLowerCase() };
+}
+
+/** Confine a remote-child-supplied path to the session's remote workspace —
+ *  the only path input import_remote_asset accepts from the model. */
+export function resolveMacosWorkspacePath(remoteWorkspace: string, relPath: string): string {
+  const raw = (relPath || "").trim().replace(/^\.\//, "");
+  if (!raw) throw new Error("remotePath is required");
+  if (raw.startsWith("/") || raw.includes("\0") || raw.split("/").includes("..")) {
+    throw new Error(
+      `remotePath must be relative inside the session's remote workspace (no leading /, no ..): ${relPath}`,
+    );
+  }
+  return `${remoteWorkspace}/${raw}`;
+}
+
+/** A minimal duck-typed process handle so pipeMacosRemoteFile can be unit
+ *  tested against a fake byte stream instead of a real SSH connection. */
+export interface MacosRemoteProcess {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill(): void;
+}
+
+export type MacosRemoteSpawner = (argv: string[]) => MacosRemoteProcess;
+
+export async function readCappedStreamText(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  failOnOverflow = false,
+): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let retained = 0;
+  let overflowed = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remaining = maxBytes - retained;
+      if (remaining <= 0) {
+        overflowed = true;
+        continue;
+      }
+      const chunk = value.byteLength <= remaining ? value : value.subarray(0, remaining);
+      chunks.push(chunk);
+      retained += chunk.byteLength;
+      if (chunk.byteLength < value.byteLength) overflowed = true;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (overflowed && failOnOverflow) {
+    throw new Error(`remote command stdout exceeds the ${maxBytes}-byte capture cap`);
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+}
+
+function defaultMacosRemoteSpawn(argv: string[]): MacosRemoteProcess {
+  const proc = Bun.spawn(argv, { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  return {
+    stdout: proc.stdout as ReadableStream<Uint8Array>,
+    stderr: proc.stderr as ReadableStream<Uint8Array>,
+    exited: proc.exited,
+    kill: () => {
+      try {
+        proc.kill();
+      } catch {}
+    },
+  };
+}
+
+/** Stream one remote file's raw bytes to a caller-provided sink. Stdout is
+ * never decoded through text/base64, and the cap is enforced mid-stream. */
+export async function pipeMacosRemoteFile<T>(
+  config: MacosSshConfig,
+  remoteWorkspace: string,
+  absPath: string,
+  maxBytes: number,
+  consume: (chunks: AsyncIterable<Uint8Array>) => Promise<T>,
+  spawn: MacosRemoteSpawner = defaultMacosRemoteSpawn,
+): Promise<T> {
+  const argv = buildSshArgs(
+    config,
+    remoteAssetCommand(remoteWorkspace, absPath, "read"),
+  );
+  const proc = spawn(argv);
+  const reader = proc.stdout.getReader();
+  const stderrPromise = readCappedStreamText(proc.stderr, 64 * 1024);
+  void stderrPromise.catch(() => {});
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, 120_000);
+  (timeout as { unref?: () => void }).unref?.();
+  const chunks = (async function* (): AsyncGenerator<Uint8Array> {
+    let total = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > maxBytes) {
+          throw new Error(`remote asset exceeds the ${maxBytes}-byte import cap`);
+        }
+        yield value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+  const stopStdout = async () => {
+    try {
+      await reader.cancel();
+    } catch {
+      try {
+        await proc.stdout.cancel();
+      } catch {}
+    }
+    try {
+      reader.releaseLock();
+    } catch {}
+  };
+  try {
+    const consumed = await consume(chunks);
+    await stopStdout();
+    const exitCode = await proc.exited;
+    const stderr = await stderrPromise;
+    if (timedOut) throw new Error("macos asset fetch timed out");
+    if (exitCode !== 0) {
+      throw new Error(
+        `macos asset fetch failed (ssh exit ${exitCode}): ${stderr.trim().slice(0, 300) || "no stderr"}`,
+      );
+    }
+    return consumed;
+  } catch (error) {
+    await stopStdout();
+    try {
+      proc.kill();
+    } catch {}
+    await proc.exited.catch(() => 1);
+    await stderrPromise.catch(() => "");
+    if (timedOut) throw new Error("macos asset fetch timed out");
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export interface MacosAssetFetchInput<T> {
+  sandboxId: string;
+  sessionId: string;
+  remotePath: string;
+  maxBytes: number;
+  consume: (
+    chunks: AsyncIterable<Uint8Array>,
+    expected: { size: number; sha256: string },
+  ) => Promise<T>;
+}
+
+export interface MacosAssetFetchResult<T> {
+  value: T;
+  remoteAbsPath: string;
+}
+
+/**
+ * Fetch one file out of a macOS execution-node session's remote workspace,
+ * over the same noninteractive SSH transport as every other macos operation.
+ * The remote child supplies only remotePath (workspace-relative); Backstage
+ * resolves the session's own sandbox state to find the workspace root and
+ * SSH config — no Linux credential or reverse connection reaches the child.
+ */
+export async function fetchMacosAsset<T>(
+  input: MacosAssetFetchInput<T>,
+): Promise<MacosAssetFetchResult<T>> {
+  const state = readRemoteState("macos", input.sandboxId);
+  if (!state) {
+    throw new Error(
+      `macos execution node has no recorded workspace for sandbox ${input.sandboxId} — run something on this session before importing an asset`,
+    );
+  }
+  if (state.sessionId !== input.sessionId) {
+    throw new Error("macos sandbox state does not belong to this session");
+  }
+  const config = validateSshConfig(sandboxConfig().macos);
+  const absPath = resolveMacosWorkspacePath(state.cwd, input.remotePath);
+  const driver = createMacosSshDriver(config, state.sessionId);
+  const info = await statMacosRemotePath(driver, state.cwd, absPath);
+  if (info.kind === "missing") {
+    throw new Error(`remote asset not found in the session workspace: ${input.remotePath}`);
+  }
+  if (info.kind === "dir") {
+    throw new Error(`remote asset path is a directory, not a file: ${input.remotePath}`);
+  }
+  if (info.size > input.maxBytes) {
+    throw new Error(
+      `remote asset is ${info.size} bytes, over the ${input.maxBytes}-byte import cap`,
+    );
+  }
+  const value = await pipeMacosRemoteFile(
+    config,
+    state.cwd,
+    absPath,
+    input.maxBytes,
+    (chunks) => input.consume(chunks, { size: info.size, sha256: info.sha256! }),
+  );
+  return { value, remoteAbsPath: absPath };
+}

--- a/src/server/sandbox/capability-status.test.ts
+++ b/src/server/sandbox/capability-status.test.ts
@@ -84,6 +84,7 @@ describe("sandboxCapabilityStatus (the /api/sandbox/status payload)", () => {
       "box",
       "modal",
       "lambda-microvm",
+      "macos",
     ]);
     expect(s.providers.every((p) => !p.configured)).toBe(true);
     expect(s.killSwitch).toBe(!sandboxesEnabled());
@@ -164,6 +165,49 @@ describe("sandboxCapabilityStatus (the /api/sandbox/status payload)", () => {
       idleSuspendSeconds: undefined,
       suspendedDurationSeconds: 90,
     });
+  });
+
+  test("macos requires a host and absolute remote home in config", () => {
+    write({ provider: "macos", macos: { host: "mac-mini.tailnet.ts.net" } });
+    expect(sandboxProviderConfigured("macos")).toBe(false);
+    write({
+      provider: "macos",
+      macos: { host: "mac-mini.tailnet.ts.net", remoteHome: "Users/opensession" },
+    });
+    expect(sandboxProviderConfigured("macos")).toBe(false);
+    write({
+      provider: "macos",
+      macos: {
+        host: "mac-mini.tailnet.ts.net",
+        user: "opensession",
+        port: 2222,
+        identityFile: "/home/ubuntu/.ssh/mac-mini",
+        remoteHome: "/Users/opensession",
+      },
+      callbackBaseUrl: "wss://os.tailnet.ts.net",
+    });
+    expect(sandboxConfig().macos).toEqual({
+      host: "mac-mini.tailnet.ts.net",
+      user: "opensession",
+      port: 2222,
+      identityFile: "/home/ubuntu/.ssh/mac-mini",
+      remoteHome: "/Users/opensession",
+    });
+    expect(sandboxProviderConfigured("macos")).toBe(true);
+    expect(
+      sandboxCapabilityStatus().providers.find((provider) => provider.id === "macos")?.note,
+    ).toBeUndefined();
+  });
+
+  test("macos specifically requires the tailnet callback URL", () => {
+    write({
+      provider: "macos",
+      macos: { host: "mac-mini.tailnet.ts.net", remoteHome: "/Users/opensession" },
+      publicIngress: { enabled: true, publicBaseUrl: "wss://public.example.com" },
+    });
+    const macos = sandboxCapabilityStatus().providers.find((provider) => provider.id === "macos")!;
+    expect(macos.configured).toBe(true);
+    expect(macos.note).toContain("Tailscale dial-back URL");
   });
 
   test("an explicit callbackBaseUrl also counts as dial-back configured", () => {
@@ -261,6 +305,7 @@ describe("resolveRequestedSandbox (create-path validation)", () => {
       daytona: { apiKey: "dtn_x" },
       modal: { tokenId: "ak-test", tokenSecret: "as-test" },
       awsLambdaMicrovm: { imageIdentifier: "arn:aws:lambda:us-east-1:123:microvm-image/test" },
+      macos: { host: "mac-mini.tailnet.ts.net", remoteHome: "/Users/opensession" },
     });
     expect(resolveRequestedSandbox("docker")).toEqual({ ok: true, provider: "docker" });
     expect(resolveRequestedSandbox("daytona")).toEqual({ ok: true, provider: "daytona" });
@@ -269,6 +314,7 @@ describe("resolveRequestedSandbox (create-path validation)", () => {
       ok: true,
       provider: "lambda-microvm",
     });
+    expect(resolveRequestedSandbox("macos")).toEqual({ ok: true, provider: "macos" });
     expect(resolveRequestedSandbox("DOCKER")).toEqual({ ok: true, provider: "docker" });
   });
 

--- a/src/server/sandbox/config.ts
+++ b/src/server/sandbox/config.ts
@@ -198,6 +198,26 @@ export interface SandboxAwsLambdaMicrovmConfig {
   logGroup?: string;
 }
 
+/** Fixed macOS execution node reached over Tailscale SSH. Credentials stay in
+ * the operator-owned config file; no host key or private key is checked in. */
+export interface SandboxMacosConfig {
+  host?: string;
+  user?: string;
+  port?: number;
+  identityFile?: string;
+  remoteHome?: string;
+}
+
+function macosConfigValid(config: SandboxMacosConfig | undefined): boolean {
+  return Boolean(
+    config?.host &&
+      !config.host.startsWith("-") &&
+      !/\s/.test(config.host) &&
+      config.remoteHome?.startsWith("/") &&
+      (!config.user || /^[A-Za-z0-9._-]+$/.test(config.user)),
+  );
+}
+
 export interface SandboxConfig {
   provider: SandboxProviderId;
   /** Container image for the docker provider (Phase 1). */
@@ -246,6 +266,8 @@ export interface SandboxConfig {
   modal?: SandboxModalConfig;
   /** AWS Lambda MicroVM adapter (provider "lambda-microvm"). */
   awsLambdaMicrovm?: SandboxAwsLambdaMicrovmConfig;
+  /** Fixed macOS SSH execution node (provider "macos"). */
+  macos?: SandboxMacosConfig;
   /** Clone auth for remote-provider workspaces + runner bootstrap. */
   cloneCredential?: SandboxCloneCredential;
   /** Warm-on-typing prewarm pool (remote providers). Absent = defaults, with
@@ -269,6 +291,7 @@ const PROVIDER_IDS = new Set<string>([
   "box",
   "modal",
   "lambda-microvm",
+  "macos",
 ]);
 
 function asProviderId(v: unknown): SandboxProviderId | undefined {
@@ -416,6 +439,22 @@ export function sandboxConfig(): SandboxConfig {
                 logGroup: str(raw.awsLambdaMicrovm.logGroup),
               }
             : undefined,
+        macos:
+          raw?.macos && typeof raw.macos === "object"
+            ? {
+                host: str(raw.macos.host),
+                user: str(raw.macos.user),
+                port:
+                  typeof raw.macos.port === "number" &&
+                  Number.isInteger(raw.macos.port) &&
+                  raw.macos.port > 0 &&
+                  raw.macos.port < 65536
+                    ? raw.macos.port
+                    : undefined,
+                identityFile: str(raw.macos.identityFile),
+                remoteHome: str(raw.macos.remoteHome),
+              }
+            : undefined,
         cloneCredential:
           raw?.cloneCredential?.type === "https-token" ||
           raw?.cloneCredential?.type === "none"
@@ -500,6 +539,7 @@ export const RUNNABLE_SANDBOX_PROVIDERS = [
   "box",
   "modal",
   "lambda-microvm",
+  "macos",
 ] as const;
 export type RunnableSandboxProviderId = (typeof RUNNABLE_SANDBOX_PROVIDERS)[number];
 
@@ -514,13 +554,14 @@ export function isRunnableSandboxProvider(v: unknown): v is RunnableSandboxProvi
  *  volume-style (cloned inside the sandbox; no host fallback for runs). */
 export function isRemoteSandboxProvider(
   v: unknown,
-): v is "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" {
+): v is "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos" {
   return (
     v === "daytona" ||
     v === "e2b" ||
     v === "box" ||
     v === "modal" ||
-    v === "lambda-microvm"
+    v === "lambda-microvm" ||
+    v === "macos"
   );
 }
 
@@ -577,6 +618,7 @@ const ALL_ENVIRONMENTS: Record<SandboxEnvironmentId, boolean> = {
   box: true,
   modal: true,
   "lambda-microvm": true,
+  macos: true,
 };
 
 export const SANDBOX_MODEL_FAMILIES: SandboxModelFamily[] = [
@@ -603,7 +645,7 @@ export const SANDBOX_MODEL_FAMILIES: SandboxModelFamily[] = [
     id: "opencode-other",
     label: "OpenCode (other providers)",
     match: { provider: "opencode" },
-    environments: { local: true, docker: false, daytona: false, e2b: false, box: false, modal: false, "lambda-microvm": false },
+    environments: { local: true, docker: false, daytona: false, e2b: false, box: false, modal: false, "lambda-microvm": false, macos: false },
     hint: "its `opencode auth login` credential only exists on the host",
   },
   {
@@ -613,7 +655,7 @@ export const SANDBOX_MODEL_FAMILIES: SandboxModelFamily[] = [
     id: "codex",
     label: "GPT (Codex)",
     match: { provider: "codex" },
-    environments: { local: true, docker: false, daytona: false, e2b: false, box: false, modal: false, "lambda-microvm": false },
+    environments: { local: true, docker: false, daytona: false, e2b: false, box: false, modal: false, "lambda-microvm": false, macos: false },
     hint: "Codex account state stays on the host; use an opencode/openai/* model to run GPT in a sandbox",
   },
   {
@@ -632,6 +674,7 @@ const ENVIRONMENT_LABELS: Record<SandboxEnvironmentId, string> = {
   box: "Box",
   modal: "Modal",
   "lambda-microvm": "AWS Lambda MicroVM",
+  macos: "macOS",
 };
 
 /** The matrix row a model (or the current default, for ""/undefined) falls
@@ -714,6 +757,7 @@ export function sandboxProviderConfigured(id: RunnableSandboxProviderId): boolea
     );
   }
   if (id === "lambda-microvm") return Boolean(cfg.awsLambdaMicrovm?.imageIdentifier);
+  if (id === "macos") return macosConfigValid(cfg.macos);
   return Boolean(cfg.e2b?.apiKey || process.env.E2B_API_KEY);
 }
 
@@ -737,6 +781,7 @@ export function sandboxCapabilityStatus(): SandboxCapabilityStatus {
         modalConfigHasCredentials(),
     );
   const lambdaMicrovmConfigured = enabled && Boolean(cfg.awsLambdaMicrovm?.imageIdentifier);
+  const macosConfigured = enabled && macosConfigValid(cfg.macos);
   // Remote sandboxes must dial back over WS: healthy = a public-ingress URL or
   // an explicit callbackBaseUrl is configured, and then the row shows no note.
   // Only an actually-missing dial-back URL surfaces a caveat (no static
@@ -749,6 +794,11 @@ export function sandboxCapabilityStatus(): SandboxCapabilityStatus {
     ? {}
     : {
         note: "no dial-back URL configured — set publicIngress.publicBaseUrl (or callbackBaseUrl) so sandboxes can reach this server; see docs/self-hosting-sandboxes.md",
+      };
+  const macosNote = cfg.callbackBaseUrl
+    ? {}
+    : {
+        note: "no Tailscale dial-back URL configured — set callbackBaseUrl so the Mac can reach this server; see docs/self-hosting-sandboxes.md",
       };
   const providers: SandboxProviderStatusEntry[] = [
     { id: "docker", configured: enabled },
@@ -776,6 +826,11 @@ export function sandboxCapabilityStatus(): SandboxCapabilityStatus {
       id: "lambda-microvm",
       configured: lambdaMicrovmConfigured,
       ...(lambdaMicrovmConfigured ? remoteNote : {}),
+    },
+    {
+      id: "macos",
+      configured: macosConfigured,
+      ...(macosConfigured ? macosNote : {}),
     },
   ];
   return {
@@ -818,7 +873,7 @@ export function resolveRequestedSandbox(
   if (!isRunnableSandboxProvider(id)) {
     return {
       ok: false,
-      error: `Unknown sandbox provider "${requested}" — valid values: docker, daytona, e2b, box, modal, lambda-microvm (or true for the configured default).`,
+      error: `Unknown sandbox provider "${requested}" — valid values: docker, daytona, e2b, box, modal, lambda-microvm, macos (or true for the configured default).`,
     };
   }
   if (!sandboxProviderConfigured(id)) {
@@ -833,6 +888,8 @@ export function resolveRequestedSandbox(
               ? 'set {"modal":{"tokenId":"…","tokenSecret":"…"}} in ~/.opensession-sandbox.json (or MODAL_TOKEN_ID/MODAL_TOKEN_SECRET)'
               : id === "lambda-microvm"
                 ? 'set {"awsLambdaMicrovm":{"imageIdentifier":"arn:aws:lambda:…:microvm-image/…"}} in ~/.opensession-sandbox.json'
+                : id === "macos"
+                  ? 'set {"macos":{"host":"mac.example.ts.net","remoteHome":"/Users/opensession"}} in ~/.opensession-sandbox.json'
                 : 'set {"e2b":{"apiKey":"…"}} in ~/.opensession-sandbox.json (or E2B_API_KEY)';
     return {
       ok: false,

--- a/src/server/sandbox/index.ts
+++ b/src/server/sandbox/index.ts
@@ -16,6 +16,7 @@ import { E2bProvider } from "./adapters/e2b";
 import { BoxProvider } from "./adapters/box";
 import { ModalProvider } from "./adapters/modal";
 import { LambdaMicrovmProvider } from "./adapters/lambda-microvm";
+import { MacosProvider } from "./adapters/macos";
 import { effectiveSandboxProvider } from "./config";
 import type { SandboxProvider, SandboxProviderId } from "./provider";
 
@@ -57,6 +58,7 @@ const e2bProvider = new E2bProvider();
 const boxProvider = new BoxProvider();
 const modalProvider = new ModalProvider();
 const lambdaMicrovmProvider = new LambdaMicrovmProvider();
+const macosProvider = new MacosProvider();
 
 /**
  * Resolve a SandboxProvider. `spec` (a provider id, e.g. from a session file's
@@ -83,6 +85,8 @@ export function getSandboxProvider(
       return modalProvider;
     case "lambda-microvm":
       return lambdaMicrovmProvider;
+    case "macos":
+      return macosProvider;
     default:
       throw new Error(`unknown sandbox provider "${id}"`);
   }

--- a/src/server/sandbox/provider.ts
+++ b/src/server/sandbox/provider.ts
@@ -30,7 +30,8 @@ export type SandboxProviderId =
   | "e2b"
   | "box"
   | "modal"
-  | "lambda-microvm";
+  | "lambda-microvm"
+  | "macos";
 
 /**
  * Everything a provider needs to create-or-reuse the sandbox for a session.

--- a/src/server/sandbox/workspace-exec.test.ts
+++ b/src/server/sandbox/workspace-exec.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { workspaceExecFor } from "./workspace-exec";
+
+describe("workspaceExecFor", () => {
+  test("fails closed for a volume workspace before sandbox materialization", async () => {
+    const exec = await workspaceExecFor({
+      worktreeDir: "/remote/workspace",
+      sandbox: { provider: "macos", workspace: "volume" },
+    });
+
+    expect(exec.sandboxed).toBe(true);
+    expect(exec.remote).toBe(true);
+    expect(await exec(["pwd"])).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "remote sandbox macos is unavailable",
+    });
+  });
+});

--- a/src/server/sandbox/workspace-exec.ts
+++ b/src/server/sandbox/workspace-exec.ts
@@ -83,8 +83,8 @@ export function hasRemoteWorkspace(
  * Resolve the exec for a session's workspace. `dir` defaults to the session's
  * primary `worktreeDir`; pass an attached repo's dir explicitly to target it
  * (attached repos are host worktrees, so they resolve to host exec unless the
- * sandbox actually mounts them). Never throws — every failure mode falls back
- * to the host exec, which is exactly the no-sandbox behavior.
+ * sandbox actually mounts them). Never throws. Host-visible workspaces retain
+ * the no-sandbox fallback; volume workspaces fail closed while unavailable.
  */
 export async function workspaceExecFor(
   session: WorkspaceExecSession | null | undefined,
@@ -93,15 +93,16 @@ export async function workspaceExecFor(
   const cwd = dir || session?.worktreeDir || "";
   const host = hostWorkspaceExec(cwd);
   const sb = session?.sandbox;
-  if (!cwd || !sb?.provider || !sb.sandboxId) return host;
   const unavailableRemote = Object.assign(
     async (): Promise<ExecResult> => ({
       exitCode: 1,
       stdout: "",
-      stderr: `remote sandbox ${sb.sandboxId} is unavailable`,
+      stderr: `remote sandbox ${sb?.sandboxId || sb?.provider || "workspace"} is unavailable`,
     }),
     { sandboxed: true, remote: true } as const,
   );
+  if (!cwd || !sb?.provider) return host;
+  if (!sb.sandboxId) return sb.workspace === "volume" ? unavailableRemote : host;
   try {
     if (!sandboxesEnabled()) {
       return sb.workspace === "volume" ? unavailableRemote : host;

--- a/src/server/session-assets.test.ts
+++ b/src/server/session-assets.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	assetsDirFor,
+	importAsset,
+	importAssetStream,
+	MAX_IMPORT_BYTES,
+	resolveAssetPath,
+	writeAsset,
+} from "./session-assets";
+
+let uniq = 0;
+const sessionIds: string[] = [];
+const tempDirs: string[] = [];
+
+function testSessionId(): string {
+	const id = `test-session-assets-${Date.now()}-${++uniq}`;
+	sessionIds.push(id);
+	return id;
+}
+
+afterEach(() => {
+	for (const id of sessionIds.splice(0)) {
+		try {
+			rmSync(assetsDirFor(id), { recursive: true, force: true });
+		} catch {}
+	}
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("resolveAssetPath (destination confinement)", () => {
+	test("resolves a relative path inside the session's assets dir", () => {
+		const id = testSessionId();
+		const { abs, rel } = resolveAssetPath(id, "reports/demo.mp4");
+		expect(rel).toBe("reports/demo.mp4");
+		expect(abs).toBe(`${assetsDirFor(id)}/reports/demo.mp4`);
+	});
+
+	test("rejects absolute paths and traversal out of the assets dir", () => {
+		const id = testSessionId();
+		expect(() => resolveAssetPath(id, "/etc/passwd")).toThrow();
+		expect(() => resolveAssetPath(id, "../secrets")).toThrow();
+		expect(() => resolveAssetPath(id, "reports/../../secrets")).toThrow();
+		expect(() => resolveAssetPath(id, "")).toThrow();
+	});
+});
+
+describe("importAsset (import_remote_asset's local write helper)", () => {
+	test("writes an already-fetched buffer and returns its listing row", async () => {
+		const id = testSessionId();
+		const payload = Buffer.from([0, 1, 2, 255, 254, 253, 128, 10, 13, 0]);
+		const row = await importAsset(id, "artifacts/demo.bin", payload);
+		expect(row.path).toBe("artifacts/demo.bin");
+		expect(row.size).toBe(payload.byteLength);
+		const onDisk = readFileSync(`${assetsDirFor(id)}/artifacts/demo.bin`);
+		expect(new Uint8Array(onDisk)).toEqual(new Uint8Array(payload));
+	});
+
+	test("enforces MAX_IMPORT_BYTES even though callers are expected to cap upstream", async () => {
+		const id = testSessionId();
+		const oversized = Buffer.allocUnsafe(MAX_IMPORT_BYTES + 1);
+		await expect(importAsset(id, "too-big.bin", oversized)).rejects.toThrow(/too large/);
+	});
+
+	test("still enforces destination confinement (no traversal via destPath)", async () => {
+		const id = testSessionId();
+		await expect(importAsset(id, "../escape.bin", Buffer.from("x"))).rejects.toThrow();
+	});
+
+	test("does not publish a streamed asset whose integrity check fails", async () => {
+		const id = testSessionId();
+		await expect(
+			importAssetStream(
+				id,
+				"artifacts/bad.bin",
+				(async function* () {
+					yield Buffer.from("first ");
+					yield Buffer.from("second");
+				})(),
+				{ size: 12, sha256: "0".repeat(64) },
+			),
+		).rejects.toThrow(/integrity check failed/);
+		expect(existsSync(join(assetsDirFor(id), "artifacts", "bad.bin"))).toBe(false);
+	});
+
+	test("removes the temporary file when the source stream is interrupted", async () => {
+		const id = testSessionId();
+		const artifacts = join(assetsDirFor(id), "artifacts");
+		await expect(
+			importAssetStream(
+				id,
+				"artifacts/interrupted.bin",
+				(async function* () {
+					yield Buffer.alloc(1024 * 1024, 1);
+					await Bun.sleep(50);
+					throw new Error("source interrupted");
+				})(),
+				{ size: 2 * 1024 * 1024, sha256: "0".repeat(64) },
+			),
+		).rejects.toThrow("source interrupted");
+		expect(existsSync(join(artifacts, "interrupted.bin"))).toBe(false);
+		expect(readdirSync(artifacts).filter((name) => name.startsWith(".opensession-import-"))).toEqual(
+			[],
+		);
+	});
+
+	test("rejects a symlinked destination directory", async () => {
+		const id = testSessionId();
+		const outside = mkdtempSync(join(tmpdir(), "opensession-asset-escape-"));
+		tempDirs.push(outside);
+		mkdirSync(assetsDirFor(id), { recursive: true });
+		symlinkSync(outside, join(assetsDirFor(id), "linked"), "dir");
+		await expect(importAsset(id, "linked/escape.bin", Buffer.from("secret"))).rejects.toThrow(
+			/symbolic link/,
+		);
+		expect(existsSync(join(outside, "escape.bin"))).toBe(false);
+	});
+
+	test("rejects a symlink used as the session assets directory", async () => {
+		const id = testSessionId();
+		const outside = mkdtempSync(join(tmpdir(), "opensession-asset-escape-"));
+		tempDirs.push(outside);
+		mkdirSync(join(assetsDirFor(id), ".."), { recursive: true });
+		symlinkSync(outside, assetsDirFor(id), "dir");
+		await expect(importAsset(id, "escape.bin", Buffer.from("secret"))).rejects.toThrow(
+			/symbolic link/,
+		);
+		expect(existsSync(join(outside, "escape.bin"))).toBe(false);
+	});
+
+	test("rejects a symlink at the final destination", async () => {
+		const id = testSessionId();
+		const outside = mkdtempSync(join(tmpdir(), "opensession-asset-escape-"));
+		tempDirs.push(outside);
+		const outsideFile = join(outside, "target.bin");
+		writeFileSync(outsideFile, "original");
+		mkdirSync(assetsDirFor(id), { recursive: true });
+		symlinkSync(outsideFile, join(assetsDirFor(id), "linked.bin"), "file");
+		await expect(importAsset(id, "linked.bin", Buffer.from("replacement"))).rejects.toThrow(
+			/symbolic link/,
+		);
+		expect(readFileSync(outsideFile, "utf8")).toBe("original");
+	});
+
+	test("importAsset's bigger cap is independent of write_asset's smaller one", async () => {
+		const id = testSessionId();
+		// A payload over write_asset's 4MB cap but comfortably under
+		// importAsset's 500MB cap must succeed via importAsset.
+		const size = 5 * 1024 * 1024;
+		const payload = Buffer.allocUnsafe(size).fill(1);
+		await expect(importAsset(id, "big-video.mp4", payload)).resolves.toBeDefined();
+		expect(() => writeAsset(id, "too-big-for-write-asset.bin", payload)).toThrow(/too large/);
+	});
+});

--- a/src/server/session-assets.ts
+++ b/src/server/session-assets.ts
@@ -20,6 +20,9 @@ import {
 	statSync,
 	writeFileSync,
 } from "fs";
+import { spawn } from "child_process";
+import { createHash, randomUUID } from "crypto";
+import { once } from "events";
 import { homedir } from "os";
 import { join, normalize, resolve } from "path";
 import { broadcastToSession } from "./ws-hub";
@@ -92,6 +95,226 @@ export function writeAsset(
 	broadcastToSession(sessionId, { type: "assets_changed", sessionId });
 	const st = statSync(abs);
 	return { path: rel, size: st.size, mtime: st.mtime.toISOString() };
+}
+
+/** Ceiling for import_remote_asset (opensession-assets' macOS execution-node
+ *  artifact transfer) — sized for bulk screenshots/video from a remote child,
+ *  not the small-scratch-file write_asset cap above. The macOS adapter's
+ *  fetch is capped to the same value by its caller (interactive-mcp.ts). */
+export const MAX_IMPORT_BYTES = 500 * 1024 * 1024;
+
+const IMPORT_ASSET_SCRIPT = `
+import os
+import signal
+import stat
+import sys
+
+root, session_id, relative, temporary, expected_size, expected_sha = sys.argv[1:7]
+expected_size = int(expected_size)
+parts = relative.split("/")
+if not relative or any(part in ("", ".", "..") for part in parts):
+    print("invalid asset destination", file=sys.stderr)
+    sys.exit(80)
+
+flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+dir_flags = flags | os.O_DIRECTORY
+fds = []
+temporary_created = False
+digest = __import__("hashlib").sha256()
+received = 0
+def terminate(_signum, _frame):
+    raise SystemExit(143)
+signal.signal(signal.SIGTERM, terminate)
+signal.signal(signal.SIGINT, terminate)
+try:
+    current = os.open("/", dir_flags)
+    fds.append(current)
+    directories = [part for part in root.split("/") if part] + [session_id] + parts[:-1]
+    for part in directories:
+        try:
+            next_fd = os.open(part, dir_flags, dir_fd=current)
+        except FileNotFoundError:
+            os.mkdir(part, 0o700, dir_fd=current)
+            next_fd = os.open(part, dir_flags, dir_fd=current)
+        current = next_fd
+        fds.append(current)
+
+    try:
+        existing = os.stat(parts[-1], dir_fd=current, follow_symlinks=False)
+        if stat.S_ISLNK(existing.st_mode):
+            print("asset destination contains a symbolic link", file=sys.stderr)
+            sys.exit(81)
+        if not stat.S_ISREG(existing.st_mode):
+            print("asset destination is not a regular file", file=sys.stderr)
+            sys.exit(81)
+    except FileNotFoundError:
+        pass
+
+    target = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+        dir_fd=current,
+    )
+    fds.append(target)
+    temporary_created = True
+    while True:
+        chunk = os.read(0, 1024 * 1024)
+        if not chunk:
+            break
+        received += len(chunk)
+        digest.update(chunk)
+        view = memoryview(chunk)
+        while view:
+            written = os.write(target, view)
+            view = view[written:]
+    if received != expected_size or digest.hexdigest() != expected_sha:
+        print("imported asset integrity check failed", file=sys.stderr)
+        sys.exit(82)
+    os.fsync(target)
+    info = os.fstat(target)
+    os.replace(temporary, parts[-1], src_dir_fd=current, dst_dir_fd=current)
+    temporary_created = False
+    print(info.st_size)
+    print(info.st_mtime_ns)
+except OSError as error:
+    print("asset destination contains a symbolic link or invalid path: %s" % error, file=sys.stderr)
+    sys.exit(81)
+finally:
+    if temporary_created:
+        try:
+            os.unlink(temporary, dir_fd=current)
+        except OSError:
+            pass
+    for fd in reversed(fds):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+`;
+
+export async function importAssetStream(
+	sessionId: string,
+	relative: string,
+	source: AsyncIterable<Uint8Array>,
+	expected: { size: number; sha256: string },
+): Promise<SessionAssetFile> {
+	if (!Number.isSafeInteger(expected.size) || expected.size < 0 || expected.size > MAX_IMPORT_BYTES)
+		throw new Error(`imported asset too large (${expected.size} bytes > ${MAX_IMPORT_BYTES})`);
+	if (!/^[0-9a-f]{64}$/i.test(expected.sha256))
+		throw new Error("imported asset has an invalid expected sha256");
+	const { rel } = resolveAssetPath(sessionId, relative);
+	const temporary = `.opensession-import-${process.pid}-${randomUUID()}`;
+	const child = spawn(
+		"/usr/bin/python3",
+		[
+			"-c",
+			IMPORT_ASSET_SCRIPT,
+			ASSETS_ROOT,
+			safeSessionId(sessionId),
+			rel,
+			temporary,
+			String(expected.size),
+			expected.sha256.toLowerCase(),
+		],
+		{ stdio: ["pipe", "pipe", "pipe"] },
+	);
+	let stdout = "";
+	let stderr = "";
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	child.stdout.on("data", (chunk) => {
+		if (stdout.length < 64 * 1024) stdout += chunk;
+	});
+	child.stderr.on("data", (chunk) => {
+		if (stderr.length < 64 * 1024) stderr += chunk;
+	});
+	const exited = new Promise<number>((resolve) => {
+		child.once("error", () => resolve(1));
+		child.once("close", (code) => resolve(code ?? 1));
+	});
+	const stdinFailed = new Promise<Error>((resolve) => {
+		child.stdin.once("error", resolve);
+	});
+	const waitForWriter = () =>
+		Promise.race([
+			exited,
+			stdinFailed.then((error) => Promise.reject(error)),
+		]);
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		child.kill();
+	}, 120_000);
+	(timeout as { unref?: () => void }).unref?.();
+	try {
+		let received = 0;
+		for await (const chunk of source) {
+			received += chunk.byteLength;
+			if (received > MAX_IMPORT_BYTES || received > expected.size) {
+				throw new Error(`remote asset exceeds its ${expected.size}-byte expected size`);
+			}
+			if (!child.stdin.write(Buffer.from(chunk))) {
+				await Promise.race([
+					once(child.stdin, "drain"),
+					waitForWriter().then((code) => {
+						throw new Error(`asset writer exited early with code ${code}`);
+					}),
+				]);
+			}
+		}
+		child.stdin.end();
+		const code = await waitForWriter();
+		if (timedOut) throw new Error("imported asset write timed out");
+		if (code !== 0) {
+			throw new Error(
+				`failed to write imported asset: ${(stderr || stdout || "unknown error").trim()}`,
+			);
+		}
+	} catch (error) {
+		child.stdin.destroy();
+		child.kill();
+		await exited.catch(() => 1);
+		if (timedOut) throw new Error("imported asset write timed out");
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+	const [sizeLine, mtimeLine] = stdout.trim().split("\n");
+	const size = Number(sizeLine);
+	const mtimeNs = Number(mtimeLine);
+	if (!Number.isFinite(size) || size < 0 || !Number.isFinite(mtimeNs) || mtimeNs < 0) {
+		throw new Error("failed to write imported asset: invalid helper response");
+	}
+	const result = { path: rel, size, mtime: new Date(mtimeNs / 1_000_000).toISOString() };
+	broadcastToSession(sessionId, { type: "assets_changed", sessionId });
+	return result;
+}
+
+/**
+ * Write an already-fetched remote artifact into the session's assets folder.
+ * Same destination confinement as writeAsset (resolveAssetPath), but sized
+ * for bulk transfers and re-checked here as defense in depth even though
+ * callers are expected to have enforced MAX_IMPORT_BYTES during the fetch.
+ */
+export async function importAsset(
+	sessionId: string,
+	relPath: string,
+	data: Buffer,
+): Promise<SessionAssetFile> {
+	if (data.byteLength > MAX_IMPORT_BYTES)
+		throw new Error(
+			`imported asset too large (${data.byteLength} bytes > ${MAX_IMPORT_BYTES})`,
+		);
+	const sha256 = createHash("sha256").update(data).digest("hex");
+	return importAssetStream(
+		sessionId,
+		relPath,
+		(async function* () {
+			yield data;
+		})(),
+		{ size: data.byteLength, sha256 },
+	);
 }
 
 /** Flat recursive listing (the UI builds the tree client-side), sorted by path. */

--- a/src/server/session-control.ts
+++ b/src/server/session-control.ts
@@ -69,11 +69,11 @@ export interface CreateSessionOpts {
   user?: string;
   /**
    * Ask for a sandboxed session (docs/sandboxes-plan.md). `true` = the config
-   * default provider; a provider id (including "modal" / "lambda-microvm")
+   * default provider; a provider id (including "modal" / "lambda-microvm" / "macos")
    * picks one explicitly and must be configured (~/.opensession-sandbox.json),
    * else the create fails with a clear error.
    */
-  sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm";
+  sandbox?: boolean | "docker" | "daytona" | "e2b" | "box" | "modal" | "lambda-microvm" | "macos";
 }
 
 /**

--- a/src/server/terminals.test.ts
+++ b/src/server/terminals.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { startSessionTerminal } from "./terminals";
+
+describe("session terminal sandbox routing", () => {
+  for (const sandboxId of ["macos-bks-1", undefined]) test(`fails closed for macOS execution-node sessions ${sandboxId ? "after" : "before"} materialization`, async () => {
+    const messages: object[] = [];
+    await startSessionTerminal(
+      {},
+      {
+        worktreeDir: "/Users/runner/.opensession-workspaces/bks-1/tella-mac",
+        sandbox: { provider: "macos", sandboxId, workspace: "volume" },
+      },
+      { send: (message) => messages.push(message) },
+    );
+
+    expect(messages).toEqual([
+      {
+        type: "term_notice",
+        message: "The Shell tab is unavailable for macOS execution-node sessions.",
+      },
+      { type: "term_exit", code: 1 },
+    ]);
+  });
+});

--- a/src/server/terminals.ts
+++ b/src/server/terminals.ts
@@ -27,6 +27,8 @@
  *    echo, a dead-looking tab (bit us 2026-07-09). No published port, no
  *    extra HTTPS surface — the SDK socket terminates at backstage and the
  *    browser only ever speaks the existing tailnet-gated session WS.
+ *  - macOS fixed node: unavailable until the provider has a remote PTY. It
+ *    fails closed rather than opening an unrelated Linux host shell.
  *
  * Trust model: the web UI is Tailscale- + team-gated and interactive users are
  * already admin-equivalent (sessions run arbitrary Bash via prompts), so a
@@ -68,7 +70,7 @@ export interface TerminalOpts {
   send: (msg: object) => void;
 }
 
-type TermTargetKind = "host" | "docker" | "daytona";
+type TermTargetKind = "host" | "docker" | "daytona" | "macos";
 
 /** A shell realized as a host process wrapped in a Bun PTY (host + docker). */
 interface SpawnTarget {
@@ -97,7 +99,14 @@ interface RemoteTarget {
   connect: (io: RemotePtyIo) => Promise<RemotePtyHandle>;
 }
 
-type TermTarget = SpawnTarget | RemoteTarget;
+interface UnavailableTarget {
+  kind: "unavailable";
+  target: "macos";
+  displayCwd: string;
+  message: string;
+}
+
+type TermTarget = SpawnTarget | RemoteTarget | UnavailableTarget;
 
 function clampCols(cols: number | undefined): number {
   return Math.max(20, Math.min(500, Math.round(cols || 100)));
@@ -142,15 +151,23 @@ function hostShellTarget(session: TerminalSessionInfo | null | undefined, notice
 }
 
 /**
- * Decide where the session's shell runs. Never throws — every failure mode
- * degrades to the host shell with a notice (same fail-open shape as
- * workspace-exec, except a terminal deliberately WAKES a stopped docker
- * container: it's an interactive gesture, not a background read).
+ * Decide where the session's shell runs. Existing providers preserve their
+ * host-shell fallback; the fixed macOS node explicitly fails closed because
+ * its volume workspace has no corresponding host checkout.
  */
 async function resolveTarget(
   session: TerminalSessionInfo | null | undefined,
 ): Promise<TermTarget> {
   const sb = session?.sandbox;
+  if (sb?.provider === "macos") {
+    const cwd = session?.worktreeDir || HOME;
+    return {
+      kind: "unavailable",
+      target: "macos",
+      displayCwd: cwd,
+      message: "The Shell tab is unavailable for macOS execution-node sessions.",
+    };
+  }
   if (!sb?.sandboxId || !sb.provider || sb.provider === "local") {
     return hostShellTarget(session);
   }
@@ -253,6 +270,12 @@ export async function startSessionTerminal(
           `sandbox terminal unavailable (${String(e?.message || e).slice(0, 160)}) — opened a host shell instead`,
         );
       }
+    }
+    if (target.kind === "unavailable") {
+      pendingStarts.delete(ws);
+      opts.send({ type: "term_notice", message: target.message });
+      opts.send({ type: "term_exit", code: 1 });
+      return;
     }
   } finally {
     clearTimeout(slow);

--- a/src/server/zz-run-journal.test.ts
+++ b/src/server/zz-run-journal.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import * as mod from "./run-journal";
@@ -31,6 +38,31 @@ afterEach(() => {
 });
 
 describe("run journal", () => {
+	it("fails closed when the journal cannot be persisted", () => {
+		const blockedParent = join(dir, "not-a-directory");
+		writeFileSync(blockedParent, "blocked");
+		mod.__setActiveRunsPathForTest(join(blockedParent, "active-runs.json"));
+
+		expect(() =>
+			mod.journalSet({
+				runKey: "unpersisted-run",
+				cwd: "/tmp",
+				startedAt: "2026-07-22T00:00:00.000Z",
+			}),
+		).toThrow();
+	});
+
+	it("does not remove a replacement lock when a stale owner releases", () => {
+		const lockPath = join(dir, "active-runs.json.lock");
+		mkdirSync(lockPath);
+		writeFileSync(join(lockPath, "owner"), "replacement-owner");
+
+		mod.__releaseRunJournalLockForTest(lockPath, "stale-owner");
+
+		expect(existsSync(lockPath)).toBe(true);
+		expect(readFileSync(join(lockPath, "owner"), "utf8")).toBe("replacement-owner");
+	});
+
 	it("preserves human-confirmed tool policy across restart drains", async () => {
 		mod.journalSet({
 			runKey: "run-1",
@@ -53,6 +85,72 @@ describe("run journal", () => {
 		expect(run.deniedTools).toEqual({ mcp__danger__delete: "No deletes" });
 		expect(run.fallbackModel).toBe("gpt-5.5");
 		expect(mod.activeRunRecords()).toEqual([]);
+	});
+
+	it("retains selected interrupted records until asynchronous recovery acknowledges them", () => {
+		mod.journalSet({
+			runKey: "mac-run",
+			bksSessionId: "bks-mac",
+			prompt: "continue",
+			cwd: "/remote/workspace",
+			sandboxId: "macos-bks-mac",
+			sandboxProvider: "macos",
+			startedAt: "2026-07-22T00:00:00.000Z",
+		});
+
+		const [run] = mod.takeInterruptedRuns((record) => record.sandboxProvider === "macos");
+		expect(run.runKey).toBe("mac-run");
+		expect(mod.activeRunRecords().map((record) => record.runKey)).toEqual(["mac-run"]);
+		mod.journalClear("mac-run");
+		expect(mod.activeRunRecords()).toEqual([]);
+	});
+
+	it("atomically replaces an interrupted run record during recovery handoff", () => {
+		mod.journalSet({
+			runKey: "old-run",
+			bksSessionId: "bks-mac",
+			cwd: "/remote/workspace",
+			sandboxId: "macos-bks-mac",
+			sandboxProvider: "macos",
+			startedAt: "2026-07-22T00:00:00.000Z",
+		});
+
+		mod.journalReplace("old-run", {
+			runKey: "replacement-run",
+			bksSessionId: "bks-mac",
+			cwd: "/remote/workspace",
+			sandboxId: "macos-bks-mac",
+			sandboxProvider: "macos",
+			startedAt: "2026-07-22T00:01:00.000Z",
+		});
+
+		expect(mod.activeRunRecords().map((record) => record.runKey)).toEqual([
+			"replacement-run",
+		]);
+	});
+
+	it("recovers only the newest record from a legacy macOS replacement pair", () => {
+		for (const [runKey, startedAt] of [
+			["old-run", "2026-07-22T00:00:00.000Z"],
+			["replacement-run", "2026-07-22T00:01:00.000Z"],
+		] as const) {
+			mod.journalSet({
+				runKey,
+				bksSessionId: "bks-mac",
+				cwd: "/remote/workspace",
+				sandboxId: "macos-bks-mac",
+				sandboxProvider: "macos",
+				startedAt,
+			});
+		}
+
+		const interrupted = mod.takeInterruptedRuns(
+			(record) => record.sandboxProvider === "macos",
+		);
+		expect(interrupted.map((record) => record.runKey)).toEqual(["replacement-run"]);
+		expect(mod.activeRunRecords().map((record) => record.runKey)).toEqual([
+			"replacement-run",
+		]);
 	});
 
 	it("emits recovered run stream events during restart resume", async () => {


### PR DESCRIPTION
## Summary
- add a fixed macOS sandbox provider that drives an Aqua LaunchAgent over authenticated SSH and a Tailscale callback
- enforce a node-wide foreground lease, per-run mutation locks, strict workspace/path confinement, and ownership-safe teardown
- stream remote screenshots and recordings into session Assets with size and SHA-256 verification
- make interrupted run recovery, cleanup retries, preview behavior, terminals, and Slack asset tools aware of macOS execution nodes
- document deployment, security boundaries, required configuration, and unsupported remote PTY behavior

## Verification
- `bun test`: 701 passed, 0 failed
- `bunx tsc --noEmit`
- `git diff --check`
- exercised against the physical Tailscale-connected Mac node with a successful Stage build, 10/10 Xcode tests, launch, screenshot, and 5-second recording

Created by [this Michael session](https://os.tella.dev/session/bks-019f861d-ffe5-7000-8638-5f69fc798fac)