### PR TITLE
Add durable report assets

### DIFF
--- a/src/agents/slack/report-tools.ts
+++ b/src/agents/slack/report-tools.ts
@@ -1,6 +1,6 @@
 /**
- * opensession-report — publish_report: lets a run publish a self-contained
- * HTML report into the Reports store (~/.opensession-reports, see
+ * opensession-report — publish_report: lets a run publish an HTML report and
+ * optional staged assets into the Reports store (~/.opensession-reports, see
  * src/server/reports.ts), grouped per automation and browsed in the frontend
  * Reports view (latest + history per automation).
  *
@@ -13,7 +13,14 @@
 
 import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
 import { z } from "zod";
-import { publishReport, MAX_REPORT_BYTES } from "../../server/reports";
+import {
+	publishReport,
+	MAX_REPORT_ASSETS,
+	MAX_REPORT_ASSET_BYTES,
+	MAX_REPORT_BYTES,
+} from "../../server/reports";
+import { assetsDirFor, resolveAssetPath } from "../../server/session-assets";
+import { lstatSync, readFileSync, realpathSync, statSync } from "fs";
 
 function text(s: string) {
 	return { content: [{ type: "text" as const, text: s }] };
@@ -24,10 +31,11 @@ export function createReportMcpServer(ctx: {
 	automationName: string;
 	sessionId?: string;
 }) {
+	const stagingDir = ctx.sessionId ? assetsDirFor(ctx.sessionId) : null;
 	const tools = [
 		tool(
 			"publish_report",
-			"Publish this run's report: one SELF-CONTAINED HTML document (inline CSS, no external resources) shown in the Reports view — latest per automation, with history. Use it when the task's outcome is a recurring readable report (a digest, an analysis); each publish adds a new entry to this automation's history, so publish once per run with the final document. Not for ordinary task output or scratch artifacts.",
+			"Publish this run's HTML report with optional durable assets shown in the Reports view — latest per automation, with history. Keep CSS inline, but store image/media evidence as assets instead of base64 data URLs. Use it when the task's outcome is a recurring readable report; each publish adds a new entry, so publish once per run with the final document.",
 			{
 				title: z
 					.string()
@@ -37,7 +45,14 @@ export function createReportMcpServer(ctx: {
 				html: z
 					.string()
 					.describe(
-						`The full HTML document (max ${Math.floor(MAX_REPORT_BYTES / 1024 / 1024)} MB). Self-contained: inline CSS, no external scripts/styles/images.`,
+						`The full HTML document (max ${Math.floor(MAX_REPORT_BYTES / 1024 / 1024)} MB). Keep CSS inline. Reference staged files as assets/<path> and list those paths in assets.`,
+					),
+				assets: z
+					.array(z.string())
+					.max(MAX_REPORT_ASSETS)
+					.optional()
+					.describe(
+						`Relative file paths staged in this run's assets folder${stagingDir ? ` (${stagingDir})` : ""}. They are copied into durable report storage and served at assets/<path>. Combined max ${Math.floor(MAX_REPORT_ASSET_BYTES / 1024 / 1024)} MB.`,
 					),
 				summary: z
 					.string()
@@ -46,8 +61,41 @@ export function createReportMcpServer(ctx: {
 						"Short plain-text gist (1-3 sentences) shown in report lists.",
 					),
 			},
-			async (args: { title: string; html: string; summary?: string }) => {
+			async (args: {
+				title: string;
+				html: string;
+				assets?: string[];
+				summary?: string;
+			}) => {
 				try {
+					if (args.assets?.length && !ctx.sessionId)
+						throw new Error("Report assets require a session id");
+					const realStagingDir = args.assets?.length
+						? realpathSync(stagingDir!)
+						: null;
+					let assetBytes = 0;
+					const assetPaths = new Set<string>();
+					const sources = (args.assets || []).map((path) => {
+						const source = resolveAssetPath(ctx.sessionId!, path);
+						if (assetPaths.has(source.rel))
+							throw new Error(`Duplicate report asset: ${source.rel}`);
+						assetPaths.add(source.rel);
+						if (!lstatSync(source.abs).isFile())
+							throw new Error(`Not a file: ${path}`);
+						const realPath = realpathSync(source.abs);
+						if (!realPath.startsWith(`${realStagingDir!}/`))
+							throw new Error(`Asset resolves outside the session folder: ${path}`);
+						assetBytes += statSync(realPath).size;
+						if (assetBytes > MAX_REPORT_ASSET_BYTES)
+							throw new Error(
+								`Report assets too large (${assetBytes} bytes > ${MAX_REPORT_ASSET_BYTES})`,
+							);
+						return { path: source.rel, realPath };
+					});
+					const assets = sources.map((source) => ({
+						path: source.path,
+						data: readFileSync(source.realPath),
+					}));
 					const meta = publishReport({
 						automationId: ctx.automationId,
 						automationName: ctx.automationName,
@@ -55,6 +103,7 @@ export function createReportMcpServer(ctx: {
 						title: args.title,
 						html: args.html,
 						summary: args.summary,
+						assets,
 					});
 					return text(
 						`Published report "${meta.title}" (${meta.id}). It's now the latest report for "${ctx.automationName}" in the Reports view.`,

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -1197,8 +1197,8 @@ export function buildOpencodeInstructions(input: {
   }
   if (inproc["opensession-report"]) {
     parts.push(
-      "## Publish your report\nThis run can publish a report: a single self-contained HTML " +
-        "document (inline CSS, no external resources) that appears in the Reports view, " +
+      "## Publish your report\nThis run can publish an HTML report with durable assets " +
+        "that appears in the Reports view, " +
         "grouped under this automation with its history. When your task's outcome is a " +
         "recurring readable report (a digest, an analysis), finish by calling " +
         "opensession-report's `publish_report` with a title, the full HTML, and a 1-2 " +

--- a/src/server/reports.test.ts
+++ b/src/server/reports.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "fs";
 import { join } from "path";
 import {
 	listReportsForSession,
+	publishReport,
+	readReportAsset,
 	REPORTS_ROOT,
 	type ReportMeta,
 } from "./reports";
@@ -69,5 +78,68 @@ describe("listReportsForSession", () => {
 			`${automationId}/newer`,
 			`${automationId}/older`,
 		]);
+	});
+});
+
+describe("report assets", () => {
+	test("publishes nested assets beside the report", () => {
+		const data = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+		const report = publishReport({
+			automationId,
+			automationName: "Test",
+			title: "Asset report",
+			html: '<img src="assets/evidence/frame.jpg">',
+			assets: [{ path: "evidence/frame.jpg", data }],
+		});
+
+		const asset = readReportAsset(
+			automationId,
+			report.id,
+			"evidence/frame.jpg",
+		);
+		expect(asset?.rel).toBe("evidence/frame.jpg");
+		expect(readFileSync(asset!.path)).toEqual(data);
+
+		unlinkSync(join(REPORTS_ROOT, automationId, `${report.id}.json`));
+		expect(
+			readReportAsset(automationId, report.id, "evidence/frame.jpg"),
+		).toBeNull();
+
+		publishReport({
+			automationId,
+			automationName: "Test",
+			title: "Next report",
+			html: "<p>next</p>",
+		});
+		expect(
+			existsSync(
+				join(REPORTS_ROOT, automationId, `${report.id}.assets`),
+			),
+		).toBe(false);
+	});
+
+	test("rejects asset traversal and duplicate paths", () => {
+		const input = {
+			automationId,
+			automationName: "Test",
+			title: "Unsafe asset report",
+			html: "<p>unsafe</p>",
+		};
+
+		expect(() =>
+			publishReport({
+				...input,
+				assets: [{ path: "../secret", data: Buffer.from("no") }],
+			}),
+		).toThrow("asset path must be relative");
+		expect(() =>
+			publishReport({
+				...input,
+				assets: [
+					{ path: "same.jpg", data: Buffer.from("one") },
+					{ path: "same.jpg", data: Buffer.from("two") },
+				],
+			}),
+		).toThrow("Duplicate report asset");
 	});
 });

--- a/src/server/reports.ts
+++ b/src/server/reports.ts
@@ -1,10 +1,11 @@
 /**
  * Reports — first-class recurring documents produced by automations (morning
- * support digest today; AWS-spend / churn / MRR analyses tomorrow). One
- * self-contained HTML file + JSON sidecar per report, grouped per automation:
+ * support digest today; AWS-spend / churn / MRR analyses tomorrow). One HTML
+ * file + JSON sidecar per report, with optional durable assets:
  *
  *   ~/.opensession-reports/<automationId>/<reportId>.html
  *   ~/.opensession-reports/<automationId>/<reportId>.json
+ *   ~/.opensession-reports/<automationId>/<reportId>.assets/<path>
  *
  * Report ids are timestamp-prefixed so lexicographic order = chronological.
  * Published from agent runs via the opensession-report in-process MCP
@@ -14,19 +15,33 @@
  * Publishes broadcast `reports_changed` so open Reports views refresh.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join, normalize, resolve } from "path";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import { broadcastToAll } from "./ws-hub";
-import { writeFileSync } from "fs";
 
 export const REPORTS_ROOT = join(homedir(), ".opensession-reports");
 
 /** Reports an automation may keep; older ones are pruned on publish. */
 const MAX_REPORTS_PER_GROUP = 100;
