### PR TITLE
Install Tailscale by default

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -53,11 +53,13 @@ UI and API at `/opensession/`.
 - `git`, and the [`gh` CLI](https://cli.github.com) for PR operations.
 - The `claude` CLI (Claude Code) — the Claude engine shells out to it
   (`OPENSESSION_CLAUDE_BIN`, default `/home/ubuntu/.local/bin/claude`).
+- **Tailscale** — the recommended way to expose the UI at all. The installer
+  installs it by default (`--no-tailscale` opts out); joining a network is a
+  separate step that needs your account.
 - Optional: **Docker** (sandboxed sessions —
   [self-hosting-sandboxes](../self-hosting-sandboxes.md)), **Caddy** (TLS for
-  live previews), **Tailscale** (the recommended way to expose the UI at all),
-  `opencode` binary (OpenCode engine), `whisper.cpp`/Groq/OpenAI key (voice
-  dictation).
+  live previews), `opencode` binary (OpenCode engine), `whisper.cpp`/Groq/OpenAI
+  key (voice dictation).
 
 ## Trust model (read this)
 

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -15,14 +15,37 @@ curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh
 ```
 
 This installs missing prerequisites, clones the source to
-`~/.opensession/src`, installs dependencies and the engine, puts an
+`~/.opensession/src`, installs dependencies, the engine and Tailscale, puts an
 `opensession` command on your `PATH`, and runs the onboarding wizard. It is
 safe to re-run: an existing install is fast-forwarded, and existing config is
 backed up rather than overwritten.
 
 Useful flags — `--dir <path>` to install elsewhere, `--channel <ref>` to track
-a branch or tag, `--no-engine` to skip OpenCode, `--yes` to accept defaults,
-`--uninstall` to remove it. `--help` lists them all.
+a branch or tag, `--no-engine` to skip OpenCode, `--no-tailscale` to skip
+Tailscale, `--yes` to accept defaults, `--uninstall` to remove it. `--help`
+lists them all.
+
+### Why Tailscale is installed by default
+
+There is no authentication (see the
+[trust model](README.md#trust-model-read-this)) — the bind address *is* the
+access control. Installing the client up front means onboarding can offer your
+tailnet address as the bind default, rather than the usual path: accept
+`127.0.0.1`, discover later that a teammate cannot reach it, and reach for
+`HOST=0.0.0.0`.
+
+**Installing the client is not joining a network.** Nothing is exposed and no
+account is touched; `tailscale up` is a separate, explicit step. To do that
+part automatically too, set an [auth
+key](https://tailscale.com/kb/1085/auth-keys):
+
+```sh
+TS_AUTHKEY=tskey-auth-... curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh | bash
+```
+
+Otherwise the installer prints the `sudo tailscale up` command and carries on.
+Run it whenever you like, then `opensession onboard --force` to pick up the
+address. Full walkthrough: [networking.md](networking.md).
 
 ### Doing it by hand
 

--- a/docs/setup/networking.md
+++ b/docs/setup/networking.md
@@ -30,25 +30,50 @@ small team.
 
 ### 1. Install it on the box
 
+**The OpenSession installer already did this** unless you passed
+`--no-tailscale`. Check with `tailscale ip -4`; if it prints a `100.x` address
+you are already on a tailnet and can skip to step 3.
+
+To install it by hand:
+
 ```sh
 curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+### 2. Join your network
+
+```sh
 sudo tailscale up
 ```
 
 It prints a URL — open it and authenticate. On a headless box, use
 `sudo tailscale up --ssh` if you also want Tailscale SSH.
 
