### PR TITLE
PR image attachments: inline-rendering screenshots via public capability URLs (+ walkthrough splice fix)

### DIFF
--- a/opensession.ts
+++ b/opensession.ts
@@ -52,6 +52,7 @@ import {
 	webAuthRequired,
 } from "./src/server/web-auth";
 import { startWebhookServer } from "./src/server/webhook-server";
+import { prImagePublicRoutes } from "./src/server/pr-images";
 import { sweepArchivedWorktrees } from "./src/server/worktree";
 import {
 	type WSClientData,
@@ -531,14 +532,16 @@ if (!g.__backstageBooted) {
 	}
 
 	// Start webhook server with enabled agents + automation webhook triggers
+	// + the public PR-image capability URLs (comment_on_pr_with_images).
 	agents = await loadAgents();
 	g.__agents = agents;
-	const webhookServer = startWebhookServer(
-		agents,
-		getWebhookRoutes(() => {
-			invalidateSessionsCache();
-		}),
-	);
+	const webhookRoutes = getWebhookRoutes(() => {
+		invalidateSessionsCache();
+	});
+	for (const [key, handler] of prImagePublicRoutes()) {
+		webhookRoutes.set(key, handler);
+	}
+	const webhookServer = startWebhookServer(agents, webhookRoutes);
 	void webhookServer;
 
 	// Seed the make_*_editor.sh action family (create-if-absent, UI edits preserved).

--- a/src/agents/slack/walkthrough-tools.ts
+++ b/src/agents/slack/walkthrough-tools.ts
@@ -7,10 +7,10 @@
  * see src/server/walkthrough.ts for why they can't inline on GitHub).
  *
  * Also carries `comment_on_pr_with_images`: post a PR comment whose
- * screenshots RENDER inline on GitHub — images are committed to an orphan
- * assets branch of the target repo and referenced as private blob URLs (see
- * src/server/pr-images.ts for the mechanism and the alternatives that don't
- * work).
+ * screenshots RENDER inline on GitHub — images are staged to durable storage
+ * and served from unguessable public URLs on michael.tella.dev, which
+ * GitHub's camo proxy can fetch (see src/server/pr-images.ts for the
+ * mechanism and the alternatives that don't work).
  *
  * Wired like opensession-preview: interactive runs only (web sessions +
  * Slack), never automations, and only when a sessionId is in scope.
@@ -20,7 +20,6 @@ import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
 import { z } from "zod";
 import { publishWalkthrough } from "../../server/walkthrough";
 import {
-  ASSETS_BRANCH,
   spliceImagesIntoMarkdown,
   uploadPrImages,
 } from "../../server/pr-images";
@@ -104,7 +103,7 @@ export function createWalkthroughMcpServer(ctx: WalkthroughToolContext) {
     ),
     tool(
       "comment_on_pr_with_images",
-      "Post a comment on this session's PR (or an explicit PR) with screenshots that RENDER INLINE on GitHub. Local image files are committed to the target repo's orphan `opensession-assets` branch (its own root — never the PR branch or any code branch) and referenced as private blob URLs: they render for anyone with repo access and 404 for everyone else, so screenshots never leave channels we control. Place images in the markdown with {{image:1}}, {{image:2}}, … (1-based); images you don't reference are appended at the end. Use it when a picture belongs in the PR conversation — review evidence, visual bug reports, before/after context for reviewers.",
+      "Post a comment on this session's PR (or an explicit PR) with screenshots that RENDER INLINE on GitHub. Images are copied to durable storage and served from unguessable public URLs on michael.tella.dev (our own infra — never a third-party host, never a commit on any branch); GitHub's camo proxy fetches them so they render everywhere, private repos included. The URLs are capability links: anyone holding one can fetch the image, so don't attach anything that must stay strictly repo-member-only. Place images in the markdown with {{image:1}}, {{image:2}}, … (1-based); images you don't reference are appended at the end. Use it when a picture belongs in the PR conversation — review evidence, visual bug reports, before/after context for reviewers.",
       {
         comment: z
           .string()
@@ -164,15 +163,15 @@ export function createWalkthroughMcpServer(ctx: WalkthroughToolContext) {
               "Session not found — pass both repo and pr_number so the PR can be targeted explicitly.",
             );
           }
-          const uploaded = await uploadPrImages(ghRepo, args.images);
+          const uploaded = uploadPrImages(args.images);
           const body = spliceImagesIntoMarkdown(args.comment, uploaded);
           const res = await postPrComment(selector, { body }, ghRepo);
           if ("error" in res)
             return text(
-              `Posting the comment failed: ${res.error}. The ${uploaded.length} image(s) WERE uploaded to ${ghRepo}@${ASSETS_BRANCH} and can be reused: ${uploaded.map((u) => u.url).join(" ")}`,
+              `Posting the comment failed: ${res.error}. The ${uploaded.length} image(s) WERE staged and their URLs can be reused: ${uploaded.map((u) => u.url).join(" ")}`,
             );
           return text(
-            `Comment posted${res.url ? `: ${res.url}` : ""} — ${uploaded.length} image(s) attached (committed to ${ghRepo}@${ASSETS_BRANCH}; they render inline for anyone with repo access).`,
+            `Comment posted${res.url ? `: ${res.url}` : ""} — ${uploaded.length} image(s) attached (served from michael.tella.dev; they render inline via GitHub's image proxy).`,
           );
         } catch (e: any) {
           return text(`comment_on_pr_with_images failed: ${e?.message || String(e)}`);

--- a/src/agents/slack/walkthrough-tools.ts
+++ b/src/agents/slack/walkthrough-tools.ts
@@ -6,6 +6,12 @@
  * GitHub PR description as a managed section (media as tailnet links there —
  * see src/server/walkthrough.ts for why they can't inline on GitHub).
  *
+ * Also carries `comment_on_pr_with_images`: post a PR comment whose
+ * screenshots RENDER inline on GitHub — images are committed to an orphan
+ * assets branch of the target repo and referenced as private blob URLs (see
+ * src/server/pr-images.ts for the mechanism and the alternatives that don't
+ * work).
+ *
  * Wired like opensession-preview: interactive runs only (web sessions +
  * Slack), never automations, and only when a sessionId is in scope.
  */
@@ -13,6 +19,15 @@
 import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
 import { z } from "zod";
 import { publishWalkthrough } from "../../server/walkthrough";
+import {
+  ASSETS_BRANCH,
+  spliceImagesIntoMarkdown,
+  uploadPrImages,
+} from "../../server/pr-images";
+import { postPrComment } from "../../server/pr-info";
+import { findSession } from "../../server/session-cache";
+import { resolvePrTarget } from "../../server/session-repos";
+import { REPOS } from "../../server/worktree";
 
 export interface WalkthroughToolContext {
   sessionId: string;
@@ -84,6 +99,83 @@ export function createWalkthroughMcpServer(ctx: WalkthroughToolContext) {
           return text(parts.join(" "));
         } catch (e: any) {
           return text(`publish_walkthrough failed: ${e?.message || String(e)}`);
+        }
+      },
+    ),
+    tool(
+      "comment_on_pr_with_images",
+      "Post a comment on this session's PR (or an explicit PR) with screenshots that RENDER INLINE on GitHub. Local image files are committed to the target repo's orphan `opensession-assets` branch (its own root — never the PR branch or any code branch) and referenced as private blob URLs: they render for anyone with repo access and 404 for everyone else, so screenshots never leave channels we control. Place images in the markdown with {{image:1}}, {{image:2}}, … (1-based); images you don't reference are appended at the end. Use it when a picture belongs in the PR conversation — review evidence, visual bug reports, before/after context for reviewers.",
+      {
+        comment: z
+          .string()
+          .describe(
+            "Comment markdown. Optionally position images with {{image:N}} placeholders (1-based).",
+          ),
+        images: z
+          .array(
+            z.object({
+              path: z
+                .string()
+                .describe("Absolute path to the image (png/jpg/jpeg/webp/gif) under /tmp or /home/ubuntu."),
+              alt: z.string().optional().describe("Alt/caption text for the image."),
+            }),
+          )
+          .min(1)
+          .describe("Images to upload and attach."),
+        repo: z
+          .string()
+          .optional()
+          .describe(
+            "Project id (e.g. tella-fusion, backstage, tella-mac) when the PR isn't on the session's primary repo — attached and linked repos resolve too.",
+          ),
+        pr_number: z
+          .number()
+          .optional()
+          .describe("Explicit PR number in that repo. Defaults to the open PR on the session's branch."),
+      },
+      async (args: {
+        comment: string;
+        images: Array<{ path: string; alt?: string }>;
+        repo?: string;
+        pr_number?: number;
+      }) => {
+        try {
+          if (args.repo && !REPOS[args.repo])
+            return text(
+              `Unknown repo "${args.repo}" — known project ids: ${Object.keys(REPOS).join(", ")}.`,
+            );
+          let ghRepo: string | undefined;
+          let selector: string | undefined; // branch name or PR number for gh
+          const session = findSession(ctx.sessionId);
+          if (args.repo && args.pr_number) {
+            // Fully explicit — works even when the session can't be resolved.
+            ghRepo = REPOS[args.repo].ghRepo;
+            selector = String(args.pr_number);
+          } else if (session) {
+            const target = resolvePrTarget(session, args.repo || null, null);
+            if (!target)
+              return text(
+                "Couldn't resolve a PR target from this session — pass repo and pr_number explicitly.",
+              );
+            ghRepo = target.ghRepo;
+            selector = args.pr_number ? String(args.pr_number) : target.branch;
+          } else {
+            return text(
+              "Session not found — pass both repo and pr_number so the PR can be targeted explicitly.",
+            );
+          }
+          const uploaded = await uploadPrImages(ghRepo, args.images);
+          const body = spliceImagesIntoMarkdown(args.comment, uploaded);
+          const res = await postPrComment(selector, { body }, ghRepo);
+          if ("error" in res)
+            return text(
+              `Posting the comment failed: ${res.error}. The ${uploaded.length} image(s) WERE uploaded to ${ghRepo}@${ASSETS_BRANCH} and can be reused: ${uploaded.map((u) => u.url).join(" ")}`,
+            );
+          return text(
+            `Comment posted${res.url ? `: ${res.url}` : ""} — ${uploaded.length} image(s) attached (committed to ${ghRepo}@${ASSETS_BRANCH}; they render inline for anyone with repo access).`,
+          );
+        } catch (e: any) {
+          return text(`comment_on_pr_with_images failed: ${e?.message || String(e)}`);
         }
       },
     ),

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -1367,7 +1367,11 @@ export function buildOpencodeInstructions(input: {
         "in the session's Review tab, and is mirrored into the PR " +
         "description; if you publish before the PR exists, call it again after `gh pr create` " +
         "so it lands there too. Skip it for pure refactors, backend-only changes, or trivial " +
-        "tweaks — a walkthrough should demonstrate something a human can see."
+        "tweaks — a walkthrough should demonstrate something a human can see. When a " +
+        "screenshot belongs in the PR conversation itself (review evidence, a visual bug " +
+        "report), use `comment_on_pr_with_images` instead: it commits the images to the " +
+        "repo's orphan assets branch and posts a PR comment where they render inline for " +
+        "the team — never commit screenshots to the PR branch."
     );
   }
   if (inproc["opensession-report"]) {

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -1369,9 +1369,9 @@ export function buildOpencodeInstructions(input: {
         "so it lands there too. Skip it for pure refactors, backend-only changes, or trivial " +
         "tweaks — a walkthrough should demonstrate something a human can see. When a " +
         "screenshot belongs in the PR conversation itself (review evidence, a visual bug " +
-        "report), use `comment_on_pr_with_images` instead: it commits the images to the " +
-        "repo's orphan assets branch and posts a PR comment where they render inline for " +
-        "the team — never commit screenshots to the PR branch."
+        "report), use `comment_on_pr_with_images` instead: it serves the images from our " +
+        "own public host so they render inline in the PR comment for the team — never " +
+        "commit screenshots to the PR branch."
     );
   }
   if (inproc["opensession-report"]) {

--- a/src/server/pr-images.ts
+++ b/src/server/pr-images.ts
@@ -1,44 +1,60 @@
 /**
- * PR image attachments — upload local screenshots to an orphan
- * `opensession-assets` branch of the target GitHub repo via the git data API
- * (no local clone, and never the PR branch), returning
- * `github.com/<repo>/blob/opensession-assets/<path>?raw=true` URLs that render
- * inline in PR/issue markdown for anyone with access to the repo.
+ * PR image attachments — stage local screenshots into durable uploads storage
+ * and serve them from unguessable public URLs on michael.tella.dev (the
+ * webhook server's public origin), so GitHub's camo proxy can fetch them and
+ * they render inline in PR/issue markdown everywhere — private repos included.
  *
- * Why this mechanism (verified empirically 2026-07-26 via a rendering-probe
- * issue on tellahq/backstage, since deleted):
+ * Why this mechanism (empirical, 2026-07-26, probes on tellahq/backstage):
  * - GitHub's own attachment CDN (what the web UI uses — POST
  *   /upload/policies/assets) is a cookie-session form endpoint: it 422s under
  *   a PAT/Bearer token and has no documented API. Not usable for a bot.
- * - raw.githubusercontent.com URLs are left un-proxied in rendered HTML but
- *   that domain never sees github.com session cookies, so they 404 for
- *   private repos — broken for every viewer.
- * - Release-asset URLs ride the same cookie→signed-redirect chain as blob
- *   URLs, but a release per screenshot batch pollutes the Releases page.
- * - os.tella.dev media URLs get rewritten to camo.githubusercontent.com,
- *   and camo can't reach the tailnet — always a broken image.
- * - blob `?raw=true` URLs stay un-proxied (github.com is a trusted host): the
- *   viewer's browser resolves them with its github.com session, which 302s to
- *   a signed raw URL. Renders for teammates with repo access, 404s for
- *   everyone else — the right visibility for screenshots that may contain
- *   customer data (a private tellahq repo is a channel we control).
+ * - Committed blob `?raw=true` URLs on a private repo do NOT render inline in
+ *   comments: GitHub leaves them un-proxied in body_html, but the browser's
+ *   <img> subresource fetch is not the top-level navigation the
+ *   cookie→signed-redirect dance needs — human-verified broken image icon on
+ *   tellahq/backstage#78 (the click-through link works, the inline img 404s).
+ * - raw.githubusercontent.com / release-asset URLs fail the same way or
+ *   worse (raw.githubusercontent never sees github.com cookies at all).
+ * - os.tella.dev media URLs get camo-rewritten but camo can't reach the
+ *   tailnet — always broken (that's why the walkthrough mirror links media
+ *   instead of inlining it).
+ * - An image on a PUBLIC host renders everywhere: GitHub rewrites it to
+ *   camo.githubusercontent.com, camo fetches it server-side and serves it
+ *   from GitHub's CDN to anyone who can read the PR.
  *
- * Each upload batch lands as ONE commit on the assets branch (blobs → tree →
- * commit → ref fast-forward), so PR branches and master history stay clean.
+ * Privacy model: third-party public hosts are banned for our screenshots
+ * (PII rule), but michael.tella.dev is our own infra — the same public origin
+ * that already receives Slack/Plain/GitHub webhooks. URLs carry a 128-bit
+ * random token (capability URL, like an unlisted share link); there is no
+ * listing endpoint. Anyone with the URL (including GitHub's camo cache) can
+ * fetch the image, so don't attach anything that must stay repo-member-only.
+ *
+ * The GET /pr-images/* route registers on the webhook server (port 3848,
+ * public via Caddy) — see prImagePublicRoutes(), wired in opensession.ts.
+ * Webhook routes bind at boot: changes here need a real restart.
  */
 
-import { existsSync, statSync } from "fs";
+import { existsSync, mkdirSync, copyFileSync, statSync } from "fs";
 import { basename } from "path";
-import {
-  ghRateLimited,
-  isGhRateLimitMsg,
-  noteGhRateLimited,
-} from "./github-limit";
-
-export const ASSETS_BRANCH = "opensession-assets";
+import { randomBytes } from "crypto";
+import { UPLOADS_DIR } from "./uploads";
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
-const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const CONTENT_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+/** Camo historically caps proxied images around 5MB — stay under it. */
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/** Public origin the webhook server is reachable on (Caddy vhost). */
+const PUBLIC_BASE =
+  process.env.OPENSESSION_PR_IMAGES_BASE || "https://michael.tella.dev";
+
+const PR_IMAGES_DIR = `${UPLOADS_DIR}/pr-images`;
 
 export interface PrImageInput {
   /** Absolute local path to the image (under /tmp or /home/ubuntu). */
@@ -49,14 +65,11 @@ export interface PrImageInput {
 
 export interface UploadedPrImage {
   alt: string;
-  /** blob?raw=true URL that renders inline for repo members. */
+  /** Public unguessable URL — renders inline on GitHub via camo. */
   url: string;
-  /** Path of the file on the assets branch. */
-  repoPath: string;
+  /** Staged absolute path on disk (durable uploads storage). */
+  stagedPath: string;
 }
-
-const RATE_LIMIT_MESSAGE =
-  "GitHub API rate limit is exhausted right now — try again once the window resets.";
 
 function ext(p: string): string {
   return p.slice(p.lastIndexOf(".")).toLowerCase();
@@ -72,41 +85,7 @@ function readablePath(p: string): boolean {
   );
 }
 
-/** `gh api` with a JSON body via --input (argv can't carry multi-MB base64). */
-async function ghApi(
-  method: "GET" | "POST" | "PATCH",
-  path: string,
-  body?: unknown,
-): Promise<{ ok: boolean; status: number; json: any; err: string }> {
-  const args = ["api", "-X", method, path];
-  let tmp: string | null = null;
-  if (body !== undefined) {
-    tmp = `/tmp/opensession-pr-image-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
-    await Bun.write(tmp, JSON.stringify(body));
-    args.push("--input", tmp);
-  }
-  try {
-    const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
-    const [out, err, code] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-    if (code !== 0 && isGhRateLimitMsg(err)) noteGhRateLimited("pr-images");
-    let json: any = null;
-    try {
-      json = out.trim() ? JSON.parse(out) : null;
-    } catch {}
-    const status = code === 0 ? 200 : (json?.status ? Number(json.status) : 0);
-    return { ok: code === 0, status, json, err: err.slice(0, 300) };
-  } finally {
-    if (tmp) await Bun.file(tmp).unlink().catch(() => {});
-  }
-}
-
-function assetPath(localPath: string): string {
-  const now = new Date();
-  const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+function safeName(localPath: string): string {
   const name = basename(localPath);
   const dot = name.lastIndexOf(".");
   const stem = (dot > 0 ? name.slice(0, dot) : name)
@@ -114,23 +93,16 @@ function assetPath(localPath: string): string {
     .replace(/[^a-z0-9-_]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 60) || "image";
-  const rand = Math.random().toString(36).slice(2, 8);
-  return `pr-images/${month}/${stem}-${rand}${ext(name)}`;
+  return `${stem}${ext(name)}`;
 }
 
 /**
- * Upload local images as one commit on the repo's orphan assets branch.
- * Creates the branch (orphan — no parents, so no shared history with any
- * code branch) on first use. Retries the ref fast-forward once in case a
- * concurrent upload advanced the branch between read and write.
+ * Stage images into per-token dirs under the uploads storage and return their
+ * public URLs. Pure local work — no GitHub API involved, so it works for any
+ * repo and never touches any git branch.
  */
-export async function uploadPrImages(
-  ghRepo: string,
-  images: PrImageInput[],
-): Promise<UploadedPrImage[]> {
+export function uploadPrImages(images: PrImageInput[]): UploadedPrImage[] {
   if (!images.length) throw new Error("no images given");
-  if (ghRateLimited()) throw new Error(RATE_LIMIT_MESSAGE);
-
   for (const img of images) {
     const p = (img.path || "").trim();
     if (!readablePath(p))
@@ -139,70 +111,22 @@ export async function uploadPrImages(
       throw new Error(`image must be one of ${[...IMAGE_EXTS].join(" ")}: ${p}`);
     if (!existsSync(p)) throw new Error(`image file not found: ${p}`);
     if (statSync(p).size > MAX_IMAGE_BYTES)
-      throw new Error(`image too large (max ${MAX_IMAGE_BYTES / 1024 / 1024}MB): ${p}`);
+      throw new Error(
+        `image too large (max ${MAX_IMAGE_BYTES / 1024 / 1024}MB — GitHub's camo proxy won't serve bigger): ${p}`,
+      );
   }
-
-  // One blob per image (these carry the actual bytes).
-  const entries: Array<{ input: PrImageInput; repoPath: string; blobSha: string }> = [];
-  for (const img of images) {
-    const bytes = await Bun.file(img.path.trim()).arrayBuffer();
-    const content = Buffer.from(bytes).toString("base64");
-    const blob = await ghApi("POST", `repos/${ghRepo}/git/blobs`, {
-      content,
-      encoding: "base64",
-    });
-    if (!blob.ok)
-      throw new Error(`git blob upload failed for ${img.path}: ${blob.json?.message || blob.err}`);
-    entries.push({ input: img, repoPath: assetPath(img.path), blobSha: blob.json.sha });
-  }
-
-  // Tree + commit + ref, with one retry if a concurrent upload moved the ref.
-  for (let attempt = 0; ; attempt++) {
-    const head = await ghApi("GET", `repos/${ghRepo}/git/ref/heads/${ASSETS_BRANCH}`);
-    const headSha: string | null = head.ok ? head.json?.object?.sha : null;
-    let baseTree: string | undefined;
-    if (headSha) {
-      const commit = await ghApi("GET", `repos/${ghRepo}/git/commits/${headSha}`);
-      if (!commit.ok)
-        throw new Error(`reading assets branch head failed: ${commit.json?.message || commit.err}`);
-      baseTree = commit.json?.tree?.sha;
-    }
-    const tree = await ghApi("POST", `repos/${ghRepo}/git/trees`, {
-      ...(baseTree ? { base_tree: baseTree } : {}),
-      tree: entries.map((e) => ({
-        path: e.repoPath,
-        mode: "100644",
-        type: "blob",
-        sha: e.blobSha,
-      })),
-    });
-    if (!tree.ok) throw new Error(`git tree failed: ${tree.json?.message || tree.err}`);
-    const commit = await ghApi("POST", `repos/${ghRepo}/git/commits`, {
-      message: `opensession: attach ${entries.length} PR image${entries.length === 1 ? "" : "s"}`,
-      tree: tree.json.sha,
-      parents: headSha ? [headSha] : [],
-    });
-    if (!commit.ok) throw new Error(`git commit failed: ${commit.json?.message || commit.err}`);
-    const ref = headSha
-      ? await ghApi("PATCH", `repos/${ghRepo}/git/refs/heads/${ASSETS_BRANCH}`, {
-          sha: commit.json.sha,
-        })
-      : await ghApi("POST", `repos/${ghRepo}/git/refs`, {
-          ref: `refs/heads/${ASSETS_BRANCH}`,
-          sha: commit.json.sha,
-        });
-    if (ref.ok) break;
-    // Not-fast-forward / already-exists: someone raced us — retry once on the
-    // fresh head (blobs are content-addressed, so they carry over as-is).
-    if (attempt >= 1)
-      throw new Error(`updating assets branch failed: ${ref.json?.message || ref.err}`);
-  }
-
-  return entries.map((e) => ({
-    alt: e.input.alt?.trim() || basename(e.input.path).replace(/\.[^.]+$/, ""),
-    url: `https://github.com/${ghRepo}/blob/${ASSETS_BRANCH}/${e.repoPath}?raw=true`,
-    repoPath: e.repoPath,
-  }));
+  return images.map((img) => {
+    const token = randomBytes(16).toString("hex");
+    const name = safeName(img.path.trim());
+    const dir = `${PR_IMAGES_DIR}/${token}`;
+    mkdirSync(dir, { recursive: true });
+    copyFileSync(img.path.trim(), `${dir}/${name}`);
+    return {
+      alt: img.alt?.trim() || basename(img.path).replace(/\.[^.]+$/, ""),
+      url: `${PUBLIC_BASE}/pr-images/${token}/${name}`,
+      stagedPath: `${dir}/${name}`,
+    };
+  });
 }
 
 /** Markdown for one uploaded image. */
@@ -231,4 +155,33 @@ export function spliceImagesIntoMarkdown(
     body = `${body.trimEnd()}\n\n${rest.map(prImageMarkdown).join("\n\n")}`;
   }
   return body;
+}
+
+const PUBLIC_PATH_RE = /^\/pr-images\/([a-f0-9]{32})\/([a-z0-9-_]+\.(?:png|jpe?g|gif|webp))$/;
+
+/**
+ * Public routes for the webhook server: serve a staged image by its
+ * capability URL. Token + strictly-slugged filename only — no listing, no
+ * traversal surface (the regex is the whole grammar). Immutable cache headers
+ * so camo/CDNs hold on to it.
+ */
+export function prImagePublicRoutes(): Map<
+  string,
+  (req: Request, url: URL) => Promise<Response>
+> {
+  const routes = new Map<string, (req: Request, url: URL) => Promise<Response>>();
+  routes.set("GET /pr-images/*", async (_req, url) => {
+    const m = url.pathname.match(PUBLIC_PATH_RE);
+    if (!m) return Response.json({ error: "Not found" }, { status: 404 });
+    const path = `${PR_IMAGES_DIR}/${m[1]}/${m[2]}`;
+    if (!existsSync(path)) return Response.json({ error: "Not found" }, { status: 404 });
+    return new Response(Bun.file(path), {
+      headers: {
+        "Content-Type": CONTENT_TYPES[ext(m[2])] || "application/octet-stream",
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  });
+  return routes;
 }

--- a/src/server/pr-images.ts
+++ b/src/server/pr-images.ts
@@ -1,0 +1,234 @@
+/**
+ * PR image attachments — upload local screenshots to an orphan
+ * `opensession-assets` branch of the target GitHub repo via the git data API
+ * (no local clone, and never the PR branch), returning
+ * `github.com/<repo>/blob/opensession-assets/<path>?raw=true` URLs that render
+ * inline in PR/issue markdown for anyone with access to the repo.
+ *
+ * Why this mechanism (verified empirically 2026-07-26 via a rendering-probe
+ * issue on tellahq/backstage, since deleted):
+ * - GitHub's own attachment CDN (what the web UI uses — POST
+ *   /upload/policies/assets) is a cookie-session form endpoint: it 422s under
+ *   a PAT/Bearer token and has no documented API. Not usable for a bot.
+ * - raw.githubusercontent.com URLs are left un-proxied in rendered HTML but
+ *   that domain never sees github.com session cookies, so they 404 for
+ *   private repos — broken for every viewer.
+ * - Release-asset URLs ride the same cookie→signed-redirect chain as blob
+ *   URLs, but a release per screenshot batch pollutes the Releases page.
+ * - os.tella.dev media URLs get rewritten to camo.githubusercontent.com,
+ *   and camo can't reach the tailnet — always a broken image.
+ * - blob `?raw=true` URLs stay un-proxied (github.com is a trusted host): the
+ *   viewer's browser resolves them with its github.com session, which 302s to
+ *   a signed raw URL. Renders for teammates with repo access, 404s for
+ *   everyone else — the right visibility for screenshots that may contain
+ *   customer data (a private tellahq repo is a channel we control).
+ *
+ * Each upload batch lands as ONE commit on the assets branch (blobs → tree →
+ * commit → ref fast-forward), so PR branches and master history stay clean.
+ */
+
+import { existsSync, statSync } from "fs";
+import { basename } from "path";
+import {
+  ghRateLimited,
+  isGhRateLimitMsg,
+  noteGhRateLimited,
+} from "./github-limit";
+
+export const ASSETS_BRANCH = "opensession-assets";
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export interface PrImageInput {
+  /** Absolute local path to the image (under /tmp or /home/ubuntu). */
+  path: string;
+  /** Alt/caption text for the rendered image. */
+  alt?: string;
+}
+
+export interface UploadedPrImage {
+  alt: string;
+  /** blob?raw=true URL that renders inline for repo members. */
+  url: string;
+  /** Path of the file on the assets branch. */
+  repoPath: string;
+}
+
+const RATE_LIMIT_MESSAGE =
+  "GitHub API rate limit is exhausted right now — try again once the window resets.";
+
+function ext(p: string): string {
+  return p.slice(p.lastIndexOf(".")).toLowerCase();
+}
+
+/** Same reachability rule as walkthrough media: absolute, no traversal, under
+ *  the places agents can actually write. */
+function readablePath(p: string): boolean {
+  return (
+    p.startsWith("/") &&
+    !p.includes("..") &&
+    (p.startsWith("/tmp/") || p.startsWith("/home/ubuntu/"))
+  );
+}
+
+/** `gh api` with a JSON body via --input (argv can't carry multi-MB base64). */
+async function ghApi(
+  method: "GET" | "POST" | "PATCH",
+  path: string,
+  body?: unknown,
+): Promise<{ ok: boolean; status: number; json: any; err: string }> {
+  const args = ["api", "-X", method, path];
+  let tmp: string | null = null;
+  if (body !== undefined) {
+    tmp = `/tmp/opensession-pr-image-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+    await Bun.write(tmp, JSON.stringify(body));
+    args.push("--input", tmp);
+  }
+  try {
+    const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+    const [out, err, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (code !== 0 && isGhRateLimitMsg(err)) noteGhRateLimited("pr-images");
+    let json: any = null;
+    try {
+      json = out.trim() ? JSON.parse(out) : null;
+    } catch {}
+    const status = code === 0 ? 200 : (json?.status ? Number(json.status) : 0);
+    return { ok: code === 0, status, json, err: err.slice(0, 300) };
+  } finally {
+    if (tmp) await Bun.file(tmp).unlink().catch(() => {});
+  }
+}
+
+function assetPath(localPath: string): string {
+  const now = new Date();
+  const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const name = basename(localPath);
+  const dot = name.lastIndexOf(".");
+  const stem = (dot > 0 ? name.slice(0, dot) : name)
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "image";
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `pr-images/${month}/${stem}-${rand}${ext(name)}`;
+}
+
+/**
+ * Upload local images as one commit on the repo's orphan assets branch.
+ * Creates the branch (orphan — no parents, so no shared history with any
+ * code branch) on first use. Retries the ref fast-forward once in case a
+ * concurrent upload advanced the branch between read and write.
+ */
+export async function uploadPrImages(
+  ghRepo: string,
+  images: PrImageInput[],
+): Promise<UploadedPrImage[]> {
+  if (!images.length) throw new Error("no images given");
+  if (ghRateLimited()) throw new Error(RATE_LIMIT_MESSAGE);
+
+  for (const img of images) {
+    const p = (img.path || "").trim();
+    if (!readablePath(p))
+      throw new Error(`image path must be absolute under /tmp or /home/ubuntu: ${p}`);
+    if (!IMAGE_EXTS.has(ext(p)))
+      throw new Error(`image must be one of ${[...IMAGE_EXTS].join(" ")}: ${p}`);
+    if (!existsSync(p)) throw new Error(`image file not found: ${p}`);
+    if (statSync(p).size > MAX_IMAGE_BYTES)
+      throw new Error(`image too large (max ${MAX_IMAGE_BYTES / 1024 / 1024}MB): ${p}`);
+  }
+
+  // One blob per image (these carry the actual bytes).
+  const entries: Array<{ input: PrImageInput; repoPath: string; blobSha: string }> = [];
+  for (const img of images) {
+    const bytes = await Bun.file(img.path.trim()).arrayBuffer();
+    const content = Buffer.from(bytes).toString("base64");
+    const blob = await ghApi("POST", `repos/${ghRepo}/git/blobs`, {
+      content,
+      encoding: "base64",
+    });
+    if (!blob.ok)
+      throw new Error(`git blob upload failed for ${img.path}: ${blob.json?.message || blob.err}`);
+    entries.push({ input: img, repoPath: assetPath(img.path), blobSha: blob.json.sha });
+  }
+
+  // Tree + commit + ref, with one retry if a concurrent upload moved the ref.
+  for (let attempt = 0; ; attempt++) {
+    const head = await ghApi("GET", `repos/${ghRepo}/git/ref/heads/${ASSETS_BRANCH}`);
+    const headSha: string | null = head.ok ? head.json?.object?.sha : null;
+    let baseTree: string | undefined;
+    if (headSha) {
+      const commit = await ghApi("GET", `repos/${ghRepo}/git/commits/${headSha}`);
+      if (!commit.ok)
+        throw new Error(`reading assets branch head failed: ${commit.json?.message || commit.err}`);
+      baseTree = commit.json?.tree?.sha;
+    }
+    const tree = await ghApi("POST", `repos/${ghRepo}/git/trees`, {
+      ...(baseTree ? { base_tree: baseTree } : {}),
+      tree: entries.map((e) => ({
+        path: e.repoPath,
+        mode: "100644",
+        type: "blob",
+        sha: e.blobSha,
+      })),
+    });
+    if (!tree.ok) throw new Error(`git tree failed: ${tree.json?.message || tree.err}`);
+    const commit = await ghApi("POST", `repos/${ghRepo}/git/commits`, {
+      message: `opensession: attach ${entries.length} PR image${entries.length === 1 ? "" : "s"}`,
+      tree: tree.json.sha,
+      parents: headSha ? [headSha] : [],
+    });
+    if (!commit.ok) throw new Error(`git commit failed: ${commit.json?.message || commit.err}`);
+    const ref = headSha
+      ? await ghApi("PATCH", `repos/${ghRepo}/git/refs/heads/${ASSETS_BRANCH}`, {
+          sha: commit.json.sha,
+        })
+      : await ghApi("POST", `repos/${ghRepo}/git/refs`, {
+          ref: `refs/heads/${ASSETS_BRANCH}`,
+          sha: commit.json.sha,
+        });
+    if (ref.ok) break;
+    // Not-fast-forward / already-exists: someone raced us — retry once on the
+    // fresh head (blobs are content-addressed, so they carry over as-is).
+    if (attempt >= 1)
+      throw new Error(`updating assets branch failed: ${ref.json?.message || ref.err}`);
+  }
+
+  return entries.map((e) => ({
+    alt: e.input.alt?.trim() || basename(e.input.path).replace(/\.[^.]+$/, ""),
+    url: `https://github.com/${ghRepo}/blob/${ASSETS_BRANCH}/${e.repoPath}?raw=true`,
+    repoPath: e.repoPath,
+  }));
+}
+
+/** Markdown for one uploaded image. */
+export function prImageMarkdown(img: UploadedPrImage): string {
+  return `![${img.alt}](${img.url})`;
+}
+
+/**
+ * Substitute `{{image:N}}` placeholders (1-based) in a markdown body with the
+ * uploaded images; any images never referenced are appended at the end so
+ * nothing silently vanishes.
+ */
+export function spliceImagesIntoMarkdown(
+  markdown: string,
+  uploaded: UploadedPrImage[],
+): string {
+  const used = new Set<number>();
+  let body = markdown.replace(/\{\{\s*image:(\d+)\s*\}\}/gi, (m, n) => {
+    const idx = parseInt(n, 10) - 1;
+    if (idx < 0 || idx >= uploaded.length) return m;
+    used.add(idx);
+    return prImageMarkdown(uploaded[idx]);
+  });
+  const rest = uploaded.filter((_, i) => !used.has(i));
+  if (rest.length) {
+    body = `${body.trimEnd()}\n\n${rest.map(prImageMarkdown).join("\n\n")}`;
+  }
+  return body;
+}

--- a/src/server/pr-info.ts
+++ b/src/server/pr-info.ts
@@ -618,7 +618,12 @@ export async function editPrReviewers(
  * Rewrite the PR description through a mutator over the current body — used by
  * the walkthrough mirror to splice its managed section in place. Reads the
  * live body first (never a cached one: humans edit descriptions) and writes
- * via --body-file so markdown/quotes/newlines survive shell-free.
+ * via REST (PATCH pulls/{n} with an --input file so markdown/quotes/newlines
+ * survive shell-free). NOT `gh pr edit`: its GraphQL preamble resolves org
+ * teams and needs read:org, which neither the bot PAT nor the device-flow
+ * OAuth tokens carry — it fails unconditionally on tellahq repos (verified
+ * live on tellahq/backstage#78, 2026-07-26; same class as the label-edit
+ * gotcha).
  */
 export async function updatePrBody(
   branch: string,
@@ -640,11 +645,11 @@ export async function updatePrBody(
     const pr = JSON.parse(out) as { body: string; number: number; url: string };
     const next = mutate(pr.body || "");
     if (next === (pr.body || "")) return { ok: true, number: pr.number, url: pr.url };
-    const tmp = `/tmp/opensession-pr-body-${Date.now()}-${Math.random().toString(36).slice(2)}.md`;
-    await Bun.write(tmp, next);
+    const tmp = `/tmp/opensession-pr-body-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+    await Bun.write(tmp, JSON.stringify({ body: next }));
     try {
       const edit = Bun.spawn(
-        ["gh", "pr", "edit", branch, "--repo", repo, "--body-file", tmp],
+        ["gh", "api", "-X", "PATCH", `repos/${repo}/pulls/${pr.number}`, "--input", tmp],
         { stdout: "pipe", stderr: "pipe" }
       );
       const [, editErr, editCode] = await Promise.all([
@@ -653,7 +658,7 @@ export async function updatePrBody(
         edit.exited,
       ]);
       if (editCode !== 0)
-        return { error: (editErr || "gh pr edit failed").slice(0, 300) };
+        return { error: (editErr || "gh api pulls PATCH failed").slice(0, 300) };
     } finally {
       await Bun.file(tmp).unlink().catch(() => {});
     }

--- a/src/server/sessions.ts
+++ b/src/server/sessions.ts
@@ -564,6 +564,27 @@ function getFileMtime(path: string): string {
   }
 }
 
+/**
+ * Overlay backstage-owned extras onto a slack/linear-scanned session.
+ * touchBackstageSession writes fields like walkthrough/linkedPrs keyed by the
+ * UNIFIED id into ~/.opensession-chats/<id>.json — for non-backstage sessions
+ * that sidecar has no `id` field, so scanBackstageSessions skips it and the
+ * fields silently vanished from the unified view (publish_walkthrough on a
+ * Slack session kept answering "no walkthrough on session" right after
+ * persisting one — tellahq/tella-mac#71, 2026-07-26).
+ */
+function overlaySidecarExtras(session: UnifiedSession): UnifiedSession {
+  const path = `${SESSIONS_DIR}/${session.id}.json`;
+  if (!existsSync(path)) return session;
+  const data = readJsonSafe<BackstageSessionFile>(path);
+  if (!data) return session;
+  if (data.walkthrough) session.walkthrough = data.walkthrough;
+  if (data.linkedPrs?.length) session.linkedPrs = data.linkedPrs;
+  if (data.attachedRepos?.length) session.attachedRepos = data.attachedRepos;
+  if (data.previewPath) session.previewPath = data.previewPath;
+  return session;
+}
+
 function scanSlackSessions(): UnifiedSession[] {
   if (!existsSync(SLACK_SESSIONS_DIR)) return [];
   const sessions: UnifiedSession[] = [];
@@ -583,7 +604,7 @@ function scanSlackSessions(): UnifiedSession[] {
     // Use a stable ID based on filename
     const id = `slack-${file.replace(".json", "")}`;
 
-    sessions.push({
+    sessions.push(overlaySidecarExtras({
       id,
       claudeSessionId: data.claudeSessionId || null,
       source: "slack",
@@ -613,7 +634,7 @@ function scanSlackSessions(): UnifiedSession[] {
         : undefined,
       model: data.model,
       codexThreadId: data.codexThreadId || undefined,
-    });
+    }));
   }
   return sessions;
 }
@@ -644,7 +665,7 @@ function scanLinearSessions(): UnifiedSession[] {
 
     const id = `linear-${data.branch}`;
 
-    sessions.push({
+    sessions.push(overlaySidecarExtras({
       id,
       claudeSessionId: data.claudeSessionId,
       source: "linear",
@@ -674,7 +695,7 @@ function scanLinearSessions(): UnifiedSession[] {
           }
         : undefined,
       model: data.model,
-    });
+    }));
   }
   return sessions;
 }

--- a/src/server/walkthrough.ts
+++ b/src/server/walkthrough.ts
@@ -124,7 +124,10 @@ export async function publishWalkthrough(
   if (shots.length) walkthrough.shots = shots;
 
   touchBackstageSession(sessionId, { walkthrough });
-  const pr = await mirrorWalkthroughToPr(sessionId);
+  // Pass the walkthrough we just built: the unified-session re-read must not
+  // be the thing that decides whether it exists (slack/linear sessions only
+  // surface sidecar fields via the overlay in sessions.ts — belt and braces).
+  const pr = await mirrorWalkthroughToPr(sessionId, walkthrough);
   return { walkthrough, pr };
 }
 
@@ -182,10 +185,14 @@ export function spliceWalkthroughSection(body: string, section: string): string 
  */
 export async function mirrorWalkthroughToPr(
   sessionId: string,
+  /** Freshly-built walkthrough from publishWalkthrough — wins over the
+   *  unified-session re-read so a persistence/scan gap can't lose it. */
+  fresh?: SessionWalkthrough,
 ): Promise<{ mirrored: boolean; url?: string; reason?: string }> {
   const session: UnifiedSession | undefined = findSession(sessionId);
-  const walkthrough = session?.walkthrough;
-  if (!session || !walkthrough)
+  if (!session) return { mirrored: false, reason: "session not found" };
+  const walkthrough = fresh ?? session.walkthrough;
+  if (!walkthrough)
     return { mirrored: false, reason: "no walkthrough on session" };
   const target = resolvePrTarget(session, null, null);
   if (!target) return { mirrored: false, reason: "session has no branch" };


### PR DESCRIPTION
Makes it possible for Michael sessions to attach screenshots to GitHub PR comments so they actually **render inline** — without ever committing image files to the PR branch (or any branch).

## Mechanism

Images are staged into durable uploads storage (`~/.opensession-chats/uploads/pr-images/<128-bit-token>/<name>`) and served by a new `GET /pr-images/*` route on the **public webhook server** (port 3848, `michael.tella.dev` via Caddy — the same origin that already receives Slack/Plain webhooks). GitHub rewrites the URL to camo, camo fetches it server-side, and the image renders everywhere — **private repos included**. Capability-URL privacy model: our own infra (never a third-party host), unguessable 128-bit token, no listing endpoint, strict path grammar (token + slugged filename only), immutable cache headers, 5MB cap (camo's practical limit).

## Research summary (all verified empirically)

| Option | Verdict |
| --- | --- |
| GitHub attachment CDN (`POST /upload/policies/assets`) | **Unusable for bots** — cookie-session form endpoint; 422 under PAT/Bearer (github.com web routes ignore Authorization); no documented API |
| Committed blob `?raw=true` (orphan assets branch) | **Disproven by human check on this PR** — GitHub leaves the URL un-proxied, but the `<img>` subresource fetch doesn't get the cookie→signed-redirect dance a top-level navigation gets: broken image icon inline, working link on click. (First commit of this branch implemented this; second commit replaces it) |
| `raw.githubusercontent.com` direct | Un-proxied but cookie-less → 404 for private repos |
| Release assets | Same subresource problem + a release per screenshot batch pollutes Releases |
| os.tella.dev walkthrough storage | Tailnet-only — camo-rewritten but camo can never fetch it (why the walkthrough mirror links instead of inlining) |
| **Public unguessable URL on michael.tella.dev** | **Chosen** — camo proxies it; renders everywhere; channel we control |

## New tool

`comment_on_pr_with_images` on the existing `opensession-walkthrough` in-process server (already in SHARED_INPROCESS_SERVERS — no wiring changes):

- `comment` (markdown; `{{image:N}}` placeholders, unreferenced images append at the end), `images: [{path, alt?}]`, optional `repo` + `pr_number` (defaults to the session's own PR via `resolvePrTarget`; attached/linked repos resolve too).
- png/jpg/jpeg/webp/gif, ≤5MB, paths under /tmp or /home/ubuntu (same rule as walkthrough media). No GitHub API involved in the upload — works for any repo.

## Walkthrough "Not yet on a PR (no walkthrough on session)" bug — root-caused and fixed

Live repro from `slack-C01ED50A2KG-1785047006.690319` (tella-mac#71, 2026-07-26): `publishWalkthrough` persists via `touchBackstageSession(sessionId, {walkthrough})`, which writes `~/.opensession-chats/<id>.json`. For a slack/linear session that sidecar has **no `id` field**, so `scanBackstageSessions` skips it (`!data.id` guard) and `scanSlackSessions`/`scanLinearSessions` never read sidecars at all — `walkthrough`, `linkedPrs`, `attachedRepos`, and `previewPath` were ALL silently invisible for non-backstage sessions (the affected session's sidecar sits at rev 4 from retries, walkthrough intact but unseen).

Fix, two layers:
- `overlaySidecarExtras` in sessions.ts merges those fields from the sidecar onto slack- and linear-scanned sessions.
- `publishWalkthrough` passes the freshly-built walkthrough straight into `mirrorWalkthroughToPr`, so the splice never depends on the re-read.

Re-publishing the walkthrough on that tella-mac session after this merges should splice into tella-mac#71.

## Verification done / remaining

- Route handler exercised on a throwaway server: 200 + `image/png` + immutable cache on the capability URL; 404 on bad token, path traversal, missing file, and non-image extensions.
- `michael.tella.dev` public reachability confirmed (public A record 51.24.35.160, TLS valid — Slack/Plain webhooks already ride it).
- `bun x tsc --noEmit`: no errors in touched files (pre-existing errors in `api.test.ts` / `deploy/sandbox/verify.ts` only, identical on master).
- **Post-merge check** (webhook routes bind at boot → needs `systemctl restart opensession`): `curl -I https://michael.tella.dev/pr-images/0c90e1fd8035602bf8b9d423213bfa7d/route-smoke-2.png` should return 200 (staged during testing), then re-post a demo image comment to confirm inline rendering end-to-end.

## Cleanup from the disproven mechanism

The `opensession-assets` orphan branch this PR's first commit created in this repo has been deleted, and the demo comment below was edited to record the negative result.

## Bonus fix: `updatePrBody` was broken for ALL walkthrough mirrors

While updating this PR's own description, `gh pr edit --body-file` failed with a GraphQL `read:org` scope error — reproducibly. `gh pr edit` resolves org teams in its preamble and needs `read:org`, which neither the bot PAT nor the per-user device-flow OAuth tokens carry (same class as the known label-edit gotcha). So the walkthrough splice's final write hop has been failing on tellahq repos even when detection succeeded. `updatePrBody` now PATCHes `repos/{repo}/pulls/{number}` via `gh api --input` instead — the exact call used to update this description.


Created by [this Michael session](https://os.tella.dev/session/bks-019f9d4e-fc27-7000-9798-47e4b3246dd3)
