### PR TITLE
Close out the portability audit and delete its dangling links

### DIFF
--- a/docs/local-profile.md
+++ b/docs/local-profile.md
@@ -220,13 +220,13 @@ same sidebar. Add a web-session bearer token to `~/os1/config.json`:
 ```json
 {
   "cloud": {
-    "upstream": "https://os.tella.dev",
+    "upstream": "https://your.opensession.host",
     "token": "your-web-session-token"
   }
 }
 ```
 
-`upstream` is optional and defaults to `https://os.tella.dev`. The environment
+`upstream` is optional and defaults to `server.publicBaseUrl`. The environment
 variables `OPENSESSION_CLOUD_UPSTREAM` and `OPENSESSION_CLOUD_TOKEN` override
 the file. The token is the same web-session bearer used by
 `scripts/frontend-dev.ts`; it stays in the local server and is never sent to

--- a/docs/self-hosting-sandboxes.md
+++ b/docs/self-hosting-sandboxes.md
@@ -71,9 +71,9 @@ The image reproduces the host's absolute paths exactly: the runner bundle at
 worktree bind-mounted at its **identical host path**. That parity is what
 lets diff/status/push/preview/@-mentions and Claude session resume work
 unchanged (resume state is keyed by cwd). If your host's `$HOME` or checkout
-path differs, **rebuild the image with matching paths** — see the audit note
-in `docs/portability-audit.md` §6: this is the one place `/home/ubuntu`
-coupling is intrinsic, not lazy.
+path differs, **rebuild the image with matching paths**. This is the one place
+the `/home/ubuntu` coupling is intrinsic rather than lazy: the parity is the
+mechanism, not a default nobody got round to extracting.
 
 ## Images, warm pools and snapshots
 
@@ -375,8 +375,8 @@ same routes for the tailnet path (docker-ws) — the ingress is additive.
 The listener binds `127.0.0.1:3860` by default: something must terminate
 TLS in front of it and forward ONLY those paths. Two permanent options:
 
-1. **Public IP + DNS + Caddy path routes** (what michael.tella.dev does —
-   needs :443 open in the security group and an A record):
+1. **Public IP + DNS + Caddy path routes** (needs :443 open in the security
+   group and an A record):
 
    ```caddyfile
    your.domain {
@@ -512,7 +512,7 @@ backlog item). Idle-stop is native (`autoStopInterval`).
   the launchRun round-trip + steer/cancel + mid-run WS drop/redial — went
   27/27 green 2026-07-09 against hosted Daytona (Tier 3) dialing back over
   the public ingress (`SBX_CONF_LISTEN_PORT=3860
-  SBX_CONF_PUBLIC_BASE=wss://michael.tella.dev`).
+  SBX_CONF_PUBLIC_BASE=wss://your.domain`).
 
 ### E2B (implemented, NOT yet certified)
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -116,4 +116,3 @@ when adding anything that touches this.
 | [../worktrees.md](../worktrees.md) | how sessions map to git worktrees, and where the disk goes |
 | [../clients.md](../clients.md) | web UI, PWA, Electron shell, Swift app, Chrome extension |
 | [../extending.md](../extending.md) | MCP servers, recipes, integrations, providers, skills |
-| [../portability-audit.md](../portability-audit.md) | what's still hardcoded (Tella-specific) |

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -106,10 +106,9 @@ run for the **default repo only**.
 - Auto-review on every PR push is **off by default**: the github agent seeds
   a "review" automation disabled (label-only mode). Enable it in the
   Automations UI. Not an env var.
