### PR TITLE
Render Read images inline

### DIFF
--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -213,6 +213,7 @@ import {
   transcriptLineCompactionSummary,
   transcriptLineToolUse,
   transcriptLineToolResult,
+  opencodeToolResultImages,
 } from "./opencode-transcript";
 import { parseTranscriptAsync } from "./jsonl-parser";
 import { buildEngineSwitchHandoffNote } from "./fork-handoff";
@@ -3604,6 +3605,7 @@ async function* runOpencodeAttempt(
             if ((state?.status === "completed" || state?.status === "error") && !finishedTools.has(part.id)) {
               finishedTools.add(part.id);
               const result = state.status === "completed" ? state.output || "" : `Error: ${state.error}`;
+              const images = opencodeToolResultImages(part);
               turnEvent({
                 direction: "in",
                 kind: "tool_result",
@@ -3612,12 +3614,19 @@ async function* runOpencodeAttempt(
                 ...summarizeText(result),
               });
               appendOpencodeTranscript(ocSessionId, [
-                transcriptLineToolResult(part.id, result, state.status === "error"),
+                transcriptLineToolResult(
+                  part.id,
+                  result,
+                  state.status === "error",
+                  undefined,
+                  images,
+                ),
               ]);
               push({
                 type: "tool_result",
                 toolUseId: part.id,
                 content: result.length > 500 ? result.slice(0, 500) + "..." : result,
+                ...(images.length ? { images } : {}),
               });
             }
           }
@@ -4579,6 +4588,7 @@ export async function tryReattachOpencodeRun(
                 finishedTools.add(part.id);
                 const result =
                   state.status === "completed" ? state.output || "" : `Error: ${state.error}`;
+                const images = opencodeToolResultImages(part);
                 turnEvent({
                   direction: "in",
                   kind: "tool_result",
@@ -4587,12 +4597,19 @@ export async function tryReattachOpencodeRun(
                   ...summarizeText(result),
                 });
                 appendOpencodeTranscript(ocSessionId!, [
-                  transcriptLineToolResult(part.id, result, state.status === "error"),
+                  transcriptLineToolResult(
+                    part.id,
+                    result,
+                    state.status === "error",
+                    undefined,
+                    images,
+                  ),
                 ]);
                 push({
                   type: "tool_result",
                   toolUseId: part.id,
                   content: result.length > 500 ? result.slice(0, 500) + "..." : result,
+                  ...(images.length ? { images } : {}),
                 });
               }
             }

--- a/src/server/opencode-transcript.test.ts
+++ b/src/server/opencode-transcript.test.ts
@@ -34,6 +34,7 @@ const {
   transcriptLineToolUse,
   transcriptLineToolResult,
   transcriptLineForEntry,
+  opencodeToolResultImages,
 } = mod;
 const { parseTranscript, parseJsonlLines } = await import("./jsonl-parser");
 
@@ -90,6 +91,38 @@ describe("isOpencodeSessionId", () => {
   });
 });
 