-### 2. Find the tailnet address
+This is the step the installer cannot do for you, because it needs your
+account. It *can* if you give it an
+[auth key](https://tailscale.com/kb/1085/auth-keys) as `TS_AUTHKEY` — see
+[install.md](install.md#why-tailscale-is-installed-by-default).
+
+### 3. Find the tailnet address
 
 ```sh
 tailscale ip -4        # e.g. 100.64.12.34
 ```
 
-### 3. Bind OpenSession to it
+### 4. Bind OpenSession to it
+
+If you joined the tailnet *before* onboarding, this is already done — the
+wizard offers the tailnet address as the bind default. Otherwise:
+
+```sh
+opensession onboard --force
+```
+
+Or set it directly — `HOST` in `~/.opensession.env`, or `server.host` in
+`~/.opensession/config.json`:
 
 ```sh
 opensession stop
-# set HOST in ~/.opensession.env, or server.host in ~/.opensession/config.json
 sed -i "s/^HOST=.*/HOST=$(tailscale ip -4)/" ~/.opensession.env
 opensession start
 ```
@@ -58,7 +83,7 @@ Then reach it from any device on the tailnet at `http://<tailnet-ip>:3850`.
 Set `OPENSESSION_UI_BASE` to the same address, or links posted into Slack,
 Linear and notes will point somewhere unreachable.
 
-### 4. Install Tailscale on the devices you want to use
+### 5. Install Tailscale on the devices you want to use
 
 Phone, laptop, whatever. They must be on the same tailnet. That is the whole
 access-control story — adding a device to the tailnet grants access, removing

--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,12 @@
 #   --no-modify-path      NO_MODIFY_PATH=1     do not touch shell profiles
 #   --no-onboard          NO_ONBOARD=1         install only, skip the wizard
 #   --no-engine           NO_ENGINE=1          do not install the OpenCode engine
+#   --no-tailscale        NO_TAILSCALE=1       do not install Tailscale
 #   --yes                 NO_PROMPT=1          accept defaults, never prompt
 #   --uninstall                                remove the install
+#
+# Tailscale is installed but not joined to a network — joining needs your
+# account. Set TS_AUTHKEY to have the installer do that part too.
 #
 set -euo pipefail
 
@@ -30,6 +34,7 @@ CHANNEL="${OPENSESSION_CHANNEL:-}"
 NO_MODIFY_PATH="${NO_MODIFY_PATH:-0}"
 NO_ONBOARD="${NO_ONBOARD:-0}"
 NO_ENGINE="${NO_ENGINE:-0}"
+NO_TAILSCALE="${NO_TAILSCALE:-0}"
 NO_PROMPT="${NO_PROMPT:-0}"
 DO_UNINSTALL=0
 OS="$(uname -s)"
@@ -42,9 +47,12 @@ while [ $# -gt 0 ]; do
     --no-modify-path) NO_MODIFY_PATH=1; shift ;;
     --no-onboard) NO_ONBOARD=1; shift ;;
     --no-engine) NO_ENGINE=1; shift ;;
+    --no-tailscale) NO_TAILSCALE=1; shift ;;
     --yes|-y) NO_PROMPT=1; shift ;;
     --uninstall) DO_UNINSTALL=1; shift ;;
-    -h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    # Print the header comment, stopping at the first line that is not one, so
+    # this does not need re-pointing every time the header grows.
+    -h|--help) awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 1 ;;
   esac
 done
@@ -91,6 +99,11 @@ if [ "$DO_UNINSTALL" = "1" ]; then
   muted "  $OPENSESSION_HOME/config.json   your configuration"
   muted "  $HOME/.opensession.env          your secrets"
   muted "  $HOME/.opensession-chats        your sessions"
+  # Tailscale is a system daemon that may now be carrying your SSH access.
+  # Removing it as a side effect of uninstalling OpenSession would be hostile.
+  if command -v tailscale >/dev/null 2>&1; then
+    muted "  tailscale                       still installed ('sudo tailscale down' to leave)"
+  fi
   exit 0
 fi
 
@@ -313,6 +326,62 @@ else
     muted "install it later: curl -fsSL https://opencode.ai/install | bash"
   fi
   rm -f "$engine_log"
+fi
+
+# ── network ─────────────────────────────────────────────────────────────────
+#
+# OpenSession has no authentication and trusts everyone who can reach the
+# address it binds to, so a private network is not a nice-to-have — it is the
+# access control. Installing Tailscale here means `opensession onboard` can
+# offer the tailnet address as the bind default, instead of the usual outcome:
+# 127.0.0.1, discovering later that nobody else can reach it, and reaching for
+# HOST=0.0.0.0.
+#
+# Installing the client is not joining a network. `tailscale up` needs your
+# account, and under `curl | bash` there is often no terminal to authenticate
+# from — so joining happens only with an auth key, or later by hand.
+
+step "Network"
+tailnet_ip() { command -v tailscale >/dev/null 2>&1 && tailscale ip -4 2>/dev/null | head -1; }
+
+if [ "$NO_TAILSCALE" = "1" ]; then
+  muted "skipped (--no-tailscale)"
+elif [ -n "$(tailnet_ip)" ]; then
+  good "tailscale $(tailnet_ip)"
+else
+  if ! command -v tailscale >/dev/null 2>&1; then
+    if [ "$OS" = "Darwin" ]; then
+      muted "install Tailscale from https://tailscale.com/download/mac"
+    elif ! sudo -n true 2>/dev/null; then
+      muted "skipped (needs sudo) — curl -fsSL https://tailscale.com/install.sh | sh"
+    else
+      muted "installing Tailscale ..."
+      ts_log="$(mktemp)"
+      if curl -fsSL https://tailscale.com/install.sh | sudo -n sh >"$ts_log" 2>&1; then
+        good "tailscale $(tailscale version 2>/dev/null | head -1 || echo installed)"
+      else
+        warn "could not install Tailscale automatically:"
+        sed 's/^/    /' "$ts_log" | tail -10
+        muted "install it later: curl -fsSL https://tailscale.com/install.sh | sh"
+      fi
+      rm -f "$ts_log"
+    fi
+  fi
+
+  if command -v tailscale >/dev/null 2>&1 && [ -z "$(tailnet_ip)" ]; then
+    if [ -n "${TS_AUTHKEY:-}" ]; then
+      muted "joining the tailnet ..."
+      if sudo -n tailscale up --authkey="$TS_AUTHKEY" >/dev/null 2>&1; then
+        good "joined as $(tailnet_ip)"
+      else
+        warn "tailscale up failed — check TS_AUTHKEY has not expired"
+      fi
+    else
+      muted "not joined to a network yet. To finish:"
+      muted "  sudo tailscale up"
+      muted "then re-run 'opensession onboard --force' to bind to the tailnet IP"
+    fi
+  fi
 fi
 
 # ── shim ────────────────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,9 @@ else
     else
       muted "installing Tailscale ..."
       ts_log="$(mktemp)"