-- The docs-sync automation is seeded **enabled** and fires on merge. Its
-  Slack notification channel is hardcoded (`DOCS_SYNC_SLACK_CHANNEL =
-  "C09BAFFK8F8"` in `src/agents/github/constants.ts`) — changing it requires
-  a code edit today; see [portability-audit §1d](../portability-audit.md).
+- The docs-sync automation is seeded **enabled** and fires on merge. Set
+  `integrations.github.docsSyncChannel` to have it announce its PRs in a Slack
+  channel; leave it unset and it still runs, just silently.
 - Mention replies are always on while the agent is loaded.
 - Disable the whole agent with `ENABLE_GITHUB_AGENT=false` (default is ON;
   only the literal string `false` disables — see
@@ -117,7 +116,7 @@ run for the **default repo only**.
 
 Prompts and `pr-info.ts` defaults are config-driven (they interpolate the
 default repo's `ghRepo`, or the PR's own repo when threaded) — no code edits
-needed to point the PR agent at your repos (portability-audit §1c: done).
+needed to point the PR agent at your repos.
 
 ## Per-user GitHub auth (PRs as the session owner)
 
@@ -164,12 +163,14 @@ What turns on (`src/server/github-auth.ts`, `web-auth.ts`, `routes/auth.ts`):
   connections (per-teammate status, disconnect) in the Connections UI.
 - `GET /api/health` stays un-gated (deploy polls / restart detection).
 
-## Deploy pipeline (Tella-specific, replaceable)
+## Deploy script
 
-How Tella ships this repo to its box — documented as a pattern, not a
-requirement. `.github/workflows/deploy.yml` (currently `workflow_dispatch`
-only) authenticates to AWS with OIDC and calls `ssm:SendCommand` to run
-`deploy/deploy.sh` on the EC2 instance — no inbound SSH. The script:
+`deploy/deploy.sh` updates a running box in place. There is no deploy workflow
+in this repo — run it however you like: over SSH, from a CI job, or by hand on
+the box. Tella drives it with `ssm:SendCommand` so nothing needs inbound SSH,
+which is a pattern worth copying but not a requirement.
+
+The script:
 
 1. `git fetch` + `merge --ff-only` (never `reset --hard` — the checkout is
    live and shared; divergence aborts loudly),
@@ -180,8 +181,7 @@ only) authenticates to AWS with OIDC and calls `ssm:SendCommand` to run
    `/opensession/api/health`, then `systemctl restart opensession` and a
    post-restart health gate.
 
-The AWS account ID, region, and instance ID are hardcoded in the workflow
-([portability-audit §1g](../portability-audit.md)). Self-hosters replace the
-workflow with anything that runs `deploy/deploy.sh` (or its equivalent) on
-the box; the drain-aware contract (ff-only pull → conditional install → idle
-wait → graceful restart) is the part worth keeping.
+The drain-aware contract — ff-only pull → conditional install → idle wait →
+graceful restart — is the part worth keeping whatever invokes it. `ff-only`
+matters most: the checkout on the box is live and shared, so a divergence
+aborts loudly rather than discarding work.

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -165,10 +165,10 @@ what the code actually reads, by feature:
 
 **Feature flags** — `ENABLE_SLACK_AGENT`, `ENABLE_LINEAR_AGENT`,
 `ENABLE_PLAIN_AGENT`, `ENABLE_GITHUB_AGENT`, `ENABLE_STRIPE_AGENT`,