+describe("opencodeToolResultImages", () => {
+  test("supports the media route image formats and rejects unscoped paths", () => {
+    for (const [extension, mime] of [
+      ["png", "image/png"],
+      ["jpg", "image/jpeg"],
+      ["jpeg", "image/jpeg"],
+      ["gif", "image/gif"],
+      ["webp", "image/webp"],
+    ]) {
+      const path = `/tmp/read-result.${extension}`;
+      expect(opencodeToolResultImages({
+        type: "tool",
+        tool: "read",
+        state: {
+          status: "completed",
+          input: { filePath: path },
+          attachments: [{ type: "file", mime }],
+        },
+      })).toEqual([`/backstage/media?path=${encodeURIComponent(path)}`]);
+    }
+    expect(opencodeToolResultImages({
+      type: "tool",
+      tool: "read",
+      state: {
+        status: "completed",
+        input: { filePath: "/etc/secrets.png" },
+        attachments: [{ type: "file", mime: "image/png" }],
+      },
+    })).toEqual([]);
+  });
+});
+
 describe("readOpencodeTranscript (SQLite)", () => {
   test("maps messages/parts to entries, strips context fences and synthetic parts", () => {
     const entries = readOpencodeTranscript(SES);
@@ -136,6 +169,51 @@ describe("readOpencodeTranscript (SQLite)", () => {
     expect(entries[0].videos).toEqual([
       "/backstage/media?path=%2Ftmp%2Fopencode-demo.mov",
     ]);
+  });
+  test("maps Read image attachments to the authenticated local media route", () => {
+    const sessionId = "ses_read_image";
+    const createdAt = 1783501500000;
+    const db = new Database(dbPath);
+    db.query("INSERT INTO session VALUES (?, 'p', 't', 1, 1)").run(sessionId);
+    db.query("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+      "msg_read_image",
+      sessionId,
+      createdAt,
+      createdAt,
+      JSON.stringify({ role: "assistant", time: { created: createdAt } }),
+    );
+    db.query("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+      "prt_read_image",
+      "msg_read_image",
+      sessionId,
+      createdAt,
+      createdAt,
+      JSON.stringify({
+        type: "tool",
+        tool: "read",
+        state: {
+          status: "completed",
+          input: { filePath: "/tmp/storyboard-videos.png" },
+          output: "Image read successfully",
+          attachments: [
+            {
+              type: "file",
+              mime: "image/png",
+              url: "data:image/png;base64,iVBORw0KGgo=",
+            },
+          ],
+        },
+      }),
+    );
+    db.close();
+
+    const entries = readOpencodeTranscript(sessionId);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      type: "tool_result",
+      content: "Image read successfully",
+      images: ["/backstage/media?path=%2Ftmp%2Fstoryboard-videos.png"],
+    });
   });
   test("autocompact summaries become compaction system entries", () => {
     const sessionId = "ses_compaction";
@@ -216,6 +294,24 @@ describe("readOpencodeTranscript (SQLite)", () => {
 });
 
 describe("persisted transcript file", () => {
+  test("tool result lines round-trip local image URLs without base64 payloads", () => {
+    const url = "/backstage/media?path=%2Ftmp%2Fstoryboard-videos.png";
+    const line = transcriptLineToolResult(
+      "tu-image",
+      "Image read successfully",
+      false,
+      "2026-07-08T00:00:00.000Z",
+      [url],
+    );
+    expect(JSON.stringify(line)).not.toContain("base64");
+    expect(parseJsonlLines([JSON.stringify(line)])[0]).toMatchObject({
+      id: "tr-tu-image",
+      type: "tool_result",
+      content: "Image read successfully",
+      images: [url],
+    });
+  });
+
   test("appended claude-shape lines round-trip through parseTranscript", () => {
     const id = "ses_roundtrip";
     appendOpencodeTranscript(id, [

--- a/src/server/opencode-transcript.ts
+++ b/src/server/opencode-transcript.ts
@@ -603,7 +603,8 @@ export function transcriptLineToolResult(
   toolUseId: string,
   content: string,
   isError?: boolean,
-  ts?: string
+  ts?: string,
+  images?: string[],
 ): JsonlLine {
   return {
     type: "user",
@@ -615,7 +616,15 @@ export function transcriptLineToolResult(
         {
           type: "tool_result",
           tool_use_id: toolUseId,
-          content,
+          content: images?.length
+            ? [
+                { type: "text", text: content },
+                ...images.map((url) => ({
+                  type: "image",
+                  source: { type: "url", url },
+                })),
+              ]
+            : content,
           ...(isError ? { is_error: true } : {}),
         },
       ],
@@ -656,7 +665,7 @@ export function transcriptLineForEntry(e: TranscriptEntry): JsonlLine | null {
       );
     case "tool_result":
       return e.toolUseId
-        ? transcriptLineToolResult(e.toolUseId, e.content, e.isError, e.timestamp)
+        ? transcriptLineToolResult(e.toolUseId, e.content, e.isError, e.timestamp, e.images)
         : null;
     case "system":
       // Compaction summaries round-trip (readOpencodeTranscript emits them and
@@ -821,7 +830,56 @@ interface PartData {
     input?: unknown;
     output?: string;
     error?: string;
+    attachments?: Array<{
+      type?: string;
+      mime?: string;
+      url?: string;
+    }>;
   };
+}
+
+const LOCAL_IMAGE_PATH_RE = /\.(png|jpe?g|gif|webp)$/i;
+const LOCAL_IMAGE_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/**
+ * OpenCode's Read tool persists image bytes as a base64 file attachment on the
+ * tool state. The transcript must not copy those bytes, so use the attachment
+ * only as proof that Read returned an image and render its original local path
+ * through the authenticated media route instead.
+ */
+export function opencodeToolResultImages(part: PartData): string[] {
+  if (part.type !== "tool" || part.state?.status !== "completed") return [];
+  if (part.tool !== "read" && part.tool !== "view_image") return [];
+  const input = part.state.input;
+  if (!input || typeof input !== "object") return [];
+  const values = input as Record<string, unknown>;
+  const path =
+    typeof values.filePath === "string"
+      ? values.filePath
+      : typeof values.file_path === "string"
+        ? values.file_path
+        : "";
+  if (
+    (!path.startsWith("/tmp/") && !path.startsWith("/home/ubuntu/")) ||
+    path.includes("..") ||
+    !LOCAL_IMAGE_PATH_RE.test(path)
+  ) {
+    return [];
+  }
+  const returnedImage = part.state.attachments?.some(
+    (attachment) =>
+      attachment?.type === "file" &&
+      typeof attachment.mime === "string" &&
+      LOCAL_IMAGE_MIMES.has(attachment.mime.toLowerCase()),
+  );
+  return returnedImage
+    ? [`/backstage/media?path=${encodeURIComponent(path)}`]
+    : [];
 }
 
 function toIso(ms: number | undefined, fallback: string): string {
@@ -999,6 +1057,7 @@ export function readOpencodeTranscript(
             ...(assistant?.videos.length ? { videos: assistant.videos } : {}),
           });
         } else if (part.type === "tool") {
+          const images = opencodeToolResultImages(part);
           entries.push({
             id: p.id,
             type: "tool_use",
@@ -1020,6 +1079,7 @@ export function readOpencodeTranscript(
               timestamp: ts,
               toolUseId: p.id,
               ...(state.status === "error" ? { isError: true } : {}),
+              ...(images.length ? { images } : {}),
             });
           }
         }

--- a/src/server/run-events.ts
+++ b/src/server/run-events.ts
@@ -62,9 +62,9 @@ export interface StreamEvent {
   content?: string;
   result?: string;
   /**
-   * Renderable image sources on a tool_result (data: URLs from base64 blocks,
-   * or direct urls). Forwarded to viewers so screenshots show up the moment
-   * the tool returns instead of waiting for the jsonl tail to catch up.
+   * Renderable image sources on a tool_result (data: URLs, direct URLs, or
+   * authenticated local-media paths). Forwarded to viewers so screenshots
+   * show up the moment the tool returns instead of waiting for persistence.
    */
   images?: string[];
   /**

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -439,8 +439,8 @@ export interface TranscriptEntry {
   // the sub-agent's own transcript to <transcript>/subagents/agent-<agentId>.jsonl,
   // so this links a tool call to its sub-agent conversation (see subagents.ts).
   agentId?: string;
-  // Ready-to-render image srcs (http(s) URLs or data: URLs) extracted from
-  // image blocks — e.g. a Read of an image file, or a pasted image.
+  // Ready-to-render image srcs (http(s), data:, or authenticated local-media
+  // URLs) extracted from image blocks — e.g. a Read or a pasted image.
   images?: string[];
   // Ready-to-render video srcs (served via /backstage/media) parsed from
   // `BACKSTAGE_VIDEO: <path>` markers a tool printed — e.g. tella-local rec.mjs.


### PR DESCRIPTION
## Summary
- detect native OpenCode Read image attachments without copying their base64 payloads into transcript entries
- render supported local PNG, JPEG, GIF, and WebP results through the existing scoped media route
- preserve image metadata in both live stream events and SQLite transcript restoration, including reattached runs

## Verification
- `bun test src/server/opencode-transcript.test.ts --test-name-pattern "isOpencodeSessionId|opencodeToolResultImages|maps messages/parts|maps Read image attachments|extracts and hides video|autocompact|compaction system entries|unknown session|tool result lines round-trip local image"` (9 passed)
- `bun test src/server/jsonl-parser.test.ts` (39 passed)
- representative persisted Read of `/tmp/storyboard-videos.png` normalized to `/backstage/media?path=%2Ftmp%2Fstoryboard-videos.png`
- `bun src/server/frontend-build.ts` (369 files built)
- `bun run typecheck` reaches only pre-existing unrelated errors: argument-count failures in `deploy/sandbox/verify.ts` and two `fetch` mock cast failures in `src/frontend/lib/api.test.ts`

Started by Michiel Westerbeek in [this Michael session](https://os.tella.dev/session/bks-019f8642-dd61-7000-9168-18569eea8bd3)