### PR TITLE
plain triage: stop pointing agents at plain-api.sh (unusable in automation runs)

### DIFF
--- a/src/agents/plain/triage-prompt.ts
+++ b/src/agents/plain/triage-prompt.ts
@@ -18,7 +18,7 @@ Default posture: solve obvious verified product bugs end-to-end. "Investigated a
 
 1. For a specific user, video, recording, upload, or export, start with the high-level TellaInternalSupportMCP investigation tools (lookup_user_by_email, lookup_story_by_slug, investigate_*). Establish what happened in production before theorizing, and verify customer claims against the data.
 2. Use the tella-fusion codebase, recent PRs, docs, and Grafana logs when the support tools do not answer the question. For user-dependent behavior, check flags with \`.agents/skills/check-user-flags\`.
-3. Useful helpers in the repo: \`.agents/skills/support/scripts/plain-api.sh thread timeline th_ID --first 50\` (full conversation), \`... thread list --customer c_ID --status all\` (prior threads), \`... customer search "name"\`. Reference docs: \`.agents/skills/support/references/product-knowledge.md\`, response templates in \`support-automation/references/common-responses/\`.
+3. Fetch the full conversation with the Plain MCP tools (the attached thread event / get_thread) — the \`.agents/skills/support/scripts/plain-api.sh\` helpers (\`thread timeline\`, \`thread list --customer\`, \`customer search\`) need PLAIN_API_KEY, which is NOT in the automation environment, so they die immediately here; they are interactive-only, don't reach for them. Cross-customer prior-ticket history isn't reachable via the Plain MCP either, so note that gap rather than chasing it. Reference docs: \`.agents/skills/support/references/product-knowledge.md\`, response templates in \`support-automation/references/common-responses/\`.
 4. Delegate only genuinely broad, independent searches to subagents. Keep root-cause judgment and the note on the main run.
 
 ## Billing


### PR DESCRIPTION
## Why

Yesterday's Dreaming digest surfaced this twice as a papercut, from two separate Plain-triage automation sessions:

> tried the documented helper `.agents/skills/support/scripts/plain-api.sh thread timeline …` … it died immediately with "PLAIN_API_KEY environment variable is required" — automation runs get the Plain MCP but no PLAIN_API_KEY in the environment, so that helper is unusable there.

The triage prompt's Investigation-order step 3 recommended three `plain-api.sh` subcommands (`thread timeline`, `thread list --customer`, `customer search`). Automation runs get a minimal env with **no PLAIN_API_KEY** (by design — least-privilege), so every one of those calls fails instantly. Agents burned tool calls discovering this each night.

## Change

Step 3 now tells the agent to fetch the conversation via the **Plain MCP** (the attached thread event / `get_thread`), marks the `plain-api.sh` helpers as interactive-only ("don't reach for them"), and is honest that cross-customer prior-ticket history isn't reachable via the Plain MCP either — so the agent notes the gap instead of chasing it.

Prompt-text only; `bunx tsc --noEmit` shows no new errors (the two pre-existing unrelated errors in `deploy/sandbox/verify.ts` and `src/frontend/lib/api.test.ts` are identical with the change stashed).

## Follow-up for a human (seeding is create-if-absent)

`triage-prompt.ts` is the git source of truth, but the **live** Plain-triage automation record in `~/.opensession-automations/` is only seeded if absent — so this commit does **not** update the running automation. To make it take effect, PUT the new prompt to `/backstage/api/automations/:id` for the Plain triage automation.

Created by [this Michael session](https://os.tella.dev/session/bks-019f9cb0-1e81-7000-920f-4be849adc13c)