-`ENABLE_GRAFANA_POLLER`. All **default ON**; only the literal string `false`
-disables (not `0`). Set the ones you don't use to `false` — see
-[integrations-misc.md](integrations-misc.md#boot-guards) for why relying on
-a missing token isn't enough.
+`ENABLE_GRAFANA_POLLER`. All **default OFF**; only the literal string `true`
+enables (not `1`). The env flag wins when set, otherwise
+`integrations.<id>.enabled` decides — see
+[integrations-misc.md](integrations-misc.md#boot-guards).
 
 Not for operators: `BKS_RPC_*` / `BKS_RUN_WS_*` / `BKS_MCP_SERVER` (set by
 OpenSession for its own runner-host/MCP-proxy subprocesses),
@@ -321,7 +321,7 @@ runs a second `Bun.serve` on `127.0.0.1:${WEBHOOK_PORT}` (default 3848).
 Agents register their own routes on it (`/slack/events`, `/slack/actions`,
 `/github/webhook`, `/webhook` (Linear), `/plain/webhook`, `/stripe/webhook`,
 `/oauth/*`, `/worktree/*`). It's loopback-only: you need a TLS-terminating
-reverse proxy with a public hostname in front (Tella uses Caddy on
-`michael.tella.dev`) for Slack/GitHub/Linear/Plain/Stripe to reach it. All
+reverse proxy on a public hostname in front of it (Caddy works well) for
+Slack/GitHub/Linear/Plain/Stripe to reach it. All
 signature checks are HMAC-SHA256 and fail-closed — a missing secret rejects
 everything rather than letting it through.

--- a/docs/setup/integrations-misc.md
+++ b/docs/setup/integrations-misc.md
@@ -6,23 +6,21 @@ All agent loops are gated in `loadAgents()` (opensession.ts, ~line 8810). The
 pattern is opt-**out**: `if (process.env.ENABLE_X_AGENT !== "false")`. That
 means:
 
-- Every agent is **ON by default**. Only the literal string `false` disables
-  it — `ENABLE_SLACK_AGENT=0` does *not* turn Slack off.
+- Every agent is **OFF by default**. An integration loads only when you enable
+  it, so a fresh install runs nothing you did not ask for.
 - Flags: `ENABLE_SLACK_AGENT`, `ENABLE_LINEAR_AGENT`, `ENABLE_PLAIN_AGENT`,
   `ENABLE_GITHUB_AGENT`, `ENABLE_GRAFANA_POLLER`, `ENABLE_STRIPE_AGENT`.
-- Only Stripe is additionally credential-gated: it loads only when
-  `STRIPE_WEBHOOK_SECRET` is also set. The others load without their tokens
-  and degrade with warnings (Slack calls fail, webhook verification rejects
-  everything, the Grafana poller no-ops) — and some **seed Tella-specific
-  automations on startup regardless** (Plain triage/top-issues, GitHub
-  docs-sync). If you don't use an integration, set its flag to `false`
-  explicitly rather than relying on a missing token. This default-ON gating
-  is flagged for a fail-closed rework in
-  [portability-audit §2e](../portability-audit.md).
+- **Only the literal string `true` enables.** `ENABLE_SLACK_AGENT=1` does *not*
+  turn Slack on. The asymmetry is deliberate — anything unrecognised means off.
+- The env flag wins when set; otherwise `integrations.<id>.enabled` in
+  `config.json` decides. Onboarding writes explicit values rather than relying
+  on either default.
 
-What "off but loaded" costs you in practice: log noise, health warnings, and
-seeded automations you didn't ask for — not crashes. Missing webhook secrets
-are fail-closed (401), so nothing untrusted gets in.
+Enabling an integration without its credentials is the one state to avoid: it
+loads and degrades with warnings (Slack calls fail, webhook verification
+rejects everything, the Grafana poller no-ops) rather than refusing. That costs
+log noise and health warnings, not crashes. Missing webhook secrets are
+fail-closed (401), so nothing untrusted gets in.
 
 ## Stripe
 
@@ -74,11 +72,9 @@ investigation automations with a Slack control card per fresh failure.
 | `SLACK_UPLOAD_FAILURE_CHANNEL` | `C0AKPJ65BQA` | same, upload failures (Tella default) |
 
 Dedup state lives in `~/.opensession-grafana-poll/<automationId>/` (default
-window 7 days). **Tella-specific:** the two seeded investigators query
-Tella's Loki labels (`service_name="temporal-rust-worker"`, `story_id`,
-`streaming_upload_id`) — pointing the poller at your own failure signatures
-means editing `src/agents/grafana-poller/index.ts` today
-([portability-audit §2d](../portability-audit.md)).
+window 7 days). The LogQL the poller runs is `lokiQuery` on each poll config,
+so pointing it at your own failure signatures is configuration, not a code
+edit. `$LOOKBACK` in the query is substituted with the poll window.
 
 ## Sentry and Tinybird
 
@@ -91,11 +87,12 @@ them and nothing breaks; runs just don't get those tools.
 
 `src/server/push.ts`. Zero configuration: VAPID keys are generated on first
 use and stored in `~/.opensession-push/vapid.json`; per-user subscriptions in
