### PR TITLE
Render assistant video markers inline

### DIFF
--- a/src/server/jsonl-parser.test.ts
+++ b/src/server/jsonl-parser.test.ts
@@ -515,6 +515,48 @@ describe("Codex rollout parsing", () => {
       "/backstage/media?path=%2Fvar%2Ftmp%2Fmcp-recording.webm",
     ]);
   });
+
+  it("extracts and hides video markers from Codex assistant messages", () => {
+    const path = writeCodexFixture([
+      JSON.stringify({
+        timestamp: TS,
+        type: "event_msg",
+        payload: {
+          type: "agent_message",
+          message: "Captured the production flow.\n\nBACKSTAGE_VIDEO: /tmp/codex-demo.mov",
+        },
+      }),
+    ]);
+
+    const entries = parseTranscript(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("assistant");
+    expect(entries[0].content).toBe("Captured the production flow.");
+    expect(entries[0].videos).toEqual([
+      "/backstage/media?path=%2Ftmp%2Fcodex-demo.mov",
+    ]);
+  });
+});
+
+describe("assistant video markers", () => {
+  it("extracts a session asset and hides the marker from assistant content", () => {
+    const assetPath =
+      "/home/ubuntu/.opensession-assets/bks-019f861d-ffe5-7000-8638-5f69fc798fac/capture/tella-production-login-recording.mov";
+    const path = writeFixture([
+      assistantLine(
+        "a-video",
+        `Captured the production flow.\n\nBACKSTAGE_VIDEO: ${assetPath}`,
+      ),
+    ]);
+
+    const entries = parseTranscript(path);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("assistant");
+    expect(entries[0].content).toBe("Captured the production flow.");
+    expect(entries[0].videos).toEqual([
+      `/backstage/media?path=${encodeURIComponent(assetPath)}`,
+    ]);
+  });
 });
 
 describe("extractBackstageVideos", () => {

--- a/src/server/jsonl-parser.ts
+++ b/src/server/jsonl-parser.ts
@@ -133,10 +133,10 @@ function attachUploads(
   }
 }
 
-// Tools can't return video blocks (unlike Read-of-image), so a tool that
-// produces a video prints `BACKSTAGE_VIDEO: <abs-path>` and we turn each marker
-// into a /backstage/media URL the frontend streams. Used by tella-local rec.mjs.
-const VIDEO_MARKER = /^\s*BACKSTAGE_VIDEO:\s*(\/\S+)\s*$/gm;
+// Transcript messages can't return video blocks (unlike Read-of-image), so a
+// tool or assistant can print `BACKSTAGE_VIDEO: <abs-path>` and we turn each
+// marker into a /backstage/media URL the frontend streams.
+const VIDEO_MARKER = /^[\t ]*BACKSTAGE_VIDEO:[\t ]*(\/\S+)[\t ]*$/gm;
 
 export function extractBackstageVideos(text: string): string[] {
   if (!text) return [];
@@ -145,6 +145,14 @@ export function extractBackstageVideos(text: string): string[] {
     out.push(`/backstage/media?path=${encodeURIComponent(m[1])}`);
   }
   return out;
+}
+
+export function extractAssistantVideos(text: string): { content: string; videos: string[] } {
+  const videos = extractBackstageVideos(text);
+  return {
+    content: videos.length > 0 ? text.replace(VIDEO_MARKER, "").trimEnd() : text,
+    videos,
+  };
 }
 
 /**
@@ -326,13 +334,15 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
     if (Array.isArray(content)) {
       for (const block of content) {
         if (block.type === "text" && block.text) {
+          const assistant = extractAssistantVideos(block.text);
           entries.push({
             id: raw.uuid || crypto.randomUUID(),
             type: "assistant",
-            content: block.text,
+            content: assistant.content,
             timestamp: ts,
             requestId: raw.requestId,
             ...(model ? { model } : {}),
+            ...(assistant.videos.length > 0 ? { videos: assistant.videos } : {}),
           });
         }
         if (block.type === "tool_use") {
@@ -351,13 +361,15 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
     } else {
       const text = extractText(content);
       if (text) {
+        const assistant = extractAssistantVideos(text);
         entries.push({
           id: raw.uuid || crypto.randomUUID(),
           type: "assistant",
-          content: text,
+          content: assistant.content,
           timestamp: ts,
           requestId: raw.requestId,
           ...(model ? { model } : {}),
+          ...(assistant.videos.length > 0 ? { videos: assistant.videos } : {}),
         });
       }
     }
@@ -443,11 +455,13 @@ function parseCodexEntry(raw: any): TranscriptEntry[] {
       }];
     }
     if (p.type === "agent_message" && typeof p.message === "string" && p.message.trim()) {
+      const assistant = extractAssistantVideos(p.message);
       return [{
         id: p.id || stableCodexId("codex-assistant", raw, p, p.message),
         type: "assistant",
-        content: p.message,
+        content: assistant.content,
         timestamp: ts,
+        ...(assistant.videos.length > 0 ? { videos: assistant.videos } : {}),
       }];
     }
     return [];

--- a/src/server/opencode-transcript.test.ts
+++ b/src/server/opencode-transcript.test.ts
@@ -105,6 +105,38 @@ describe("readOpencodeTranscript (SQLite)", () => {
     expect(entries[2].toolUseId).toBe("prt_tool");
     expect(entries[3].content).toBe("OK, noted.");
   });
+  test("extracts and hides video markers from assistant text parts", () => {
+    const sessionId = "ses_video_marker";
+    const createdAt = 1783501000000;
+    const db = new Database(dbPath);
+    db.query("INSERT INTO session VALUES (?, 'p', 't', 1, 1)").run(sessionId);
+    db.query("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+      "msg_video",
+      sessionId,
+      createdAt,
+      createdAt,
+      JSON.stringify({ role: "assistant", time: { created: createdAt } }),
+    );
+    db.query("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+      "prt_video",
+      "msg_video",
+      sessionId,
+      createdAt,
+      createdAt,
+      JSON.stringify({
+        type: "text",
+        text: "Captured the production flow.\n\nBACKSTAGE_VIDEO: /tmp/opencode-demo.mov",
+      }),
+    );
+    db.close();
+
+    const entries = readOpencodeTranscript(sessionId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].content).toBe("Captured the production flow.");
+    expect(entries[0].videos).toEqual([
+      "/backstage/media?path=%2Ftmp%2Fopencode-demo.mov",
+    ]);
+  });
   test("unknown session / missing db degrade to []", () => {
     expect(readOpencodeTranscript("ses_nope")).toEqual([]);
     expect(readOpencodeTranscript(SES, join(scratch, "missing.db"))).toEqual([]);

--- a/src/server/opencode-transcript.ts
+++ b/src/server/opencode-transcript.ts
@@ -32,6 +32,7 @@ import { Database } from "bun:sqlite";
 import type { TranscriptEntry } from "./types";
 import type { ImageInput } from "./run-events";
 import { stripContext } from "./prompt-context";
+import { extractAssistantVideos } from "./jsonl-parser";
 
 const HOME = process.env.HOME || "/home/ubuntu";
 
@@ -624,12 +625,14 @@ export function readOpencodeTranscript(
           if (part.synthetic) continue;
           const text = role === "user" ? stripContext(part.text || "") : part.text || "";
           if (!text.trim()) continue;
+          const assistant = role === "assistant" ? extractAssistantVideos(text) : undefined;
           entries.push({
             id: p.id,
             type: role,
-            content: text,
+            content: assistant?.content ?? text,
             timestamp: ts,
             ...(model ? { model } : {}),
+            ...(assistant?.videos.length ? { videos: assistant.videos } : {}),
           });
         } else if (part.type === "tool") {
           entries.push({


### PR DESCRIPTION
## Summary
- parse `BACKSTAGE_VIDEO:` markers from assistant messages as inline video attachments
- remove marker control lines from visible assistant content
- support Claude/OpenCode JSONL, Codex agent messages, and direct OpenCode SQLite transcript reads
- add regressions for the production session asset path and each engine shape

## Testing
- `bun test` (703 passed)
- `bun test src/server/jsonl-parser.test.ts src/server/opencode-transcript.test.ts` (45 passed after rebase)
- strict standalone TypeScript check for both touched parser modules
- `git diff --check`

## Typecheck note
- repository-wide `bun run typecheck` remains blocked by an unrelated existing error in `scripts/frontend-dev.ts:224`: `Type {} does not satisfy the constraint string`

Started by Michiel Westerbeek in [this Michael session](https://os.tella.dev/session/bks-019f861d-ffe5-7000-8638-5f69fc798fac)