-      if curl -fsSL https://tailscale.com/install.sh | sudo -n sh >"$ts_log" 2>&1; then
+      # Redirect the whole pipeline, not the sudo: the log belongs to us, and
+      # a redirect on `sudo` is applied by this shell anyway (shellcheck SC2024).
+      if { curl -fsSL https://tailscale.com/install.sh | sudo -n sh; } >"$ts_log" 2>&1; then
         good "tailscale $(tailscale version 2>/dev/null | head -1 || echo installed)"
       else
         warn "could not install Tailscale automatically:"

--- a/scripts/lib/onboard.ts
+++ b/scripts/lib/onboard.ts
@@ -32,6 +32,23 @@ function backup(path: string): string | undefined {
   return dest;
 }
 
+/**
+ * This box's tailnet address, if it is on one.
+ *
+ * Worth asking Tailscale rather than inferring from the interface list: it is
+ * the only thing that knows whether the daemon is actually up and logged in,
+ * and a stale 100.x address on a logged-out box is a bind that never works.
+ */
+function tailnetIp(): string | undefined {
+  try {
+    const proc = Bun.spawnSync(["tailscale", "ip", "-4"]);
+    if (proc.exitCode !== 0) return undefined;
+    return proc.stdout.toString().trim().split("\n")[0]?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** "OpenSession" -> "OS". Falls back to the first two characters. */
 function deriveMark(name: string): string {
   const caps = name.replace(/[^A-Z]/g, "");
@@ -60,7 +77,14 @@ function collect(): Answers {
   );
 
   const productName = ask("Product name", "OpenSession");
-  const host = ask("Bind address (a Tailscale IP shares it with your team)", "127.0.0.1");
+
+  // Defaulting to the tailnet address when there is one is the whole point of
+  // installing Tailscale up front: the alternative default, 127.0.0.1, works
+  // until someone else needs to reach it and then gets "fixed" with 0.0.0.0.
+  const tailnet = tailnetIp();
+  const host = tailnet
+    ? ask(`Bind address (${tailnet} is this box's tailnet address)`, tailnet)
+    : ask("Bind address (a Tailscale IP shares it with your team)", "127.0.0.1");
   const port = Number(ask("Port", "3850")) || 3850;
   const publicBaseUrl = ask(
     "Public base URL",


### PR DESCRIPTION
OpenSession has no authentication — the bind address *is* the access control. Leaving Tailscale as a manual step meant `opensession onboard` could only ever offer `127.0.0.1` as the bind default, and the common path from there is: accept it, discover later that a teammate cannot reach the UI, reach for `HOST=0.0.0.0`.

## What changed

- `install.sh` installs the Tailscale client by default. `--no-tailscale` / `NO_TAILSCALE=1` opts out, matching the existing `--no-engine` shape.
- `onboard.ts` defaults the bind-address prompt to the tailnet address when `tailscale ip -4` returns one, instead of `127.0.0.1`.

## Installing the client is not joining a network

Nothing is exposed and no account is touched by the install itself. `tailscale up` needs the operator's account, and under `curl | bash` there is usually no terminal to authenticate from — so blocking on it would hang the installer.

- `TS_AUTHKEY` set → joins non-interactively.
- Otherwise → prints `sudo tailscale up` and carries on.

Deliberately **not** passing `--ssh`: enabling Tailscale SSH changes how the box is reached and is the operator's call, not a side effect of an installer.

`--uninstall` leaves Tailscale installed and only mentions it. By that point it may be carrying the SSH access you would need to fix anything.

## Drive-by

`--help` printed a hardcoded `sed -n '2,25p'` line range that had drifted, so it was emitting `set -euo pipefail` and the first few variable assignments as if they were documentation. Now it prints the header and stops at the first non-comment line.

## Docs

`install.md` (new "Why Tailscale is installed by default"), `networking.md` (step 1 now says the installer already did it, split out joining as its own step, renumbered), `setup/README.md` (promoted out of the "optional extras" list).

## Verification

- `bash -n install.sh` clean; `--help` output checked by hand.
- `bunx tsc --noEmit` clean.
- `bun test`: 1160 pass / 42 fail — **identical to the baseline on `main`**. The 42 are pre-existing and unrelated (opencode transcript mirroring, worktree revival, slack memory scopes).