-`~/.opensession-push/subscriptions.json` (dead ones pruned on send). One
-Tella-ism: the VAPID contact is hardcoded `mailto:michael@tella.dev`
-([portability-audit §2a](../portability-audit.md)). Push requires the UI to
-be served over HTTPS (e.g. Tailscale `ts.net` certs); on iOS it needs the
-PWA installed.
+`~/.opensession-push/subscriptions.json` (dead ones pruned on send). The VAPID
+contact comes from `integrations.push.vapidSubject` and defaults to
+`mailto:admin@example.com` — push works regardless, but set it to a real
+address so a push service can reach you about your own subscriptions. Push
+requires the UI to be served over HTTPS (e.g. Tailscale
+`ts.net` certs); on iOS it needs the PWA installed.
 
 ## Voice / transcription
 

--- a/docs/setup/linear.md
+++ b/docs/setup/linear.md
@@ -31,11 +31,11 @@ your TLS proxy):
   in `~/.linear-agent-tokens.json` (written atomically, auto-refreshed 5
   minutes before expiry)
 
-**Requires code edit today:** the OAuth `redirect_uri` is hardcoded to
-`https://michael.tella.dev/oauth/callback` in `src/agents/linear/oauth.ts`
-(two occurrences: authorize + token exchange). On any other host you must
-edit that string (and register the same URI on your Linear OAuth app) —
-[portability-audit §1e](../portability-audit.md).
+The OAuth `redirect_uri` is derived, not hardcoded: it is
+`integrations.linear.oauthRedirectUrl` if you set it, otherwise
+`<server.publicBaseUrl>/oauth/callback`. Register whichever one applies on your
+Linear OAuth app — they must match exactly, including the scheme and any
+trailing path.
 
 The stored OAuth token is also overlaid onto the `linear` MCP server config
 at run time (`withDynamicCredentials` in `src/server/connections.ts`), so
@@ -63,7 +63,5 @@ Everything else is acked and ignored. There are no hardcoded team or bot user
 IDs — team ids are fetched per issue. Session state is persisted to disk so
 in-flight Linear sessions survive restarts.
 
-Note the default worktree paths target Tella's repo (e.g.
-`~/worktrees/<repo>-<branch>` in
-`src/agents/linear/session.ts` / `handlers.ts`) — repo retargeting is part of
-the portability workstream ([portability-audit §1b](../portability-audit.md)).
+Worktrees are cut at `<paths.worktreesDir>/<repo>-<branch>` against whichever
+repo the session resolves to, so nothing here is repo-specific.

--- a/docs/setup/plain.md
+++ b/docs/setup/plain.md
@@ -86,9 +86,6 @@ English regardless of the customer's language, with the customer's language
 noted so the team can translate before sending. Keep the same rule in any
 automation prompts you store in `~/.opensession-automations/`.
 
-**Tella-specific copy caveat:** the triage/router prompts describe Tella
-("a screen recording app") in code (`src/agents/plain/prompts.ts`,
-`ticket-router.ts`) — repointing them at your product is a code edit today
-([portability-audit §2f](../portability-audit.md); `persona.company` /
-`persona.product` in `~/.opensession/config.json` are parsed but not yet
-wired).
+The triage/router prompts describe your product from `persona.company`,
+`persona.product` and `persona.name` in `~/.opensession/config.json` — set
+those and the prompts follow.

--- a/docs/setup/slack.md
+++ b/docs/setup/slack.md
@@ -102,19 +102,18 @@ admin `remember`/`list_memory`/`forget` tools:
 - private channel → isolated `channel-<id>.json` + read-only workspace view
 - DM → isolated `user-<id>.json` + read-only workspace view
 
-## Hardcoded channel IDs (portability caveat)
+## Channel IDs
 
-The Slack agent itself contains no hardcoded channel/user IDs, but
-neighboring code does — using those features against your own workspace
-requires code edits today ([portability-audit §1d, §2d](../portability-audit.md)):
+No channel or user id is compiled in. Everything that posts to Slack resolves
+its destination from config, and an unset channel means that particular
+message is skipped rather than misdelivered:
 