-/** A report is one self-contained HTML document — keep it bounded. */
+/** Keep the authored document bounded; binary evidence belongs in assets. */
 export const MAX_REPORT_BYTES = 4 * 1024 * 1024;
+export const MAX_REPORT_ASSET_BYTES = 64 * 1024 * 1024;
+export const MAX_REPORT_ASSETS = 500;
+
+export interface ReportAsset {
+	path: string;
+	data: Uint8Array;
+}
 
 export interface ReportMeta {
 	/** Timestamp-prefixed id, unique within the group (= the filename stem). */
@@ -59,6 +74,47 @@ function safeSegment(s: string): boolean {
 
 function groupDir(automationId: string): string {
 	return join(REPORTS_ROOT, automationId);
+}
+
+function reportAssetsDir(automationId: string, reportId: string): string {
+	return join(groupDir(automationId), `${reportId}.assets`);
+}
+
+function removeOrphanAssets(automationId: string): void {
+	const dir = groupDir(automationId);
+	if (!existsSync(dir)) return;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (!entry.isDirectory() || !entry.name.endsWith(".assets")) continue;
+		const reportId = entry.name.slice(0, -".assets".length);
+		if (!existsSync(join(dir, `${reportId}.json`)))
+			rmSync(join(dir, entry.name), { recursive: true, force: true });
+	}
+}
+
+function safeAssetPath(path: string): string {
+	const raw = (path || "").trim().replace(/^\.\//, "");
+	if (!raw) throw new Error("asset path is required");
+	if (raw.startsWith("/") || raw.includes("\\") || raw.split("/").includes(".."))
+		throw new Error(`asset path must be relative (no leading /, no ..): ${path}`);
+	const rel = normalize(raw).replace(/\\/g, "/");
+	if (rel === "." || rel.startsWith("../"))
+		throw new Error(`asset path escapes the report: ${path}`);
+	return rel;
+}
+
+function resolveReportAssetPath(
+	automationId: string,
+	reportId: string,
+	path: string,
+): { abs: string; rel: string } {
+	if (!safeSegment(automationId) || !safeSegment(reportId))
+		throw new Error("invalid report id");
+	const dir = reportAssetsDir(automationId, reportId);
+	const rel = safeAssetPath(path);
+	const abs = resolve(dir, rel);
+	if (!abs.startsWith(dir + "/"))
+		throw new Error(`asset path escapes the report: ${path}`);
+	return { abs, rel };
 }
 
 /** Sidecar filenames in a group dir, newest first (ids sort chronologically). */
@@ -108,6 +164,7 @@ export function publishReport(input: {
 	title: string;
 	html: string;
 	summary?: string;
+	assets?: ReportAsset[];
 }): ReportMeta {
 	if (!safeSegment(input.automationId)) {
 		throw new Error(`Invalid automation id "${input.automationId}"`);
@@ -116,9 +173,27 @@ export function publishReport(input: {
 	if (!input.html.trim()) throw new Error("Report HTML is empty");
 	if (bytes > MAX_REPORT_BYTES) {
 		throw new Error(
-			`Report too large (${bytes} bytes > ${MAX_REPORT_BYTES}) — a report is one self-contained HTML document, trim embedded data`,
+			`Report HTML too large (${bytes} bytes > ${MAX_REPORT_BYTES}) — move binary evidence into report assets`,
 		);
 	}
+	const assets = input.assets || [];
+	if (assets.length > MAX_REPORT_ASSETS)
+		throw new Error(
+			`Too many report assets (${assets.length} > ${MAX_REPORT_ASSETS})`,
+		);
+	let assetBytes = 0;
+	const assetPaths = new Set<string>();
+	const validatedAssets = assets.map((asset) => {
+		const path = safeAssetPath(asset.path);
+		if (assetPaths.has(path)) throw new Error(`Duplicate report asset: ${path}`);
+		assetPaths.add(path);
+		assetBytes += asset.data.byteLength;
+		return { path, data: asset.data };
+	});
+	if (assetBytes > MAX_REPORT_ASSET_BYTES)
+		throw new Error(
+			`Report assets too large (${assetBytes} bytes > ${MAX_REPORT_ASSET_BYTES})`,
+		);
 	const now = new Date();
 	// 2026-07-12-060002-4f3a: lexicographic = chronological, readable on disk.
 	const stamp = now
@@ -140,17 +215,44 @@ export function publishReport(input: {
 	};
 	const dir = groupDir(input.automationId);
 	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, `${id}.html`), input.html, "utf8");
-	writeJsonAtomic(join(dir, `${id}.json`), meta);
+	removeOrphanAssets(input.automationId);
+	try {
+		for (const asset of validatedAssets) {
+			const { abs } = resolveReportAssetPath(
+				input.automationId,
+				id,
+				asset.path,
+			);
+			mkdirSync(dirname(abs), { recursive: true });
+			writeFileSync(abs, asset.data);
+		}
+		writeFileSync(join(dir, `${id}.html`), input.html, "utf8");
+		// The sidecar is written last: its presence makes the report discoverable.
+		writeJsonAtomic(join(dir, `${id}.json`), meta);
+	} catch (error) {
+		rmSync(join(dir, `${id}.html`), { force: true });
+		rmSync(join(dir, `${id}.json`), { force: true });
+		rmSync(reportAssetsDir(input.automationId, id), {
+			recursive: true,
+			force: true,
+		});
+		throw error;
+	}
 	indexReport(meta);
 	// Prune beyond the cap (both files) — newest first, drop the tail.
 	for (const stale of sidecarsFor(input.automationId).slice(
 		MAX_REPORTS_PER_GROUP,
 	)) {
 		try {
-			removeIndexedReport(readMeta(input.automationId, stale));
+			const staleMeta = readMeta(input.automationId, stale);
+			removeIndexedReport(staleMeta);
 			rmSync(join(dir, stale));
 			rmSync(join(dir, stale.replace(/\.json$/, ".html")), {
+				force: true,
+			});
+			const staleId = stale.replace(/\.json$/, "");
+			rmSync(reportAssetsDir(input.automationId, staleId), {
+				recursive: true,
 				force: true,
 			});
 		} catch {}
@@ -219,6 +321,23 @@ export function readReportHtml(
 	if (!existsSync(file)) return null;
 	try {
 		return readFileSync(file, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+/** A durable report asset's absolute path, or null when it doesn't exist. */
+export function readReportAsset(
+	automationId: string,
+	reportId: string,
+	path: string,
+): { path: string; rel: string } | null {
+	try {
+		if (!safeSegment(automationId) || !safeSegment(reportId)) return null;
+		if (!existsSync(join(groupDir(automationId), `${reportId}.json`))) return null;
+		const { abs, rel } = resolveReportAssetPath(automationId, reportId, path);
+		if (!existsSync(abs) || !statSync(abs).isFile()) return null;
+		return { path: abs, rel };
 	} catch {
 		return null;
 	}

--- a/src/server/routes/reports.test.ts
+++ b/src/server/routes/reports.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "fs";
+import { join } from "path";
+import { publishReport, REPORTS_ROOT } from "../reports";
+import { handleReportsRoutes } from "./reports";
+
+const automationId = `test-report-assets-route-${process.pid}`;
+
+afterEach(() => {
+	rmSync(join(REPORTS_ROOT, automationId), { recursive: true, force: true });
+});
+
+describe("report asset routes", () => {
+	test("serves a published asset with its content type", async () => {
+		const data = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+		const report = publishReport({
+			automationId,
+			automationName: "Test",
+			title: "Asset report",
+			html: '<img src="assets/evidence/frame.jpg">',
+			assets: [{ path: "evidence/frame.jpg", data }],
+		});
+		const path = `/backstage/api/reports/${automationId}/${report.id}/assets/evidence/frame.jpg`;
+		const url = new URL(`http://localhost${path}`);
+
+		const response = await handleReportsRoutes({
+			req: new Request(url),
+			url,
+			path,
+			publicPrefix: "/backstage",
+		});
+
+		expect(response?.status).toBe(200);
+		expect(response?.headers.get("content-type")).toBe("image/jpeg");
+		expect(response?.headers.get("content-security-policy")).toBe("sandbox");
+		expect(Buffer.from(await response!.arrayBuffer())).toEqual(data);
+	});
+});

--- a/src/server/routes/reports.ts
+++ b/src/server/routes/reports.ts
@@ -9,8 +9,10 @@ import {
 	listReportGroups,
 	listReports,
 	listReportsForSession,
+	readReportAsset,
 	readReportHtml,
 } from "../reports";
+import { assetMime } from "../session-assets";
 
 export async function handleReportsRoutes(
 	ctx: RouteContext,
@@ -51,6 +53,29 @@ export async function handleReportsRoutes(
 				"Content-Type": "text/html; charset=utf-8",
 				"Cache-Control": "no-store",
 				"Content-Security-Policy": "sandbox allow-same-origin",
+			},
+		});
+	}
+
+	// Durable files referenced by report HTML as assets/<path>.
+	const assetMatch = path.match(
+		/^\/backstage\/api\/reports\/([^/]+)\/([^/]+)\/assets\/(.+)$/,
+	);
+	if (assetMatch) {
+		const asset = readReportAsset(
+			decodeURIComponent(assetMatch[1]),
+			decodeURIComponent(assetMatch[2]),
+			decodeURIComponent(assetMatch[3]),
+		);
+		if (!asset) return new Response("Report asset not found", { status: 404 });
+		const file = Bun.file(asset.path);
+		return new Response(file, {
+			headers: {
+				"Content-Type": assetMime(asset.rel),
+				"Content-Length": String(file.size),
+				"Cache-Control": "no-store",
+				"Content-Security-Policy": "sandbox",
+				"X-Content-Type-Options": "nosniff",
 			},
 		});
 	}


### PR DESCRIPTION
## Summary
- store optional report assets beside each published HTML report
- let automations publish staged session files and reference them as relative asset URLs
- serve report assets with MIME types, sandboxing, traversal protection, size limits, cleanup, and retention pruning

## Validation
- `bun test` (729 passing)
- focused report storage and HTTP route tests
- `git diff --check`
- `bun run typecheck` reaches an existing error in untouched `scripts/frontend-dev.ts:224`: `Type {} does not satisfy the constraint string`