### PR TITLE
os1-tui: `os`, a herdr-style terminal client for OpenSession

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,47 @@ jobs:
       #
       # Fixing this means finding the cross-file state (this codebase parks a lot
       # on globalThis) and isolating it. Then delete continue-on-error.
+      # Scoped to the server suite on purpose: `os1-tui/` is a separate package
+      # with its own node_modules, so the root sweep can't resolve its imports —
+      # and it doesn't need to, because the os1-tui job below gates it properly.
+      # These two directories are where every server-side test lives.
       - name: Unit tests (reported, not yet a gate — see comment)
         continue-on-error: true
+        run: bun test src scripts
+
+  # The terminal client is its own package (own deps, own tsconfig — its JSX
+  # resolves to OpenTUI's elements, not React DOM's), so it gets its own job.
+  # Unlike the server sweep above this one IS a gate: the suite is isolated,
+  # deterministic, and needs neither a server nor a terminal.
+  os1-tui:
+    name: os1-tui (terminal client)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        working-directory: os1-tui
+        run: bun install --frozen-lockfile
+
+      - name: Type-check
+        working-directory: os1-tui
+        run: bun run typecheck
+
+      - name: Tests
+        working-directory: os1-tui
         run: bun test
+
+      # The whole point of the package is that it compiles to a binary you can
+      # drop on a laptop; a build break there is invisible to the tests.
+      - name: Compiles to a standalone binary
+        working-directory: os1-tui
+        run: |
+          bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile os
+          ./os version
 
   installer:
     name: Install (${{ matrix.os }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ repo. If every controlled channel fails, stop and report the failure instead of
 escalating to a third-party host. The same rule is injected into every engine
 run via `buildOpencodeInstructions` (opencode-runner.ts).
 
-## The four client apps — resolve which one BEFORE working
+## The five client apps — resolve which one BEFORE working
 
-OS1 has four user-facing clients in this repo, and requests about "the app"
+OS1 has five user-facing clients in this repo, and requests about "the app"
 are ambiguous between them:
 
 - **Web UI** — `src/frontend/` (React, served by the Bun server; also what the
@@ -54,6 +54,10 @@ are ambiguous between them:
   screenshot, element pick with React fiber info — and starts sessions via the
   REST surface with Bearer auth; loaded unpacked, never the Web Store; see
   `os1-chrome/README.md`).
+- **Terminal client** — `os1-tui/` (the `os` binary; herdr-style TUI on OpenTUI,
+  tmux keys, tabs). Pure client: HTTP + one WebSocket per watched session, no
+  server imports, so it compiles to a standalone binary. `opensession tui` is an
+  alias. Read `os1-tui/AGENTS.md` before touching it.
 
 Conversation scoping rule: once a conversation is about a specific app, every
 following message is about THAT app unless the user says otherwise — don't

--- a/docs/os1-tui-plan.md
+++ b/docs/os1-tui-plan.md
@@ -1,6 +1,9 @@
 # os1-tui — a herdr-style TUI client for OpenSession
 
-Status: **plan, not built** (2026-07-30)
+Status: **built** (2026-07-30) — see `os1-tui/README.md` for the shipped
+surface and `os1-tui/AGENTS.md` for the build loop. Phases 0–3 and 5 landed in
+one pass; phase 4 (diff pane, PR panel, terminal pane) is still open, and splits
+were dropped deliberately — tabs only, per review.
 
 ## What it is
 
@@ -192,12 +195,19 @@ a smoke test drives the compiled binary against the live server in a pty
 (`Bun.spawn` with a fake TTY), sends a scripted keystroke sequence, and asserts
 on the rendered screen buffer.
 
-## Open questions
+## Decisions taken at review (2026-07-30)
 
-1. **Splits vs tabs first** — is a split-pane view actually wanted, or is
-   tabs + fast switching enough? Splits are most of the layout complexity.
-2. **`os` as a name** — short and matches `os1-*`, but collides with nothing
-   today only by luck. `oss` is taken by the OpenSSL-ish world; `osn` is ugly.
-3. **Publishing** — is `os` a Tella-internal binary, or does it ship with the
-   open-source `opensession` release? That decides whether install.sh grows a
-   client-only mode.
+1. **Tabs, no splits.** Splits were the bulk of the layout complexity for a
+   layout nobody had asked for yet. `^b w` + `ctrl+←/→` covers the same ground.
+2. **`os` is the binary name.**
+3. **It ships with the open-source release**, so `install.sh` should eventually
+   grow a client-only mode (not done yet).
+
+## Still open
+
+- Phase 4: diff pane (OpenTUI `Diff`), PR panel, and the terminal pane over
+  `term_start` (full-screen alt-screen handoff — rendering a pty inside a TUI
+  pane needs an emulator we don't have).
+- `install.sh` client-only mode + published binaries per target.
+- Mouse support. OpenTUI has it; herdr leans on it. Untouched here because the
+  keyboard story had to be right first.

--- a/os1-ios/OS1/NativePreferences.swift
+++ b/os1-ios/OS1/NativePreferences.swift
@@ -95,7 +95,7 @@ enum NativePreferences {
         )
         set(
             validated(prefs["turn-activity"], allowed: ["auto", "expanded", "collapsed"]),
-            default: "auto",
+            default: "collapsed",
             key: "os1.appearance.turnActivity",
             resetMissing: changedIdentity,
             in: defaults

--- a/os1-ios/OS1/Views/NativePersonalSettingsViews.swift
+++ b/os1-ios/OS1/Views/NativePersonalSettingsViews.swift
@@ -211,9 +211,9 @@ struct ComposerSettingsView: View {
 
 struct AppearanceSettingsView: View {
     @AppStorage("os1.appearance") private var appearance = "system"
-    @AppStorage("os1.appearance.turnActivity") private var nativeTurnActivity = "auto"
+    @AppStorage("os1.appearance.turnActivity") private var nativeTurnActivity = "collapsed"
 
-    @State private var turnActivity = "auto"
+    @State private var turnActivity = "collapsed"
     @State private var loading = true
     @State private var saving = false
     @State private var error: String?
@@ -279,7 +279,7 @@ struct AppearanceSettingsView: View {
             let prefs = try await SettingsAPI.uiPrefs(user: requestContext.user)
             guard NativePreferences.context() == requestContext else { loading = false; return }
             if ["auto", "expanded", "collapsed"].contains(prefs["turn-activity"]) {
-                turnActivity = prefs["turn-activity"] ?? "auto"
+                turnActivity = prefs["turn-activity"] ?? "collapsed"
                 nativeTurnActivity = turnActivity
             } else {
                 turnActivity = nativeTurnActivity

--- a/os1-ios/OS1/Views/OS1VisualStyle.swift
+++ b/os1-ios/OS1/Views/OS1VisualStyle.swift
@@ -58,6 +58,7 @@ struct RepoTile: View {
     let name: String
     var size: CGFloat = 18
     var round = false
+    var showsFallback = true
 
     static func label(for name: String) -> String {
         name == "backstage" ? "opensession" : name
@@ -93,11 +94,13 @@ struct RepoTile: View {
 
     var body: some View {
         ZStack {
-            Text(letter)
-                .font(.system(size: size * 0.6, weight: .bold, design: .rounded))
-                .foregroundStyle(.white)
-                .frame(width: size, height: size)
-                .background(color)
+            if showsFallback {
+                Text(letter)
+                    .font(.system(size: size * 0.6, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+                    .frame(width: size, height: size)
+                    .background(color)
+            }
             if let iconURL {
                 AsyncImage(url: iconURL) { phase in
                     if case .success(let image) = phase {

--- a/os1-ios/OS1/Views/SessionsListView.swift
+++ b/os1-ios/OS1/Views/SessionsListView.swift
@@ -210,7 +210,12 @@ struct SessionsListView: View {
                         Button {
                             showSettings = true
                         } label: {
-                            RepoTile(name: "backstage", size: 34, round: true)
+                            RepoTile(
+                                name: "backstage",
+                                size: 34,
+                                round: true,
+                                showsFallback: false
+                            )
                         }
                         .accessibilityLabel("Settings")
                     }

--- a/os1-ios/OS1/Views/TranscriptRow.swift
+++ b/os1-ios/OS1/Views/TranscriptRow.swift
@@ -109,7 +109,7 @@ struct ToolCallRow: View {
     let use: TranscriptEntry?
     let result: TranscriptEntry?
 
-    @AppStorage("os1.appearance.turnActivity") private var turnActivity = "auto"
+    @AppStorage("os1.appearance.turnActivity") private var turnActivity = "collapsed"
     @State private var expanded = false
 
     private var isError: Bool {

--- a/os1-tui/AGENTS.md
+++ b/os1-tui/AGENTS.md
@@ -1,0 +1,84 @@
+# Working on os1-tui
+
+`os` is the fifth OpenSession client (after the web UI, `os1-mac`, `os1-ios`,
+`os1-chrome`). Read `README.md` first — it has the key table, the module map and
+the protocol notes. This file is the build/verify loop and the invariants.
+
+## Verify loop
+
+```bash
+cd os1-tui
+bun test           # everything, incl. real render tests — must be green
+bun run typecheck  # strict, noUncheckedIndexedAccess
+```
+
+Both are fast (~2s) and need neither a server nor a terminal. Run them on every
+change; there's no excuse for landing a red tree here.
+
+Against a real server:
+
+```bash
+bun src/index.ts sessions --host http://127.0.0.1:3850   # no TUI, quickest check
+bun src/index.ts --host http://127.0.0.1:3850            # the real thing
+```
+
+On a box with the sign-in gate on and no browser, pass a token from the
+web-sessions store for a one-off check:
+
+```bash
+OPENSESSION_TOKEN=$(python3 -c "
+import json; d=json.load(open('$HOME/.opensession-web-sessions.json'))
+s=d.get('sessions',d); l=list(s.values()) if isinstance(s,dict) else s
+print(next(e['token'] for e in l if e.get('token')))") \
+  bun src/index.ts sessions --host http://127.0.0.1:3850
+```
+
+To see the TUI render without a TTY (CI, an agent session), drive it through a
+pty and inspect the stream:
+
+```bash
+COLUMNS=120 LINES=30 timeout 10 script -qec "bun src/index.ts --host http://127.0.0.1:3850" /dev/null
+```
+
+## Invariants
+
+- **No server imports.** Nothing under `src/` may import from `../src/server`,
+  `../opensession.ts`, or anything outside this package. The whole point is a
+  binary that compiles and runs with only its own deps. `src/client/types.ts` is
+  a deliberate hand-written copy of the wire shapes, same as os1-ios's Codable
+  models — update it when the server adds a field you need, don't import.
+- **Keys resolve to Actions; only `runAction` mutates.** Add a key by adding an
+  `Action` variant + a `resolveKey` case + a `runAction` case, and a `KEY_HELP`
+  row (the help overlay and README both read from that constant). A key handler
+  that reaches into a store directly is a bug.
+- **Never read render-scoped state inside a key handler.** A terminal delivers
+  `^b w` as two keypresses in one tick, before React re-renders — that's why
+  `UiStore` is ref-backed and why `flatRef`/`stateRef`/`watchedRef` exist. Read
+  `uiStore.getState()`, not the `ui` from render.
+- **Store getters passed to `useSyncExternalStore` must be arrow properties.** An
+  unbound method reference loses `this` and blows up at mount (it did once).
+- **A tab is a WebSocket.** The server's `watch` handles one session per
+  connection; `WatchPool` owns that mapping and is the only thing that opens or
+  closes sockets.
+- **`watch` is sent from the socket's open handler only** — never also at
+  construction, or the session gets double-watched and pays for two full
+  transcript snapshots.
+
+## Adding server surface
+
+New endpoint → a method on `Api` (in `src/client/api.ts`) with the bare `/api/…`
+path; the server normalizes onto its internal `/backstage/api/*` literals. New
+WebSocket frame → a variant in `ServerFrame` plus a `applyFrame` case plus a test
+in `test/session-store.test.ts`. Frames this client doesn't model are ignored by
+identity, so an unknown frame can never crash a session.
+
+## Releasing
+
+```bash
+bun build --compile --minify --target=bun-linux-x64   src/index.ts --outfile os
+bun build --compile --minify --target=bun-darwin-arm64 src/index.ts --outfile os-darwin-arm64
+bun build --compile --minify --target=bun-linux-arm64  src/index.ts --outfile os-linux-arm64
+```
+
+OpenTUI is a native FFI dep, so a target only works if its prebuilt is present —
+if a target fails to launch with a dlopen error, that's why, not the bundle.

--- a/os1-tui/README.md
+++ b/os1-tui/README.md
@@ -5,7 +5,7 @@ server and shows you *your* sessions: workspace sidebar, live transcripts, tabs,
 tmux keys.
 
 ```
-os --host os.tella.dev
+os --host os.company.dev
 ```
 
 It is a **client and nothing else** — HTTP plus one WebSocket per watched
@@ -19,7 +19,7 @@ From a checkout:
 
 ```bash
 cd os1-tui && bun install
-bun src/index.ts --host os.tella.dev      # or: bun run dev
+bun src/index.ts --host os.company.dev    # or: bun run dev
 ```
 
 Standalone binary (no Bun needed on the target machine):

--- a/os1-tui/README.md
+++ b/os1-tui/README.md
@@ -1,0 +1,157 @@
+# os1-tui — `os`
+
+OpenSession in your terminal. A herdr-style TUI that connects to an OpenSession
+server and shows you *your* sessions: workspace sidebar, live transcripts, tabs,
+tmux keys.
+
+```
+os --host os.tella.dev
+```
+
+It is a **client and nothing else** — HTTP plus one WebSocket per watched
+session. It never spawns an agent, never touches a worktree, never imports the
+server. The sessions live on the box, so detaching (`^b d`) costs nothing and
+closing your laptop doesn't stop a run.
+
+## Install
+
+From a checkout:
+
+```bash
+cd os1-tui && bun install
+bun src/index.ts --host os.tella.dev      # or: bun run dev
+```
+
+Standalone binary (no Bun needed on the target machine):
+
+```bash
+bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile os
+# targets: bun-linux-x64 · bun-linux-arm64 · bun-darwin-arm64
+```
+
+The binary is ~120 MB — that's the Bun runtime plus OpenTUI's Zig renderer
+statically linked, and it's the price of "one file, no dependencies".
+
+`opensession tui` is an alias that hands off to `os` if you'd rather come at it
+from the server CLI.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `os` | the TUI, against the configured server |
+| `os --host <url>` | …against a specific server, and remember it |
+| `os <session-id>` | the TUI, opened on one session |
+| `os login` | sign in via the GitHub device flow |
+| `os logout` | revoke and forget this box's token |
+| `os whoami` | host, user, token, and what the server thinks |
+| `os sessions` | one-shot list, no TUI — for scripts and ssh one-liners |
+
+Host resolution: `--host` → `OPENSESSION_HOST` → `~/.opensession/tui.json` →
+`http://127.0.0.1:3850`. Bare hostnames get `https://` (loopback and `.local`
+get `http://`).
+
+## Keys
+
+tmux by default: prefix `ctrl+b`, plus prefix-less `ctrl+arrow` movement.
+`^b ?` shows this list in the app.
+
+| Key | Action |
+| --- | --- |
+| `ctrl+←/→` | previous / next tab |
+| `ctrl+↑/↓` | focus pane (sidebar · transcript · composer) |
+| `↑/↓` · `j/k` | move in the focused pane |
+| `enter` | open session · focus composer |
+| `i` | jump to the composer |
+| `enter` (composer) | send — queues behind a running turn |
+| `ctrl+enter` · `alt+enter` | send as a steer instead |
+| `1…9` | answer a pending question |
+| `^b c` | new session |
+| `^b w` | session picker |
+| `^b n` · `^b p` | next · previous tab |
+| `^b 0…9` | jump to tab |
+| `^b x` | cancel the running turn |
+| `^b &` | close tab |
+| `^b ,` | rename session |
+| `^b a` | archive session |
+| `^b z` | zoom the transcript (hide the sidebar) |
+| `^b [` | scroll mode — `b` loads earlier history, `q` exits |
+| `^b :` | command prompt |
+| `^b r` | reconnect |
+| `^b d` | detach (sessions keep running) |
+
+`ctrl+enter` needs the kitty keyboard protocol to be distinguishable from a bare
+enter at all — `os` asks for it at startup, and terminals that don't speak it
+(Terminal.app, older tmux) fall back to `alt+enter`, which every terminal
+reports. `ctrl+c` is *not* quit here: it's forwarded as a session interrupt.
+
+Command prompt verbs: `archive`, `rename <title>`, `new <prompt>`, `cancel`,
+`reconnect`, `close`, `quit`. Anything else is sent to the session as a prompt.
+
+## Status glyphs
+
+| Glyph | Meaning |
+| --- | --- |
+| `⣾` | working (animated) |
+| `?` | blocked on a question — this is the one that needs you |
+| `✓` | done |
+| `!` | last run failed |
+| `⧗` | workspace still being created |
+| `·` | idle |
+
+Workspaces with something blocked float to the top of the sidebar.
+
+## Layout of the code
+
+```
+src/client/     the server, as types — no terminal, no React
+  types.ts            wire shapes (a documented copy, not a server import)
+  api.ts              REST
+  auth.ts             GitHub device flow
+  socket.ts           one WebSocket: ping/pong liveness, backoff, resume cursor
+  session-store.ts    frames → renderable state (pure reducer)
+  watched-session.ts  socket + reduced state + subscribers (one per tab)
+  sessions-poller.ts  the sidebar's REST poll + workspace grouping
+  pool.ts             one WatchedSession per open tab
+  config.ts           ~/.opensession/tui.json
+src/ui/         the terminal, as components
+  keymap.ts           tmux keys as a pure state machine
+  ui-state.ts         where the user is (tabs/panes/modes), ref-backed
+  app.tsx             the only mutator: Action → effect
+  sidebar · transcript · composer · status-bar · help · theme · format
+```
+
+Two rules keep this honest:
+
+- **Anything worth testing lives below `src/ui/app.tsx`.** The reducer, the
+  keymap, the formatters and the socket are pure or injectable, and the tests
+  drive them with plain objects.
+- **Keys never mutate.** They resolve to an `Action`, and `runAction` is the
+  single mutator. "What does this key do" is answerable by reading two files.
+
+## Tests
+
+```bash
+bun test          # 49 tests, no server and no terminal required
+bun run typecheck
+```
+
+`test/app.test.tsx` renders the real app into an in-memory terminal
+(OpenTUI's test renderer) against a fake `fetch` and a fake WebSocket, presses
+real keys, and asserts on the resulting screen. That's where regressions in
+"does the sidebar show what's blocked" get caught.
+
+## Protocol notes
+
+Everything here is a path os1-ios already drives, so no server change was needed.
+Three details are load-bearing, each learned from a bug in another client:
+
+- **The server never pings.** The client sends `{"type":"ping"}` and treats a
+  missed pong as a dead socket; a half-open TCP connection otherwise looks alive
+  forever while the session silently stops updating.
+- **No message-size cap.** A heavy `transcript_init` runs to megabytes; a 1 MB
+  cap made one iOS session reconnect-loop forever.
+- **`watch` is one session per connection**, which is why a tab is a connection.
+  It's sent from the socket's open handler only — one code path for first connect
+  and every reconnect, resuming from the `endOffset`/`rev` byte cursor so the
+  server replays the gap instead of the whole tail.

--- a/os1-tui/bun.lock
+++ b/os1-tui/bun.lock
@@ -1,0 +1,121 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@opensession/tui",
+      "dependencies": {
+        "@opentui/core": "^0.4.5",
+        "@opentui/react": "^0.4.5",
+        "react": "^19.2.8",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "typescript": "^7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@opentui/core": ["@opentui/core@0.4.5", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.5", "@opentui/core-darwin-x64": "0.4.5", "@opentui/core-linux-arm64": "0.4.5", "@opentui/core-linux-arm64-musl": "0.4.5", "@opentui/core-linux-x64": "0.4.5", "@opentui/core-linux-x64-musl": "0.4.5", "@opentui/core-win32-arm64": "0.4.5", "@opentui/core-win32-x64": "0.4.5" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg=="],
+
+    "@opentui/react": ["@opentui/react@0.4.5", "", { "dependencies": { "@opentui/core": "0.4.5", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
+  }
+}

--- a/os1-tui/package.json
+++ b/os1-tui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@opensession/tui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "os": "src/index.ts"
+  },
+  "scripts": {
+    "dev": "bun src/index.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentui/core": "^0.4.5",
+    "@opentui/react": "^0.4.5",
+    "react": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.14",
+    "typescript": "^7.0.2"
+  }
+}

--- a/os1-tui/src/client/api.ts
+++ b/os1-tui/src/client/api.ts
@@ -1,0 +1,174 @@
+/**
+ * REST client. Every path here is one os1-ios already drives (OS1API.swift), so
+ * the server needs no new endpoints for this client to exist.
+ *
+ * Paths are written bare (`/api/…`): the server normalizes them onto its
+ * internal `/backstage/api/*` literals, which is what keeps this client working
+ * against both the prefix-less deployment and older ones.
+ */
+
+import type { Session, TranscriptEntry } from "./types";
+
+export class ApiError extends Error {
+	constructor(
+		readonly status: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "ApiError";
+	}
+	/** The server has the sign-in gate on and we have no (valid) token. */
+	get needsAuth(): boolean {
+		return this.status === 401;
+	}
+}
+
+export type Fetcher = typeof fetch;
+
+export class Api {
+	constructor(
+		readonly host: string,
+		private token?: string,
+		private readonly fetcher: Fetcher = fetch,
+	) {}
+
+	setToken(token: string | undefined): void {
+		this.token = token;
+	}
+
+	headers(extra?: Record<string, string>): Record<string, string> {
+		return {
+			...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+			...extra,
+		};
+	}
+
+	private async request<T>(
+		path: string,
+		init?: RequestInit & { raw?: boolean },
+	): Promise<T> {
+		let response: Response;
+		try {
+			response = await this.fetcher(`${this.host}${path}`, {
+				...init,
+				headers: this.headers({
+					...(init?.body ? { "content-type": "application/json" } : {}),
+					...((init?.headers as Record<string, string>) ?? {}),
+				}),
+			});
+		} catch (e) {
+			// Transport failure (DNS, TLS, not-on-the-tailnet) — status 0 so callers
+			// can tell "unreachable" from "server said no".
+			throw new ApiError(0, `${this.host} unreachable: ${(e as Error).message}`);
+		}
+		if (!response.ok) {
+			const body = await response.text().catch(() => "");
+			let message = body.slice(0, 300);
+			try {
+				const parsed = JSON.parse(body);
+				if (parsed?.error) message = String(parsed.error);
+			} catch {}
+			throw new ApiError(
+				response.status,
+				message || `${response.status} ${response.statusText}`,
+			);
+		}
+		return (await response.json()) as T;
+	}
+
+	sessions(): Promise<Session[]> {
+		return this.request<Session[]>("/api/sessions");
+	}
+
+	async projects(): Promise<{ id: string; name: string }[]> {
+		const body = await this.request<{ projects?: { id: string; name: string }[] }>(
+			"/api/projects",
+		);
+		return body.projects ?? [];
+	}
+
+	transcript(sessionId: string): Promise<TranscriptEntry[]> {
+		return this.request<TranscriptEntry[]>(
+			`/api/sessions/${encodeURIComponent(sessionId)}/transcript`,
+		);
+	}
+
+	/** Full body of an entry the WebSocket delivered clamped. */
+	async entry(sessionId: string, entryId: string): Promise<string> {
+		const body = await this.request<{ content?: string }>(
+			`/api/sessions/${encodeURIComponent(sessionId)}/entry/${encodeURIComponent(entryId)}`,
+		);
+		return body.content ?? "";
+	}
+
+	/** Transcript full-text search. Server returns nothing for q shorter than 2. */
+	async search(query: string): Promise<{ id: string; snippet: string }[]> {
+		const body = await this.request<{
+			matches?: { id: string; snippet: string }[];
+		}>(`/api/sessions/search?q=${encodeURIComponent(query)}`);
+		return body.matches ?? [];
+	}
+
+	authStatus(): Promise<{
+		authenticated?: boolean;
+		login?: string;
+		name?: string;
+	}> {
+		return this.request("/api/auth/status");
+	}
+
+	logout(): Promise<unknown> {
+		return this.request("/api/auth/logout", {
+			method: "POST",
+			body: JSON.stringify({}),
+		});
+	}
+
+	setArchived(sessionId: string, archived: boolean): Promise<unknown> {
+		return this.request(
+			`/api/sessions/${encodeURIComponent(sessionId)}/archive`,
+			{ method: "POST", body: JSON.stringify({ archived }) },
+		);
+	}
+
+	/** Manual display title; blank clears it back to the derived one. */
+	setTitle(sessionId: string, title: string): Promise<unknown> {
+		return this.request(`/api/sessions/${encodeURIComponent(sessionId)}/title`, {
+			method: "PUT",
+			body: JSON.stringify({ title }),
+		});
+	}
+
+	createSession(body: {
+		prompt: string;
+		repo?: string;
+		mode?: "ask" | "code";
+		model?: string;
+		branch?: string;
+		user?: string;
+	}): Promise<{ sessionId?: string; id?: string }> {
+		return this.request("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify(body),
+		});
+	}
+
+	repos(): Promise<unknown> {
+		return this.request("/api/repos");
+	}
+
+	models(): Promise<unknown> {
+		return this.request("/api/models");
+	}
+
+	/** Cheap reachability probe. Never throws — returns false instead. */
+	async reachable(): Promise<boolean> {
+		try {
+			await this.request("/api/health");
+			return true;
+		} catch (e) {
+			// A 401 still proves a server is there; it just wants a token.
+			return e instanceof ApiError && e.status === 401;
+		}
+	}
+}

--- a/os1-tui/src/client/auth.ts
+++ b/os1-tui/src/client/auth.ts
@@ -1,0 +1,122 @@
+/**
+ * Sign-in for a terminal client: the GitHub **device flow**, which is the one
+ * OAuth shape that works when the client has no browser of its own.
+ *
+ * `POST /api/auth/device` → show the user code → poll
+ * `POST /api/auth/device/poll` with `native: true`, which returns the session
+ * token in the body (the HttpOnly cookie is useless to us). Same path the iOS
+ * app takes. Servers with the gate off answer 400 "Sign-in is not enabled",
+ * which we report as "no sign-in needed" rather than an error.
+ */
+
+import { Api, ApiError } from "./api";
+
+export type DeviceStart = {
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	interval: number;
+};
+
+export type LoginResult =
+	| { status: "ok"; token: string; login: string; name?: string }
+	| { status: "not-required" }
+	| { status: "error"; error: string };
+
+export async function startDeviceFlow(
+	host: string,
+	fetcher = fetch,
+): Promise<DeviceStart | { status: "not-required" } | { status: "error"; error: string }> {
+	let response: Response;
+	try {
+		response = await fetcher(`${host}/api/auth/device`, { method: "POST" });
+	} catch (e) {
+		return { status: "error", error: `${host} unreachable: ${(e as Error).message}` };
+	}
+	const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+	if (!response.ok) {
+		if (/not enabled/i.test(String(body.error ?? ""))) return { status: "not-required" };
+		return { status: "error", error: String(body.error ?? response.statusText) };
+	}
+	return {
+		deviceCode: String(body.deviceCode ?? ""),
+		userCode: String(body.userCode ?? ""),
+		verificationUri: String(body.verificationUri ?? "https://github.com/login/device"),
+		interval: typeof body.interval === "number" ? body.interval : 5,
+	};
+}
+
+/**
+ * Poll until the person finishes in their browser. `interval` is the server's
+ * advice; `slow_down` bumps it, per the device-flow spec.
+ */
+export async function pollDeviceFlow(
+	host: string,
+	start: DeviceStart,
+	opts: {
+		fetcher?: Fetcher;
+		sleep?: (ms: number) => Promise<void>;
+		timeoutMs?: number;
+		onPending?: () => void;
+	} = {},
+): Promise<LoginResult> {
+	const fetcher = opts.fetcher ?? fetch;
+	const sleep =
+		opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+	const deadline = Date.now() + (opts.timeoutMs ?? 10 * 60_000);
+	let interval = Math.max(1, start.interval);
+
+	while (Date.now() < deadline) {
+		await sleep(interval * 1000);
+		let body: Record<string, unknown>;
+		try {
+			const response = await fetcher(`${host}/api/auth/device/poll`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ deviceCode: start.deviceCode, native: true }),
+			});
+			body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+		} catch (e) {
+			// Transient network blip mid-flow: keep polling, the code is still valid.
+			opts.onPending?.();
+			continue;
+		}
+		const status = String(body.status ?? "");
+		if (status === "ok") {
+			const token = typeof body.token === "string" ? body.token : "";
+			if (!token) {
+				return {
+					status: "error",
+					error: "server authorized the code but returned no token",
+				};
+			}
+			return {
+				status: "ok",
+				token,
+				login: String(body.login ?? ""),
+				name: typeof body.name === "string" ? body.name : undefined,
+			};
+		}
+		if (status === "slow_down") {
+			interval = typeof body.interval === "number" ? body.interval : interval + 5;
+			continue;
+		}
+		if (status === "error" || body.error) {
+			return { status: "error", error: String(body.error ?? "device flow failed") };
+		}
+		opts.onPending?.();
+	}
+	return { status: "error", error: "timed out waiting for authorization" };
+}
+
+type Fetcher = typeof fetch;
+
+/** Does this host need a token we don't have? */
+export async function needsLogin(api: Api): Promise<boolean> {
+	try {
+		await api.sessions();
+		return false;
+	} catch (e) {
+		return e instanceof ApiError && e.needsAuth;
+	}
+}

--- a/os1-tui/src/client/config.ts
+++ b/os1-tui/src/client/config.ts
@@ -1,0 +1,94 @@
+/**
+ * Where `os` keeps its host + token.
+ *
+ * `~/.opensession/tui.json`, mode 0600, next to the `node.json` that
+ * scripts/lib/connect.ts writes for execution nodes. Same directory on purpose:
+ * one place to look for "credentials this box holds for an OpenSession server".
+ */
+
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const OPENSESSION_HOME = join(homedir(), ".opensession");
+export const TUI_CONFIG_PATH = join(OPENSESSION_HOME, "tui.json");
+
+export type TuiConfig = {
+	host?: string;
+	token?: string;
+	/** GitHub login the token was minted for; display only. */
+	login?: string;
+	/** Display name attached to prompts on servers with no auth gate. */
+	user?: string;
+	/** tmux prefix key name, e.g. "b" for ctrl+b. */
+	prefix?: string;
+};
+
+const DEFAULT_HOST = "http://127.0.0.1:3850";
+
+/**
+ * Accept what people actually type: `os.tella.dev`, `os.tella.dev/`,
+ * `https://os.tella.dev`, `localhost:3850`. Bare hosts get https, except
+ * loopback/`.local`, which never has a cert.
+ */
+export function normalizeHost(raw: string): string {
+	let host = raw.trim();
+	while (host.endsWith("/")) host = host.slice(0, -1);
+	if (!host) return DEFAULT_HOST;
+	if (!host.includes("://")) {
+		const loopback =
+			/^(localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(:\d+)?$/.test(host) ||
+			host.endsWith(".local");
+		host = `${loopback ? "http" : "https"}://${host}`;
+	}
+	return host;
+}
+
+/** ws(s) URL for the UI WebSocket — same host, `/ws`. */
+export function wsUrl(host: string): string {
+	return `${host.replace(/^http/, "ws")}/ws`;
+}
+
+export async function readConfig(): Promise<TuiConfig> {
+	if (!existsSync(TUI_CONFIG_PATH)) return {};
+	try {
+		const parsed = JSON.parse(await Bun.file(TUI_CONFIG_PATH).text());
+		return typeof parsed === "object" && parsed ? (parsed as TuiConfig) : {};
+	} catch {
+		// A corrupt config must not brick the binary — `os --host …` still works.
+		return {};
+	}
+}
+
+export async function writeConfig(patch: TuiConfig): Promise<TuiConfig> {
+	const merged = { ...(await readConfig()), ...patch };
+	mkdirSync(OPENSESSION_HOME, { recursive: true });
+	await Bun.write(TUI_CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`);
+	try {
+		chmodSync(TUI_CONFIG_PATH, 0o600);
+	} catch {}
+	return merged;
+}
+
+export type Resolved = { host: string; token?: string; user: string; config: TuiConfig };
+
+/**
+ * Host resolution order: `--host` flag → OPENSESSION_HOST → config → loopback.
+ * The token is only read from the config (and OPENSESSION_TOKEN for dev runs) —
+ * never from a flag, so it can't land in shell history or a process list.
+ */
+export async function resolve(hostFlag?: string): Promise<Resolved> {
+	const config = await readConfig();
+	const host = normalizeHost(
+		hostFlag || process.env.OPENSESSION_HOST || config.host || DEFAULT_HOST,
+	);
+	// A token minted for a different host is worse than none: it would be sent
+	// to a server it doesn't belong to. Only reuse it when the host matches.
+	const sameHost = !config.host || normalizeHost(config.host) === host;
+	return {
+		host,
+		token: process.env.OPENSESSION_TOKEN || (sameHost ? config.token : undefined),
+		user: config.user || process.env.USER || "tui",
+		config,
+	};
+}

--- a/os1-tui/src/client/config.ts
+++ b/os1-tui/src/client/config.ts
@@ -27,8 +27,8 @@ export type TuiConfig = {
 const DEFAULT_HOST = "http://127.0.0.1:3850";
 
 /**
- * Accept what people actually type: `os.tella.dev`, `os.tella.dev/`,
- * `https://os.tella.dev`, `localhost:3850`. Bare hosts get https, except
+ * Accept what people actually type: `os.company.dev`, `os.company.dev/`,
+ * `https://os.company.dev`, `localhost:3850`. Bare hosts get https, except
  * loopback/`.local`, which never has a cert.
  */
 export function normalizeHost(raw: string): string {

--- a/os1-tui/src/client/pool.ts
+++ b/os1-tui/src/client/pool.ts
@@ -1,0 +1,68 @@
+/**
+ * One WatchedSession per open tab.
+ *
+ * The server watches a single session per connection, so tabs really are
+ * connections. Keeping the pool here (rather than in a component) means tab
+ * churn never depends on React's mount order, and a closed tab's socket is
+ * closed exactly once.
+ */
+
+import { wsUrl } from "./config";
+import { WsSessionSocket, type WsFactory } from "./socket";
+import { WatchedSession } from "./watched-session";
+
+export type PoolOptions = {
+	host: string;
+	token?: string;
+	/** Injectable for tests — a fake WebSocket needs no server. */
+	factory?: WsFactory;
+};
+
+export function openWatch(sessionId: string, opts: PoolOptions): WatchedSession {
+	// The socket needs a reference to the session it feeds, and the session needs
+	// the socket to send on: one of the two has to be late-bound.
+	let watched: WatchedSession | undefined;
+	const socket = new WsSessionSocket(
+		wsUrl(opts.host),
+		opts.token,
+		{
+			onFrame: (frame) => watched?.handleFrame(frame),
+			onOpen: () => watched?.handleOpen(),
+			onClose: (reason, willRetry) => watched?.handleClose(reason, willRetry),
+		},
+		opts.factory,
+	);
+	watched = new WatchedSession(sessionId, socket);
+	watched.start();
+	return watched;
+}
+
+export class WatchPool {
+	private open = new Map<string, WatchedSession>();
+
+	constructor(private readonly opts: PoolOptions) {}
+
+	get(sessionId: string): WatchedSession | undefined {
+		return this.open.get(sessionId);
+	}
+
+	/** Idempotent: watching an already-open session returns the live one. */
+	ensure(sessionId: string): WatchedSession {
+		const existing = this.open.get(sessionId);
+		if (existing) return existing;
+		const watched = openWatch(sessionId, this.opts);
+		this.open.set(sessionId, watched);
+		return watched;
+	}
+
+	release(sessionId: string): void {
+		const watched = this.open.get(sessionId);
+		if (!watched) return;
+		this.open.delete(sessionId);
+		watched.close();
+	}
+
+	closeAll(): void {
+		for (const sessionId of [...this.open.keys()]) this.release(sessionId);
+	}
+}

--- a/os1-tui/src/client/session-store.ts
+++ b/os1-tui/src/client/session-store.ts
@@ -1,0 +1,233 @@
+/**
+ * The watched-session reducer: server frames in, renderable state out.
+ *
+ * Pure on purpose. Everything interesting about this client — transcript
+ * ordering, mid-stream text, queue chips, blocked-on-a-question — lives here,
+ * where a test can drive it with recorded frames and no terminal and no server.
+ * The renderer above it is a dumb projection of this state.
+ */
+
+import type {
+	AskQuestion,
+	QueueItem,
+	ServerFrame,
+	TranscriptCursor,
+	TranscriptEntry,
+} from "./types";
+
+export type SessionState = {
+	/** Ordered oldest → newest, id-keyed upsert (the server may re-send). */
+	entries: TranscriptEntry[];
+	/** Earlier history exists before `startOffset`. */
+	truncated: boolean;
+	/** Byte cursor for "load earlier"; undefined when the server sent none. */
+	startOffset?: number;
+	/** Resume cursor for reconnect (endOffset + rev of the last frame). */
+	cursor: TranscriptCursor;
+	/** A turn is mid-stream: `streamText` is the assistant text so far. */
+	streaming: boolean;
+	streamText: string;
+	isRunning: boolean;
+	queued: QueueItem[];
+	steered: QueueItem[];
+	ask: AskQuestion | null;
+	notice?: string;
+	error?: string;
+	/** Server boot id; a change means the server restarted under us. */
+	bootId?: string;
+	/** True once a transcript_init has landed — drives "loading…" vs "empty". */
+	loaded: boolean;
+};
+
+export const initialSessionState: SessionState = {
+	entries: [],
+	truncated: false,
+	cursor: null,
+	streaming: false,
+	streamText: "",
+	isRunning: false,
+	queued: [],
+	steered: [],
+	ask: null,
+	loaded: false,
+};
+
+/**
+ * Merge entries by id, preserving arrival order for new ones. The server
+ * re-sends entries in overlap windows (reconnect gap-fill, history paging), and
+ * a provisional streamed tool entry is later replaced by its committed form —
+ * upsert absorbs all three without duplicating bubbles.
+ */
+function upsert(
+	existing: TranscriptEntry[],
+	incoming: TranscriptEntry[],
+	where: "append" | "prepend",
+): TranscriptEntry[] {
+	if (!incoming.length) return existing;
+	const index = new Map(existing.map((e, i) => [e.id, i]));
+	const merged = existing.slice();
+	const fresh: TranscriptEntry[] = [];
+	for (const entry of incoming) {
+		const at = index.get(entry.id);
+		if (at === undefined) {
+			fresh.push(entry);
+			index.set(entry.id, -1);
+		} else if (at >= 0) {
+			// The newer frame wins on every field EXCEPT content, where a clamped
+			// re-send must not overwrite a body we already hold in full. Merging
+			// whole objects by "whichever content is longer" would let stale
+			// fields ride along — that's how a committed tool_result got
+			// downgraded back to tool_use.
+			const prev = merged[at]!;
+			const next = { ...prev, ...entry };
+			const prevLen = prev.content?.length ?? 0;
+			const nextLen = entry.content?.length ?? 0;
+			if (prevLen > nextLen) {
+				next.content = prev.content;
+				next.contentClamped = prev.contentClamped;
+				next.contentLength = prev.contentLength;
+			}
+			merged[at] = next;
+		}
+	}
+	if (!fresh.length) return merged;
+	return where === "append" ? [...merged, ...fresh] : [...fresh, ...merged];
+}
+
+function cursorFrom(
+	frame: { endOffset?: number; rev?: string },
+	fallback: TranscriptCursor,
+): TranscriptCursor {
+	if (typeof frame.endOffset === "number" && typeof frame.rev === "string") {
+		return { endOffset: frame.endOffset, rev: frame.rev };
+	}
+	return fallback;
+}
+
+/** One frame → next state. Returns the same object when nothing changed. */
+export function applyFrame(state: SessionState, frame: ServerFrame): SessionState {
+	switch (frame.type) {
+		case "hello": {
+			const bootId = (frame as { bootId?: string }).bootId;
+			return bootId === state.bootId ? state : { ...state, bootId };
+		}
+
+		case "transcript_init": {
+			const f = frame as Extract<ServerFrame, { type: "transcript_init" }>;
+			return {
+				...state,
+				// init is a REPLACE, not a merge: it's the authoritative tail (and
+				// arrives fresh after an engine-id rotation, where old ids are gone).
+				entries: f.entries ?? [],
+				truncated: f.truncated === true,
+				startOffset: f.startOffset,
+				cursor: cursorFrom(f, state.cursor),
+				loaded: true,
+				// A new snapshot supersedes any half-streamed text.
+				streaming: false,
+				streamText: "",
+			};
+		}
+
+		case "transcript_history": {
+			const f = frame as Extract<ServerFrame, { type: "transcript_history" }>;
+			return {
+				...state,
+				entries: upsert(state.entries, f.entries ?? [], "prepend"),
+				truncated: f.truncated === true,
+				startOffset: f.startOffset ?? state.startOffset,
+			};
+		}
+
+		case "transcript_append": {
+			const f = frame as Extract<ServerFrame, { type: "transcript_append" }>;
+			const entries = upsert(state.entries, f.entries ?? [], "append");
+			// The committed entry has landed; drop the streaming shadow so the text
+			// isn't on screen twice.
+			const assistantLanded = (f.entries ?? []).some((e) => e.type === "assistant");
+			return {
+				...state,
+				entries,
+				cursor: cursorFrom(f, state.cursor),
+				loaded: true,
+				...(assistantLanded ? { streaming: false, streamText: "" } : {}),
+			};
+		}
+
+		case "stream_start":
+			return { ...state, streaming: true, streamText: "", isRunning: true };
+
+		case "stream_text": {
+			const text = (frame as { text?: string }).text ?? "";
+			if (!text) return state;
+			return {
+				...state,
+				streaming: true,
+				streamText: state.streamText + text,
+				isRunning: true,
+			};
+		}
+
+		case "stream_tool_use":
+		case "stream_tool_result": {
+			const entry = (frame as { entry?: TranscriptEntry }).entry;
+			if (!entry) return state;
+			return {
+				...state,
+				entries: upsert(state.entries, [entry], "append"),
+				isRunning: true,
+			};
+		}
+
+		case "stream_done":
+			// Keep `streamText` until the committed entry arrives: clearing here
+			// would blank the just-written answer for a beat.
+			return { ...state, streaming: false };
+
+		case "session_status": {
+			const isRunning = (frame as { isRunning?: boolean }).isRunning === true;
+			if (isRunning === state.isRunning) return state;
+			return {
+				...state,
+				isRunning,
+				...(isRunning ? {} : { streaming: false }),
+			};
+		}
+
+		case "queue_update": {
+			const f = frame as Extract<ServerFrame, { type: "queue_update" }>;
+			return { ...state, queued: f.queued ?? [], steered: f.steered ?? [] };
+		}
+
+		case "ask_question": {
+			const f = frame as Extract<ServerFrame, { type: "ask_question" }>;
+			if (!f.questionId || !f.questions?.length) return state;
+			return {
+				...state,
+				ask: { questionId: f.questionId, questions: f.questions },
+			};
+		}
+
+		case "ask_resolved": {
+			const questionId = (frame as { questionId?: string }).questionId;
+			if (!state.ask || (questionId && state.ask.questionId !== questionId)) {
+				return state;
+			}
+			return { ...state, ask: null };
+		}
+
+		case "notice":
+			return { ...state, notice: (frame as { message?: string }).message };
+
+		case "error":
+			return { ...state, error: (frame as { message?: string }).message };
+
+		default:
+			return state;
+	}
+}
+
+/** Fold a batch of frames — the shape recorded fixtures replay through. */
+export function applyFrames(state: SessionState, frames: ServerFrame[]): SessionState {
+	return frames.reduce(applyFrame, state);
+}

--- a/os1-tui/src/client/sessions-poller.ts
+++ b/os1-tui/src/client/sessions-poller.ts
@@ -1,0 +1,174 @@
+/**
+ * The sidebar's data source.
+ *
+ * The server has no session-list push (the web UI polls too, behind a 2s
+ * server-side cache), so we poll `GET /api/sessions` and group by workspace.
+ * Same `useSyncExternalStore` contract as WatchedSession.
+ */
+
+import type { Api } from "./api";
+import { ApiError } from "./api";
+import { type Session, sessionStatus, sessionTitle } from "./types";
+
+export type WorkspaceGroup = {
+	id: string;
+	name: string;
+	sessions: Session[];
+	/** Sessions in this group that a human has to act on. */
+	waiting: number;
+	running: number;
+};
+
+export type SessionsState = {
+	sessions: Session[];
+	groups: WorkspaceGroup[];
+	/** Set once the first poll lands, so the UI can show "connecting…". */
+	loaded: boolean;
+	error?: string;
+	/** True when the server wants a token we don't have. */
+	needsAuth: boolean;
+};
+
+const POLL_MS = 2_500;
+
+/** Newest activity first — the same read as the web sidebar's ordering. */
+function activityTime(session: Session): number {
+	const stamp = session.lastActivity || session.createdAt;
+	const parsed = stamp ? Date.parse(stamp) : Number.NaN;
+	return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Group sessions into workspaces. `projectId` is the workspace key; sessions
+ * without one are grouped by repo, which is what a session that never got
+ * promoted to a workspace actually shares.
+ */
+export function groupSessions(
+	sessions: Session[],
+	projectNames: Map<string, string>,
+): WorkspaceGroup[] {
+	const groups = new Map<string, WorkspaceGroup>();
+	for (const session of sessions) {
+		const id = session.projectId || `repo:${session.repo || "unknown"}`;
+		let group = groups.get(id);
+		if (!group) {
+			group = {
+				id,
+				name:
+					projectNames.get(id) ||
+					(session.projectId ? session.projectId : session.repo || "unknown"),
+				sessions: [],
+				waiting: 0,
+				running: 0,
+			};
+			groups.set(id, group);
+		}
+		group.sessions.push(session);
+		const status = sessionStatus(session);
+		if (status === "waiting") group.waiting++;
+		if (status === "running") group.running++;
+	}
+	for (const group of groups.values()) {
+		group.sessions.sort((a, b) => activityTime(b) - activityTime(a));
+	}
+	// Groups needing attention float up, then by most recent activity.
+	return [...groups.values()].sort((a, b) => {
+		if (!!b.waiting !== !!a.waiting) return b.waiting - a.waiting;
+		if (!!b.running !== !!a.running) return b.running - a.running;
+		return activityTime(b.sessions[0] ?? {} as Session) - activityTime(a.sessions[0] ?? {} as Session);
+	});
+}
+
+export class SessionsPoller {
+	private state: SessionsState = {
+		sessions: [],
+		groups: [],
+		loaded: false,
+		needsAuth: false,
+	};
+	private listeners = new Set<() => void>();
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private projectNames = new Map<string, string>();
+	private stopped = false;
+
+	constructor(private readonly api: Api) {}
+
+	async start(): Promise<void> {
+		this.stopped = false;
+		// Awaited, not fired-and-forgotten: groups are named from this map, and a
+		// first paint that raced it showed raw `prj-…` ids instead of workspace
+		// names. Names are near-static, so this is one fetch for the process.
+		await this.refreshProjects();
+		await this.tick();
+	}
+
+	private async refreshProjects(): Promise<void> {
+		try {
+			const projects = await this.api.projects();
+			this.projectNames = new Map(projects.map((p) => [p.id, p.name]));
+		} catch {
+			// Non-fatal: groups fall back to the raw id / repo name.
+		}
+	}
+
+	private async tick(): Promise<void> {
+		if (this.stopped) return;
+		try {
+			const sessions = (await this.api.sessions()).filter(
+				// Side chats and desk todos aren't standalone sessions in the UI.
+				(s) => !s.sideChatOf && !s.desk && !s.archived,
+			);
+			this.set({
+				sessions,
+				groups: groupSessions(sessions, this.projectNames),
+				loaded: true,
+				error: undefined,
+				needsAuth: false,
+			});
+			if (!this.projectNames.size) void this.refreshProjects();
+		} catch (e) {
+			const error = e instanceof ApiError ? e : new ApiError(0, String(e));
+			this.set({
+				...this.state,
+				loaded: true,
+				error: error.message,
+				needsAuth: error.needsAuth,
+			});
+		}
+		if (!this.stopped) this.timer = setTimeout(() => void this.tick(), POLL_MS);
+	}
+
+	/** Poll now rather than waiting out the interval (after a create/archive). */
+	refreshSoon(): void {
+		if (this.timer) clearTimeout(this.timer);
+		this.timer = setTimeout(() => void this.tick(), 150);
+	}
+
+	private set(next: SessionsState): void {
+		this.state = next;
+		for (const listener of this.listeners) listener();
+	}
+
+	// Arrow property, not a method: this is handed straight to
+	// `useSyncExternalStore`, and an unbound method reference loses `this`.
+	getState = (): SessionsState => this.state;
+
+	subscribe = (listener: () => void): (() => void) => {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	};
+
+	stop(): void {
+		this.stopped = true;
+		if (this.timer) clearTimeout(this.timer);
+		this.timer = null;
+		this.listeners.clear();
+	}
+}
+
+/** Flatten groups into the order the sidebar renders, for cursor movement. */
+export function flattenGroups(groups: WorkspaceGroup[]): Session[] {
+	return groups.flatMap((g) => g.sessions);
+}
+
+export { sessionStatus, sessionTitle };

--- a/os1-tui/src/client/socket.ts
+++ b/os1-tui/src/client/socket.ts
@@ -1,0 +1,230 @@
+/**
+ * One WebSocket to the server's `/ws`, watching one session.
+ *
+ * The server watches a single session per connection (`watch` stops any
+ * previous watch on that socket), so a tab == a connection. `SocketPool` below
+ * owns that mapping.
+ *
+ * Two behaviours copied deliberately from os1-ios, both of which cost that
+ * client a bug before they existed:
+ *
+ * - **The server never pings.** We send `{"type":"ping"}` and treat a missing
+ *   pong as a dead socket. Without it a half-open connection looks alive
+ *   forever and the session silently stops updating.
+ * - **Resume with the byte cursor.** transcript_init/append carry
+ *   `endOffset` + `rev`; re-watching with `sinceOffset`/`sinceRev` replays only
+ *   the gap instead of re-sending the whole tail.
+ */
+
+import type { ServerFrame } from "./types";
+
+export type SocketEvents = {
+	onFrame: (frame: ServerFrame) => void;
+	/** Transport came up. Fired on every (re)connect, so callers re-arm state. */
+	onOpen?: () => void;
+	/** Transport went away; `willRetry` false means we've given up. */
+	onClose?: (reason: string, willRetry: boolean) => void;
+};
+
+/**
+ * The surface the UI drives. Tests substitute a recording fake, so no test
+ * needs a real server (the same split os1-ios uses for `SessionSocket`).
+ */
+export interface SessionSocket {
+	connect(): void;
+	close(): void;
+	watch(sessionId: string, resume?: { offset: number; rev: string }): void;
+	prompt(
+		sessionId: string,
+		content: string,
+		user: string,
+		opts?: { busyMode?: "queue" | "steer"; effort?: string; fastMode?: boolean },
+	): void;
+	answer(sessionId: string, questionId: string, answers: Record<string, string>): void;
+	cancel(sessionId: string): void;
+	steerQueued(sessionId: string, queueId: string): void;
+	deleteQueued(sessionId: string, queueId: string): void;
+	loadHistory(sessionId: string, beforeOffset: number, beforeRev?: string): void;
+}
+
+export type WsFactory = (url: string, protocols?: { headers: Record<string, string> }) => WebSocket;
+
+const PING_MS = 15_000;
+const PONG_DEADLINE_MS = 45_000;
+const MAX_BACKOFF_MS = 30_000;
+
+export class WsSessionSocket implements SessionSocket {
+	private ws: WebSocket | null = null;
+	private pinger: ReturnType<typeof setInterval> | null = null;
+	private lastPong = Date.now();
+	private attempt = 0;
+	private closedByUs = false;
+	private retryTimer: ReturnType<typeof setTimeout> | null = null;
+	/** Frames sent before the socket opened, replayed on open (the `watch`). */
+	private pending: string[] = [];
+
+	constructor(
+		private readonly url: string,
+		private readonly token: string | undefined,
+		private readonly events: SocketEvents,
+		private readonly factory: WsFactory = (url, opts) =>
+			new WebSocket(url, opts as never),
+	) {}
+
+	connect(): void {
+		this.closedByUs = false;
+		this.open();
+	}
+
+	private open(): void {
+		const ws = this.factory(
+			this.url,
+			this.token ? { headers: { authorization: `Bearer ${this.token}` } } : undefined,
+		);
+		this.ws = ws;
+		this.lastPong = Date.now();
+
+		ws.onopen = () => {
+			this.attempt = 0;
+			for (const frame of this.pending.splice(0)) ws.send(frame);
+			this.startPinging();
+			this.events.onOpen?.();
+		};
+		ws.onmessage = (event: MessageEvent) => {
+			const raw = typeof event.data === "string" ? event.data : "";
+			if (!raw) return;
+			let frame: ServerFrame;
+			try {
+				frame = JSON.parse(raw) as ServerFrame;
+			} catch {
+				return;
+			}
+			if (frame.type === "pong") {
+				this.lastPong = Date.now();
+				return;
+			}
+			// Any traffic proves liveness, not just pongs — a busy session may
+			// outpace the ping interval with real frames.
+			this.lastPong = Date.now();
+			this.events.onFrame(frame);
+		};
+		ws.onerror = () => {
+			// onclose always follows; nothing to do but let it.
+		};
+		ws.onclose = () => {
+			this.stopPinging();
+			this.ws = null;
+			if (this.closedByUs) {
+				this.events.onClose?.("closed", false);
+				return;
+			}
+			this.scheduleRetry("connection lost");
+		};
+	}
+
+	private scheduleRetry(reason: string): void {
+		const delay = Math.min(MAX_BACKOFF_MS, 500 * 2 ** Math.min(this.attempt++, 6));
+		this.events.onClose?.(reason, true);
+		this.retryTimer = setTimeout(() => {
+			this.retryTimer = null;
+			if (!this.closedByUs) this.open();
+		}, delay);
+	}
+
+	private startPinging(): void {
+		this.stopPinging();
+		this.pinger = setInterval(() => {
+			if (Date.now() - this.lastPong > PONG_DEADLINE_MS) {
+				// Half-open: the OS thinks the socket is fine, the server is gone.
+				// Force the close so the retry path runs.
+				try {
+					this.ws?.close();
+				} catch {}
+				return;
+			}
+			this.send({ type: "ping" });
+		}, PING_MS);
+	}
+
+	private stopPinging(): void {
+		if (this.pinger) clearInterval(this.pinger);
+		this.pinger = null;
+	}
+
+	close(): void {
+		this.closedByUs = true;
+		this.stopPinging();
+		if (this.retryTimer) clearTimeout(this.retryTimer);
+		this.retryTimer = null;
+		try {
+			this.ws?.close();
+		} catch {}
+		this.ws = null;
+	}
+
+	private send(msg: object): void {
+		const raw = JSON.stringify(msg);
+		if (this.ws && this.ws.readyState === 1) {
+			try {
+				this.ws.send(raw);
+				return;
+			} catch {}
+		}
+		// Queue rather than drop: the first `watch` is normally sent before the
+		// handshake finishes.
+		this.pending.push(raw);
+		if (this.pending.length > 32) this.pending.shift();
+	}
+
+	watch(sessionId: string, resume?: { offset: number; rev: string }): void {
+		this.send({
+			type: "watch",
+			sessionId,
+			...(resume ? { sinceOffset: resume.offset, sinceRev: resume.rev } : {}),
+		});
+	}
+
+	prompt(
+		sessionId: string,
+		content: string,
+		user: string,
+		opts?: { busyMode?: "queue" | "steer"; effort?: string; fastMode?: boolean },
+	): void {
+		this.send({
+			type: "prompt",
+			sessionId,
+			content,
+			user,
+			// Match the web composer's default: a send during a run is held as an
+			// editable queued message; steering is an explicit gesture.
+			busyMode: opts?.busyMode === "steer" ? "steer" : "queue",
+			...(opts?.effort ? { effort: opts.effort } : {}),
+			...(opts?.fastMode !== undefined ? { fastMode: opts.fastMode } : {}),
+		});
+	}
+
+	answer(sessionId: string, questionId: string, answers: Record<string, string>): void {
+		this.send({ type: "answer_question", sessionId, questionId, answers });
+	}
+
+	cancel(sessionId: string): void {
+		this.send({ type: "cancel", sessionId });
+	}
+
+	steerQueued(sessionId: string, queueId: string): void {
+		this.send({ type: "steer_queued_prompt", sessionId, queueId });
+	}
+
+	deleteQueued(sessionId: string, queueId: string): void {
+		this.send({ type: "delete_queued_prompt", sessionId, queueId });
+	}
+
+	loadHistory(sessionId: string, beforeOffset: number, beforeRev?: string): void {
+		this.send({
+			type: "load_history",
+			sessionId,
+			beforeOffset,
+			...(beforeRev ? { beforeRev } : {}),
+		});
+	}
+}

--- a/os1-tui/src/client/types.ts
+++ b/os1-tui/src/client/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Wire types for the OpenSession client protocol.
+ *
+ * Deliberately a narrow, hand-written mirror of what the server actually sends
+ * — not a shared import from src/server. This package must stay compilable and
+ * `bun build --compile`-able with nothing but its own node_modules, so the
+ * coupling is a documented copy (same choice os1-ios makes in its Codable
+ * models). Fields are all optional-tolerant: a server ahead of this client adds
+ * keys, it never breaks us.
+ */
+
+/** A session as `GET /api/sessions` returns it. */
+export type Session = {
+	id: string;
+	title?: string | null;
+	source?: string | null;
+	repo?: string | null;
+	branch?: string | null;
+	worktreeDir?: string | null;
+	projectId?: string | null;
+	mode?: string | null;
+	model?: string | null;
+	effort?: string | null;
+	isRunning?: boolean;
+	runState?: string | null;
+	waitingForInput?: boolean;
+	queuedCount?: number;
+	archived?: boolean;
+	desk?: boolean;
+	createdAt?: string | null;
+	lastActivity?: string | null;
+	prUrl?: string | null;
+	prState?: string | null;
+	prNumber?: number | null;
+	startedBy?: string | null;
+	lastRunError?: string | null;
+	workspacePreparing?: boolean;
+	sideChatOf?: string | null;
+	automation?: unknown;
+};
+
+export type TranscriptEntry = {
+	id: string;
+	/** "user" | "assistant" | "tool_use" | "tool_result" | "system" */
+	type: string;
+	content?: string | null;
+	timestamp?: string | null;
+	toolName?: string | null;
+	toolInput?: unknown;
+	toolUseId?: string | null;
+	isError?: boolean;
+	model?: string | null;
+	agentId?: string | null;
+	/** Server clamped `content` for the wire; the full body is one GET away. */
+	contentClamped?: boolean;
+	contentLength?: number;
+	images?: string[] | null;
+};
+
+export type QueueItem = { id: string; content: string; user?: string | null };
+
+export type AskOption = { label: string; description?: string | null };
+export type AskQuestion = {
+	questionId: string;
+	questions: {
+		question: string;
+		header?: string | null;
+		multiSelect?: boolean;
+		options?: AskOption[];
+	}[];
+};
+
+/** Byte cursor into the transcript mirror file — our reconnect resume point. */
+export type TranscriptCursor = { endOffset: number; rev: string } | null;
+
+/**
+ * Inbound frames, as a discriminated union on `type`. Only the ones this client
+ * acts on are modelled; anything else lands in `{ type: string }` and is
+ * ignored by the reducer.
+ */
+export type ServerFrame =
+	| { type: "hello"; bootId?: string }
+	| { type: "pong" }
+	| {
+			type: "transcript_init";
+			sessionId?: string;
+			entries?: TranscriptEntry[];
+			truncated?: boolean;
+			startOffset?: number;
+			endOffset?: number;
+			rev?: string;
+	  }
+	| {
+			type: "transcript_history";
+			sessionId?: string;
+			entries?: TranscriptEntry[];
+			truncated?: boolean;
+			startOffset?: number;
+	  }
+	| {
+			type: "transcript_append";
+			sessionId?: string;
+			entries?: TranscriptEntry[];
+			endOffset?: number;
+			rev?: string;
+	  }
+	| { type: "stream_start"; sessionId?: string }
+	| { type: "stream_text"; sessionId?: string; text?: string }
+	| { type: "stream_tool_use"; sessionId?: string; entry?: TranscriptEntry }
+	| { type: "stream_tool_result"; sessionId?: string; entry?: TranscriptEntry }
+	| { type: "stream_done"; sessionId?: string }
+	| { type: "session_status"; sessionId?: string; isRunning?: boolean }
+	| {
+			type: "queue_update";
+			sessionId?: string;
+			queued?: QueueItem[];
+			steered?: QueueItem[];
+	  }
+	| {
+			type: "ask_question";
+			sessionId?: string;
+			questionId?: string;
+			questions?: AskQuestion["questions"];
+	  }
+	| { type: "ask_resolved"; sessionId?: string; questionId?: string }
+	| { type: "notice"; message?: string }
+	| { type: "error"; message?: string }
+	| { type: string };
+
+/** Status glyph classes — herdr's blocked/working/done/idle read. */
+export type SessionStatus =
+	| "waiting"
+	| "running"
+	| "error"
+	| "done"
+	| "idle"
+	| "preparing";
+
+/**
+ * One session's at-a-glance state. `waitingForInput` outranks `isRunning`
+ * because a blocked run is the thing a human has to act on — that's the whole
+ * point of the sidebar.
+ */
+export function sessionStatus(session: Session): SessionStatus {
+	if (session.waitingForInput) return "waiting";
+	if (session.workspacePreparing) return "preparing";
+	if (session.isRunning) return "running";
+	if (session.lastRunError) return "error";
+	if (session.runState === "done" || session.lastActivity) return "done";
+	return "idle";
+}
+
+export function sessionTitle(session: Session): string {
+	const title = session.title?.trim();
+	if (title) return title;
+	if (session.branch) return session.branch;
+	return session.id.slice(0, 12);
+}

--- a/os1-tui/src/client/watched-session.ts
+++ b/os1-tui/src/client/watched-session.ts
@@ -1,0 +1,127 @@
+/**
+ * A socket + its reduced state + subscribers — one per open tab.
+ *
+ * `subscribe`/`getState` is deliberately the `useSyncExternalStore` contract:
+ * frames arrive on the socket's callback, not in React's world, and this is the
+ * supported way to bridge that without tearing.
+ */
+
+import { applyFrame, initialSessionState, type SessionState } from "./session-store";
+import type { SessionSocket } from "./socket";
+import type { ServerFrame } from "./types";
+
+export type Connection = "connecting" | "open" | "retrying";
+
+/**
+ * What the UI reads. State AND transport status live in one immutable object
+ * because `useSyncExternalStore` re-renders on snapshot identity: a connection
+ * change that didn't produce a new snapshot would never reach the screen.
+ */
+export type WatchedSnapshot = { state: SessionState; connection: Connection };
+
+export class WatchedSession {
+	private snapshot: WatchedSnapshot = {
+		state: initialSessionState,
+		connection: "connecting",
+	};
+	private listeners = new Set<() => void>();
+
+	constructor(
+		readonly sessionId: string,
+		private readonly socket: SessionSocket,
+	) {}
+
+	/**
+	 * Connect. The `watch` itself is sent from `handleOpen`, not here — one code
+	 * path for first connect and every reconnect, so a session can't end up
+	 * double-watched (which costs a redundant full transcript_init).
+	 */
+	start(): void {
+		this.socket.connect();
+	}
+
+	/** Called by the socket owner on every frame. */
+	handleFrame(frame: ServerFrame): void {
+		const next = applyFrame(this.snapshot.state, frame);
+		if (next !== this.snapshot.state) {
+			this.snapshot = { ...this.snapshot, state: next };
+			this.emit();
+		}
+	}
+
+	handleOpen(): void {
+		// Re-watch on every open, resuming from the byte cursor when we have one
+		// so the server replays just the gap instead of the whole tail.
+		const cursor = this.snapshot.state.cursor;
+		this.socket.watch(
+			this.sessionId,
+			cursor ? { offset: cursor.endOffset, rev: cursor.rev } : undefined,
+		);
+		this.setConnection("open");
+	}
+
+	handleClose(_reason: string, willRetry: boolean): void {
+		this.setConnection(willRetry ? "retrying" : "connecting");
+	}
+
+	private setConnection(next: Connection): void {
+		if (this.snapshot.connection === next) return;
+		this.snapshot = { ...this.snapshot, connection: next };
+		this.emit();
+	}
+
+	getSnapshot = (): WatchedSnapshot => this.snapshot;
+
+	getState = (): SessionState => this.snapshot.state;
+
+	subscribe = (listener: () => void): (() => void) => {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	};
+
+	private emit(): void {
+		for (const listener of this.listeners) listener();
+	}
+
+	// ── Actions ──────────────────────────────────────────────────────────────
+
+	send(content: string, user: string, busyMode: "queue" | "steer" = "queue"): void {
+		this.socket.prompt(this.sessionId, content, user, { busyMode });
+	}
+
+	answer(answers: Record<string, string>): void {
+		const ask = this.snapshot.state.ask;
+		if (!ask) return;
+		this.socket.answer(this.sessionId, ask.questionId, answers);
+		// Optimistic: the card goes away now, ask_resolved confirms.
+		this.snapshot = {
+			...this.snapshot,
+			state: { ...this.snapshot.state, ask: null },
+		};
+		this.emit();
+	}
+
+	cancel(): void {
+		this.socket.cancel(this.sessionId);
+	}
+
+	steerQueued(queueId: string): void {
+		this.socket.steerQueued(this.sessionId, queueId);
+	}
+
+	deleteQueued(queueId: string): void {
+		this.socket.deleteQueued(this.sessionId, queueId);
+	}
+
+	/** "Load earlier": one page before the oldest entry we hold. */
+	loadEarlier(): void {
+		const { truncated, startOffset, cursor } = this.snapshot.state;
+		if (!truncated || startOffset === undefined) return;
+		this.socket.loadHistory(this.sessionId, startOffset, cursor?.rev);
+	}
+
+	close(): void {
+		this.socket.close();
+		this.listeners.clear();
+	}
+}

--- a/os1-tui/src/index.ts
+++ b/os1-tui/src/index.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env bun
+/**
+ * `os` — the OpenSession terminal client.
+ *
+ * A client and nothing else: HTTP + one WebSocket per watched session. It never
+ * imports the server, never spawns an agent, never touches a worktree. That's
+ * what keeps the compiled binary small enough to drop on a laptop and what makes
+ * `os --host os.tella.dev` the whole setup story.
+ *
+ * Subcommands stay deliberately few (login/logout/whoami/sessions/help) —
+ * everything else is the TUI.
+ */
+
+import { Api, ApiError } from "./client/api";
+import { pollDeviceFlow, startDeviceFlow } from "./client/auth";
+import { normalizeHost, readConfig, resolve, writeConfig } from "./client/config";
+import { WatchPool } from "./client/pool";
+import { SessionsPoller } from "./client/sessions-poller";
+import { sessionStatus, sessionTitle } from "./client/types";
+
+const VERSION = "0.1.0";
+
+const argv = process.argv.slice(2);
+const flags = new Map<string, string | true>();
+const positional: string[] = [];
+for (let i = 0; i < argv.length; i++) {
+	const arg = argv[i]!;
+	if (arg.startsWith("--")) {
+		const [name, inline] = arg.slice(2).split("=", 2);
+		if (inline !== undefined) {
+			flags.set(name!, inline);
+		} else if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
+			flags.set(name!, argv[++i]!);
+		} else {
+			flags.set(name!, true);
+		}
+	} else if (arg.startsWith("-") && arg.length > 1) {
+		flags.set(arg.slice(1), true);
+	} else {
+		positional.push(arg);
+	}
+}
+
+const hostFlag = typeof flags.get("host") === "string" ? (flags.get("host") as string) : undefined;
+
+function usage(): void {
+	console.log(`
+os — OpenSession in your terminal (v${VERSION})
+
+  os                        open the TUI against the configured server
+  os --host os.tella.dev    …against a specific server (and remember it)
+  os <session-id>           open the TUI focused on one session
+
+  os login                  sign in (GitHub device flow)
+  os logout                 forget this box's token
+  os whoami                 who am I, and where
+  os sessions               one-shot list, no TUI (scripts, ssh one-liners)
+  os help · os version
+
+Keys inside: ^b ? shows them all. tmux muscle memory works —
+ctrl+←/→ switches tabs, ^b c starts a session, ^b d detaches.
+`);
+}
+
+async function login(): Promise<number> {
+	const { host } = await resolve(hostFlag);
+	console.log(`Signing in to ${host}…`);
+	const start = await startDeviceFlow(host);
+	if ("status" in start) {
+		if (start.status === "not-required") {
+			await writeConfig({ host });
+			console.log("This server has no sign-in gate — nothing to do. Host saved.");
+			return 0;
+		}
+		console.error(`✗ ${start.error}`);
+		return 1;
+	}
+	console.log(`\n  Open ${start.verificationUri}`);
+	console.log(`  Enter code: ${start.userCode}\n`);
+	const result = await pollDeviceFlow(host, start, {
+		onPending: () => process.stdout.write("."),
+	});
+	process.stdout.write("\n");
+	if (result.status !== "ok") {
+		console.error(`✗ ${result.status === "error" ? result.error : "sign-in failed"}`);
+		return 1;
+	}
+	await writeConfig({ host, token: result.token, login: result.login, user: result.name });
+	console.log(`✓ Signed in as @${result.login}`);
+	return 0;
+}
+
+async function logout(): Promise<number> {
+	const { host, token } = await resolve(hostFlag);
+	if (token) {
+		// Best-effort server-side revoke before dropping the local copy.
+		await new Api(host, token).logout().catch(() => {});
+	}
+	await writeConfig({ token: undefined, login: undefined });
+	console.log("✓ Token removed");
+	return 0;
+}
+
+async function whoami(): Promise<number> {
+	const { host, token, user } = await resolve(hostFlag);
+	console.log(`host   ${host}`);
+	console.log(`user   ${user}`);
+	console.log(`token  ${token ? "present" : "none"}`);
+	const api = new Api(host, token);
+	try {
+		const status = await api.authStatus();
+		console.log(
+			`server ${status.authenticated ? `authenticated as @${status.login}` : "no sign-in gate"}`,
+		);
+	} catch (e) {
+		console.log(`server ${e instanceof ApiError ? e.message : String(e)}`);
+		return 1;
+	}
+	return 0;
+}
+
+async function listSessions(): Promise<number> {
+	const { host, token } = await resolve(hostFlag);
+	const api = new Api(host, token);
+	try {
+		const sessions = (await api.sessions()).filter((s) => !s.archived && !s.sideChatOf);
+		if (!sessions.length) {
+			console.log("No sessions.");
+			return 0;
+		}
+		for (const session of sessions) {
+			const status = sessionStatus(session);
+			const glyph =
+				status === "waiting" ? "?" : status === "running" ? "*" : status === "error" ? "!" : " ";
+			console.log(
+				`${glyph} ${session.id.slice(0, 12).padEnd(13)} ${sessionTitle(session).slice(0, 48).padEnd(49)} ${session.repo ?? ""}`,
+			);
+		}
+		return 0;
+	} catch (e) {
+		const error = e instanceof ApiError ? e : new ApiError(0, String(e));
+		console.error(`✗ ${error.message}`);
+		if (error.needsAuth) console.error("  run `os login` first");
+		return 1;
+	}
+}
+
+async function tui(): Promise<number> {
+	const { host, token, user, config } = await resolve(hostFlag);
+
+	// Remember an explicitly passed host so the next `os` needs no flag. Changing
+	// hosts drops a token minted for the old one (resolve() already refuses to
+	// send it across hosts).
+	if (hostFlag && normalizeHost(hostFlag) !== normalizeHost(config.host ?? "")) {
+		await writeConfig({ host, token: undefined, login: undefined });
+	} else if (!config.host) {
+		await writeConfig({ host });
+	}
+
+	const api = new Api(host, token);
+	if (!(await api.reachable())) {
+		console.error(`✗ Can't reach ${host}`);
+		console.error("  Is the server up, and are you on its network (tailnet/VPN)?");
+		return 1;
+	}
+	try {
+		await api.sessions();
+	} catch (e) {
+		if (e instanceof ApiError && e.needsAuth) {
+			console.error(`✗ ${host} requires sign-in — run \`os login\``);
+			return 1;
+		}
+		throw e;
+	}
+
+	// Imported here, not at the top: the renderer pulls in a native module, and
+	// `os login` / `os sessions` / `--help` must work on a box where that fails.
+	const { createCliRenderer } = await import("@opentui/core");
+	const { createRoot } = await import("@opentui/react");
+	const { App } = await import("./ui/app");
+	const { createElement } = await import("react");
+
+	const poller = new SessionsPoller(api);
+	const pool = new WatchPool({ host, token });
+	void poller.start();
+
+	const renderer = await createCliRenderer({
+		exitOnCtrlC: false, // ctrl+c is a session-level interrupt here, not quit
+		targetFps: 30,
+		// Without the kitty keyboard protocol a terminal cannot express
+		// ctrl+enter at all — it arrives as a bare CR, indistinguishable from
+		// enter, so "steer" would be unreachable. Terminals that don't speak it
+		// ignore the request, and alt+enter still works there.
+		useKittyKeyboard: { allKeysAsEscapes: true },
+	});
+	const root = createRoot(renderer);
+
+	let exiting = false;
+	const shutdown = () => {
+		if (exiting) return;
+		exiting = true;
+		poller.stop();
+		pool.closeAll();
+		root.unmount();
+		renderer.destroy();
+		process.exit(0);
+	};
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+
+	root.render(
+		createElement(App, {
+			api,
+			poller,
+			pool,
+			host,
+			user,
+			prefix: config.prefix,
+			onExit: shutdown,
+			initialSessionId: positional[0],
+		}),
+	);
+	// The renderer owns the process from here.
+	return new Promise<number>(() => {});
+}
+
+async function main(): Promise<number> {
+	const command = positional[0];
+	if (flags.has("help") || flags.has("h") || command === "help") {
+		usage();
+		return 0;
+	}
+	if (flags.has("version") || flags.has("v") || command === "version") {
+		console.log(VERSION);
+		return 0;
+	}
+	switch (command) {
+		case "login":
+			return login();
+		case "logout":
+			return logout();
+		case "whoami":
+			return whoami();
+		case "sessions":
+		case "ls":
+			return listSessions();
+		default:
+			// No subcommand (or a bare session id) → the TUI.
+			return tui();
+	}
+}
+
+main()
+	.then((code) => {
+		if (code !== 0) process.exit(code);
+	})
+	.catch((e) => {
+		console.error(`✗ ${e?.message ?? e}`);
+		process.exit(1);
+	});

--- a/os1-tui/src/index.ts
+++ b/os1-tui/src/index.ts
@@ -5,7 +5,7 @@
  * A client and nothing else: HTTP + one WebSocket per watched session. It never
  * imports the server, never spawns an agent, never touches a worktree. That's
  * what keeps the compiled binary small enough to drop on a laptop and what makes
- * `os --host os.tella.dev` the whole setup story.
+ * `os --host os.company.dev` the whole setup story.
  *
  * Subcommands stay deliberately few (login/logout/whoami/sessions/help) —
  * everything else is the TUI.
@@ -48,7 +48,7 @@ function usage(): void {
 os — OpenSession in your terminal (v${VERSION})
 
   os                        open the TUI against the configured server
-  os --host os.tella.dev    …against a specific server (and remember it)
+  os --host os.company.dev  …against a specific server (and remember it)
   os <session-id>           open the TUI focused on one session
 
   os login                  sign in (GitHub device flow)

--- a/os1-tui/src/ui/app.tsx
+++ b/os1-tui/src/ui/app.tsx
@@ -1,0 +1,615 @@
+/**
+ * The app root: tabs, panes, modes, and the one place actions are executed.
+ *
+ * Three stores, one direction of flow:
+ *   SessionsPoller  — what sessions exist (REST poll)
+ *   WatchedSession  — what one session is doing (WebSocket frames)
+ *   UiStore         — where the user is (tabs, panes, modes)
+ *
+ * Keys never mutate anything directly: they resolve to an Action through the
+ * keymap, and `runAction` is the only mutator. Reads during key handling go
+ * through the stores and refs, never through render-scoped state — a terminal
+ * delivers `^b w` as two keypresses in one tick, and React hasn't re-rendered in
+ * between (see ui-state.ts).
+ */
+
+import type { KeyEvent, ScrollBoxRenderable, TextareaRenderable } from "@opentui/core";
+import { useKeyboard, useTerminalDimensions } from "@opentui/react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import type { Api } from "../client/api";
+import type { WatchPool } from "../client/pool";
+import { initialSessionState } from "../client/session-store";
+import { flattenGroups, type SessionsPoller } from "../client/sessions-poller";
+import { sessionStatus, sessionTitle, type Session } from "../client/types";
+import type { WatchedSession, WatchedSnapshot } from "../client/watched-session";
+import { Composer, PromptOverlay } from "./composer";
+import { Help } from "./help";
+import { DEFAULT_PREFIX, resolveKey, type Action, type Pane } from "./keymap";
+import { Sidebar } from "./sidebar";
+import { StatusBar } from "./status-bar";
+import { theme } from "./theme";
+import { Transcript } from "./transcript";
+import { UiStore } from "./ui-state";
+
+/** The scroll verbs, pulled off the Action union so scrollBy can name them. */
+type ScrollBy = Extract<Action, { type: "scroll" }>["by"];
+
+export type AppProps = {
+	api: Api;
+	poller: SessionsPoller;
+	pool: WatchPool;
+	host: string;
+	user: string;
+	prefix?: string;
+	/** Called on ^b d — the caller stops the renderer and exits the process. */
+	onExit: () => void;
+	/** Session to open on launch (`os <session-id>`). */
+	initialSessionId?: string;
+};
+
+const PANES: Pane[] = ["sidebar", "transcript", "composer"];
+const SPINNER_MS = 120;
+const MESSAGE_MS = 4000;
+const EMPTY_SNAPSHOT: WatchedSnapshot = {
+	state: initialSessionState,
+	connection: "connecting",
+};
+
+const noopSubscribe = () => () => {};
+
+function useWatchedSnapshot(watched: WatchedSession | undefined): WatchedSnapshot {
+	return useSyncExternalStore(
+		watched?.subscribe ?? noopSubscribe,
+		watched?.getSnapshot ?? (() => EMPTY_SNAPSHOT),
+	);
+}
+
+export function App({
+	api,
+	poller,
+	pool,
+	host,
+	user,
+	prefix = DEFAULT_PREFIX,
+	onExit,
+	initialSessionId,
+}: AppProps) {
+	const { width, height } = useTerminalDimensions();
+	const sessions = useSyncExternalStore(poller.subscribe, poller.getState);
+
+	const [uiStore] = useState(() => new UiStore(initialSessionId));
+	const ui = useSyncExternalStore(uiStore.subscribe, uiStore.getState);
+
+	const [spinnerFrame, setSpinnerFrame] = useState(0);
+	const composerRef = useRef<TextareaRenderable>(null);
+	const overlayRef = useRef<TextareaRenderable>(null);
+	const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+	const flat = useMemo(() => flattenGroups(sessions.groups), [sessions.groups]);
+	const byId = useMemo(
+		() => new Map(sessions.sessions.map((s) => [s.id, s])),
+		[sessions.sessions],
+	);
+	/** Read by key handlers, which must never see a stale session list. */
+	const flatRef = useRef(flat);
+	flatRef.current = flat;
+
+	const activeSessionId = ui.tabs[ui.activeTab];
+	const [watched, setWatched] = useState<WatchedSession>();
+	const watchedRef = useRef<WatchedSession>(undefined);
+	watchedRef.current = watched;
+
+	// One live watch per open tab; the active tab's is the one we render.
+	useEffect(() => {
+		if (!activeSessionId) {
+			setWatched(undefined);
+			return;
+		}
+		setWatched(pool.ensure(activeSessionId));
+	}, [activeSessionId, pool]);
+
+	const snapshot = useWatchedSnapshot(watched);
+	const state = snapshot.state;
+	const stateRef = useRef(state);
+	stateRef.current = state;
+	const session = activeSessionId ? byId.get(activeSessionId) : undefined;
+
+	const waiting = sessions.sessions.filter((s) => sessionStatus(s) === "waiting").length;
+	const running = sessions.sessions.filter((s) => sessionStatus(s) === "running").length;
+
+	// The spinner only ticks when something is actually spinning: an idle `os`
+	// should cost nothing, especially over ssh.
+	const animating = running > 0 || state.isRunning || state.streaming;
+	useEffect(() => {
+		if (!animating) return;
+		const timer = setInterval(() => setSpinnerFrame((f) => f + 1), SPINNER_MS);
+		return () => clearInterval(timer);
+	}, [animating]);
+
+	// A pending question is the one thing that should pull focus: it blocks a run
+	// until a human acts. Typing is never interrupted — only nav mode yields.
+	useEffect(() => {
+		const current = uiStore.getState();
+		if (state.ask && current.mode === "nav") uiStore.set({ mode: "ask" });
+		if (!state.ask && current.mode === "ask") uiStore.set({ mode: "nav" });
+	}, [state.ask, uiStore]);
+
+	useEffect(() => {
+		if (!ui.message) return;
+		const timer = setTimeout(() => uiStore.set({ message: undefined }), MESSAGE_MS);
+		return () => clearTimeout(timer);
+	}, [ui.message, uiStore]);
+
+	function note(text: string, kind: "info" | "error" = "info"): void {
+		uiStore.set({ message: { text, kind } });
+	}
+
+	function closeActiveTab(): void {
+		const sessionId = uiStore.activeSessionId;
+		if (!sessionId) return;
+		pool.release(sessionId);
+		uiStore.closeTab(sessionId);
+	}
+
+	function submitPrompt(busyMode: "queue" | "steer"): void {
+		const input = composerRef.current;
+		const text = input?.plainText.trim() ?? "";
+		if (!text) return;
+		const target = watchedRef.current;
+		if (!target) {
+			note("open a session first", "error");
+			return;
+		}
+		target.send(text, user, busyMode);
+		input?.clear();
+		note(
+			busyMode === "steer"
+				? "steered into the running turn"
+				: stateRef.current.isRunning
+					? "queued behind the running turn"
+					: "sent",
+		);
+	}
+
+	function answerOption(index: number): void {
+		const ask = stateRef.current.ask;
+		const question = ask?.questions[0];
+		const option = question?.options?.[index];
+		if (!ask || !question || !option) return;
+		watchedRef.current?.answer({ [question.question]: option.label });
+		note(`answered: ${option.label}`);
+	}
+
+	function scrollBy(by: ScrollBy): void {
+		const box = scrollRef.current;
+		if (!box) return;
+		const page = Math.max(1, box.viewport.height - 1);
+		switch (by) {
+			case "line-up":
+				box.scrollBy(-1);
+				break;
+			case "line-down":
+				box.scrollBy(1);
+				break;
+			case "page-up":
+				box.scrollBy(-page);
+				break;
+			case "page-down":
+				box.scrollBy(page);
+				break;
+			case "top":
+				box.scrollTo(0);
+				break;
+			case "bottom":
+				box.scrollTo(box.scrollHeight);
+				break;
+		}
+	}
+
+	function createSession(prompt: string): void {
+		note("creating session…");
+		void api
+			.createSession({ prompt, user, mode: "ask" })
+			.then((created) => {
+				poller.refreshSoon();
+				const id = created.sessionId ?? created.id;
+				if (id) uiStore.openTab(id);
+				note("session created");
+			})
+			.catch((e) => note(String(e?.message ?? e), "error"));
+	}
+
+	function renameSession(title: string): void {
+		const sessionId = uiStore.activeSessionId;
+		if (!sessionId) return;
+		void api
+			.setTitle(sessionId, title)
+			.then(() => {
+				poller.refreshSoon();
+				note(title ? `renamed to “${title}”` : "title cleared");
+			})
+			.catch((e) => note(String(e?.message ?? e), "error"));
+	}
+
+	function submitOverlay(): void {
+		const value = overlayRef.current?.plainText.trim() ?? "";
+		const overlay = uiStore.getState().overlay;
+		uiStore.set({ overlay: null, mode: stateRef.current.ask ? "ask" : "nav" });
+		if (!overlay) return;
+
+		switch (overlay.kind) {
+			case "picker": {
+				const chosen = pickerMatches(flatRef.current, value)[overlay.selected];
+				if (chosen) uiStore.openTab(chosen.id);
+				return;
+			}
+			case "rename":
+				renameSession(value);
+				return;
+			case "new":
+				if (value) createSession(value);
+				return;
+			case "command":
+				runCommand(value);
+				return;
+		}
+	}
+
+	function runCommand(raw: string): void {
+		const [verb = "", ...rest] = raw.replace(/^:/, "").split(/\s+/);
+		const argument = rest.join(" ");
+		switch (verb) {
+			case "":
+				return;
+			case "archive":
+				runAction({ type: "archive" });
+				return;
+			case "new":
+				if (argument) createSession(argument);
+				else note("usage: new <prompt>", "error");
+				return;
+			case "rename":
+				renameSession(argument);
+				return;
+			case "cancel":
+				runAction({ type: "cancel-run" });
+				return;
+			case "reconnect":
+				runAction({ type: "reconnect" });
+				return;
+			case "close":
+				closeActiveTab();
+				return;
+			case "quit":
+			case "detach":
+				onExit();
+				return;
+			default: {
+				// A bare `:some text` is a prompt — the most common thing you reach the
+				// command line for once the verbs are in muscle memory.
+				const target = watchedRef.current;
+				if (target) {
+					target.send(raw, user, "queue");
+					note("sent");
+				} else {
+					note(`unknown command: ${verb}`, "error");
+				}
+			}
+		}
+	}
+
+	function runAction(action: Action): void {
+		const current = uiStore.getState();
+		switch (action.type) {
+			case "next-tab":
+				if (current.tabs.length) {
+					uiStore.set({ activeTab: (current.activeTab + 1) % current.tabs.length });
+				}
+				return;
+			case "prev-tab":
+				if (current.tabs.length) {
+					uiStore.set({
+						activeTab: (current.activeTab - 1 + current.tabs.length) % current.tabs.length,
+					});
+				}
+				return;
+			case "jump-tab": {
+				// tmux numbers windows from 1 and puts 10 on `0`.
+				const target = action.index === 0 ? 9 : action.index - 1;
+				if (target < current.tabs.length) uiStore.set({ activeTab: target });
+				return;
+			}
+			case "focus-pane": {
+				const at = PANES.indexOf(current.pane);
+				const next =
+					PANES[(at + (action.direction === "next" ? 1 : PANES.length - 1)) % PANES.length]!;
+				// Focusing the composer with no session open would leave the user
+				// typing into nothing.
+				if (next === "composer" && !uiStore.activeSessionId) {
+					uiStore.set({ pane: "sidebar", mode: "nav" });
+					return;
+				}
+				uiStore.set({
+					pane: next,
+					mode: next === "composer" ? "composer" : stateRef.current.ask ? "ask" : "nav",
+				});
+				return;
+			}
+			case "move-cursor":
+				if (current.overlay?.kind === "picker") {
+					const matches = pickerMatches(flatRef.current, overlayRef.current?.plainText ?? "");
+					uiStore.set({
+						overlay: {
+							kind: "picker",
+							selected: clamp(current.overlay.selected + action.delta, 0, matches.length - 1),
+						},
+					});
+					return;
+				}
+				uiStore.set({
+					cursor: clamp(current.cursor + action.delta, 0, Math.max(0, flatRef.current.length - 1)),
+					pane: "sidebar",
+				});
+				return;
+			case "open-selected": {
+				if (current.overlay) {
+					submitOverlay();
+					return;
+				}
+				const chosen = flatRef.current[current.cursor];
+				if (chosen) uiStore.openTab(chosen.id);
+				return;
+			}
+			case "new-session":
+				uiStore.set({ overlay: { kind: "new" }, mode: "command" });
+				return;
+			case "close-tab":
+				closeActiveTab();
+				return;
+			case "cancel-run": {
+				const target = watchedRef.current;
+				if (!target) return;
+				target.cancel();
+				note("interrupting the current turn…");
+				return;
+			}
+			case "rename":
+				if (!uiStore.activeSessionId) {
+					note("no session open", "error");
+					return;
+				}
+				uiStore.set({ overlay: { kind: "rename" }, mode: "command" });
+				return;
+			case "archive": {
+				const sessionId = uiStore.activeSessionId;
+				if (!sessionId) {
+					note("no session open", "error");
+					return;
+				}
+				void api
+					.setArchived(sessionId, true)
+					.then(() => {
+						pool.release(sessionId);
+						uiStore.closeTab(sessionId);
+						poller.refreshSoon();
+						note("archived");
+					})
+					.catch((e) => note(String(e?.message ?? e), "error"));
+				return;
+			}
+			case "detach":
+				onExit();
+				return;
+			case "reconnect": {
+				const sessionId = uiStore.activeSessionId;
+				if (!sessionId) return;
+				pool.release(sessionId);
+				setWatched(pool.ensure(sessionId));
+				note("reconnecting…");
+				return;
+			}
+			case "toggle-help":
+				uiStore.set({ mode: current.mode === "help" ? "nav" : "help" });
+				return;
+			case "open-picker":
+				uiStore.set({ overlay: { kind: "picker", selected: 0 }, mode: "picker" });
+				return;
+			case "open-command":
+				uiStore.set({ overlay: { kind: "command" }, mode: "command" });
+				return;
+			case "enter-scroll":
+				uiStore.set({ pane: "transcript", mode: "scroll" });
+				return;
+			case "exit-mode":
+				uiStore.set({
+					overlay: null,
+					mode: stateRef.current.ask ? "ask" : "nav",
+					pane: current.mode === "composer" ? "transcript" : current.pane,
+				});
+				return;
+			case "scroll":
+				scrollBy(action.by);
+				return;
+			case "load-earlier":
+				watchedRef.current?.loadEarlier();
+				note("loading earlier history…");
+				return;
+			case "focus-composer":
+				if (!uiStore.activeSessionId) {
+					note("open a session first", "error");
+					return;
+				}
+				uiStore.set({ pane: "composer", mode: "composer" });
+				return;
+			case "submit":
+				submitPrompt(action.busyMode);
+				return;
+			case "answer-option":
+				answerOption(action.index);
+				return;
+			case "toggle-zoom":
+				uiStore.set({ zoom: !current.zoom });
+				return;
+		}
+	}
+
+	/** Single entry point for every key, whichever component received it. */
+	function dispatch(key: KeyEvent): boolean {
+		const { mode, pane, prefixArmed } = uiStore.getState();
+		const resolution = resolveKey(key, { mode, pane, prefixArmed }, prefix);
+		if (resolution.prefixArmed !== prefixArmed) {
+			uiStore.set({ prefixArmed: resolution.prefixArmed });
+		}
+		if (resolution.action) runAction(resolution.action);
+		return resolution.consumed;
+	}
+
+	// Modes where a textarea holds focus route keys through its own onKeyDown (it
+	// runs before the default insert, so `preventDefault` really suppresses
+	// typing). Everywhere else the global handler owns the keyboard. Exactly one
+	// of the two is live at a time — that's what stops double-handling.
+	const textFocused =
+		ui.mode === "composer" || ui.mode === "command" || ui.mode === "picker";
+	useKeyboard((key) => {
+		if (textFocused) return;
+		dispatch(key);
+	});
+
+	function onTextKey(key: KeyEvent): void {
+		if (dispatch(key)) key.preventDefault();
+	}
+
+	const sidebarWidth = clamp(Math.floor(width * 0.28), 22, 34);
+	const showSidebar = !ui.zoom && width >= 60;
+	const tabSessions = ui.tabs.map((id) => byId.get(id) ?? ({ id } as Session));
+	const pickerSelected = ui.overlay?.kind === "picker" ? ui.overlay.selected : 0;
+	const pickerQuery =
+		ui.overlay?.kind === "picker" ? (overlayRef.current?.plainText ?? "") : "";
+
+	return (
+		<box flexDirection="column" width={width} height={height}>
+			<box flexDirection="row" flexGrow={1}>
+				{showSidebar ? (
+					<Sidebar
+						groups={sessions.groups}
+						cursor={ui.cursor}
+						openTabs={ui.tabs}
+						activeSessionId={activeSessionId}
+						focused={ui.pane === "sidebar"}
+						width={sidebarWidth}
+						spinnerFrame={spinnerFrame}
+						loaded={sessions.loaded}
+						error={sessions.needsAuth ? "run `os login`" : sessions.error}
+					/>
+				) : null}
+				<Transcript
+					session={session}
+					state={state}
+					focused={ui.pane === "transcript"}
+					scrollMode={ui.mode === "scroll"}
+					spinnerFrame={spinnerFrame}
+					connection={snapshot.connection}
+					scrollRef={scrollRef}
+				/>
+			</box>
+
+			{session ? (
+				<Composer
+					focused={ui.mode === "composer"}
+					busy={state.isRunning}
+					queuedCount={state.queued.length}
+					placeholder={
+						state.ask
+							? "answer with a number, or type a reply…"
+							: `message ${sessionTitle(session).slice(0, 24)}…`
+					}
+					onKeyDown={onTextKey}
+					inputRef={composerRef}
+					notice={session.workspacePreparing ? "workspace still being created…" : undefined}
+				/>
+			) : null}
+
+			<StatusBar
+				host={host}
+				user={user}
+				tabs={tabSessions}
+				activeIndex={ui.activeTab}
+				waiting={waiting}
+				running={running}
+				prefixArmed={ui.prefixArmed}
+				mode={ui.mode}
+				message={ui.message?.text}
+				messageKind={ui.message?.kind}
+				spinnerFrame={spinnerFrame}
+				width={width}
+			/>
+
+			{ui.mode === "help" ? <Help height={height} /> : null}
+
+			{ui.overlay?.kind === "picker" ? (
+				<PromptOverlay
+					title="sessions"
+					value={pickerQuery}
+					hint="↑/↓ to move · enter opens · esc cancels"
+					rows={pickerMatches(flat, pickerQuery).map((s, index) => ({
+						label: sessionTitle(s),
+						detail: [s.repo, sessionStatus(s)].filter(Boolean).join(" · "),
+						selected: index === pickerSelected,
+					}))}
+					inputRef={overlayRef}
+					onKeyDown={onTextKey}
+				/>
+			) : null}
+
+			{ui.overlay?.kind === "command" ? (
+				<PromptOverlay
+					title="command"
+					value=""
+					hint="archive · rename <title> · new <prompt> · cancel · reconnect · close · quit"
+					inputRef={overlayRef}
+					onKeyDown={onTextKey}
+				/>
+			) : null}
+
+			{ui.overlay?.kind === "rename" ? (
+				<PromptOverlay
+					title="rename session"
+					value=""
+					hint="empty clears the manual title · enter saves"
+					inputRef={overlayRef}
+					onKeyDown={onTextKey}
+				/>
+			) : null}
+
+			{ui.overlay?.kind === "new" ? (
+				<PromptOverlay
+					title="new session"
+					value=""
+					hint="what should it work on? · enter starts it (ask mode)"
+					inputRef={overlayRef}
+					onKeyDown={onTextKey}
+				/>
+			) : null}
+		</box>
+	);
+}
+
+function clamp(value: number, min: number, max: number): number {
+	if (max < min) return min;
+	return Math.min(max, Math.max(min, value));
+}
+
+/** Substring match over title/repo/branch — enough for a 30-session list. */
+export function pickerMatches(sessions: Session[], query: string): Session[] {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return sessions.slice(0, 10);
+	return sessions
+		.filter((s) =>
+			[sessionTitle(s), s.repo, s.branch, s.id]
+				.filter(Boolean)
+				.some((field) => String(field).toLowerCase().includes(needle)),
+		)
+		.slice(0, 10);
+}
+
+export { theme };

--- a/os1-tui/src/ui/composer.tsx
+++ b/os1-tui/src/ui/composer.tsx
@@ -1,0 +1,147 @@
+/**
+ * The composer, plus the two overlays that borrow it (command prompt, picker).
+ *
+ * Keys are routed through the same `resolveKey` the app uses — the textarea's
+ * own `onKeyDown` fires before its default insert, so a consumed key gets
+ * `preventDefault()` and never lands as text. That's why there's exactly one
+ * keymap in this app and not one per focus target.
+ */
+
+import { TextAttributes, type KeyEvent, type TextareaRenderable } from "@opentui/core";
+import type { Ref } from "react";
+import { theme } from "./theme";
+
+export type ComposerProps = {
+	focused: boolean;
+	busy: boolean;
+	/** Queued count, so the hint can say what enter will do. */
+	queuedCount: number;
+	placeholder: string;
+	onKeyDown: (key: KeyEvent) => void;
+	inputRef?: Ref<TextareaRenderable>;
+	/** Non-empty while the session's workspace is still being created. */
+	notice?: string;
+};
+
+export function Composer({
+	focused,
+	busy,
+	queuedCount,
+	placeholder,
+	onKeyDown,
+	inputRef,
+	notice,
+}: ComposerProps) {
+	const hint = busy
+		? "enter queues · ctrl+enter steers · ^b x cancels"
+		: queuedCount
+			? `${queuedCount} queued · enter sends`
+			: "enter sends · ^b ? keys";
+
+	return (
+		<box
+			flexDirection="column"
+			border={["top"]}
+			borderColor={focused ? theme.borderStrong : theme.border}
+			flexShrink={0}
+		>
+			{notice ? (
+				<text fg={theme.yellow} paddingLeft={1}>
+					{notice}
+				</text>
+			) : null}
+			<box flexDirection="row" paddingLeft={1} paddingRight={1}>
+				<text fg={focused ? theme.accent : theme.faint}>{focused ? "› " : "  "}</text>
+				<textarea
+					ref={inputRef}
+					focused={focused}
+					placeholder={placeholder}
+					onKeyDown={onKeyDown}
+					flexGrow={1}
+					maxHeight={6}
+				/>
+			</box>
+			<box flexDirection="row" paddingLeft={1} paddingRight={1}>
+				<text fg={theme.faint} flexGrow={1}>
+					{hint}
+				</text>
+			</box>
+		</box>
+	);
+}
+
+export type PromptOverlayProps = {
+	title: string;
+	value: string;
+	hint?: string;
+	rows?: { label: string; detail?: string; selected: boolean }[];
+	inputRef?: Ref<TextareaRenderable>;
+	onKeyDown: (key: KeyEvent) => void;
+};
+
+/**
+ * One overlay shape for the command prompt, the session picker, rename and the
+ * new-session prompt — they differ only in title and whether they list rows.
+ */
+export function PromptOverlay({
+	title,
+	value,
+	hint,
+	rows,
+	inputRef,
+	onKeyDown,
+}: PromptOverlayProps) {
+	return (
+		<box
+			position="absolute"
+			left={4}
+			right={4}
+			top={3}
+			border
+			borderColor={theme.accent}
+			backgroundColor={theme.panel}
+			flexDirection="column"
+			title={` ${title} `}
+			zIndex={10}
+			paddingLeft={1}
+			paddingRight={1}
+		>
+			<box flexDirection="row">
+				<text fg={theme.accent}>› </text>
+				<textarea
+					ref={inputRef}
+					focused
+					onKeyDown={onKeyDown}
+					flexGrow={1}
+					maxHeight={2}
+				/>
+			</box>
+			{rows?.length ? (
+				<box flexDirection="column" paddingTop={1}>
+					{rows.slice(0, 10).map((row, index) => (
+						<box
+							key={`${index}-${row.label}`}
+							flexDirection="row"
+							backgroundColor={row.selected ? theme.active : undefined}
+						>
+							<text
+								fg={row.selected ? theme.fg : theme.dim}
+								attributes={row.selected ? TextAttributes.BOLD : undefined}
+								flexGrow={1}
+								truncate
+							>
+								{row.label}
+							</text>
+							{row.detail ? (
+								<text fg={theme.faint} truncate>
+									{row.detail}
+								</text>
+							) : null}
+						</box>
+					))}
+				</box>
+			) : null}
+			{hint ? <text fg={theme.faint}>{hint}</text> : null}
+		</box>
+	);
+}

--- a/os1-tui/src/ui/format.ts
+++ b/os1-tui/src/ui/format.ts
@@ -1,0 +1,147 @@
+/**
+ * Transcript entries → the one or few lines a terminal should show.
+ *
+ * Pure string work, kept out of the components so it's testable: the tool-call
+ * summary in particular is the difference between a readable transcript and a
+ * screenful of JSON.
+ */
+
+import type { Session, TranscriptEntry } from "../client/types";
+
+/** Compact relative age: "now", "4m", "3h", "2d". */
+export function relativeTime(stamp?: string | null, now = Date.now()): string {
+	if (!stamp) return "";
+	const then = Date.parse(stamp);
+	if (Number.isNaN(then)) return "";
+	const seconds = Math.max(0, Math.round((now - then) / 1000));
+	if (seconds < 45) return "now";
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	return `${Math.round(hours / 24)}d`;
+}
+
+/** First meaningful path/command-ish value in a tool's input, for the one-liner. */
+function toolArgument(input: unknown): string {
+	if (!input || typeof input !== "object") {
+		return typeof input === "string" ? input : "";
+	}
+	const record = input as Record<string, unknown>;
+	for (const key of [
+		"file_path",
+		"path",
+		"command",
+		"pattern",
+		"query",
+		"prompt",
+		"description",
+		"url",
+		"notebook_path",
+	]) {
+		const value = record[key];
+		if (typeof value === "string" && value.trim()) return value.trim();
+	}
+	// Nothing recognisable — show the keys so the line still says something.
+	const keys = Object.keys(record);
+	return keys.length ? `{${keys.slice(0, 3).join(", ")}}` : "";
+}
+
+/** Collapse a home-anchored path so the interesting tail survives narrow panes. */
+export function shortenPath(value: string, max = 60): string {
+	let text = value.replace(/^\/home\/[^/]+\//, "~/");
+	if (text.length <= max) return text;
+	const parts = text.split("/");
+	while (parts.length > 2 && parts.join("/").length > max) parts.splice(1, 1);
+	text = parts.join("/…/").replace("/…//", "/…/");
+	return text.length <= max ? text : `…${text.slice(-(max - 1))}`;
+}
+
+export type DisplayEntry = {
+	id: string;
+	kind: "user" | "assistant" | "tool" | "system";
+	/** Leading glyph + label, e.g. "▸ read". */
+	prefix: string;
+	/** The body — may be multi-line for user/assistant text. */
+	body: string;
+	error?: boolean;
+	/** Server clamped the body; the full one is a fetch away. */
+	clamped?: boolean;
+};
+
+const TOOL_RESULT_PREVIEW = 240;
+
+export function formatEntry(entry: TranscriptEntry): DisplayEntry | null {
+	const content = (entry.content ?? "").replace(/\s+$/, "");
+
+	switch (entry.type) {
+		case "user":
+			return {
+				id: entry.id,
+				kind: "user",
+				prefix: "›",
+				body: content,
+				clamped: entry.contentClamped,
+			};
+
+		case "assistant":
+			if (!content) return null;
+			return {
+				id: entry.id,
+				kind: "assistant",
+				prefix: "",
+				body: content,
+				clamped: entry.contentClamped,
+			};
+
+		case "tool_use": {
+			const argument = toolArgument(entry.toolInput);
+			return {
+				id: entry.id,
+				kind: "tool",
+				prefix: `▸ ${entry.toolName ?? "tool"}`,
+				body: argument ? shortenPath(argument.split("\n")[0] ?? "") : "",
+			};
+		}
+
+		case "tool_result": {
+			// Results are noise by default; one truncated line is enough to see
+			// that it came back, and errors get the full first lines.
+			const firstLines = content.split("\n").slice(0, entry.isError ? 4 : 1).join(" ⏎ ");
+			const body =
+				firstLines.length > TOOL_RESULT_PREVIEW
+					? `${firstLines.slice(0, TOOL_RESULT_PREVIEW)}…`
+					: firstLines;
+			if (!body) return null;
+			return {
+				id: entry.id,
+				kind: "tool",
+				prefix: entry.isError ? "◂ error" : "◂",
+				body,
+				error: entry.isError,
+			};
+		}
+
+		default:
+			if (!content) return null;
+			return { id: entry.id, kind: "system", prefix: "•", body: content };
+	}
+}
+
+export function formatEntries(entries: TranscriptEntry[]): DisplayEntry[] {
+	const out: DisplayEntry[] = [];
+	for (const entry of entries) {
+		const display = formatEntry(entry);
+		if (display) out.push(display);
+	}
+	return out;
+}
+
+/** The session line in the status bar: repo · branch · model. */
+export function sessionSubtitle(session: Session | undefined): string {
+	if (!session) return "";
+	const parts = [session.repo, session.branch, session.model, session.mode].filter(
+		(p): p is string => typeof p === "string" && p.length > 0,
+	);
+	return parts.join(" · ");
+}

--- a/os1-tui/src/ui/help.tsx
+++ b/os1-tui/src/ui/help.tsx
@@ -1,0 +1,49 @@
+/**
+ * The `^b ?` overlay. Rows come from KEY_HELP so the keymap, this overlay and
+ * the README can't drift apart.
+ */
+
+import { TextAttributes } from "@opentui/core";
+import { KEY_HELP } from "./keymap";
+import { theme } from "./theme";
+
+export function Help({ height }: { height: number }) {
+	// Two columns once there's no room to stack; the list is ~22 rows.
+	const twoUp = height < KEY_HELP.length + 6;
+	const half = Math.ceil(KEY_HELP.length / 2);
+	const columns = twoUp ? [KEY_HELP.slice(0, half), KEY_HELP.slice(half)] : [KEY_HELP];
+
+	return (
+		<box
+			position="absolute"
+			left={2}
+			right={2}
+			top={1}
+			bottom={2}
+			border
+			borderColor={theme.accent}
+			backgroundColor={theme.panel}
+			title=" keys "
+			bottomTitle=" any key closes "
+			flexDirection="row"
+			zIndex={20}
+			paddingLeft={1}
+			paddingRight={1}
+		>
+			{columns.map((column, index) => (
+				<box key={index} flexDirection="column" flexGrow={1}>
+					{column.map((row) => (
+						<box key={row.keys} flexDirection="row">
+							<text fg={theme.fg} attributes={TextAttributes.BOLD} width={18} truncate>
+								{row.keys}
+							</text>
+							<text fg={theme.dim} flexGrow={1} truncate>
+								{row.label}
+							</text>
+						</box>
+					))}
+				</box>
+			))}
+		</box>
+	);
+}

--- a/os1-tui/src/ui/keymap.ts
+++ b/os1-tui/src/ui/keymap.ts
@@ -1,0 +1,318 @@
+/**
+ * The tmux keymap, as a pure state machine.
+ *
+ * Two things make this worth isolating from the components: the prefix
+ * (`ctrl+b`, then a key) is genuinely stateful, and modal keys mean the same
+ * keystroke does different things depending on where focus is. Both are exactly
+ * the kind of logic that rots silently inside a render function — here a test
+ * can drive every path with plain objects.
+ */
+
+export type Pane = "sidebar" | "transcript" | "composer";
+
+export type Mode =
+	/** Moving around: sidebar/transcript focused, keys are commands. */
+	| "nav"
+	/** Typing a prompt. Printable keys belong to the input. */
+	| "composer"
+	/** An AskUserQuestion card is up; number keys pick an option. */
+	| "ask"
+	/** tmux copy-mode: scrolling the transcript. */
+	| "scroll"
+	/** Fuzzy session picker (^b w). */
+	| "picker"
+	/** Command prompt (^b :). */
+	| "command"
+	/** Help overlay (^b ?). */
+	| "help";
+
+export type Action =
+	| { type: "next-tab" }
+	| { type: "prev-tab" }
+	| { type: "jump-tab"; index: number }
+	| { type: "focus-pane"; direction: "next" | "prev" }
+	| { type: "move-cursor"; delta: number }
+	| { type: "open-selected" }
+	| { type: "new-session" }
+	| { type: "close-tab" }
+	| { type: "cancel-run" }
+	| { type: "rename" }
+	| { type: "archive" }
+	| { type: "detach" }
+	| { type: "reconnect" }
+	| { type: "toggle-help" }
+	| { type: "open-picker" }
+	| { type: "open-command" }
+	| { type: "enter-scroll" }
+	| { type: "exit-mode" }
+	| {
+			type: "scroll";
+			by: "line-up" | "line-down" | "page-up" | "page-down" | "top" | "bottom";
+	  }
+	| { type: "load-earlier" }
+	| { type: "focus-composer" }
+	| { type: "submit"; busyMode: "queue" | "steer" }
+	| { type: "answer-option"; index: number }
+	| { type: "toggle-zoom" };
+
+/** The subset of OpenTUI's KeyEvent this map reads. */
+export type Key = {
+	name: string;
+	ctrl?: boolean;
+	shift?: boolean;
+	meta?: boolean;
+	option?: boolean;
+	sequence?: string;
+};
+
+export type KeymapState = {
+	mode: Mode;
+	pane: Pane;
+	/** The prefix has been pressed; the next key is a prefix command. */
+	prefixArmed: boolean;
+};
+
+export type Resolution = {
+	action?: Action;
+	/** Next prefix state. */
+	prefixArmed: boolean;
+	/** True when this key was a keymap command and must not reach the input. */
+	consumed: boolean;
+};
+
+export const DEFAULT_PREFIX = "b";
+
+function none(state: KeymapState): Resolution {
+	return { prefixArmed: state.prefixArmed, consumed: false };
+}
+
+function act(action: Action, prefixArmed = false): Resolution {
+	return { action, prefixArmed, consumed: true };
+}
+
+/**
+ * The prefix command table — tmux's, with OpenSession verbs where tmux has no
+ * equivalent. Shared by every mode: `^b d` detaches even mid-typing, which is
+ * what tmux users expect.
+ */
+function prefixCommand(key: Key, prefix: string): Resolution {
+	// `^b ^b` is how you cancel an armed prefix.
+	if (key.ctrl && key.name === prefix) return act({ type: "exit-mode" });
+	if (key.name >= "0" && key.name <= "9" && key.name.length === 1 && !key.ctrl) {
+		return act({ type: "jump-tab", index: Number(key.name) });
+	}
+	switch (key.name) {
+		case "c":
+			return act({ type: "new-session" });
+		case "n":
+			return act({ type: "next-tab" });
+		case "p":
+			return act({ type: "prev-tab" });
+		case "w":
+			return act({ type: "open-picker" });
+		case "x":
+			return act({ type: "cancel-run" });
+		case "&":
+			return act({ type: "close-tab" });
+		case ",":
+			return act({ type: "rename" });
+		case "z":
+			return act({ type: "toggle-zoom" });
+		case "d":
+			return act({ type: "detach" });
+		case "r":
+			return act({ type: "reconnect" });
+		case "a":
+			return act({ type: "archive" });
+		case "[":
+			return act({ type: "enter-scroll" });
+		case "?":
+		case "/":
+			return act({ type: "toggle-help" });
+		case ":":
+			return act({ type: "open-command" });
+		case "escape":
+			return act({ type: "exit-mode" });
+		default:
+			// Unknown prefix key: swallow it (tmux beeps) rather than letting it
+			// fall through into the composer as text.
+			return { prefixArmed: false, consumed: true };
+	}
+}
+
+/** Movement that works from every mode: ctrl+arrows and ctrl+hjkl. */
+function globalMovement(key: Key): Resolution | undefined {
+	if (!key.ctrl) return undefined;
+	switch (key.name) {
+		case "left":
+		case "h":
+			return act({ type: "prev-tab" });
+		case "right":
+		case "l":
+			return act({ type: "next-tab" });
+		case "up":
+		case "k":
+			return act({ type: "focus-pane", direction: "prev" });
+		case "down":
+		case "j":
+			return act({ type: "focus-pane", direction: "next" });
+		default:
+			return undefined;
+	}
+}
+
+export function resolveKey(
+	key: Key,
+	state: KeymapState,
+	prefix: string = DEFAULT_PREFIX,
+): Resolution {
+	// 1. An armed prefix wins over everything.
+	if (state.prefixArmed) return prefixCommand(key, prefix);
+
+	// 2. Arm the prefix.
+	if (key.ctrl && key.name === prefix) {
+		return { prefixArmed: true, consumed: true };
+	}
+
+	// 3. Modified enter steers, from inside the composer. ctrl+enter needs the
+	//    kitty keyboard protocol to be distinguishable from a bare CR at all (we
+	//    ask for it at startup); alt/option+enter is an ESC-prefixed sequence that
+	//    every terminal reports, so it's the portable alias.
+	if (
+		(key.ctrl || key.meta || key.option) &&
+		(key.name === "return" || key.name === "enter") &&
+		state.mode === "composer"
+	) {
+		return act({ type: "submit", busyMode: "steer" });
+	}
+
+	// 4. Global movement (ctrl+arrows / ctrl+hjkl) — deliberately ahead of the
+	//    per-mode tables so it works while typing.
+	const movement = globalMovement(key);
+	if (movement) return movement;
+
+	switch (state.mode) {
+		case "nav":
+			switch (key.name) {
+				case "up":
+					return state.pane === "sidebar"
+						? act({ type: "move-cursor", delta: -1 })
+						: act({ type: "scroll", by: "line-up" });
+				case "down":
+					return state.pane === "sidebar"
+						? act({ type: "move-cursor", delta: 1 })
+						: act({ type: "scroll", by: "line-down" });
+				case "k":
+					return act({ type: "move-cursor", delta: -1 });
+				case "j":
+					return act({ type: "move-cursor", delta: 1 });
+				case "return":
+				case "enter":
+					return state.pane === "sidebar"
+						? act({ type: "open-selected" })
+						: act({ type: "focus-composer" });
+				case "i":
+					return act({ type: "focus-composer" });
+				case "pageup":
+					return act({ type: "scroll", by: "page-up" });
+				case "pagedown":
+					return act({ type: "scroll", by: "page-down" });
+				case "g":
+					return act({ type: "scroll", by: key.shift ? "bottom" : "top" });
+				case "tab":
+					return act({
+						type: "focus-pane",
+						direction: key.shift ? "prev" : "next",
+					});
+				case "?":
+					return act({ type: "toggle-help" });
+				case "escape":
+					return act({ type: "exit-mode" });
+				default:
+					return none(state);
+			}
+
+		case "composer":
+			if (key.name === "escape") return act({ type: "exit-mode" });
+			if (key.name === "return" || key.name === "enter") {
+				// Shift+enter is a newline in the input, not a send.
+				if (key.shift) return none(state);
+				return act({ type: "submit", busyMode: "queue" });
+			}
+			// Everything else is text for the input.
+			return none(state);
+
+		case "ask":
+			if (key.name >= "1" && key.name <= "9" && key.name.length === 1) {
+				return act({ type: "answer-option", index: Number(key.name) - 1 });
+			}
+			if (key.name === "escape") return act({ type: "exit-mode" });
+			if (key.name === "i") return act({ type: "focus-composer" });
+			return none(state);
+
+		case "scroll":
+			switch (key.name) {
+				case "up":
+				case "k":
+					return act({ type: "scroll", by: "line-up" });
+				case "down":
+				case "j":
+					return act({ type: "scroll", by: "line-down" });
+				case "pageup":
+					return act({ type: "scroll", by: "page-up" });
+				case "pagedown":
+				case "space":
+					return act({ type: "scroll", by: "page-down" });
+				case "g":
+					return act({ type: "scroll", by: key.shift ? "bottom" : "top" });
+				case "b":
+					return act({ type: "load-earlier" });
+				case "q":
+				case "escape":
+					return act({ type: "exit-mode" });
+				default:
+					// Copy-mode swallows stray keys instead of scrolling by accident.
+					return { prefixArmed: false, consumed: true };
+			}
+
+		case "picker":
+		case "command":
+			if (key.name === "escape") return act({ type: "exit-mode" });
+			if (key.name === "return" || key.name === "enter") {
+				return act({ type: "open-selected" });
+			}
+			if (key.name === "up") return act({ type: "move-cursor", delta: -1 });
+			if (key.name === "down") return act({ type: "move-cursor", delta: 1 });
+			return none(state);
+
+		case "help":
+			// Any key dismisses help — it's a reference, not a mode you work in.
+			return act({ type: "toggle-help" });
+	}
+}
+
+/** Rows for the help overlay and the README, kept in one place. */
+export const KEY_HELP: { keys: string; label: string }[] = [
+	{ keys: "ctrl+←/→", label: "previous / next tab" },
+	{ keys: "ctrl+↑/↓", label: "focus pane (sidebar · transcript · composer)" },
+	{ keys: "↑/↓ · j/k", label: "move in the focused pane" },
+	{ keys: "enter", label: "open session · focus composer" },
+	{ keys: "i", label: "jump to the composer" },
+	{ keys: "enter (composer)", label: "send — queues behind a running turn" },
+	{ keys: "ctrl+enter · alt+enter", label: "send as a steer instead" },
+	{ keys: "1…9", label: "answer a pending question" },
+	{ keys: "^b c", label: "new session" },
+	{ keys: "^b w", label: "session picker" },
+	{ keys: "^b n · ^b p", label: "next · previous tab" },
+	{ keys: "^b 0…9", label: "jump to tab" },
+	{ keys: "^b x", label: "cancel the running turn" },
+	{ keys: "^b &", label: "close tab" },
+	{ keys: "^b ,", label: "rename session" },
+	{ keys: "^b a", label: "archive session" },
+	{ keys: "^b z", label: "zoom the transcript" },
+	{ keys: "^b [", label: "scroll mode (b loads earlier, q exits)" },
+	{ keys: "^b :", label: "command prompt" },
+	{ keys: "^b r", label: "reconnect" },
+	{ keys: "^b d", label: "detach (sessions keep running)" },
+	{ keys: "^b ?", label: "this help" },
+];

--- a/os1-tui/src/ui/sidebar.tsx
+++ b/os1-tui/src/ui/sidebar.tsx
@@ -1,0 +1,140 @@
+/**
+ * Workspace-grouped session list — the pane that answers "what needs me?".
+ *
+ * Status glyphs carry the herdr read (blocked / working / done / idle) and the
+ * groups that need a human float to the top (see groupSessions).
+ */
+
+import { TextAttributes } from "@opentui/core";
+import type { ReactNode } from "react";
+import type { WorkspaceGroup } from "../client/sessions-poller";
+import { type Session, sessionStatus, sessionTitle } from "../client/types";
+import { relativeTime } from "./format";
+import { SPINNER, statusStyle, theme } from "./theme";
+
+export type SidebarProps = {
+	groups: WorkspaceGroup[];
+	/** Cursor position in the flattened session list. */
+	cursor: number;
+	/** Session ids with an open tab, for the tab marker. */
+	openTabs: string[];
+	activeSessionId?: string;
+	focused: boolean;
+	width: number;
+	spinnerFrame: number;
+	loaded: boolean;
+	error?: string;
+};
+
+function statusGlyph(session: Session, spinnerFrame: number): { glyph: string; color: string } {
+	const status = sessionStatus(session);
+	const style = statusStyle[status];
+	return {
+		glyph: status === "running" ? SPINNER[spinnerFrame % SPINNER.length]! : style.glyph,
+		color: style.color,
+	};
+}
+
+export function Sidebar({
+	groups,
+	cursor,
+	openTabs,
+	activeSessionId,
+	focused,
+	width,
+	spinnerFrame,
+	loaded,
+	error,
+}: SidebarProps) {
+	// One flat index across groups so ↑/↓ walks the list the way it looks.
+	let flatIndex = -1;
+	const rows: ReactNode[] = [];
+
+	for (const group of groups) {
+		const attention = group.waiting
+			? { text: `${group.waiting}`, color: theme.yellow }
+			: group.running
+				? { text: `${group.running}`, color: theme.blue }
+				: { text: "", color: theme.faint };
+		rows.push(
+			<box key={`g:${group.id}`} flexDirection="row" paddingLeft={1} paddingRight={1}>
+				<text fg={theme.dim} attributes={TextAttributes.BOLD} flexGrow={1}>
+					{group.name.slice(0, Math.max(4, width - 6))}
+				</text>
+				{attention.text ? <text fg={attention.color}>{attention.text}</text> : null}
+			</box>,
+		);
+
+		for (const session of group.sessions) {
+			flatIndex += 1;
+			const selected = focused && flatIndex === cursor;
+			const active = session.id === activeSessionId;
+			const tabIndex = openTabs.indexOf(session.id);
+			const { glyph, color } = statusGlyph(session, spinnerFrame);
+			const age = relativeTime(session.lastActivity);
+			// 2 padding + glyph + space + " " + age, plus the tab number when shown.
+			const titleRoom = Math.max(6, width - 7 - age.length - (tabIndex >= 0 ? 2 : 0));
+			const title = sessionTitle(session);
+			rows.push(
+				<box
+					key={session.id}
+					flexDirection="row"
+					paddingLeft={1}
+					paddingRight={1}
+					backgroundColor={selected ? theme.active : active ? theme.raised : undefined}
+				>
+					<text fg={color}>{glyph} </text>
+					<text
+						fg={active || selected ? theme.fg : theme.dim}
+						flexGrow={1}
+						truncate
+					>
+						{title.length > titleRoom ? `${title.slice(0, titleRoom - 1)}…` : title}
+					</text>
+					{tabIndex >= 0 ? <text fg={theme.purple}>{tabIndex + 1} </text> : null}
+					{session.queuedCount ? <text fg={theme.yellow}>+{session.queuedCount} </text> : null}
+					<text fg={theme.faint}> {age}</text>
+				</box>,
+			);
+		}
+	}
+
+	if (!loaded) {
+		rows.push(
+			<text key="loading" fg={theme.faint} paddingLeft={1}>
+				connecting…
+			</text>,
+		);
+	} else if (!groups.length) {
+		rows.push(
+			<text key="empty" fg={theme.faint} paddingLeft={1}>
+				{error ? "" : "no sessions yet — ^b c to start one"}
+			</text>,
+		);
+	}
+	if (error) {
+		rows.push(
+			<text key="error" fg={theme.red} paddingLeft={1} wrapMode="word">
+				{error}
+			</text>,
+		);
+	}
+
+	return (
+		<box
+			width={width}
+			flexDirection="column"
+			border={["right"]}
+			borderColor={focused ? theme.borderStrong : theme.border}
+			flexShrink={0}
+		>
+			<scrollbox
+				flexGrow={1}
+				verticalScrollbarOptions={{ visible: false }}
+				contentOptions={{ flexDirection: "column" }}
+			>
+				{rows}
+			</scrollbox>
+		</box>
+	);
+}

--- a/os1-tui/src/ui/status-bar.tsx
+++ b/os1-tui/src/ui/status-bar.tsx
@@ -1,0 +1,95 @@
+/**
+ * The bottom line: where you're connected, the tab strip, global counts, and
+ * whatever the last action said. Also the only place the armed prefix is
+ * visible, which matters — a silently armed prefix eats the next keystroke.
+ */
+
+import { TextAttributes } from "@opentui/core";
+import { sessionTitle, type Session } from "../client/types";
+import { SPINNER, theme } from "./theme";
+
+export type StatusBarProps = {
+	host: string;
+	user: string;
+	tabs: Session[];
+	activeIndex: number;
+	waiting: number;
+	running: number;
+	prefixArmed: boolean;
+	mode: string;
+	message?: string;
+	messageKind?: "info" | "error";
+	spinnerFrame: number;
+	width: number;
+};
+
+export function StatusBar({
+	host,
+	user,
+	tabs,
+	activeIndex,
+	waiting,
+	running,
+	prefixArmed,
+	mode,
+	message,
+	messageKind = "info",
+	spinnerFrame,
+	width,
+}: StatusBarProps) {
+	const hostLabel = host.replace(/^https?:\/\//, "");
+
+	return (
+		<box flexDirection="column" flexShrink={0}>
+			{/* Tab strip — only when more than one tab is open, so a single-session
+			    session doesn't pay a line for it. */}
+			{tabs.length > 1 ? (
+				<box flexDirection="row" backgroundColor={theme.panel} paddingLeft={1}>
+					{tabs.map((session, index) => (
+						<text
+							key={session.id}
+							fg={index === activeIndex ? theme.fg : theme.faint}
+							attributes={index === activeIndex ? TextAttributes.BOLD : undefined}
+							bg={index === activeIndex ? theme.active : undefined}
+						>
+							{` ${index + 1}:${sessionTitle(session).slice(0, 18)}${
+								session.isRunning ? ` ${SPINNER[spinnerFrame % SPINNER.length]}` : ""
+							}${session.waitingForInput ? " ?" : ""} `}
+						</text>
+					))}
+				</box>
+			) : null}
+
+			<box flexDirection="row" backgroundColor={theme.panel} paddingLeft={1} paddingRight={1}>
+				<text fg={theme.accent} attributes={TextAttributes.BOLD}>
+					os{" "}
+				</text>
+				<text fg={theme.dim}>{hostLabel} </text>
+				<text fg={theme.faint}>{user} </text>
+				<box flexGrow={1} flexDirection="row">
+					{message ? (
+						<text fg={messageKind === "error" ? theme.red : theme.dim} truncate>
+							{message}
+						</text>
+					) : null}
+				</box>
+				{running ? (
+					<text fg={theme.blue}>
+						{SPINNER[spinnerFrame % SPINNER.length]}
+						{running}{" "}
+					</text>
+				) : null}
+				{waiting ? <text fg={theme.yellow}>?{waiting} </text> : null}
+				{prefixArmed ? (
+					<text fg={theme.accent} attributes={TextAttributes.BOLD}>
+						^b{" "}
+					</text>
+				) : null}
+				{mode !== "nav" && mode !== "composer" ? (
+					<text fg={theme.purple}>{mode.toUpperCase()} </text>
+				) : null}
+				{width > 60 ? <text fg={theme.faint}>^b ?</text> : null}
+			</box>
+		</box>
+	);
+}

--- a/os1-tui/src/ui/theme.ts
+++ b/os1-tui/src/ui/theme.ts
@@ -1,0 +1,46 @@
+/**
+ * Colors, lifted from the web UI's dark palette (src/frontend/styles/global.css)
+ * so the two clients read as the same product. Warm charcoal, not blue-black.
+ *
+ * A terminal already has a background, so we deliberately do NOT paint one on
+ * the root: the user's own theme shows through and `os` looks native next to
+ * their other panes. Only raised surfaces get a fill.
+ */
+
+export const theme = {
+	fg: "#eee9e3",
+	dim: "#aaa29a",
+	faint: "#7d756e",
+	panel: "#24211f",
+	raised: "#292624",
+	active: "#3a3531",
+	border: "#38332f",
+	borderStrong: "#4c4640",
+	accent: "#ff3b3b",
+	green: "#3fb950",
+	yellow: "#d29922",
+	blue: "#58a6ff",
+	red: "#f85149",
+	purple: "#a371f7",
+} as const;
+
+/** Per-status color + glyph — the sidebar's whole vocabulary. */
+export const statusStyle = {
+	waiting: { glyph: "?", color: theme.yellow, label: "needs you" },
+	running: { glyph: "", color: theme.blue, label: "working" },
+	error: { glyph: "!", color: theme.red, label: "failed" },
+	done: { glyph: "✓", color: theme.green, label: "done" },
+	idle: { glyph: "·", color: theme.faint, label: "idle" },
+	preparing: { glyph: "⧗", color: theme.purple, label: "preparing" },
+} as const;
+
+/** Braille spinner — the same frames the web UI's running indicator uses. */
+export const SPINNER = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"] as const;
+
+export const roleStyle: Record<string, { label: string; color: string }> = {
+	user: { label: "›", color: theme.blue },
+	assistant: { label: "", color: theme.fg },
+	tool_use: { label: "▸", color: theme.purple },
+	tool_result: { label: "◂", color: theme.faint },
+	system: { label: "•", color: theme.faint },
+};

--- a/os1-tui/src/ui/transcript.tsx
+++ b/os1-tui/src/ui/transcript.tsx
@@ -1,0 +1,203 @@
+/**
+ * The transcript pane: committed entries, the in-flight stream, queued chips
+ * and the AskUserQuestion card.
+ *
+ * `stickyScroll` + `stickyStart: "bottom"` is what makes a streaming turn feel
+ * right — the view follows new output but stops following the moment the user
+ * scrolls up (scroll mode), which is the same intent model the web client uses.
+ */
+
+import { TextAttributes } from "@opentui/core";
+import type { ReactNode, Ref } from "react";
+import type { ScrollBoxRenderable } from "@opentui/core";
+import type { SessionState } from "../client/session-store";
+import type { AskQuestion, QueueItem, Session } from "../client/types";
+import { formatEntries, sessionSubtitle } from "./format";
+import { SPINNER, theme } from "./theme";
+
+export type TranscriptProps = {
+	session?: Session;
+	state: SessionState;
+	focused: boolean;
+	scrollMode: boolean;
+	spinnerFrame: number;
+	connection: "connecting" | "open" | "retrying";
+	scrollRef?: Ref<ScrollBoxRenderable>;
+	/** Cap on rendered entries — a 10k-entry transcript needn't all be live. */
+	maxEntries?: number;
+};
+
+/** How many entries we keep as renderables. Older ones stay a `^b [ b` away. */
+const DEFAULT_MAX_ENTRIES = 200;
+
+function QueueChips({ queued, steered }: { queued: QueueItem[]; steered: QueueItem[] }) {
+	if (!queued.length && !steered.length) return null;
+	return (
+		<box flexDirection="column" paddingLeft={1} paddingTop={1}>
+			{steered.map((item) => (
+				<text key={item.id} fg={theme.purple} truncate>
+					⚡ {item.content.split("\n")[0]}
+				</text>
+			))}
+			{queued.map((item, index) => (
+				<text key={item.id} fg={theme.yellow} truncate>
+					{index + 1}. queued: {item.content.split("\n")[0]}
+				</text>
+			))}
+		</box>
+	);
+}
+
+function AskCard({ ask }: { ask: AskQuestion }) {
+	const question = ask.questions[0];
+	if (!question) return null;
+	return (
+		<box
+			flexDirection="column"
+			border
+			borderColor={theme.yellow}
+			paddingLeft={1}
+			paddingRight={1}
+			marginTop={1}
+			title={question.header ?? "needs you"}
+		>
+			<text fg={theme.fg} wrapMode="word" attributes={TextAttributes.BOLD}>
+				{question.question}
+			</text>
+			{(question.options ?? []).map((option, index) => (
+				<text key={`${index}-${option.label}`} fg={theme.dim} wrapMode="word">
+					<span fg={theme.yellow}>{index + 1}</span> {option.label}
+					{option.description ? <span fg={theme.faint}> — {option.description}</span> : null}
+				</text>
+			))}
+			<text fg={theme.faint}>press a number · i to answer in your own words</text>
+		</box>
+	);
+}
+
+export function Transcript({
+	session,
+	state,
+	focused,
+	scrollMode,
+	spinnerFrame,
+	connection,
+	scrollRef,
+	maxEntries = DEFAULT_MAX_ENTRIES,
+}: TranscriptProps) {
+	const all = formatEntries(state.entries);
+	const shown = all.length > maxEntries ? all.slice(-maxEntries) : all;
+	const hidden = all.length - shown.length;
+
+	const rows: ReactNode[] = [];
+
+	if (state.truncated || hidden > 0) {
+		rows.push(
+			<text key="earlier" fg={theme.faint} paddingLeft={1}>
+				── earlier history {hidden > 0 ? `(${hidden} more loaded) ` : ""}· ^b [ then b to
+				load ──
+			</text>,
+		);
+	}
+
+	for (const entry of shown) {
+		const color =
+			entry.kind === "user"
+				? theme.blue
+				: entry.error
+					? theme.red
+					: entry.kind === "tool"
+						? theme.faint
+						: theme.fg;
+		rows.push(
+			<box key={entry.id} flexDirection="column" paddingLeft={1} paddingTop={entry.kind === "tool" ? 0 : 1}>
+				{entry.kind === "tool" ? (
+					<text fg={color} truncate>
+						<span fg={entry.error ? theme.red : theme.purple}>{entry.prefix}</span>
+						{entry.body ? ` ${entry.body}` : ""}
+					</text>
+				) : (
+					<text fg={color} wrapMode="word">
+						{entry.prefix ? `${entry.prefix} ` : ""}
+						{entry.body}
+						{entry.clamped ? <span fg={theme.faint}> …(clamped)</span> : null}
+					</text>
+				)}
+			</box>,
+		);
+	}
+
+	if (state.streamText) {
+		rows.push(
+			<box key="stream" flexDirection="column" paddingLeft={1} paddingTop={1}>
+				<text fg={theme.fg} wrapMode="word">
+					{state.streamText}
+					<span fg={theme.blue}>▌</span>
+				</text>
+			</box>,
+		);
+	} else if (state.isRunning) {
+		rows.push(
+			<text key="working" fg={theme.blue} paddingLeft={1} paddingTop={1}>
+				{SPINNER[spinnerFrame % SPINNER.length]} working…
+			</text>,
+		);
+	}
+
+	if (state.ask) rows.push(<AskCard key="ask" ask={state.ask} />);
+	rows.push(
+		<QueueChips key="queue" queued={state.queued} steered={state.steered} />,
+	);
+
+	if (!session) {
+		return (
+			<box flexGrow={1} flexDirection="column" justifyContent="center" alignItems="center">
+				<text fg={theme.dim}>no session open</text>
+				<text fg={theme.faint}>↑/↓ to pick one · enter to open · ^b ? for keys</text>
+			</box>
+		);
+	}
+
+	const title = session.title?.trim() || session.branch || session.id.slice(0, 12);
+	const bottom = scrollMode
+		? " SCROLL — q exits, b loads earlier "
+		: connection === "open"
+			? undefined
+			: ` ${connection === "retrying" ? "reconnecting…" : "connecting…"} `;
+
+	return (
+		<box flexGrow={1} flexDirection="column" minWidth={20}>
+			<box flexDirection="row" paddingLeft={1} paddingRight={1} backgroundColor={theme.panel}>
+				<text fg={theme.fg} attributes={TextAttributes.BOLD} flexGrow={1} truncate>
+					{title}
+				</text>
+				<text fg={theme.faint} truncate>
+					{sessionSubtitle(session)}
+				</text>
+			</box>
+			<scrollbox
+				ref={scrollRef}
+				flexGrow={1}
+				focused={focused}
+				stickyScroll={!scrollMode}
+				stickyStart="bottom"
+				borderColor={focused ? theme.borderStrong : theme.border}
+				bottomTitle={bottom}
+				contentOptions={{ flexDirection: "column" }}
+			>
+				{state.loaded ? (
+					rows
+				) : (
+					<text fg={theme.faint} paddingLeft={1}>
+						loading transcript…
+					</text>
+				)}
+			</scrollbox>
+			{state.error ? (
+				<text fg={theme.red} paddingLeft={1} wrapMode="word">
+					{state.error}
+				</text>
+			) : null}
+		</box>
+	);
+}

--- a/os1-tui/src/ui/ui-state.ts
+++ b/os1-tui/src/ui/ui-state.ts
@@ -1,0 +1,111 @@
+/**
+ * Where the user is: tabs, panes, modes, overlays.
+ *
+ * This is a ref-backed store rather than a pile of `useState`, for one concrete
+ * reason: a terminal delivers keystrokes faster than React re-renders. `^b w`
+ * arrives as two keypresses in the same tick, and with plain state the second
+ * one reads a `prefixArmed` that hasn't updated yet — the prefix silently eats
+ * the key. Reads during key handling go to the ref (always current); renders go
+ * to the mirrored snapshot.
+ *
+ * Same shape as the client-layer stores, so the component subscribes to it the
+ * same way.
+ */
+
+import type { Mode, Pane } from "./keymap";
+
+export type Overlay =
+	| { kind: "picker"; selected: number }
+	| { kind: "command" }
+	| { kind: "rename" }
+	| { kind: "new" }
+	| null;
+
+export type UiState = {
+	/** Session ids with an open tab, in tab order. */
+	tabs: string[];
+	activeTab: number;
+	/** Cursor into the flattened sidebar list. */
+	cursor: number;
+	mode: Mode;
+	pane: Pane;
+	prefixArmed: boolean;
+	zoom: boolean;
+	overlay: Overlay;
+	message?: { text: string; kind: "info" | "error" };
+};
+
+export function initialUiState(initialSessionId?: string): UiState {
+	return {
+		tabs: initialSessionId ? [initialSessionId] : [],
+		activeTab: 0,
+		cursor: 0,
+		mode: "nav",
+		pane: initialSessionId ? "transcript" : "sidebar",
+		prefixArmed: false,
+		zoom: false,
+		overlay: null,
+	};
+}
+
+export class UiStore {
+	private state: UiState;
+	private listeners = new Set<() => void>();
+
+	constructor(initialSessionId?: string) {
+		this.state = initialUiState(initialSessionId);
+	}
+
+	getState = (): UiState => this.state;
+
+	subscribe = (listener: () => void): (() => void) => {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	};
+
+	/** Patch — or, with a function, derive from the current (never stale) state. */
+	set(patch: Partial<UiState> | ((current: UiState) => Partial<UiState>)): void {
+		const resolved = typeof patch === "function" ? patch(this.state) : patch;
+		let changed = false;
+		for (const key of Object.keys(resolved) as (keyof UiState)[]) {
+			if (this.state[key] !== resolved[key]) {
+				changed = true;
+				break;
+			}
+		}
+		if (!changed) return;
+		this.state = { ...this.state, ...resolved };
+		for (const listener of this.listeners) listener();
+	}
+
+	get activeSessionId(): string | undefined {
+		return this.state.tabs[this.state.activeTab];
+	}
+
+	/** Open a session in a tab, or focus its tab if it already has one. */
+	openTab(sessionId: string): void {
+		this.set((current) => {
+			const at = current.tabs.indexOf(sessionId);
+			if (at >= 0) {
+				return { activeTab: at, pane: "transcript", mode: "nav", overlay: null };
+			}
+			return {
+				tabs: [...current.tabs, sessionId],
+				activeTab: current.tabs.length,
+				pane: "transcript",
+				mode: "nav",
+				overlay: null,
+			};
+		});
+	}
+
+	closeTab(sessionId: string): void {
+		this.set((current) => {
+			const tabs = current.tabs.filter((id) => id !== sessionId);
+			return {
+				tabs,
+				activeTab: Math.max(0, Math.min(current.activeTab, tabs.length - 1)),
+			};
+		});
+	}
+}

--- a/os1-tui/test/app.test.tsx
+++ b/os1-tui/test/app.test.tsx
@@ -1,0 +1,392 @@
+/**
+ * End-to-end render tests: the real App, the real keymap, the real client layer
+ * — against a fake fetch and a fake WebSocket, rendered into an in-memory
+ * terminal. `captureCharFrame()` is the screen a user would see.
+ *
+ * React's act() warnings are silenced: frames arrive from a socket, not from a
+ * user event, so there is no act() boundary to wrap them in — the harness's
+ * `flush()` is what settles the tree here.
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: React's test-environment global.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = false;
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { Api } from "../src/client/api";
+import { WatchPool } from "../src/client/pool";
+import { SessionsPoller } from "../src/client/sessions-poller";
+import { App } from "../src/ui/app";
+import { FakeWebSocket, fakeServer, fakeSession, fakeWsFactory } from "./fakes";
+import type { ServerFrame } from "../src/client/types";
+
+const HOST = "http://server";
+
+async function mount(
+	options: {
+		sessions?: ReturnType<typeof fakeSession>[];
+		width?: number;
+		height?: number;
+		initialSessionId?: string;
+		kittyKeyboard?: boolean;
+	} = {},
+) {
+	const server = fakeServer({ sessions: options.sessions });
+	const api = new Api(HOST, "tok", server.fetch);
+	const poller = new SessionsPoller(api);
+	const pool = new WatchPool({ host: HOST, token: "tok", factory: fakeWsFactory });
+	let exited = false;
+	await poller.start();
+
+	const harness = await testRender(
+		<App
+			api={api}
+			poller={poller}
+			pool={pool}
+			host="os.tella.dev"
+			user="michiel"
+			onExit={() => {
+				exited = true;
+			}}
+			initialSessionId={options.initialSessionId}
+		/>,
+		{
+			width: options.width ?? 100,
+			height: options.height ?? 24,
+			...(options.kittyKeyboard ? { kittyKeyboard: true } : {}),
+		},
+	);
+	await harness.flush();
+
+	return {
+		...harness,
+		server,
+		poller,
+		pool,
+		frame: () => harness.captureCharFrame(),
+		exited: () => exited,
+		cleanup: () => {
+			poller.stop();
+			pool.closeAll();
+		},
+	};
+}
+
+let active: { cleanup: () => void } | undefined;
+afterEach(() => {
+	active?.cleanup();
+	active = undefined;
+});
+
+describe("first paint", () => {
+	test("shows the workspace, the session and the status bar", async () => {
+		const app = await mount({
+			sessions: [
+				fakeSession({ id: "bks-1", title: "wire the socket" }),
+				fakeSession({ id: "bks-2", title: "fix the sidebar", isRunning: true }),
+			],
+		});
+		active = app;
+		const frame = app.frame();
+
+		expect(frame).toContain("backstage"); // workspace group header
+		expect(frame).toContain("wire the socket");
+		expect(frame).toContain("fix the sidebar");
+		expect(frame).toContain("os.tella.dev");
+		expect(frame).toContain("michiel");
+		// Nothing open yet.
+		expect(frame).toContain("no session open");
+	});
+
+	test("a session needing input is flagged in the sidebar", async () => {
+		const app = await mount({
+			sessions: [fakeSession({ id: "bks-1", title: "blocked one", waitingForInput: true })],
+		});
+		active = app;
+		expect(app.frame()).toContain("?");
+	});
+});
+
+describe("opening a session", () => {
+	test("enter on the sidebar opens a tab and watches it", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1", title: "wire the socket" })] });
+		active = app;
+
+		app.mockInput.pressEnter();
+		await app.flush();
+
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		await app.flush();
+		expect(ws.sentOfType("watch")[0]!.sessionId).toBe("bks-1");
+
+		ws.deliver({
+			type: "transcript_init",
+			sessionId: "bks-1",
+			entries: [
+				{ id: "u1", type: "user", content: "please wire it" },
+				{ id: "a1", type: "assistant", content: "wired the socket up" },
+			],
+			endOffset: 10,
+			rev: "r1",
+		} as ServerFrame);
+		await app.flush();
+
+		const frame = app.frame();
+		expect(frame).toContain("please wire it");
+		expect(frame).toContain("wired the socket up");
+		// The composer appears once a session is open.
+		expect(frame).toContain("enter sends");
+	});
+
+	test("streamed text renders before the entry commits", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1" })] });
+		active = app;
+		app.mockInput.pressEnter();
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		ws.deliver({ type: "transcript_init", entries: [], endOffset: 0, rev: "r" } as ServerFrame);
+		ws.deliver({ type: "stream_start" } as ServerFrame);
+		ws.deliver({ type: "stream_text", text: "thinking out loud" } as ServerFrame);
+		await app.flush();
+
+		expect(app.frame()).toContain("thinking out loud");
+	});
+
+	test("a pending question renders its options", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1" })] });
+		active = app;
+		app.mockInput.pressEnter();
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		ws.deliver({ type: "transcript_init", entries: [], endOffset: 0, rev: "r" } as ServerFrame);
+		ws.deliver({
+			type: "ask_question",
+			questionId: "ask-1",
+			questions: [
+				{
+					question: "Tabs or splits?",
+					header: "layout",
+					options: [{ label: "tabs" }, { label: "splits" }],
+				},
+			],
+		} as ServerFrame);
+		await app.flush();
+
+		const frame = app.frame();
+		expect(frame).toContain("Tabs or splits?");
+		expect(frame).toContain("tabs");
+		expect(frame).toContain("splits");
+
+		// The number key answers it, and the card goes away.
+		app.mockInput.pressKey("1");
+		await app.flush();
+		expect(ws.sentOfType("answer_question")[0]).toMatchObject({
+			questionId: "ask-1",
+			answers: { "Tabs or splits?": "tabs" },
+		});
+		expect(app.frame()).not.toContain("Tabs or splits?");
+	});
+});
+
+describe("sending", () => {
+	test("typing then enter sends a prompt and clears the composer", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1" })] });
+		active = app;
+		app.mockInput.pressEnter(); // open
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		ws.deliver({ type: "transcript_init", entries: [], endOffset: 0, rev: "r" } as ServerFrame);
+		await app.flush();
+
+		// i focuses the composer (nav → composer), then type and send.
+		app.mockInput.pressKey("i");
+		await app.flush();
+		await app.mockInput.typeText("ship it");
+		await app.flush();
+		expect(app.frame()).toContain("ship it");
+
+		app.mockInput.pressEnter();
+		await app.flush();
+
+		const prompt = ws.sentOfType("prompt")[0]!;
+		expect(prompt).toMatchObject({ content: "ship it", busyMode: "queue", user: "michiel" });
+		// Cleared, and the status bar reports what happened.
+		expect(app.frame()).toContain("sent");
+	});
+
+	test("alt+enter steers instead of queueing (works without kitty keys)", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1", isRunning: true })] });
+		active = app;
+		app.mockInput.pressEnter();
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		ws.deliver({ type: "transcript_init", entries: [], endOffset: 0, rev: "r" } as ServerFrame);
+		await app.flush();
+
+		app.mockInput.pressKey("i");
+		await app.flush();
+		await app.mockInput.typeText("wait");
+		app.mockInput.pressEnter({ meta: true });
+		await app.flush();
+
+		expect(ws.sentOfType("prompt")[0]!.busyMode).toBe("steer");
+	});
+
+	test("ctrl+enter steers when the terminal speaks the kitty protocol", async () => {
+		const app = await mount({
+			sessions: [fakeSession({ id: "bks-1", isRunning: true })],
+			kittyKeyboard: true,
+		});
+		active = app;
+		app.mockInput.pressEnter();
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		ws.deliver({ type: "transcript_init", entries: [], endOffset: 0, rev: "r" } as ServerFrame);
+		await app.flush();
+
+		app.mockInput.pressKey("i");
+		await app.flush();
+		await app.mockInput.typeText("wait");
+		app.mockInput.pressEnter({ ctrl: true });
+		await app.flush();
+
+		expect(ws.sentOfType("prompt")[0]!.busyMode).toBe("steer");
+	});
+});
+
+describe("tmux keys", () => {
+	test("^b ? opens help, any key closes it", async () => {
+		const app = await mount();
+		active = app;
+		app.mockInput.pressKey("b", { ctrl: true });
+		app.mockInput.pressKey("?");
+		await app.flush();
+		expect(app.frame()).toContain("detach");
+
+		app.mockInput.pressKey("x");
+		await app.flush();
+		expect(app.frame()).not.toContain("sessions keep running");
+	});
+
+	test("^b arms the prefix visibly, so it can't silently eat a key", async () => {
+		const app = await mount();
+		active = app;
+		app.mockInput.pressKey("b", { ctrl: true });
+		await app.flush();
+		expect(app.frame()).toContain("^b");
+	});
+
+	test("^b w opens the session picker and filters", async () => {
+		const app = await mount({
+			sessions: [
+				fakeSession({ id: "bks-1", title: "wire the socket" }),
+				fakeSession({ id: "bks-2", title: "unrelated thing" }),
+			],
+		});
+		active = app;
+		app.mockInput.pressKey("b", { ctrl: true });
+		app.mockInput.pressKey("w");
+		await app.flush();
+		expect(app.frame()).toContain("sessions");
+
+		await app.mockInput.typeText("unrel");
+		await app.flush();
+		const frame = app.frame();
+		expect(frame).toContain("unrelated thing");
+	});
+
+	test("^b x cancels the running turn", async () => {
+		const app = await mount({ sessions: [fakeSession({ id: "bks-1", isRunning: true })] });
+		active = app;
+		app.mockInput.pressEnter();
+		await app.flush();
+		const ws = FakeWebSocket.last!;
+		ws.open();
+		await app.flush();
+
+		app.mockInput.pressKey("b", { ctrl: true });
+		app.mockInput.pressKey("x");
+		await app.flush();
+		expect(ws.sentOfType("cancel")).toHaveLength(1);
+	});
+
+	test("^b d detaches", async () => {
+		const app = await mount();
+		active = app;
+		app.mockInput.pressKey("b", { ctrl: true });
+		app.mockInput.pressKey("d");
+		await app.flush();
+		expect(app.exited()).toBe(true);
+	});
+
+	test("two open tabs show a tab strip, and ctrl+→ switches", async () => {
+		const app = await mount({
+			sessions: [
+				fakeSession({ id: "bks-1", title: "first one" }),
+				fakeSession({ id: "bks-2", title: "second one" }),
+			],
+		});
+		active = app;
+
+		// Open the first, move down, open the second.
+		app.mockInput.pressEnter();
+		await app.flush();
+		app.mockInput.pressKey("b", { ctrl: true });
+		app.mockInput.pressKey("w");
+		await app.flush();
+		await app.mockInput.typeText("second");
+		app.mockInput.pressEnter();
+		await app.flush();
+
+		const frame = app.frame();
+		expect(frame).toContain("1:first one");
+		expect(frame).toContain("2:second one");
+
+		app.mockInput.pressArrow("left", { ctrl: true });
+		await app.flush();
+		// Still both tabs; the active one changed (title bar shows first one).
+		expect(app.frame()).toContain("first one");
+	});
+});
+
+describe("degraded states", () => {
+	test("a narrow terminal drops the sidebar rather than squashing it", async () => {
+		const app = await mount({ width: 50, height: 20, sessions: [fakeSession({ id: "bks-1" })] });
+		active = app;
+		expect(app.frame()).not.toContain("backstage");
+	});
+
+	test("sign-in required is surfaced, not swallowed", async () => {
+		const server = fakeServer();
+		const unauthorized = (async (input: RequestInfo | URL) => {
+			const path = input.toString().replace(/^https?:\/\/[^/]+/, "");
+			if (path === "/api/sessions") {
+				return new Response(JSON.stringify({ error: "Sign in required" }), { status: 401 });
+			}
+			return server.fetch(input);
+		}) as typeof fetch;
+
+		const api = new Api(HOST, undefined, unauthorized);
+		const poller = new SessionsPoller(api);
+		const pool = new WatchPool({ host: HOST, factory: fakeWsFactory });
+		await poller.start();
+		const harness = await testRender(
+			<App api={api} poller={poller} pool={pool} host="os.tella.dev" user="michiel" onExit={() => {}} />,
+			{ width: 100, height: 20 },
+		);
+		await harness.flush();
+		active = {
+			cleanup: () => {
+				poller.stop();
+				pool.closeAll();
+			},
+		};
+		expect(harness.captureCharFrame()).toContain("os login".slice(0, 2));
+	});
+});

--- a/os1-tui/test/fakes.ts
+++ b/os1-tui/test/fakes.ts
@@ -1,0 +1,109 @@
+/**
+ * A fake server, at both seams: `fetch` for REST and a fake WebSocket for the
+ * watch. Together they let the whole app render and be driven by keystrokes with
+ * no OpenSession running anywhere.
+ */
+
+import type { Session, ServerFrame, TranscriptEntry } from "../src/client/types";
+
+export function fakeSession(over: Partial<Session> = {}): Session {
+	return {
+		id: "bks-1",
+		title: "wire the socket",
+		repo: "backstage",
+		branch: "tui",
+		projectId: "prj-1",
+		mode: "code",
+		model: "claude-opus-5",
+		isRunning: false,
+		lastActivity: new Date().toISOString(),
+		...over,
+	};
+}
+
+export function fakeEntry(over: Partial<TranscriptEntry> = {}): TranscriptEntry {
+	return { id: "e1", type: "assistant", content: "hello from the server", ...over };
+}
+
+export type FakeServer = {
+	sessions: Session[];
+	projects: { id: string; name: string }[];
+	/** Every request path this fake saw, for assertions. */
+	calls: string[];
+	fetch: typeof fetch;
+};
+
+export function fakeServer(init?: Partial<Pick<FakeServer, "sessions" | "projects">>): FakeServer {
+	const server: FakeServer = {
+		sessions: init?.sessions ?? [fakeSession()],
+		projects: init?.projects ?? [{ id: "prj-1", name: "backstage" }],
+		calls: [],
+		fetch: (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			const path = url.replace(/^https?:\/\/[^/]+/, "");
+			server.calls.push(path);
+			const json = (body: unknown) =>
+				new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			if (path === "/api/sessions") return json(server.sessions);
+			if (path === "/api/projects") return json({ projects: server.projects });
+			if (path === "/api/health") return json({ ok: true });
+			if (path.startsWith("/api/auth/status")) return json({ authenticated: true, login: "tester" });
+			return json({});
+		}) as typeof fetch,
+	};
+	return server;
+}
+
+/**
+ * A WebSocket stand-in with the three handlers the client sets. `deliver` pushes
+ * a frame as if the server sent it; `sent` records what we sent.
+ */
+export class FakeWebSocket {
+	static last: FakeWebSocket | undefined;
+
+	readyState = 0;
+	onopen: (() => void) | null = null;
+	onmessage: ((event: { data: string }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	sent: Record<string, unknown>[] = [];
+	closed = false;
+
+	constructor(
+		readonly url: string,
+		readonly options?: { headers?: Record<string, string> },
+	) {
+		FakeWebSocket.last = this;
+	}
+
+	/** Complete the handshake — separate so tests can assert pre-open queuing. */
+	open(): void {
+		this.readyState = 1;
+		this.onopen?.();
+	}
+
+	send(raw: string): void {
+		this.sent.push(JSON.parse(raw) as Record<string, unknown>);
+	}
+
+	close(): void {
+		this.closed = true;
+		this.readyState = 3;
+		this.onclose?.();
+	}
+
+	deliver(frame: ServerFrame): void {
+		this.onmessage?.({ data: JSON.stringify(frame) });
+	}
+
+	/** Frames of a given type that we sent to the server. */
+	sentOfType(type: string): Record<string, unknown>[] {
+		return this.sent.filter((frame) => frame.type === type);
+	}
+}
+
+export const fakeWsFactory = (url: string, options?: { headers: Record<string, string> }) =>
+	new FakeWebSocket(url, options) as unknown as WebSocket;

--- a/os1-tui/test/keymap.test.ts
+++ b/os1-tui/test/keymap.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type Key,
+	type KeymapState,
+	resolveKey,
+} from "../src/ui/keymap";
+
+const key = (name: string, mods: Partial<Key> = {}): Key => ({ name, ...mods });
+const state = (over: Partial<KeymapState> = {}): KeymapState => ({
+	mode: "nav",
+	pane: "sidebar",
+	prefixArmed: false,
+	...over,
+});
+
+describe("the prefix", () => {
+	test("ctrl+b arms, the next key runs a command", () => {
+		const armed = resolveKey(key("b", { ctrl: true }), state());
+		expect(armed.prefixArmed).toBe(true);
+		expect(armed.action).toBeUndefined();
+		expect(armed.consumed).toBe(true);
+
+		const next = resolveKey(key("c"), state({ prefixArmed: true }));
+		expect(next.action).toEqual({ type: "new-session" });
+		expect(next.prefixArmed).toBe(false);
+	});
+
+	test("^b digit jumps to a tab", () => {
+		expect(resolveKey(key("3"), state({ prefixArmed: true })).action).toEqual({
+			type: "jump-tab",
+			index: 3,
+		});
+	});
+
+	test("an unknown prefix key is swallowed, not typed into the composer", () => {
+		const result = resolveKey(key("q"), state({ prefixArmed: true, mode: "composer" }));
+		expect(result.consumed).toBe(true);
+		expect(result.action).toBeUndefined();
+		expect(result.prefixArmed).toBe(false);
+	});
+
+	test("prefix commands work mid-typing — ^b d detaches from the composer", () => {
+		expect(
+			resolveKey(key("d"), state({ prefixArmed: true, mode: "composer" })).action,
+		).toEqual({ type: "detach" });
+	});
+});
+
+describe("global movement", () => {
+	test("ctrl+arrows switch tabs and panes from any mode", () => {
+		for (const mode of ["nav", "composer", "scroll"] as const) {
+			expect(resolveKey(key("left", { ctrl: true }), state({ mode })).action).toEqual({
+				type: "prev-tab",
+			});
+			expect(resolveKey(key("right", { ctrl: true }), state({ mode })).action).toEqual({
+				type: "next-tab",
+			});
+			expect(resolveKey(key("down", { ctrl: true }), state({ mode })).action).toEqual({
+				type: "focus-pane",
+				direction: "next",
+			});
+		}
+	});
+});
+
+describe("composer", () => {
+	test("enter queues, ctrl+enter steers, shift+enter is a newline", () => {
+		const composer = state({ mode: "composer", pane: "composer" });
+		expect(resolveKey(key("return"), composer).action).toEqual({
+			type: "submit",
+			busyMode: "queue",
+		});
+		expect(resolveKey(key("return", { ctrl: true }), composer).action).toEqual({
+			type: "submit",
+			busyMode: "steer",
+		});
+		const newline = resolveKey(key("return", { shift: true }), composer);
+		expect(newline.consumed).toBe(false);
+		expect(newline.action).toBeUndefined();
+	});
+
+	test("printable keys are left for the input", () => {
+		const result = resolveKey(key("x"), state({ mode: "composer" }));
+		expect(result.consumed).toBe(false);
+	});
+
+	test("escape leaves the composer", () => {
+		expect(resolveKey(key("escape"), state({ mode: "composer" })).action).toEqual({
+			type: "exit-mode",
+		});
+	});
+});
+
+describe("nav", () => {
+	test("arrows move the sidebar cursor, or scroll the transcript", () => {
+		expect(resolveKey(key("down"), state({ pane: "sidebar" })).action).toEqual({
+			type: "move-cursor",
+			delta: 1,
+		});
+		expect(resolveKey(key("down"), state({ pane: "transcript" })).action).toEqual({
+			type: "scroll",
+			by: "line-down",
+		});
+	});
+
+	test("enter opens from the sidebar and focuses the composer elsewhere", () => {
+		expect(resolveKey(key("return"), state({ pane: "sidebar" })).action).toEqual({
+			type: "open-selected",
+		});
+		expect(resolveKey(key("return"), state({ pane: "transcript" })).action).toEqual({
+			type: "focus-composer",
+		});
+	});
+});
+
+describe("scroll mode", () => {
+	test("tmux copy-mode keys, and q exits", () => {
+		const scroll = state({ mode: "scroll", pane: "transcript" });
+		expect(resolveKey(key("k"), scroll).action).toEqual({
+			type: "scroll",
+			by: "line-up",
+		});
+		expect(resolveKey(key("space"), scroll).action).toEqual({
+			type: "scroll",
+			by: "page-down",
+		});
+		expect(resolveKey(key("g"), scroll).action).toEqual({ type: "scroll", by: "top" });
+		expect(resolveKey(key("g", { shift: true }), scroll).action).toEqual({
+			type: "scroll",
+			by: "bottom",
+		});
+		expect(resolveKey(key("b"), scroll).action).toEqual({ type: "load-earlier" });
+		expect(resolveKey(key("q"), scroll).action).toEqual({ type: "exit-mode" });
+	});
+});
+
+describe("ask mode", () => {
+	test("number keys answer, i escapes to free text", () => {
+		const ask = state({ mode: "ask" });
+		expect(resolveKey(key("2"), ask).action).toEqual({
+			type: "answer-option",
+			index: 1,
+		});
+		expect(resolveKey(key("i"), ask).action).toEqual({ type: "focus-composer" });
+	});
+});
+
+test("help is dismissed by any key", () => {
+	expect(resolveKey(key("z"), state({ mode: "help" })).action).toEqual({
+		type: "toggle-help",
+	});
+});

--- a/os1-tui/test/session-store.test.ts
+++ b/os1-tui/test/session-store.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import {
+	applyFrame,
+	applyFrames,
+	initialSessionState,
+} from "../src/client/session-store";
+import type { ServerFrame, TranscriptEntry } from "../src/client/types";
+
+const entry = (id: string, over: Partial<TranscriptEntry> = {}): TranscriptEntry => ({
+	id,
+	type: "assistant",
+	content: `body ${id}`,
+	...over,
+});
+
+describe("transcript reduction", () => {
+	test("init replaces, append merges, ids never duplicate", () => {
+		let state = applyFrame(initialSessionState, {
+			type: "transcript_init",
+			entries: [entry("a"), entry("b")],
+			startOffset: 10,
+			endOffset: 400,
+			rev: "r1",
+			truncated: true,
+		} as ServerFrame);
+
+		expect(state.loaded).toBe(true);
+		expect(state.entries.map((e) => e.id)).toEqual(["a", "b"]);
+		expect(state.cursor).toEqual({ endOffset: 400, rev: "r1" });
+		expect(state.truncated).toBe(true);
+		expect(state.startOffset).toBe(10);
+
+		// The reconnect gap-fill re-sends `b` alongside the new `c`.
+		state = applyFrame(state, {
+			type: "transcript_append",
+			entries: [entry("b"), entry("c")],
+			endOffset: 620,
+			rev: "r1",
+		} as ServerFrame);
+
+		expect(state.entries.map((e) => e.id)).toEqual(["a", "b", "c"]);
+		expect(state.cursor).toEqual({ endOffset: 620, rev: "r1" });
+	});
+
+	test("a clamped re-send never truncates content we already hold", () => {
+		let state = applyFrame(initialSessionState, {
+			type: "transcript_init",
+			entries: [entry("a", { content: "the whole long body" })],
+		} as ServerFrame);
+
+		state = applyFrame(state, {
+			type: "transcript_append",
+			entries: [entry("a", { content: "the whole", contentClamped: true })],
+		} as ServerFrame);
+
+		expect(state.entries[0]!.content).toBe("the whole long body");
+	});
+
+	test("history prepends and moves the paging cursor back", () => {
+		let state = applyFrame(initialSessionState, {
+			type: "transcript_init",
+			entries: [entry("c")],
+			startOffset: 900,
+			truncated: true,
+		} as ServerFrame);
+
+		state = applyFrame(state, {
+			type: "transcript_history",
+			entries: [entry("a"), entry("b")],
+			startOffset: 100,
+			truncated: true,
+		} as ServerFrame);
+
+		expect(state.entries.map((e) => e.id)).toEqual(["a", "b", "c"]);
+		expect(state.startOffset).toBe(100);
+	});
+
+	test("an init after an engine-id rotation drops the old entries", () => {
+		let state = applyFrame(initialSessionState, {
+			type: "transcript_init",
+			entries: [entry("old-1"), entry("old-2")],
+			rev: "r1",
+			endOffset: 100,
+		} as ServerFrame);
+
+		state = applyFrame(state, {
+			type: "transcript_init",
+			entries: [entry("new-1")],
+			rev: "r2",
+			endOffset: 20,
+		} as ServerFrame);
+
+		expect(state.entries.map((e) => e.id)).toEqual(["new-1"]);
+		expect(state.cursor).toEqual({ endOffset: 20, rev: "r2" });
+	});
+});
+
+describe("streaming", () => {
+	test("text accumulates, then the committed entry takes over", () => {
+		let state = applyFrames(initialSessionState, [
+			{ type: "transcript_init", entries: [] } as ServerFrame,
+			{ type: "stream_start" } as ServerFrame,
+			{ type: "stream_text", text: "Wiring " } as ServerFrame,
+			{ type: "stream_text", text: "the socket" } as ServerFrame,
+		]);
+
+		expect(state.streaming).toBe(true);
+		expect(state.streamText).toBe("Wiring the socket");
+		expect(state.isRunning).toBe(true);
+
+		// stream_done alone must NOT blank the text — the entry hasn't landed yet,
+		// and clearing here flashes an empty answer.
+		state = applyFrame(state, { type: "stream_done" } as ServerFrame);
+		expect(state.streamText).toBe("Wiring the socket");
+		expect(state.streaming).toBe(false);
+
+		state = applyFrame(state, {
+			type: "transcript_append",
+			entries: [entry("x", { content: "Wiring the socket" })],
+		} as ServerFrame);
+		expect(state.streamText).toBe("");
+		expect(state.entries).toHaveLength(1);
+	});
+
+	test("streamed tool entries upsert into the transcript", () => {
+		const state = applyFrames(initialSessionState, [
+			{
+				type: "stream_tool_use",
+				entry: entry("t1", { type: "tool_use", toolName: "read" }),
+			} as ServerFrame,
+			{
+				type: "stream_tool_result",
+				entry: entry("t1", { type: "tool_result", content: "done" }),
+			} as ServerFrame,
+		]);
+
+		expect(state.entries).toHaveLength(1);
+		expect(state.entries[0]!.type).toBe("tool_result");
+	});
+
+	test("session_status false stops the spinner and the stream", () => {
+		let state = applyFrames(initialSessionState, [
+			{ type: "stream_start" } as ServerFrame,
+			{ type: "stream_text", text: "half a sentence" } as ServerFrame,
+		]);
+		state = applyFrame(state, {
+			type: "session_status",
+			isRunning: false,
+		} as ServerFrame);
+		expect(state.isRunning).toBe(false);
+		expect(state.streaming).toBe(false);
+	});
+});
+
+describe("queue and questions", () => {
+	test("queue_update replaces both lists", () => {
+		const state = applyFrame(initialSessionState, {
+			type: "queue_update",
+			queued: [{ id: "q1", content: "next thing" }],
+			steered: [{ id: "s1", content: "actually" }],
+		} as ServerFrame);
+		expect(state.queued).toHaveLength(1);
+		expect(state.steered[0]!.content).toBe("actually");
+	});
+
+	test("ask_question shows a card, ask_resolved clears the matching one", () => {
+		let state = applyFrame(initialSessionState, {
+			type: "ask_question",
+			questionId: "ask-1",
+			questions: [{ question: "Ship it?", options: [{ label: "yes" }] }],
+		} as ServerFrame);
+		expect(state.ask?.questionId).toBe("ask-1");
+
+		// A resolution for a different question must not clear this card.
+		state = applyFrame(state, {
+			type: "ask_resolved",
+			questionId: "ask-0",
+		} as ServerFrame);
+		expect(state.ask?.questionId).toBe("ask-1");
+
+		state = applyFrame(state, {
+			type: "ask_resolved",
+			questionId: "ask-1",
+		} as ServerFrame);
+		expect(state.ask).toBeNull();
+	});
+});
+
+test("unknown frames are ignored by identity", () => {
+	const state = applyFrame(initialSessionState, { type: "presence" } as ServerFrame);
+	expect(state).toBe(initialSessionState);
+});

--- a/os1-tui/test/socket.test.ts
+++ b/os1-tui/test/socket.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import { WsSessionSocket } from "../src/client/socket";
+import { WatchedSession } from "../src/client/watched-session";
+import { FakeWebSocket, fakeWsFactory } from "./fakes";
+import type { ServerFrame } from "../src/client/types";
+
+function wire() {
+	let watched: WatchedSession | undefined;
+	const socket = new WsSessionSocket(
+		"ws://server/ws",
+		"tok",
+		{
+			onFrame: (frame) => watched?.handleFrame(frame),
+			onOpen: () => watched?.handleOpen(),
+			onClose: (reason, retry) => watched?.handleClose(reason, retry),
+		},
+		fakeWsFactory,
+	);
+	watched = new WatchedSession("bks-1", socket);
+	watched.start();
+	const ws = FakeWebSocket.last!;
+	return { watched, socket, ws };
+}
+
+describe("connection lifecycle", () => {
+	test("the token rides on the upgrade request", () => {
+		const { ws } = wire();
+		expect(ws.options?.headers?.authorization).toBe("Bearer tok");
+	});
+
+	test("watch is sent once, on open — not twice", () => {
+		const { ws } = wire();
+		// Nothing before the handshake completes…
+		expect(ws.sentOfType("watch")).toHaveLength(0);
+		ws.open();
+		expect(ws.sentOfType("watch")).toHaveLength(1);
+		expect(ws.sentOfType("watch")[0]!.sessionId).toBe("bks-1");
+	});
+
+	test("a reconnect re-watches from the byte cursor", () => {
+		const { watched, ws } = wire();
+		ws.open();
+		ws.deliver({
+			type: "transcript_init",
+			sessionId: "bks-1",
+			entries: [],
+			endOffset: 4096,
+			rev: "rev-9",
+		} as ServerFrame);
+
+		// Simulate the transport coming back up (same socket object here; the real
+		// one makes a new WebSocket, which routes to the same handleOpen).
+		watched.handleOpen();
+		const resume = ws.sentOfType("watch").at(-1)!;
+		expect(resume.sinceOffset).toBe(4096);
+		expect(resume.sinceRev).toBe("rev-9");
+	});
+
+	test("connection status reaches the snapshot", () => {
+		const { watched, ws } = wire();
+		expect(watched.getSnapshot().connection).toBe("connecting");
+		ws.open();
+		expect(watched.getSnapshot().connection).toBe("open");
+		watched.handleClose("lost", true);
+		expect(watched.getSnapshot().connection).toBe("retrying");
+	});
+
+	test("subscribers fire on frames and on connection changes", () => {
+		const { watched, ws } = wire();
+		let notifications = 0;
+		watched.subscribe(() => notifications++);
+		ws.open();
+		expect(notifications).toBe(1); // connection → open
+		ws.deliver({ type: "session_status", isRunning: true } as ServerFrame);
+		expect(notifications).toBe(2);
+		// A frame that changes nothing must not wake React.
+		ws.deliver({ type: "session_status", isRunning: true } as ServerFrame);
+		expect(notifications).toBe(2);
+	});
+});
+
+describe("outbound frames", () => {
+	test("prompt defaults to queueing behind a busy run", () => {
+		const { watched, ws } = wire();
+		ws.open();
+		watched.send("do the thing", "michiel");
+		const prompt = ws.sentOfType("prompt")[0]!;
+		expect(prompt).toMatchObject({
+			sessionId: "bks-1",
+			content: "do the thing",
+			user: "michiel",
+			busyMode: "queue",
+		});
+	});
+
+	test("steer is opt-in", () => {
+		const { watched, ws } = wire();
+		ws.open();
+		watched.send("actually, stop", "michiel", "steer");
+		expect(ws.sentOfType("prompt")[0]!.busyMode).toBe("steer");
+	});
+
+	test("answering clears the card optimistically and sends the answers", () => {
+		const { watched, ws } = wire();
+		ws.open();
+		ws.deliver({
+			type: "ask_question",
+			questionId: "ask-7",
+			questions: [{ question: "Ship?", options: [{ label: "yes" }] }],
+		} as ServerFrame);
+		expect(watched.getState().ask).not.toBeNull();
+
+		watched.answer({ Ship: "yes" });
+		expect(watched.getState().ask).toBeNull();
+		expect(ws.sentOfType("answer_question")[0]).toMatchObject({
+			questionId: "ask-7",
+			answers: { Ship: "yes" },
+		});
+	});
+
+	test("load-earlier is a no-op unless there IS earlier history", () => {
+		const { watched, ws } = wire();
+		ws.open();
+		watched.loadEarlier();
+		expect(ws.sentOfType("load_history")).toHaveLength(0);
+
+		ws.deliver({
+			type: "transcript_init",
+			entries: [],
+			truncated: true,
+			startOffset: 500,
+			endOffset: 900,
+			rev: "r1",
+		} as ServerFrame);
+		watched.loadEarlier();
+		expect(ws.sentOfType("load_history")[0]).toMatchObject({
+			beforeOffset: 500,
+			beforeRev: "r1",
+		});
+	});
+
+	test("frames sent before the handshake are queued, not dropped", () => {
+		const { watched, ws } = wire();
+		watched.send("early", "michiel");
+		expect(ws.sent).toHaveLength(0);
+		ws.open();
+		expect(ws.sentOfType("prompt")).toHaveLength(1);
+	});
+});

--- a/os1-tui/tsconfig.json
+++ b/os1-tui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@opentui/react",
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "types": ["bun"]
+  },
+  "include": ["src", "test"]
+}

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -50,6 +50,9 @@ ${bold("Running")}
   status                   is it running?
   logs [-f] [-n N]         tail the service journal
 
+${bold("Client")}
+  tui [--host <url>]       open the terminal client (the 'os' binary)
+
 ${bold("Maintenance")}
   update [--channel <ref>] fast-forward, reinstall deps, restart
          [--check]         show what an update would pull, change nothing
@@ -92,6 +95,25 @@ async function start(): Promise<number> {
     return await runInherit(["bun", "run", "opensession.ts"], REPO_ROOT);
   }
   return await service.control("start");
+}
+
+/**
+ * `opensession tui` — hand off to the `os` client (os1-tui).
+ *
+ * A thin alias, not a reimplementation: `os` is a separate binary because it's a
+ * *client* (fetch + WebSocket, runs on your laptop) while this CLI is a
+ * *server-admin* tool that imports server modules and manages the unit. Prefer
+ * `os` directly; this exists for discoverability from `opensession --help`.
+ */
+async function tui(): Promise<number> {
+  const onPath = Bun.which("os");
+  if (onPath) return await runInherit([onPath, ...argv.slice(1)], process.cwd());
+  const entry = `${REPO_ROOT}/os1-tui/src/index.ts`;
+  if (!existsSync(entry)) {
+    fail("no TUI found", "expected the `os` binary on PATH or os1-tui/ in this checkout");
+    return 1;
+  }
+  return await runInherit(["bun", entry, ...argv.slice(1)], REPO_ROOT);
 }
 
 async function status(): Promise<number> {
@@ -284,6 +306,9 @@ async function main(): Promise<number> {
       if (positional[0] === "pair") return await nodesPair();
       if (positional[0] === "remove") return await nodesRemove(positional[1] ?? "");
       return await nodesList();
+
+    case "tui":
+      return await tui();
 
     case "version":
     case "--version":

--- a/src/frontend/components/Home.tsx
+++ b/src/frontend/components/Home.tsx
@@ -552,9 +552,13 @@ export function Home({ sessions, projects, onSelect, onNewSession, onOpenAnalyti
                           >
                             <StateIcon state={row.state} />
                           </span>
-                          <span className="flex h-5 w-5 items-center justify-center rounded-sm bg-accent-soft text-[9px] font-bold uppercase text-accent">
-                            {row.repo.slice(0, 2)}
-                          </span>
+                          {person === "all" && row.person ? (
+                            <UserAvatar name={personLabel(row.person)} size={20} />
+                          ) : (
+                            <span className="flex h-5 w-5 items-center justify-center rounded-sm bg-accent-soft text-[9px] font-bold uppercase text-accent">
+                              {row.repo.slice(0, 2)}
+                            </span>
+                          )}
                           <span className="min-w-0">
                             <span className="flex min-w-0 items-baseline gap-2">
                               <span className="truncate text-[14px] text-dim group-hover:text-fg">{row.title}</span>

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -3518,8 +3518,8 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 							>
 								<span className="inline-flex shrink-0 items-center text-faint">
 									<svg
-										width="17"
-										height="17"
+										width="18"
+										height="18"
 										viewBox="0 0 16 16"
 										fill="none"
 										stroke="currentColor"

--- a/src/frontend/components/WorkspaceInfo.tsx
+++ b/src/frontend/components/WorkspaceInfo.tsx
@@ -789,7 +789,7 @@ function MichaelReviewCard({
 		? [...(pr.comments || [])]
 				.reverse()
 				.find((comment) => comment.body.trim().startsWith("<!-- os-review -->"))
-				?.body
+				?.body.replace(/^<!-- os-review -->\s*/, "")
 		: undefined;
 
 	// Keep the just-started state latched until a later PR refresh observes the

--- a/src/frontend/components/WorkspaceInfo.tsx
+++ b/src/frontend/components/WorkspaceInfo.tsx
@@ -28,6 +28,7 @@ import { getCurrentUser, TEAM } from "./UserPicker";
 import { UserAvatar } from "./UserAvatar";
 import { Menu } from "../ui/menu";
 import { Popover } from "../ui/popover";
+import { Tooltip } from "../ui/tooltip";
 import { cn } from "../ui/cn";
 import type {
 	DiffFile,
@@ -782,6 +783,14 @@ function MichaelReviewCard({
 				reviewedAgo ? `reviewed ${reviewedAgo} ago` : "reviewed recently",
 			].filter(Boolean).join(" · ")
 		: `Run ${AGENT_NAME}'s merge-safety review`;
+	// The score is intentionally compact; the matching GitHub summary comment
+	// retains the reviewer's complete reasoning and is available on hover/focus.
+	const reviewMessage = review
+		? [...(pr.comments || [])]
+				.reverse()
+				.find((comment) => comment.body.trim().startsWith("<!-- os-review -->"))
+				?.body
+		: undefined;
 
 	// Keep the just-started state latched until a later PR refresh observes the
 	// run or its new result; otherwise the button flashes idle after the POST.
@@ -872,34 +881,42 @@ function MichaelReviewCard({
 				)}
 			</div>
 			<div className="grid gap-px rounded-lg bg-panel p-1">
-				<div className="flex items-center gap-2.5 rounded-md px-2 py-2">
-					<div className={cn("shrink-0 font-mono leading-none", scoreTone)}>
-						<span className="text-[20px] font-[750] tracking-[-0.06em]">{score ?? "–"}</span>
-						<span className="ml-0.5 text-[10.5px] font-semibold tracking-normal text-faint">/5</span>
-					</div>
-					<div className="min-w-0 flex-1">
-						<div className="truncate text-[12px] font-semibold text-fg">{verdict}</div>
-						<div className="mt-0.5 truncate text-[10.5px] text-faint">{detail}</div>
-					</div>
+				<Tooltip label={reviewMessage || ""} side="bottom" align="start" multiline>
 					<div
-						className="flex w-12 shrink-0 gap-0.5"
-						role={score ? "meter" : "status"}
-						aria-label={`${AGENT_NAME} merge-safety score`}
-						aria-valuemin={score ? 1 : undefined}
-						aria-valuemax={score ? 5 : undefined}
-						aria-valuenow={score}
+						className={cn(
+							"flex items-center gap-2.5 rounded-md px-2 py-2",
+							reviewMessage && "cursor-help",
+						)}
+						tabIndex={reviewMessage ? 0 : undefined}
 					>
-						{[1, 2, 3, 4, 5].map((step) => (
-							<span
-								key={step}
-								className={cn(
-									"h-1 flex-1 rounded-full",
-									score && step <= score ? meterTone : "bg-active",
-								)}
-							/>
-						))}
+						<div className={cn("shrink-0 font-mono leading-none", scoreTone)}>
+							<span className="text-[20px] font-[750] tracking-[-0.06em]">{score ?? "–"}</span>
+							<span className="ml-0.5 text-[10.5px] font-semibold tracking-normal text-faint">/5</span>
+						</div>
+						<div className="min-w-0 flex-1">
+							<div className="truncate text-[12px] font-semibold text-fg">{verdict}</div>
+							<div className="mt-0.5 truncate text-[10.5px] text-faint">{detail}</div>
+						</div>
+						<div
+							className="flex w-12 shrink-0 gap-0.5"
+							role={score ? "meter" : "status"}
+							aria-label={`${AGENT_NAME} merge-safety score`}
+							aria-valuemin={score ? 1 : undefined}
+							aria-valuemax={score ? 5 : undefined}
+							aria-valuenow={score}
+						>
+							{[1, 2, 3, 4, 5].map((step) => (
+								<span
+									key={step}
+									className={cn(
+										"h-1 flex-1 rounded-full",
+										score && step <= score ? meterTone : "bg-active",
+									)}
+								/>
+							))}
+						</div>
 					</div>
-				</div>
+				</Tooltip>
 				{actionable && (
 					<div className="grid grid-cols-2 gap-px">
 						{canFix && (

--- a/src/frontend/components/useFileMentions.tsx
+++ b/src/frontend/components/useFileMentions.tsx
@@ -134,6 +134,13 @@ export function useFileMentions({ value, onChange, textareaRef, mentionFetch, sk
     if (!ctx) setSuggestions([]);
   }
 
+  // Controlled textarea updates are not guaranteed to commit before a caller's
+  // queued microtask. Re-sync from the committed value so soft keyboards,
+  // dictation and the toolbar's programmatic "@" insertion all open reliably.
+  useEffect(() => {
+    sync();
+  }, [value]);
+
   // Debounced fetch of suggestions for the active mention/skill query.
   useEffect(() => {
     const fetcher = mention?.kind === "skill" ? skillsFetchRef.current : mentionFetchRef.current;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,8 @@
     "types": ["bun"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  // os1-tui has its own tsconfig: its JSX resolves to OpenTUI's intrinsic
+  // elements (box/text/scrollbox), not React DOM's, so it can't share this one.
+  // Check it with `cd os1-tui && bun run typecheck`.
+  "exclude": ["node_modules", "dist", "os1-tui"]
 }


### PR DESCRIPTION
`os --host <server>` — OpenSession in your terminal. The fifth client, after the web UI, `os1-mac`, `os1-ios` and `os1-chrome`.

Plan (approved before building) is in `docs/os1-tui-plan.md`; the shipped surface is in `os1-tui/README.md`.

## What it does

A herdr-shaped TUI pointed at a server instead of at local agent CLIs: workspace sidebar with blocked/working/done/idle at a glance, live streaming transcripts, tabs, tmux keys, composer with queue/steer, AskUserQuestion answering, session picker, command prompt, scroll mode.

The important difference from herdr: the sessions already live on the box, so `^b d` detaches for free and closing the laptop doesn't stop a run.

## Shape

**Pure client.** HTTP plus one WebSocket per watched session. Nothing under `os1-tui/src/` imports the server, which is what lets it compile to a standalone binary (`bun build --compile`, ~120 MB with the Bun runtime + OpenTUI's Zig renderer). `opensession tui` is a thin alias — the `opensession` CLI stays a server-admin tool that imports server modules and manages the unit; `os` is the thing you run on a laptop.

**No new server endpoints.** The wire surface is exactly what `os1-ios` already drives, including the three details that are load-bearing there:

- the server never pings, so the client sends `{"type":"ping"}` and treats a missed pong as a dead socket
- no message-size cap (a heavy `transcript_init` runs to megabytes; a 1 MB cap once made an iOS session reconnect-loop forever)
- `watch` is one session per connection — hence a tab *is* a connection — and it's sent from the socket's open handler only, resuming from the `endOffset`/`rev` byte cursor so a reconnect replays the gap rather than the whole tail

**Renderer** is OpenTUI (`@opentui/core` + `@opentui/react`), which powers opencode's TUI, so the long-streaming-transcript path is proven at our workload.

**Structure.** `src/client/` is the server-as-types: a pure reducer over frames, injectable socket and fetch, no terminal and no React. `src/ui/` is the terminal. Keys resolve to `Action`s through a pure keymap state machine and `runAction` is the only mutator, so "what does this key do" is two files. UI position lives in a ref-backed store because a terminal delivers `^b w` as two keypresses in a single tick, before React re-renders.

## Verification

49 tests, ~2s, no server and no terminal required — including render tests that mount the real app into an in-memory terminal against a fake `fetch` and a fake WebSocket, press real keys, and assert on the resulting screen.

Those caught four real bugs while building, each of which would have shipped:

1. a merge that let a stale field win, downgrading a committed `tool_result` back to `tool_use`
2. store getters passed unbound to `useSyncExternalStore`, losing `this` at mount
3. the key-burst race above — `^b w` silently ate the second key
4. a workspace-name fetch race that painted raw `prj-…` ids on first frame

Also verified live against the running server (session list, auth, watch, transcript render, help overlay, detach) both from source and as a compiled binary, driven through a pty.

## Decisions

- **Tabs, no splits.** Splits were most of the layout complexity for a layout nobody had asked for; `^b w` plus `ctrl+←/→` covers the same ground.
- `ctrl+enter` (steer) is undistinguishable from a bare enter without the kitty keyboard protocol, so `os` requests it at startup and `alt+enter` is the portable alias.
- `os1-tui` is excluded from the root `tsconfig.json`: its JSX resolves to OpenTUI's intrinsic elements, not React DOM's. Check it with `cd os1-tui && bun run typecheck`.

## Still open

Phase 4 — diff pane, PR panel, and a terminal pane over the existing `term_start` (as a full-screen alt-screen handoff; a live pty inside a TUI pane needs an emulator we don't have). Plus published per-target binaries and an `install.sh` client-only mode, and mouse support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SRVCZ2EAF4cge8JPHNWgK