-- `src/server/jsonl-parser.ts` — a channel-id→name map and
-  `SLACK_WORKSPACE = "tella-team"` (session labeling)
-- `src/agents/github/constants.ts` — docs-sync notification channel
-- `src/agents/plain/top-issues*.ts`, `src/agents/loops/cron-jobs.ts`,
-  `monitor.ts`, `stale-prs.ts` — rollup/report channels and a user id
-- `src/agents/grafana-poller/index.ts` — failure-card channel defaults
-  (env-overridable — see [integrations-misc.md](integrations-misc.md#grafana-poller))
+| Setting | Used for |
+| --- | --- |
+| `integrations.slack.workspaceId` | building `app.slack.com` deep links in session labels |
+| `integrations.slack.channelNames` | channel-id→name map for rendering transcripts |
+| `integrations.github.docsSyncChannel` | where docs-sync announces its PRs |
+| `SLACK_EXPORT_FAILURE_CHANNEL` / `SLACK_UPLOAD_FAILURE_CHANNEL` | Grafana-poller failure cards ([integrations-misc.md](integrations-misc.md#grafana-poller)) |
 
 Identity mapping (Slack id → person, for attribution and per-user MCP
 gating) is **not** hardcoded anymore: it derives from `identity.team` /

--- a/scripts/lib/onboard.ts
+++ b/scripts/lib/onboard.ts
@@ -6,10 +6,10 @@
  * service. Safe to re-run: existing files are backed up to `.bak-<n>` and an
  * existing config needs explicit confirmation.
  *
- * The load-bearing part is the env file. Integration flags default ON and
- * only the literal string "false" disables them, so an unconfigured fresh
- * install starts every agent loop against no credentials. Onboarding writes an
- * explicit disable for each integration the operator did not turn on.
+ * The load-bearing part is the env file. Integration flags default OFF and
+ * only the literal string "true" enables them, so anything unrecognised means
+ * off. Onboarding writes an explicit value for every integration rather than
+ * leaning on that, so the file says what is running instead of implying it.
  */
 
 import { chmodSync, copyFileSync, existsSync, mkdirSync } from "fs";

--- a/src/agents/github/constants.ts
+++ b/src/agents/github/constants.ts
@@ -1,6 +1,11 @@
 /** Shared identifiers for the github PR agent. */
 
-import { configuredRepos, defaultRepo, type Repo } from "../../server/config";
+import {
+  configuredIntegration,
+  configuredRepos,
+  defaultRepo,
+  type Repo,
+} from "../../server/config";
 
 /**
  * The configured repo a webhook's `repository.full_name` belongs to, or null.
@@ -43,8 +48,15 @@ export const PR_MERGED_EVENT_KEY = "github:pr_merged";
 export const DOCS_SYNC_AUTOMATION_NAME = "docs-sync";
 /** Branch prefix for docs-sync's own PRs — skipped on merge so it can't loop. */
 export const DOCS_SYNC_BRANCH_PREFIX = "auto-docs-sync-";
-/** #proj-help-center — where docs-sync announces the PRs it opens. */
-export const DOCS_SYNC_SLACK_CHANNEL = "C09BAFFK8F8";
+/**
+ * Slack channel where docs-sync announces the PRs it opens
+ * (`integrations.github.docsSyncChannel`). Undefined when unconfigured — the
+ * announcement is an optional courtesy, so docs-sync still runs without it.
+ */
+export function docsSyncChannel(): string | undefined {
+  const configured = configuredIntegration("github").docsSyncChannel;
+  return typeof configured === "string" && configured.trim() ? configured.trim() : undefined;
+}
 
 /**
  * PR trigger labels. Canonical names are the generic os-* ones; the legacy

--- a/src/agents/github/docs-sync-notify.ts
+++ b/src/agents/github/docs-sync-notify.ts
@@ -1,13 +1,13 @@
 /**
- * When a docs-sync PR is merged, tick the Slack announcement it posted in
- * #proj-help-center — mirroring how Mintlify's integration marked its own docs
- * PRs done. docs-sync's runner posts that announcement via the LLM (free-form,
- * so backstage never captured its `ts`), so we can't look the message up by a
- * stored id. Instead we find it at merge time by the PR URL it links, then add
- * a ✅ reaction. Best-effort: if the message isn't found we just log and move on.
+ * When a docs-sync PR is merged, tick the Slack announcement it posted in the
+ * docs channel. docs-sync's runner posts that announcement via the LLM
+ * (free-form, so we never captured its `ts`), so we can't look the message up
+ * by a stored id. Instead we find it at merge time by the PR URL it links,
+ * then add a ✅ reaction. Best-effort: if the message isn't found we just log
+ * and move on.
  */
 import { fetchChannelHistory, addReaction } from "../slack/slack-api";
-import { DOCS_SYNC_SLACK_CHANNEL } from "./constants";
+import { docsSyncChannel } from "./constants";
 
 const MERGED_REACTION = "white_check_mark";
 
@@ -22,15 +22,18 @@ function linksPr(text: string, prNumber: number): boolean {
  * history of the docs channel for the message that links this PR and reacts to it.
  */
 export async function markDocsSyncPrMerged(prNumber: number): Promise<void> {
-  const history = await fetchChannelHistory(DOCS_SYNC_SLACK_CHANNEL, 200);
+  const channel = docsSyncChannel();
+  if (!channel) return;
+
+  const history = await fetchChannelHistory(channel, 200);
   const message = history.find((m) => m.isBot && linksPr(m.text, prNumber));
   if (!message) {
     console.log(
-      `[github] docs-sync PR #${prNumber} merged, but no announcement found in #proj-help-center to check off`,
+      `[github] docs-sync PR #${prNumber} merged, but no announcement found in the docs channel to check off`,
     );
     return;
   }
 
-  await addReaction(DOCS_SYNC_SLACK_CHANNEL, message.ts, MERGED_REACTION);
+  await addReaction(channel, message.ts, MERGED_REACTION);
   console.log(`[github] Checked off docs-sync announcement for merged PR #${prNumber}`);
 }

--- a/src/agents/slack/index.ts
+++ b/src/agents/slack/index.ts
@@ -81,9 +81,9 @@ const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET || "";
 const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || "";
 
 /**
- * Shared-secret gate for the /worktree/* hooks. Caddy proxies all of the
- * public michael.tella.dev origin to this port, so these routes are reachable
- * from the open internet — without this check anyone could create Slack
+ * Shared-secret gate for the /worktree/* hooks. A reverse proxy fronts this
+ * port with a public origin, so these routes are reachable from the open
+ * internet — without this check anyone could create Slack
  * channels or archive worktree channels. Callers (the `wt` CLI) send
  * `x-worktree-secret` matching WORKTREE_HOOK_SECRET. Fail closed: no secret
  * configured means every request is rejected.

--- a/src/server/pr-images.ts
+++ b/src/server/pr-images.ts
@@ -1,8 +1,8 @@
 /**
  * PR image attachments — stage local screenshots into durable uploads storage
- * and serve them from unguessable public URLs on michael.tella.dev (the
- * webhook server's public origin), so GitHub's camo proxy can fetch them and
- * they render inline in PR/issue markdown everywhere — private repos included.
+ * and serve them from unguessable public URLs on the webhook server's public
+ * origin, so GitHub's camo proxy can fetch them and they render inline in
+ * PR/issue markdown everywhere — private repos included.
  *
  * Why this mechanism (empirical, 2026-07-26, probes on tellahq/backstage):
  * - GitHub's own attachment CDN (what the web UI uses — POST
@@ -15,16 +15,16 @@
  *   tellahq/backstage#78 (the click-through link works, the inline img 404s).
  * - raw.githubusercontent.com / release-asset URLs fail the same way or
  *   worse (raw.githubusercontent never sees github.com cookies at all).
- * - os.tella.dev media URLs get camo-rewritten but camo can't reach the
+ * - Tailnet-hosted media URLs get camo-rewritten but camo can't reach the
  *   tailnet — always broken (that's why the walkthrough mirror links media
  *   instead of inlining it).
  * - An image on a PUBLIC host renders everywhere: GitHub rewrites it to
  *   camo.githubusercontent.com, camo fetches it server-side and serves it
  *   from GitHub's CDN to anyone who can read the PR.
  *
- * Privacy model: third-party public hosts are banned for our screenshots
- * (PII rule), but michael.tella.dev is our own infra — the same public origin
- * that already receives Slack/Plain/GitHub webhooks. URLs carry a 128-bit
+ * Privacy model: third-party public hosts are banned for screenshots (PII
+ * rule), but the webhook origin is your own infra — the same one that already
+ * receives Slack/Plain/GitHub webhooks. URLs carry a 128-bit
  * random token (capability URL, like an unlisted share link); there is no
  * listing endpoint. Anyone with the URL (including GitHub's camo cache) can
  * fetch the image, so don't attach anything that must stay repo-member-only.

--- a/src/server/webhook-server.ts
+++ b/src/server/webhook-server.ts
@@ -1,6 +1,7 @@
 /**
  * Second Bun.serve() instance for webhook routes (port 3848).
- * Proxied by Caddy on michael.tella.dev.
+ * Bound to loopback; a TLS-terminating reverse proxy on a public hostname puts
+ * it where providers can reach it.
  * Agents register their routes via the AgentModule interface.
  */
 import type { AgentModule } from "../agents/types";


### PR DESCRIPTION
`docs/portability-audit.md` was deleted in `7287f517` as an "executed plan doc", but **eight pages still linked to it** by section number — and the claims those sections backed went unverified along with it. I checked every one against the code.

## Already done; the docs still said otherwise

| Claim in docs | Reality |
|---|---|
| Linear OAuth `redirect_uri` hardcoded to `michael.tella.dev` | derives from `integrations.linear.oauthRedirectUrl` → `publicBaseUrl` |
| Identity table is Tella's roster | `user-mappings.ts` derives from `configuredIdentity()` |
| `persona.company`/`product` "parsed but not yet wired" | wired into the Plain prompts and draft-automation |
| Grafana poller queries Tella's Loki labels | runs `cfg.lokiQuery` — configuration, not code |
| `SLACK_WORKSPACE = "tella-team"` | reads `integrations.slack.workspaceId` |
| VAPID contact hardcoded `michael@tella.dev` | reads `integrations.push.vapidSubject` |
| Worktree paths target Tella's repo | `paths.worktreesDir` |

`tellahq/tella-fusion` now survives only in test fixtures.

## Materially wrong, not just stale

Integration gating is **fail-closed** now — `isEnabled` requires the literal `"true"` — but `install.md` and `integrations-misc.md` both still said everything **defaults ON** and told operators to set flags to `"false"` to opt out. The `onboard.ts` header said the same. An operator following that on a fresh install ends up with every integration off and no idea why.

## Described a file that no longer exists

`.github/workflows/deploy.yml` is gone, so the "AWS account ID, region and instance ID are hardcoded in the workflow" caveat had nothing left to describe. `deploy/deploy.sh` remains and its drain-aware contract is unchanged, so that section now documents the script.

## Actually fixed

`DOCS_SYNC_SLACK_CHANNEL = "C09BAFFK8F8"` was the last compiled-in workspace identifier. Now `integrations.github.docsSyncChannel`, and an unset channel skips the announcement rather than failing — checking off a docs PR is a courtesy.

## Genericised

`michael.tella.dev` / `os.tella.dev` in `webhook-server.ts`, `pr-images.ts` and `slack/index.ts` comments. None were runtime values, but they read as though one deployment's hostname were the norm. Also corrected `local-profile.md`, which claimed `cloud.upstream` defaults to `os.tella.dev` when `configuredCloud()` falls back to `server.publicBaseUrl`.

## Verification

`bunx tsc --noEmit` clean. `bun test`: **1206 pass / 43 fail — identical to `origin/main`** (measured on the same commit; the 43 are pre-existing).