### PR TITLE
Migrate frontend styling from global CSS to Tailwind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ it from descending into chaos:
   something looks wrong, inspect and fix forward; don't roll back the shared tree.
 - **`git add <specific files>`, not `git add -A`** — multiple sessions may have
   uncommitted edits in this tree; only commit your own. High-traffic files
-  (`global.css`, `opensession.ts`, `App.tsx`) are sweep magnets: even a specific
+  (`adapters.css`, `opensession.ts`, `App.tsx`) are sweep magnets: even a specific
   `git add` on one of them can pick up another session's uncommitted hunks
   (it's happened three times: 2c89f14, 5a372890, and Kent's title commit). For
   those files use `git add -p` to stage only your hunks, and check
@@ -153,23 +153,24 @@ it from descending into chaos:
 
 ## Frontend UI system (Base UI + Tailwind + Motion)
 
-New UI goes through this stack; legacy `global.css` classes are migrated
-opportunistically when touched (strangler pattern — never a big-bang rewrite):
+New UI goes through this stack. Component-owned presentation belongs in
+Tailwind utilities; `adapters.css` is reserved for non-utility contracts:
 
-- **Tokens**: `src/frontend/styles/tailwind.css` maps the existing `global.css`
+- **Tokens**: `src/frontend/styles/tailwind.css` maps the variables from
+  `adapters.css`
   variables (`--bg`, `--text-dim`, …) into Tailwind's namespace via
   `@theme inline` — use `bg-panel text-dim border-line text-fg bg-surface` etc.,
   never raw hex or stock Tailwind grays. Dark/light theming comes for free
   because the vars re-resolve under `html[data-theme]`. The spacing/radius/text
-  scales are px-anchored there (global.css sets `html { font-size: 14px }`,
+  scales are px-anchored there (`adapters.css` sets `html { font-size: 14px }`,
   which would otherwise shrink every rem-based utility to 87.5%) — so `p-3` is
   a true 12px and `text-xs` a true 12px. Bare `rounded` bypasses the radius
   scale; use `rounded-sm/md/lg` (4/6/8px).
 - **Compile**: Tailwind is compiled by an `@tailwindcss/cli` subprocess inside
-  `buildFrontend()` (opensession.ts) and linked *after* `global.css`; utilities
-  are imported unlayered so they win source-order ties against legacy rules.
-  Preflight is intentionally NOT imported (global.css assumes browser
-  defaults). Don't import tailwind.css from App.tsx — Bun can't compile it.
+  `buildFrontend()` (opensession.ts). `tailwind.css` imports `adapters.css`
+  first, then imports utilities unlayered so they win equal-specificity ties.
+  Preflight is intentionally NOT imported (`adapters.css` owns the document and
+  form-control reset). Don't import tailwind.css from App.tsx — Bun can't compile it.
 - **Primitives**: wrap Base UI (`@base-ui/react`) per component in
   `src/frontend/ui/` (see `ui/tooltip.tsx` for the pattern). Rules: always
   pass `className` through `cn()` (ui/cn.ts); keep Base UI's composable parts

--- a/os1-tui/src/ui/theme.ts
+++ b/os1-tui/src/ui/theme.ts
@@ -1,5 +1,5 @@
 /**
- * Colors, lifted from the web UI's dark palette (src/frontend/styles/global.css)
+ * Colors, lifted from the web UI's dark palette (src/frontend/styles/adapters.css)
  * so the two clients read as the same product. Warm charcoal, not blue-black.
  *
  * A terminal already has a background, so we deliberately do NOT paint one on

--- a/os1-tui/test/app.test.tsx
+++ b/os1-tui/test/app.test.tsx
@@ -386,8 +386,16 @@ describe("tmux keys", () => {
 	test("two open tabs show a tab strip, and alt+← switches", async () => {
 		const app = await mount({
 			sessions: [
-				fakeSession({ id: "bks-1", title: "first one" }),
-				fakeSession({ id: "bks-2", title: "second one" }),
+				fakeSession({
+					id: "bks-1",
+					title: "first one",
+					lastActivity: "2026-01-02T00:00:00.000Z",
+				}),
+				fakeSession({
+					id: "bks-2",
+					title: "second one",
+					lastActivity: "2026-01-01T00:00:00.000Z",
+				}),
 			],
 		});
 		active = app;

--- a/scripts/frontend-dev.ts
+++ b/scripts/frontend-dev.ts
@@ -191,11 +191,9 @@ async function tailwindCss(): Promise<Response> {
 }
 
 // Serve the SPA shell through a rewriter: fetch Bun's HTML-import output from
-// the internal /__shell route and add the Tailwind link (after the bundled
-// global.css so utilities keep winning source-order ties, as in prod), plus a
-// watcher that hot-swaps that link when the compiled output changes — Bun's
-// HMR covers the bundle (App.tsx, global.css) but knows nothing about our
-// injected stylesheet.
+// the internal /__shell route and add the compiled Tailwind link, plus a watcher
+// that hot-swaps that link when the compiled output changes. Bun's HMR covers
+// the JS bundle but knows nothing about our injected stylesheet.
 const TW_REFRESH = `<script>
 (() => {
 	let last = null;
@@ -226,7 +224,7 @@ async function shell(req: Request): Promise<Response> {
 
 const server = Bun.serve<Bridge>({
 	port: PORT,
-	// hmr: edits to App.tsx/global.css hot-apply without a manual Cmd+R
+	// hmr: edits to App.tsx hot-apply without a manual Cmd+R
 	// (React Fast Refresh through Bun's dev pipeline).
 	development: { hmr: true, console: true },
 	idleTimeout: 240,

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -37,9 +37,8 @@ language instead of introducing a new local style for each feature.
 
 ## Styling
 
-- Use Tailwind utilities for new and touched UI. Migrate nearby legacy
-  `global.css` classes when it is practical, but do not perform unrelated
-  broad rewrites.
+- Use Tailwind utilities for component-owned presentation. Keep marker classes
+  only when JavaScript or a shared state selector consumes them.
 - Use the semantic tokens from `styles/tailwind.css`, such as `bg-panel`,
   `text-fg`, `text-dim`, and `border-line`. Never add raw color values or stock
   Tailwind palette colors to product UI.
@@ -47,7 +46,7 @@ language instead of introducing a new local style for each feature.
   primitives so callers can adjust layout without copying the component.
 - Paint interaction states with the hover washes — `hover:bg-hover` /
   `bg-pressed` in Tailwind, `var(--hover)` / `var(--hover-strong)` in
-  `global.css`. They are translucent ink, so one token reads at the same
+  `adapters.css`. They are translucent ink, so one token reads at the same
   strength on any surface. Do not use `--bg-hover` or `--bg-raised` as a hover:
   they are absolute surfaces, so they land as a heavy wash on `--bg` and a
   nearly invisible one on `--bg-panel`, and `--bg-raised` steps the wrong way in
@@ -61,9 +60,9 @@ language instead of introducing a new local style for each feature.
 - Match the surrounding surface before adding visual emphasis. Accent colors,
   raised surfaces, shadows, and animation should communicate meaning, not make
   a new feature louder than its neighbors.
-- Add rules to `global.css` only when they are truly global, theme-level, or
-  part of a legacy surface that cannot yet be migrated. Component styling
-  belongs with the component.
+- Add rules to `adapters.css` only for document/theme foundations,
+  generated-content or third-party adapters, native shell hooks, responsive
+  state coupling, and shared keyframes. Component styling belongs in JSX.
 
 ## Interaction and accessibility
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -154,10 +154,6 @@ import {
 import { copySessionTranscript } from "./lib/transcript-copy";
 import { effectiveTheme, setThemePref } from "./lib/theme";
 import type { UnifiedSession } from "./lib/types";
-// Legacy stylesheet remains only for cross-tree state selectors (`html.wco`,
-// `body.kb-open`, `body.chrome-collapsed`, and sidebar-owned chrome). This shell
-// keeps those hooks, but its visual layout is expressed by local utilities below.
-import "./styles/global.css";
 
 type Route =
 	| { view: "home" }

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -3496,7 +3496,7 @@ function App() {
 						/>
 					</div>
 
-					<div className="workspace-shell flex min-w-0 flex-1 overflow-hidden rounded-panel bg-bg min-[721px]:m-2 min-[721px]:border min-[721px]:border-line">
+					<div className="workspace-shell flex min-w-0 flex-1 overflow-hidden rounded-panel bg-bg max-[720px]:contents min-[721px]:m-2 min-[721px]:border min-[721px]:border-line">
 						<main className="detail-pane relative flex min-h-0 min-w-0 flex-1 flex-col" ref={detailPaneRef}>
 						{/* WCO back/forward fallback: the primary cluster lives in the
 						    sidebar's top chrome row, which vanishes when the sidebar is

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -154,6 +154,9 @@ import {
 import { copySessionTranscript } from "./lib/transcript-copy";
 import { effectiveTheme, setThemePref } from "./lib/theme";
 import type { UnifiedSession } from "./lib/types";
+// Legacy stylesheet remains only for cross-tree state selectors (`html.wco`,
+// `body.kb-open`, `body.chrome-collapsed`, and sidebar-owned chrome). This shell
+// keeps those hooks, but its visual layout is expressed by local utilities below.
 import "./styles/global.css";
 
 type Route =
@@ -3069,7 +3072,7 @@ function App() {
 					</Modal.Footer>
 				</Modal.Content>
 			</Modal.Root>
-			<div className="app">
+			<div className="app relative flex h-full min-h-0 flex-col overflow-hidden bg-bg text-body text-fg">
 				{/* Mobile-only top bar. On the sidebar-root page it shows the brand;
 				    on a pushed page (a session or other view) the brand is replaced by
 				    a Back chevron that pops back to the root, iOS-style. On desktop the
@@ -3078,16 +3081,16 @@ function App() {
 				    suppress this one there to avoid a duplicate back bar. */}
 				{route.view !== "catchup" && (
 				<header
-					className={`app-header${mobileDetail ? " app-header-detail" : ""}${
+					className={`app-header relative z-20 hidden min-h-[calc(env(safe-area-inset-top,0px)+52px)] shrink-0 items-center justify-between px-3 pb-0 pt-[max(env(safe-area-inset-top,0px),8px)] max-[720px]:flex max-[390px]:px-2 ${mobileDetail ? " app-header-detail" : ""}${
 						route.view === "home" || route.view === "session"
 							? " app-header-overlay"
 							: ""
 					}`}
 				>
-					<div className="app-header-left">
+					<div className="app-header-left flex min-w-0 items-center gap-2">
 						{mobileDetail ? (
 							<button
-								className="mobile-back"
+								className="mobile-back hit-target inline-flex size-10 items-center justify-center rounded-full border border-line bg-panel p-0 text-accent shadow-[0_2px_12px_rgba(0,0,0,0.1)] active:opacity-35"
 								onClick={goBack}
 								aria-label="Back to sidebar"
 							>
@@ -3116,7 +3119,7 @@ function App() {
 					    title. Desktop hides the whole bar. */}
 					{mobileDetail && (
 						<span
-							className={`app-header-title ${
+							className={`app-header-title absolute left-[56px] right-[56px] bottom-0 flex h-[52px] min-w-0 items-center justify-center gap-1.5 truncate text-item-title font-semibold tracking-[-0.01em] text-fg ${
 								route.view === "session" && currentSession
 									? "session-settings-trigger app-header-title-tappable"
 									: ""
@@ -3137,11 +3140,11 @@ function App() {
 							    metadata below it in a stacked column. The whole pill is one
 							    tap target that opens the session's deeper info page. */}
 							{route.view === "session" && currentSession && (
-								<span className="app-header-repo" ref={setHeaderRepoEl} />
+								<span className="app-header-repo inline-flex shrink-0 items-center" ref={setHeaderRepoEl} />
 							)}
-							<span className="app-header-title-col">
-								<span className="app-header-title-row">
-									<span className="app-header-title-text">
+							<span className="app-header-title-col flex min-w-0 flex-col items-center">
+								<span className="app-header-title-row flex min-w-0 items-center gap-1.5">
+									<span className="app-header-title-text max-w-full truncate">
 										{route.view === "session"
 											? (activeProjectId
 												? projects.find((p) => p.id === activeProjectId)?.name
@@ -3153,18 +3156,18 @@ function App() {
 								</span>
 								{route.view === "session" && currentSession && (
 									// Filled by SessionViewer's portal (compact model selector).
-									<span className="app-header-model" ref={setHeaderModelEl} />
+									<span className="app-header-model min-w-0 text-meta text-dim" ref={setHeaderModelEl} />
 								)}
 							</span>
 						</span>
 					)}
-					<div className="app-header-actions" ref={setHeaderActionsEl}>
+					<div className="app-header-actions ml-auto flex min-w-0 items-center gap-2" ref={setHeaderActionsEl}>
 						{/* On the root page the actions slot is otherwise empty (session
 						    actions only portal in on pushed pages) — it carries Search,
 						    which lives in the top bar on phones instead of the sidebar. */}
 						{!mobileDetail && (
 							<button
-								className="mobile-search-btn"
+								className="mobile-search-btn hit-target inline-flex size-10 items-center justify-center rounded-full border border-line bg-panel p-0 text-accent shadow-[0_2px_12px_rgba(0,0,0,0.1)] active:opacity-35"
 								onClick={() => setSearchOpen(true)}
 								aria-label="Open command menu"
 							>
@@ -3228,7 +3231,7 @@ function App() {
 				    full page and replaces it. */}
 				{(!settingsActive || isPhone) && (
 				<div
-					className={`app-body ${mobileDetail ? "mobile-detail" : "mobile-root"}${
+					className={`app-body flex min-h-0 flex-1 ${mobileDetail ? "mobile-detail" : "mobile-root"}${
 						sidebarCollapsed ? " sidebar-collapsed" : ""
 					}`}
 				>
@@ -3497,8 +3500,8 @@ function App() {
 						/>
 					</div>
 
-					<div className="workspace-shell">
-						<main className="detail-pane" ref={detailPaneRef}>
+					<div className="workspace-shell flex min-w-0 flex-1 overflow-hidden rounded-panel bg-bg min-[721px]:m-2 min-[721px]:border min-[721px]:border-line">
+						<main className="detail-pane relative flex min-h-0 min-w-0 flex-1 flex-col" ref={detailPaneRef}>
 						{/* WCO back/forward fallback: the primary cluster lives in the
 						    sidebar's top chrome row, which vanishes when the sidebar is
 						    collapsed — this floating copy shows only then (CSS-gated). */}
@@ -3508,7 +3511,7 @@ function App() {
 						    sidebar can always be brought back. */}
 						<Tooltip label="Show sidebar" side="right" shortcut={["⌘", "B"]}>
 							<button
-								className="sidebar-reopen"
+								className="sidebar-reopen hidden items-center justify-center rounded-md border border-line bg-panel p-1.5 text-dim shadow-control hover:bg-hover hover:text-fg min-[721px]:[.sidebar-collapsed_&]:inline-flex"
 								onClick={toggleSidebarCollapsed}
 								aria-label="Show sidebar"
 							>
@@ -3518,15 +3521,15 @@ function App() {
 						{/* Top bar: session name + actions (portaled in by SessionViewer)
 						    on session routes, a plain title otherwise. Sits above the tab
 						    strip so the session identity reads first, tabs below it. */}
-						<div className="detail-topbar" ref={setTopbarEl}>
+						<div className="detail-topbar flex min-w-0 shrink-0 flex-col empty:hidden" ref={setTopbarEl}>
 							{route.view !== "session" && topbarTitle && (
-								<span className="detail-topbar-title">{topbarTitle}</span>
+								<span className="detail-topbar-title flex h-[var(--desktop-header-h)] items-center border-b border-line bg-surface px-4 text-body font-semibold text-fg">{topbarTitle}</span>
 							)}
 						</div>
 						{!activeTabSplit && renderTabBar(null)}
 						{splitDropSide && (
 							<div
-								className={`tab-split-drop-preview tab-split-drop-preview-${splitDropSide}`}
+								className={`tab-split-drop-preview tab-split-drop-preview-${splitDropSide} pointer-events-none absolute bottom-2 z-20 w-[calc(50%-12px)] rounded-md border-2 border-accent bg-[color-mix(in_srgb,var(--accent)_18%,transparent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,white_16%,transparent)] ${splitDropSide === "left" ? "left-2" : "right-2"}`}
 								aria-hidden="true"
 							/>
 						)}
@@ -3553,7 +3556,7 @@ function App() {
 									onOpenSession={(id) => navigate({ view: "session", id })}
 								/>
 							) : (
-								<div className="panel-placeholder">
+								<div className="panel-placeholder px-4 py-12 text-center text-control-label text-faint">
 									{projectsLoaded ? "Workspace not found." : "Loading workspace…"}
 								</div>
 							)
@@ -3723,14 +3726,14 @@ function App() {
 									)
 								)
 							) : (
-								<div className="detail-empty">
-									<div className="detail-empty-inner">
+								<div className="detail-empty flex flex-1 items-center justify-center">
+									<div className="detail-empty-inner text-center">
 										{(() => {
 											const isLoading =
 												loading || route.id === pendingSessionId;
 											return (
 												<>
-													<div className="detail-empty-title">
+													<div className="detail-empty-title text-section-title font-semibold text-fg">
 														{!isLoading
 															? "Session not found"
 															: route.id === pendingSessionId
@@ -3739,7 +3742,7 @@ function App() {
 																	: "Starting a new chat…"
 																: "Loading session…"}
 													</div>
-													<div className="detail-empty-sub">
+													<div className="detail-empty-sub mt-1.5 text-control-label text-dim">
 														{isLoading ? "" : "It may have been deleted."}
 													</div>
 												</>
@@ -3763,7 +3766,7 @@ function App() {
 						{/* Full-height right column inside the same rounded workspace shell as
 						    the detail pane. The active session's workspace/sub-agent panel
 						    portals in here. */}
-						<div className="right-panel-slot" ref={setRightPanelEl} />
+						<div className="right-panel-slot contents" ref={setRightPanelEl} />
 					</div>
 				</div>
 				)}

--- a/src/frontend/components/Actions.tsx
+++ b/src/frontend/components/Actions.tsx
@@ -98,7 +98,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
         className={sel ? "mb-3.5 items-center" : "max-[560px]:mb-5 max-[560px]:flex-col max-[560px]:items-start max-[560px]:gap-3.5"}
       >
         <div>
-          <PageTitle className={sel ? "text-base" : undefined}>Actions</PageTitle>
+          <PageTitle className={sel ? "text-body" : undefined}>Actions</PageTitle>
           <PageDescription className={sel ? "hidden" : undefined}>
             Run a registered repo script behind a form. Each run opens as a session you can fork.
           </PageDescription>
@@ -195,7 +195,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
           </div>
           <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto px-5 pb-10 pt-[18px]">
             {sel.description && (
-              <div className="bg-surface border border-line rounded-panel px-3.5 py-3 text-[13px] leading-relaxed text-dim">
+              <div className="bg-surface border border-line rounded-panel px-3.5 py-3 text-control-label leading-relaxed text-dim">
                 {sel.description}
               </div>
             )}
@@ -630,7 +630,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
       <div className="flex justify-end gap-2.5">
         <Button
           size="sm"
-          className="min-h-7 border-line-strong bg-transparent px-3 text-[13px]"
+          className="min-h-7 border-line-strong bg-transparent px-3 text-control-label"
           onClick={onClose}
           disabled={saving}
         >

--- a/src/frontend/components/Actions.tsx
+++ b/src/frontend/components/Actions.tsx
@@ -17,6 +17,7 @@ import { Button } from "../ui/button";
 import { PageSection } from "../ui/page";
 import { PageDescription, PageHeader, PageTitle } from "../ui/page-header";
 import { InlineAlert } from "../ui/state";
+import { cn } from "../ui/cn";
 
 interface Props {
   onOpenSession: (sessionId: string) => void;
@@ -90,8 +91,8 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
   }
 
   return (
-    <div className={`automations-page ${sel ? "automations-page-has-detail" : ""}`}>
-    <div className="automations-page-main">
+    <div className="relative flex min-h-0 min-w-0 flex-1">
+    <div className={cn("min-w-0 flex-1 overflow-y-auto px-6 pb-[60px] pt-7 max-[560px]:px-4 max-[560px]:pb-12 max-[560px]:pt-5", sel && "basis-[340px] grow-0 border-r border-line px-3.5 pb-10 pt-4 max-[900px]:hidden")}>
     <PageSection>
       <PageHeader
         className={sel ? "mb-3.5 items-center" : "max-[560px]:mb-5 max-[560px]:flex-col max-[560px]:items-start max-[560px]:gap-3.5"}
@@ -126,23 +127,23 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
       {loading ? (
         <div className="loading">Loading…</div>
       ) : actions.length === 0 ? (
-        <div className="automations-empty">
+        <div className="px-4 py-12 text-center text-dim">
           <p>No actions yet.</p>
-          <p className="automations-empty-sub">
+          <p className="text-control-label text-faint">
             Register a script from a repo (e.g. scripts/run-maintenance.sh).
           </p>
         </div>
       ) : (
-        <div className="automations-table">
+        <div className="flex flex-col border-t border-line">
           {actions.map((a) => (
             <button
               key={a.id}
-              className={`automations-row ${sel?.id === a.id ? "active" : ""}`}
+              className={cn("flex w-full min-w-0 items-center gap-3 border-0 border-b border-line bg-transparent px-2.5 py-2.5 text-left text-fg hover:bg-hover max-[560px]:gap-2.5 max-[560px]:px-1 max-[560px]:py-3", sel?.id === a.id && "bg-active")}
               onClick={() => onSelect(a.id)}
             >
-              <span className="automations-row-main">
-                <span className="automations-row-name">{a.name}</span>
-                <span className="automations-row-trigger">
+              <span className="flex min-w-0 flex-1 flex-col gap-px">
+                <span className="truncate text-body font-semibold">{a.name}</span>
+                <span className="truncate font-mono text-meta text-faint">
                   {a.kind === "mcp"
                     ? `${a.mcpServer} · ${a.toolName}`
                     : `${a.repo} · ${a.scriptPath}`}
@@ -153,7 +154,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
                   confirm
                 </span>
               )}
-              <span className="automations-row-next">
+              <span className="w-[84px] shrink-0 text-right text-label text-faint max-[560px]:hidden">
                 {a.lastRunAt ? relativeTime(a.lastRunAt) : ""}
               </span>
             </button>
@@ -164,10 +165,10 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
     </div>
 
       {sel && (
-        <aside className="automations-drawer">
-          <div className="automations-drawer-head">
+        <aside className="flex min-h-0 min-w-0 flex-1 flex-col border-l border-line bg-panel max-[900px]:border-l-0">
+          <div className="flex shrink-0 items-center gap-2.5 border-b border-line px-4 py-3">
             <button
-              className="automations-drawer-back"
+              className="-my-1 -ml-0.5 hidden shrink-0 items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-body font-medium text-fg max-[900px]:inline-flex"
               onClick={() => onSelect("")}
               title="Back to actions"
             >
@@ -176,14 +177,14 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
               Actions
             </button>
-            <span className="automations-drawer-title">{sel.name}</span>
-            <div className="automations-drawer-actions">
+            <span className="min-w-0 truncate text-control-label font-semibold">{sel.name}</span>
+            <div className="ml-auto flex shrink-0 gap-1.5">
               <Button size="sm" variant="danger" onClick={() => handleDelete(sel)}>
                 Delete
               </Button>
             </div>
             <button
-              className="automations-drawer-close"
+              className="flex size-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-dim hover:bg-hover hover:text-fg max-[900px]:hidden"
               onClick={() => onSelect("")}
               title="Close"
             >
@@ -192,7 +193,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
             </button>
           </div>
-          <div className="automations-drawer-body">
+          <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto px-5 pb-10 pt-[18px]">
             {sel.description && (
               <div className="bg-surface border border-line rounded-panel px-3.5 py-3 text-[13px] leading-relaxed text-dim">
                 {sel.description}
@@ -200,7 +201,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
             )}
 
             <div>
-              <div className="automations-drawer-section-label mb-1.5">Run</div>
+              <div className="mb-1.5 text-label font-semibold text-faint">Run</div>
               <RunForm
                 key={sel.id}
                 action={sel}
@@ -212,8 +213,8 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
             </div>
 
             <div>
-              <div className="automations-drawer-section-label mb-1.5">Configuration</div>
-              <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-[13px]">
+              <div className="mb-1.5 text-label font-semibold text-faint">Configuration</div>
+              <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-control-label">
                 <DetailKey>Type</DetailKey>
                 <span className="text-dim">
                   {sel.kind === "mcp"
@@ -223,7 +224,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
 
                 <DetailKey>{sel.kind === "mcp" ? "Tool" : "Script"}</DetailKey>
                 <span className="text-dim min-w-0">
-                  <span className="automation-cron">
+                  <span className="rounded-sm bg-active px-1.5 py-px font-mono text-meta">
                     {sel.kind === "mcp"
                       ? `${sel.mcpServer} · ${sel.toolName}`
                       : `${sel.repo}:${sel.scriptPath}`}
@@ -252,7 +253,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
             </div>
 
             <div>
-              <div className="automations-drawer-section-label mb-1.5">Activity</div>
+              <div className="mb-1.5 text-label font-semibold text-faint">Activity</div>
               {sel.lastRunAt ? (
                 <div className="text-dim text-supporting">
                   last run {relativeTime(sel.lastRunAt)}
@@ -260,7 +261,7 @@ export function Actions({ onOpenSession, selectedId, onSelect }: Props) {
                     <>
                       {" · "}
                       <a
-                        className="automation-session-link"
+                        className="text-accent hover:underline"
                         onClick={(e) => {
                           e.preventDefault();
                           onOpenSession(sel.lastRunSessionId!);
@@ -320,7 +321,7 @@ function RunForm({
   }
 
   return (
-    <div className="automation-form automation-form-inline">
+    <div className="flex flex-col gap-3.5 [&_label]:flex [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg">
       {action.inputs.length === 0 && (
         <div className="mt-1 text-supporting text-faint">This action takes no inputs.</div>
       )}
@@ -370,7 +371,7 @@ function RunForm({
 
       {error && <InlineAlert>{error}</InlineAlert>}
 
-      <div className="automation-form-actions" style={{ justifyContent: "flex-start" }}>
+      <div className="flex justify-start gap-2.5">
         <Button variant="primary" className="px-[22px]" onClick={run} disabled={busy}>
           {busy ? "Starting…" : action.confirm ? "Confirm & run" : "Run"}
         </Button>
@@ -464,8 +465,8 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
   }
 
   return (
-    <div className="automation-form">
-      <div className="automation-form-title">New action</div>
+    <div className="flex flex-col gap-3.5 rounded-panel border border-line-strong bg-panel p-[18px] [&_label]:flex [&_label]:flex-1 [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg">
+      <div className="text-body font-semibold">New action</div>
 
       <label>
         Name
@@ -490,7 +491,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
       </label>
 
       {kind === "repo" ? (
-        <div className="automation-form-row">
+        <div className="flex gap-3.5">
           <label>
             Repo
             <select value={repo} onChange={(e) => setRepo(e.target.value)}>
@@ -518,7 +519,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
           </label>
         </div>
       ) : (
-        <div className="automation-form-row">
+        <div className="flex gap-3.5">
           <label style={{ flex: 2 }}>
             MCP server
             <input
@@ -548,7 +549,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
       )}
 
       {kind === "repo" && (
-        <div className="automation-form-actions" style={{ justifyContent: "flex-start" }}>
+        <div className="flex justify-start gap-2.5">
           <Button
             size="sm"
             className="border-line-strong bg-transparent"
@@ -560,12 +561,12 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
         </div>
       )}
 
-      <div className="automation-form-title" style={{ fontSize: 14, marginTop: 8 }}>
+      <div className="mt-2 text-body font-semibold">
         Inputs {kind === "mcp" ? "(arg names)" : argMode === "positional" ? "(in order →)" : ""}
       </div>
       {inputs.length === 0 && <div className="mt-1 text-supporting text-faint">No inputs — the script runs with no args.</div>}
       {inputs.map((input, idx) => (
-        <div className="automation-form-row" key={idx} style={{ alignItems: "flex-end" }}>
+        <div className="flex items-end gap-3.5" key={idx}>
           <label>
             Variable name
             <input
@@ -609,7 +610,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
           </Button>
         </div>
       ))}
-      <div className="automation-form-actions" style={{ justifyContent: "flex-start" }}>
+      <div className="flex justify-start gap-2.5">
         <Button size="sm" className="border-line-strong bg-transparent" onClick={addInput}>
           + Add input
         </Button>
@@ -626,7 +627,7 @@ function ActionForm({ onClose, onCreated }: { onClose: () => void; onCreated: ()
 
       {error && <InlineAlert>{error}</InlineAlert>}
 
-      <div className="automation-form-actions">
+      <div className="flex justify-end gap-2.5">
         <Button
           size="sm"
           className="min-h-7 border-line-strong bg-transparent px-3 text-[13px]"

--- a/src/frontend/components/Archived.tsx
+++ b/src/frontend/components/Archived.tsx
@@ -4,6 +4,7 @@ import { relativeTime, archiveSessionApi } from "../lib/api";
 import { useCurrentUser } from "./UserPicker";
 import { docTitle, DEFAULT_DOC_TITLE } from "../lib/brand";
 import { PageLayout } from "../ui/page";
+import { cn } from "../ui/cn";
 
 interface Props {
   sessions: UnifiedSession[];
@@ -130,8 +131,7 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
       }
       actions={
         <input
-          className="sidebar-search"
-          style={{ maxWidth: 260 }}
+          className="w-full max-w-[260px] rounded-md border border-line bg-panel px-2.5 py-1.5 text-control-label text-fg outline-none placeholder:text-faint focus:border-accent"
           placeholder="Search archived…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -139,24 +139,24 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
       }
       filters={
         <>
-          <div className="seg-control" role="group" aria-label="Owner">
+          <div className="inline-flex gap-0.5 rounded-md bg-hover p-0.5" role="group" aria-label="Owner">
             <button
-              className={`seg-control-btn${owner === "mine" ? " active" : ""}`}
+              className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", owner === "mine" && "bg-active text-fg")}
               onClick={() => setOwner("mine")}
             >
               My archived
             </button>
             <button
-              className={`seg-control-btn${owner === "everyone" ? " active" : ""}`}
+              className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", owner === "everyone" && "bg-active text-fg")}
               onClick={() => setOwner("everyone")}
             >
               Everyone
             </button>
           </div>
           {repos.length > 1 && (
-            <div className="seg-control" role="group" aria-label="Repo">
+            <div className="inline-flex gap-0.5 rounded-md bg-hover p-0.5" role="group" aria-label="Repo">
               <button
-                className={`seg-control-btn${repo === "all" ? " active" : ""}`}
+                className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", repo === "all" && "bg-active text-fg")}
                 onClick={() => setRepo("all")}
               >
                 All repos
@@ -164,7 +164,7 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
               {repos.map((name) => (
                 <button
                   key={name}
-                  className={`seg-control-btn${repo === name ? " active" : ""}`}
+                  className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", repo === name && "bg-active text-fg")}
                   onClick={() => setRepo(name)}
                 >
                   {name}
@@ -172,21 +172,21 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
               ))}
             </div>
           )}
-          <div className="seg-control" role="group" aria-label="Reason">
+          <div className="inline-flex gap-0.5 rounded-md bg-hover p-0.5" role="group" aria-label="Reason">
             <button
-              className={`seg-control-btn${reason === "all" ? " active" : ""}`}
+              className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", reason === "all" && "bg-active text-fg")}
               onClick={() => setReason("all")}
             >
               All
             </button>
             <button
-              className={`seg-control-btn${reason === "auto" ? " active" : ""}`}
+              className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", reason === "auto" && "bg-active text-fg")}
               onClick={() => setReason("auto")}
             >
               Auto-archived
             </button>
             <button
-              className={`seg-control-btn${reason === "manual" ? " active" : ""}`}
+              className={cn("whitespace-nowrap rounded-sm border-0 bg-transparent px-2.5 py-1 text-supporting font-medium text-faint hover:text-dim", reason === "manual" && "bg-active text-fg")}
               onClick={() => setReason("manual")}
             >
               Manual
@@ -196,7 +196,7 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
       }
     >
       {archived.length === 0 ? (
-        <div className="automations-empty">
+        <div className="px-4 py-12 text-center text-dim">
           <p>Nothing archived{search || owner === "mine" || repo !== "all" ? " matches" : " yet"}.</p>
         </div>
       ) : (

--- a/src/frontend/components/Archived.tsx
+++ b/src/frontend/components/Archived.tsx
@@ -219,7 +219,7 @@ export function Archived({ sessions, onSelect, onChanged }: Props) {
                 </span>
               </span>
               <span
-                className="inline-flex cursor-pointer rounded-sm border border-line-strong px-2.5 py-[3px] text-xs text-dim hover:border-faint hover:text-fg"
+                className="inline-flex cursor-pointer rounded-sm border border-line-strong px-2.5 py-[3px] text-label text-dim hover:border-faint hover:text-fg"
                 role="button"
                 onClick={(e) => handleUnarchive(e, s.id)}
               >

--- a/src/frontend/components/AskCard.tsx
+++ b/src/frontend/components/AskCard.tsx
@@ -21,7 +21,7 @@ interface Props {
  *
  * Selection is NEUTRAL, not accent: the accent is red here, and filling a
  * chosen row with it read as an error/warning rather than a pick. Same reason
- * the composer keeps its resting border on focus (see .composer in global.css).
+ * the composer keeps its resting border on focus (see .composer in adapters.css).
  * It also doesn't tint the row at all — the filled indicator carries it, with
  * the hairline stepping up. The indicator is a circle for single-select and a
  * rounded square for multi-select, so the shape says how many answers are

--- a/src/frontend/components/AssetsPanel.tsx
+++ b/src/frontend/components/AssetsPanel.tsx
@@ -201,7 +201,7 @@ export function AssetsPanel({
 	if (!files.length) {
 		return (
 			<div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-1 px-6 text-center">
-				<div className="text-[13px] text-dim">No assets yet</div>
+				<div className="text-control-label text-dim">No assets yet</div>
 				<div className="max-w-[360px] text-label text-faint">
 					Ask the agent to save a visualization, report, or demo page here —
 					it writes files with opensession-assets' write_asset and they
@@ -216,7 +216,7 @@ export function AssetsPanel({
 			{showTree ? (
 			<div className="flex max-h-[38%] min-h-[88px] flex-col overflow-hidden border-b border-line">
 				<div className="flex items-center justify-between px-3 pt-2 pb-1">
-					<span className="text-[11px] font-medium uppercase tracking-wide text-faint">
+                    <span className="text-meta font-medium uppercase tracking-wide text-faint">
 						Files · {files.length}
 					</span>
 					<Button
@@ -248,11 +248,11 @@ export function AssetsPanel({
 						>
 							{file.path}
 						</span>
-						<span className="shrink-0 text-[11px] text-faint">
+                        <span className="shrink-0 text-meta text-faint">
 							{fmtSize(file.size)}
 						</span>
 						<a
-							className="shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-dim hover:bg-hover hover:text-fg"
+                            className="shrink-0 rounded-sm px-1.5 py-0.5 text-meta text-dim hover:bg-hover hover:text-fg"
 							href={rawUrl}
 							target="_blank"
 							rel="noreferrer"
@@ -260,13 +260,13 @@ export function AssetsPanel({
 							Open
 						</a>
 						<a
-							className="shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-dim hover:bg-hover hover:text-fg"
+                            className="shrink-0 rounded-sm px-1.5 py-0.5 text-meta text-dim hover:bg-hover hover:text-fg"
 							href={`${rawUrl}&download=1`}
 						>
 							Download
 						</a>
 						<button
-							className="shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-dim hover:bg-hover hover:text-red"
+                            className="shrink-0 rounded-sm px-1.5 py-0.5 text-meta text-dim hover:bg-hover hover:text-red"
 							onClick={onDelete}
 						>
 							Delete
@@ -323,7 +323,7 @@ export function AssetsPanel({
 								<div className="p-4 text-label text-faint">Loading…</div>
 							) : (
 								<MarkdownBody
-									className="markdown px-4 py-3 text-[13px]"
+                                    className="markdown px-4 py-3 text-control-label"
 									html={marked.parse(text, { async: false }) as string}
 								/>
 							)

--- a/src/frontend/components/Automations.tsx
+++ b/src/frontend/components/Automations.tsx
@@ -23,6 +23,7 @@ import { AGENT_NAME, PUBLIC_BASE_URL, docTitle, DEFAULT_DOC_TITLE } from "../lib
 import { Button } from "../ui/button";
 import { PageDescription, PageHeader, PageTitle } from "../ui/page-header";
 import { InlineAlert } from "../ui/state";
+import { cn } from "../ui/cn";
 
 interface AutomationRun {
   at: string;
@@ -201,9 +202,9 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
   }
 
   return (
-    <div className={`automations-page ${sel ? "automations-page-has-detail" : ""}`}>
-    <div className="automations-page-main">
-    <div className="automations-page-inner">
+    <div className="relative flex min-h-0 min-w-0 flex-1">
+    <div className={cn("min-w-0 flex-1 overflow-y-auto px-6 pb-[60px] pt-7 max-[560px]:px-4 max-[560px]:pb-12 max-[560px]:pt-5", sel && "basis-[340px] grow-0 border-r border-line px-3.5 pb-10 pt-4 max-[900px]:hidden")}>
+    <div className={cn("mx-auto max-w-[860px]", sel && "max-w-none")}>
       <PageHeader
         className={`max-[560px]:mb-5 max-[560px]:flex-col max-[560px]:items-start max-[560px]:gap-3.5 ${sel ? "mb-3.5 items-center" : ""}`}
       >
@@ -230,38 +231,38 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
       {loading ? (
         <div className="loading">Loading…</div>
       ) : automations.length === 0 && !showModal ? (
-        <div className="automations-empty">
+        <div className="px-4 py-12 text-center text-dim">
           <p>No automations yet.</p>
-          <p className="automations-empty-sub">
+          <p className="text-control-label text-faint">
             Schedule recurring work: daily PR-review sweeps, dependency checks, weekly
             changelog drafts, flaky-test hunts…
           </p>
         </div>
       ) : (
-        <div className="automations-table">
+        <div className="flex flex-col border-t border-line">
           {automations.map((a) => {
             const running = a.isRunning || a.lastRunStatus === "running";
             return (
               <button
                 key={a.id}
-                className={`automations-row ${sel?.id === a.id ? "active" : ""} ${a.enabled ? "" : "automations-row-off"}`}
+                className={cn("flex w-full min-w-0 items-center gap-3 border-0 border-b border-line bg-transparent px-2.5 py-2.5 text-left text-fg hover:bg-hover max-[560px]:gap-2.5 max-[560px]:px-1 max-[560px]:py-3", sel?.id === a.id && "bg-active", !a.enabled && "[&_.automation-row-main]:opacity-55")}
                 onClick={() => onSelect(a.id)}
               >
                 {/* Inner controls are spans — the row itself is a button. */}
                 <span
                   role="button"
-                  className={`auto-toggle ${a.enabled ? "auto-toggle-on" : ""}`}
+                  className={cn("relative h-[19px] w-[34px] shrink-0 rounded-full border border-line-strong bg-active p-0 transition-colors", a.enabled && "border-green bg-green-soft [&>span]:translate-x-[15px] [&>span]:bg-green")}
                   onClick={(e) => {
                     e.stopPropagation();
                     handleToggle(a);
                   }}
                   title={a.enabled ? "Disable" : "Enable"}
                 >
-                  <span className="auto-toggle-knob" />
+                  <span className="absolute left-0.5 top-0.5 size-[13px] rounded-full bg-faint transition-[transform,background-color]" />
                 </span>
-                <span className="automations-row-main">
-                  <span className="automations-row-name">{a.name}</span>
-                  <span className="automations-row-trigger">{triggerSummary(a)}</span>
+                <span className="automation-row-main flex min-w-0 flex-1 flex-col gap-px">
+                  <span className="truncate text-body font-semibold">{a.name}</span>
+                  <span className="truncate font-mono text-meta text-faint">{triggerSummary(a)}</span>
                 </span>
                 {running ? (
                   <span className="working-pill">
@@ -269,20 +270,20 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
                   </span>
                 ) : a.lastRunStatus === "ok" ? (
                   <span
-                    className="auto-status-ok"
+                    className="text-green"
                     title={`Last run ok${a.lastRunAt ? ` — ${relativeTime(a.lastRunAt)}` : ""}`}
                   >
                     ✓
                   </span>
                 ) : a.lastRunStatus === "error" ? (
-                  <span className="auto-status-err" title={a.lastRunError || "Last run failed"}>
+                  <span className="text-red" title={a.lastRunError || "Last run failed"}>
                     ✗
                   </span>
                 ) : null}
-                <span className="automations-row-graph">
+                <span className="flex shrink-0 max-[560px]:hidden">
                   {(a.runs?.length ?? 0) > 0 && <TriggerGraph runs={a.runs!} compact />}
                 </span>
-                <span className="automations-row-next">
+                <span className="w-[84px] shrink-0 text-right text-label text-faint max-[560px]:hidden">
                   {!a.enabled ? "off" : a.nextRunAt ? `next ${formatNext(a.nextRunAt)}` : ""}
                 </span>
               </button>
@@ -294,10 +295,10 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
     </div>
 
       {sel && (
-        <aside className="automations-drawer">
-          <div className="automations-drawer-head">
+        <aside className="flex min-h-0 min-w-0 flex-1 flex-col border-l border-line bg-panel max-[900px]:border-l-0">
+          <div className="flex shrink-0 items-center gap-2.5 border-b border-line px-4 py-3">
             <button
-              className="automations-drawer-back"
+              className="-my-1 -ml-0.5 hidden shrink-0 items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-body font-medium text-fg max-[900px]:inline-flex"
               onClick={() => onSelect("")}
               title="Back to automations"
             >
@@ -306,11 +307,11 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
               Automations
             </button>
-            <span className="automations-drawer-title">
+            <span className="min-w-0 truncate text-control-label font-semibold">
               {editMode ? `Edit — ${sel.name}` : sel.name}
             </span>
             {!editMode && (
-              <div className="automations-drawer-actions">
+              <div className="ml-auto flex shrink-0 gap-1.5">
                 <Button
                   size="sm"
                   className="border-line-strong bg-transparent shadow-none hover:bg-transparent"
@@ -332,7 +333,7 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
               </div>
             )}
             <button
-              className="automations-drawer-close"
+              className="flex size-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-dim hover:bg-hover hover:text-fg max-[900px]:hidden"
               onClick={() => onSelect("")}
               title="Close"
             >
@@ -341,9 +342,9 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
             </button>
           </div>
-          <div className="automations-drawer-body">
+          <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto px-5 pb-10 pt-[18px]">
             {editMode ? (
-              <div className="automation-form automation-form-inline">
+              <div>
                 <AutomationForm
                   key={sel.id}
                   kind={sel.slackWatch?.channel ? "watch" : "classic"}
@@ -362,11 +363,11 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
               <>
                 <div className="flex items-center gap-2.5">
                   <button
-                    className={`auto-toggle ${sel.enabled ? "auto-toggle-on" : ""}`}
+                    className={cn("relative h-[19px] w-[34px] shrink-0 rounded-full border border-line-strong bg-active p-0 transition-colors", sel.enabled && "border-green bg-green-soft [&>span]:translate-x-[15px] [&>span]:bg-green")}
                     onClick={() => handleToggle(sel)}
                     title={sel.enabled ? "Disable" : "Enable"}
                   >
-                    <span className="auto-toggle-knob" />
+                    <span className="absolute left-0.5 top-0.5 size-[13px] rounded-full bg-faint transition-[transform,background-color]" />
                   </button>
                   <span className="text-dim text-[13px]">
                     {sel.enabled ? "Enabled" : "Disabled"}
@@ -384,21 +385,21 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
                 </div>
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Instructions</div>
-                  <div className="bg-surface border border-line rounded-panel px-3.5 py-3 text-[13px] leading-relaxed text-dim whitespace-pre-wrap">
+                  <div className="mb-1.5 text-label font-semibold text-faint">Instructions</div>
+                  <div className="whitespace-pre-wrap rounded-panel border border-line bg-surface px-3.5 py-3 text-control-label leading-relaxed text-dim">
                     {sel.prompt}
                   </div>
                 </div>
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Configuration</div>
-                  <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-[13px]">
+                  <div className="mb-1.5 text-label font-semibold text-faint">Configuration</div>
+                  <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-control-label">
                     <DetailKey>Trigger</DetailKey>
                     <span className="text-dim min-w-0">
                       {sel.slackWatch?.channel ? (
                         <>
                           watches{" "}
-                          <span className="automation-cron automation-event">
+                            <span className="rounded-sm bg-active px-1.5 py-px font-mono text-meta">
                             #{sel.slackWatch.channel}
                           </span>{" "}
                           — one run per top-level message
@@ -409,7 +410,7 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
                             <>
                               {scheduleLabel(sel.schedule) &&
                                 `${scheduleLabel(sel.schedule)} · `}
-                              <span className="automation-cron" title="Cron, UTC">
+                              <span className="rounded-sm bg-active px-1.5 py-px font-mono text-meta" title="Cron, UTC">
                                 {sel.schedule}
                               </span>
                             </>
@@ -487,20 +488,20 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
                 </div>
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Activity</div>
+                  <div className="mb-1.5 text-label font-semibold text-faint">Activity</div>
                   {sel.lastRunAt ? (
                     <div className="text-dim text-supporting">
                       last run {relativeTime(sel.lastRunAt)}
                       {sel.lastTrigger ? ` via ${sel.lastTrigger}` : ""}
-                      {sel.lastRunStatus === "ok" && <span className="auto-status-ok"> ✓</span>}
+                      {sel.lastRunStatus === "ok" && <span className="text-green"> ✓</span>}
                       {sel.lastRunStatus === "error" && (
-                        <span className="auto-status-err" title={sel.lastRunError}> ✗</span>
+                        <span className="text-red" title={sel.lastRunError}> ✗</span>
                       )}
                       {sel.lastRunSessionId && (
                         <>
                           {" · "}
                           <a
-                            className="automation-session-link"
+                            className="text-accent hover:underline"
                             onClick={(e) => {
                               e.preventDefault();
                               onOpenSession(sel.lastRunSessionId!);
@@ -684,7 +685,7 @@ function RunLedger({
             </span>
           )}
           <a
-            className="automation-session-link ml-auto shrink-0"
+            className="ml-auto shrink-0 text-accent hover:underline"
             href={`${BASE_PATH}/session/${r.sessionId}`}
             onClick={(e) => {
               e.preventDefault();
@@ -695,7 +696,7 @@ function RunLedger({
           </a>
           {r.status !== "running" && (
             <button
-              className="automation-session-link shrink-0 bg-transparent border-none p-0 font-[inherit] text-label"
+              className="shrink-0 border-0 bg-transparent p-0 font-[inherit] text-label text-accent hover:underline"
               title={
                 r.trigger === "event" || r.trigger === "webhook"
                   ? "Start a fresh run replaying this run's triggering event"
@@ -719,7 +720,7 @@ function WebhookUrl({ id, secret }: { id: string; secret: string }) {
 
   return (
     <span className="flex items-center gap-2 min-w-0">
-      <span className="automation-webhook-url" title={url}>
+      <span className="min-w-0 flex-1 truncate font-mono text-meta text-dim" title={url}>
         POST {url.replace(secret, secret.slice(0, 6) + "…")}
       </span>
       <Button
@@ -784,7 +785,7 @@ function CreateAutomationModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="automation-form w-full max-w-[680px] my-auto shadow-2xl">
+      <div className="w-full max-w-[680px] my-auto rounded-panel border border-line-strong bg-panel p-[18px] shadow-2xl">
         {step === "type" ? (
           <TypeChooser
             onPick={(draft, s) => {
@@ -838,10 +839,10 @@ function TypeChooser({
   }
 
   return (
-    <>
+    <div className="flex flex-col gap-3.5 [&_label]:flex [&_label]:flex-1 [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_input]:outline-none [&_input:focus]:border-accent [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg [&_select]:outline-none [&_select:focus]:border-accent [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:leading-relaxed [&_textarea]:text-fg [&_textarea]:outline-none [&_textarea:focus]:border-accent">
       <div>
-        <div className="automation-form-title">Create automation</div>
-        <div className="text-dim text-[13px] mt-0.5">
+        <div className="text-body font-semibold">Create automation</div>
+        <div className="mt-0.5 text-control-label text-dim">
           Choose the type of automation you want to create.
         </div>
       </div>
@@ -916,12 +917,12 @@ function TypeChooser({
         </div>
       )}
 
-      <div className="automation-form-actions">
-        <Button size="sm" className="px-3 text-[13px]" onClick={onClose}>
+        <div className="flex justify-end gap-2.5">
+        <Button size="sm" className="px-3 text-control-label" onClick={onClose}>
           Cancel
         </Button>
       </div>
-    </>
+    </div>
   );
 }
 
@@ -1155,7 +1156,7 @@ function AutomationForm({
   }
 
   return (
-    <>
+    <div className="flex flex-col gap-3.5 [&_label]:flex [&_label]:flex-1 [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_input]:outline-none [&_input:focus]:border-accent [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg [&_select]:outline-none [&_select:focus]:border-accent [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:leading-relaxed [&_textarea]:text-fg [&_textarea]:outline-none [&_textarea:focus]:border-accent">
       {!inline && (
         <div className="flex items-center gap-2">
           {onBack && (
@@ -1163,7 +1164,7 @@ function AutomationForm({
               ←
             </Button>
           )}
-          <div className="automation-form-title" style={{ marginBottom: 0 }}>
+          <div className="text-body font-semibold">
             {initial
               ? `Edit "${initial.name}"`
               : isWatch
@@ -1273,7 +1274,7 @@ function AutomationForm({
       </div>
 
       {showAdvanced && (
-        <div className="automation-form-row">
+        <div className="flex gap-3.5">
           <label>
             Mode
             <select value={mode} onChange={(e) => setMode(e.target.value as "ask" | "code")}>
@@ -1347,7 +1348,7 @@ function AutomationForm({
 
       {error && <InlineAlert onDismiss={() => setError(null)}>{error}</InlineAlert>}
 
-      <div className="automation-form-actions">
+      <div className="flex justify-end gap-2.5">
         <Button size="sm" className="px-3 text-[13px]" onClick={onClose} disabled={saving}>
           Cancel
         </Button>
@@ -1361,6 +1362,6 @@ function AutomationForm({
           {saving ? "Saving…" : initial ? "Save changes" : "Create automation"}
         </Button>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/frontend/components/Automations.tsx
+++ b/src/frontend/components/Automations.tsx
@@ -209,7 +209,7 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
         className={`max-[560px]:mb-5 max-[560px]:flex-col max-[560px]:items-start max-[560px]:gap-3.5 ${sel ? "mb-3.5 items-center" : ""}`}
       >
         <div>
-          <PageTitle className={sel ? "text-base" : undefined}>Automations</PageTitle>
+          <PageTitle className={sel ? "text-body" : undefined}>Automations</PageTitle>
           <PageDescription className={sel ? "hidden" : undefined}>
             Scheduled {AGENT_NAME} sessions — cron runs in UTC (server time).
           </PageDescription>
@@ -369,7 +369,7 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
                   >
                     <span className="absolute left-0.5 top-0.5 size-[13px] rounded-full bg-faint transition-[transform,background-color]" />
                   </button>
-                  <span className="text-dim text-[13px]">
+                  <span className="text-dim text-control-label">
                     {sel.enabled ? "Enabled" : "Disabled"}
                   </span>
                   {(sel.isRunning || sel.lastRunStatus === "running") && (
@@ -635,7 +635,7 @@ function TriggerGraph({ runs, compact }: { runs: AutomationRun[]; compact?: bool
         })}
       </svg>
       {!compact && (
-        <span className="pb-px text-meta leading-none text-faint">
+		<span className="pb-px text-meta leading-none text-faint">
           {total} run{total === 1 ? "" : "s"} · last {GRAPH_DAYS}d
         </span>
       )}
@@ -852,7 +852,7 @@ function TypeChooser({
           className="text-left bg-surface border border-line rounded-panel px-4 py-3.5 cursor-pointer hover:border-line-strong hover:bg-hover transition-colors"
           onClick={() => onPick(null, "classic")}
         >
-          <div className="text-fg text-[14px] font-medium mb-1">Classical automation</div>
+          <div className="text-fg text-body font-medium mb-1">Classical automation</div>
           <div className="text-dim text-supporting leading-snug">
             Trigger {AGENT_NAME} sessions based on schedules, internal events, and webhooks.
           </div>
@@ -861,7 +861,7 @@ function TypeChooser({
           className="text-left bg-surface border border-line rounded-panel px-4 py-3.5 cursor-pointer hover:border-line-strong hover:bg-hover transition-colors"
           onClick={() => onPick(null, "watch")}
         >
-          <div className="text-fg text-[14px] font-medium mb-1">Watch a channel</div>
+          <div className="text-fg text-body font-medium mb-1">Watch a channel</div>
           <div className="text-dim text-supporting leading-snug">
             {AGENT_NAME} triages every incoming message in a Slack channel, using the
             channel's memory as standing context.
@@ -905,8 +905,8 @@ function TypeChooser({
                 onClick={() => onPick(t, "classic")}
               >
                 <div className="flex items-baseline gap-2 mb-1">
-                  <span className="text-fg text-[13px] font-medium">{t.name}</span>
-                  <span className="ml-auto shrink-0 text-meta tracking-[-0.01em] text-faint">
+					<span className="text-control-label font-medium text-fg">{t.name}</span>
+					<span className="ml-auto shrink-0 text-meta tracking-[-0.01em] text-faint">
                     {CATEGORY_LABELS[t.category] || t.category}
                   </span>
                 </div>
@@ -972,7 +972,7 @@ function McpPicker({
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline gap-2">
-        <span className="text-fg text-[13px] font-medium">MCPs</span>
+        <span className="text-fg text-control-label font-medium">MCPs</span>
         <span className="text-dim text-label">
           Select which connectors this automation's runs can use
         </span>
@@ -989,7 +989,7 @@ function McpPicker({
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search MCPs…"
-            className="flex-1 bg-transparent border-0 outline-none text-[13px] text-fg placeholder:text-faint"
+            className="flex-1 bg-transparent border-0 outline-none text-control-label text-fg placeholder:text-faint"
             style={{ border: "none", padding: 0, background: "transparent" }}
           />
           <span className="text-faint text-[11px] shrink-0">
@@ -1192,7 +1192,7 @@ function AutomationForm({
             placeholder="C0123456789 (channel id)"
             className="mono-input"
           />
-          <span className="mt-1 text-meta leading-snug text-faint">
+			<span className="mt-1 text-meta leading-snug text-faint">
             Invite @michael to the channel first — the bot only receives messages
             for channels it's a member of. One run per top-level message; thread
             replies don't re-trigger. Channel id is in the channel's “About” tab.
@@ -1201,7 +1201,7 @@ function AutomationForm({
       ) : (
         <div className="flex flex-col gap-1.5">
           <div>
-            <span className="text-fg text-[13px] font-medium">Triggers</span>
+            <span className="text-fg text-control-label font-medium">Triggers</span>
             <span className="text-dim text-label ml-2">
               Run the automation when any of these conditions are met
             </span>
@@ -1239,7 +1239,7 @@ function AutomationForm({
                 ))}
               </select>
             </label>
-            <div className="text-meta text-faint">
+			<div className="text-meta text-faint">
               Every automation also gets a secret webhook URL you can POST to —
               shown on its card after creation.
             </div>
@@ -1349,7 +1349,7 @@ function AutomationForm({
       {error && <InlineAlert onDismiss={() => setError(null)}>{error}</InlineAlert>}
 
       <div className="flex justify-end gap-2.5">
-        <Button size="sm" className="px-3 text-[13px]" onClick={onClose} disabled={saving}>
+        <Button size="sm" className="px-3 text-control-label" onClick={onClose} disabled={saving}>
           Cancel
         </Button>
         <Button

--- a/src/frontend/components/CodeHighlight.tsx
+++ b/src/frontend/components/CodeHighlight.tsx
@@ -179,7 +179,7 @@ export function CodeHighlight({ code, lang, gutter, requireGutter }: Props) {
 	}, [code, gutter, lang, requireGutter, theme, visible]);
 
 	return (
-		<div ref={ref}>
+		<div ref={ref} className="[&_.tool-pre]:m-0 [&_.tool-pre]:max-h-80 [&_.tool-pre]:overflow-y-auto [&_.tool-pre]:break-words [&_.tool-pre]:whitespace-pre-wrap [&_.tool-pre]:font-mono [&_.tool-pre]:text-supporting [&_.tool-pre]:leading-normal [&_.tool-pre]:text-dim [&_.tool-pre]:[tab-size:2] [&_.tool-pre-code_pre.shiki]:m-0 [&_.tool-pre-code_pre.shiki]:bg-transparent! [&_.tool-pre-code_pre.shiki]:p-0 [&_.tool-pre-code_pre.shiki]:font-inherit [&_.tool-pre-code_pre.shiki]:text-inherit [&_.tool-pre-code_pre.shiki]:leading-inherit [&_.tool-pre-code_pre.shiki]:whitespace-pre-wrap [&_.tool-pre-code_pre.shiki]:break-words [&_.shiki-gutter]:select-none [&_.shiki-gutter]:text-faint">
 			{html === null ? (
 				<pre className="tool-pre">{code}</pre>
 			) : (

--- a/src/frontend/components/CommentableDiff.tsx
+++ b/src/frontend/components/CommentableDiff.tsx
@@ -277,15 +277,15 @@ export function CommentableDiff({
           ? `line ${comment.startLine}`
           : `lines ${comment.startLine}–${comment.endLine}`;
       return (
-        <div className="diff-pending-comment" onClick={(e) => e.stopPropagation()}>
-          <div className="diff-pending-head">
-            <span className="diff-comment-target">
+        <div className="diff-pending-comment m-2 flex flex-col gap-1.5 rounded-md border border-line-strong border-l-[3px] border-l-accent bg-panel px-2.5 py-[9px] font-sans" onClick={(e) => e.stopPropagation()}>
+          <div className="diff-pending-head flex items-center justify-between gap-2">
+            <span className="diff-comment-target font-mono text-meta text-faint">
               {comment.path} · {lineLabel}
               {comment.side === "deletions" ? " (removed)" : ""}
             </span>
             {onRemovePending && (
               <button
-                className="diff-pending-remove"
+                className="diff-pending-remove border-0 bg-transparent px-1 py-0.5 text-meta text-faint hover:text-red"
                 onClick={() => onRemovePending(comment.id)}
                 title="Remove this pending comment"
               >
@@ -293,7 +293,7 @@ export function CommentableDiff({
               </button>
             )}
           </div>
-          <div className="diff-pending-text">{comment.text}</div>
+          <div className="diff-pending-text whitespace-pre-wrap break-words text-control-label leading-[1.45] text-fg">{comment.text}</div>
         </div>
       );
     },
@@ -372,9 +372,9 @@ export function CommentableDiff({
       : pend;
 
     return (
-      <div className="diff-file" key={`${file.name}-${i}`} data-diff-file={file.name}>
+      <div className="diff-file overflow-hidden rounded-md border border-line bg-panel" key={`${file.name}-${i}`} data-diff-file={file.name}>
         <div
-          className="diff-file-header"
+          className="diff-file-header relative flex w-full items-center gap-2 border-0 bg-transparent px-2.5 py-2 text-left text-fg hover:bg-hover"
           role="button"
           tabIndex={0}
           aria-expanded={isOpen}
@@ -392,13 +392,13 @@ export function CommentableDiff({
         >
           <IconChevronRight
             size={16}
-            className={`diff-file-caret ${isOpen ? "diff-file-caret-open" : ""}`}
+            className={`diff-file-caret shrink-0 text-faint transition-transform duration-100 ${isOpen ? "diff-file-caret-open rotate-90" : ""}`}
           />
-          <span className="diff-file-name" onClick={(e) => e.stopPropagation()}>
-            {dir && <span className="diff-file-dir">{dir}</span>}
-            <span className="diff-file-base">{base}</span>
+          <span className="diff-file-name flex min-w-0 flex-1 cursor-text select-text overflow-hidden font-mono text-supporting" onClick={(e) => e.stopPropagation()}>
+            {dir && <span className="diff-file-dir min-w-0 shrink overflow-hidden text-ellipsis whitespace-nowrap text-faint">{dir}</span>}
+            <span className="diff-file-base shrink-0 whitespace-nowrap font-semibold text-fg">{base}</span>
           </span>
-          {pend.length > 0 && <span className="diff-file-comments">{pend.length}</span>}
+          {pend.length > 0 && <span className="diff-file-comments inline-flex shrink-0 items-center gap-1 font-sans text-meta text-faint before:content-['💬']">{pend.length}</span>}
           {onDiscard && (
             <Tooltip
               label={
@@ -411,7 +411,7 @@ export function CommentableDiff({
             >
               <button
                 type="button"
-                className={`diff-file-discard ${armed === file.name ? "diff-file-discard-armed" : ""}`}
+                className={`diff-file-discard absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-sm border-0 bg-transparent p-0.5 text-faint opacity-0 pointer-events-none transition-[color,background,opacity] duration-100 hover:bg-hover hover:text-red focus-visible:opacity-100 focus-visible:pointer-events-auto disabled:pointer-events-auto disabled:opacity-100 disabled:cursor-default ${armed === file.name ? "diff-file-discard-armed pointer-events-auto text-red opacity-100" : ""}`}
                 disabled={discarding === file.name}
                 aria-label="Discard this file's changes (reset to base)"
                 onClick={(e) => {
@@ -423,9 +423,9 @@ export function CommentableDiff({
               </button>
             </Tooltip>
           )}
-          <span className="diff-file-stats">
-            {s.add > 0 && <span className="diff-add">+{s.add}</span>}
-            {s.del > 0 && <span className="diff-del">−{s.del}</span>}
+          <span className="diff-file-stats ml-auto flex shrink-0 gap-2 font-mono text-label group-hover:invisible">
+            {s.add > 0 && <span className="diff-add font-semibold text-green">+{s.add}</span>}
+            {s.del > 0 && <span className="diff-del font-semibold text-red">−{s.del}</span>}
           </span>
         </div>
         {isOpen &&
@@ -449,19 +449,19 @@ export function CommentableDiff({
   };
 
   return (
-    <div className="commentable-diff">
-      {confirmation && <div className="diff-comment-confirmation">{confirmation}</div>}
-      <div className="diff-file-toolbar">
+    <div className="commentable-diff flex flex-col gap-2.5">
+      {confirmation && <div className="diff-comment-confirmation rounded-sm bg-green-soft px-3 py-1.5 text-supporting font-semibold text-green">{confirmation}</div>}
+      <div className="diff-file-toolbar -mb-1 flex items-center justify-end">
         {groupsLoading && (
-          <span className="diff-groups-loading" role="status">
+          <span className="diff-groups-loading mr-auto flex items-center gap-2 text-label text-faint" role="status">
             <PixelSpinner cycling={false} className="text-faint" />
             Organizing files…
           </span>
         )}
         {!groupsLoading && groupedFiles && (
-          <span className="diff-groups-ready">AI organized</span>
+          <span className="diff-groups-ready mr-auto flex items-center gap-2 text-label text-faint before:size-1.5 before:rounded-full before:bg-accent before:content-['']">AI organized</span>
         )}
-        <button type="button" className="diff-file-toggle-all" onClick={toggleAll}>
+        <button type="button" className="diff-file-toggle-all border-0 bg-transparent px-1 py-0.5 text-label font-medium text-faint hover:text-fg" onClick={toggleAll}>
           {allOpen ? "Collapse all" : "Expand all"}
         </button>
       </div>
@@ -477,10 +477,10 @@ export function CommentableDiff({
               { add: 0, del: 0 },
             );
             return (
-              <section className="diff-file-group" key={groupKey}>
+              <section className="diff-file-group flex flex-col gap-2 [&+&]:mt-1" key={groupKey}>
                 <button
                   type="button"
-                  className="diff-file-group-header"
+                  className="diff-file-group-header flex w-full items-center gap-2 border-0 bg-transparent px-1 py-1 text-left text-dim hover:text-fg"
                   data-diff-group-files={JSON.stringify(
                     group.indices.map((index) => files[index].name),
                   )}
@@ -496,17 +496,17 @@ export function CommentableDiff({
                 >
                   <IconChevronRight
                     size={16}
-                    className={`diff-file-caret ${collapsed ? "" : "diff-file-caret-open"}`}
+                    className={`diff-file-caret shrink-0 text-faint transition-transform duration-100 ${collapsed ? "" : "diff-file-caret-open rotate-90"}`}
                   />
-                  <span className="diff-file-group-title">{group.title}</span>
-                  <span className="diff-file-group-count">{group.indices.length}</span>
-                  <span className="diff-file-group-stats">
-                    {totals.add > 0 && <span className="diff-add">+{totals.add}</span>}
-                    {totals.del > 0 && <span className="diff-del">−{totals.del}</span>}
+                  <span className="diff-file-group-title text-control-label font-semibold">{group.title}</span>
+                  <span className="diff-file-group-count text-meta text-faint">{group.indices.length}</span>
+                  <span className="diff-file-group-stats ml-auto flex gap-2 font-mono text-meta">
+                    {totals.add > 0 && <span className="diff-add font-semibold text-green">+{totals.add}</span>}
+                    {totals.del > 0 && <span className="diff-del font-semibold text-red">−{totals.del}</span>}
                   </span>
                 </button>
                 {!collapsed && (
-                  <div className="diff-file-group-files">
+                  <div className="diff-file-group-files flex flex-col gap-2 border-l border-line pl-3">
                     {group.indices.map((index) => renderFile(files[index], index))}
                   </div>
                 )}
@@ -514,7 +514,7 @@ export function CommentableDiff({
             );
           })
         : files.map(renderFile)}
-      <div className="diff-comment-hint">
+      <div className="diff-comment-hint pb-2 text-center text-meta text-faint">
         {reviewMode
           ? "Click a line number (drag for a range) to add a comment. They stay pending until you finish the review."
           : "Click a line number (drag for a range) to comment."}
@@ -540,19 +540,19 @@ function ImageDiffRow({
   const showOld = !!srcs?.oldSrc && file.type !== "new" && !oldErr;
   const showNew = !!srcs?.newSrc && file.type !== "deleted" && !newErr;
   if (!showOld && !showNew)
-    return <div className="diff-image-empty">Image not available to preview</div>;
+    return <div className="diff-image-empty p-3 text-label text-dim">Image not available to preview</div>;
   return (
-    <div className="diff-image-row">
+    <div className="diff-image-row flex flex-wrap gap-3 p-3">
       {showOld && (
-        <figure className="diff-image-cell diff-image-old">
-          <img src={srcs!.oldSrc} alt="" loading="lazy" onError={() => setOldErr(true)} />
-          <figcaption>{file.type === "deleted" ? "Deleted" : "Before"}</figcaption>
+        <figure className="diff-image-cell diff-image-old m-0 min-w-0 max-w-full flex-[0_1_auto]">
+          <img className="block max-h-[360px] max-w-full rounded-sm border border-line bg-[repeating-conic-gradient(rgba(128,128,128,0.18)_0%_25%,transparent_0%_50%)_0_0/16px_16px] opacity-80" src={srcs!.oldSrc} alt="" loading="lazy" onError={() => setOldErr(true)} />
+          <figcaption className="mt-1 text-meta text-dim before:mr-1 before:text-red before:content-['−']">{file.type === "deleted" ? "Deleted" : "Before"}</figcaption>
         </figure>
       )}
       {showNew && (
-        <figure className="diff-image-cell diff-image-new">
-          <img src={srcs!.newSrc} alt="" loading="lazy" onError={() => setNewErr(true)} />
-          <figcaption>{file.type === "new" ? "Added" : "After"}</figcaption>
+        <figure className="diff-image-cell diff-image-new m-0 min-w-0 max-w-full flex-[0_1_auto]">
+          <img className="block max-h-[360px] max-w-full rounded-sm border border-line bg-[repeating-conic-gradient(rgba(128,128,128,0.18)_0%_25%,transparent_0%_50%)_0_0/16px_16px]" src={srcs!.newSrc} alt="" loading="lazy" onError={() => setNewErr(true)} />
+          <figcaption className="mt-1 text-meta text-dim before:mr-1 before:text-green before:content-['+']">{file.type === "new" ? "Added" : "After"}</figcaption>
         </figure>
       )}
     </div>
@@ -602,14 +602,14 @@ const CommentForm = React.memo(function CommentForm({
   }
 
   return (
-    <div className="diff-comment-form" onClick={(e) => e.stopPropagation()}>
-      <div className="diff-comment-target">{targetLabel}</div>
+    <div className="diff-comment-form m-2 flex flex-col gap-2 rounded-md border border-accent bg-panel p-2.5 font-sans" onClick={(e) => e.stopPropagation()}>
+      <div className="diff-comment-target font-mono text-meta text-faint">{targetLabel}</div>
       {disabled ? (
-        <div className="diff-comment-disabled">{disabledHint || "Unavailable right now"}</div>
+        <div className="diff-comment-disabled text-supporting text-faint">{disabledHint || "Unavailable right now"}</div>
       ) : (
         <>
           <textarea
-            className="diff-comment-input"
+            className="diff-comment-input resize-y rounded-sm border border-line-strong bg-raised px-2.5 py-2 text-control-label leading-[1.45] text-fg outline-none focus:border-accent"
             autoFocus
             rows={3}
             placeholder={placeholder}
@@ -625,12 +625,12 @@ const CommentForm = React.memo(function CommentForm({
               }
             }}
           />
-          {error && <div className="diff-comment-error">{error}</div>}
-          <div className="diff-comment-actions">
+          {error && <div className="diff-comment-error text-label text-red">{error}</div>}
+          <div className="diff-comment-actions flex justify-end gap-2">
             <Button
               variant="default"
               size="sm"
-              className="min-h-0 border-line-strong bg-transparent px-3 py-[5px] text-[13px] font-normal shadow-none"
+              className="min-h-0 border-line-strong bg-transparent px-3 py-[5px] text-control-label font-normal shadow-none"
               onClick={onCancel}
               disabled={sending}
             >

--- a/src/frontend/components/Composer.tsx
+++ b/src/frontend/components/Composer.tsx
@@ -34,6 +34,7 @@ import { composerMorph, composerChipMotion } from "../ui/motion";
 import { ModelEffortSelect, shortModelLabel } from "./ModelEffortSelect";
 import { UsageMeter } from "./UsageMeter";
 import type { SessionUsage } from "../lib/types";
+import { cn } from "../ui/cn";
 
 interface Props {
   /**
@@ -649,7 +650,7 @@ export function Composer({
   const effectiveModel = model || defaultModel;
 
   return (
-    <div className="composer-wrap">
+    <div className="composer-wrap mx-auto w-full max-w-[calc(var(--chat-col)+40px)]">
       {/* Queued/steered messages fold out from behind the composer box —
           a sibling flap tucked under its top edge, not a box-in-box. */}
       {attached}
@@ -664,18 +665,12 @@ export function Composer({
         initial={false}
         animate={{ borderRadius: minimized ? 999 : 28 }}
         transition={composerMorph}
-        className={`composer ${disabled ? "composer-disabled" : ""} ${minimized ? "composer-min" : ""} ${noteMode ? "composer-note" : ""}`}
-        style={
-          noteMode
-            ? {
-                borderColor: "color-mix(in srgb, var(--yellow) 45%, transparent)",
-                backgroundColor:
-                  "color-mix(in srgb, var(--yellow) 10%, var(--control-surface))",
-                backgroundImage:
-                  "linear-gradient(to bottom, transparent 15%, color-mix(in srgb, var(--yellow) 10%, var(--control-surface)) 72%), repeating-linear-gradient(45deg, color-mix(in srgb, var(--yellow) 6%, transparent) 0, color-mix(in srgb, var(--yellow) 6%, transparent) 12px, transparent 12px, transparent 24px)",
-              }
-            : undefined
-        }
+        className={cn(
+          "composer relative border border-line bg-control px-3.5 pt-3.5 pb-2.5 shadow-[var(--composer-shadow)] transition-[border-color,box-shadow] duration-150 max-[720px]:!rounded-xl max-[720px]:px-3 max-[720px]:pt-2.5 max-[720px]:pb-[9px]",
+          disabled && "composer-disabled opacity-60",
+          minimized && "composer-min max-[720px]:mx-1.5 max-[720px]:flex max-[720px]:items-center max-[720px]:gap-1 max-[720px]:!p-1",
+          noteMode && "composer-note border-[color-mix(in_srgb,var(--yellow)_45%,transparent)] bg-[color-mix(in_srgb,var(--yellow)_10%,var(--control-surface))] [background-image:linear-gradient(to_bottom,transparent_15%,color-mix(in_srgb,var(--yellow)_10%,var(--control-surface))_72%),repeating-linear-gradient(45deg,color-mix(in_srgb,var(--yellow)_6%,transparent)_0,color-mix(in_srgb,var(--yellow)_6%,transparent)_12px,transparent_12px,transparent_24px)]",
+        )}
         onDrop={handleDrop}
         onDragOver={(e) => canAttach && e.preventDefault()}
       >
@@ -696,21 +691,25 @@ export function Composer({
         <motion.div
           layout="position"
           transition={composerMorph}
-          className="composer-input-wrap"
+          className={cn("composer-input-wrap relative", minimized && "max-[720px]:order-2 max-[720px]:min-w-0 max-[720px]:flex-1")}
           ref={mentions.inputWrapRef}
         >
           {mentions.popup}
           {hlActive && (
             <div
               ref={hlRef}
-              className="composer-textarea composer-hl"
+              className="composer-textarea composer-hl pointer-events-none absolute inset-0 z-0 block w-full overflow-hidden text-sm leading-[1.55] whitespace-pre-wrap text-fg select-none [overflow-wrap:break-word] [&_.cmp-code]:rounded-sm [&_.cmp-code]:bg-white/10 [&_.cmp-code]:text-[#e8b3b9] [&_.cmp-fence]:rounded-sm [&_.cmp-fence]:bg-white/[0.06] [&_.cmp-fence]:text-[#dde1f0] [html[data-theme=light]_&_.cmp-code]:bg-black/[0.07] [html[data-theme=light]_&_.cmp-code]:text-[#953b39] [html[data-theme=light]_&_.cmp-fence]:bg-black/[0.05] [html[data-theme=light]_&_.cmp-fence]:text-[#1f2328]"
               aria-hidden="true"
               dangerouslySetInnerHTML={{ __html: hlHtml }}
             />
           )}
           <textarea
             ref={textareaRef}
-            className={`composer-textarea ${hlActive ? "has-hl" : ""}`}
+            className={cn(
+              "composer-textarea block min-h-32 max-h-80 w-full resize-none border-0 bg-transparent py-0.5 pr-0 pb-1 text-sm leading-[1.55] text-fg outline-none placeholder:text-faint max-[720px]:!min-h-0 max-[720px]:!max-h-60 max-[720px]:text-[16px]",
+              minimized && "max-[720px]:!min-h-0 max-[720px]:px-1 max-[720px]:py-0",
+              hlActive && "has-hl relative z-[1] text-transparent caret-fg [overflow-wrap:break-word]",
+            )}
             // In the resting pill the full prompt would clip, so show a short
             // "Ask <model>" (ChatGPT-style) that fits the single row; the
             // descriptive placeholder returns once it expands.
@@ -750,7 +749,7 @@ export function Composer({
           />
         </motion.div>
         <div
-          className="composer-toolbar"
+          className={cn("composer-toolbar mt-2.5 flex items-center gap-2 [&>*]:shrink-0 max-[720px]:mt-1.5 max-[720px]:gap-1.5", minimized && "max-[720px]:contents")}
           ref={toolbarRef}
           // Phones: a toolbar tap must not blur the textarea — the blur would
           // collapse the empty composer mid-tap (unmounting the model pill and
@@ -768,7 +767,7 @@ export function Composer({
             <motion.div
               layout="position"
               transition={composerMorph}
-              className="composer-pop-wrap"
+              className={cn("composer-pop-wrap relative inline-flex", minimized && "max-[720px]:order-1")}
               style={
                 !minimized && (onSetGoal || onNoteModeChange)
                   ? { marginRight: -8 }
@@ -778,7 +777,7 @@ export function Composer({
               <Tooltip label="Add files or a file reference">
                 <button
                   type="button"
-                  className="palette-icon-btn composer-add-btn"
+                  className={cn("palette-icon-btn composer-add-btn", minimized && "max-[720px]:rounded-full")}
                   {...tapProps(() => setMenu(menu === "add" ? null : "add"))}
                   disabled={disabled}
                   aria-label="Add"
@@ -788,16 +787,16 @@ export function Composer({
                 </button>
               </Tooltip>
               {menu === "add" && (
-                <div className="composer-menu">
+                <div className="composer-menu absolute bottom-[calc(100%+6px)] left-0 z-40 min-w-[172px] rounded-lg border border-line-strong bg-panel p-1 shadow-[0_8px_28px_rgba(0,0,0,0.28)]">
                   <button
                     type="button"
-                    className="composer-menu-item"
+                    className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
                     {...tapProps(() => {
                       setMenu(null);
                       fileInputRef.current?.click();
                     })}
                   >
-                    <span className="composer-menu-icon">
+                    <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
                       <IconPaperclip size={22} />
                     </span>
                     {onFilesChange ? "Attach files" : "Attach an image"}
@@ -805,13 +804,13 @@ export function Composer({
                   {mentionFetch && (
                     <button
                       type="button"
-                      className="composer-menu-item"
+                      className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
                       {...tapProps(() => {
                         setMenu(null);
                         startMention();
                       })}
                     >
-                      <span className="composer-menu-icon">
+                      <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
                         <IconAtSign size={22} />
                       </span>
                       Reference a file
@@ -854,19 +853,19 @@ export function Composer({
                 key="goal"
                 layout="position"
                 {...composerChipMotion}
-                className="composer-pop-wrap"
+                className="composer-pop-wrap relative inline-flex max-[720px]:hidden"
                 style={onNoteModeChange ? { marginRight: -8 } : undefined}
               >
                 <Tooltip label={goal ? `Goal: ${goal}` : "Pin a goal for this session"}>
                   <button
                     type="button"
-                    className={`palette-icon-btn composer-goal-btn ${goal ? "is-on" : ""}`}
+                    className={cn("palette-icon-btn composer-goal-btn", goal && "is-on w-auto gap-[5px] px-[9px] text-accent")}
                     {...tapProps(() => setMenu(menu === "goal" ? null : "goal"))}
                     disabled={disabled}
                     aria-pressed={!!goal}
                   >
                     <IconCrosshair size={24} />
-                    {goal && <span className="composer-goal-label">Goal</span>}
+                    {goal && <span className="composer-goal-label text-xs font-medium">Goal</span>}
                   </button>
                 </Tooltip>
                 <GoalModal
@@ -889,7 +888,7 @@ export function Composer({
                 key="note"
                 layout="position"
                 {...composerChipMotion}
-                className="composer-pop-wrap"
+                className="composer-pop-wrap relative inline-flex"
               >
                 <Tooltip
                   label={
@@ -900,24 +899,14 @@ export function Composer({
                 >
                   <button
                     type="button"
-                    className="palette-icon-btn composer-note-btn"
-                    style={
-                      noteMode
-                        ? {
-                            width: "auto",
-                            gap: 6,
-                            padding: "0 9px",
-                            color: "var(--yellow)",
-                          }
-                        : undefined
-                    }
+                    className={cn("palette-icon-btn composer-note-btn", noteMode && "w-auto gap-1.5 px-[9px] text-yellow")}
                     {...tapProps(() => onNoteModeChange(!noteMode))}
                     disabled={disabled}
                     aria-pressed={!!noteMode}
                   >
                     <IconNote size={24} />
                     {noteMode && (
-                      <span className="composer-goal-label">Note</span>
+                      <span className="composer-goal-label text-xs font-medium">Note</span>
                     )}
                   </button>
                 </Tooltip>
@@ -926,7 +915,7 @@ export function Composer({
           </AnimatePresence>
 
           {leftExtra}
-          <div className="composer-spacer" />
+          <div className={cn("composer-spacer flex-1", minimized && "max-[720px]:hidden")} />
 
           {/* Model + effort live together on the right edge (ChatGPT-style):
               one pill, effort levels up top, the model behind a submenu.
@@ -938,7 +927,7 @@ export function Composer({
                 key="model-effort"
                 layout="position"
                 {...composerChipMotion}
-                className="palette-select-motion"
+                className="palette-select-motion min-w-0 shrink max-[720px]:order-[-1]"
               >
                 <ModelEffortSelect
                   className="palette-pill"
@@ -971,14 +960,14 @@ export function Composer({
                 key="usage"
                 layout="position"
                 {...composerChipMotion}
-                className="composer-pop-wrap"
+                className="composer-pop-wrap relative inline-flex"
               >
                 <UsageMeter usage={usage} />
               </motion.div>
             )}
           </AnimatePresence>
 
-          <motion.div layout="position" transition={composerMorph} className="composer-voice-wrap">
+            <motion.div layout="position" transition={composerMorph} className={cn("composer-voice-wrap inline-flex items-center", minimized && "max-[720px]:order-3")}>
             <VoiceInput onText={insertDictation} disabled={disabled} />
           </motion.div>
 
@@ -986,7 +975,10 @@ export function Composer({
             <Tooltip label="Stop — interrupts the current turn; the session stays ready">
               <button
                 type="button"
-                className="composer-send composer-stop"
+                className={cn(
+                  "composer-send composer-stop inline-flex size-8 shrink-0 items-center justify-center rounded-full border-0 bg-red text-[15px] leading-none font-semibold text-white transition-[filter,transform] duration-150 hover:not-disabled:scale-105 hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-35 max-[720px]:size-10",
+                  minimized && "max-[720px]:order-4",
+                )}
                 {...tapProps(() => onStop())}
                 disabled={disabled}
                 aria-label="Stop current turn"
@@ -1003,7 +995,7 @@ export function Composer({
             <motion.div
               layout="position"
               transition={composerMorph}
-              className="composer-send-split"
+              className={cn("composer-send-split relative inline-flex shrink-0 items-stretch", minimized && "max-[720px]:order-5")}
             >
               <Tooltip
                 label={
@@ -1026,13 +1018,11 @@ export function Composer({
                 }
               >
                 <button
-                  className={`composer-send ${
-                    steerSend
-                      ? "composer-send-interrupt"
-                      : busy && !noteMode
-                        ? "composer-send-queue-main"
-                        : ""
-                  }`}
+                  className={cn(
+                    "composer-send inline-flex size-8 shrink-0 items-center justify-center rounded-full border-0 bg-accent text-[15px] leading-none font-semibold text-white transition-[filter,transform] duration-150 hover:not-disabled:scale-105 hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-35 max-[720px]:size-10",
+                    steerSend && "composer-send-interrupt border border-red bg-red-soft text-red",
+                    busy && !noteMode && "composer-send-queue-main border-2 border-accent bg-raised text-accent",
+                  )}
                   {...tapProps(() =>
                     fireSend(onSend, steerSend ? { steer: true } : undefined),
                   )}
@@ -1109,7 +1099,7 @@ export function Composer({
           </div>
         )}
       </motion.div>
-      {hint && <div className="composer-hint">{hint}</div>}
+      {hint && <div className="composer-hint mt-[7px] text-center text-[11px] text-faint max-[720px]:hidden">{hint}</div>}
     </div>
   );
 }

--- a/src/frontend/components/Composer.tsx
+++ b/src/frontend/components/Composer.tsx
@@ -698,7 +698,7 @@ export function Composer({
           {hlActive && (
             <div
               ref={hlRef}
-              className="composer-textarea composer-hl pointer-events-none absolute inset-0 z-0 block w-full overflow-hidden text-sm leading-[1.55] whitespace-pre-wrap text-fg select-none [overflow-wrap:break-word] [&_.cmp-code]:rounded-sm [&_.cmp-code]:bg-white/10 [&_.cmp-code]:text-[#e8b3b9] [&_.cmp-fence]:rounded-sm [&_.cmp-fence]:bg-white/[0.06] [&_.cmp-fence]:text-[#dde1f0] [html[data-theme=light]_&_.cmp-code]:bg-black/[0.07] [html[data-theme=light]_&_.cmp-code]:text-[#953b39] [html[data-theme=light]_&_.cmp-fence]:bg-black/[0.05] [html[data-theme=light]_&_.cmp-fence]:text-[#1f2328]"
+              className="composer-textarea composer-hl pointer-events-none absolute inset-0 z-0 block w-full overflow-hidden text-control-label leading-[1.55] whitespace-pre-wrap text-fg select-none [overflow-wrap:break-word] [&_.cmp-code]:rounded-sm [&_.cmp-code]:bg-white/10 [&_.cmp-code]:text-[#e8b3b9] [&_.cmp-fence]:rounded-sm [&_.cmp-fence]:bg-white/[0.06] [&_.cmp-fence]:text-[#dde1f0] [html[data-theme=light]_&_.cmp-code]:bg-black/[0.07] [html[data-theme=light]_&_.cmp-code]:text-[#953b39] [html[data-theme=light]_&_.cmp-fence]:bg-black/[0.05] [html[data-theme=light]_&_.cmp-fence]:text-[#1f2328]"
               aria-hidden="true"
               dangerouslySetInnerHTML={{ __html: hlHtml }}
             />
@@ -706,7 +706,7 @@ export function Composer({
           <textarea
             ref={textareaRef}
             className={cn(
-              "composer-textarea block min-h-32 max-h-80 w-full resize-none border-0 bg-transparent py-0.5 pr-0 pb-1 text-sm leading-[1.55] text-fg outline-none placeholder:text-faint max-[720px]:!min-h-0 max-[720px]:!max-h-60 max-[720px]:text-[16px]",
+              "composer-textarea block min-h-32 max-h-80 w-full resize-none border-0 bg-transparent py-0.5 pr-0 pb-1 text-control-label leading-[1.55] text-fg outline-none placeholder:text-faint max-[720px]:!min-h-0 max-[720px]:!max-h-60 max-[720px]:text-[16px]",
               minimized && "max-[720px]:!min-h-0 max-[720px]:px-1 max-[720px]:py-0",
               hlActive && "has-hl relative z-[1] text-transparent caret-fg [overflow-wrap:break-word]",
             )}
@@ -790,13 +790,13 @@ export function Composer({
                 <div className="composer-menu absolute bottom-[calc(100%+6px)] left-0 z-40 min-w-[172px] rounded-lg border border-line-strong bg-panel p-1 shadow-[0_8px_28px_rgba(0,0,0,0.28)]">
                   <button
                     type="button"
-                    className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
+                    className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-supporting text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
                     {...tapProps(() => {
                       setMenu(null);
                       fileInputRef.current?.click();
                     })}
                   >
-                    <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
+                    <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-control-label text-dim">
                       <IconPaperclip size={22} />
                     </span>
                     {onFilesChange ? "Attach files" : "Attach an image"}
@@ -804,13 +804,13 @@ export function Composer({
                   {mentionFetch && (
                     <button
                       type="button"
-                      className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
+                      className="composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-supporting text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)]"
                       {...tapProps(() => {
                         setMenu(null);
                         startMention();
                       })}
                     >
-                      <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
+                      <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-control-label text-dim">
                         <IconAtSign size={22} />
                       </span>
                       Reference a file
@@ -865,7 +865,7 @@ export function Composer({
                     aria-pressed={!!goal}
                   >
                     <IconCrosshair size={24} />
-                    {goal && <span className="composer-goal-label text-xs font-medium">Goal</span>}
+                    {goal && <span className="composer-goal-label text-label font-medium">Goal</span>}
                   </button>
                 </Tooltip>
                 <GoalModal
@@ -906,7 +906,7 @@ export function Composer({
                   >
                     <IconNote size={24} />
                     {noteMode && (
-                      <span className="composer-goal-label text-xs font-medium">Note</span>
+                      <span className="composer-goal-label text-label font-medium">Note</span>
                     )}
                   </button>
                 </Tooltip>
@@ -920,7 +920,7 @@ export function Composer({
           {/* Model + effort live together on the right edge (ChatGPT-style):
               one pill, effort levels up top, the model behind a submenu.
               Phones reorder it next to the + button via flex order (see the
-              "Lightweight phone inputs" block in global.css). */}
+              "Lightweight phone inputs" block in adapters.css). */}
           <AnimatePresence initial={false}>
             {!minimized && (
               <motion.div

--- a/src/frontend/components/ComposerAgents.tsx
+++ b/src/frontend/components/ComposerAgents.tsx
@@ -96,12 +96,12 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 
 	return (
 		<div
-			className="composer-agents relative -mb-3.5 ml-[18px] flex w-[calc(100%-36px)] flex-col gap-2.5 rounded-t-lg border border-b-0 border-line bg-panel px-3.5 pt-2.5 pb-[22px] text-sm font-medium text-fg"
+			className="composer-agents relative -mb-3.5 ml-[18px] flex w-[calc(100%-36px)] flex-col gap-2.5 rounded-t-lg border border-b-0 border-line bg-panel px-3.5 pt-2.5 pb-[22px] text-control-label font-medium text-fg"
 			data-open={open ? "" : undefined}
 		>
 			{open && (
 				<div className="composer-agents-detail flex flex-col gap-2.5">
-					<div className="composer-agents-name truncate text-xs font-semibold text-dim">
+					<div className="composer-agents-name truncate text-label font-semibold text-dim">
 						{single
 							? single.name
 							: runs.length > 0
@@ -121,7 +121,7 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 									)}
 								>
 									<span className={cn(
-										"composer-agents-step-mark inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-line text-[10px] font-semibold",
+										"composer-agents-step-mark inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-line text-meta font-semibold",
 										i === curIdx && "border-green text-green",
 										i < curIdx && "border-transparent bg-green-soft text-green",
 									)}>
@@ -133,7 +133,7 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 						</ol>
 					)}
 
-					<div className="composer-agents-tallies flex flex-wrap gap-x-3 gap-y-1 text-xs font-medium">
+					<div className="composer-agents-tallies flex flex-wrap gap-x-3 gap-y-1 text-label font-medium">
 						<span>
 							<i className="composer-agents-dot size-2 shrink-0 rounded-full bg-green motion-safe:animate-[pulse_1.4s_ease-in-out_infinite]" />
 							{runningCount} running
@@ -148,7 +148,7 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 					</div>
 
 					{running.length > 0 && (
-						<ul className="composer-agents-list m-0 flex max-h-[108px] list-none flex-col gap-[5px] overflow-y-auto p-0 text-xs font-medium">
+						<ul className="composer-agents-list m-0 flex max-h-[108px] list-none flex-col gap-[5px] overflow-y-auto p-0 text-label font-medium">
 							{running.slice(0, 4).map((a) => (
 								<li key={a.key} className="flex min-w-0 items-center gap-[7px]">
 									<i className="composer-agents-dot sm size-1.5 shrink-0 rounded-full bg-green motion-safe:animate-[pulse_1.4s_ease-in-out_infinite]" />
@@ -166,7 +166,7 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 
 					<button
 						type="button"
-						className="composer-agents-open inline-flex self-start items-center gap-0.5 rounded-full border border-line bg-hover py-[5px] pr-2.5 pl-3 text-xs font-semibold text-fg active:bg-pressed"
+						className="composer-agents-open inline-flex self-start items-center gap-0.5 rounded-full border border-line bg-hover py-[5px] pr-2.5 pl-3 text-label font-semibold text-fg active:bg-pressed"
 						onClick={onOpenPanel}
 					>
 						Open full panel

--- a/src/frontend/components/ComposerAgents.tsx
+++ b/src/frontend/components/ComposerAgents.tsx
@@ -95,10 +95,13 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 	} = stats;
 
 	return (
-		<div className="composer-agents" data-open={open ? "" : undefined}>
+		<div
+			className="composer-agents relative -mb-3.5 ml-[18px] flex w-[calc(100%-36px)] flex-col gap-2.5 rounded-t-lg border border-b-0 border-line bg-panel px-3.5 pt-2.5 pb-[22px] text-sm font-medium text-fg"
+			data-open={open ? "" : undefined}
+		>
 			{open && (
-				<div className="composer-agents-detail">
-					<div className="composer-agents-name">
+				<div className="composer-agents-detail flex flex-col gap-2.5">
+					<div className="composer-agents-name truncate text-xs font-semibold text-dim">
 						{single
 							? single.name
 							: runs.length > 0
@@ -107,17 +110,21 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 					</div>
 
 					{steps.length > 1 && (
-						<ol className="composer-agents-steps">
+						<ol className="composer-agents-steps m-0 flex list-none flex-col gap-1.5 p-0">
 							{steps.map((s, i) => (
 								<li
 									key={s}
 									className={cn(
-										"composer-agents-step",
-										i < curIdx && "is-done",
-										i === curIdx && "is-current",
+										"composer-agents-step flex items-center gap-2 font-medium text-faint",
+										i < curIdx && "is-done text-dim",
+										i === curIdx && "is-current font-semibold text-fg",
 									)}
 								>
-									<span className="composer-agents-step-mark">
+									<span className={cn(
+										"composer-agents-step-mark inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-line text-[10px] font-semibold",
+										i === curIdx && "border-green text-green",
+										i < curIdx && "border-transparent bg-green-soft text-green",
+									)}>
 										{i < curIdx ? "✓" : i + 1}
 									</span>
 									<span className="composer-agents-step-label">{s}</span>
@@ -126,40 +133,40 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 						</ol>
 					)}
 
-					<div className="composer-agents-tallies">
+					<div className="composer-agents-tallies flex flex-wrap gap-x-3 gap-y-1 text-xs font-medium">
 						<span>
-							<i className="composer-agents-dot" />
+							<i className="composer-agents-dot size-2 shrink-0 rounded-full bg-green motion-safe:animate-[pulse_1.4s_ease-in-out_infinite]" />
 							{runningCount} running
 						</span>
 						{done > 0 && (
-							<span className="is-done">
+							<span className="is-done text-dim">
 								{done}/{total} done
 							</span>
 						)}
-						{pending > 0 && <span className="is-dim">{pending} queued</span>}
-						{error > 0 && <span className="is-error">{error} failed</span>}
+						{pending > 0 && <span className="is-dim text-faint">{pending} queued</span>}
+						{error > 0 && <span className="is-error text-red">{error} failed</span>}
 					</div>
 
 					{running.length > 0 && (
-						<ul className="composer-agents-list">
+						<ul className="composer-agents-list m-0 flex max-h-[108px] list-none flex-col gap-[5px] overflow-y-auto p-0 text-xs font-medium">
 							{running.slice(0, 4).map((a) => (
-								<li key={a.key}>
-									<i className="composer-agents-dot sm" />
-									<span className="composer-agents-list-label">{a.label}</span>
+								<li key={a.key} className="flex min-w-0 items-center gap-[7px]">
+									<i className="composer-agents-dot sm size-1.5 shrink-0 rounded-full bg-green motion-safe:animate-[pulse_1.4s_ease-in-out_infinite]" />
+									<span className="composer-agents-list-label truncate">{a.label}</span>
 									{a.phase && single?.phases?.length !== 1 ? (
-										<span className="is-dim"> · {a.phase}</span>
+										<span className="is-dim shrink-0 text-faint"> · {a.phase}</span>
 									) : null}
 								</li>
 							))}
 							{running.length > 4 && (
-								<li className="is-dim">+{running.length - 4} more</li>
+								<li className="is-dim text-faint">+{running.length - 4} more</li>
 							)}
 						</ul>
 					)}
 
 					<button
 						type="button"
-						className="composer-agents-open"
+						className="composer-agents-open inline-flex self-start items-center gap-0.5 rounded-full border border-line bg-hover py-[5px] pr-2.5 pl-3 text-xs font-semibold text-fg active:bg-pressed"
 						onClick={onOpenPanel}
 					>
 						Open full panel
@@ -170,22 +177,22 @@ export function ComposerAgents({ runs, subagents, onOpenPanel }: Props) {
 
 			<button
 				type="button"
-				className="composer-agents-summary"
+				className="composer-agents-summary flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent p-0 text-left text-inherit font-medium"
 				aria-expanded={open}
 				aria-label={open ? "Collapse running agents" : "Show running agents"}
 				onClick={() => setOpen((v) => !v)}
 			>
-				<span className="composer-agents-dot" />
-				<span className="composer-agents-label">
+				<span className="composer-agents-dot size-2 shrink-0 rounded-full bg-green motion-safe:animate-[pulse_1.4s_ease-in-out_infinite]" />
+				<span className="composer-agents-label min-w-0 flex-1 truncate">
 					<strong>{runningCount} running</strong>
 					{total > runningCount ? (
-						<span className="is-dim"> · {done}/{total} done</span>
+						<span className="is-dim font-medium text-faint"> · {done}/{total} done</span>
 					) : null}
-					{!open && phase ? <span className="is-dim"> · {phase}</span> : null}
+					{!open && phase ? <span className="is-dim font-medium text-faint"> · {phase}</span> : null}
 				</span>
 				<IconChevronDown
 					size={16}
-					className={cn("composer-agents-caret", open && "is-open")}
+					className={cn("composer-agents-caret shrink-0 text-faint motion-safe:transition-transform motion-safe:duration-180", open && "is-open rotate-180")}
 				/>
 			</button>
 		</div>

--- a/src/frontend/components/ConversationPane.tsx
+++ b/src/frontend/components/ConversationPane.tsx
@@ -103,9 +103,9 @@ export function ConversationPane({
 		<div className={`flex-1 min-h-0 overflow-y-auto ${className || ""}`}>
 			<div className="w-full max-w-[760px] mx-auto px-5 py-6">
 				{loading && !thread ? (
-					<div className="panel-placeholder">Loading ticket…</div>
+					<div className="panel-placeholder px-4 py-12 text-center text-control-label text-faint">Loading ticket…</div>
 				) : error && !thread ? (
-					<div className="panel-placeholder">
+					<div className="panel-placeholder px-4 py-12 text-center text-control-label text-faint">
 						Couldn't load this Plain thread: {error}
 					</div>
 				) : (
@@ -124,13 +124,13 @@ export function ConversationPane({
 							)}
 							{status && (
 								<span
-									className={`plain-status plain-status-${status.toLowerCase()}`}
+									className={`plain-status plain-status-${status.toLowerCase()} shrink-0 rounded-full bg-active px-1.5 py-0.5 text-meta font-bold text-faint ${status === "TODO" ? "bg-accent-soft text-accent" : status === "DONE" ? "bg-green-soft text-green" : "bg-yellow/20 text-yellow"}`}
 								>
 									{STATUS_LABEL[status] || status}
 								</span>
 							)}
 							<a
-								className="plain-open ml-auto shrink-0"
+								className="plain-open ml-auto shrink-0 whitespace-nowrap text-meta font-semibold text-accent no-underline hover:underline"
 								href={plainThreadUrl(threadId)}
 								target="_blank"
 								rel="noreferrer"
@@ -193,7 +193,7 @@ export function ConversationPane({
 
 						<div className="flex flex-col gap-3 mt-5">
 							{thread && thread.entries.length === 0 ? (
-								<div className="plain-loading">
+								<div className="plain-loading mt-5 text-center text-control-label text-faint">
 									No messages in this thread yet.
 								</div>
 							) : (

--- a/src/frontend/components/DeskConversation.tsx
+++ b/src/frontend/components/DeskConversation.tsx
@@ -5,6 +5,7 @@ import { getCurrentUser } from "./UserPicker";
 import { renderMarkdown } from "../lib/markdown";
 import { fetchFileMentions } from "../lib/api";
 import { TranscriptBlocks } from "./TranscriptBlocks";
+import { MARKDOWN_STYLES } from "./MarkdownBody";
 import { useFileMentions } from "./useFileMentions";
 import { IconArrowUp } from "./icons";
 import { mergeTranscriptEntries } from "../lib/transcript-state";
@@ -225,16 +226,16 @@ export function DeskConversation({
 				onScroll={onScroll}
 			>
 				{!hasContent ? (
-					<div className="mx-auto mt-6 max-w-[320px] text-center text-[13px] font-medium leading-relaxed text-dim">
+					<div className="mx-auto mt-6 max-w-[320px] text-center text-control-label font-medium leading-relaxed text-dim">
 						{emptyState ?? "Ask your Desk anything."}
 					</div>
 				) : (
 					<>
 						<TranscriptBlocks entries={visibleEntries} live={isRunning} />
 						{streamText && (
-							<div className="msg msg-assistant msg-streaming">
+							<div className="msg msg-assistant msg-streaming mb-[18px] flex w-full max-w-[var(--chat-col)] flex-col [overflow-anchor:none]">
 								<div
-									className="msg-body msg-body-assistant markdown"
+									className={`msg-body msg-body-assistant markdown ${MARKDOWN_STYLES} flex flex-col items-stretch text-body leading-6 break-words text-fg [overflow-anchor:none] [&::after]:ml-[3px] [&::after]:inline-block [&::after]:h-[14px] [&::after]:w-[7px] [&::after]:rounded-xs [&::after]:bg-accent [&::after]:align-[-2px] [&::after]:content-[''] [&::after]:animate-pulse`}
 									dangerouslySetInnerHTML={{ __html: renderMarkdown(streamText) }}
 								/>
 							</div>
@@ -244,8 +245,8 @@ export function DeskConversation({
 						    delivered the instant Enter lands; reconciles away when the
 						    real user entry arrives. */}
 						{pending && (
-							<div className="msg msg-user">
-								<div className="msg-body msg-body-user">{pending}</div>
+							<div className="msg msg-user mb-[18px] mt-1 flex w-full max-w-[var(--chat-col)] flex-col">
+								<div className="msg-body msg-body-user inline-block max-w-[min(600px,90%)] self-end rounded-panel bg-panel px-3.5 py-2.5 text-body leading-6 text-fg">{pending}</div>
 							</div>
 						)}
 					</>
@@ -259,7 +260,7 @@ export function DeskConversation({
 				{mentions.popup}
 				<textarea
 					ref={textareaRef}
-					className="max-h-40 min-h-[36px] flex-1 resize-none rounded-md border border-line bg-surface px-2 py-1.5 text-[13px] font-medium text-fg outline-none placeholder:text-dim focus:border-fg/30"
+					className="max-h-40 min-h-[36px] flex-1 resize-none rounded-md border border-line bg-surface px-2 py-1.5 text-control-label font-medium text-fg outline-none placeholder:text-dim focus:border-fg/30 focus-ring"
 					rows={1}
 					value={draft}
 					placeholder={
@@ -279,7 +280,7 @@ export function DeskConversation({
 					}}
 				/>
 				<button
-					className="flex shrink-0 items-center justify-center rounded-md bg-fg p-1.5 text-panel disabled:opacity-40"
+					className="flex shrink-0 items-center justify-center rounded-md bg-fg p-1.5 text-panel transition-transform active:scale-[0.96] disabled:opacity-40 focus-ring"
 					onClick={handleSend}
 					disabled={!connected || !draft.trim()}
 					aria-label="Send"

--- a/src/frontend/components/DiffPanel.tsx
+++ b/src/frontend/components/DiffPanel.tsx
@@ -169,33 +169,33 @@ export function DiffPanel({ sessionId, isRunning, canSend, send, diff }: Props) 
   const d = cur.diff;
 
   return (
-    <div className="diff-panel">
+    <div className="diff-panel flex min-h-0 flex-col">
       {multi && (
-        <div className="diff-repo-tabs">
+          <div className="diff-repo-tabs sticky top-0 z-[2] flex gap-1 overflow-x-auto border-b border-line bg-raised px-2.5 py-1.5">
           {changed.map((r, i) => {
             const n = r.diff.totalAdditions + r.diff.totalDeletions;
             return (
               <button
                 key={r.repo}
-                className={`diff-repo-tab ${i === active ? "diff-repo-tab-active" : ""}`}
+                className={`diff-repo-tab inline-flex items-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent bg-transparent px-2.5 py-[3px] text-label text-dim hover:text-fg ${i === active ? "diff-repo-tab-active border-line bg-panel text-fg" : ""}`}
                 onClick={() => setActive(i)}
                 title={r.primary ? "Primary repo" : "Attached repo"}
               >
                 {r.repo}
-                <span className="diff-repo-tab-count">{r.diff.files.length}</span>
+                <span className="diff-repo-tab-count rounded-full bg-[color-mix(in_srgb,var(--text-faint)_20%,transparent)] px-1.5 text-meta text-faint">{r.diff.files.length}</span>
               </button>
             );
           })}
         </div>
       )}
 
-      <div className="diff-summary">
-        <span className="diff-summary-files">
+      <div className="diff-summary sticky top-0 z-[1] flex items-center gap-2.5 border-b border-line bg-raised px-3.5 py-2.5 text-supporting">
+        <span className="diff-summary-files text-dim">
           {d.files.length} file{d.files.length === 1 ? "" : "s"} changed
         </span>
-        <span className="diff-add">+{d.totalAdditions}</span>
-        <span className="diff-del">−{d.totalDeletions}</span>
-        {d.truncated && <span className="diff-truncated">truncated</span>}
+        <span className="diff-add font-semibold text-green">+{d.totalAdditions}</span>
+        <span className="diff-del font-semibold text-red">−{d.totalDeletions}</span>
+        {d.truncated && <span className="diff-truncated rounded-sm bg-yellow/15 px-1.5 py-px text-meta font-bold text-yellow">truncated</span>}
         <Tooltip label="Refresh diff">
           <Button
             variant="ghost"
@@ -209,7 +209,7 @@ export function DiffPanel({ sessionId, isRunning, canSend, send, diff }: Props) 
         </Tooltip>
       </div>
 
-      <div className="diff-render">
+      <div className="diff-render p-2.5 pb-7 [&_[class*='pierre']]:max-w-full">
         <CommentableDiff
           key={cur.repo}
           patch={d.rawPatch || ""}

--- a/src/frontend/components/DiffPanel.tsx
+++ b/src/frontend/components/DiffPanel.tsx
@@ -200,7 +200,7 @@ export function DiffPanel({ sessionId, isRunning, canSend, send, diff }: Props) 
           <Button
             variant="ghost"
             size="xs"
-            className="ml-auto min-h-0 px-1.5 py-0.5 text-sm text-faint hover:text-fg"
+            className="ml-auto min-h-0 px-1.5 py-0.5 text-control-label text-faint hover:text-fg"
             onClick={reload}
             aria-label="Refresh diff"
           >
@@ -269,11 +269,11 @@ function DiffEmptyState({ isRunning }: { isRunning: boolean }) {
         <path d="M13 18v5a4 4 0 0 0 4 4h5" />
       </svg>
       <div className="flex flex-col gap-1">
-        <div className="text-item-title font-medium text-dim">No file changes yet</div>
-        <div className="text-sm text-faint">Changes appear here.</div>
+		<div className="text-item-title font-medium text-dim">No file changes yet</div>
+		<div className="text-control-label text-faint">Changes appear here.</div>
       </div>
       {isRunning && (
-        <div className="mt-1 flex items-center gap-2 text-xs text-faint">
+        <div className="mt-1 flex items-center gap-2 text-label text-faint">
           <PixelSpinner className="pixel-spinner-slow text-faint" interval={4000} />
           <span>Pulling latest…</span>
         </div>

--- a/src/frontend/components/FileChips.tsx
+++ b/src/frontend/components/FileChips.tsx
@@ -30,8 +30,8 @@ export function FileChips({ files, onRemove, disabled }: Props) {
             {extBadge(f.name)}
           </span>
           <span className="composer-file-meta flex min-w-0 flex-col gap-px">
-            <span className="composer-file-name truncate text-[12.5px] text-fg">{f.name}</span>
-            <span className="composer-file-sub text-[10.5px] text-faint">Attachment</span>
+            <span className="composer-file-name truncate text-supporting text-fg">{f.name}</span>
+            <span className="composer-file-sub text-meta text-faint">Attachment</span>
           </span>
           <button
             type="button"

--- a/src/frontend/components/FileChips.tsx
+++ b/src/frontend/components/FileChips.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { FileAttachment } from "../lib/images";
+import { cn } from "../ui/cn";
 
 interface Props {
   files: FileAttachment[];
@@ -18,17 +19,26 @@ function extBadge(name: string): string {
 export function FileChips({ files, onRemove, disabled }: Props) {
   if (files.length === 0) return null;
   return (
-    <div className="composer-files">
+    <div className="composer-files mb-2 flex flex-wrap gap-2">
       {files.map((f, i) => (
-        <div key={i} className="composer-file-card" title={f.name}>
-          <span className="composer-file-thumb">{extBadge(f.name)}</span>
-          <span className="composer-file-meta">
-            <span className="composer-file-name">{f.name}</span>
-            <span className="composer-file-sub">Attachment</span>
+        <div
+          key={i}
+          className="composer-file-card relative inline-flex max-w-60 items-center gap-[9px] rounded-lg border border-line-strong bg-hover py-1.5 pr-[26px] pl-1.5"
+          title={f.name}
+        >
+          <span className="composer-file-thumb inline-flex size-[34px] shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--accent)_16%,transparent)] text-[9.5px] font-bold tracking-[0.02em] text-accent">
+            {extBadge(f.name)}
+          </span>
+          <span className="composer-file-meta flex min-w-0 flex-col gap-px">
+            <span className="composer-file-name truncate text-[12.5px] text-fg">{f.name}</span>
+            <span className="composer-file-sub text-[10.5px] text-faint">Attachment</span>
           </span>
           <button
             type="button"
-            className="composer-file-remove"
+            className={cn(
+              "composer-file-remove absolute top-1 right-1.5 shrink-0 border-0 bg-transparent p-0 text-[15px] leading-none text-faint hover:not-disabled:text-fg",
+              "disabled:cursor-default disabled:opacity-50",
+            )}
             onClick={() => onRemove(i)}
             disabled={disabled}
             title="Remove file"

--- a/src/frontend/components/Goals.tsx
+++ b/src/frontend/components/Goals.tsx
@@ -20,6 +20,7 @@ import { docTitle, DEFAULT_DOC_TITLE } from "../lib/brand";
 import { Button } from "../ui/button";
 import { PageDescription, PageHeader, PageTitle } from "../ui/page-header";
 import { InlineAlert } from "../ui/state";
+import { cn } from "../ui/cn";
 
 type GoalStatus = "active" | "paused" | "done" | "failed";
 
@@ -137,16 +138,16 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
   }
 
   return (
-    <div className={`automations-page ${sel ? "automations-page-has-detail" : ""}`}>
-    <div className="automations-page-main">
-    <div className="automations-page-inner">
+    <div className="relative flex min-h-0 min-w-0 flex-1">
+    <div className={cn("min-w-0 flex-1 overflow-y-auto px-6 pb-[60px] pt-7 max-[560px]:px-4 max-[560px]:pb-12 max-[560px]:pt-5", sel && "basis-[340px] grow-0 border-r border-line px-3.5 pb-10 pt-4 max-[900px]:hidden")}>
+    <div className={cn("mx-auto max-w-[860px]", sel && "max-w-none")}>
       <PageHeader
         className={`max-[560px]:mb-5 max-[560px]:flex-col max-[560px]:items-start max-[560px]:gap-3.5 ${
           sel ? "mb-3.5 items-center" : ""
         }`}
       >
         <div>
-          <PageTitle className={sel ? "text-item-title" : undefined}>Goals</PageTitle>
+			<PageTitle className={sel ? "text-item-title" : undefined}>Goals</PageTitle>
           <PageDescription className={sel ? "hidden" : undefined}>
             Long-running, self-pacing missions — one managed session that remembers its own
             progress, paces itself, and stops when done.
@@ -182,21 +183,21 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
       {loading ? (
         <div className="loading">Loading…</div>
       ) : goals.length === 0 && !showForm ? (
-        <div className="automations-empty">
+        <div className="px-4 py-12 text-center text-dim">
           <p>No goals yet.</p>
-          <p className="automations-empty-sub">
+          <p className="text-control-label text-faint">
             A goal pursues one mission over days/weeks — it wakes itself, reads its ledger,
             ships work via PRs, measures, and iterates until the objective is met.
           </p>
         </div>
       ) : (
-        <div className="automations-table">
+        <div className="flex flex-col border-t border-line">
           {goals.map((g) => {
             const running = g.isRunning || g.lastRunStatus === "running";
             return (
               <button
                 key={g.id}
-                className={`automations-row ${sel?.id === g.id ? "active" : ""} ${g.status === "active" ? "" : "automations-row-off"}`}
+                className={cn("flex w-full min-w-0 items-center gap-3 border-0 border-b border-line bg-transparent px-2.5 py-2.5 text-left text-fg hover:bg-hover max-[560px]:gap-2.5 max-[560px]:px-1 max-[560px]:py-3", sel?.id === g.id && "bg-active", g.status !== "active" && "[&_.goal-row-main]:opacity-55")}
                 onClick={() => onSelect(g.id)}
               >
                 <span
@@ -204,9 +205,9 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
                   style={{ background: STATUS_COLOR[g.status] }}
                   title={g.pauseReason || g.doneReason || g.status}
                 />
-                <span className="automations-row-main">
-                  <span className="automations-row-name">{g.name}</span>
-                  <span className="automations-row-trigger">
+                <span className="goal-row-main flex min-w-0 flex-1 flex-col gap-px">
+                  <span className="truncate text-body font-semibold">{g.name}</span>
+                  <span className="truncate font-mono text-meta text-faint">
                     {g.status}
                     {g.phase ? ` · ${g.phase}` : ""}
                     {` · wake #${g.wakeCount}${g.maxWakes ? ` / ${g.maxWakes}` : ""}`}
@@ -218,17 +219,17 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
                   </span>
                 ) : g.lastRunStatus === "ok" ? (
                   <span
-                    className="auto-status-ok"
+                    className="text-green"
                     title={`Last wake ok${g.lastRunAt ? ` — ${relativeTime(g.lastRunAt)}` : ""}`}
                   >
                     ✓
                   </span>
                 ) : g.lastRunStatus === "error" ? (
-                  <span className="auto-status-err" title={g.lastRunError || "Last wake failed"}>
+                  <span className="text-red" title={g.lastRunError || "Last wake failed"}>
                     ✗
                   </span>
                 ) : null}
-                <span className="automations-row-next">
+                <span className="w-[84px] shrink-0 text-right text-label text-faint max-[560px]:hidden">
                   {g.status === "active" && g.nextWakeAt
                     ? `next ${formatNext(g.nextWakeAt)}`
                     : g.status}
@@ -242,10 +243,10 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
     </div>
 
       {sel && (
-        <aside className="automations-drawer">
-          <div className="automations-drawer-head">
+        <aside className="flex min-h-0 min-w-0 flex-1 flex-col border-l border-line bg-panel max-[900px]:border-l-0">
+          <div className="flex shrink-0 items-center gap-2.5 border-b border-line px-4 py-3">
             <button
-              className="automations-drawer-back"
+              className="-my-1 -ml-0.5 hidden shrink-0 items-center gap-1.5 border-0 bg-transparent px-1.5 py-1 text-body font-medium text-fg max-[900px]:inline-flex"
               onClick={() => onSelect("")}
               title="Back to goals"
             >
@@ -254,11 +255,11 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
               Goals
             </button>
-            <span className="automations-drawer-title">
+            <span className="min-w-0 truncate text-control-label font-semibold">
               {editMode ? `Edit — ${sel.name}` : sel.name}
             </span>
             {!editMode && (
-              <div className="automations-drawer-actions">
+              <div className="ml-auto flex shrink-0 gap-1.5">
                 {sel.status === "active" && (
                   <Button
                     size="sm"
@@ -287,7 +288,7 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
               </div>
             )}
             <button
-              className="automations-drawer-close"
+              className="flex size-7 shrink-0 items-center justify-center rounded-md border-0 bg-transparent text-dim hover:bg-hover hover:text-fg max-[900px]:hidden"
               onClick={() => onSelect("")}
               title="Close"
             >
@@ -296,7 +297,7 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
               </svg>
             </button>
           </div>
-          <div className="automations-drawer-body">
+          <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto px-5 pb-10 pt-[18px]">
             {editMode ? (
               <GoalForm
                 key={sel.id}
@@ -340,15 +341,15 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
                 )}
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Mission</div>
-                  <div className="bg-surface border border-line rounded-panel px-3.5 py-3 text-[13px] leading-relaxed text-dim whitespace-pre-wrap">
+                  <div className="mb-1.5 text-label font-semibold text-faint">Mission</div>
+                  <div className="whitespace-pre-wrap rounded-panel border border-line bg-surface px-3.5 py-3 text-control-label leading-relaxed text-dim">
                     {sel.mission}
                   </div>
                 </div>
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Configuration</div>
-                  <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-[13px]">
+                  <div className="mb-1.5 text-label font-semibold text-faint">Configuration</div>
+                  <div className="grid grid-cols-[max-content_1fr] items-baseline gap-x-5 gap-y-2 text-control-label">
                     <DetailKey>Mode</DetailKey>
                     <span className="text-dim">
                       {sel.mode === "ask"
@@ -392,7 +393,7 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
                         <DetailKey>Session</DetailKey>
                         <span className="min-w-0">
                           <a
-                            className="automation-session-link"
+                            className="text-accent hover:underline"
                             onClick={(e) => {
                               e.preventDefault();
                               onOpenSession(sel.bksSessionId!);
@@ -411,17 +412,17 @@ export function Goals({ onOpenSession, selectedId, onSelect }: Props) {
                 </div>
 
                 <div>
-                  <div className="automations-drawer-section-label mb-1.5">Activity</div>
-                  <div className="text-dim text-supporting mb-2">
+                  <div className="mb-1.5 text-label font-semibold text-faint">Activity</div>
+                  <div className="mb-2 text-supporting text-dim">
                     wake #{sel.wakeCount}
                     {sel.maxWakes ? ` of ${sel.maxWakes}` : ""}
                     {sel.lastRunAt && (
                       <>
                         {" · last wake "}
                         {relativeTime(sel.lastRunAt)}
-                        {sel.lastRunStatus === "ok" && <span className="auto-status-ok"> ✓</span>}
+                        {sel.lastRunStatus === "ok" && <span className="text-green"> ✓</span>}
                         {sel.lastRunStatus === "error" && (
-                          <span className="auto-status-err" title={sel.lastRunError}> ✗</span>
+                          <span className="text-red" title={sel.lastRunError}> ✗</span>
                         )}
                       </>
                     )}
@@ -459,23 +460,7 @@ function GoalLedger({ id }: { id: string }) {
     };
   }, [id]);
   return (
-    <pre
-      style={{
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-word",
-        maxHeight: 360,
-        overflow: "auto",
-        margin: 0,
-        padding: "10px 12px",
-        background: "var(--bg-raised)",
-        color: "var(--text)",
-        border: "1px solid var(--border)",
-        borderRadius: 8,
-        fontFamily: "var(--mono)",
-        fontSize: 13,
-        lineHeight: 1.5,
-      }}
-    >
+    <pre className="m-0 max-h-[360px] overflow-auto whitespace-pre-wrap break-words rounded-md border border-line bg-raised px-3 py-2.5 font-mono text-label leading-relaxed text-fg">
       {ledger === null ? "Loading ledger…" : ledger}
     </pre>
   );
@@ -564,9 +549,9 @@ function GoalForm({
   }
 
   return (
-    <div className={`automation-form ${inline ? "automation-form-inline" : ""}`}>
+    <div className={cn("flex flex-col gap-3.5", !inline && "rounded-panel border border-line-strong bg-panel p-[18px]", "[&_label]:flex [&_label]:flex-1 [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:leading-relaxed [&_textarea]:text-fg")}>
       {!inline && (
-        <div className="automation-form-title">
+          <div className="text-body font-semibold">
           {initial ? `Edit "${initial.name}"` : "New goal"}
         </div>
       )}
@@ -590,7 +575,7 @@ function GoalForm({
         />
       </label>
 
-      <div className="automation-form-row">
+        <div className="flex gap-3.5">
         <label>
           Mode
           <select value={mode} onChange={(e) => setMode(e.target.value as "ask" | "code")}>
@@ -635,7 +620,7 @@ function GoalForm({
         </label>
       </div>
 
-      <div className="automation-form-row">
+        <div className="flex gap-3.5">
         <label>
           MCP servers (comma-separated; blank = all)
           <input
@@ -669,7 +654,7 @@ function GoalForm({
 
       {error && <InlineAlert>{error}</InlineAlert>}
 
-      <div className="automation-form-actions">
+      <div className="flex justify-end gap-2.5">
         <Button size="md" onClick={onClose} disabled={saving}>
           Cancel
         </Button>

--- a/src/frontend/components/Home.tsx
+++ b/src/frontend/components/Home.tsx
@@ -629,11 +629,11 @@ export function Home({ sessions, projects, onSelect, onNewSession, onOpenAnalyti
               <section key={section.state} className="mb-10">
                 <div className="mb-4 flex items-baseline gap-2 px-2 text-item-title font-semibold text-fg">
                   <span>{section.label}</span>
-                  <span className="text-label font-medium text-faint">{section.rows.length}</span>
-                </div>
-                {section.groups.map(([label, rows]) => (
-                  <div key={label} className="mb-5">
-                    <div className="mb-1.5 flex items-baseline gap-2 px-2 text-label font-medium text-dim">
+					<span className="text-label font-medium text-faint">{section.rows.length}</span>
+				</div>
+				{section.groups.map(([label, rows]) => (
+					<div key={label} className="mb-5">
+						<div className="mb-1.5 flex items-baseline gap-2 px-2 text-label font-medium text-dim">
                       <span>{label}</span>
                       <span className="text-faint">{rows.length}</span>
                     </div>
@@ -666,7 +666,7 @@ export function Home({ sessions, projects, onSelect, onNewSession, onOpenAnalyti
                               <span className="truncate">{row.branch}</span>
                             </span>
                           </span>
-                          <span className="justify-self-end text-label max-[720px]:hidden">
+								<span className="justify-self-end text-label max-[720px]:hidden">
                             {row.additions !== undefined && (
                               <span className="text-green">+{compactDiff(row.additions)}</span>
                             )}
@@ -674,7 +674,7 @@ export function Home({ sessions, projects, onSelect, onNewSession, onOpenAnalyti
                               <span className="ml-2 text-red">-{compactDiff(row.deletions)}</span>
                             )}
                           </span>
-                          <span className="justify-self-end text-label text-faint">{compactAge(row.updatedAt)}</span>
+								<span className="justify-self-end text-label text-faint">{compactAge(row.updatedAt)}</span>
                         </button>
                         );
                       })}

--- a/src/frontend/components/Home.tsx
+++ b/src/frontend/components/Home.tsx
@@ -608,12 +608,12 @@ export function Home({ sessions, projects, onSelect, onNewSession, onOpenAnalyti
 
         {sections.length === 0 ? (
           <div className="px-2 py-16 text-center">
-            <div className="text-sm font-medium text-fg">
-              {query
-                ? "No matching worktrees"
-                : person === "all"
-                  ? "No pull request worktrees yet"
-                  : `Nothing open for ${personLabel(person)}`}
+			<div className="text-control-label font-medium text-fg">
+				{query
+					? "No matching worktrees"
+					: person === "all"
+						? "No pull request worktrees yet"
+						: `Nothing open for ${personLabel(person)}`}
             </div>
             <div className="mt-1 text-body text-faint">
               {query

--- a/src/frontend/components/ImageThumbs.tsx
+++ b/src/frontend/components/ImageThumbs.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { openLightbox } from "./MediaLightbox";
+import { cn } from "../ui/cn";
 
 interface Props {
   /** Attached images as `data:` URLs. */
@@ -12,12 +13,12 @@ interface Props {
 export function ImageThumbs({ images, onRemove, disabled }: Props) {
   if (images.length === 0) return null;
   return (
-    <div className="composer-images">
+    <div className="composer-images mb-2 flex flex-wrap gap-2">
       {images.map((src, i) => (
-        <div key={i} className="composer-image-thumb">
+        <div key={i} className="composer-image-thumb relative leading-none">
           <button
             type="button"
-            className="composer-image-preview"
+            className="composer-image-preview block cursor-zoom-in border-0 bg-transparent p-0 leading-none outline-none focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
             onClick={() =>
               openLightbox(
                 images.map((image) => ({ kind: "image", src: image })),
@@ -26,11 +27,18 @@ export function ImageThumbs({ images, onRemove, disabled }: Props) {
             }
             aria-label="Open image preview"
           >
-            <img src={src} alt="" />
+            <img
+              src={src}
+              alt=""
+              className="h-14 w-auto max-w-30 rounded-md border border-line-strong object-cover"
+            />
           </button>
           <button
             type="button"
-            className="composer-image-remove"
+            className={cn(
+              "composer-image-remove absolute -top-1.5 -right-1.5 flex size-[18px] items-center justify-center rounded-full border-0 bg-fg p-0 text-[13px] leading-none text-panel",
+              "disabled:cursor-default disabled:opacity-50",
+            )}
             onClick={() => onRemove(i)}
             disabled={disabled}
             title="Remove image"

--- a/src/frontend/components/ImageThumbs.tsx
+++ b/src/frontend/components/ImageThumbs.tsx
@@ -36,7 +36,7 @@ export function ImageThumbs({ images, onRemove, disabled }: Props) {
           <button
             type="button"
             className={cn(
-              "composer-image-remove absolute -top-1.5 -right-1.5 flex size-[18px] items-center justify-center rounded-full border-0 bg-fg p-0 text-[13px] leading-none text-panel",
+              "composer-image-remove absolute -top-1.5 -right-1.5 flex size-[18px] items-center justify-center rounded-full border-0 bg-fg p-0 text-control-label leading-none text-panel",
               "disabled:cursor-default disabled:opacity-50",
             )}
             onClick={() => onRemove(i)}

--- a/src/frontend/components/MarkdownBody.tsx
+++ b/src/frontend/components/MarkdownBody.tsx
@@ -1,6 +1,25 @@
 import React, { useEffect, useRef, useState } from "react";
 import { effectiveTheme, onThemeChanged, type EffectiveTheme } from "../lib/theme";
 
+// Keep the stable `.markdown` hook for generated HTML while making the rendered
+// document own its presentation instead of depending on global.css.
+export const MARKDOWN_STYLES = [
+	"text-body leading-6 break-words",
+	"[&_p]:mb-1.5 [&_p]:mt-0",
+	"[&_a]:text-accent [&_a]:no-underline hover:[&_a]:underline",
+	"[&_strong]:font-semibold [&_strong]:text-fg",
+	"[&_pre]:my-0.5 [&_pre]:mb-2 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:border [&_pre]:border-line [&_pre]:bg-[#0c0c10] [&_pre]:px-3 [&_pre]:py-2.5 [&_pre]:font-mono [&_pre]:text-label [&_pre]:leading-[1.55] [html[data-theme=light]_&_*]:[color-scheme:light] [html[data-theme=light]_&_pre]:border-[#d8dee4] [html[data-theme=light]_&_pre]:bg-[#f6f8fa] [html[data-theme=light]_&_pre]:text-[#1f2328]",
+	"[&_code]:rounded-sm [&_code]:bg-white/6 [&_code]:px-[5px] [&_code]:py-[1.5px] [&_code]:font-mono [&_code]:text-[0.9em] [&_code]:text-[#dde1f0] [html[data-theme=light]_&_code]:bg-black/6 [html[data-theme=light]_&_code]:text-[#953b39] [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-label [&_pre_code]:text-inherit",
+	"[&_ul]:mb-1.5 [&_ul]:mt-0 [&_ul]:pl-5 [&_ol]:mb-1.5 [&_ol]:mt-0 [&_ol]:pl-5 [&_li]:my-[2.5px] [&_li>ul]:mb-0 [&_li>ul]:mt-0.5 [&_li>ol]:mb-0 [&_li>ol]:mt-0.5",
+	"[&_h1]:mb-px [&_h1]:mt-1.5 [&_h1]:text-item-title [&_h1]:font-semibold [&_h1]:leading-[1.3] [&_h1]:text-fg [&_h2]:mb-px [&_h2]:mt-1.5 [&_h2]:text-body [&_h2]:font-semibold [&_h2]:leading-[1.3] [&_h2]:text-fg [&_h3]:mb-px [&_h3]:mt-1.5 [&_h3]:text-control-label [&_h3]:font-semibold [&_h3]:leading-[1.3] [&_h3]:text-fg [&_h4]:mb-px [&_h4]:mt-1.5 [&_h4]:text-control-label [&_h4]:font-semibold [&_h4]:leading-[1.3] [&_h4]:text-fg",
+	"[&>:first-child]:mt-0 [&>:last-child]:mb-0",
+	"[&_blockquote]:my-0.5 [&_blockquote]:mb-2 [&_blockquote]:border-l-2 [&_blockquote]:border-accent/40 [&_blockquote]:px-3 [&_blockquote]:py-[3px] [&_blockquote]:text-dim",
+	"[&_table]:my-0.5 [&_table]:mb-2.5 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_table]:border-collapse [&_table]:text-supporting [&_th]:border-b [&_th]:border-line-strong [&_th]:pb-[5px] [&_th]:pr-4 [&_th]:pt-1 [&_th]:text-left [&_th]:text-meta [&_th]:font-semibold [&_th]:tracking-[-0.01em] [&_th]:text-faint [&_td]:border-b [&_td]:border-line [&_td]:py-1.5 [&_td]:pr-4 [&_td]:align-top [&_tr:last-child_td]:border-b-0",
+	"[&_hr]:my-3 [&_hr]:border-0 [&_hr]:border-t [&_hr]:border-line",
+	"[&_img]:my-1.5 [&_img]:block [&_img]:h-auto [&_img]:max-h-[360px] [&_img]:max-w-full [&_img]:rounded-md [&_img]:border [&_img]:border-[#7f7f7f]/25",
+	"[&_.md-details]:my-2 [&_.md-details]:overflow-hidden [&_.md-details]:rounded-md [&_.md-details]:border [&_.md-details]:border-line [&_.md-details]:bg-surface [&_.md-details>summary]:flex [&_.md-details>summary]:cursor-pointer [&_.md-details>summary]:items-center [&_.md-details>summary]:gap-1.5 [&_.md-details>summary]:px-3 [&_.md-details>summary]:py-2 [&_.md-details>summary]:font-semibold [&_.md-details>summary]:text-fg",
+].join(" ");
+
 /**
  * Rendered-markdown container that upgrades ```lang fences to shiki-highlighted
  * blocks after mount. Shiki is multi-MB, so it's only dynamically imported when
@@ -78,7 +97,7 @@ export function MarkdownBody({
 	return (
 		<div
 			ref={ref}
-			className={className}
+			className={[MARKDOWN_STYLES, className].filter(Boolean).join(" ")}
 			dangerouslySetInnerHTML={{ __html: html }}
 		/>
 	);

--- a/src/frontend/components/MarkdownBody.tsx
+++ b/src/frontend/components/MarkdownBody.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { effectiveTheme, onThemeChanged, type EffectiveTheme } from "../lib/theme";
 
 // Keep the stable `.markdown` hook for generated HTML while making the rendered
-// document own its presentation instead of depending on global.css.
+// document own its presentation instead of depending on adapter selectors.
 export const MARKDOWN_STYLES = [
 	"text-body leading-6 break-words",
 	"[&_p]:mb-1.5 [&_p]:mt-0",

--- a/src/frontend/components/MessageBubble.tsx
+++ b/src/frontend/components/MessageBubble.tsx
@@ -450,13 +450,13 @@ export const MessageBubble = React.memo(function MessageBubble({
 						workerReportOpen ? "bg-panel" : "hover:bg-hover",
 					)}
 				>
-					<div className="flex items-center gap-2 px-2.5 py-1.5 text-xs font-medium text-dim">
+					<div className="flex items-center gap-2 px-2.5 py-1.5 text-label font-medium text-dim">
 						<Button
 							variant="ghost"
 							size="xs"
 							aria-expanded={workerReportOpen}
 							onClick={() => setWorkerReportOpen((open) => !open)}
-							className="min-h-0 min-w-0 flex-1 justify-start gap-1.5 whitespace-normal rounded-md border-0 px-1 py-0.5 text-left font-sans text-xs font-medium hover:bg-transparent"
+							className="min-h-0 min-w-0 flex-1 justify-start gap-1.5 whitespace-normal rounded-md border-0 px-1 py-0.5 text-left font-sans text-label font-medium hover:bg-transparent"
 						>
 							<span
 								className={cn(
@@ -533,13 +533,13 @@ export const MessageBubble = React.memo(function MessageBubble({
 						reviewHandoffOpen ? "bg-panel" : "hover:bg-hover",
 					)}
 				>
-					<div className="flex items-center gap-2 px-2.5 py-1.5 text-xs font-medium text-dim">
+					<div className="flex items-center gap-2 px-2.5 py-1.5 text-label font-medium text-dim">
 						<Button
 							variant="ghost"
 							size="xs"
 							aria-expanded={reviewHandoffOpen}
 							onClick={() => setReviewHandoffOpen((open) => !open)}
-							className="min-h-0 min-w-0 flex-1 justify-start gap-1.5 whitespace-normal rounded-md border-0 px-1 py-0.5 text-left font-sans text-xs font-medium hover:bg-transparent"
+							className="min-h-0 min-w-0 flex-1 justify-start gap-1.5 whitespace-normal rounded-md border-0 px-1 py-0.5 text-left font-sans text-label font-medium hover:bg-transparent"
 						>
 							<span
 								className={cn(

--- a/src/frontend/components/MessageBubble.tsx
+++ b/src/frontend/components/MessageBubble.tsx
@@ -53,6 +53,11 @@ export function ClampedBody({
 	entry?: TranscriptEntry;
 	sessionId?: string;
 }) {
+	const bubbleStyles = className.includes("msg-body-user")
+		? "inline-block max-w-[min(600px,90%)] self-end rounded-panel bg-panel px-3.5 py-2.5 text-fg"
+		: className.includes("msg-body-human")
+			? "inline-block max-w-[min(600px,90%)] self-end rounded-lg bg-[rgb(31_158_138_/_0.12)] px-3.5 py-[9px] text-fg"
+			: "text-fg";
 	const wireClamped = !!entry?.contentClamped;
 	const fullLength = entry?.contentLength ?? content.length;
 	const isLong = wireClamped || content.length > EAGER_MD_CHARS;
@@ -100,7 +105,10 @@ export function ClampedBody({
 	return (
 		<>
 			{asMarkdown ? (
-				<MarkdownBody className={className} html={html || ""} />
+				<MarkdownBody
+					className={`flex flex-col items-stretch text-body leading-6 break-words ${bubbleStyles} ${className}`}
+					html={html || ""}
+				/>
 			) : (
 				<pre
 					className={
@@ -145,11 +153,11 @@ function CollapsibleSystemNotice({
 }) {
 	const [open, setOpen] = useState(false);
 	return (
-		<div className="msg msg-system" data-eid={entry.id}>
+		<div className="msg msg-system mb-3 flex w-full max-w-[var(--chat-col)] flex-col text-center" data-eid={entry.id}>
 			<button
 				type="button"
 				onClick={() => setOpen((v) => !v)}
-				className="msg-system-text cursor-pointer [font-family:inherit]"
+			className="msg-system-text inline-block max-w-[min(560px,100%)] self-center rounded-lg bg-panel px-3.5 py-1.5 text-center text-supporting leading-[1.45] text-faint cursor-pointer [font-family:inherit]"
 			>
 				{label} ·{" "}
 				<span className="font-medium text-dim">
@@ -251,7 +259,7 @@ function BubbleHoverTime({ ts }: { ts?: string }) {
 	if (!ts) return null;
 	const label = fullTime(ts);
 	if (!label) return null;
-	return <span className="msg-hover-time">{label}</span>;
+	return <span className="msg-hover-time hidden select-none whitespace-nowrap text-meta font-medium text-faint [@media(hover:hover)]:block [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity">{label}</span>;
 }
 
 interface Props {
@@ -279,7 +287,7 @@ function EntryImages({
 }) {
 	if (!images || images.length === 0) return null;
 	return (
-		<div className="msg-images">
+		<div className="msg-images mt-1.5 flex flex-wrap gap-2">
 			{images.map((raw, i) => {
 				const src = resolveEntryImageSrc(raw, sessionId);
 				return (
@@ -302,7 +310,7 @@ function EntryImages({
 function EntryVideos({ videos }: { videos?: string[] }) {
 	if (!videos || videos.length === 0) return null;
 	return (
-		<div className="msg-videos">
+		<div className="msg-videos mt-1.5 flex flex-wrap gap-2">
 			{videos.map((src, i) => (
 				<div key={i} className="md-video-wrap">
 					<video
@@ -329,7 +337,7 @@ function extBadge(name: string): string {
 function EntryFiles({ files }: { files?: TranscriptEntry["files"] }) {
 	if (!files || files.length === 0) return null;
 	return (
-		<div className="msg-files">
+		<div className="msg-files mt-1.5 flex flex-wrap gap-2">
 			{files.map((f, i) => (
 				<a
 					key={i}
@@ -580,10 +588,10 @@ export const MessageBubble = React.memo(function MessageBubble({
 	if (entry.type === "user" && humanReply) {
 		return (
 			<div
-				className="msg msg-human"
+				className="msg msg-human mb-[18px] mt-1 flex w-full max-w-[var(--chat-col)] flex-col"
 				data-eid={entry.id}
 			>
-				<div className="msg-label msg-label-human">
+				<div className="msg-label msg-label-human mb-1.5 flex flex-row-reverse items-center gap-[7px] text-meta font-semibold tracking-[-0.01em] text-[#1f9e8a] before:size-[7px] before:shrink-0 before:rounded-full before:bg-[linear-gradient(135deg,#28d3b4,#0f8f7a)]">
 					💬 {humanReply.name} · via Slack
 					<MsgTime ts={entry.timestamp} />
 				</div>
@@ -626,17 +634,17 @@ export const MessageBubble = React.memo(function MessageBubble({
 		// attribution label.
 		return (
 			<div
-				className={cn("msg msg-user", !fromOther && "msg-user-own")}
+				className={cn("msg msg-user mb-[18px] mt-1 flex w-full max-w-[var(--chat-col)] flex-col", !fromOther && "msg-user-own [@media(hover:hover)]:mb-[35px]")}
 				data-eid={entry.id}
 			>
 				{fromOther && (
-					<div className="msg-label msg-label-user">
+					<div className="msg-label msg-label-user mb-1.5 flex flex-row-reverse items-center gap-[7px] text-meta font-semibold tracking-[-0.01em] text-faint before:size-[7px] before:shrink-0 before:rounded-xs before:bg-[#5b7cfa] before:opacity-90">
 						{fromOther}
 						<MsgTime ts={entry.timestamp} />
 					</div>
 				)}
 				{/* One stack anchors the hover time below both the bubble and attachments. */}
-				<div className="msg-user-row">
+				<div className="msg-user-row relative flex min-w-0 flex-col [&_.msg-hover-time]:absolute [&_.msg-hover-time]:right-0 [&_.msg-hover-time]:top-[calc(100%+8px)] [&_.msg-hover-time]:leading-none hover:[&_.msg-hover-time]:opacity-100">
 					{!fromOther && <BubbleHoverTime ts={entry.timestamp} />}
 					{displayContent && (
 						<ClampedBody
@@ -658,7 +666,7 @@ export const MessageBubble = React.memo(function MessageBubble({
 	// the name row was pure noise above each answer.
 	return (
 		<div
-			className="msg msg-assistant"
+			className="msg msg-assistant mb-[18px] flex w-full max-w-[var(--chat-col)] flex-col"
 			data-eid={entry.id}
 		>
 			<ClampedBody

--- a/src/frontend/components/ModelEffortSelect.tsx
+++ b/src/frontend/components/ModelEffortSelect.tsx
@@ -390,7 +390,7 @@ export function ModelEffortSelect({
 				type="button"
 				// Quiet pill: no outline at rest, hover state only, no chevron.
 				className={cn(
-					"border-transparent hover:border-transparent hover:bg-hover",
+					"relative inline-flex min-w-0 items-center gap-1.5 rounded-full border border-line px-2.5 py-1 text-supporting font-medium text-dim transition-[border-color,color] hover:border-faint hover:text-fg disabled:cursor-default disabled:opacity-55",
 					className,
 				)}
 				title={title}
@@ -403,8 +403,8 @@ export function ModelEffortSelect({
 							: "Model"
 				}
 			>
-				<span className="palette-pill-label">{modelLabel}</span>
-				{hasEffort && <span className="palette-pill-effort flex-none text-faint">{effortLabel}</span>}
+				<span className="palette-pill-label truncate">{modelLabel}</span>
+				{hasEffort && <span className="palette-pill-effort flex-none text-faint max-[374px]:hidden">{effortLabel}</span>}
 				{hasFastMode && fastMode && (
 					<span className="palette-pill-effort flex-none text-faint">Fast</span>
 				)}

--- a/src/frontend/components/ModelEffortSelect.tsx
+++ b/src/frontend/components/ModelEffortSelect.tsx
@@ -367,7 +367,7 @@ export function ModelEffortSelect({
 				{option.description ? (
 					<span className="flex min-w-0 flex-1 flex-col">
 						<span className="truncate">{option.label}</span>
-						<span className="truncate text-xs text-faint">{option.description}</span>
+						<span className="truncate text-label text-faint">{option.description}</span>
 					</span>
 				) : (
 					<span className="min-w-0 truncate">{option.label}</span>

--- a/src/frontend/components/MoveToCloudDialog.tsx
+++ b/src/frontend/components/MoveToCloudDialog.tsx
@@ -64,7 +64,7 @@ export function MoveToCloudDialog({
 					>
 						<div>{error}</div>
 						{uncommittedFiles.length > 0 && (
-							<ul className="mb-0 mt-2 max-h-40 overflow-y-auto pl-5 font-mono text-[11px]">
+							<ul className="mb-0 mt-2 max-h-40 overflow-y-auto pl-5 font-mono text-meta">
 								{uncommittedFiles.map((file) => (
 									<li key={file}>{file}</li>
 								))}

--- a/src/frontend/components/MoveToCloudDialog.tsx
+++ b/src/frontend/components/MoveToCloudDialog.tsx
@@ -59,7 +59,7 @@ export function MoveToCloudDialog({
 
 				{error && (
 					<div
-						className="rounded-md border border-red/30 bg-red-soft px-3 py-2.5 text-xs leading-relaxed text-red"
+						className="rounded-md border border-red/30 bg-red-soft px-3 py-2.5 text-label leading-relaxed text-red"
 						role="alert"
 					>
 						<div>{error}</div>

--- a/src/frontend/components/NewSession.tsx
+++ b/src/frontend/components/NewSession.tsx
@@ -70,7 +70,7 @@ interface RepoOption {
 }
 
 // Light mode paints the Create split-button ink-on-paper instead of accent.
-// global.css scopes that override under `.palette-card`, which the shared Modal
+// adapters.css scopes that override under `.palette-card`, which the shared Modal
 // shell no longer carries, so the two buttons opt in explicitly.
 const LIGHT_CREATE =
   "[html[data-theme=light]_&]:bg-fg [html[data-theme=light]_&]:text-bg";

--- a/src/frontend/components/NewSession.tsx
+++ b/src/frontend/components/NewSession.tsx
@@ -662,12 +662,12 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
         {/* Header: repo (left) · create-from (right). The repo picker is
             always visible — on phones the create-from picker hides until the
             options toggle in the footer opens it. */}
-        <div className="palette-header">
+        <div className="palette-header flex items-center justify-between gap-2 border-b border-line px-3 py-2.5">
           {mode === "scratch" ? (
             // Scratch sessions are repo-less — a picker here would imply the
             // choice matters. A muted chip holds the slot instead.
             <span
-              className="palette-trigger palette-trigger-strong pointer-events-none opacity-60"
+              className="palette-trigger palette-trigger-strong pointer-events-none inline-flex max-w-[46%] items-center gap-1.5 rounded-control border-0 bg-transparent px-2 py-1.5 text-body font-semibold text-fg opacity-60"
               title="Scratch sessions have no repository"
             >
               <RepoTile name="scratch" />
@@ -675,7 +675,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
             </span>
           ) : (
           <PaletteSelect
-            className="palette-trigger palette-trigger-strong"
+            className="palette-trigger palette-trigger-strong relative inline-flex max-w-[46%] items-center gap-1.5 rounded-control border-0 bg-transparent px-2 py-1.5 text-body font-semibold text-fg transition-colors hover:bg-hover disabled:cursor-default disabled:opacity-55"
             title="Repository"
             value={repo}
             options={[
@@ -707,16 +707,16 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
             isPhone={isPhone}
           >
             <RepoTile name={repo} />
-            <span className="palette-trigger-label">
+              <span className="palette-trigger-label truncate">
               {repos.find((p) => p.id === repo)?.label || repo || "No repositories"}
             </span>
-            <IconChevronDown className="palette-chevron" size={22} />
+            <IconChevronDown className="palette-chevron -ml-0.5 shrink-0 text-faint" size={22} />
           </PaletteSelect>
           )}
 
           {optionsVisible && (
           <PaletteSelect
-            className="palette-trigger"
+            className="palette-trigger relative inline-flex max-w-[46%] items-center gap-1.5 rounded-control border-0 bg-transparent px-2 py-1.5 text-control-label font-medium text-dim transition-colors hover:bg-hover hover:text-fg disabled:cursor-default disabled:opacity-55"
             title="What to create from"
             value={createFromValue}
             options={createFromOptions}
@@ -732,8 +732,8 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               <circle cx="12" cy="5.5" r="1.7" stroke="currentColor" strokeWidth="1.3" />
               <path d="M4 5.7v4.6M4 8h4a4 4 0 004-4" stroke="currentColor" strokeWidth="1.3" />
             </svg>
-            <span className="palette-trigger-label">{createFromLabel}</span>
-            <IconChevronDown className="palette-chevron" size={22} />
+            <span className="palette-trigger-label truncate">{createFromLabel}</span>
+            <IconChevronDown className="palette-chevron -ml-0.5 shrink-0 text-faint" size={22} />
           </PaletteSelect>
           )}
         </div>
@@ -757,7 +757,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
 
         {/* Prompt */}
         <div
-          className="palette-body"
+          className="palette-body relative px-4 pt-3"
           style={planBody}
           onDrop={(e) => {
             if (e.dataTransfer?.files?.length) {
@@ -771,7 +771,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
           {mentions.popup}
           <textarea
             ref={promptRef}
-            className="palette-textarea"
+            className="palette-textarea block min-h-[132px] max-h-[62vh] w-full resize-none border-0 bg-transparent font-sans text-item-title leading-relaxed text-fg outline-none placeholder:text-faint disabled:opacity-60"
             value={prompt}
             onChange={(e) => {
               setPrompt(e.target.value);
@@ -797,20 +797,20 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
           <FileChips files={files} onRemove={(i) => setFiles((p) => p.filter((_, idx) => idx !== i))} disabled={creating} />
         </div>
 
-        {error && <div className="palette-error">{error}</div>}
+        {error && <div className="palette-error mx-4 mb-2 rounded-md bg-red-soft px-2.5 py-1.5 text-supporting text-red">{error}</div>}
         {sandboxModelWarning && (
-          <div className="palette-error" role="alert">
+          <div className="palette-error mx-4 mb-2 rounded-md bg-red-soft px-2.5 py-1.5 text-supporting text-red" role="alert">
             {sandboxModelWarning}
           </div>
         )}
 
         {/* Footer toolbar */}
-        <div className="palette-footer" style={planSurface}>
-          <div className="palette-footer-left">
+        <div className="palette-footer flex items-center justify-between gap-2 border-t border-line px-2.5 py-2" style={planSurface}>
+          <div className="palette-footer-left flex min-w-0 items-center gap-1.5">
             {isPhone && (
               <button
                 type="button"
-                className={`palette-icon-btn palette-options-btn ${showOptions ? "is-on" : ""}`}
+                className={`palette-icon-btn palette-options-btn relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50 ${showOptions ? "is-on before:bg-accent-soft before:shadow-[inset_0_0_0_1px_var(--accent)]" : ""}`}
                 onClick={() => setShowOptions((v) => !v)}
                 disabled={creating}
                 aria-label="Advanced options — base branch, plan first, run environment"
@@ -821,7 +821,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
             )}
             <button
               type="button"
-              className="palette-icon-btn"
+              className="palette-icon-btn relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50"
               onClick={() => fileInputRef.current?.click()}
               disabled={creating}
               title="Attach a file"
@@ -845,14 +845,14 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               <Menu.Root>
                 <Menu.Trigger
                   type="button"
-                  className={`palette-icon-btn palette-mcp-picker-btn ${selectedMcpServers.length ? "is-on" : ""}`}
+                  className={`palette-icon-btn palette-mcp-picker-btn relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50 ${selectedMcpServers.length ? "is-on text-accent before:bg-accent-soft before:shadow-[inset_0_0_0_1px_var(--accent)]" : ""}`}
                   disabled={creating}
                   title={`Connected services${selectedMcpServers.length ? ` (${selectedMcpServers.length})` : ""}`}
                   aria-label="Choose connected services"
                 >
                   <IconConnections size={24} />
                   {selectedMcpServers.length > 0 && (
-                    <span className="palette-mcp-picker-badge">{selectedMcpServers.length}</span>
+                    <span className="palette-mcp-picker-badge absolute -right-1 -top-1 z-20 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent text-meta font-semibold text-panel">{selectedMcpServers.length}</span>
                   )}
                 </Menu.Trigger>
                 <Menu.Popup align="start" sideOffset={6} className="max-w-[min(360px,calc(100vw-1rem))]">
@@ -880,10 +880,10 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                 </Menu.Popup>
               </Menu.Root>
             ) : (
-            <div className="palette-mcp-picker-container" ref={mcpPickerRef}>
+            <div className="palette-mcp-picker-container relative shrink-0" ref={mcpPickerRef}>
               <button
                 type="button"
-                className={`palette-icon-btn palette-mcp-picker-btn ${selectedMcpServers.length ? "is-on" : ""}`}
+                className={`palette-icon-btn palette-mcp-picker-btn relative inline-flex h-10 w-10 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50 ${selectedMcpServers.length ? "is-on text-accent before:bg-accent-soft before:shadow-[inset_0_0_0_1px_var(--accent)]" : ""}`}
                 onClick={() => setMcpPickerOpen((v) => !v)}
                 disabled={creating}
                 title={`Connected services${selectedMcpServers.length ? ` (${selectedMcpServers.length})` : ""}`}
@@ -892,15 +892,15 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               >
                 <IconConnections size={24} />
                 {selectedMcpServers.length > 0 && (
-                  <span className="palette-mcp-picker-badge">{selectedMcpServers.length}</span>
+                  <span className="palette-mcp-picker-badge absolute -right-1 -top-1 z-20 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent text-meta font-semibold text-panel">{selectedMcpServers.length}</span>
                 )}
               </button>
               {mcpPickerOpen && (
-                <div className="palette-mcp-picker-popover">
-                  <div className="palette-mcp-picker-header">Connected services</div>
-                  <div className="palette-mcp-picker-grid">
+                <div className="palette-mcp-picker-popover fixed bottom-15 left-3 right-3 z-[1000] max-h-[50vh] overflow-y-auto rounded-lg border border-line-strong bg-panel p-3 shadow-[0_8px_24px_rgba(0,0,0,0.3)]">
+                  <div className="palette-mcp-picker-header mb-2 px-1 text-meta font-semibold text-dim">Connected services</div>
+                  <div className="palette-mcp-picker-grid grid grid-cols-1 gap-1">
                     {availableMcpServers.map((mcp) => (
-                      <label key={mcp} className="palette-mcp-checkbox-compact">
+                      <label key={mcp} className="palette-mcp-checkbox-compact flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-control-label text-dim transition-colors hover:bg-hover hover:text-fg">
                         <input
                           type="checkbox"
                           checked={selectedMcpServers.includes(mcp)}
@@ -922,7 +922,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               <Tooltip label={planFirst ? "Exit plan mode" : "Enter plan mode"}>
                 <button
                   type="button"
-                  className={`palette-icon-btn ${planFirst ? "is-on" : ""}`}
+                  className={`palette-icon-btn relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50 ${planFirst ? "is-on before:bg-accent-soft before:shadow-[inset_0_0_0_1px_var(--accent)]" : ""}`}
                   onClick={() => setPlanFirst((v) => !v)}
                   disabled={creating}
                   aria-label={planFirst ? "Exit plan mode" : "Enter plan mode"}
@@ -938,7 +938,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               <Menu.Root>
                 <Menu.Trigger
                   type="button"
-                  className={`palette-icon-btn ${sandboxProvider ? "is-on" : ""}`}
+                  className={`palette-icon-btn relative inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-control border border-transparent bg-transparent text-dim transition-colors hover:text-fg hover:before:bg-hover before:absolute before:inset-1 before:rounded-control before:transition-[background,box-shadow] [&>*]:relative [&>*]:z-10 disabled:cursor-default disabled:opacity-50 ${sandboxProvider ? "is-on before:bg-accent-soft before:shadow-[inset_0_0_0_1px_var(--accent)]" : ""}`}
                   disabled={creating}
                   title={`Run environment — ${sandboxLabel(sandboxProvider)}${
                     sandboxWarmed && shouldPrewarm ? " (warmed)" : ""
@@ -975,12 +975,12 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                                 )}
                               </span>
                               {opt.note && (
-                                <span className="whitespace-normal text-[11px] font-medium leading-snug text-faint">
+            <span className="whitespace-normal text-meta font-medium leading-snug text-faint">
                                   {opt.note}
                                 </span>
                               )}
                               {hostEngineWorkspace && (
-                                <span className="whitespace-normal text-[11px] font-medium leading-snug text-faint">
+            <span className="whitespace-normal text-meta font-medium leading-snug text-faint">
                                   Model on Host · workspace isolated here
                                 </span>
                               )}
@@ -995,11 +995,11 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
             )}
           </div>
 
-          <div className="palette-footer-right">
+          <div className="palette-footer-right flex min-w-0 items-center gap-1.5">
             {/* Always visible — on phones too, so a non-default (dumber) model
                 is never silently in effect behind the options toggle. */}
             <ModelEffortSelect
-              className="palette-pill"
+              className="palette-pill max-w-[180px] shrink min-w-0"
               title="Model and reasoning effort"
               models={models}
               defaultModel={defaultModel}
@@ -1022,12 +1022,12 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
               }}
             />
 
-            <div className="palette-create-split" ref={createSplitRef}>
+            <div className="palette-create-split relative inline-flex shrink-0 items-stretch" ref={createSplitRef}>
               <button
                 // In light mode the Create button is ink-on-paper rather than
                 // accent — carried here since the shell no longer supplies the
                 // `.palette-card` that scoped that override.
-                className={`palette-create palette-create-main ${LIGHT_CREATE}`}
+                className={`palette-create palette-create-main inline-flex items-center gap-1.5 rounded-l-control rounded-r-none border-0 bg-accent px-3.5 py-1.5 text-control-label font-semibold text-white transition-[filter,opacity] hover:brightness-110 disabled:cursor-default disabled:opacity-40 ${LIGHT_CREATE}`}
                 onClick={handleCreate}
                 disabled={!canCreate}
               >
@@ -1040,11 +1040,11 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                     : createMore
                       ? "Create more"
                       : "Create"}
-                <IconReturn className="palette-create-kbd" size={20} />
+                <IconReturn className="palette-create-kbd -mx-0.5 opacity-70" size={20} />
               </button>
               <button
                 type="button"
-                className={`palette-create palette-create-caret ${LIGHT_CREATE} ${createMenuOpen ? "is-open" : ""}`}
+                className={`palette-create palette-create-caret inline-flex items-center gap-1.5 rounded-l-none rounded-r-control border-0 bg-accent px-1.5 py-1.5 text-control-label font-semibold text-white shadow-[inset_1px_0_0_rgba(0,0,0,0.14)] transition-[filter,opacity] hover:brightness-110 disabled:cursor-default disabled:opacity-40 [&>svg]:transition-transform ${LIGHT_CREATE} ${createMenuOpen ? "is-open opacity-100 [&>svg]:rotate-180" : ""}`}
                 onClick={() => setCreateMenuOpen((v) => !v)}
                 disabled={creating}
                 aria-haspopup="menu"
@@ -1054,7 +1054,7 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                 <IconChevronDown size={22} />
               </button>
               {createMenuOpen && (
-                <div className="palette-create-menu" role="menu">
+                <div className="palette-create-menu absolute bottom-[calc(100%+6px)] right-0 z-20 min-w-[208px] rounded-lg border border-line bg-raised p-1 shadow-[0_10px_30px_rgba(0,0,0,0.28)]" role="menu">
                   {auth?.local && (
                     <>
                       {[
@@ -1066,20 +1066,20 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                           type="button"
                           role="menuitemradio"
                           aria-checked={createTarget === opt.target}
-                          className={`palette-create-menu-item ${createTarget === opt.target ? "is-active" : ""}`}
+                          className={`palette-create-menu-item flex w-full items-start gap-2 rounded-md border-0 bg-transparent px-2 py-1.5 text-left text-fg transition-colors hover:bg-hover ${createTarget === opt.target ? "is-active" : ""}`}
                           onClick={() => {
                             setCreateTarget(opt.target);
                             setCreateMenuOpen(false);
                           }}
                         >
                           <IconCheck
-                            className="palette-create-menu-check"
+                            className="palette-create-menu-check mt-px shrink-0 text-dim"
                             size={22}
                             style={{ visibility: createTarget === opt.target ? "visible" : "hidden" }}
                           />
-                          <span className="palette-create-menu-text">
-                            <span className="palette-create-menu-title">{opt.title}</span>
-                            <span className="palette-create-menu-desc">{opt.desc}</span>
+                          <span className="palette-create-menu-text flex min-w-0 flex-col gap-px">
+                            <span className="palette-create-menu-title text-control-label font-semibold">{opt.title}</span>
+                            <span className="palette-create-menu-desc text-meta text-dim">{opt.desc}</span>
                           </span>
                         </button>
                       ))}
@@ -1095,20 +1095,20 @@ export function NewSession({ onBack, send, addHandler, connected, prefillPrompt,
                       type="button"
                       role="menuitemradio"
                       aria-checked={createMore === opt.more}
-                      className={`palette-create-menu-item ${createMore === opt.more ? "is-active" : ""}`}
+                      className={`palette-create-menu-item flex w-full items-start gap-2 rounded-md border-0 bg-transparent px-2 py-1.5 text-left text-fg transition-colors hover:bg-hover ${createMore === opt.more ? "is-active" : ""}`}
                       onClick={() => {
                         setCreateMore(opt.more);
                         setCreateMenuOpen(false);
                       }}
                     >
                       <IconCheck
-                        className="palette-create-menu-check"
+                        className="palette-create-menu-check mt-px shrink-0 text-dim"
                         size={22}
                         style={{ visibility: createMore === opt.more ? "visible" : "hidden" }}
                       />
-                      <span className="palette-create-menu-text">
-                        <span className="palette-create-menu-title">{opt.title}</span>
-                        <span className="palette-create-menu-desc">{opt.desc}</span>
+                      <span className="palette-create-menu-text flex min-w-0 flex-col gap-px">
+                        <span className="palette-create-menu-title text-control-label font-semibold">{opt.title}</span>
+                        <span className="palette-create-menu-desc text-meta text-dim">{opt.desc}</span>
                       </span>
                     </button>
                   ))}

--- a/src/frontend/components/NoteBubble.tsx
+++ b/src/frontend/components/NoteBubble.tsx
@@ -72,7 +72,7 @@ export function NoteBubble({ note }: { note: ChatMessage }) {
 				>
 					Note
 				</span>
-				<span className="text-[11px] text-faint">{noteTime(note.ts)}</span>
+				<span className="text-meta text-faint">{noteTime(note.ts)}</span>
 			</div>
 			{note.text && (
 				<div className="whitespace-pre-wrap text-body leading-relaxed text-fg">

--- a/src/frontend/components/Notes.tsx
+++ b/src/frontend/components/Notes.tsx
@@ -247,7 +247,7 @@ export function Notes({
                     <div className="flex items-center justify-between px-3.5 pb-1 pt-2.5 text-meta font-bold text-faint">
 						<span>Notes</span>
 						<button
-                            className="rounded-md border-0 bg-transparent px-1.5 py-0.5 text-base leading-none text-dim hover:bg-hover hover:text-fg"
+                            className="rounded-md border-0 bg-transparent px-1.5 py-0.5 text-body leading-none text-dim hover:bg-hover hover:text-fg"
 							title="New note"
 							onClick={() => setCreating((c) => !c)}
 						>
@@ -539,7 +539,7 @@ function NotePane({
 						title={`Also here: ${others.join(", ")}`}
 					>
 						{others.slice(0, 4).map((v, i) => (
-                            <span key={i} className="inline-flex size-[18px] items-center justify-center rounded-full bg-purple text-[10px] font-bold text-white">
+                            <span key={i} className="inline-flex size-[18px] items-center justify-center rounded-full bg-purple text-meta font-bold text-white">
 								{v.charAt(0).toUpperCase()}
 							</span>
 						))}

--- a/src/frontend/components/Notes.tsx
+++ b/src/frontend/components/Notes.tsx
@@ -26,6 +26,7 @@ import {
 import type { WSClientMessage, WSServerMessage } from "../lib/types";
 import type { MentionKind } from "./NoteEditor";
 import { PRODUCT_NAME, DEFAULT_DOC_TITLE } from "../lib/brand";
+import { cn } from "../ui/cn";
 
 const NoteEditor = lazy(() => import("./NoteEditor"));
 
@@ -239,14 +240,14 @@ export function Notes({
 	}
 
 	return (
-		<div className="notes">
-			<div className={`notes-nav wiki-nav ${navOpen ? "wiki-nav-open" : ""}`}>
+        <div className="flex min-h-0 flex-1">
+            <div className={cn("flex min-h-0 w-[300px] shrink-0 flex-col border-r border-line bg-raised max-[920px]:fixed max-[920px]:inset-y-[var(--header-h)] max-[920px]:left-0 max-[920px]:z-30 max-[920px]:w-[min(320px,88vw)] max-[920px]:-translate-x-full max-[920px]:shadow-[12px_0_32px_rgba(0,0,0,0.5)] max-[920px]:transition-transform", navOpen && "max-[920px]:translate-x-0")}>
 				{/* Notes section (writable, shared) */}
-				<div className="notes-section">
-					<div className="notes-section-head">
+                <div className="flex min-h-0 flex-col">
+                    <div className="flex items-center justify-between px-3.5 pb-1 pt-2.5 text-meta font-bold text-faint">
 						<span>Notes</span>
 						<button
-							className="notes-add"
+                            className="rounded-md border-0 bg-transparent px-1.5 py-0.5 text-base leading-none text-dim hover:bg-hover hover:text-fg"
 							title="New note"
 							onClick={() => setCreating((c) => !c)}
 						>
@@ -255,7 +256,7 @@ export function Notes({
 					</div>
 					{creating && (
 						<input
-							className="notes-new-input"
+                            className="mx-2.5 mb-1.5 mt-0.5 rounded-md border border-line-strong bg-panel px-2 py-1.5 text-control-label text-fg outline-none focus:border-accent"
 							autoFocus
 							placeholder="Note title…"
 							value={newTitle}
@@ -270,23 +271,23 @@ export function Notes({
 							onBlur={() => doCreate()}
 						/>
 					)}
-					<div className="notes-list">
+                    <div className="max-h-[38vh] overflow-y-auto px-1.5 pb-1.5">
 						{notes.length === 0 && !creating ? (
-							<div className="notes-empty">No notes yet</div>
+                            <div className="px-3.5 py-1.5 text-label text-faint">No notes yet</div>
 						) : (
 							notes.map((n) => (
 								<div
 									key={n.id}
-									className={`notes-item ${selNoteId === n.id ? "notes-item-active" : ""}`}
+                                    className={cn("group flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-dim hover:bg-hover hover:text-fg", selNoteId === n.id && "bg-active text-fg")}
 									onClick={() => {
 										setNavOpen(false);
 										onSelectNote(n.id);
 									}}
 									title={n.title}
 								>
-									<span className="notes-item-title">{n.title}</span>
+                                    <span className="flex-1 truncate text-control-label">{n.title}</span>
 									<span
-										className={`notes-item-pin ${pinnedNoteIds.has(n.id) ? "on" : ""}`}
+                                        className={cn("px-0.5 text-label text-faint opacity-0 group-hover:opacity-80", pinnedNoteIds.has(n.id) && "text-yellow opacity-100")}
 										title={pinnedNoteIds.has(n.id) ? "Unpin tab" : "Pin as tab"}
 										onClick={(e) => {
 											e.stopPropagation();
@@ -296,7 +297,7 @@ export function Notes({
 										{pinnedNoteIds.has(n.id) ? "★" : "☆"}
 									</span>
 									<span
-										className="notes-item-del"
+                                        className="px-0.5 text-label text-faint opacity-0 group-hover:opacity-80 hover:text-red"
 										title="Delete note"
 										onClick={(e) => doDelete(n.id, e)}
 									>
@@ -309,24 +310,24 @@ export function Notes({
 				</div>
 
 				{/* Docs section (read-only wiki) */}
-				<div className="notes-section notes-section-docs">
-					<div className="notes-section-head">
+                <div className="mt-1.5 flex min-h-0 flex-1 flex-col border-t border-line pt-1">
+                    <div className="flex items-center justify-between px-3.5 pb-1 pt-2.5 text-meta font-bold text-faint">
 						<span>Docs</span>
 					</div>
-					<div className="wiki-search-wrap">
+                    <div className="border-b border-line p-3">
 						<input
-							className="wiki-search"
+                            className="w-full rounded-md border border-line bg-panel px-2.5 py-1.5 text-control-label text-fg outline-none placeholder:text-faint focus:border-accent"
 							placeholder="Search notes + docs…"
 							value={query}
 							onChange={(e) => setQuery(e.target.value)}
 						/>
 					</div>
 					{hits !== null ? (
-						<div className="wiki-results">
+                        <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-6 pt-2">
 							{noteHits.map((h) => (
 								<button
 									key={`note-${h.id}`}
-									className="wiki-result"
+                                    className="flex w-full min-w-0 flex-col gap-px rounded-md border-0 bg-transparent px-2.5 py-2 text-left hover:bg-hover"
 									onClick={() => {
 										setQuery("");
 										setHits(null);
@@ -334,29 +335,29 @@ export function Notes({
 										onSelectNote(h.id);
 									}}
 								>
-									<span className="wiki-result-title">📝 {h.title}</span>
-									<span className="wiki-result-snippet">{h.snippet}</span>
-									<span className="wiki-result-path">note</span>
+                                    <span className="text-control-label font-semibold text-fg">📝 {h.title}</span>
+                                    <span className="truncate text-label text-dim">{h.snippet}</span>
+                                    <span className="truncate font-mono text-meta text-faint">note</span>
 								</button>
 							))}
 							{hits.length === 0 && noteHits.length === 0 ? (
-								<div className="wiki-empty">No results</div>
+                                <div className="px-0 py-6 text-center text-control-label text-faint">No results</div>
 							) : (
 								hits.map((h, i) => (
 									<button
 										key={i}
-										className="wiki-result"
+                                        className="flex w-full min-w-0 flex-col gap-px rounded-md border-0 bg-transparent px-2.5 py-2 text-left hover:bg-hover"
 										onClick={() => openDoc(h.path)}
 									>
-										<span className="wiki-result-title">{h.title}</span>
-										<span className="wiki-result-snippet">{h.snippet}</span>
-										<span className="wiki-result-path">{h.path}</span>
+                                        <span className="text-control-label font-semibold text-fg">{h.title}</span>
+                                        <span className="truncate text-label text-dim">{h.snippet}</span>
+                                        <span className="truncate font-mono text-meta text-faint">{h.path}</span>
 									</button>
 								))
 							)}
 						</div>
 					) : (
-						<div className="wiki-tree">
+                        <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-4 pt-1.5">
 							{paths.length > 0 && (
 								<WikiTree paths={paths} docPath={selDocPath} onOpen={openDoc} />
 							)}
@@ -366,10 +367,10 @@ export function Notes({
 			</div>
 
 			<div
-				className={`notes-content wiki-content ${selNoteId ? "notes-editing" : ""}`}
+                className={cn("min-w-0 flex-1 overflow-y-auto px-8 pb-20 pt-6 max-[920px]:px-4 max-[920px]:pb-[60px] max-[920px]:pt-4", selNoteId && "flex overflow-hidden p-0")}
 			>
 				<button
-					className="wiki-nav-toggle"
+                    className="mb-3.5 hidden rounded-md border border-line-strong bg-panel px-3 py-1.5 text-control-label text-dim max-[920px]:inline-block"
 					onClick={() => setNavOpen(!navOpen)}
 				>
 					☰ Browse
@@ -392,7 +393,7 @@ export function Notes({
 						<div className="loading">Loading…</div>
 					) : (
 						<>
-							<div className="wiki-doc-path">{selDocPath}</div>
+                            <div className="mb-4 font-mono text-meta text-faint">{selDocPath}</div>
 							<div
 								className="markdown wiki-doc"
 								dangerouslySetInnerHTML={{ __html: docHtml }}
@@ -400,7 +401,7 @@ export function Notes({
 						</>
 					)
 				) : (
-					<div className="wiki-welcome">
+                    <div className="mx-auto my-[60px] max-w-[560px] text-center text-dim">
 						<h2>Notes</h2>
 						<p>
 							Shared, real-time collaborative notes — todos and longer ideas,
@@ -408,7 +409,7 @@ export function Notes({
 							sessions/notes/docs, pin a note as a tab, or prompt Haiku to
 							update it.
 						</p>
-						<p className="wiki-welcome-hint">
+                        <p className="text-control-label text-faint">
 							The <b>Docs</b> section below is the read-only knowledge base from{" "}
 							<code>the default repository's docs</code>.
 						</p>
@@ -529,31 +530,31 @@ function NotePane({
 	}
 
 	return (
-		<div className="note-pane">
-			<div className="note-pane-bar">
-				<span className="note-pane-id">{noteId}</span>
+        <div className="flex h-full min-h-0 flex-1 flex-col">
+            <div className="flex shrink-0 items-center gap-2.5 border-b border-line px-3.5 py-2">
+                <span className="font-mono text-label text-faint">{noteId}</span>
 				{others.length > 0 && (
 					<span
-						className="note-presence"
+                        className="inline-flex items-center gap-1"
 						title={`Also here: ${others.join(", ")}`}
 					>
 						{others.slice(0, 4).map((v, i) => (
-							<span key={i} className="note-presence-dot">
+                            <span key={i} className="inline-flex size-[18px] items-center justify-center rounded-full bg-purple text-[10px] font-bold text-white">
 								{v.charAt(0).toUpperCase()}
 							</span>
 						))}
-						<span className="note-presence-label">editing</span>
+                        <span className="ml-0.5 text-meta text-dim">editing</span>
 					</span>
 				)}
 				<button
-					className="note-share"
+                    className="ml-auto whitespace-nowrap rounded-md border border-line-strong bg-panel px-2.5 py-1 text-label text-dim hover:bg-hover hover:text-fg"
 					onClick={togglePreview}
 					title={preview !== null ? "Back to editing" : "Preview the rendered markdown"}
 				>
 					{preview !== null ? "✎ Edit" : "◫ Preview"}
 				</button>
 				<button
-					className="note-share"
+                    className="whitespace-nowrap rounded-md border border-line-strong bg-panel px-2.5 py-1 text-label text-dim hover:bg-hover hover:text-fg"
 					onClick={discuss}
 					disabled={discussing}
 					title="Start an Ask session seeded with this note"
@@ -561,7 +562,7 @@ function NotePane({
 					{discussing ? "Starting…" : "💬 Discuss"}
 				</button>
 				<button
-					className="note-share"
+                    className="whitespace-nowrap rounded-md border border-line-strong bg-panel px-2.5 py-1 text-label text-dim hover:bg-hover hover:text-fg"
 					onClick={shareNote}
 					title="Copy a link to this note"
 				>
@@ -569,7 +570,7 @@ function NotePane({
 				</button>
 			</div>
 
-			<div className="note-editor-wrap">
+            <div className="flex min-h-0 flex-1 overflow-hidden">
 				{preview !== null ? (
 					<div
 						className="markdown wiki-doc overflow-y-auto px-[18px] py-4"
@@ -597,7 +598,7 @@ function NotePane({
 					{backlinks.map((b) => (
 						<button
 							key={b.id}
-							className="note-chip note-chip-note cursor-pointer border-0"
+                            className="inline-flex cursor-pointer items-center gap-px whitespace-nowrap rounded-full border border-green/30 bg-green-soft px-1.5 py-px text-label text-green hover:brightness-110"
 							onClick={() => onOpenMention("note", b.id)}
 							title={`Open “${b.title}”`}
 						>
@@ -608,28 +609,28 @@ function NotePane({
 			)}
 
 			<div
-				className={`note-prompt ${promptOpen ? "" : "note-prompt-collapsed"} ${running ? "note-prompt-running" : ""}`}
+                className="shrink-0 border-t border-line bg-raised px-2.5 pb-2 pt-1.5"
 			>
 				<button
-					className="note-prompt-toggle"
+                    className={cn("inline-flex items-center gap-1.5 border-0 bg-transparent py-px text-meta text-faint hover:text-dim", running && "text-accent")}
 					onClick={() => setPromptOpen((o) => !o)}
 					title={promptOpen ? "Collapse" : "Expand"}
 				>
-					<span className={`note-prompt-caret ${promptOpen ? "open" : ""}`}>
+                    <span className={cn("inline-block transition-transform", promptOpen && "rotate-90")}>
 						›
 					</span>
 					prompt
-					{running && <span className="note-spinner" />}
+                    {running && <span className="inline-block size-[11px] animate-spin rounded-full border-2 border-line-strong border-t-accent" />}
 				</button>
 				{promptOpen &&
 					(running ? (
-						<div className="note-prompt-loading">
-							<span className="note-spinner note-spinner-lg" />
+                        <div className="flex items-center gap-2 rounded-md border border-line-strong bg-panel px-3 py-2 text-control-label text-dim">
+                            <span className="inline-block size-[15px] animate-spin rounded-full border-2 border-line-strong border-t-accent" />
 							<span>Haiku is updating the note…</span>
 						</div>
 					) : (
 						<textarea
-							className="note-prompt-input"
+                            className="block h-[30px] min-h-[30px] max-h-[140px] w-full resize-none rounded-md border border-line-strong bg-panel px-2.5 py-1.5 text-control-label leading-snug text-fg outline-none focus:border-accent"
 							placeholder="Ask Haiku to update this note… (↵ to run)"
 							value={prompt}
 							onChange={(e) => {
@@ -648,7 +649,7 @@ function NotePane({
 							}}
 						/>
 					))}
-				{error && <div className="note-prompt-error">{error}</div>}
+                {error && <div className="mt-1 text-label text-red">{error}</div>}
 			</div>
 		</div>
 	);

--- a/src/frontend/components/PaletteSelect.tsx
+++ b/src/frontend/components/PaletteSelect.tsx
@@ -38,10 +38,10 @@ export function PaletteSelect({
 }: Props) {
 	if (isPhone) {
 		return (
-			<div className={className} title={title}>
+			<div className={cn("relative inline-flex min-w-0 items-center", className)} title={title}>
 				{children}
 				<select
-					className="palette-select-overlay"
+					className="palette-select-overlay absolute inset-0 h-full w-full cursor-pointer appearance-none border-0 opacity-0 disabled:cursor-default"
 					value={value}
 					onChange={(e) => onChange(e.target.value)}
 					disabled={disabled}

--- a/src/frontend/components/PixelSpinner.tsx
+++ b/src/frontend/components/PixelSpinner.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "../ui/cn";
 
 /**
  * Pixel spinner — a 3×3 grid of tiny pixels that light up in a single,
@@ -10,9 +11,7 @@ import React from "react";
  * color is controlled by the caller's text class (e.g. `text-fg` for a
  * neutral black/white loader).
  *
- * Styling + keyframes live in global.css under the "PIXEL SPINNER" section.
- *
- * The pattern is intentionally fixed (not random per instance) so every
+	 * The pattern is intentionally fixed (not random per instance) so every
  * loader in the app looks identical — a row of session spinners reads as one
  * consistent indicator rather than a different animation each. `cycling` and
  * `interval` are kept for call-site compatibility but no longer switch the
@@ -27,10 +26,30 @@ interface Props {
 }
 
 export function PixelSpinner({ className = "" }: Props) {
+	const sidebar = className.includes("sidebar-spinner");
+	const slow = className.includes("pixel-spinner-slow");
+	const delays = sidebar
+		? ["0ms", "170ms", "170ms", "345ms", "345ms", "345ms", "520ms", "520ms", "690ms"]
+		: ["0ms", "210ms", "210ms", "420ms", "420ms", "420ms", "630ms", "630ms", "840ms"];
+
 	return (
-		<div className={`pixel-spinner diagonal-br ${className}`.trim()} aria-hidden>
+		<div
+			className={cn(
+				"pixel-spinner diagonal-br grid grid-cols-3 gap-px [--glow-color:currentColor] [--glow-dim:currentColor]",
+				className,
+			)}
+			aria-hidden
+		>
 			{Array.from({ length: 9 }, (_, i) => (
-				<div key={i} className="pixel" />
+				<div
+					key={i}
+					className={cn(
+						"pixel rounded-[calc(1px*var(--rf))] bg-[color-mix(in_srgb,currentColor_35%,transparent)] [animation-name:pixel-snake-trail] [animation-duration:1.4s] [animation-iteration-count:infinite] [animation-timing-function:ease-out] [corner-shape:var(--cs)] transition-[background,box-shadow,opacity] duration-150 motion-reduce:animate-none motion-reduce:bg-current motion-reduce:opacity-60",
+						sidebar ? "size-[3.5px] [animation-duration:1.15s]" : "size-[3px]",
+						slow && !sidebar && "[animation-duration:2.4s]",
+					)}
+					style={{ animationDelay: delays[i] }}
+				/>
 			))}
 		</div>
 	);

--- a/src/frontend/components/PlainThreadPanel.tsx
+++ b/src/frontend/components/PlainThreadPanel.tsx
@@ -120,20 +120,20 @@ export function PlainThreadPanel({ sessionId, threadId, plainUrl }: Props) {
 	const status = thread?.status;
 
 	return (
-		<div className="plain-panel">
-			<div className="plain-panel-head">
-				<div className="plain-head-info">
-					<span className="plain-customer" title={thread?.customer?.email || ""}>
+		<div className="plain-panel flex h-full min-h-0 flex-col bg-raised">
+			<div className="plain-panel-head flex shrink-0 items-center justify-between gap-2 border-b border-line px-3 py-2">
+				<div className="plain-head-info flex min-w-0 items-center gap-2">
+					<span className="plain-customer truncate text-control-label font-semibold text-fg" title={thread?.customer?.email || ""}>
 						{thread?.customer?.name || thread?.customer?.email || "Plain thread"}
 					</span>
 					{status && (
-						<span className={`plain-status plain-status-${status.toLowerCase()}`}>
+						<span className={`plain-status plain-status-${status.toLowerCase()} shrink-0 rounded-full bg-active px-1.5 py-0.5 text-meta font-bold text-faint ${status === "TODO" ? "bg-accent-soft text-accent" : status === "DONE" ? "bg-green-soft text-green" : "bg-yellow/20 text-yellow"}`}>
 							{STATUS_LABEL[status] || status}
 						</span>
 					)}
 				</div>
 				<a
-					className="plain-open"
+					className="plain-open shrink-0 whitespace-nowrap text-meta font-semibold text-accent no-underline hover:underline"
 					href={plainUrl}
 					target="_blank"
 					rel="noreferrer"
@@ -159,15 +159,15 @@ export function PlainThreadPanel({ sessionId, threadId, plainUrl }: Props) {
 				/>
 			)}
 
-			{thread?.title && <div className="plain-title">{thread.title}</div>}
+			{thread?.title && <div className="plain-title shrink-0 border-b border-line px-3 py-2 text-control-label font-semibold text-fg">{thread.title}</div>}
 
-			<div className="plain-timeline" ref={bodyRef}>
+			<div className="plain-timeline flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3" ref={bodyRef}>
 				{loading && !thread ? (
-					<div className="plain-loading">Loading conversation…</div>
+					<div className="plain-loading mt-5 text-center text-control-label text-faint">Loading conversation…</div>
 				) : error && !thread ? (
-					<div className="plain-loading">Couldn't load Plain thread: {error}</div>
+					<div className="plain-loading mt-5 text-center text-control-label text-faint">Couldn't load Plain thread: {error}</div>
 				) : thread && thread.entries.length === 0 ? (
-					<div className="plain-loading">No messages in this thread yet.</div>
+					<div className="plain-loading mt-5 text-center text-control-label text-faint">No messages in this thread yet.</div>
 				) : (
 					thread?.entries.map((e) => (
 						<PlainEntryRow key={e.id} entry={e} threadId={threadId} />
@@ -589,7 +589,7 @@ export function PlainReplyBox({
 				)}
 			</div>
 			<textarea
-				className="plain-reply-textarea w-full min-h-[128px] resize-y rounded-md border border-line bg-surface text-fg text-[13px] leading-normal p-2 focus:outline-none focus:border-line-strong placeholder:text-faint"
+				className="plain-reply-textarea w-full min-h-[128px] resize-y rounded-md border border-line bg-surface p-2 text-control-label leading-normal text-fg placeholder:text-faint focus:border-line-strong focus:outline-none"
 				placeholder={
 					kind === "note"
 						? "Internal note for the team (English)…"
@@ -798,22 +798,22 @@ export function PlainEntryRow({
 	if (entry.kind === "note") {
 		const author = noteAuthor(entry);
 		return (
-			<div className="plain-entry plain-entry-note">
-				<div className="plain-entry-head">
-					<span className="plain-kind-badge plain-kind-note">note</span>
-					<span className="plain-actor">{author.name}</span>
+					<div className="plain-entry plain-entry-note flex max-w-full flex-col gap-1 rounded-lg border border-yellow/30 bg-yellow/10 px-3 py-2">
+					<div className="plain-entry-head flex flex-wrap items-baseline gap-1.5">
+						<span className="plain-kind-badge plain-kind-note rounded-sm border border-yellow/40 px-1 text-meta font-bold text-yellow">note</span>
+						<span className="plain-actor text-supporting font-bold text-fg">{author.name}</span>
 					{author.isAgent && (
 						<span
-							className="plain-kind-badge"
+							className="plain-kind-badge rounded-sm border border-line-strong px-1 text-meta font-bold text-faint"
 							title="Written by an agent run, not a teammate"
 						>
 							agent
 						</span>
 					)}
-					<span className="plain-time">{timeOf(entry.timestamp)}</span>
+						<span className="plain-time text-meta text-faint">{timeOf(entry.timestamp)}</span>
 					{author.isAgent && threadId && (
 						<a
-							className="plain-open ml-auto"
+							className="plain-open ml-auto shrink-0 whitespace-nowrap text-meta font-semibold text-accent no-underline hover:underline"
 							href={`${BASE_PATH}/plain-triage/${encodeURIComponent(threadId)}`}
 							target="_blank"
 							rel="noreferrer"
@@ -824,7 +824,7 @@ export function PlainEntryRow({
 					)}
 				</div>
 				<div
-					className="plain-note-body markdown"
+					className="plain-note-body markdown break-words text-control-label leading-relaxed text-fg [&>:first-child]:mt-0 [&>:last-child]:mb-0"
 					dangerouslySetInnerHTML={{ __html: renderMarkdown(author.text) }}
 				/>
 				{entry.attachments?.length ? (
@@ -836,14 +836,14 @@ export function PlainEntryRow({
 
 	const side = entry.actorType === "customer" ? "in" : "out";
 	return (
-		<div className={`plain-entry plain-entry-${side}`}>
-			<div className="plain-entry-head">
-				<span className="plain-actor">{entry.actorName}</span>
-				<span className="plain-kind-badge">{entry.kind}</span>
-				<span className="plain-time">{timeOf(entry.timestamp)}</span>
+		<div className={`plain-entry plain-entry-${side} flex max-w-[88%] flex-col gap-1 rounded-lg border border-line bg-panel px-3 py-2 ${side === "in" ? "self-start rounded-bl-sm" : "self-end rounded-br-sm border-accent/25 bg-accent-soft/50"}`}>
+			<div className="plain-entry-head flex flex-wrap items-baseline gap-1.5">
+				<span className="plain-actor text-supporting font-bold text-fg">{entry.actorName}</span>
+				<span className="plain-kind-badge rounded-sm border border-line-strong px-1 text-meta font-bold text-faint">{entry.kind}</span>
+				<span className="plain-time text-meta text-faint">{timeOf(entry.timestamp)}</span>
 			</div>
-			{entry.subject && <div className="plain-subject">{entry.subject}</div>}
-			{entry.text && <div className="plain-entry-text">{entry.text}</div>}
+			{entry.subject && <div className="plain-subject text-supporting font-semibold text-fg">{entry.subject}</div>}
+			{entry.text && <div className="plain-entry-text break-words whitespace-pre-wrap text-control-label leading-relaxed text-fg">{entry.text}</div>}
 			{entry.attachments?.length ? (
 				<PlainAttachments attachments={entry.attachments} />
 			) : null}

--- a/src/frontend/components/PrChecksPopover.tsx
+++ b/src/frontend/components/PrChecksPopover.tsx
@@ -159,7 +159,7 @@ export function PrChecksPopover({
 								<span className={`inline-flex size-4 shrink-0 ${checkToneClass(status.kind)}`}>
 									<CheckStatusIcon kind={status.kind} />
 								</span>
-								<span className="min-w-0 flex-1 truncate text-[13px] font-medium text-fg">
+								<span className="min-w-0 flex-1 truncate text-control-label font-medium text-fg">
 									{check.name}
 								</span>
 								<span className="shrink-0 text-label font-medium text-dim">

--- a/src/frontend/components/PrPanel.tsx
+++ b/src/frontend/components/PrPanel.tsx
@@ -1149,7 +1149,7 @@ export function PrPanel({
         {/* The row's bottom line is an inset shadow, not a border: the active tab
             covers it with its own surface-coloured bottom border while sitting
             flush inside the box, so nothing overflows vertically (a 1px overflow
-            here parks a scrollbar, since global.css opts Chrome out of overlay
+            here parks a scrollbar, since adapters.css opts Chrome out of overlay
             scrollbars). Horizontal scrollbars are hidden for the same reason. */}
         <div
           className="flex h-[52px] shrink-0 items-end gap-1 overflow-x-auto overflow-y-hidden px-6 shadow-[inset_0_-1px_0_var(--border)] [scrollbar-width:none] max-[720px]:px-2 [&::-webkit-scrollbar]:hidden"

--- a/src/frontend/components/PrPreview.tsx
+++ b/src/frontend/components/PrPreview.tsx
@@ -367,9 +367,9 @@ export function PrPreview({
 		: "";
 
 	return (
-		<div className="flex flex-col h-full min-h-0">
-			<div className="flex-1 min-h-0 overflow-y-auto">
-				<div className="w-full max-w-[860px] mx-auto px-5 py-6">
+		<div className="flex h-full min-h-0 flex-col">
+			<div className="min-h-0 flex-1 overflow-y-auto">
+				<div className="mx-auto w-full max-w-[860px] px-5 py-6">
 					{loading ? (
 						<div className="panel-placeholder">Loading PR…</div>
 					) : loadError && !pr ? (
@@ -393,10 +393,10 @@ export function PrPreview({
 							merged or closed.
 						</div>
 					) : (
-						<div className="pr-panel-info">
-							<div className="pr-head">
-								<span className={`pr-pill ${stateClass}`}>{stateLabel}</span>
-								<a className="pr-number" href={pr.url} target="_blank" rel="noopener">
+						<div className="pr-panel-info flex min-w-0 flex-col gap-3">
+							<div className="pr-head flex items-center gap-2">
+								<span className={`pr-pill rounded-full px-2.5 py-[3px] text-meta font-bold tracking-[-0.01em] ${stateClass === "pr-pill-open" ? "bg-green-soft text-green" : stateClass === "pr-pill-merged" ? "bg-purple/15 text-purple" : stateClass === "pr-pill-closed" ? "bg-red-soft text-red" : "bg-active text-dim"}`}>{stateLabel}</span>
+								<a className="pr-number text-control-label text-dim no-underline hover:text-accent" href={pr.url} target="_blank" rel="noopener">
 									#{pr.number}
 								</a>
 								<span className="text-faint text-label">
@@ -406,7 +406,7 @@ export function PrPreview({
 									<Button
 										variant={confirmClose ? "danger" : "default"}
 										size="sm"
-										className="min-h-[30px] px-2.5 text-[13px] font-[650] leading-none"
+										className="min-h-[30px] px-2.5 text-control-label font-[650] leading-none"
 										icon={!closing && !confirmClose ? <IconX size={16} /> : undefined}
 										disabled={closing}
 										onClick={handleClose}
@@ -418,12 +418,12 @@ export function PrPreview({
 							</div>
 							{closeError && <div className="pr-bar-error mt-2">{closeError}</div>}
 
-							<a className="pr-title" href={pr.url} target="_blank" rel="noopener">
+							<a className="pr-title text-item-title font-semibold leading-[1.28] text-fg no-underline hover:text-accent" href={pr.url} target="_blank" rel="noopener">
 								{pr.title}
 							</a>
 
-							<div className="pr-meta">
-								<span className="pr-branch">
+							<div className="pr-meta flex flex-wrap items-center gap-x-3.5 gap-y-1.5 text-supporting text-dim">
+								<span className="pr-branch rounded-sm border border-line bg-panel px-2 py-0.5 font-mono text-meta">
 									{pr.headRefName} → {pr.baseRefName}
 								</span>
 								<span>
@@ -641,7 +641,7 @@ export function PrPreview({
 				</div>
 			</div>
 
-			<div className="w-full max-w-[860px] mx-auto px-5 pb-5 shrink-0">
+			<div className="mx-auto w-full max-w-[860px] shrink-0 px-5 pb-5">
 				<Composer
 					value={prompt}
 					onChange={setPrompt}

--- a/src/frontend/components/PrPreview.tsx
+++ b/src/frontend/components/PrPreview.tsx
@@ -624,7 +624,7 @@ export function PrPreview({
 									</div>
 									{!diffLoading && diffError && (
 										<button
-											className="mt-3 rounded-sm border border-line bg-panel px-3 py-1.5 text-xs text-fg hover:bg-hover"
+											className="mt-3 rounded-sm border border-line bg-panel px-3 py-1.5 text-label text-fg hover:bg-hover"
 											onClick={() => {
 												setDiffLoading(true);
 												setDiffError(null);

--- a/src/frontend/components/PrRow.tsx
+++ b/src/frontend/components/PrRow.tsx
@@ -12,6 +12,7 @@ import {
 import { ContextMenu } from "../ui/menu";
 import { Popover } from "../ui/popover";
 import { Tooltip } from "../ui/tooltip";
+import { cn } from "../ui/cn";
 import {
 	PrRowCard,
 	ROW_CARD_CLASS,
@@ -80,7 +81,10 @@ export function PrRow({
 						render={
 							<button
 								type="button"
-								className={`sidebar-item sidebar-ws-row${selected ? " sidebar-item-selected" : ""}`}
+								className={cn(
+									"sidebar-item sidebar-ws-row relative mt-0.5 flex w-full items-center gap-[9px] rounded-lg border-0 bg-transparent px-2 py-[9px] pl-2.5 text-left text-fg transition-colors hover:bg-hover",
+									selected && "sidebar-item-selected !bg-hover-strong",
+								)}
 								onClick={onOpen}
 								onContextMenu={card.close}
 								aria-label={item.pr.title}
@@ -89,13 +93,13 @@ export function PrRow({
 					/>
 				}
 			>
-			<span className="sidebar-rail">
+			<span className="sidebar-rail relative flex size-[22px] shrink-0 items-center justify-center">
 				<PrStateMark item={item} size={18} />
 			</span>
-			<span className="sidebar-item-title">{item.pr.title}</span>
+			<span className="sidebar-item-title min-w-0 flex-1 truncate text-item-title font-medium leading-[1.35] text-dim">{item.pr.title}</span>
 			{!isPhone && (
 				<span
-					className="sidebar-ws-time"
+					className="sidebar-ws-time ml-auto min-w-[34px] shrink-0 text-right text-label text-faint"
 					aria-label={new Date(item.pr.updatedAt).toLocaleString()}
 				>
 					{shortTime(item.pr.updatedAt)}
@@ -106,12 +110,12 @@ export function PrRow({
 			    (confirmed). It deliberately does NOT wear the archive icon —
 			    this row sits beside workspace rows whose trailing icon archives
 			    locally, and a mis-click here closes someone's PR on GitHub. */}
-			<span className="sidebar-ws-actions">
+			<span className="sidebar-ws-actions absolute right-[7px] top-1/2 hidden -translate-y-1/2 items-center gap-1 rounded-sm bg-hover shadow-[-6px_0_5px_-2px_var(--bg-hover)] [@media(hover:hover)]:group-hover:inline-flex">
 				<Tooltip label={pinned ? "Unpin pull request" : "Pin pull request"}>
 					<span
 						role="button"
 						tabIndex={0}
-						className={`sidebar-ws-action${pinned ? " is-on" : ""}`}
+						className={cn("sidebar-ws-action inline-flex size-8 items-center justify-center rounded-sm text-faint hover:bg-hover hover:text-fg", pinned && "is-on text-accent")}
 						aria-label={pinned ? "Unpin pull request" : "Pin pull request"}
 						onMouseEnter={card.close}
 						onClick={(e) => {
@@ -132,7 +136,7 @@ export function PrRow({
 					<span
 						role="button"
 						tabIndex={0}
-						className="sidebar-ws-action"
+						className="sidebar-ws-action inline-flex size-8 items-center justify-center rounded-sm text-faint hover:bg-hover hover:text-fg"
 						aria-label="Close pull request"
 						onMouseEnter={card.close}
 						onClick={(e) => {

--- a/src/frontend/components/PrSessions.tsx
+++ b/src/frontend/components/PrSessions.tsx
@@ -151,7 +151,7 @@ export function PrSessionsList({
 	return (
 		<div className="flex flex-col">
 			{sessions.length === 0 && (
-				<div className="px-2 py-1.5 -mx-2 text-xs text-faint">
+				<div className="px-2 py-1.5 -mx-2 text-label text-faint">
 					No sessions are linked to this PR yet.
 				</div>
 			)}
@@ -199,7 +199,7 @@ export function PrSessionsList({
 					}}
 				>
 					<input
-						className="min-w-0 flex-1 rounded-sm border border-line bg-surface px-2.5 py-2 text-xs text-fg outline-none placeholder:text-faint focus:border-line-strong"
+						className="min-w-0 flex-1 rounded-sm border border-line bg-surface px-2.5 py-2 text-label text-fg outline-none placeholder:text-faint focus:border-line-strong"
 						placeholder="Start a new session on this PR…"
 						value={prompt}
 						onChange={(e) => setPrompt(e.target.value)}
@@ -208,14 +208,14 @@ export function PrSessionsList({
 					<Button
 						type="submit"
 						variant="primary"
-						className="shrink-0 text-xs"
+						className="shrink-0 text-label"
 						disabled={starting || !prompt.trim()}
 					>
 						{starting ? "Starting…" : "Start"}
 					</Button>
 				</form>
 			)}
-			{error && <div className="mt-1.5 text-xs text-red">{error}</div>}
+			{error && <div className="mt-1.5 text-label text-red">{error}</div>}
 		</div>
 	);
 }

--- a/src/frontend/components/PrStatusBar.tsx
+++ b/src/frontend/components/PrStatusBar.tsx
@@ -264,7 +264,7 @@ function PrBarButton({
 		<button
 			type="button"
 			className={cn(
-				"inline-flex min-h-[30px] items-center justify-center gap-1.5 rounded-lg border px-2.5 py-[5px] text-[13px] leading-none font-[650] whitespace-nowrap text-white shadow-control transition-[background-color,border-color,color,filter,transform] duration-150 ease-in-out hover:brightness-[1.08] active:scale-[0.98] active:brightness-[0.98] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 disabled:cursor-default disabled:opacity-60 disabled:shadow-none",
+				"inline-flex min-h-[30px] items-center justify-center gap-1.5 rounded-lg border px-2.5 py-[5px] text-control-label leading-none font-[650] whitespace-nowrap text-white shadow-control transition-[background-color,border-color,color,filter,transform] duration-150 ease-in-out hover:brightness-[1.08] active:scale-[0.98] active:brightness-[0.98] focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 disabled:cursor-default disabled:opacity-60 disabled:shadow-none",
 				tones[tone],
 				confirm && "outline-2 outline-[color-mix(in_srgb,var(--green)_45%,transparent)] outline-offset-1",
 				className,

--- a/src/frontend/components/PrTinder.tsx
+++ b/src/frontend/components/PrTinder.tsx
@@ -483,10 +483,10 @@ export function PrTinder({ onExit }: Props) {
 
 			{error ? (
 				<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
-					<div className="text-sm font-semibold text-red">
+					<div className="text-control-label font-semibold text-red">
 						Couldn't load the deck
 					</div>
-					<div className="max-w-sm text-sm text-dim">{error}</div>
+					<div className="max-w-sm text-control-label text-dim">{error}</div>
 				</div>
 			) : deck === null ? (
 				<div className="flex flex-1 items-center justify-center text-control-label text-faint">
@@ -560,7 +560,7 @@ export function PrTinder({ onExit }: Props) {
 			{deck !== null && !done && !error && (
 				<div className="flex w-full max-w-[640px] items-stretch gap-2.5 px-4 pb-[max(16px,env(safe-area-inset-bottom))]">
 					<button
-						className="flex items-center justify-center rounded-lg border border-red/40 bg-red-soft px-4 py-3 text-sm font-semibold text-red hover:border-red/70 disabled:opacity-50"
+						className="flex items-center justify-center rounded-lg border border-red/40 bg-red-soft px-4 py-3 text-control-label font-semibold text-red hover:border-red/70 disabled:opacity-50"
 						onClick={close}
 						disabled={busy}
 						title="Close PR (← or c) — undo available"
@@ -568,28 +568,28 @@ export function PrTinder({ onExit }: Props) {
 						Close
 					</button>
 					<button
-						className={`flex-1 rounded-lg border border-line px-3 py-3 text-sm font-semibold hover:bg-surface ${panel === "label" ? "bg-surface text-fg" : "bg-panel text-dim hover:text-fg"}`}
+						className={`flex-1 rounded-lg border border-line px-3 py-3 text-control-label font-semibold hover:bg-surface ${panel === "label" ? "bg-surface text-fg" : "bg-panel text-dim hover:text-fg"}`}
 						onClick={() => setPanel((p) => (p === "label" ? null : "label"))}
 						title="Labels (l)"
 					>
 						Label
 					</button>
 					<button
-						className={`flex-1 rounded-lg border border-line px-3 py-3 text-sm font-semibold hover:bg-surface ${panel === "comment" ? "bg-surface text-fg" : "bg-panel text-dim hover:text-fg"}`}
+						className={`flex-1 rounded-lg border border-line px-3 py-3 text-control-label font-semibold hover:bg-surface ${panel === "comment" ? "bg-surface text-fg" : "bg-panel text-dim hover:text-fg"}`}
 						onClick={() => setPanel((p) => (p === "comment" ? null : "comment"))}
 						title="Comment (m)"
 					>
 						Comment
 					</button>
 					<button
-						className="flex-1 rounded-lg border border-line bg-panel px-3 py-3 text-sm font-semibold text-dim hover:bg-surface hover:text-fg"
+						className="flex-1 rounded-lg border border-line bg-panel px-3 py-3 text-control-label font-semibold text-dim hover:bg-surface hover:text-fg"
 						onClick={() => card && window.open(card.url, "_blank", "noopener")}
 						title={`Open on ${providerFromUrl(card?.url).name} (o)`}
 					>
 						{providerFromUrl(card?.url).name}
 					</button>
 					<button
-						className="flex-1 rounded-lg bg-green px-4 py-3 text-sm font-semibold text-white hover:opacity-90"
+						className="flex-1 rounded-lg bg-green px-4 py-3 text-control-label font-semibold text-white hover:opacity-90"
 						onClick={keep}
 						title="Keep (→ or k)"
 					>
@@ -601,7 +601,7 @@ export function PrTinder({ onExit }: Props) {
 			{/* Undo / status toast. */}
 			{toast && (
 				<div className="pointer-events-none absolute bottom-24 left-1/2 z-20 -translate-x-1/2">
-					<div className="pointer-events-auto flex items-center gap-3 rounded-lg border border-line-strong bg-panel px-4 py-2.5 text-sm text-fg shadow-[0_6px_20px_rgba(0,0,0,0.35)]">
+					<div className="pointer-events-auto flex items-center gap-3 rounded-lg border border-line-strong bg-panel px-4 py-2.5 text-control-label text-fg shadow-[0_6px_20px_rgba(0,0,0,0.35)]">
 						{toast.text}
 						{toast.undo && (
 							<button
@@ -684,13 +684,13 @@ function SwipeCard({
 		>
 			{/* Swipe intent stamps. */}
 			<motion.div
-				className="pointer-events-none absolute left-4 top-16 z-10 rounded-md border-2 border-red px-2.5 py-1 text-sm font-bold tracking-wide text-red"
+				className="pointer-events-none absolute left-4 top-16 z-10 rounded-md border-2 border-red px-2.5 py-1 text-control-label font-bold tracking-wide text-red"
 				style={{ opacity: closeTint, rotate: -12 }}
 			>
 				Close
 			</motion.div>
 			<motion.div
-				className="pointer-events-none absolute right-4 top-16 z-10 rounded-md border-2 border-green px-2.5 py-1 text-sm font-bold tracking-wide text-green"
+				className="pointer-events-none absolute right-4 top-16 z-10 rounded-md border-2 border-green px-2.5 py-1 text-control-label font-bold tracking-wide text-green"
 				style={{ opacity: keepTint, rotate: 12 }}
 			>
 				Keep
@@ -698,7 +698,7 @@ function SwipeCard({
 
 			{/* Card head: number/author/ages, title, labels, diffstat. */}
 			<div className="shrink-0 border-b border-line px-5 py-3.5">
-				<div className="flex items-center gap-2 text-xs text-faint">
+				<div className="flex items-center gap-2 text-label text-faint">
 					<a
 						className="font-semibold tabular-nums text-dim hover:text-fg hover:underline"
 						href={pr.url}
@@ -739,7 +739,7 @@ function SwipeCard({
 							onRemove={() => onRemoveLabel(l.name)}
 						/>
 					))}
-					<span className="ml-auto flex items-center gap-2 text-xs tabular-nums">
+					<span className="ml-auto flex items-center gap-2 text-label tabular-nums">
 						<span className="text-green">+{pr.additions}</span>
 						<span className="text-red">−{pr.deletions}</span>
 						<span className="text-faint">
@@ -761,7 +761,7 @@ function SwipeCard({
 						dangerouslySetInnerHTML={{ __html: bodyHtml }}
 					/>
 				) : (
-					<div className="text-sm italic text-faint">(no description)</div>
+					<div className="text-control-label italic text-faint">(no description)</div>
 				)}
 			</div>
 		</motion.div>
@@ -795,17 +795,17 @@ function CommentPanel({
 						if (text.trim()) onSubmit(text.trim());
 					}
 				}}
-				className="w-full resize-none appearance-none rounded-md border border-line bg-surface px-3 py-2 text-sm leading-relaxed text-fg outline-none [-webkit-appearance:none] placeholder:text-faint focus:border-line-strong"
+				className="w-full resize-none appearance-none rounded-md border border-line bg-surface px-3 py-2 text-control-label leading-relaxed text-fg outline-none [-webkit-appearance:none] placeholder:text-faint focus:border-line-strong"
 			/>
 			<div className="mt-2 flex justify-end gap-2">
 				<button
-					className="rounded-md border border-line bg-transparent px-3 py-1.5 text-xs font-semibold text-dim hover:text-fg"
+					className="rounded-md border border-line bg-transparent px-3 py-1.5 text-label font-semibold text-dim hover:text-fg"
 					onClick={onCancel}
 				>
 					Cancel
 				</button>
 				<button
-					className="rounded-md bg-accent px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40"
+					className="rounded-md bg-accent px-3 py-1.5 text-label font-semibold text-white disabled:opacity-40"
 					disabled={busy || !text.trim()}
 					onClick={() => onSubmit(text.trim())}
 				>
@@ -846,10 +846,10 @@ function LabelPanel({
 					value={q}
 					placeholder="Filter labels…"
 					onChange={(e) => setQ(e.target.value)}
-					className="flex-1 appearance-none border-0 bg-transparent text-sm text-fg outline-none placeholder:text-faint"
+					className="flex-1 appearance-none border-0 bg-transparent text-control-label text-fg outline-none placeholder:text-faint"
 				/>
 				<button
-					className="text-xs font-semibold text-dim hover:text-fg"
+					className="text-label font-semibold text-dim hover:text-fg"
 					onClick={onClose}
 				>
 					Done
@@ -857,14 +857,14 @@ function LabelPanel({
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto p-2">
 				{rows.length === 0 ? (
-					<div className="px-2 py-3 text-sm text-faint">No matching labels.</div>
+					<div className="px-2 py-3 text-control-label text-faint">No matching labels.</div>
 				) : (
 					rows.map((l) => {
 						const on = active.has(l.name);
 						return (
 							<button
 								key={l.name}
-								className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-surface ${on ? "text-fg" : "text-dim"}`}
+								className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-control-label hover:bg-surface ${on ? "text-fg" : "text-dim"}`}
 								onClick={() => onToggle(l.name, l.color)}
 							>
 								<span className={`w-4 text-center ${on ? "text-green" : "text-transparent"}`}>
@@ -895,7 +895,7 @@ function DeckDone({
 		<div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
 			<div className="text-4xl">🔥</div>
 			<div className="text-item-title font-semibold text-fg">Deck done</div>
-			<div className="max-w-xs text-sm text-dim">
+			<div className="max-w-xs text-control-label text-dim">
 				{reviewed > 0
 					? `You went through ${reviewed} PR${reviewed === 1 ? "" : "s"}.`
 					: "Nothing new to triage."}
@@ -903,14 +903,14 @@ function DeckDone({
 			<div className="mt-2 flex gap-2">
 				{keptCount > 0 && (
 					<button
-						className="rounded-lg border border-line bg-panel px-4 py-2.5 text-sm font-semibold text-dim hover:bg-surface hover:text-fg"
+						className="rounded-lg border border-line bg-panel px-4 py-2.5 text-control-label font-semibold text-dim hover:bg-surface hover:text-fg"
 						onClick={onShowKept}
 					>
 						Deal {keptCount} kept PR{keptCount === 1 ? "" : "s"}
 					</button>
 				)}
 				<button
-					className="rounded-lg bg-panel px-4 py-2.5 text-sm font-semibold text-fg hover:bg-surface"
+					className="rounded-lg bg-panel px-4 py-2.5 text-control-label font-semibold text-fg hover:bg-surface"
 					onClick={onExit}
 				>
 					Done

--- a/src/frontend/components/PrTinder.tsx
+++ b/src/frontend/components/PrTinder.tsx
@@ -141,11 +141,11 @@ function LabelChip({
 
 function ReviewBadge({ decision }: { decision: string }) {
 	if (decision === "APPROVED")
-		return <span className="text-xs font-semibold text-green">Approved</span>;
+		return <span className="text-label font-semibold text-green">Approved</span>;
 	if (decision === "CHANGES_REQUESTED")
-		return <span className="text-xs font-semibold text-red">Changes requested</span>;
+		return <span className="text-label font-semibold text-red">Changes requested</span>;
 	if (decision === "REVIEW_REQUIRED")
-		return <span className="text-xs font-semibold text-yellow">Review required</span>;
+		return <span className="text-label font-semibold text-yellow">Review required</span>;
 	return null;
 }
 
@@ -455,7 +455,7 @@ export function PrTinder({ onExit }: Props) {
 						/>
 					</svg>
 				</button>
-				<div className="text-sm font-semibold text-fg">
+				<div className="text-control-label font-semibold text-fg">
 					{deck === null
 						? "PR Tinder"
 						: done
@@ -489,7 +489,7 @@ export function PrTinder({ onExit }: Props) {
 					<div className="max-w-sm text-sm text-dim">{error}</div>
 				</div>
 			) : deck === null ? (
-				<div className="flex flex-1 items-center justify-center text-sm text-faint">
+				<div className="flex flex-1 items-center justify-center text-control-label text-faint">
 					Dealing open PRs…
 				</div>
 			) : done ? (
@@ -757,7 +757,7 @@ function SwipeCard({
 					/* .pr-body-md clamps itself to 360px + inner scroll for the PR
 					   panel — undo that here: the card shows the whole description. */
 					<div
-						className="pr-body-md markdown max-h-none overflow-visible p-0 text-[13px]"
+						className="pr-body-md markdown max-h-none overflow-visible p-0 text-control-label"
 						dangerouslySetInnerHTML={{ __html: bodyHtml }}
 					/>
 				) : (

--- a/src/frontend/components/PreviewWait.tsx
+++ b/src/frontend/components/PreviewWait.tsx
@@ -111,7 +111,7 @@ export function PreviewWait({ sessionId }: { sessionId: string }) {
 
 	return (
 		<div className="fixed inset-0 flex flex-col items-center justify-center gap-4 bg-surface px-6 text-center">
-			<div className="text-[13px] font-semibold tracking-wide text-faint select-none">
+			<div className="text-control-label font-semibold tracking-wide text-faint select-none">
 				{PRODUCT_NAME}
 			</div>
 			{state === "waiting" ? (
@@ -124,11 +124,11 @@ export function PreviewWait({ sessionId }: { sessionId: string }) {
 						Starting the dev server…
 					</div>
 					{who && (
-						<div className="max-w-sm truncate text-[13px] font-semibold text-dim">
+						<div className="max-w-sm truncate text-control-label font-semibold text-dim">
 							{who}
 						</div>
 					)}
-					<div className="max-w-sm text-[13px] font-medium leading-relaxed text-dim">
+					<div className="max-w-sm text-control-label font-medium leading-relaxed text-dim">
 						The first build can take a minute. This tab will open the app
 						automatically when it's ready — keep it in the background.
 					</div>
@@ -140,14 +140,14 @@ export function PreviewWait({ sessionId }: { sessionId: string }) {
 							? "Session not found"
 							: "The dev server didn't come up"}
 					</div>
-					<div className="max-w-sm text-[13px] font-medium leading-relaxed text-dim">
+					<div className="max-w-sm text-control-label font-medium leading-relaxed text-dim">
 						{state === "gone"
 							? "This preview link points at a session that no longer exists."
 							: "It's been a few minutes with nothing listening — the boot may have failed. Check the session's Preview services for details, or try starting it again."}
 					</div>
 					<a
 						href={backHref}
-						className="rounded-md border border-line-strong px-3.5 py-1.5 text-[13px] font-semibold text-fg no-underline hover:border-accent hover:bg-accent-soft"
+						className="rounded-md border border-line-strong px-3.5 py-1.5 text-control-label font-semibold text-fg no-underline hover:border-accent hover:bg-accent-soft"
 					>
 						{state === "gone" ? "Open " + PRODUCT_NAME : "Back to the session"}
 					</a>

--- a/src/frontend/components/RepoTile.tsx
+++ b/src/frontend/components/RepoTile.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "../ui/cn";
 
 // Deterministic swatch palette shared by the sidebar's person dots and the
 // per-repo tiles. The (lowercased) key hashes to a stable color, so each
@@ -70,13 +71,17 @@ export function RepoTile({
 	if (failedFor !== name) {
 		return (
 			<span
-				className={`repo-tile repo-tile--img${name === "backstage" ? " repo-tile--app-icon" : ""}`}
+				className={cn(
+					"repo-tile repo-tile--img inline-flex size-[18px] shrink-0 items-center justify-center overflow-hidden rounded-[5px] text-label font-bold text-white",
+					name === "backstage" && "repo-tile--app-icon [&_img]:scale-80",
+				)}
 				style={style}
 			>
 				<img
 					src={`/repo-icon/${encodeURIComponent(name)}.png`}
 					alt=""
 					loading="lazy"
+					className="size-full rounded-[inherit] object-cover"
 					onError={() => setFailedFor(name)}
 				/>
 			</span>
@@ -85,7 +90,10 @@ export function RepoTile({
 	style.background = repoColor(name);
 	const letter = REPO_DISPLAY[name]?.letter ?? (name[0] || "?").toUpperCase();
 	return (
-		<span className="repo-tile" style={style}>
+		<span
+			className="repo-tile inline-flex size-[18px] shrink-0 items-center justify-center rounded-[5px] text-label font-bold text-white"
+			style={style}
+		>
 			{letter}
 		</span>
 	);

--- a/src/frontend/components/Reports.tsx
+++ b/src/frontend/components/Reports.tsx
@@ -131,11 +131,11 @@ export function Reports({
 					<div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-lg bg-surface text-dim">
 						<IconFile size={24} />
 					</div>
-					<h1 className="m-0 text-page-title font-semibold text-fg">Reports</h1>
-					<p className="mt-2 text-sm leading-6 text-dim">
+					<h1 className="m-0 text-section-title font-semibold text-fg">Reports</h1>
+					<p className="mt-2 text-body leading-relaxed text-dim">
 						Recurring automation reports will collect here, with the latest result and full history in one place.
 					</p>
-					{error && <p className="mt-3 text-sm text-red">{error}</p>}
+                    {error && <p className="mt-3 text-body text-red">{error}</p>}
 				</div>
 			</div>
 		);
@@ -151,7 +151,7 @@ export function Reports({
 				<aside className={`flex min-h-0 flex-col bg-panel ${isPhone ? "w-full flex-1" : "w-[300px] shrink-0 border-r border-line"}`}>
 					<div className="border-b border-line px-4 py-4">
 						<h1 className="m-0 text-section-title font-semibold tracking-[-0.02em] text-fg">Reports</h1>
-						<p className="m-0 mt-1 text-xs text-dim">Recurring intelligence, organized by automation</p>
+						<p className="m-0 mt-1 text-label text-dim">Recurring intelligence, organized by automation</p>
 					</div>
 					<div className="min-h-0 flex-1 overflow-y-auto p-2">
 						{groups.map((group) => (
@@ -163,8 +163,8 @@ export function Reports({
 							>
 								<span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-surface text-accent"><IconFile size={17} /></span>
 								<span className="min-w-0 flex-1">
-									<span className="block truncate text-sm font-medium text-fg">{group.automationName}</span>
-									<span className="mt-1 block truncate text-xs text-dim">{group.latest.title}</span>
+                                    <span className="block truncate text-control-label font-medium text-fg">{group.automationName}</span>
+                                    <span className="mt-1 block truncate text-label text-dim">{group.latest.title}</span>
 									<span className="mt-1.5 block text-meta text-faint">{formatDate(group.latest.createdAt)} · {group.count} {group.count === 1 ? "report" : "reports"}</span>
 								</span>
 								<IconChevronRight size={16} className="mt-2 shrink-0 text-faint" />
@@ -180,7 +180,7 @@ export function Reports({
 						<header className="shrink-0 border-b border-line px-3 pb-3 pt-2">
 							<button
 								type="button"
-								className="-ml-1 flex items-center gap-0.5 rounded-md border-0 bg-transparent py-1.5 pl-1 pr-2.5 text-sm font-medium text-accent cursor-pointer"
+                                className="-ml-1 flex items-center gap-0.5 rounded-md border-0 bg-transparent py-1.5 pl-1 pr-2.5 text-control-label font-medium text-accent cursor-pointer"
 								onClick={onBack}
 							>
 								<IconChevronLeft size={18} />
@@ -188,12 +188,12 @@ export function Reports({
 							</button>
 							{selected && (
 								<>
-									<h2 className="m-0 mt-1 px-1 text-base font-semibold leading-snug text-fg">{selected.title}</h2>
-									<p className="m-0 mt-1 px-1 text-xs leading-5 text-dim line-clamp-2">{formatDate(selected.createdAt, true)}{selected.summary ? ` · ${selected.summary}` : ""}</p>
+                                    <h2 className="m-0 mt-1 px-1 text-body font-semibold leading-snug text-fg">{selected.title}</h2>
+                                    <p className="m-0 mt-1 px-1 text-label leading-5 text-dim line-clamp-2">{formatDate(selected.createdAt, true)}{selected.summary ? ` · ${selected.summary}` : ""}</p>
 									<div className="mt-2.5 flex items-center gap-2 px-1">
 										<select
 											aria-label="Report history"
-											className="min-w-0 flex-1 rounded-md border border-line bg-panel px-2 py-1.5 text-xs text-fg"
+                                            className="min-w-0 flex-1 rounded-md border border-line bg-panel px-2 py-1.5 text-label text-fg"
 											value={selected.id}
 											onChange={(event) => onSelect(selected.automationId, event.target.value)}
 										>
@@ -209,14 +209,14 @@ export function Reports({
 						selected && (
 							<header className="flex shrink-0 items-start gap-4 border-b border-line px-5 py-3">
 								<div className="min-w-0 flex-1">
-									<h2 className="m-0 truncate text-base font-semibold text-fg">{selected.title}</h2>
-									<p className="m-0 mt-1 text-xs text-dim">{formatDate(selected.createdAt, true)}{selected.summary ? ` · ${selected.summary}` : ""}</p>
+                                    <h2 className="m-0 truncate text-body font-semibold text-fg">{selected.title}</h2>
+                                    <p className="m-0 mt-1 text-label text-dim">{formatDate(selected.createdAt, true)}{selected.summary ? ` · ${selected.summary}` : ""}</p>
 								</div>
 								<Button size="sm" className="min-h-[30px] w-[30px] shrink-0" icon={<CopyCheck copied={copied} size={15} idle={<IconLink size={15} />} />} aria-label="Share report" title="Share report" onClick={shareSelected} />
 								{selected.sessionId && <Button size="sm" className="min-h-[30px] shrink-0" onClick={() => onOpenSession(selected.sessionId!)}>Open run</Button>}
 								<select
 									aria-label="Report history"
-									className="max-w-[190px] shrink-0 rounded-md border border-line bg-panel px-2 py-1.5 text-xs text-fg"
+                                    className="max-w-[190px] shrink-0 rounded-md border border-line bg-panel px-2 py-1.5 text-label text-fg"
 									value={selected.id}
 									onChange={(event) => onSelect(selected.automationId, event.target.value)}
 								>

--- a/src/frontend/components/RestartOverlay.tsx
+++ b/src/frontend/components/RestartOverlay.tsx
@@ -239,19 +239,19 @@ export function RestartOverlay({ connected, addHandler }: Props) {
   if (phase !== "crashed") return null;
 
   return (
-    <div className="restart-overlay" role="alertdialog" aria-live="assertive">
-      <div className="restart-card">
-        <div className={`restart-spinner ${backOnline ? "restart-spinner-done" : ""}`} />
-        <div className="restart-title">
+    <div className="restart-overlay fixed inset-0 z-[10000] flex items-center justify-center bg-[#070506]/82 p-6 backdrop-blur-sm" role="alertdialog" aria-live="assertive">
+      <div className="restart-card flex max-w-[340px] flex-col items-center gap-3.5 rounded-panel border border-line bg-panel px-[26px] py-7 text-center">
+        <div className={`restart-spinner size-[30px] animate-spin rounded-full border-[2.5px] border-line-strong border-t-accent ${backOnline ? "restart-spinner-done !animate-none !border-green !border-t-green" : ""}`} />
+        <div className="restart-title text-item-title font-semibold text-fg">
           {backOnline ? "Back online" : `${PRODUCT_NAME} is restarting`}
         </div>
-        <div className="restart-sub">
+        <div className="restart-sub text-supporting leading-normal text-dim">
           {backOnline
             ? "Refreshing…"
             : "Hang tight. The page will refresh automatically once it's back up."}
         </div>
         {!backOnline && restartBy && (
-          <div className="restart-by">Triggered by {restartBy}</div>
+          <div className="restart-by mt-1.5 max-w-full truncate text-label font-medium leading-normal text-dim opacity-80">Triggered by {restartBy}</div>
         )}
       </div>
     </div>

--- a/src/frontend/components/Reviews.tsx
+++ b/src/frontend/components/Reviews.tsx
@@ -83,7 +83,7 @@ function StateIcon({ kind }: { kind: string }) {
 function ChecksCell({ s }: { s: UnifiedSession }) {
   const c = s.prChecks;
   if (!c || c.total === 0)
-    return <span className="rv-checks rv-checks-empty">—</span>;
+    return <span className="rv-checks rv-checks-empty inline-flex items-center gap-2 text-supporting text-faint">—</span>;
   const tone = c.failed > 0 ? "fail" : c.pending > 0 ? "pending" : "pass";
   const label =
     tone === "fail"
@@ -93,13 +93,13 @@ function ChecksCell({ s }: { s: UnifiedSession }) {
         : `${c.passed} passed`;
   const pct = (n: number) => `${(n / c.total) * 100}%`;
   return (
-    <span className={`rv-checks rv-checks-${tone}`} title={`${c.passed} passed · ${c.failed} failed · ${c.pending} pending · ${c.total} total`}>
-      <span className={`rv-check-dot rv-check-dot-${tone}`} />
-      <span className="rv-checks-label">{label}</span>
-      <span className="rv-checks-bar" aria-hidden>
-        <span className="rv-bar-seg rv-bar-pass" style={{ width: pct(c.passed) }} />
-        <span className="rv-bar-seg rv-bar-fail" style={{ width: pct(c.failed) }} />
-        <span className="rv-bar-seg rv-bar-pending" style={{ width: pct(c.pending) }} />
+    <span className={`rv-checks rv-checks-${tone} inline-flex items-center gap-2 text-supporting`} title={`${c.passed} passed · ${c.failed} failed · ${c.pending} pending · ${c.total} total`}>
+      <span className={`rv-check-dot rv-check-dot-${tone} size-2 shrink-0 rounded-full ${tone === "pass" ? "bg-green" : tone === "fail" ? "bg-red" : "animate-[rv-pulse_1.4s_ease-in-out_infinite] bg-[#d9a23a]"}`} />
+      <span className={`rv-checks-label whitespace-nowrap ${tone === "pass" ? "text-green" : tone === "fail" ? "text-red" : "text-[#d9a23a]"}`}>{label}</span>
+      <span className="rv-checks-bar inline-flex h-1 w-[46px] shrink-0 overflow-hidden rounded-full bg-active" aria-hidden>
+        <span className="rv-bar-seg rv-bar-pass h-full bg-green" style={{ width: pct(c.passed) }} />
+        <span className="rv-bar-seg rv-bar-fail h-full bg-red" style={{ width: pct(c.failed) }} />
+        <span className="rv-bar-seg rv-bar-pending h-full bg-[#d9a23a]" style={{ width: pct(c.pending) }} />
       </span>
     </span>
   );
@@ -107,7 +107,7 @@ function ChecksCell({ s }: { s: UnifiedSession }) {
 
 function ReviewCell({ s }: { s: UnifiedSession }) {
   const d = s.prReviewDecision || "";
-  if ((s.prState || "OPEN") !== "OPEN") return <span className="rv-dim">—</span>;
+  if ((s.prState || "OPEN") !== "OPEN") return <span className="rv-dim text-supporting text-faint">—</span>;
   if (d === "APPROVED")
     return <span className="rv-review rv-review-approved">Approved</span>;
   if (d === "CHANGES_REQUESTED")
@@ -127,20 +127,20 @@ function ChangesCell({ s }: { s: UnifiedSession }) {
   const reds = Math.max(del > 0 ? 1 : 0, Math.round((del / total) * blocks));
   const grays = Math.max(0, blocks - greens - reds);
   return (
-    <span className="rv-changes" title={`${files} file${files === 1 ? "" : "s"} changed`}>
-      <span className="rv-diffstat">
-        <span className="rv-add">+{add}</span>
-        <span className="rv-del">−{del}</span>
+    <span className="rv-changes inline-flex flex-col gap-1" title={`${files} file${files === 1 ? "" : "s"} changed`}>
+      <span className="rv-diffstat inline-flex gap-2 font-mono text-label tabular-nums">
+        <span className="rv-add text-green">+{add}</span>
+        <span className="rv-del text-red">−{del}</span>
       </span>
-      <span className="rv-diffsquares" aria-hidden>
+      <span className="rv-diffsquares inline-flex gap-0.5" aria-hidden>
         {Array.from({ length: greens }).map((_, i) => (
-          <span key={`g${i}`} className="rv-sq rv-sq-add" />
+          <span key={`g${i}`} className="rv-sq rv-sq-add size-2 rounded-xs bg-green" />
         ))}
         {Array.from({ length: reds }).map((_, i) => (
-          <span key={`r${i}`} className="rv-sq rv-sq-del" />
+          <span key={`r${i}`} className="rv-sq rv-sq-del size-2 rounded-xs bg-red" />
         ))}
         {Array.from({ length: grays }).map((_, i) => (
-          <span key={`n${i}`} className="rv-sq rv-sq-none" />
+          <span key={`n${i}`} className="rv-sq rv-sq-none size-2 rounded-xs bg-line-strong" />
         ))}
       </span>
     </span>
@@ -287,16 +287,16 @@ export function Reviews({
   }
 
   return (
-    <div className="reviews">
-      <div className="reviews-main">
-        <div className="reviews-header">
-          <div className="reviews-header-top">
-            <h1 className="reviews-title">Reviews</h1>
-            <div className="reviews-search">
+    <div className="reviews relative flex min-h-0 flex-1">
+      <div className="reviews-main flex min-w-0 flex-1 flex-col overflow-y-auto max-[720px]:overflow-x-hidden">
+        <div className="reviews-header sticky top-0 z-[3] bg-surface px-[22px] pt-4">
+          <div className="reviews-header-top mb-3 flex items-center justify-between gap-4">
+            <h1 className="reviews-title m-0 text-section-title font-semibold tracking-[-0.01em]">Reviews</h1>
+            <div className="reviews-search flex w-60 items-center gap-2 rounded-sm border border-line bg-raised px-2.5 py-1.5 text-faint transition-[border-color,background] duration-100 focus-within:border-line-strong focus-within:bg-panel">
               <svg width="19" height="19" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
                 <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z" />
               </svg>
-              <input
+                <input className="min-w-0 flex-1 border-0 bg-transparent text-control-label text-fg outline-none placeholder:text-faint"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search pull requests…"
@@ -304,20 +304,20 @@ export function Reviews({
               />
             </div>
           </div>
-          <div className="reviews-tabs">
+          <div className="reviews-tabs -mx-[22px] flex gap-0.5 overflow-x-auto border-b border-line px-[22px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             {TABS.map((t) => (
               <button
                 key={t.key}
-                className={`reviews-tab ${filter === t.key ? "active" : ""}`}
+                className={`reviews-tab mb-[-1px] flex shrink-0 items-center gap-2 whitespace-nowrap border-0 border-b-2 border-transparent bg-transparent px-3 py-2 pb-2.5 text-control-label font-medium text-dim transition-colors hover:text-fg ${filter === t.key ? "active border-accent text-fg" : ""}`}
                 onClick={() => setFilter(t.key)}
               >
                 {t.label}
-                <span className="reviews-tab-count">{t.count}</span>
+                <span className={`reviews-tab-count min-w-5 rounded-full bg-active px-1.5 py-px text-center text-meta font-semibold text-dim ${filter === t.key ? "bg-accent-soft text-accent" : ""}`}>{t.count}</span>
               </button>
             ))}
           </div>
           {filtered.length > 0 && (
-            <div className="reviews-row reviews-row-head" role="row">
+            <div className="reviews-row reviews-row-head -mx-[22px] grid grid-cols-[92px_minmax(0,1fr)_156px_132px_116px_132px_78px] items-center gap-3.5 border-b border-line bg-surface px-[22px] py-2 text-meta font-semibold tracking-[-0.01em] text-faint max-[1180px]:grid-cols-[88px_minmax(0,1fr)_150px_118px_78px] max-[720px]:hidden" role="row">
               <span className="rv-c-state">Status</span>
               <span className="rv-c-title">Pull request</span>
               <span className="rv-c-checks">Checks</span>
@@ -330,7 +330,7 @@ export function Reviews({
         </div>
 
         {filtered.length === 0 ? (
-          <div className="reviews-empty">
+          <div className="reviews-empty flex flex-1 items-center justify-center">
             <div className="detail-empty-inner">
               <div className="detail-empty-title">
                 {prSessions.length === 0 ? "No pull requests yet" : "Nothing here"}
@@ -345,27 +345,27 @@ export function Reviews({
             </div>
           </div>
         ) : (
-          <div className="reviews-table" role="table">
+          <div className="reviews-table flex flex-col" role="table">
             {filtered.map((s) => {
               const meta = stateMeta(s);
               return (
                 <button
                   key={s.prUrl}
-                  className="reviews-row"
+                  className="reviews-row grid w-full grid-cols-[92px_minmax(0,1fr)_156px_132px_116px_132px_78px] items-center gap-3.5 border-0 border-b border-line bg-transparent px-[22px] py-2.5 text-left text-fg hover:bg-hover max-[1180px]:grid-cols-[88px_minmax(0,1fr)_150px_118px_78px] max-[1180px]:[&_.rv-c-review]:hidden max-[1180px]:[&_.rv-c-author]:hidden max-[720px]:flex max-[720px]:flex-wrap max-[720px]:gap-x-3 max-[720px]:gap-y-2 max-[720px]:px-4 max-[720px]:py-3.5"
                   onClick={() => onSelect(s.id)}
                   role="row"
                 >
-                  <span className={`rv-c-state rv-state-${meta.key}`} role="cell">
+                  <span className={`rv-c-state rv-state-${meta.key} flex items-center gap-2 text-supporting font-medium ${meta.key === "open" ? "text-green" : meta.key === "draft" ? "text-dim" : meta.key === "merged" ? "text-purple" : "text-red"} max-[720px]:order-1`} role="cell">
                     <StateIcon kind={meta.key} />
                     <span className="rv-state-label">{meta.label}</span>
                   </span>
-                  <span className="rv-c-title" role="cell">
-                    <span className="rv-title-line">
-                      <span className="rv-title-text">{cleanTitle(s)}</span>
-                      {prNum(s) && <span className="rv-num">{prNum(s)}</span>}
+                  <span className="rv-c-title flex min-w-0 flex-col gap-0.5 max-[720px]:order-2 max-[720px]:min-w-0 max-[720px]:flex-[1_1_calc(100%-90px)]" role="cell">
+                    <span className="rv-title-line flex min-w-0 items-baseline gap-2">
+                      <span className="rv-title-text overflow-hidden text-ellipsis whitespace-nowrap text-body font-medium leading-[1.3]">{cleanTitle(s)}</span>
+                      {prNum(s) && <span className="rv-num shrink-0 text-supporting tabular-nums text-faint">{prNum(s)}</span>}
                       {s.prUrl && (
                         <span
-                          className="rv-open-gh"
+                          className="rv-open-gh inline-flex shrink-0 items-center self-center rounded-xs p-0.5 text-faint opacity-0 transition-opacity hover:text-accent group-hover:opacity-100 focus-visible:opacity-100"
                           title={`Open on ${providerFromUrl(s.prUrl).name}`}
                           onClick={(e) => {
                             e.stopPropagation();
@@ -378,12 +378,12 @@ export function Reviews({
                         </span>
                       )}
                     </span>
-                    <span className="rv-sub-line">
+                    <span className="rv-sub-line flex min-w-0 items-center gap-3 text-label text-faint">
                       {multiRepo && (
-                        <span className="rv-repo">{s.repo || "repository"}</span>
+                          <span className="rv-repo shrink-0 rounded-sm bg-active px-1.5 py-px font-mono text-meta font-semibold text-dim">{s.repo || "repository"}</span>
                       )}
                       {s.branch && (
-                        <span className="rv-branch">
+                          <span className="rv-branch inline-flex min-w-0 max-w-full items-center gap-1 overflow-hidden font-mono text-meta text-dim [&_svg]:shrink-0 [&_svg]:opacity-70">
                           <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
                             <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
                           </svg>
@@ -391,36 +391,36 @@ export function Reviews({
                         </span>
                       )}
                       {s.linearIssue && (
-                        <span className="rv-linear">{s.linearIssue.identifier}</span>
+                          <span className="rv-linear shrink-0 rounded-sm bg-active px-1.5 py-px text-meta font-semibold tracking-[0.02em] text-dim">{s.linearIssue.identifier}</span>
                       )}
                       {s.isRunning && <span className="rv-running">● running</span>}
                     </span>
                   </span>
-                  <span className="rv-c-checks" role="cell">
+                  <span className="rv-c-checks max-[720px]:order-3 max-[720px]:inline-flex" role="cell">
                     <ChecksCell s={s} />
                   </span>
-                  <span className="rv-c-review" role="cell">
+                  <span className="rv-c-review max-[720px]:order-5 max-[720px]:inline-flex" role="cell">
                     <ReviewCell s={s} />
                   </span>
-                  <span className="rv-c-changes" role="cell">
+                  <span className="rv-c-changes max-[720px]:order-4 max-[720px]:inline-flex max-[720px]:flex-row max-[720px]:items-center max-[720px]:gap-2" role="cell">
                     <ChangesCell s={s} />
                   </span>
-                  <span className="rv-c-author" role="cell">
+                  <span className="rv-c-author flex min-w-0 items-center gap-2 max-[720px]:order-6 max-[720px]:inline-flex" role="cell">
                     {s.prAuthor ? (
                       <>
                         <img
-                          className="rv-avatar"
+                          className="rv-avatar size-[22px] shrink-0 rounded-[32%] bg-active"
                           src={avatarUrl(s.prAuthor, providerFromUrl(s.prUrl), 40) || ""}
                           alt=""
                           loading="lazy"
                         />
-                        <span className="rv-author-name">{s.prAuthor}</span>
+                        <span className="rv-author-name overflow-hidden text-ellipsis whitespace-nowrap text-supporting text-dim">{s.prAuthor}</span>
                       </>
                     ) : (
                       <span className="rv-dim">—</span>
                     )}
                   </span>
-                  <span className="rv-c-updated" role="cell">
+                  <span className="rv-c-updated whitespace-nowrap text-supporting tabular-nums text-faint max-[720px]:order-7 max-[720px]:ml-auto" role="cell">
                     {relativeTime(s.prUpdatedAt || s.lastActivity)}
                   </span>
                 </button>

--- a/src/frontend/components/Reviews.tsx
+++ b/src/frontend/components/Reviews.tsx
@@ -257,7 +257,7 @@ export function Reviews({
       <div className="flex h-full min-h-0 flex-col bg-surface">
         <div className="hidden shrink-0 items-center border-b border-line px-3 py-2 max-[720px]:flex">
           <button
-            className="inline-flex items-center gap-1.5 rounded-sm border-0 bg-transparent px-2 py-1.5 text-sm font-medium text-fg hover:bg-hover"
+            className="inline-flex items-center gap-1.5 rounded-sm border-0 bg-transparent px-2 py-1.5 text-control-label font-medium text-fg hover:bg-hover"
             onClick={() => onSelect("")}
           >
             <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden>

--- a/src/frontend/components/SchedulePrompt.tsx
+++ b/src/frontend/components/SchedulePrompt.tsx
@@ -25,7 +25,7 @@ const toDateInput = (d: Date) =>
   `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 
 const menuItemClass =
-  "composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] disabled:cursor-default disabled:opacity-45";
+  "composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-supporting text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] disabled:cursor-default disabled:opacity-45";
 
 /**
  * Composer "send later": schedules the *current composer draft* for this
@@ -199,7 +199,7 @@ export function SchedulePromptButton({
       >
         {variant === "menu-item" ? (
           <>
-            <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
+            <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-control-label text-dim">
               <IconClock size={22} />
             </span>
             <span>Schedule message</span>
@@ -208,7 +208,7 @@ export function SchedulePromptButton({
           <IconChevronDown size={20} />
         )}
         {pending.length > 0 && (
-          <span className="composer-schedule-badge pointer-events-none absolute -top-[5px] -right-[5px] h-[15px] min-w-[15px] rounded-full bg-yellow px-[3px] text-center text-[10px] leading-[15px] font-bold text-white shadow-[0_0_0_2px_var(--bg)]">{pending.length}</span>
+          <span className="composer-schedule-badge pointer-events-none absolute -top-[5px] -right-[5px] h-[15px] min-w-[15px] rounded-full bg-yellow px-[3px] text-center text-meta leading-[15px] font-bold text-white shadow-[0_0_0_2px_var(--bg)]">{pending.length}</span>
         )}
       </button>
 
@@ -217,7 +217,7 @@ export function SchedulePromptButton({
           {pending.length > 0 && (
             <div className="composer-schedule-pending mb-0.5 flex flex-col gap-px border-b border-line pb-1">
               {pending.map((p) => (
-                <div key={p.id} className="composer-schedule-perow flex min-w-0 items-baseline gap-2 px-[9px] py-[5px] text-xs">
+                <div key={p.id} className="composer-schedule-perow flex min-w-0 items-baseline gap-2 px-[9px] py-[5px] text-label">
                   <span
                     className="composer-schedule-pin shrink-0 font-semibold text-yellow"
                     title={new Date(p.at).toLocaleString()}
@@ -229,7 +229,7 @@ export function SchedulePromptButton({
                   </span>
                   <button
                     type="button"
-                    className="composer-schedule-pcancel ml-auto shrink-0 border-0 bg-transparent p-0 text-xs text-faint hover:text-red"
+                    className="composer-schedule-pcancel ml-auto shrink-0 border-0 bg-transparent p-0 text-label text-faint hover:text-red"
                     title="Cancel this scheduled message"
                     onClick={async () => {
                       try {
@@ -245,7 +245,7 @@ export function SchedulePromptButton({
             </div>
           )}
 
-          <div className="composer-schedule-head px-[9px] pt-1.5 pb-1 text-xs font-medium text-faint">Schedule message</div>
+          <div className="composer-schedule-head px-[9px] pt-1.5 pb-1 text-label font-medium text-faint">Schedule message</div>
           {quickOptions().map((o) => (
             <button
               key={o.at.toISOString()}
@@ -269,7 +269,7 @@ export function SchedulePromptButton({
             Custom time
           </button>
           {error && !customOpen && (
-            <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-xs text-red">{error}</div>
+            <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-label text-red">{error}</div>
           )}
         </div>
       )}
@@ -285,7 +285,7 @@ export function SchedulePromptButton({
             <div className="composer-schedule-modal-head flex items-start justify-between gap-3">
               <div>
                 <div className="composer-schedule-modal-title text-[17px] font-semibold text-fg">Schedule message</div>
-                <div className="composer-schedule-modal-tz mt-[3px] text-[12.5px] text-dim">Time zone: {tz}</div>
+                <div className="composer-schedule-modal-tz mt-[3px] text-supporting text-dim">Time zone: {tz}</div>
               </div>
               <button
                 type="button"
@@ -302,27 +302,27 @@ export function SchedulePromptButton({
                 value={date}
                 min={toDateInput(new Date())}
                 onChange={(e) => setDate(e.target.value)}
-                className="composer-schedule-input min-w-0 flex-1 rounded-md border border-line bg-surface px-3 py-[9px] text-sm font-medium text-fg outline-none focus:border-line-strong"
+                className="composer-schedule-input min-w-0 flex-1 rounded-md border border-line bg-surface px-3 py-[9px] text-control-label font-medium text-fg outline-none focus:border-line-strong"
               />
               <input
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                className="composer-schedule-input composer-schedule-input-time min-w-0 flex-[0_0_130px] rounded-md border border-line bg-surface px-3 py-[9px] text-sm font-medium text-fg outline-none focus:border-line-strong"
+                className="composer-schedule-input composer-schedule-input-time min-w-0 flex-[0_0_130px] rounded-md border border-line bg-surface px-3 py-[9px] text-control-label font-medium text-fg outline-none focus:border-line-strong"
               />
             </div>
-            {error && <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-xs text-red">{error}</div>}
+            {error && <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-label text-red">{error}</div>}
             <div className="composer-schedule-modal-actions mt-5 flex justify-end gap-2">
               <button
                 type="button"
-                className="composer-schedule-cancel rounded-md border border-line-strong bg-transparent px-4 py-[9px] text-sm font-semibold text-fg hover:bg-surface"
+                className="composer-schedule-cancel rounded-md border border-line-strong bg-transparent px-4 py-[9px] text-control-label font-semibold text-fg hover:bg-surface"
                 onClick={() => setCustomOpen(false)}
               >
                 Cancel
               </button>
               <button
                 type="button"
-                className="composer-schedule-submit rounded-md border-0 bg-accent px-4 py-[9px] text-sm font-semibold text-white transition-[filter] hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-45"
+                className="composer-schedule-submit rounded-md border-0 bg-accent px-4 py-[9px] text-control-label font-semibold text-white transition-[filter] hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-45"
                 onClick={scheduleCustom}
                 disabled={saving || !date || !time}
               >

--- a/src/frontend/components/SchedulePrompt.tsx
+++ b/src/frontend/components/SchedulePrompt.tsx
@@ -7,6 +7,7 @@ import {
 } from "../lib/api";
 import { getCurrentUser } from "./UserPicker";
 import { IconChevronDown, IconClock } from "./icons";
+import { cn } from "../ui/cn";
 
 /** "in 45m" / "in 3h" / "in 2d" for a future instant (short form). */
 function inTime(iso: string): string {
@@ -22,6 +23,9 @@ const fmtTime = (d: Date) =>
   d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 const toDateInput = (d: Date) =>
   `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+const menuItemClass =
+  "composer-menu-item flex w-full cursor-pointer items-center gap-[9px] rounded-md border-0 bg-transparent px-[9px] py-[7px] text-left text-[12.5px] text-fg hover:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] disabled:cursor-default disabled:opacity-45";
 
 /**
  * Composer "send later": schedules the *current composer draft* for this
@@ -174,14 +178,17 @@ export function SchedulePromptButton({
   return (
     <div
       ref={rootRef}
-      className={`composer-schedule-wrap ${variant === "menu-item" ? "composer-schedule-wrap-menu" : ""}`}
+      className={cn(
+        "composer-schedule-wrap relative inline-flex items-stretch",
+        variant === "menu-item" && "composer-schedule-wrap-menu block w-full",
+      )}
     >
       <button
         type="button"
         className={
           variant === "menu-item"
-            ? "composer-menu-item composer-schedule-item"
-            : `composer-send-caret ${open ? "is-open" : ""}`
+            ? `${menuItemClass} composer-schedule-item relative justify-start disabled:hover:bg-transparent`
+            : cn("composer-send-caret relative inline-flex w-[30px] items-center justify-center rounded-r-lg border-0 bg-accent text-white transition-[filter] hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-35 before:absolute before:left-0 before:top-1/2 before:h-4 before:w-px before:-translate-y-1/2 before:bg-white/45 [&>svg]:transition-transform", open && "is-open [&>svg]:rotate-180")
         }
         onClick={() => setOpen(!open)}
         disabled={disabled}
@@ -192,7 +199,7 @@ export function SchedulePromptButton({
       >
         {variant === "menu-item" ? (
           <>
-            <span className="composer-menu-icon">
+            <span className="composer-menu-icon inline-flex w-5 items-center justify-center text-[13px] text-dim">
               <IconClock size={22} />
             </span>
             <span>Schedule message</span>
@@ -201,28 +208,28 @@ export function SchedulePromptButton({
           <IconChevronDown size={20} />
         )}
         {pending.length > 0 && (
-          <span className="composer-schedule-badge">{pending.length}</span>
+          <span className="composer-schedule-badge pointer-events-none absolute -top-[5px] -right-[5px] h-[15px] min-w-[15px] rounded-full bg-yellow px-[3px] text-center text-[10px] leading-[15px] font-bold text-white shadow-[0_0_0_2px_var(--bg)]">{pending.length}</span>
         )}
       </button>
 
       {open && (
-        <div className="composer-menu composer-schedule-menu" role="menu">
+        <div className="composer-menu composer-schedule-menu min-w-[236px]" role="menu">
           {pending.length > 0 && (
-            <div className="composer-schedule-pending">
+            <div className="composer-schedule-pending mb-0.5 flex flex-col gap-px border-b border-line pb-1">
               {pending.map((p) => (
-                <div key={p.id} className="composer-schedule-perow">
+                <div key={p.id} className="composer-schedule-perow flex min-w-0 items-baseline gap-2 px-[9px] py-[5px] text-xs">
                   <span
-                    className="composer-schedule-pin"
+                    className="composer-schedule-pin shrink-0 font-semibold text-yellow"
                     title={new Date(p.at).toLocaleString()}
                   >
                     {inTime(p.at)}
                   </span>
-                  <span className="composer-schedule-ptext" title={p.prompt}>
+                  <span className="composer-schedule-ptext truncate text-dim" title={p.prompt}>
                     {p.prompt}
                   </span>
                   <button
                     type="button"
-                    className="composer-schedule-pcancel"
+                    className="composer-schedule-pcancel ml-auto shrink-0 border-0 bg-transparent p-0 text-xs text-faint hover:text-red"
                     title="Cancel this scheduled message"
                     onClick={async () => {
                       try {
@@ -238,84 +245,84 @@ export function SchedulePromptButton({
             </div>
           )}
 
-          <div className="composer-schedule-head">Schedule message</div>
+          <div className="composer-schedule-head px-[9px] pt-1.5 pb-1 text-xs font-medium text-faint">Schedule message</div>
           {quickOptions().map((o) => (
             <button
               key={o.at.toISOString()}
               type="button"
               role="menuitem"
-              className="composer-menu-item"
+              className={menuItemClass}
               onClick={() => schedule(o.at)}
               disabled={saving || !hasText}
             >
               {o.label}
             </button>
           ))}
-          <div className="composer-schedule-sep" />
+          <div className="composer-schedule-sep mx-1.5 my-1 h-px bg-line" />
           <button
             type="button"
             role="menuitem"
-            className="composer-menu-item"
+            className={menuItemClass}
             onClick={openCustom}
             disabled={!hasText}
           >
             Custom time
           </button>
           {error && !customOpen && (
-            <div className="composer-schedule-err">{error}</div>
+            <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-xs text-red">{error}</div>
           )}
         </div>
       )}
 
       {customOpen && (
         <div
-          className="composer-schedule-modal-backdrop"
+          className="composer-schedule-modal-backdrop fixed inset-0 z-[300] flex items-center justify-center bg-black/40 p-5"
           onMouseDown={(e) => {
             if (e.target === e.currentTarget) setCustomOpen(false);
           }}
         >
-          <div className="composer-schedule-modal">
-            <div className="composer-schedule-modal-head">
+          <div className="composer-schedule-modal w-[420px] max-w-[92vw] rounded-xl border border-line-strong bg-raised p-5 shadow-[0_20px_60px_rgba(0,0,0,0.4)]">
+            <div className="composer-schedule-modal-head flex items-start justify-between gap-3">
               <div>
-                <div className="composer-schedule-modal-title">Schedule message</div>
-                <div className="composer-schedule-modal-tz">Time zone: {tz}</div>
+                <div className="composer-schedule-modal-title text-[17px] font-semibold text-fg">Schedule message</div>
+                <div className="composer-schedule-modal-tz mt-[3px] text-[12.5px] text-dim">Time zone: {tz}</div>
               </div>
               <button
                 type="button"
-                className="composer-schedule-modal-close"
+                className="composer-schedule-modal-close border-0 bg-transparent px-1 py-0.5 text-[15px] leading-none text-faint hover:text-fg"
                 onClick={() => setCustomOpen(false)}
                 aria-label="Close"
               >
                 ✕
               </button>
             </div>
-            <div className="composer-schedule-modal-fields">
+            <div className="composer-schedule-modal-fields mt-4 flex gap-2">
               <input
                 type="date"
                 value={date}
                 min={toDateInput(new Date())}
                 onChange={(e) => setDate(e.target.value)}
-                className="composer-schedule-input"
+                className="composer-schedule-input min-w-0 flex-1 rounded-md border border-line bg-surface px-3 py-[9px] text-sm font-medium text-fg outline-none focus:border-line-strong"
               />
               <input
                 type="time"
                 value={time}
                 onChange={(e) => setTime(e.target.value)}
-                className="composer-schedule-input composer-schedule-input-time"
+                className="composer-schedule-input composer-schedule-input-time min-w-0 flex-[0_0_130px] rounded-md border border-line bg-surface px-3 py-[9px] text-sm font-medium text-fg outline-none focus:border-line-strong"
               />
             </div>
-            {error && <div className="composer-schedule-err">{error}</div>}
-            <div className="composer-schedule-modal-actions">
+            {error && <div className="composer-schedule-err px-[9px] pt-1 pb-0.5 text-xs text-red">{error}</div>}
+            <div className="composer-schedule-modal-actions mt-5 flex justify-end gap-2">
               <button
                 type="button"
-                className="composer-schedule-cancel"
+                className="composer-schedule-cancel rounded-md border border-line-strong bg-transparent px-4 py-[9px] text-sm font-semibold text-fg hover:bg-surface"
                 onClick={() => setCustomOpen(false)}
               >
                 Cancel
               </button>
               <button
                 type="button"
-                className="composer-schedule-submit"
+                className="composer-schedule-submit rounded-md border-0 bg-accent px-4 py-[9px] text-sm font-semibold text-white transition-[filter] hover:not-disabled:brightness-110 disabled:cursor-default disabled:opacity-45"
                 onClick={scheduleCustom}
                 disabled={saving || !date || !time}
               >

--- a/src/frontend/components/Security.tsx
+++ b/src/frontend/components/Security.tsx
@@ -85,7 +85,7 @@ export function Security({ onOpenSession }: Props) {
   }
 
   return (
-    <div className="automations">
+    <div className="mx-auto min-h-0 w-full max-w-[860px] flex-1 overflow-y-auto px-6 pb-[60px] pt-7 max-[560px]:px-4 max-[560px]:pb-12 max-[560px]:pt-5">
       <PageHeader>
         <div>
           <PageTitle>Security</PageTitle>
@@ -154,26 +154,26 @@ export function Security({ onOpenSession }: Props) {
       {loading ? (
         <div className="loading">Loading…</div>
       ) : tab === "profiles" ? (
-        <div className="automation-list">
+        <div className="flex flex-col gap-2.5">
           <div>
             <Button size="sm" onClick={() => setEditProfile("new")}>
               + Create a profile
             </Button>
           </div>
           {profiles.length === 0 ? (
-            <div className="automations-empty">
+            <div className="px-4 py-12 text-center text-dim">
               <p>No scan profiles yet</p>
-              <p className="automations-empty-sub">
+              <p className="text-control-label text-faint">
                 Profiles customize how scans analyze your code — threat model
                 focus, known false positives, severity bar.
               </p>
             </div>
           ) : (
             profiles.map((p) => (
-              <div key={p.id} className="automation-card">
-                <div className="automation-top">
-                  <span className="automation-name">{p.name}</span>
-                  <div className="automation-actions">
+              <div key={p.id} className="rounded-panel border border-line bg-panel px-4 py-3.5">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <span className="truncate text-body font-semibold">{p.name}</span>
+                  <div className="ml-auto flex shrink-0 gap-1.5">
                     <Button size="sm" onClick={() => setEditProfile(p)}>
                       Edit
                     </Button>
@@ -194,16 +194,16 @@ export function Security({ onOpenSession }: Props) {
                     </Button>
                   </div>
                 </div>
-                <div className="automation-prompt">{p.prompt}</div>
-                <div className="automation-meta">
-                  <span className="automation-by">by {p.createdBy}</span>
+                <div className="my-2 line-clamp-2 text-control-label leading-relaxed text-dim">{p.prompt}</div>
+                <div className="flex flex-wrap items-center gap-x-3.5 gap-y-1.5 text-label text-faint">
+                  <span className="ml-auto">by {p.createdBy}</span>
                 </div>
               </div>
             ))
           )}
         </div>
       ) : (
-        <div className="automation-list">
+        <div className="flex flex-col gap-2.5">
           {recurring.length > 0 && (
             <div className="bg-panel border border-line rounded-panel px-3.5 py-3">
               <div className="text-fg text-[13px] font-medium mb-1.5">Recurring</div>
@@ -229,18 +229,18 @@ export function Security({ onOpenSession }: Props) {
           )}
 
           {scans.length === 0 ? (
-            <div className="automations-empty">
+            <div className="px-4 py-12 text-center text-dim">
               <p>No scans yet</p>
-              <p className="automations-empty-sub">
+              <p className="text-control-label text-faint">
                 Start a scan to search for findings across your repositories.
               </p>
             </div>
           ) : (
             scans.map((s) => (
-              <div key={s.id} className="automation-card">
-                <div className="automation-top">
+              <div key={s.id} className="rounded-panel border border-line bg-panel px-4 py-3.5">
+                <div className="flex min-w-0 items-center gap-2.5">
                   <StatusPill status={s.status} />
-                  <span className="automation-name">
+                  <span className="truncate text-body font-semibold">
                     {s.interactive ? "Interactive scan" : "Scan"} —{" "}
                     {s.repos.join(", ")}
                   </span>
@@ -249,7 +249,7 @@ export function Security({ onOpenSession }: Props) {
                       {s.profileName}
                     </span>
                   )}
-                  <div className="automation-actions">
+                  <div className="ml-auto flex shrink-0 gap-1.5">
                     <Button
                       size="sm"
                       variant="danger"
@@ -261,7 +261,7 @@ export function Security({ onOpenSession }: Props) {
                 </div>
 
                 {s.instructions && (
-                  <div className="automation-prompt">{s.instructions}</div>
+                  <div className="my-2 line-clamp-2 text-control-label leading-relaxed text-dim">{s.instructions}</div>
                 )}
 
                 <div className="mt-1.5 flex flex-col gap-1">
@@ -299,10 +299,10 @@ export function Security({ onOpenSession }: Props) {
                   ))}
                 </div>
 
-                <div className="automation-meta">
+                <div className="flex flex-wrap items-center gap-x-3.5 gap-y-1.5 text-label text-faint">
                   <span>started {relativeTime(s.createdAt)}</span>
                   {s.finishedAt && <span>finished {relativeTime(s.finishedAt)}</span>}
-                  <span className="automation-by">by {s.createdBy}</span>
+                  <span className="ml-auto">by {s.createdBy}</span>
                 </div>
               </div>
             ))
@@ -397,9 +397,9 @@ function NewScanModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="automation-form w-full max-w-[560px] my-auto shadow-2xl">
+      <div className="flex w-full max-w-[560px] my-auto flex-col gap-3.5 rounded-panel border border-line-strong bg-panel p-[18px] shadow-2xl [&_label]:flex [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:text-fg">
         <div>
-          <div className="automation-form-title">New scan</div>
+          <div className="text-body font-semibold">New scan</div>
           <div className="text-dim text-[13px] mt-0.5">
             Start a search for findings across your repositories.
           </div>
@@ -508,7 +508,7 @@ function NewScanModal({
 
         {error && <InlineAlert className="text-[13px]">{error}</InlineAlert>}
 
-        <div className="automation-form-actions">
+        <div className="flex justify-end gap-2.5">
           <Button size="sm" onClick={onClose} disabled={starting}>
             Cancel
           </Button>
@@ -576,8 +576,8 @@ function ProfileModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="automation-form w-full max-w-[560px] my-auto shadow-2xl">
-        <div className="automation-form-title">
+      <div className="flex w-full max-w-[560px] my-auto flex-col gap-3.5 rounded-panel border border-line-strong bg-panel p-[18px] shadow-2xl [&_label]:flex [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:text-fg">
+        <div className="text-body font-semibold">
           {initial ? `Edit "${initial.name}"` : "New scan profile"}
         </div>
 
@@ -604,7 +604,7 @@ function ProfileModal({
 
         {error && <InlineAlert className="text-[13px]">{error}</InlineAlert>}
 
-        <div className="automation-form-actions">
+        <div className="flex justify-end gap-2.5">
           <Button size="sm" onClick={onClose} disabled={saving}>
             Cancel
           </Button>

--- a/src/frontend/components/Security.tsx
+++ b/src/frontend/components/Security.tsx
@@ -122,7 +122,7 @@ export function Security({ onOpenSession }: Props) {
       </div>
 
       {error && (
-        <InlineAlert className="text-[13px]" onDismiss={() => setError(null)}>
+        <InlineAlert className="text-control-label" onDismiss={() => setError(null)}>
           {error}
         </InlineAlert>
       )}
@@ -206,7 +206,7 @@ export function Security({ onOpenSession }: Props) {
         <div className="flex flex-col gap-2.5">
           {recurring.length > 0 && (
             <div className="bg-panel border border-line rounded-panel px-3.5 py-3">
-              <div className="text-fg text-[13px] font-medium mb-1.5">Recurring</div>
+              <div className="text-fg text-control-label font-medium mb-1.5">Recurring</div>
               <div className="flex flex-col gap-1">
                 {recurring.map((r) => (
                   <div key={r.id} className="flex items-baseline gap-2 text-supporting text-dim min-w-0">
@@ -400,7 +400,7 @@ function NewScanModal({
       <div className="flex w-full max-w-[560px] my-auto flex-col gap-3.5 rounded-panel border border-line-strong bg-panel p-[18px] shadow-2xl [&_label]:flex [&_label]:flex-col [&_label]:gap-1.5 [&_label]:text-supporting [&_label]:font-medium [&_label]:text-dim [&_input]:rounded-md [&_input]:border [&_input]:border-line-strong [&_input]:bg-raised [&_input]:px-3 [&_input]:py-2 [&_input]:text-control-label [&_input]:text-fg [&_select]:rounded-md [&_select]:border [&_select]:border-line-strong [&_select]:bg-raised [&_select]:px-3 [&_select]:py-2 [&_select]:text-control-label [&_select]:text-fg [&_textarea]:resize-y [&_textarea]:rounded-md [&_textarea]:border [&_textarea]:border-line-strong [&_textarea]:bg-raised [&_textarea]:px-3 [&_textarea]:py-2 [&_textarea]:text-control-label [&_textarea]:text-fg">
         <div>
           <div className="text-body font-semibold">New scan</div>
-          <div className="text-dim text-[13px] mt-0.5">
+          <div className="text-dim text-control-label mt-0.5">
             Start a search for findings across your repositories.
           </div>
         </div>
@@ -450,7 +450,7 @@ function NewScanModal({
             ))}
           </select>
           {profiles.length === 0 && (
-            <span className="mt-1 text-meta text-faint">
+			<span className="mt-1 text-meta text-faint">
               No scan profiles yet — profiles customize how scans analyze your
               code. Create one under Security → Profiles.
             </span>
@@ -479,7 +479,7 @@ function NewScanModal({
             <option value="weekly">Weekly</option>
           </select>
           {!singleRepo && (
-            <span className="mt-1 text-meta text-faint">
+			<span className="mt-1 text-meta text-faint">
               Recurring and interactive scans support one repository at a time.
             </span>
           )}
@@ -506,7 +506,7 @@ function NewScanModal({
           </span>
         </label>
 
-        {error && <InlineAlert className="text-[13px]">{error}</InlineAlert>}
+        {error && <InlineAlert className="text-control-label">{error}</InlineAlert>}
 
         <div className="flex justify-end gap-2.5">
           <Button size="sm" onClick={onClose} disabled={starting}>
@@ -602,7 +602,7 @@ function ProfileModal({
           />
         </label>
 
-        {error && <InlineAlert className="text-[13px]">{error}</InlineAlert>}
+        {error && <InlineAlert className="text-control-label">{error}</InlineAlert>}
 
         <div className="flex justify-end gap-2.5">
           <Button size="sm" onClick={onClose} disabled={saving}>

--- a/src/frontend/components/SelectionToSession.tsx
+++ b/src/frontend/components/SelectionToSession.tsx
@@ -94,23 +94,23 @@ export function SelectionToSession({ sessionId, label, send, children }: Props) 
   }, [send, sel, message, label, sessionId, dismiss]);
 
   return (
-    <div ref={hostRef} className="selection-host" onMouseUp={onMouseUp}>
+    <div ref={hostRef} className="selection-host contents" onMouseUp={onMouseUp}>
       {children}
       {sel && send && (
         <div
           ref={popRef}
-          className="selection-popover"
+          className="selection-popover fixed z-[1000] max-w-[min(340px,90vw)] -translate-x-1/2 rounded-md border border-accent bg-panel font-sans shadow-[0_6px_24px_rgba(0,0,0,0.4)]"
           style={{ left: sel.x, top: sel.y + 6 }}
           onMouseDown={(e) => e.stopPropagation()}
         >
           {sent ? (
-            <div className="selection-sent">Sent to session ✓</div>
+            <div className="selection-sent whitespace-nowrap px-3.5 py-2 text-supporting text-accent">Sent to session ✓</div>
           ) : composing ? (
-            <div className="selection-compose">
-              <div className="selection-quote">{sel.text}</div>
+            <div className="selection-compose flex flex-col gap-2 p-2.5">
+              <div className="selection-quote max-h-16 overflow-y-auto break-words whitespace-pre-wrap border-l-2 border-line-strong pl-2 text-meta text-faint">{sel.text}</div>
               <textarea
                 autoFocus
-                className="selection-input"
+                className="selection-input resize-y rounded-sm border border-line-strong bg-raised px-2.5 py-2 text-control-label leading-[1.45] text-fg outline-none focus:border-accent"
                 rows={2}
                 placeholder="Message to the session (optional)… ⌘↵ to send"
                 value={message}
@@ -122,11 +122,11 @@ export function SelectionToSession({ sessionId, label, send, children }: Props) 
                   }
                 }}
               />
-              <div className="selection-actions">
+              <div className="selection-actions flex justify-end gap-2">
                 <Button
                   variant="default"
                   size="sm"
-                  className="min-h-0 border-line-strong bg-transparent px-3 py-[5px] text-[13px] font-normal shadow-none"
+                  className="min-h-0 border-line-strong bg-transparent px-3 py-[5px] text-control-label font-normal shadow-none"
                   onClick={dismiss}
                 >
                   Cancel
@@ -142,7 +142,7 @@ export function SelectionToSession({ sessionId, label, send, children }: Props) 
               </div>
             </div>
           ) : (
-            <button className="selection-trigger" onClick={() => setComposing(true)}>
+            <button className="selection-trigger block whitespace-nowrap border-0 bg-transparent px-3 py-1.5 text-supporting text-fg hover:rounded-md hover:bg-hover" onClick={() => setComposing(true)}>
               💬 Send to session
             </button>
           )}

--- a/src/frontend/components/SessionReportsPanel.tsx
+++ b/src/frontend/components/SessionReportsPanel.tsx
@@ -80,15 +80,15 @@ export function SessionReportsPanel({
 			<div className="shrink-0 border-b border-line px-3 py-2.5">
 				<div className="flex items-start gap-2">
 					<div className="min-w-0 flex-1">
-						<div className="truncate text-[13px] font-semibold text-fg">
+                        <div className="truncate text-control-label font-semibold text-fg">
 							{selected.title}
 						</div>
-						<div className="mt-0.5 text-[11px] text-faint">
+                        <div className="mt-0.5 text-meta text-faint">
 							{formatDate(selected.createdAt)}
 						</div>
 					</div>
 					<a
-						className="shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] text-dim hover:bg-hover hover:text-fg"
+                        className="shrink-0 rounded-sm px-1.5 py-0.5 text-meta text-dim hover:bg-hover hover:text-fg"
 						href={fullReportUrl}
 					>
 						Open full report
@@ -97,7 +97,7 @@ export function SessionReportsPanel({
 				{reports.length > 1 && (
 					<select
 						aria-label="Report from this session"
-						className="mt-2 w-full rounded-md border border-line bg-panel px-2 py-1.5 text-xs text-fg"
+                        className="mt-2 w-full rounded-md border border-line bg-panel px-2 py-1.5 text-label text-fg"
 						value={reportKey(selected)}
 						onChange={(event) => setSelectedKey(event.target.value)}
 					>

--- a/src/frontend/components/SessionSearch.tsx
+++ b/src/frontend/components/SessionSearch.tsx
@@ -40,11 +40,11 @@ function sessionRepo(s: UnifiedSession): string {
 type Status = "needsinput" | "running" | "review" | "merged" | "pending";
 
 const STATUS_META: Record<Status, { label: string; dotClass: string }> = {
-	needsinput: { label: "Needs input", dotClass: "ss-dot-accent" },
-	running: { label: "Running", dotClass: "ss-dot-green" },
-	review: { label: "In review", dotClass: "ss-dot-yellow" },
-	merged: { label: "Merged", dotClass: "ss-dot-purple" },
-	pending: { label: "Pending", dotClass: "ss-dot-dim" },
+	needsinput: { label: "Needs input", dotClass: "ss-dot-accent bg-accent" },
+	running: { label: "Running", dotClass: "ss-dot-green bg-green" },
+	review: { label: "In review", dotClass: "ss-dot-yellow bg-yellow" },
+	merged: { label: "Merged", dotClass: "ss-dot-purple bg-purple" },
+	pending: { label: "Pending", dotClass: "ss-dot-dim bg-faint" },
 };
 
 const STATUS_ORDER: Status[] = [
@@ -126,12 +126,12 @@ function FilterPill({
 	const active = value !== "all";
 	const current = options.find((option) => option.value === value);
 	return (
-		<div className={`ss-pill${active ? " ss-pill-active" : ""}`}>
-			<span className="ss-pill-key">{label}</span>
-			<span className="ss-pill-val">{current?.label ?? value}</span>
-			<span className="ss-pill-caret">▾</span>
+		<div className={`ss-pill relative inline-flex cursor-pointer items-center gap-1 rounded-full border border-line-strong bg-raised px-2 py-1 text-supporting text-dim transition-[border-color,color] hover:border-faint hover:text-fg${active ? " ss-pill-active border-accent text-fg" : ""}`}>
+			<span className={`ss-pill-key font-medium text-faint${active ? " text-accent" : ""}`}>{label}</span>
+			<span className="ss-pill-val font-medium">{current?.label ?? value}</span>
+			<span className="ss-pill-caret text-[8px] text-faint">▾</span>
 			<select
-				className="ss-pill-select"
+				className="ss-pill-select absolute inset-0 h-full w-full cursor-pointer appearance-none border-0 opacity-0"
 				value={value}
 				onChange={(event) => onChange(event.target.value)}
 				aria-label={label}
@@ -377,16 +377,16 @@ export function SessionSearch({
 				variant="palette"
 				// .ss-card also scopes the touch rule that hides the keyboard chrome.
 				widthClassName="w-[min(640px,100%)]"
-				className="ss-card h-[min(500px,76vh)] max-[560px]:h-[min(560px,82vh)]"
+				className="ss-card flex h-[min(500px,76vh)] w-[min(640px,100%)] flex-col max-[560px]:h-[min(560px,82vh)]"
 				aria-label="Command menu"
 				initialFocus={inputRef}
 				onKeyDown={onKeyDown}
 			>
-				<div className="ss-search-row">
-					<IconSearch className="ss-search-icon" size={22} />
+				<div className="ss-search-row flex items-center gap-2.5 border-b border-line px-4 py-3.5">
+					<IconSearch className="ss-search-icon shrink-0 text-faint" size={22} />
 					<input
 						ref={inputRef}
-						className="ss-search-input"
+						className="ss-search-input min-w-0 flex-1 border-0 bg-transparent font-sans text-item-title leading-snug text-fg outline-none placeholder:text-faint"
 						value={query}
 						onChange={(e) => {
 							setQuery(e.target.value);
@@ -402,12 +402,12 @@ export function SessionSearch({
 						aria-activedescendant={results[active] ? `command-result-${active}` : undefined}
 					/>
 					{(searching || loadingPrs) && (
-						<span className="ss-searching" aria-label="Searching" />
+						<span className="ss-searching h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-line-strong border-t-accent" aria-label="Searching" />
 					)}
 					<kbd className="ss-kbd">esc</kbd>
 				</div>
 
-				<div className="ss-filters" aria-label="Session filters">
+				<div className="ss-filters flex flex-wrap items-center gap-1.5 border-b border-line px-3.5 py-2" aria-label="Session filters">
 					<FilterPill
 						label="Person"
 						value={person}
@@ -428,7 +428,7 @@ export function SessionSearch({
 					/>
 					{hasSessionFilter && (
 						<button
-							className="ss-clear"
+							className="ss-clear ml-auto rounded-md border-0 bg-transparent px-1.5 py-1 text-supporting text-faint hover:bg-hover hover:text-fg"
 							onClick={() => {
 								setPerson("all");
 								setRepo("all");
@@ -442,12 +442,12 @@ export function SessionSearch({
 
 				<div
 					id="command-palette-results"
-					className="ss-results"
+					className="ss-results min-h-0 flex-1 overflow-y-auto p-1.5"
 					ref={listRef}
 					role="listbox"
 				>
 					{results.length === 0 && (
-						<div className="ss-empty">
+							<div className="ss-empty px-4 py-7 text-center text-control-label text-faint">
 							{searching ? "Searching conversations…" : "Nothing found"}
 						</div>
 					)}
@@ -456,7 +456,7 @@ export function SessionSearch({
 						if (result.type === "action") {
 							return (
 								<React.Fragment key={`action:${result.action.id}`}>
-									{startsGroup && <div className="ss-group-heading">{result.category}</div>}
+									{startsGroup && <div className="ss-group-heading px-2.5 pb-1 pt-2.5 text-label font-semibold text-faint">{result.category}</div>}
 									<button
 										id={`command-result-${i}`}
 										data-idx={i}
@@ -464,21 +464,21 @@ export function SessionSearch({
 										role="option"
 										aria-selected={i === active}
 										tabIndex={-1}
-										className={`ss-item ss-command-item${i === active ? " ss-item-active" : ""}`}
+										className={`ss-item ss-command-item flex w-full items-center gap-2.5 rounded-control border-0 bg-transparent px-2.5 py-2 text-left text-fg${i === active ? " ss-item-active bg-active" : ""}`}
 										onMouseMove={() => setActiveKey(resultKey(result))}
 										onClick={() => selectResult(result)}
 									>
 										{result.action.icon && (
-											<span className="ss-command-icon">{result.action.icon}</span>
+											<span className={`ss-command-icon inline-flex h-5 w-5 shrink-0 items-center justify-center text-dim${i === active ? " text-fg" : ""}`}>{result.action.icon}</span>
 										)}
-										<span className="ss-item-main">
-											<span className="ss-item-title">{result.action.label}</span>
+										<span className="ss-item-main flex min-w-0 flex-1 flex-col gap-0.5">
+											<span className="ss-item-title truncate text-control-label font-medium">{result.action.label}</span>
 											{result.action.description && (
-												<span className="ss-item-snippet">{result.action.description}</span>
+												<span className="ss-item-snippet line-clamp-1 text-meta leading-snug text-faint">{result.action.description}</span>
 											)}
 										</span>
 										{result.action.shortcut && (
-											<span className="ss-shortcut">
+											<span className="ss-shortcut inline-flex shrink-0 items-center gap-0.5">
 												{result.action.shortcut.map((key) => <kbd key={key} className="ss-kbd">{key}</kbd>)}
 											</span>
 										)}
@@ -490,7 +490,7 @@ export function SessionSearch({
 							const pr = result.pr;
 							return (
 								<React.Fragment key={`pr:${pr.url}`}>
-									{startsGroup && <div className="ss-group-heading">{result.category}</div>}
+									{startsGroup && <div className="ss-group-heading px-2.5 pb-1 pt-2.5 text-label font-semibold text-faint">{result.category}</div>}
 									<button
 										id={`command-result-${i}`}
 										data-idx={i}
@@ -498,20 +498,20 @@ export function SessionSearch({
 										role="option"
 										aria-selected={i === active}
 										tabIndex={-1}
-										className={`ss-item${i === active ? " ss-item-active" : ""}`}
+										className={`ss-item flex w-full items-center gap-2.5 rounded-control border-0 bg-transparent px-2.5 py-2 text-left text-fg${i === active ? " ss-item-active bg-active" : ""}`}
 										onMouseMove={() => setActiveKey(resultKey(result))}
 										onClick={() => selectResult(result)}
 									>
-										<span className="ss-command-icon"><IconPullRequest size={18} /></span>
-										<span className="ss-item-main">
-											<span className="ss-item-title">{pr.title}</span>
-											<span className="ss-item-meta">
+										<span className={`ss-command-icon inline-flex h-5 w-5 shrink-0 items-center justify-center text-dim${i === active ? " text-fg" : ""}`}><IconPullRequest size={18} /></span>
+										<span className="ss-item-main flex min-w-0 flex-1 flex-col gap-0.5">
+											<span className="ss-item-title truncate text-control-label font-medium">{pr.title}</span>
+											<span className="ss-item-meta flex min-w-0 items-center gap-1.5 text-meta text-faint">
 												<span className="ss-item-repo">{pr.repo} #{pr.number}</span>
 												<span className="ss-item-branch">{pr.branch}</span>
 												<span>{pr.author}</span>
 											</span>
 										</span>
-										<span className="ss-item-status">{prStatus(pr)}</span>
+										<span className="ss-item-status shrink-0 text-meta text-dim">{prStatus(pr)}</span>
 									</button>
 								</React.Fragment>
 							);
@@ -521,7 +521,7 @@ export function SessionSearch({
 						const meta = STATUS_META[st];
 						return (
 							<React.Fragment key={`session:${s.id}`}>
-								{startsGroup && <div className="ss-group-heading">{result.category}</div>}
+								{startsGroup && <div className="ss-group-heading px-2.5 pb-1 pt-2.5 text-label font-semibold text-faint">{result.category}</div>}
 								<button
 									id={`command-result-${i}`}
 									data-idx={i}
@@ -529,17 +529,17 @@ export function SessionSearch({
 									role="option"
 									aria-selected={i === active}
 									tabIndex={-1}
-									className={`ss-item${i === active ? " ss-item-active" : ""}`}
+									className={`ss-item flex w-full items-center gap-2.5 rounded-control border-0 bg-transparent px-2.5 py-2 text-left text-fg${i === active ? " ss-item-active bg-active" : ""}`}
 									onMouseMove={() => setActiveKey(resultKey(result))}
 									onClick={() => selectResult(result)}
 								>
-									<span className={`ss-item-dot ${meta.dotClass}`} />
-									<span className="ss-item-main">
-										<span className="ss-item-title">{s.title}</span>
+									<span className={`ss-item-dot h-2 w-2 shrink-0 rounded-full ${meta.dotClass}`} />
+									<span className="ss-item-main flex min-w-0 flex-1 flex-col gap-0.5">
+										<span className="ss-item-title truncate text-control-label font-medium">{s.title}</span>
 										{result.snippet && (
-											<span className="ss-item-snippet">{result.snippet}</span>
+											<span className="ss-item-snippet line-clamp-1 text-meta leading-snug text-faint">{result.snippet}</span>
 										)}
-										<span className="ss-item-meta">
+										<span className="ss-item-meta flex min-w-0 items-center gap-1.5 text-meta text-faint">
 											{s.automation ? (
 												<span className="ss-tag ss-tag-auto">{s.automation}</span>
 											) : (
@@ -550,14 +550,14 @@ export function SessionSearch({
 											<span className="ss-item-time">{relativeTime(s.lastActivity)}</span>
 										</span>
 									</span>
-									<span className="ss-item-status">{meta.label}</span>
+									<span className="ss-item-status shrink-0 text-meta text-dim">{meta.label}</span>
 								</button>
 							</React.Fragment>
 						);
 					})}
 				</div>
 
-				<div className="ss-hint">
+				<div className="ss-hint flex items-center gap-3 border-t border-line px-4 py-2 text-meta text-faint">
 					<span>
 						<kbd className="ss-kbd">↑</kbd>
 						<kbd className="ss-kbd">↓</kbd> navigate
@@ -565,7 +565,7 @@ export function SessionSearch({
 					<span>
 						<kbd className="ss-kbd">↵</kbd> open
 					</span>
-					<span className="ss-hint-count">
+					<span className="ss-hint-count ml-auto">
 						{results.length} result{results.length === 1 ? "" : "s"}
 					</span>
 				</div>

--- a/src/frontend/components/SessionSplit.tsx
+++ b/src/frontend/components/SessionSplit.tsx
@@ -92,7 +92,7 @@ export function SessionSplit({
 
 	const column = (side: SplitSide, socket: Socket) => (
 		<div
-			className="session-split-pane"
+			className={`session-split-pane relative min-h-0 min-w-0 overflow-hidden ${focusedSide === side ? "session-split-pane-focused" : "after:pointer-events-none after:absolute after:inset-0 after:shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--border)_75%,transparent)]"}`}
 			onPointerDownCapture={() => {
 				if (focusedSide !== side) onFocusSide(side);
 			}}
@@ -104,12 +104,12 @@ export function SessionSplit({
 	return (
 		<div
 			ref={rootRef}
-			className="session-split"
+			className="session-split grid min-h-0 min-w-0 flex-1 overflow-hidden"
 			style={{ gridTemplateColumns: splitColumns(draftRatio) }}
 		>
 			{column("left", leftSocket)}
 			<div
-				className="session-split-resize"
+				className="session-split-resize group relative z-[5] cursor-col-resize touch-none after:absolute after:inset-y-0 after:left-[3px] after:w-0.5 after:bg-line after:transition-colors hover:after:bg-accent"
 				role="separator"
 				aria-orientation="vertical"
 				aria-label="Resize split tabs"

--- a/src/frontend/components/SessionTabs.tsx
+++ b/src/frontend/components/SessionTabs.tsx
@@ -100,6 +100,13 @@ type TabMember =
 	| { kind: "chat"; id: string; session: UnifiedSession }
 	| { kind: "view"; id: string; view: ViewTab };
 
+const TAB_CLASS =
+	"session-tab inline-flex max-w-[200px] shrink-0 items-center gap-1.5 rounded-md border border-transparent bg-panel px-2.5 py-1.5 text-supporting text-dim shadow-[0_1px_2px_rgba(0,0,0,0.12)] transition-[background,color] hover:bg-hover hover:text-fg min-[721px]:h-11 min-[721px]:rounded-none min-[721px]:border-0 min-[721px]:bg-transparent min-[721px]:shadow-[inset_0_-2px_0_transparent]";
+const ACTIVE_TAB_CLASS =
+	"session-tab-active bg-[color-mix(in_srgb,var(--bg-active)_94%,var(--text))] text-fg min-[721px]:bg-transparent min-[721px]:shadow-[inset_0_-3px_0_var(--accent)]";
+const TAB_CLOSE_CLASS =
+	"session-tab-close inline-flex size-4 shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0 font-sans text-[15px] leading-none text-dim hover:bg-pressed hover:text-fg max-[720px]:size-[26px] max-[720px]:-my-0.5 max-[720px]:-mr-1 max-[720px]:opacity-100";
+
 const isApple = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
 
 /** Right-aligned keyboard-shortcut hint on a menu row. */
@@ -362,7 +369,6 @@ export function SessionTabs({
 		else onCloseView(member.view.id);
 	}
 
-
 	function commitRename() {
 		if (editKey !== null) onRename(editKey, draft.trim());
 		setEditKey(null);
@@ -393,7 +399,7 @@ export function SessionTabs({
 	const newTabButton = (
 		<button
 			type="button"
-			className="session-tab session-tab-new"
+			className={`${TAB_CLASS} session-tab-new justify-center bg-transparent px-2 py-1.5 text-[15px] shadow-none hover:bg-hover min-[721px]:self-center min-[721px]:px-[5px] min-[721px]:py-[3px] min-[721px]:text-[22px]`}
 			aria-label="New chat in this workspace"
 			title="New chat. Shares this workspace's worktree (right-click for options)"
 			onClick={() => onNewChat("share")}
@@ -411,7 +417,7 @@ export function SessionTabs({
 	// the ⟲ restores it into the strip for good.
 	const historyMenu = showHistory && archived.length > 0 && (
 		<Menu.Root>
-			<Menu.Trigger className="session-tab session-tab-history" aria-label="Archived chats" title="Archived chats">
+			<Menu.Trigger className={`${TAB_CLASS} session-tab-history bg-transparent px-2.5 py-[7px] shadow-none hover:bg-hover min-[721px]:self-center`} aria-label="Archived chats" title="Archived chats">
 				<IconHistory size={ctrlIconSize} />
 			</Menu.Trigger>
 			<Menu.Popup align="end" sideOffset={4} className="min-w-[240px] max-w-[320px]">
@@ -438,13 +444,13 @@ export function SessionTabs({
 	);
 
 	return (
-		<div className="session-tabs" role="tablist">
-			<div className="session-tabs-scroll" ref={scrollRef}>
+		<div className="session-tabs flex min-w-0 shrink-0 items-center gap-[3px] bg-[linear-gradient(to_bottom,var(--topbar-bg),var(--bg))] px-2 py-1.5 min-[721px]:-mt-px min-[721px]:h-11 min-[721px]:items-stretch min-[721px]:bg-bg min-[721px]:p-0 min-[721px]:shadow-[inset_0_1px_0_var(--border),inset_0_-1px_0_var(--border)] max-[720px]:absolute max-[720px]:left-0 max-[720px]:right-0 max-[720px]:top-[var(--pane-header-h)] max-[720px]:z-[6] max-[720px]:border-b max-[720px]:border-line max-[720px]:bg-bg max-[720px]:shadow-[0_6px_12px_-8px_rgba(0,0,0,0.22)]" role="tablist">
+			<div className="session-tabs-scroll flex min-w-0 flex-1 items-center gap-[3px] overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden min-[721px]:flex-[0_1_auto] min-[721px]:items-stretch" ref={scrollRef}>
 				<Reorder.Group
 					as="div"
 					axis="x"
 					ref={groupRef}
-					className="session-tabs-chatgroup"
+					className="session-tabs-chatgroup inline-flex min-w-0 items-center gap-[3px] min-[721px]:self-stretch min-[721px]:items-stretch"
 					values={tabUnits.units.map((unit) => unit.key)}
 					onReorder={reorderUnits}
 				>
@@ -495,7 +501,7 @@ export function SessionTabs({
 										e.preventDefault();
 									}
 								}}
-								className={`session-tab-reorder ${dropSlot?.key === key ? "is-dragging" : ""}`}
+								className={`session-tab-reorder relative inline-flex shrink-0 items-center min-[721px]:self-stretch min-[721px]:items-stretch ${dropSlot?.key === key ? "is-dragging" : ""}`}
 							>
 								<ContextMenu.Root>
 									<ContextMenu.Trigger
@@ -503,7 +509,7 @@ export function SessionTabs({
 											<div
 												role="tab"
 												aria-selected={key === activeId}
-												className={`session-tab ${key === activeId ? "session-tab-active" : ""} ${
+											className={`${TAB_CLASS} ${key === activeId ? ACTIVE_TAB_CLASS : ""} ${
 													waiting ? "session-tab-waiting" : ""
 												} ${hex ? "session-tab-colored" : ""}`}
 												style={hex ? ({ "--tab-color": hex } as React.CSSProperties) : undefined}
@@ -519,7 +525,7 @@ export function SessionTabs({
 										)}
 										{editKey === key ? (
 											<input
-												className="session-tab-rename"
+												className="session-tab-rename max-w-[150px] rounded-xs border border-accent bg-bg px-[3px] py-0 text-inherit outline-none"
 												value={draft}
 												autoFocus
 												onChange={(e) => setDraft(e.target.value)}
@@ -534,7 +540,7 @@ export function SessionTabs({
 											/>
 										) : (
 											<span
-												className="session-tab-title"
+											className="session-tab-title max-w-[150px] truncate"
 												onDoubleClick={(e) => {
 													e.stopPropagation();
 													setDraft(session.title);
@@ -553,7 +559,7 @@ export function SessionTabs({
 										)}
 										<button
 											type="button"
-											className="session-tab-close"
+										className={TAB_CLOSE_CLASS}
 											aria-label="Close chat"
 											title="Close chat"
 											onClick={(e) => {
@@ -631,7 +637,7 @@ export function SessionTabs({
 						role="tab"
 						aria-selected={v.active}
 						aria-label={v.icon ? v.label : undefined}
-						className={`session-tab session-tab-view ${v.icon ? "session-tab-view-icon" : ""} ${v.active ? "session-tab-active" : ""}`}
+						className={`${TAB_CLASS} session-tab-view ${v.icon ? "session-tab-view-icon" : ""} ${v.active ? ACTIVE_TAB_CLASS : ""}`}
 						drag={!isPhone}
 						dragMomentum={false}
 						dragSnapToOrigin
@@ -658,7 +664,7 @@ export function SessionTabs({
 						)}
 						<button
 							type="button"
-							className="session-tab-close"
+							className={TAB_CLOSE_CLASS}
 							aria-label={`Close ${v.label}`}
 							title={`Close ${v.label}`}
 							onClick={(e) => {
@@ -678,17 +684,17 @@ export function SessionTabs({
 			{/* Desktop: the "+" sits OUTSIDE the scroll so it's pinned and always
 				    visible — never scrolled off when the tabs overflow a narrow pane. */}
 			{!isPhone && newTabButton}
-			{!isPhone && <div className="session-tabs-actions">{historyMenu}</div>}
+			{!isPhone && <div className="session-tabs-actions ml-auto flex shrink-0 items-center gap-[3px]">{historyMenu}</div>}
 
 			{newMenu && (
 				<div
-					className="tab-color-menu session-tab-new-menu"
+					className="tab-color-menu session-tab-new-menu fixed z-[1000] flex gap-2 rounded-xl border border-line-strong bg-panel px-2.5 py-[9px] shadow-[0_10px_30px_rgba(0,0,0,0.32)]"
 					style={{ left: newMenu.x, top: newMenu.y }}
 					onClick={(e) => e.stopPropagation()}
 				>
 					<button
 						type="button"
-						className="session-tab-new-menu-item"
+						className="session-tab-new-menu-item rounded-sm px-2 py-1 text-control-label text-dim hover:bg-hover hover:text-fg"
 						onClick={() => {
 							setNewMenu(null);
 							onNewChat("share");
@@ -698,7 +704,7 @@ export function SessionTabs({
 					</button>
 					<button
 						type="button"
-						className="session-tab-new-menu-item"
+						className="session-tab-new-menu-item rounded-sm px-2 py-1 text-control-label text-dim hover:bg-hover hover:text-fg"
 						onClick={() => {
 							setNewMenu(null);
 							onNewChat("stack");
@@ -708,7 +714,7 @@ export function SessionTabs({
 					</button>
 					<button
 						type="button"
-						className="session-tab-new-menu-item"
+						className="session-tab-new-menu-item rounded-sm px-2 py-1 text-control-label text-dim hover:bg-hover hover:text-fg"
 						onClick={() => {
 							setNewMenu(null);
 							onNewChat("ask");

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -4204,7 +4204,7 @@ export function SessionViewer({
 									/>
 								}
 								className={cn(
-									// global.css turns on the squircle via
+									// adapters.css turns on the squircle via
 									// `[class*="rounded-"]:not([class*="rounded-full"])`. That
 									// `:not` is a substring test on the whole class attribute,
 									// so the mobile `rounded-full` below disqualifies this

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -1127,7 +1127,7 @@ export function SessionViewer({
 	}, [notes, session.id]);
 	const panelResizeHandle = (
 		<div
-			className="panel-resize"
+			className="panel-resize absolute -left-[3px] top-0 z-[6] h-full w-[7px] cursor-col-resize after:absolute after:left-[3px] after:top-0 after:h-full after:w-0.5 after:bg-transparent after:transition-colors hover:after:bg-line-strong max-[720px]:hidden"
 			onMouseDown={startPanelResize}
 			aria-hidden="true"
 		/>
@@ -2987,13 +2987,13 @@ export function SessionViewer({
 					<div className="composer-queue-image relative mt-px h-[34px] w-[46px] shrink-0">
 						<img className="block size-full rounded-md border border-line object-cover" src={firstImage} alt="" />
 						{extraImages > 0 && (
-							<span className="composer-queue-image-count absolute -right-1 -bottom-1 h-[18px] min-w-[18px] rounded-full border border-line bg-raised px-1 text-center text-[10px] leading-4 font-bold text-dim">+{extraImages}</span>
+							<span className="composer-queue-image-count absolute -right-1 -bottom-1 h-[18px] min-w-[18px] rounded-full border border-line bg-raised px-1 text-center text-meta leading-4 font-bold text-dim">+{extraImages}</span>
 						)}
 					</div>
 				)}
 				<div
 					className={cn(
-						"composer-queue-body min-w-0 flex-1 overflow-hidden text-[13px] leading-[1.45] text-ellipsis whitespace-nowrap text-fg",
+						"composer-queue-body min-w-0 flex-1 overflow-hidden text-control-label leading-[1.45] text-ellipsis whitespace-nowrap text-fg",
 						opts.human && "text-[color-mix(in_srgb,var(--text)_88%,#1f9e8a)]",
 						opts.github && "text-dim",
 						opts.sending && "text-dim",
@@ -3079,7 +3079,7 @@ export function SessionViewer({
 	const attachedQueue =
 		queueCount > 0 ? (
 			<div className="composer-queue relative -mb-3.5 mx-[18px] flex flex-col gap-2 rounded-t-lg border border-b-0 border-line bg-[color-mix(in_srgb,var(--bg-panel)_70%,var(--control-surface))] px-4 pt-2.5 pb-[26px]" aria-label="Queued and steered messages">
-				<div className="composer-queue-title text-xs font-semibold text-faint">{queueTitle}</div>
+				<div className="composer-queue-title text-label font-semibold text-faint">{queueTitle}</div>
 				{visibleSteered.map((s, i) => {
 					const hr = parseHumanReply(s.content);
 					return (
@@ -3089,7 +3089,7 @@ export function SessionViewer({
 						>
 							<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
 								<Tooltip label="Already delivered into the running turn — shown here until the turn finishes">
-									<span className="composer-queue-pill inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-accent-soft px-[13px] text-sm font-semibold text-accent">
+									<span className="composer-queue-pill inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-accent-soft px-[13px] text-control-label font-semibold text-accent">
 										<IconCrosshair size={20} />
 										Steered
 									</span>
@@ -3148,7 +3148,7 @@ export function SessionViewer({
 						>
 							<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
 								{isGitHub ? (
-									<span className="composer-queue-pill composer-queue-pill-github inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-sm font-semibold text-dim">
+									<span className="composer-queue-pill composer-queue-pill-github inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-control-label font-semibold text-dim">
 										<IconPullRequest size={20} />
 										FYI
 									</span>
@@ -3219,7 +3219,7 @@ export function SessionViewer({
 				{pendingQueue.map((p) => (
 					<div key={p.id} className="composer-queue-item composer-queue-sending relative min-h-[18.85px]">
 						<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
-							<span className="composer-queue-pill composer-queue-pill-sending inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-sm font-semibold text-faint">
+							<span className="composer-queue-pill composer-queue-pill-sending inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-control-label font-semibold text-faint">
 								{waitingForWorkspace ? "Queued" : "Queueing…"}
 							</span>
 						</div>
@@ -3735,7 +3735,7 @@ export function SessionViewer({
 					role="status"
 					aria-live="polite"
 				>
-					<div className="flex flex-col items-center gap-[14px] rounded-xl border border-line bg-panel px-8 py-[26px] shadow-[0_8px_30px_rgba(0,0,0,0.35)]">
+					<div className="flex flex-col items-center gap-3.5 rounded-xl border border-line bg-panel px-8 py-[26px] shadow-[0_8px_30px_rgba(0,0,0,0.35)]">
 						<div className="restart-spinner" />
 						<span className="session-delete-label">{deleteLabel}</span>
 					</div>
@@ -3978,7 +3978,7 @@ export function SessionViewer({
 								href={session.linearIssue.url}
 								target="_blank"
 								rel="noopener"
-								className="session-link session-link-linear"
+								className="session-link session-link-linear inline-flex items-center rounded-md border border-[rgba(94,106,210,0.5)] px-2.5 py-1 text-control-label font-semibold text-[#7b86e8] no-underline hover:bg-hover focus-ring"
 							>
 								{session.linearIssue.identifier}
 							</a>
@@ -3992,7 +3992,7 @@ export function SessionViewer({
 								href={plainUrl}
 								target="_blank"
 								rel="noopener"
-								className="session-link session-link-plain"
+								className="session-link session-link-plain inline-flex items-center rounded-md border border-[rgba(13,148,136,0.5)] px-2.5 py-1 text-control-label font-semibold text-[#5eead4] no-underline hover:bg-hover focus-ring"
 							>
 								Plain ↗
 							</a>
@@ -4006,7 +4006,7 @@ export function SessionViewer({
 								href={feedRef.url}
 								target="_blank"
 								rel="noopener"
-								className="session-link session-link-plain"
+								className="session-link session-link-plain inline-flex items-center rounded-md border border-[rgba(13,148,136,0.5)] px-2.5 py-1 text-control-label font-semibold text-[#5eead4] no-underline hover:bg-hover focus-ring"
 							>
 								{feedRefLabel} ↗
 							</a>
@@ -4015,22 +4015,22 @@ export function SessionViewer({
 				);
 				const header = (
 					<div
-						className={`viewer-header ${compactHeader ? "viewer-header-compact" : ""}`}
+						className={`viewer-header flex h-[var(--desktop-header-h)] min-w-0 shrink-0 items-center justify-between gap-3 border-b border-line bg-bg px-4 ${compactHeader ? "viewer-header-compact" : ""}`}
 						ref={headerRef}
 					>
-						<div className="viewer-title">
+						<div className="viewer-title flex min-w-0 items-center gap-2.5 font-medium">
 					{/* Automation runs skip the "ask" chip: the automation chip after
 					    the title already says where the chat came from, and ask/code is
 					    the automation's own setting rather than something about this
 					    run — two origin chips on one row just read as noise. */}
 					{isAsk && !session.automation ? (
-						<span className="source-chip source-ask">ask</span>
+						<span className="source-chip source-ask shrink-0 rounded-full bg-[rgba(210,153,34,0.18)] px-2 py-0.5 text-meta font-bold tracking-[-0.01em] text-yellow">ask</span>
 					) : (
 						// "backstage" is the default origin (web UI) — as a chip it's noise,
 						// and for backstage-repo sessions it read as the repo said twice.
 						// Only surface the unusual origins (slack/linear/cli).
 						session.source !== "backstage" && (
-							<span className={`source-chip source-${session.source}`}>
+							<span className={`source-chip source-${session.source} shrink-0 rounded-full px-2 py-0.5 text-meta font-bold tracking-[-0.01em] ${session.source === "slack" ? "bg-[rgba(74,21,75,0.55)] text-[#d9a8db]" : session.source === "linear" ? "bg-[rgba(94,106,210,0.25)] text-[#9da6ee]" : "bg-active text-dim"}`}>
 								{session.source}
 							</span>
 						)
@@ -4067,7 +4067,7 @@ export function SessionViewer({
 						))}
 					{renameDraft !== null ? (
 						<input
-							className="viewer-branch-rename"
+							className="viewer-branch-rename min-w-0 max-w-[280px] rounded-md border border-accent bg-bg px-1 py-px text-body text-inherit outline-none"
 							value={renameDraft}
 							autoFocus
 							onChange={(e) => setRenameDraft(e.target.value)}
@@ -4081,7 +4081,7 @@ export function SessionViewer({
 						/>
 					) : (
 						<span
-							className={`viewer-branch ${onRename ? "viewer-branch-editable" : ""}`}
+							className={`viewer-branch max-w-[420px] min-w-0 truncate select-text text-body ${onRename ? "viewer-branch-editable cursor-text rounded-md px-2 py-[5px] -my-[5px] -mx-2 hover:bg-hover" : ""}`}
 							title={
 								workspaceName
 									? `${session.title} — double-click to rename the workspace`
@@ -4157,7 +4157,7 @@ export function SessionViewer({
 					{session.archived && (
 						<button
 							type="button"
-							className="source-chip source-cli archived-chip"
+							className="source-chip source-cli archived-chip shrink-0 rounded-full bg-active px-2.5 py-[3px] text-meta font-bold text-dim hover:bg-hover hover:text-fg disabled:cursor-default disabled:opacity-60"
 							onClick={handleArchive}
 							disabled={archiving}
 							title="Click to unarchive"
@@ -4166,19 +4166,19 @@ export function SessionViewer({
 						</button>
 					)}
 				</div>
-				<div className="viewer-header-actions">
+					<div className="viewer-header-actions flex shrink-0 items-center gap-2">
 					{!isPhone && secondaryActions(false)}
 					{/* Everyone with the session open, Figma/Notion-style, right
 					    before Share. You're always in it (rightmost); others stack
 					    in front with their GitHub picture. */}
 					{!isPhone && viewers.length > 0 && (
-						<div className="presence" title={`Viewing: ${viewers.join(", ")}`}>
+						<div className="presence flex items-center" title={`Viewing: ${viewers.join(", ")}`}>
 							{dedupeViewers(viewers, me).map((v) => (
 								<UserAvatar
 									key={v.name}
 									name={v.name}
 									size={24}
-									className="presence-avatar"
+									className="presence-avatar -ml-2 shadow-[0_0_0_2px_var(--bg)] first:ml-0"
 								/>
 							))}
 						</div>
@@ -4190,7 +4190,7 @@ export function SessionViewer({
 					    and Delete live only in there. */}
 					{!compactHeader && !isPhone && shareAction(false)}
 					<Menu.Root open={overflowOpen} onOpenChange={setOverflowOpen}>
-						<div className="viewer-overflow">
+						<div className="viewer-overflow relative inline-flex">
 							<Menu.Trigger
 								// Rendered AS the Button primitive rather than restyled to
 								// look like one, so the box, radius, hover wash, transition
@@ -4314,19 +4314,19 @@ export function SessionViewer({
 					isPhone && infoPageOpen ? (
 						createPortal(
 							<div
-								className="session-info-page"
+								className="session-info-page fixed inset-0 z-[60] flex flex-col gap-0.5 overflow-y-auto bg-bg pb-[max(16px,env(safe-area-inset-bottom,0px))] max-[720px]:animate-[session-info-in_0.22s_cubic-bezier(0.32,0.72,0,1)]"
 								ref={infoPageRef}
 								role="dialog"
 								aria-modal="true"
 								aria-label="Workspace details"
 							>
 								<div
-									className={`session-info-topbar${
+									className={`session-info-topbar sticky top-0 z-[4] flex min-h-[calc(env(safe-area-inset-top,0px)+52px)] items-center border-b border-transparent bg-transparent px-2 pb-0 pt-[env(safe-area-inset-top,0px)] transition-[background-color,border-color] ${
 										infoPageScrolled ? " session-info-topbar-scrolled" : ""
 									}`}
 								>
 									<button
-										className="panel-back"
+										className="panel-back hit-target relative z-[1] inline-flex size-10 items-center justify-center rounded-full border border-line bg-panel p-0 text-accent shadow-[0_2px_12px_rgba(0,0,0,0.1)]"
 										onClick={() => setInfoPageOpen(false)}
 										aria-label="Back to chat"
 										autoFocus
@@ -4341,16 +4341,16 @@ export function SessionViewer({
 											/>
 										</svg>
 									</button>
-									<div className="session-info-topbar-title">
+									<div className="session-info-topbar-title absolute bottom-0 left-14 right-14 flex h-[52px] items-center justify-center truncate text-item-title font-semibold tracking-[-0.01em] text-fg opacity-0 transition-[opacity,transform]">
 										{workspaceName || session.title}
 									</div>
 								</div>
-								<div className="session-info-hero">
+								<div className="session-info-hero flex flex-col items-center gap-2 px-5 pb-5 pt-0.5 text-center">
 									<RepoTile name={session.repo || "repository"} size={40} />
-									<div className="session-info-name" ref={infoHeroNameRef}>
+									<div className="session-info-name max-w-full break-words text-section-title font-semibold leading-[1.2] tracking-[-0.02em] text-fg" ref={infoHeroNameRef}>
 										{workspaceName || session.title}
 									</div>
-									<div className="session-info-sub">
+									<div className="session-info-sub text-control-label font-medium text-dim">
 										{[
 											session.repo || "repository",
 											models.length > 0
@@ -4362,7 +4362,7 @@ export function SessionViewer({
 									</div>
 								</div>
 								{hasWorkspace && (
-									<div className="session-info-status">
+									<div className="session-info-status mx-3 mb-3 rounded-xl border border-line bg-panel p-2">
 										<PrStatusBar
 											sessionId={session.id}
 											repo={session.repo || undefined}
@@ -4390,8 +4390,8 @@ export function SessionViewer({
 										/>
 									</div>
 								)}
-								<div className="session-info-content">
-									<div className="session-info-list">
+								<div className="session-info-content min-h-[320px]">
+									<div className="session-info-list mx-3 flex flex-col gap-1 rounded-xl border border-line bg-panel p-1.5">
 										{hasWorkspace && (
 											<RepoBar
 												sessionId={session.id}
@@ -4411,7 +4411,7 @@ export function SessionViewer({
 											/>
 										)}
 									</div>
-									<div className="session-info-overview">
+									<div className="session-info-overview pt-2">
 										<WorkspaceInfo
 											sessionId={session.id}
 											workspaceId={session.projectId || null}
@@ -4481,7 +4481,7 @@ export function SessionViewer({
 										/>
 									</div>
 									{(workflowRuns.length > 0 || subagents.length > 0) && (
-										<div className="session-info-section">
+										<div className="session-info-section mt-2 border-t border-line p-3">
 											<WorkflowPanel
 												sessionId={session.id}
 												runs={workflowRuns}
@@ -4495,7 +4495,7 @@ export function SessionViewer({
 										</div>
 									)}
 									{sessionReports.length > 0 && (
-										<div className="session-info-section">
+										<div className="session-info-section mt-2 border-t border-line p-3">
 											<SessionReportsPanel
 												reports={sessionReports}
 												onOpenNewSession={onOpenNewSession}
@@ -4556,7 +4556,7 @@ export function SessionViewer({
 						{/* The engine-running status dot rides the metadata line on
 						    phones (it used to sit next to the title) so the name stays
 						    steady and the working state reads alongside model · cost. */}
-						{isRunningLive && <span className="working-dot" />}
+						{isRunningLive && <span className="working-dot size-[7px] shrink-0 animate-pulse rounded-full bg-green" />}
 						{/* Repo now leads the pill (portaled into headerRepoEl in front of
 						    the title), so the metadata line is just model · cost. */}
 						{models.length > 0 && (
@@ -4584,7 +4584,7 @@ export function SessionViewer({
 				)}
 
 			{(session.goal || session.loop || runErrorBanner) && (
-				<div className="session-banners">
+				<div className="session-banners flex flex-wrap gap-2 border-b border-line bg-raised px-4 py-[7px]">
 					{/* The last run died on a terminal failure (usage limits/credits
 					    exhausted, API errors) — say why the session stopped; the error
 					    itself was only ever a transient toast. Hidden while a retry
@@ -4593,7 +4593,7 @@ export function SessionViewer({
 					    clean run. */}
 					{runErrorBanner && (
 						<span
-							className="session-banner text-red"
+							className="session-banner inline-flex max-w-full items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap rounded-full border border-line bg-panel px-3 py-[3px] text-label text-red"
 							title={runErrorBanner.message}
 						>
 							⚠ Last run failed: {runErrorBanner.message.slice(0, 160)}
@@ -4624,7 +4624,7 @@ export function SessionViewer({
 			<div className="viewer-split flex min-h-0 flex-1">
 				<div className="viewer-chat flex min-h-0 min-w-0 flex-1 flex-col [--chat-under:16px]">
 					{showPreviewTab ? (
-						<div className="viewer-review-main">
+					<div className="viewer-review-main min-h-0 flex-1">
 							<PreviewPane
 								session={session}
 								status={previewStatus}
@@ -4642,9 +4642,9 @@ export function SessionViewer({
 							// logged-OUT one gets a blank frame (staging redirects to
 							// WorkOS AuthKit, which refuses framing), so the header keeps a
 							// first-party "Open" break-out to log in, then come back.
-							<div className="viewer-review-main">
+							<div className="viewer-review-main min-h-0 flex-1">
 								<div className="flex h-full flex-col">
-									<div className="flex items-center gap-2 border-b border-line bg-panel px-3 py-1.5 text-xs text-dim">
+									<div className="flex items-center gap-2 border-b border-line bg-panel px-3 py-1.5 text-label text-dim">
 										<IconGlobe size={14} />
 										<span className="truncate">
 											Preview environment
@@ -4688,14 +4688,14 @@ export function SessionViewer({
 							// Deploy hasn't opted into being framed (older preview, or the
 							// fusion CSP change hasn't reached it yet) — open it
 							// first-party in a new tab rather than show a blocked frame.
-							<div className="viewer-review-main">
+							<div className="viewer-review-main min-h-0 flex-1">
 								<div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
 									<IconGlobe size={40} className="text-dim" />
 									<div className="flex flex-col items-center gap-1">
-										<div className="text-base font-medium text-fg">
+										<div className="text-item-title font-medium text-fg">
 											Preview environment
 										</div>
-										<div className="text-xs text-dim">
+										<div className="text-label text-dim">
 											{staging?.status === "Ready"
 												? "Test this PR on real infra"
 												: `Deploy is ${(staging?.status ?? "building").toLowerCase()}…`}
@@ -4705,7 +4705,7 @@ export function SessionViewer({
 										href={stagingUrl}
 										target="_blank"
 										rel="noopener"
-										className="inline-flex items-center gap-2 rounded-md border border-line bg-surface px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-panel"
+										className="inline-flex items-center gap-2 rounded-md border border-line bg-surface px-4 py-2 text-control-label font-medium text-fg transition-colors hover:bg-panel"
 									>
 										<IconGlobe size={16} />
 										Open staging
@@ -4716,12 +4716,12 @@ export function SessionViewer({
 										onClick={() =>
 											shareLink(stagingUrl, { toast: "Link copied" })
 										}
-										className="inline-flex items-center gap-1.5 text-xs text-dim transition-colors hover:text-fg"
+										className="inline-flex items-center gap-1.5 text-label text-dim transition-colors hover:text-fg"
 									>
 										<IconCopy size={14} />
 										Copy link
 									</button>
-									<div className="max-w-xs text-xs leading-relaxed text-dim">
+									<div className="max-w-xs text-label leading-relaxed text-dim">
 										Opens in a new tab — this deploy isn&apos;t set up to
 										embed here yet.
 									</div>
@@ -4733,7 +4733,7 @@ export function SessionViewer({
 						// the Info panel's Assets button opens). AssetsPanel is
 						// `h-full`, so the flex-column viewer-review-main gives it
 						// height exactly like the Review PrPanel.
-						<div className="viewer-review-main">
+						<div className="viewer-review-main min-h-0 flex-1">
 							<AssetsPanel
 								sessionId={session.id}
 								files={assetFiles}
@@ -4760,7 +4760,7 @@ export function SessionViewer({
 						// The workspace's Plain ticket thread, full-width — same
 						// ConversationPane the chat-less workspace route renders, so
 						// the chat stays mounted underneath exactly like Review.
-						<div className="viewer-review-main">
+						<div className="viewer-review-main min-h-0 flex-1">
 							<ConversationPane
 								threadId={conversationThreadId}
 								onOpenSession={() => {}}
@@ -4771,7 +4771,7 @@ export function SessionViewer({
 						// The workspace's feed panel — web embed (Tella) or a custom
 						// component (Slack channel Conversation) via the panel
 						// registry (docs/feeds-design.md).
-						<div className="viewer-review-main">
+						<div className="viewer-review-main min-h-0 flex-1">
 							{videoPanel.component === "slack-channel" ? (
 								<SlackChannelPane channelId={videoPanel.refId} />
 							) : (
@@ -4784,14 +4784,14 @@ export function SessionViewer({
 					) : showReview && hasWorkspace ? (
 						<div className="viewer-review-main">
 							{localRepoCapabilityLoading ? (
-								<div className="flex h-full items-center justify-center text-sm text-faint">
+								<div className="flex h-full items-center justify-center text-control-label text-faint">
 									Loading repository…
 								</div>
 							) : localRepoHasNoGitHubRemote ? (
 								<div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
 									<IconGlobe size={32} className="text-faint" />
-									<div className="text-sm font-medium text-fg">No GitHub remote</div>
-									<div className="max-w-xs text-xs leading-relaxed text-dim">
+									<div className="text-item-title font-medium text-fg">No GitHub remote</div>
+									<div className="max-w-xs text-label leading-relaxed text-dim">
 										This repository is not connected to GitHub, so pull request details are unavailable.
 									</div>
 								</div>
@@ -4822,9 +4822,9 @@ export function SessionViewer({
 						</div>
 					) : (
 					<>
-					<div className="viewer-messages-region">
+					<div className="viewer-messages-region relative min-h-0 flex-1">
 						<div
-							className="viewer-messages"
+							className="viewer-messages h-full min-h-0 overflow-y-auto px-4 pb-2 pt-[18px] max-[720px]:px-3 max-[720px]:pt-[calc(var(--pane-header-h)+var(--strip-clearance,0px)+8px)]"
 							ref={messagesRef}
 							onScroll={handleMessagesScroll}
 							onClick={handleMessagesClick}
@@ -5069,7 +5069,7 @@ export function SessionViewer({
 								)}
 							</div>
 
-							<div className="viewer-input">
+							<div className="viewer-input relative z-[1] max-[720px]:-mt-[var(--chat-under)] max-[720px]:bg-[linear-gradient(to_bottom,transparent_0,var(--bg)_var(--chat-under))] max-[720px]:px-3 max-[720px]:pt-1 max-[720px]:pb-[max(10px,env(safe-area-inset-bottom,0px))]">
 								{noEngine ? (
 									<div className="mx-auto max-w-[var(--chat-col)] text-[13px] text-faint">
 										No engine session to resume
@@ -5196,10 +5196,10 @@ export function SessionViewer({
 				const rightRegion = (
 					<>
 				{!isPhone && panelAvailable && panelOpen && (
-					<div className="panel-overlay" onClick={() => setPanelOpen(false)} />
+					<div className="panel-overlay hidden max-[920px]:fixed max-[920px]:inset-0 max-[920px]:z-20 max-[920px]:block max-[920px]:bg-black/20" onClick={() => setPanelOpen(false)} />
 				)}
 				{!isPhone && panelAvailable && panelOpen ? (
-					<div className="viewer-panel" style={panelStyle}>
+					<div className="viewer-panel relative flex min-h-0 w-[var(--panel-w,44%)] min-w-[320px] max-w-[max(480px,calc(100vw-620px))] shrink-0 flex-col border-l border-line bg-raised max-[920px]:fixed max-[920px]:inset-y-0 max-[920px]:right-0 max-[920px]:z-30 max-[920px]:w-[min(440px,92vw)] max-[920px]:max-w-none max-[720px]:inset-x-0 max-[720px]:top-[calc(env(safe-area-inset-top,0px)+10px)] max-[720px]:bottom-0 max-[720px]:w-auto max-[720px]:border max-[720px]:border-line max-[720px]:rounded-t-xl" style={panelStyle}>
 						{panelResizeHandle}
 						{/* Phones open this panel as a full-width bottom sheet, so it
 						    carries one clean header row: chevron-back to the chat on the
@@ -5263,9 +5263,9 @@ export function SessionViewer({
 								}
 							/>
 						)}
-						<div className="panel-tabs">
+						<div className="panel-tabs flex items-center gap-0.5 overflow-x-auto px-2.5 pb-2 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 							<button
-								className={`panel-tab ${panelTab === "info" ? "active" : ""}`}
+								className={`panel-tab inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-[5px] text-control-label font-medium text-dim hover:bg-hover hover:text-fg ${panelTab === "info" ? "active bg-[color-mix(in_srgb,var(--bg-active)_28%,var(--bg-raised))] text-fg" : ""}`}
 								onClick={() => selectPanelTab("info")}
 							>
 								Info
@@ -5273,7 +5273,7 @@ export function SessionViewer({
 							{hasWorkspace && (
 								<>
 									<button
-										className={`panel-tab ${panelTab === "changes" ? "active" : ""}`}
+								className={`panel-tab inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-[5px] text-control-label font-medium text-dim hover:bg-hover hover:text-fg ${panelTab === "changes" ? "active bg-[color-mix(in_srgb,var(--bg-active)_28%,var(--bg-raised))] text-fg" : ""}`}
 										onClick={() => selectPanelTab("changes")}
 									>
 										Changes
@@ -5284,7 +5284,7 @@ export function SessionViewer({
 										) : null}
 									</button>
 									<button
-										className={`panel-tab ${panelTab === "shell" ? "active" : ""}`}
+								className={`panel-tab inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-[5px] text-control-label font-medium text-dim hover:bg-hover hover:text-fg ${panelTab === "shell" ? "active bg-[color-mix(in_srgb,var(--bg-active)_28%,var(--bg-raised))] text-fg" : ""}`}
 										onClick={() => selectPanelTab("shell")}
 										title="Interactive terminal tabs in this session's workspace (inside its sandbox when sandboxed)"
 									>
@@ -5300,7 +5300,7 @@ export function SessionViewer({
 								workflowRuns.length > 0 ||
 								subagents.length > 0) && (
 								<button
-									className={`panel-tab ${panelTab === "workflows" ? "active" : ""}`}
+									className={`panel-tab inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-[5px] text-control-label font-medium text-dim hover:bg-hover hover:text-fg ${panelTab === "workflows" ? "active bg-[color-mix(in_srgb,var(--bg-active)_28%,var(--bg-raised))] text-fg" : ""}`}
 									onClick={() => selectPanelTab("workflows")}
 								>
 									Agents
@@ -5319,7 +5319,7 @@ export function SessionViewer({
 							    sidebar assets tab — see the Assets view-tab in App.tsx. */}
 							{sessionReports.length > 0 && (
 								<button
-									className={`panel-tab ${panelTab === "reports" ? "active" : ""}`}
+									className={`panel-tab inline-flex shrink-0 items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-[5px] text-control-label font-medium text-dim hover:bg-hover hover:text-fg ${panelTab === "reports" ? "active bg-[color-mix(in_srgb,var(--bg-active)_28%,var(--bg-raised))] text-fg" : ""}`}
 									onClick={() => selectPanelTab("reports")}
 								>
 									Reports
@@ -5327,7 +5327,7 @@ export function SessionViewer({
 								</button>
 							)}
 						</div>
-						<div className="panel-body">
+						<div className="panel-body min-h-0 flex-1 overflow-y-auto">
 							{/* Plain-only sessions (no code workspace) show just the timeline. */}
 							{panelTab === "info" ? (
 								<div className="px-1">
@@ -5446,12 +5446,12 @@ export function SessionViewer({
 // the slow git work — see create_session in backstage.ts).
 function WorkspaceWaiting({ detail }: { detail: string }) {
 	return (
-		<div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-1 px-6 text-center">
+			<div className="flex h-full min-h-[240px] flex-col items-center justify-center gap-1 px-6 text-center">
 			<PixelSpinner className="mb-2 text-dim" />
-			<div className="text-[14px] font-semibold text-fg">
+			<div className="text-body font-semibold text-fg">
 				Waiting for workspace
 			</div>
-			<div className="max-w-[340px] text-[13px] font-medium leading-relaxed text-dim">
+			<div className="max-w-[340px] text-control-label font-medium leading-relaxed text-dim">
 				{detail}
 			</div>
 		</div>
@@ -5466,7 +5466,7 @@ function ConversationLoading() {
 			aria-live="polite"
 		>
 			<PixelSpinner className="text-dim" />
-			<div className="text-[13px] font-medium text-dim">Loading conversation</div>
+			<div className="text-control-label font-medium text-dim">Loading conversation</div>
 		</div>
 	);
 }

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -3910,7 +3910,7 @@ export function SessionViewer({
 							<Button
 								variant="danger"
 								size="sm"
-								className="min-h-0 px-3 py-[5px] text-[13px]"
+								className="min-h-0 px-3 py-[5px] text-control-label"
 								onClick={() => handleDelete(true)}
 								disabled={deleting}
 							>
@@ -3920,7 +3920,7 @@ export function SessionViewer({
 						<Button
 							variant="warning"
 							size="sm"
-							className="min-h-0 px-3 py-[5px] text-[13px]"
+							className="min-h-0 px-3 py-[5px] text-control-label"
 							onClick={() => handleDelete(false)}
 							disabled={deleting}
 						>
@@ -3929,7 +3929,7 @@ export function SessionViewer({
 						<Button
 							variant="ghost"
 							size="sm"
-							className="min-h-0 border-line-strong px-3 py-[5px] text-[13px] text-dim hover:bg-transparent hover:text-fg"
+							className="min-h-0 border-line-strong px-3 py-[5px] text-control-label text-dim hover:bg-transparent hover:text-fg"
 							onClick={() => setShowDeleteConfirm(false)}
 							disabled={deleting}
 						>
@@ -4042,7 +4042,7 @@ export function SessionViewer({
 						(session.mode === "scratch" ? (
 							<span className="flex min-w-0 items-center gap-1.5">
 								<span
-									className="flex min-w-0 items-center gap-1.5 text-[13px] font-medium text-dim"
+									className="flex min-w-0 items-center gap-1.5 text-control-label font-medium text-dim"
 									title="Scratch session — no repo"
 								>
 									<RepoTile
@@ -5071,7 +5071,7 @@ export function SessionViewer({
 
 							<div className="viewer-input relative z-[1] max-[720px]:-mt-[var(--chat-under)] max-[720px]:bg-[linear-gradient(to_bottom,transparent_0,var(--bg)_var(--chat-under))] max-[720px]:px-3 max-[720px]:pt-1 max-[720px]:pb-[max(10px,env(safe-area-inset-bottom,0px))]">
 								{noEngine ? (
-									<div className="mx-auto max-w-[var(--chat-col)] text-[13px] text-faint">
+									<div className="mx-auto max-w-[var(--chat-col)] text-control-label text-faint">
 										No engine session to resume
 									</div>
 								) : (

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -2963,7 +2963,11 @@ export function SessionViewer({
 
 	function renderQueueContent(
 		item: QueueReceipt,
-		opts: { human?: ReturnType<typeof parseHumanReply>; github?: boolean },
+		opts: {
+			human?: ReturnType<typeof parseHumanReply>;
+			github?: boolean;
+			sending?: boolean;
+		},
 	) {
 		const firstImage = item.images?.[0];
 		const extraImages = Math.max(0, (item.images?.length ?? 0) - 1);
@@ -2978,24 +2982,31 @@ export function SessionViewer({
 			? opts.human.body
 			: (worker?.body ?? workflow?.body ?? sessionNotice?.body ?? item.content);
 		return (
-			<div className="composer-queue-content">
+			<div className="composer-queue-content flex min-w-0 items-start gap-2 pr-28">
 				{firstImage && (
-					<div className="composer-queue-image">
-						<img src={firstImage} alt="" />
+					<div className="composer-queue-image relative mt-px h-[34px] w-[46px] shrink-0">
+						<img className="block size-full rounded-md border border-line object-cover" src={firstImage} alt="" />
 						{extraImages > 0 && (
-							<span className="composer-queue-image-count">+{extraImages}</span>
+							<span className="composer-queue-image-count absolute -right-1 -bottom-1 h-[18px] min-w-[18px] rounded-full border border-line bg-raised px-1 text-center text-[10px] leading-4 font-bold text-dim">+{extraImages}</span>
 						)}
 					</div>
 				)}
-				<div className="composer-queue-body">
-					{opts.human && (
-						<span className="composer-queue-from">💬 {opts.human.name}</span>
+				<div
+					className={cn(
+						"composer-queue-body min-w-0 flex-1 overflow-hidden text-[13px] leading-[1.45] text-ellipsis whitespace-nowrap text-fg",
+						opts.human && "text-[color-mix(in_srgb,var(--text)_88%,#1f9e8a)]",
+						opts.github && "text-dim",
+						opts.sending && "text-dim",
 					)}
-					{opts.github && <span className="composer-queue-from">GitHub</span>}
-					{worker && <span className="composer-queue-from">🤖 Worker report</span>}
-					{workflow && <span className="composer-queue-from">⚙️ Workflow</span>}
+				>
+					{opts.human && (
+						<span className="composer-queue-from mr-1.5 font-semibold text-faint">💬 {opts.human.name}</span>
+					)}
+					{opts.github && <span className="composer-queue-from mr-1.5 font-semibold text-faint">GitHub</span>}
+					{worker && <span className="composer-queue-from mr-1.5 font-semibold text-faint">🤖 Worker report</span>}
+					{workflow && <span className="composer-queue-from mr-1.5 font-semibold text-faint">⚙️ Workflow</span>}
 					{sessionNotice && (
-						<span className="composer-queue-from">System message</span>
+						<span className="composer-queue-from mr-1.5 font-semibold text-faint">System message</span>
 					)}
 					{body}
 				</div>
@@ -3067,18 +3078,18 @@ export function SessionViewer({
 				: `${queuedOnlyCount} queued · ${visibleSteered.length} steered`;
 	const attachedQueue =
 		queueCount > 0 ? (
-			<div className="composer-queue" aria-label="Queued and steered messages">
-				<div className="composer-queue-title">{queueTitle}</div>
+			<div className="composer-queue relative -mb-3.5 mx-[18px] flex flex-col gap-2 rounded-t-lg border border-b-0 border-line bg-[color-mix(in_srgb,var(--bg-panel)_70%,var(--control-surface))] px-4 pt-2.5 pb-[26px]" aria-label="Queued and steered messages">
+				<div className="composer-queue-title text-xs font-semibold text-faint">{queueTitle}</div>
 				{visibleSteered.map((s, i) => {
 					const hr = parseHumanReply(s.content);
 					return (
 						<div
 							key={`steered-${i}`}
-							className={`composer-queue-item composer-queue-steered ${hr ? "is-human" : ""}`}
+							className={cn("composer-queue-item composer-queue-steered relative min-h-[18.85px]", hr && "is-human")}
 						>
-							<div className="composer-queue-actions">
+							<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
 								<Tooltip label="Already delivered into the running turn — shown here until the turn finishes">
-									<span className="composer-queue-pill">
+									<span className="composer-queue-pill inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-transparent bg-accent-soft px-[13px] text-sm font-semibold text-accent">
 										<IconCrosshair size={20} />
 										Steered
 									</span>
@@ -3087,7 +3098,7 @@ export function SessionViewer({
 									<Tooltip label="Dismiss — the run keeps going; this message won't be re-sent">
 										<button
 											type="button"
-											className="composer-queue-action danger"
+											className="composer-queue-action danger inline-flex size-[34px] items-center justify-center rounded-md border border-transparent bg-transparent text-dim hover:not-disabled:border-red hover:not-disabled:bg-red-soft hover:not-disabled:text-red disabled:cursor-default disabled:opacity-35"
 											onClick={() =>
 												send({
 													type: "delete_queued_prompt",
@@ -3111,7 +3122,7 @@ export function SessionViewer({
 					axis="y"
 					values={queued}
 					onReorder={handleQueueReorder}
-					className="composer-queue-list"
+					className="composer-queue-list flex flex-col gap-2"
 				>
 				{queued.map((q, i) => {
 					const hr = parseHumanReply(q.content);
@@ -3133,11 +3144,11 @@ export function SessionViewer({
 							}}
 							onDragEnd={commitQueueReorder}
 							whileDrag={{ scale: 1.01, zIndex: 2 }}
-							className={`composer-queue-item ${canReorder ? "is-draggable" : ""} ${hr ? "is-human" : ""} ${isGitHub ? "is-github" : ""}`}
+							className={cn("composer-queue-item relative min-h-[18.85px]", canReorder && "is-draggable cursor-grab touch-none active:cursor-grabbing", hr && "is-human", isGitHub && "is-github")}
 						>
-							<div className="composer-queue-actions">
+							<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
 								{isGitHub ? (
-									<span className="composer-queue-pill composer-queue-pill-github">
+									<span className="composer-queue-pill composer-queue-pill-github inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-sm font-semibold text-dim">
 										<IconPullRequest size={20} />
 										FYI
 									</span>
@@ -3146,7 +3157,7 @@ export function SessionViewer({
 										<Tooltip label="Edit — puts the message back into the composer">
 											<button
 												type="button"
-												className="composer-queue-action"
+											className="composer-queue-action inline-flex size-[34px] items-center justify-center rounded-md border border-transparent bg-transparent text-dim hover:not-disabled:border-line hover:not-disabled:bg-hover hover:not-disabled:text-fg disabled:cursor-default disabled:opacity-35"
 												onClick={() => editQueuedInComposer(q, i)}
 											>
 												<IconPencil size={24} />
@@ -3157,7 +3168,7 @@ export function SessionViewer({
 								<Tooltip label="Delete queued message">
 									<button
 										type="button"
-										className="composer-queue-action danger"
+										className="composer-queue-action danger inline-flex size-[34px] items-center justify-center rounded-md border border-transparent bg-transparent text-dim hover:not-disabled:border-red hover:not-disabled:bg-red-soft hover:not-disabled:text-red disabled:cursor-default disabled:opacity-35"
 										onClick={() =>
 											send({
 												type: "delete_queued_prompt",
@@ -3180,7 +3191,7 @@ export function SessionViewer({
 									>
 										<button
 											type="button"
-											className="composer-queue-action composer-queue-steer"
+											className="composer-queue-action composer-queue-steer inline-flex size-[34px] items-center justify-center rounded-md border border-transparent bg-transparent text-accent hover:not-disabled:border-transparent hover:not-disabled:bg-accent-soft disabled:cursor-default disabled:opacity-35"
 											aria-label="Steer into the running turn"
 											disabled={!canSteer}
 											onClick={() =>
@@ -3206,13 +3217,13 @@ export function SessionViewer({
 				{/* Just-sent while busy: already visually in the queue, awaiting the
 				    server's echo (which swaps in the real item with actions). */}
 				{pendingQueue.map((p) => (
-					<div key={p.id} className="composer-queue-item composer-queue-sending">
-						<div className="composer-queue-actions">
-							<span className="composer-queue-pill composer-queue-pill-sending">
+					<div key={p.id} className="composer-queue-item composer-queue-sending relative min-h-[18.85px]">
+						<div className="composer-queue-actions absolute -top-2 right-0 z-[1] inline-flex items-center gap-0.5">
+							<span className="composer-queue-pill composer-queue-pill-sending inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border border-line bg-raised px-[13px] text-sm font-semibold text-faint">
 								{waitingForWorkspace ? "Queued" : "Queueing…"}
 							</span>
 						</div>
-						{renderQueueContent(p, {})}
+						{renderQueueContent(p, { sending: true })}
 					</div>
 				))}
 			</div>

--- a/src/frontend/components/SettingsMenu.tsx
+++ b/src/frontend/components/SettingsMenu.tsx
@@ -440,7 +440,7 @@ export function SettingsMenu({
 				    connection state inside the menu. */}
 				{!footer && !top && !user && (
 					<>
-						<div className="flex items-center gap-2 px-2 py-0.5 text-xs text-dim">
+						<div className="flex items-center gap-2 px-2 py-0.5 text-label text-dim">
 							<span
 								className={cn(
 									"h-2 w-2 rounded-full",
@@ -456,7 +456,7 @@ export function SettingsMenu({
 
 				<Menu.Item
 					onClick={() => onOpenSettings?.()}
-					className="gap-2.5 rounded-lg px-2.5 py-2 text-sm"
+					className="gap-2.5 rounded-lg px-2.5 py-2 text-control-label"
 				>
 					<span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-active text-dim">
 						<IconGear size={20} />
@@ -466,7 +466,7 @@ export function SettingsMenu({
 				{githubAuth && !githubAuth.local && (
 					<Menu.Item
 						onClick={() => void signOut()}
-						className="gap-2.5 rounded-lg px-2.5 py-2 text-sm text-dim data-[highlighted]:text-fg"
+						className="gap-2.5 rounded-lg px-2.5 py-2 text-control-label text-dim data-[highlighted]:text-fg"
 					>
 						<span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-active text-faint">
 							<IconLogOut size={20} />

--- a/src/frontend/components/SettingsMenu.tsx
+++ b/src/frontend/components/SettingsMenu.tsx
@@ -74,8 +74,8 @@ function UserRow({
 		<>
 			<UserAvatar name={name} size={30} className="shrink-0" />
 			<span className="flex min-w-0 flex-1 flex-col gap-0.5 text-left leading-tight">
-				<span className="truncate text-[13px] font-semibold text-fg">{name}</span>
-				<span className="flex items-center gap-1.5 text-[11px] font-medium text-faint">
+				<span className="truncate text-control-label font-semibold text-fg">{name}</span>
+				<span className="flex items-center gap-1.5 text-meta font-medium text-faint">
 					<span
 						className={cn(
 							"h-1.5 w-1.5 shrink-0 rounded-full",
@@ -128,10 +128,10 @@ function SettingsSheet({
 			) : variant === "brand" ? (
 				<button
 					aria-label="Account menu"
-					className="app-logo-button"
+					className="app-logo-button inline-flex h-[42px] w-[42px] items-center justify-center rounded-control border-0 bg-transparent p-0 text-inherit active:bg-hover"
 					onClick={() => setOpen(true)}
 				>
-					<img className="app-logo-image" src="/mac-app-icon.png" alt="" />
+					<img className="app-logo-image block h-8 w-8" src="/mac-app-icon.png" alt="" />
 				</button>
 			) : (
 				<button
@@ -174,7 +174,7 @@ function SettingsSheet({
 								</div>
 							) : (
 								<>
-									<div className="mb-2 px-1 text-[13px] font-semibold text-faint">
+									<div className="mb-2 px-1 text-control-label font-semibold text-faint">
 										Acting as
 									</div>
 									<div className="overflow-hidden rounded-xl border border-line bg-panel">
@@ -218,7 +218,7 @@ function SettingsSheet({
 								</button>
 							</div>
 
-							<div className="mt-4 flex items-center gap-2 px-2 text-[13px] font-medium text-dim">
+							<div className="mt-4 flex items-center gap-2 px-2 text-control-label font-medium text-dim">
 								<span
 									className={cn(
 										"h-2 w-2 rounded-full",
@@ -356,10 +356,10 @@ export function SettingsMenu({
 					<div className="flex items-center gap-3 rounded-lg px-2.5 py-2">
 						<Avatar name={currentUser} size={30} />
 						<span className="flex min-w-0 flex-1 flex-col gap-0.5 leading-tight">
-							<span className="text-[11px] font-medium text-faint">
+							<span className="text-meta font-medium text-faint">
 								Signed in with GitHub
 							</span>
-							<span className="truncate text-[14px] font-semibold text-fg">
+							<span className="truncate text-body font-semibold text-fg">
 								{currentUser}
 								{githubAuth.login && (
 									<span className="ml-1.5 font-normal text-dim">

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -7815,9 +7815,7 @@ function WsOverviewInfo({
 						<button
 							key={`${m.sessionId}:${m.at}:${i}`}
 							type="button"
-							onClick={(event) =>
-								openLightbox(media, i, event.currentTarget)
-							}
+							onClick={() => openLightbox(media, i)}
 							className="relative block aspect-video w-[124px] shrink-0 snap-start overflow-hidden rounded-sm border border-line bg-surface p-0"
 							title={[m.chatTitle, new Date(m.at).toLocaleString()]
 								.filter(Boolean)

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -212,7 +212,7 @@ const SWIPE_AXIS_LOCK_PX = 8;
 
 // Keep the semantic hooks below for sticky-state tracking, platform chrome and
 // test selectors. Their visual contract lives here so the sidebar no longer
-// relies on global.css for its own rows.
+// relies on adapters.css for its own rows.
 const SIDEBAR_ITEM_CLASS =
 	"sidebar-item relative mt-0.5 block w-full rounded-lg border-0 bg-transparent px-2 py-[9px] pl-2.5 text-left text-fg transition-colors hover:bg-hover max-[720px]:px-2.5";
 const SIDEBAR_WS_ROW_CLASS =
@@ -3738,7 +3738,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 					return (
 						<div className="sidebar-status-group">
 							<button
-								className="sidebar-group-header flex w-full items-center gap-[9px] rounded-md px-[10px] py-1 text-[14px] font-medium text-dim transition-colors hover:bg-hover hover:text-fg"
+								className="sidebar-group-header flex w-full items-center gap-[9px] rounded-md px-[10px] py-1 text-body font-medium text-dim transition-colors hover:bg-hover hover:text-fg"
 								onClick={() => toggleGroup("hidden")}
 							>
 								<span className="inline-flex shrink-0 items-center text-faint">
@@ -4897,13 +4897,13 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						const rowClass = cn(
 							// The desktop look lives in these utilities and MUST stay
 							// desktop-only: utilities win cascade ties against the phone
-							// card CSS (global.css @media), so an unconditional w-full/
+							// card CSS (adapters.css @media), so an unconditional w-full/
 							// py-* here is exactly the "full-width Home card on mobile"
 							// bug. Phones render the Slack-home style 132px card strip
 							// purely from .sidebar-nav-item's media rules.
 							"sidebar-nav-item group flex text-left transition-colors max-[720px]:h-[84px] max-[720px]:w-[132px] max-[720px]:shrink-0 max-[720px]:flex-col max-[720px]:items-start max-[720px]:justify-between max-[720px]:gap-2.5 max-[720px]:rounded-[14px] max-[720px]:border max-[720px]:border-line max-[720px]:bg-panel max-[720px]:p-3 max-[720px]:text-control-label max-[720px]:font-semibold max-[720px]:leading-[1.25] max-[720px]:text-fg",
 							// `active` is what the phone card CSS keys its selected state
-							// off (.sidebar-nav-item.active in global.css's @media block);
+							// off (.sidebar-nav-item.active in adapters.css's @media block);
 							// the desktop selected look comes from the utilities below.
 							// Dropping it in the Tailwind migration left the phone cards
 							// with no "you are here".

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -210,6 +210,40 @@ const SWIPE_FULL_RATIO = 0.45;
 const SWIPE_COMMIT_MS = 210;
 const SWIPE_AXIS_LOCK_PX = 8;
 
+// Keep the semantic hooks below for sticky-state tracking, platform chrome and
+// test selectors. Their visual contract lives here so the sidebar no longer
+// relies on global.css for its own rows.
+const SIDEBAR_ITEM_CLASS =
+	"sidebar-item relative mt-0.5 block w-full rounded-lg border-0 bg-transparent px-2 py-[9px] pl-2.5 text-left text-fg transition-colors hover:bg-hover max-[720px]:px-2.5";
+const SIDEBAR_WS_ROW_CLASS =
+	"sidebar-ws-row group relative flex items-center gap-[9px]";
+const SIDEBAR_GROUP_HEADER_CLASS =
+	"sidebar-group-header group flex w-full items-center gap-[9px] rounded-md border-0 bg-transparent px-1.5 py-1 pl-2.5 text-left text-body font-medium text-dim transition-colors hover:bg-hover hover:text-fg max-[720px]:pl-2.5";
+const SIDEBAR_RAIL_CLASS =
+	"sidebar-rail relative flex size-[22px] shrink-0 items-center justify-center";
+const SIDEBAR_TITLE_CLASS =
+	"sidebar-item-title min-w-0 flex-1 truncate text-item-title font-medium leading-[1.35] text-dim";
+const SIDEBAR_GROUP_NAME_CLASS = "sidebar-group-name min-w-0 truncate text-left";
+const SIDEBAR_GROUP_COUNT_CLASS =
+	"sidebar-group-count ml-auto shrink-0 pr-1 text-meta font-medium text-faint";
+const SIDEBAR_GROUP_CHEVRON_CLASS =
+	"sidebar-group-chevron ml-auto shrink-0 text-faint opacity-0 transition-[transform,opacity] duration-150 group-hover:opacity-100 group-hover:text-fg";
+const SIDEBAR_ACTION_CLASS =
+	"sidebar-ws-action inline-flex size-8 items-center justify-center rounded-sm text-faint transition-colors hover:bg-hover hover:text-fg";
+const SIDEBAR_ACTIONS_CLASS =
+	"sidebar-ws-actions absolute right-[7px] top-1/2 hidden -translate-y-1/2 items-center gap-1 rounded-sm bg-hover shadow-[-6px_0_5px_-2px_var(--bg-hover)] [@media(hover:hover)]:group-hover:inline-flex";
+const MOBILE_SHEET_ITEM_CLASS =
+	"mobile-sheet-item flex w-full items-center gap-[13px] rounded-md border-0 bg-transparent px-3.5 py-[15px] text-left text-body text-fg active:bg-hover-strong [&_svg]:shrink-0 [&_svg]:text-faint";
+const HOVERCARD_HEAD_CLASS = "hovercard-head flex min-w-0 items-center gap-[7px]";
+const HOVERCARD_BRANCH_CLASS =
+	"hovercard-branch min-w-0 flex-1 truncate text-label text-dim";
+const HOVERCARD_TITLE_CLASS =
+	"hovercard-title mt-[5px] text-control-label font-semibold leading-[1.3]";
+const HOVERCARD_CALLOUT_CLASS =
+	"hovercard-callout mt-[7px] rounded-sm bg-accent-soft px-2 py-[5px] text-label text-dim";
+const HOVERCARD_ROWS_CLASS = "hovercard-rows mt-[9px] flex flex-col gap-[3px]";
+const HOVERCARD_ROW_CLASS = "hovercard-row flex gap-2 text-label leading-[1.35]";
+
 type SwipeAction = "archive" | "star";
 type SwipeState = { key: string; offset: number; action?: SwipeAction };
 
@@ -230,45 +264,11 @@ function swipeCommitOffset(action: SwipeAction, rowWidth: number): number {
 	return action === "archive" ? -rowWidth : rowWidth;
 }
 
-// Inline styles for the right-click menus. Kept inline (not in a CSS file)
-// because component-imported CSS isn't linked into the served bundle — only
-// global.css is — so a separate stylesheet silently doesn't apply.
-const CTX_MENU_STYLE: React.CSSProperties = {
-	position: "fixed",
-	zIndex: 3000,
-	minWidth: 210,
-	maxWidth: 320,
-	maxHeight: "60vh",
-	overflowY: "auto",
-	padding: 4,
-	background: "var(--bg-panel)",
-	border: "1px solid var(--border-strong)",
-	borderRadius: 14,
-	boxShadow: "0 10px 30px rgba(0, 0, 0, 0.32)",
-	display: "flex",
-	flexDirection: "column",
-	gap: 1,
-};
-const CTX_ITEM_STYLE: React.CSSProperties = {
-	display: "block",
-	width: "100%",
-	textAlign: "left",
-	background: "none",
-	border: "none",
-	color: "var(--text)",
-	fontSize: 13,
-	padding: "6px 8px",
-	borderRadius: 6,
-	cursor: "pointer",
-	whiteSpace: "nowrap",
-	overflow: "hidden",
-	textOverflow: "ellipsis",
-};
-const CTX_SEP_STYLE: React.CSSProperties = {
-	height: 1,
-	background: "var(--border-strong)",
-	margin: "4px 3px",
-};
+const CTX_MENU_CLASS =
+	"sidebar-ctx-menu fixed z-[3000] flex max-h-[60vh] min-w-[210px] max-w-80 flex-col gap-px overflow-y-auto rounded-[14px] border border-line-strong bg-panel p-1 shadow-[0_10px_30px_rgba(0,0,0,0.32)]";
+const CTX_ITEM_CLASS =
+	"flex w-full items-center gap-[11px] overflow-hidden rounded-md border-0 bg-transparent px-2 py-1.5 text-left text-control-label text-fg hover:bg-hover";
+const CTX_SEPARATOR_CLASS = "mx-[3px] my-1 h-px bg-line-strong";
 
 // Per-person group dots share the repo-tile swatch palette (RepoTile.tsx) —
 // the same deterministic hash keeps each teammate's color stable.
@@ -295,7 +295,7 @@ function SupportPriorityIcon({ p, cls }: { p: number; cls: string }) {
 	// The rail keeps these narrower glyphs on the same column — and the same
 	// text rail — as the 22px icons the other group headers wear.
 	return (
-		<span className="sidebar-rail">
+		<span className={SIDEBAR_RAIL_CLASS}>
 			<Glyph size={20} className={cls} />
 		</span>
 	);
@@ -340,24 +340,26 @@ function SupportRow({
 				render={
 					<button
 						type="button"
-						className={`sidebar-item sidebar-ws-row${
-							active ? " sidebar-item-selected" : ""
-						}`}
+						className={cn(
+							SIDEBAR_ITEM_CLASS,
+							SIDEBAR_WS_ROW_CLASS,
+							active && "sidebar-item-selected !bg-hover-strong",
+						)}
 						onClick={onOpen}
 						aria-label={label}
 					/>
 				}
 			>
-				<span className="sidebar-rail">
+				<span className={SIDEBAR_RAIL_CLASS}>
 					<span
 						className="size-[7px] rounded-full"
 						style={{ backgroundColor: dot }}
 					/>
 				</span>
-				<span className="sidebar-item-title">{label}</span>
+				<span className={SIDEBAR_TITLE_CLASS}>{label}</span>
 				{!isPhone && t.statusChangedAt && (
 					<span
-						className="sidebar-ws-time"
+						className="sidebar-ws-time ml-auto min-w-[34px] shrink-0 text-right text-label text-faint"
 						aria-label={new Date(t.statusChangedAt).toLocaleString()}
 					>
 						{shortTime(t.statusChangedAt)}
@@ -366,11 +368,11 @@ function SupportRow({
 				{/* Hover actions: the same pin + finish pair the workspace rows
 				    wear — pin keeps the ticket in the Pinned band, the check
 				    marks it done in Plain. */}
-				<span className="sidebar-ws-actions">
+				<span className={SIDEBAR_ACTIONS_CLASS}>
 					<span
 						role="button"
 						tabIndex={0}
-						className={`sidebar-ws-action${pinned ? " is-on" : ""}`}
+						className={cn(SIDEBAR_ACTION_CLASS, pinned && "is-on text-accent")}
 						aria-label={pinned ? "Unpin ticket" : "Pin ticket"}
 						onClick={(e) => {
 							e.stopPropagation();
@@ -389,7 +391,7 @@ function SupportRow({
 						<span
 							role="button"
 							tabIndex={0}
-							className="sidebar-ws-action sidebar-ws-action--done"
+							className={`${SIDEBAR_ACTION_CLASS} sidebar-ws-action--done hover:text-green`}
 							aria-label="Mark done in Plain"
 							onClick={(e) => {
 								e.stopPropagation();
@@ -455,38 +457,40 @@ function FeedRow({
 				render={
 					<button
 						type="button"
-						className={`sidebar-item sidebar-ws-row${
-							active ? " sidebar-item-selected" : ""
-						}`}
+						className={cn(
+							SIDEBAR_ITEM_CLASS,
+							SIDEBAR_WS_ROW_CLASS,
+							active && "sidebar-item-selected !bg-hover-strong",
+						)}
 						onClick={onOpen}
 						aria-label={item.title}
 					/>
 				}
 			>
-				<span className="sidebar-rail">
+				<span className={SIDEBAR_RAIL_CLASS}>
 					<span
 						className="size-[7px] rounded-full"
 						style={{ backgroundColor: dot }}
 					/>
 				</span>
 				<span
-					className={`sidebar-item-title${unread ? " font-semibold text-fg" : ""}`}
+					className={cn(SIDEBAR_TITLE_CLASS, unread && "font-semibold text-fg")}
 				>
 					{item.title}
 				</span>
 				{!isPhone && ts && (
 					<span
-						className="sidebar-ws-time"
+						className="sidebar-ws-time ml-auto min-w-[34px] shrink-0 text-right text-label text-faint"
 						aria-label={new Date(ts).toLocaleString()}
 					>
 						{shortTime(ts)}
 					</span>
 				)}
-				<span className="sidebar-ws-actions">
+				<span className={SIDEBAR_ACTIONS_CLASS}>
 					<span
 						role="button"
 						tabIndex={0}
-						className={`sidebar-ws-action${pinned ? " is-on" : ""}`}
+						className={cn(SIDEBAR_ACTION_CLASS, pinned && "is-on text-accent")}
 						aria-label={pinned ? "Unpin" : "Pin"}
 						onClick={(e) => {
 							e.stopPropagation();
@@ -505,11 +509,11 @@ function FeedRow({
 			</Popover.Trigger>
 			<Popover.Popup side="right" align="start" className={ROW_CARD_CLASS}>
 				<div className="flex max-w-[280px] flex-col gap-1.5 p-3">
-					<div className="text-[13px] font-medium text-fg">{item.title}</div>
+					<div className="text-control-label font-medium text-fg">{item.title}</div>
 					{item.preview && (
-						<div className="line-clamp-4 text-xs text-dim">{item.preview}</div>
+					<div className="line-clamp-4 text-meta text-dim">{item.preview}</div>
 					)}
-					<div className="flex items-center gap-2 text-[11px] text-faint">
+					<div className="flex items-center gap-2 text-label text-faint">
 						{ts && <span>{relativeTime(ts)}</span>}
 						{session && <span>· linked session</span>}
 					</div>
@@ -657,7 +661,7 @@ function FeedFilterMenu({
 							<Menu.GroupLabel>{spec.label}</Menu.GroupLabel>
 							{item(spec.key, "Any", "", sel === "")}
 							{options === undefined ? (
-								<div className="px-3 py-1 text-xs text-faint">Loading…</div>
+								<div className="px-3 py-1 text-meta text-faint">Loading…</div>
 							) : (
 								options.map((o) =>
 									item(spec.key, o.label, o.value, sel === o.value),
@@ -933,41 +937,22 @@ function CtxItem({
 	return (
 		<button
 			type="button"
-			style={{
-				...CTX_ITEM_STYLE,
-				display: "flex",
-				alignItems: "center",
-				gap: 11,
-				...(danger ? { color: "var(--red, #e5534b)" } : {}),
-			}}
+			className={cn(CTX_ITEM_CLASS, danger && "text-red")}
 			onClick={onClick}
 			onMouseEnter={onMouseEnter}
 		>
 			{icon !== undefined && (
 				<span
-					style={{
-						width: 20,
-						display: "inline-flex",
-						justifyContent: "center",
-						flexShrink: 0,
-						color: danger ? "inherit" : "var(--text-dim)",
-					}}
+					className={cn("inline-flex w-5 shrink-0 justify-center", !danger && "text-dim")}
 				>
 					{icon}
 				</span>
 			)}
-			<span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
+			<span className="min-w-0 flex-1 truncate">
 				{label}
 			</span>
 			{shortcut && (
-				<span
-					style={{
-						color: "var(--text-faint)",
-						fontSize: 13,
-						flexShrink: 0,
-						marginLeft: 12,
-					}}
-				>
+				<span className="ml-3 shrink-0 text-control-label text-faint">
 					{shortcut}
 				</span>
 			)}
@@ -1026,24 +1011,19 @@ function SidebarCtxMenu({
 	return createPortal(
 		<>
 			<div
-				className="sidebar-ctx-menu"
-				style={{ ...CTX_MENU_STYLE, left: x, top: y }}
+				className={CTX_MENU_CLASS}
+				style={{ left: x, top: y }}
 				onClick={(e) => e.stopPropagation()}
 			>
 				{entries.map((entry, i) => {
 					if (entry.kind === "sep")
-						return <div key={i} style={CTX_SEP_STYLE} />;
+						return <div key={i} className={CTX_SEPARATOR_CLASS} />;
 					if (entry.kind === "status") {
 						return (
 							<button
 								key={i}
 								type="button"
-								style={{
-									...CTX_ITEM_STYLE,
-									display: "flex",
-									alignItems: "center",
-									gap: 11,
-								}}
+								className={CTX_ITEM_CLASS}
 								onMouseEnter={(e) => {
 									cancelClose();
 									setSub({
@@ -1061,20 +1041,14 @@ function SidebarCtxMenu({
 								}}
 							>
 								<span
-									style={{
-										width: 20,
-										display: "inline-flex",
-										justifyContent: "center",
-										flexShrink: 0,
-										color: "var(--text-dim)",
-									}}
+									className="inline-flex w-5 shrink-0 justify-center text-dim"
 								>
 									<IconStatusRing size={20} />
 								</span>
-								<span style={{ flex: 1 }}>Set status</span>
+								<span className="flex-1">Set status</span>
 								<IconChevronRight
 									size={16}
-									style={{ color: "var(--text-faint)", flexShrink: 0 }}
+									className="shrink-0 text-faint"
 								/>
 							</button>
 						);
@@ -1084,12 +1058,7 @@ function SidebarCtxMenu({
 							<button
 								key={i}
 								type="button"
-								style={{
-									...CTX_ITEM_STYLE,
-									display: "flex",
-									alignItems: "center",
-									gap: 11,
-								}}
+								className={CTX_ITEM_CLASS}
 								onMouseEnter={(e) => {
 									cancelClose();
 									setSub({
@@ -1107,20 +1076,14 @@ function SidebarCtxMenu({
 								}}
 							>
 								<span
-									style={{
-										width: 20,
-										display: "inline-flex",
-										justifyContent: "center",
-										flexShrink: 0,
-										color: "var(--text-dim)",
-									}}
+									className="inline-flex w-5 shrink-0 justify-center text-dim"
 								>
 									<IconMoon size={20} />
 								</span>
-								<span style={{ flex: 1 }}>Snooze</span>
+								<span className="flex-1">Snooze</span>
 								<IconChevronRight
 									size={16}
-									style={{ color: "var(--text-faint)", flexShrink: 0 }}
+									className="shrink-0 text-faint"
 								/>
 							</button>
 						);
@@ -1143,9 +1106,8 @@ function SidebarCtxMenu({
 			</div>
 			{sub?.kind === "status" && statusEntry && (
 				<div
-					className="sidebar-ctx-menu"
+					className={CTX_MENU_CLASS}
 					style={{
-						...CTX_MENU_STYLE,
 						left: subLeft,
 						top: subTop,
 						minWidth: SUB_W,
@@ -1168,7 +1130,7 @@ function SidebarCtxMenu({
 							}}
 						/>
 					))}
-					<div style={CTX_SEP_STYLE} />
+					<div className={CTX_SEPARATOR_CLASS} />
 					<CtxItem
 						icon={<span />}
 						label="Auto (default)"
@@ -1182,9 +1144,8 @@ function SidebarCtxMenu({
 			)}
 			{sub?.kind === "snooze" && snoozeEntry && (
 				<div
-					className="sidebar-ctx-menu"
+					className={CTX_MENU_CLASS}
 					style={{
-						...CTX_MENU_STYLE,
 						left: subLeft,
 						top: subTop,
 						minWidth: SUB_W,
@@ -1205,7 +1166,7 @@ function SidebarCtxMenu({
 					))}
 					{snoozeEntry.until && (
 						<>
-							<div style={CTX_SEP_STYLE} />
+							<div className={CTX_SEPARATOR_CLASS} />
 							<CtxItem
 								label="Unsnooze"
 								onClick={() => {
@@ -3636,7 +3597,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 					return (
 						<div className="sidebar-status-group">
 							<button
-								className="sidebar-group-header flex w-full items-center gap-[9px] rounded-md px-[10px] py-1 text-[14px] font-medium text-dim transition-colors hover:bg-hover hover:text-fg"
+						className={SIDEBAR_GROUP_HEADER_CLASS}
 								onClick={() => toggleGroup("archived")}
 							>
 								<span className="inline-flex shrink-0 items-center text-faint">
@@ -3653,10 +3614,10 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 										<path d="M6.5 8.5h3" strokeLinecap="round" />
 									</svg>
 								</span>
-								<span className="sidebar-group-name">Archived</span>
-								<span className="sidebar-group-count">{archivedCount}</span>
+								<span className={SIDEBAR_GROUP_NAME_CLASS}>Archived</span>
+								<span className="sidebar-group-count ml-0 shrink-0 pr-0 text-meta font-medium text-faint">{archivedCount}</span>
 								<IconChevronDown
-									className="sidebar-group-chevron"
+									className={SIDEBAR_GROUP_CHEVRON_CLASS}
 									size={22}
 									style={{ transform: open ? "none" : "rotate(-90deg)" }}
 								/>
@@ -3665,15 +3626,15 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 								archivedRows.slice(0, ARCHIVED_INLINE_MAX).map((r) => (
 									<button
 										key={r.key}
-										className="sidebar-item sidebar-ws-row sidebar-archived-row"
+										className={cn(SIDEBAR_ITEM_CLASS, SIDEBAR_WS_ROW_CLASS, "sidebar-archived-row max-[720px]:pr-[72px]")}
 										onClick={() => onSelect(r.chats[0])}
 										aria-label={r.name}
 									>
-										<span className="sidebar-rail">
+										<span className={SIDEBAR_RAIL_CLASS}>
 											<span className="sidebar-item-status sidebar-status-idle" />
 										</span>
 										<span
-											className="sidebar-item-title"
+											className={SIDEBAR_TITLE_CLASS}
 											style={{ color: "var(--text-dim)" }}
 										>
 											{stripPrTitlePrefix(r.name)}
@@ -3686,12 +3647,12 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 										{/* Hover actions, mirroring a live row's pin + archive pair:
 										    here they bring the row back, with pin as the one-gesture
 										    "unarchive AND put it where I'll see it". */}
-										<span className="sidebar-ws-actions">
+										<span className="sidebar-ws-actions absolute right-[7px] top-1/2 flex -translate-y-1/2 items-center gap-1 max-[720px]:bg-transparent max-[720px]:shadow-none [@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:inline-flex">
 											<Tooltip label="Unarchive and pin">
 												<span
 													role="button"
 													tabIndex={0}
-													className="sidebar-ws-action"
+													className={SIDEBAR_ACTION_CLASS}
 													aria-label={
 														r.chats.length > 1
 															? `Unarchive workspace (${r.chats.length} chats) and pin`
@@ -3721,7 +3682,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 												<span
 													role="button"
 													tabIndex={0}
-													className="sidebar-ws-action"
+													className={SIDEBAR_ACTION_CLASS}
 													aria-label="Unarchive"
 													onClick={(e) => {
 														e.stopPropagation();
@@ -3743,16 +3704,16 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 							{open && (
 								<button
 									className={cn(
-										"sidebar-item",
-										"sidebar-ws-row",
+										SIDEBAR_ITEM_CLASS,
+										SIDEBAR_WS_ROW_CLASS,
 										archivedActive && "sidebar-item-selected",
 									)}
 									onClick={onOpenArchived}
 									title="View all archived sessions"
 								>
-									<span className="sidebar-rail" />
+										<span className={SIDEBAR_RAIL_CLASS} />
 									<span
-										className="sidebar-item-title"
+											className={SIDEBAR_TITLE_CLASS}
 										style={{ color: "var(--text-faint)" }}
 									>
 										{archivedCount > ARCHIVED_INLINE_MAX
@@ -3951,7 +3912,13 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 					</button>
 				)}
 				<button
-					className={`sidebar-item sidebar-ws-row ${active ? "sidebar-item-selected" : ""} ${waiting ? "sidebar-item-waiting" : ""} ${row.unread ? "sidebar-item-unread" : ""}`}
+				className={cn(
+					SIDEBAR_ITEM_CLASS,
+					SIDEBAR_WS_ROW_CLASS,
+					active && "sidebar-item-selected !bg-hover-strong",
+					waiting && "sidebar-item-waiting !bg-blue-soft",
+					row.unread && "sidebar-item-unread",
+				)}
 					style={
 						swipeOffset
 							? ({ "--swipe-x": `${swipeOffset}px` } as React.CSSProperties)
@@ -4004,7 +3971,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 				{/* Flat repo grouping has no lane heading, so its leading mark must carry
 				    the workspace status. Grouped lanes already provide that context and
 				    keep the richer PR lifecycle mark here instead. */}
-				<span className="sidebar-rail">
+				<span className={SIDEBAR_RAIL_CLASS}>
 					{!flatRepoGrouping && !isPhone && waiting && (
 						<span
 							className="absolute left-[-9px] top-[7px] block size-[7px] rounded-full bg-green"
@@ -4021,7 +3988,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 				</span>
 				{editing ? (
 					<input
-						className="min-w-0 flex-1 rounded-md border border-[var(--accent,#6b8afd)] bg-bg px-[3px] text-[14px] font-medium text-inherit outline-none"
+						className="min-w-0 flex-1 rounded-md border border-[var(--accent,#6b8afd)] bg-bg px-[3px] text-item-title font-medium text-inherit outline-none"
 						value={row.workspace ? projectDraft : chatDraft}
 						autoFocus
 						onChange={(e) =>
@@ -4053,7 +4020,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						// Same class as a session row's title, so workspace rows pick up
 						// the shared type scale (incl. the phone bump) and the
 						// selected/waiting/unread emphasis from the row's own classes.
-						className="sidebar-item-title"
+						className={SIDEBAR_TITLE_CLASS}
 						onDoubleClick={(e) => {
 							e.stopPropagation();
 							if (row.workspace) {
@@ -4140,11 +4107,11 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 					</span>
 				)}
 				{/* Hover actions: pin + archive, side by side. */}
-				<span className="sidebar-ws-actions">
+				<span className={SIDEBAR_ACTIONS_CLASS}>
 					<span
 						role="button"
 						tabIndex={0}
-						className={`sidebar-ws-action${pinned ? " is-on" : ""}`}
+						className={cn(SIDEBAR_ACTION_CLASS, pinned && "is-on text-accent")}
 						aria-label={pinned ? "Unpin workspace" : "Pin workspace"}
 						onClick={(e) => {
 							e.stopPropagation();
@@ -4180,7 +4147,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 							<span
 								role="button"
 								tabIndex={0}
-								className="sidebar-ws-action"
+							className={SIDEBAR_ACTION_CLASS}
 								aria-label="Archive workspace"
 								onClick={(e) => {
 									e.stopPropagation();
@@ -4313,17 +4280,17 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						// Layout, padding and type all come from .sidebar-group-header —
 						// utilities here would out-specify its phone overrides and leave
 						// these two headers indented (and smaller) than the rest.
-						className="sidebar-group-header transition-colors"
+						className={SIDEBAR_GROUP_HEADER_CLASS}
 						onClick={() => toggleGroup(gkey)}
 					>
 						<SidebarGroupIcon status={meta.key} color={meta.dotColor} />
-						<span className="sidebar-group-name">{meta.label}</span>
+						<span className={SIDEBAR_GROUP_NAME_CLASS}>{meta.label}</span>
 						{/* Count rides directly behind the lane name, not pinned right. */}
-						<span className="sidebar-group-count">
+						<span className="sidebar-group-count ml-0 shrink-0 pr-0 text-meta font-medium text-faint">
 							{items.length + prs.length}
 						</span>
 						<IconChevronDown
-							className="sidebar-group-chevron"
+							className={SIDEBAR_GROUP_CHEVRON_CLASS}
 							size={22}
 							style={{ transform: open ? "none" : "rotate(-90deg)" }}
 						/>
@@ -4346,17 +4313,17 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						// Same bare .sidebar-group-header as the lanes above: utilities
 						// here would out-specify its phone/nesting overrides and leave
 						// this one header out of line with the rest.
-						className="sidebar-group-header transition-colors"
+						className={SIDEBAR_GROUP_HEADER_CLASS}
 						onClick={() => toggleGroup(gkey)}
 					>
 						<IconMoon
 							className="sidebar-group-icon"
 							style={{ color: "var(--text-dim)" }}
 						/>
-						<span className="sidebar-group-name">Snoozed</span>
-						<span className="sidebar-group-count">{snoozedRows.length}</span>
+						<span className={SIDEBAR_GROUP_NAME_CLASS}>Snoozed</span>
+						<span className="sidebar-group-count ml-0 shrink-0 pr-0 text-meta font-medium text-faint">{snoozedRows.length}</span>
 						<IconChevronDown
-							className="sidebar-group-chevron"
+							className={SIDEBAR_GROUP_CHEVRON_CLASS}
 							size={22}
 							style={{ transform: open ? "none" : "rotate(-90deg)" }}
 						/>
@@ -4541,7 +4508,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						>
 							{/* The tile is 18px; the rail holds it on the same column
 							    (and text rail) as every other header's mark. */}
-							<span className="sidebar-rail">
+							<span className={SIDEBAR_RAIL_CLASS}>
 								<RepoTile name={repo} />
 							</span>
 							<span className="sidebar-group-name">{repoLabel(repo)}</span>
@@ -4649,7 +4616,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 					key={`support-prio-${group.p}`}
 				>
 					<button
-						className="sidebar-group-header"
+						className={SIDEBAR_GROUP_HEADER_CLASS}
 						onClick={() => toggleGroup(gkey)}
 					>
 						<SupportPriorityIcon p={group.p} cls={group.cls} />
@@ -4806,7 +4773,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 							/>
 						}
 					>
-						<span className="sidebar-rail">
+						<span className={SIDEBAR_RAIL_CLASS}>
 							<RepoTile name={feed.id} />
 						</span>
 						<span className="sidebar-group-name">{feed.title}</span>
@@ -4848,7 +4815,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 
 	return (
 		<div
-			className="sidebar"
+			className="sidebar flex min-h-0 w-full flex-1 flex-col overflow-x-hidden overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-[720px]:pt-[var(--header-h)] max-[720px]:pb-[max(24px,env(safe-area-inset-bottom))]"
 			ref={sidebarScrollRef}
 			onDragOver={handleRepoAutoScroll}
 			onDragLeave={(event) => {
@@ -4858,7 +4825,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 		>
 			{localMode && cloudUnreachable && (
 				<div
-					className="mx-2 mt-2 flex items-center gap-2 rounded-md border border-line bg-panel px-2.5 py-2 text-[11px] text-dim"
+					className="mx-2 mt-2 flex items-center gap-2 rounded-md border border-line bg-panel px-2.5 py-2 text-label text-dim"
 					role="status"
 					title="Local sessions are still available"
 				>
@@ -4867,11 +4834,11 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 				</div>
 			)}
 			<div
-				className="sidebar-sticky-section sidebar-tools-section"
+				className="sidebar-sticky-section sidebar-tools-section block min-w-0 max-w-full shrink-0"
 				style={{ order: 0 }}
 			>
 			{!isPhone && visibleTools.length > 0 && (
-				<div className="sidebar-band-label sidebar-tools-head sidebar-sticky-head">
+				<div className="sidebar-band-label sidebar-tools-head sidebar-sticky-head sticky top-0 z-20 flex h-11 min-h-11 items-center px-1.5 pt-[7px] pb-[7px] text-meta font-semibold tracking-[-0.01em] text-faint max-[720px]:hidden [&.is-stuck]:before:absolute [&.is-stuck]:before:-inset-x-[400px] [&.is-stuck]:before:-bottom-px [&.is-stuck]:before:-z-10 [&.is-stuck]:before:bg-[linear-gradient(var(--sidebar-material),var(--sidebar-material)),var(--bg-raised)]">
 					<div className="group flex min-h-[30px] w-full items-center rounded-md hover:bg-hover hover:text-dim">
 						<button
 							className="sidebar-band-toggle w-auto flex-1 hover:bg-transparent"
@@ -4925,7 +4892,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 				</div>
 			)}
 			{visibleTools.length > 0 && (isPhone || toolsOpen) && (
-				<nav className="sidebar-nav">
+				<nav className="sidebar-nav flex flex-col gap-0.5 px-[var(--sidebar-nav-x)] pt-1 pb-1.5 [--sidebar-nav-x:6px] max-[720px]:flex-none max-[720px]:flex-row max-[720px]:flex-nowrap max-[720px]:gap-2 max-[720px]:overflow-x-auto max-[720px]:overflow-y-hidden max-[720px]:px-3 max-[720px]:pt-3 max-[720px]:pb-2.5 max-[720px]:pl-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					{visibleTools.map((tool) => {
 						const rowClass = cn(
 							// The desktop look lives in these utilities and MUST stay
@@ -4934,7 +4901,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 							// py-* here is exactly the "full-width Home card on mobile"
 							// bug. Phones render the Slack-home style 132px card strip
 							// purely from .sidebar-nav-item's media rules.
-							"sidebar-nav-item group flex text-left transition-colors",
+							"sidebar-nav-item group flex text-left transition-colors max-[720px]:h-[84px] max-[720px]:w-[132px] max-[720px]:shrink-0 max-[720px]:flex-col max-[720px]:items-start max-[720px]:justify-between max-[720px]:gap-2.5 max-[720px]:rounded-[14px] max-[720px]:border max-[720px]:border-line max-[720px]:bg-panel max-[720px]:p-3 max-[720px]:text-control-label max-[720px]:font-semibold max-[720px]:leading-[1.25] max-[720px]:text-fg",
 							// `active` is what the phone card CSS keys its selected state
 							// off (.sidebar-nav-item.active in global.css's @media block);
 							// the desktop selected look comes from the utilities below.
@@ -4972,7 +4939,9 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 								</span>
 								{tool.label}
 								{!!tool.count && (
-									<span className="sidebar-nav-count">{tool.count}</span>
+									<span className="sidebar-nav-count ml-auto rounded-full bg-accent px-[7px] py-px text-label font-semibold leading-[1.5] text-white max-[720px]:absolute max-[720px]:top-2.5 max-[720px]:right-2.5 max-[720px]:ml-0">
+										{tool.count}
+									</span>
 								)}
 							</>
 						);
@@ -5037,11 +5006,11 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 			</div>
 
 			<div
-				className="sidebar-sticky-section"
+				className="sidebar-sticky-section block min-w-0 max-w-full shrink-0"
 				style={{ order: sectionOrder("workspaces") }}
 			>
 			<div
-				className="sidebar-workspace sidebar-sticky-head mt-1 px-[16px] pb-0.5 pr-[7px] pt-3"
+				className="sidebar-workspace sidebar-sticky-head sticky top-0 z-20 mt-1 flex h-11 min-h-11 items-center px-4 pb-[7px] pr-[7px] pt-[7px] text-meta font-semibold tracking-[-0.01em] text-faint max-[720px]:mt-0 max-[720px]:h-auto max-[720px]:min-h-0 max-[720px]:px-4 max-[720px]:pt-[5px] max-[720px]:pb-px [&.is-stuck]:before:absolute [&.is-stuck]:before:-inset-x-[400px] [&.is-stuck]:before:-bottom-px [&.is-stuck]:before:-z-10 [&.is-stuck]:before:bg-[linear-gradient(var(--sidebar-material),var(--sidebar-material)),var(--bg-raised)]"
 			>
 				<div className="sidebar-workspace-head flex min-w-0 items-center gap-1.5" ref={headRef}>
 					<button
@@ -5367,7 +5336,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 			{workspacesOpen && (
 				<div className="sidebar-list">
 				{workspaceListEmpty && (
-					<div className="mx-4 my-7 text-center text-[13px] leading-[1.4] text-faint">
+					<div className="mx-4 my-7 text-center text-control-label leading-[1.4] text-faint">
 						{hasWorkspaceFilter
 							? "No matching workspaces"
 							: "No workspaces yet"}
@@ -5386,7 +5355,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						return (
 							<div className="sidebar-group sidebar-group--review">
 								<button
-									className="sidebar-group-header"
+									className={SIDEBAR_GROUP_HEADER_CLASS}
 									onClick={() => toggleGroup("needsreview")}
 								>
 									<IconBell
@@ -5424,7 +5393,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						return (
 							<div className="sidebar-group sidebar-group--review">
 								<button
-									className="sidebar-group-header"
+									className={SIDEBAR_GROUP_HEADER_CLASS}
 									onClick={() => toggleGroup("awaitingreview")}
 								>
 									<IconEye
@@ -5602,10 +5571,10 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 									title={n.title}
 								>
 									<span className="sidebar-item-top">
-										<span className="sidebar-rail" style={{ opacity: 0.9 }}>
+										<span className={`${SIDEBAR_RAIL_CLASS} opacity-90`}>
 											📝
 										</span>
-										<span className="sidebar-item-title">{n.title}</span>
+										<span className={SIDEBAR_TITLE_CLASS}>{n.title}</span>
 									</span>
 								</button>
 							),
@@ -5725,7 +5694,7 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 						<div className="sidebar-group sidebar-group--pinned">
 							{/* Same header treatment as the status lanes below. */}
 							<button
-								className="sidebar-group-header"
+								className={SIDEBAR_GROUP_HEADER_CLASS}
 								onClick={() => toggleGroup("pinned")}
 							>
 								<IconPin
@@ -5886,12 +5855,12 @@ export const Sidebar = React.forwardRef<SidebarHandle, Props>(function Sidebar({
 									return (
 									<React.Fragment key={group.key}>
 										<button
-											className="sidebar-group-header"
+											className={SIDEBAR_GROUP_HEADER_CLASS}
 											onClick={() => toggleGroup(group.key)}
 										>
 											{/* The dot is 7px but the header's leading column is a
 											    rail, so its name lands where every other one does. */}
-											<span className="sidebar-rail">
+											<span className={SIDEBAR_RAIL_CLASS}>
 												{group.dotColor && (
 													<span
 														className="sidebar-group-dot"
@@ -6259,9 +6228,9 @@ function FilterPopover({
 	return createPortal(
 		<>
 			<div className="menu-backdrop" onClick={onClose} />
-			<div className="filter-popover" style={{ left, top, width }}>
-				<div className="filter-row">
-					<span className="filter-row-label">Group by</span>
+			<div className="filter-popover fixed z-[301] flex flex-col gap-2.5 rounded-lg border border-line-strong bg-panel px-3.5 py-3 shadow-[0_12px_34px_rgba(0,0,0,0.4)]" style={{ left, top, width }}>
+				<div className="filter-row flex items-center justify-between gap-3.5">
+					<span className="filter-row-label shrink-0 text-body text-dim">Group by</span>
 					<MiniSelect
 						value={filter.groupBy}
 						options={[
@@ -6272,16 +6241,16 @@ function FilterPopover({
 						onSelect={(v) => onChange({ groupBy: v as GroupBy })}
 					/>
 				</div>
-				<div className="filter-row">
-					<span className="filter-row-label">Repo</span>
+				<div className="filter-row flex items-center justify-between gap-3.5">
+					<span className="filter-row-label shrink-0 text-body text-dim">Repo</span>
 					<MiniSelect
 						value={filter.repo}
 						options={repoOptions}
 						onSelect={(v) => onChange({ repo: v })}
 					/>
 				</div>
-				<div className="filter-row">
-					<span className="filter-row-label">Person</span>
+				<div className="filter-row flex items-center justify-between gap-3.5">
+					<span className="filter-row-label shrink-0 text-body text-dim">Person</span>
 					<MiniSelect
 						value={filter.person}
 						options={personOptions}
@@ -6290,8 +6259,8 @@ function FilterPopover({
 				</div>
 				{/* Session-less PR rows in the project lanes (the dissolved PR
 				    band): whose PRs surface. */}
-				<div className="filter-row">
-					<span className="filter-row-label">Pull requests</span>
+				<div className="filter-row flex items-center justify-between gap-3.5">
+					<span className="filter-row-label shrink-0 text-body text-dim">Pull requests</span>
 					<MiniSelect
 						value={filter.prs}
 						options={[
@@ -6302,8 +6271,8 @@ function FilterPopover({
 						onSelect={(v) => onChange({ prs: v as PrsFilter })}
 					/>
 				</div>
-				<div className="filter-row">
-					<span className="filter-row-label">Sort by</span>
+				<div className="filter-row flex items-center justify-between gap-3.5">
+					<span className="filter-row-label shrink-0 text-body text-dim">Sort by</span>
 					<MiniSelect
 						value={filter.sort}
 						options={[
@@ -6346,20 +6315,20 @@ function MiniSelect({
 					onClick={() => setOpen(false)}
 				/>
 				<div
-					className="mini-select-menu"
+					className="mini-select-menu fixed z-[321] max-h-[60vh] overflow-y-auto rounded-md border border-line-strong bg-panel p-[5px] shadow-[0_12px_34px_rgba(0,0,0,0.4)]"
 					style={{ left, top: r.bottom + 4, minWidth: menuW }}
 				>
 					{options.map((o) => (
 						<button
 							key={o.value}
-							className={`mini-select-item${o.value === value ? " selected" : ""}`}
+							className={cn("mini-select-item flex w-full items-center gap-[9px] rounded-sm border-0 bg-transparent px-[9px] py-2 text-left text-body text-fg hover:bg-hover", o.value === value && "selected !bg-hover-strong")}
 							onClick={() => {
 								onSelect(o.value);
 								setOpen(false);
 							}}
 						>
 							{o.icon}
-							<span className="mini-select-item-text">{o.label}</span>
+							<span className="mini-select-item-text min-w-0 flex-1 truncate">{o.label}</span>
 							{o.value === value && (
 								<svg
 									className="mini-select-check"
@@ -6386,18 +6355,18 @@ function MiniSelect({
 	}
 
 	return (
-		<div className="mini-select-wrap">
+		<div className="mini-select-wrap relative">
 			<button
 				ref={btnRef}
-				className="mini-select"
+				className="mini-select flex min-w-[148px] items-center gap-2 rounded-md border border-line-strong bg-panel py-2 pr-2.5 pl-3 text-body text-fg hover:bg-hover"
 				onClick={() => setOpen((o) => !o)}
 			>
-				<span className="mini-select-value">
+				<span className="mini-select-value flex min-w-0 flex-1 items-center gap-[7px]">
 					{current?.icon}
-					<span className="mini-select-text">{current?.label ?? value}</span>
+					<span className="mini-select-text truncate">{current?.label ?? value}</span>
 				</span>
 				<svg
-					className="mini-select-caret"
+					className="mini-select-caret shrink-0 text-faint"
 					width="16"
 					height="16"
 					viewBox="0 0 16 16"
@@ -6497,7 +6466,7 @@ const RepoFilterChip = React.forwardRef<
 		<span
 			ref={ref}
 			className={cn(
-				"sidebar-repo-chip inline-flex min-w-0 max-w-full items-center gap-px rounded-full border border-line bg-panel px-1 py-[3px] text-[13px] leading-[1.15]",
+				"sidebar-repo-chip inline-flex min-w-0 max-w-full items-center gap-px rounded-full border border-line bg-panel px-1 py-[3px] text-control-label leading-[1.15]",
 				variant === "inline" && "shrink-0 max-w-none",
 				variant === "probe" && "pointer-events-none absolute left-[-9999px] top-0 max-w-none invisible",
 				variant === "inline" && "sidebar-repo-chip--inline",
@@ -6519,7 +6488,7 @@ const RepoFilterChip = React.forwardRef<
 			</button>
 			<button
 				type="button"
-				className="sidebar-repo-chip-x inline-flex size-[19px] shrink-0 items-center justify-center rounded-full text-[14px] leading-none text-faint hover:bg-hover hover:text-fg"
+				className="sidebar-repo-chip-x inline-flex size-[19px] shrink-0 items-center justify-center rounded-full text-body leading-none text-faint hover:bg-hover hover:text-fg"
 				title="Clear repo filter"
 				tabIndex={probe ? -1 : undefined}
 				onClick={probe ? undefined : onClear}
@@ -6818,7 +6787,14 @@ function SidebarItem({
 			)}
 		<button
 			ref={btnRef}
-			className={`sidebar-item ${!mine ? "sidebar-item--twoline" : ""} ${selected ? "sidebar-item-selected" : ""} ${waiting ? "sidebar-item-waiting" : ""} ${unread ? "sidebar-item-unread" : ""}`}
+			className={cn(
+				SIDEBAR_ITEM_CLASS,
+				"group",
+				!mine && "sidebar-item--twoline py-[7px]",
+				selected && "sidebar-item-selected !bg-hover-strong",
+				waiting && "sidebar-item-waiting !bg-blue-soft",
+				unread && "sidebar-item-unread",
+			)}
 			style={
 				visibleSwipeOffset
 					? ({ "--swipe-x": `${visibleSwipeOffset}px` } as React.CSSProperties)
@@ -6860,10 +6836,10 @@ function SidebarItem({
 				setCtxMenu({ x: e.clientX, y: e.clientY });
 			}}
 		>
-			<div className="sidebar-item-top">
+			<div className="sidebar-item-top flex min-w-0 items-center gap-[9px]">
 				{/* Match workspace rows: attention sits before the fixed PR glyph, and
 				    merged PRs keep the glyph itself purple instead of adding metadata. */}
-				<span className="sidebar-rail">
+				<span className={SIDEBAR_RAIL_CLASS}>
 					{waiting && (
 						<span
 							className="sidebar-workspace-attention"
@@ -6878,7 +6854,7 @@ function SidebarItem({
 				</span>
 				{editing ? (
 					<input
-						className="sidebar-item-rename"
+					className="sidebar-item-rename min-w-0 flex-1 rounded-md border border-[var(--accent,#6b8afd)] bg-bg px-[3px] text-item-title font-medium text-inherit outline-none"
 						value={draft}
 						autoFocus
 						onChange={(e) => setDraft(e.target.value)}
@@ -6894,7 +6870,7 @@ function SidebarItem({
 					/>
 				) : (
 					<span
-						className="sidebar-item-title"
+					className={cn(SIDEBAR_TITLE_CLASS, unread && "font-semibold text-fg", waiting && "font-semibold text-fg")}
 						onDoubleClick={(e) => {
 							e.stopPropagation();
 							setDraft(session.title);
@@ -6910,7 +6886,7 @@ function SidebarItem({
 					</span>
 				)}
 				{mine && !editing && metaParts.length > 0 && (
-					<span className="sidebar-item-inline-meta">
+					<span className="sidebar-item-inline-meta ml-auto flex min-w-[40px] shrink-0 items-center justify-end gap-1 pl-2.5 text-meta text-faint">
 						{metaParts.map((part, i) => (
 							<React.Fragment key={i}>
 								{i > 0 && <span className="sidebar-meta-sep">·</span>}
@@ -6929,7 +6905,7 @@ function SidebarItem({
 				)}
 			</div>
 			{!mine && (
-				<div className="sidebar-item-meta pl-[28px]">
+				<div className="sidebar-item-meta mt-[3px] flex items-center gap-1 overflow-hidden whitespace-nowrap pl-7 text-meta text-faint">
 					{metaParts.map((part, i) => (
 						<React.Fragment key={i}>
 							{i > 0 && <span className="sidebar-meta-sep">·</span>}
@@ -6943,7 +6919,7 @@ function SidebarItem({
 				shortcut={selected ? PIN_SHORTCUT_KEYS : undefined}
 			>
 				<span
-					className={`sidebar-item-pin${pinned ? " is-on" : ""}`}
+					className={cn("sidebar-item-pin absolute right-[35px] top-1/2 hidden size-[26px] -translate-y-1/2 items-center justify-center rounded-md bg-hover text-faint shadow-[-6px_0_5px_-2px_var(--bg-hover)] [@media(hover:hover)]:group-hover:flex hover:bg-active hover:text-fg", pinned && "is-on text-accent")}
 					role="button"
 					aria-label={pinned ? "Unpin session" : "Pin session"}
 					onMouseEnter={closeHover}
@@ -6960,7 +6936,7 @@ function SidebarItem({
 				shortcut={selected ? ARCHIVE_SHORTCUT_KEYS : undefined}
 			>
 				<span
-					className="sidebar-item-x"
+					className="sidebar-item-x absolute right-[7px] top-1/2 hidden size-[26px] -translate-y-1/2 items-center justify-center rounded-md bg-hover text-faint shadow-[-6px_0_5px_-2px_var(--bg-hover)] [@media(hover:hover)]:group-hover:flex hover:bg-active hover:text-fg"
 					role="button"
 					aria-label="Archive session"
 					onMouseEnter={closeHover}
@@ -7137,17 +7113,17 @@ function MobileActionSheet({
 		};
 	}, []);
 	return createPortal(
-		<div className="mobile-action-sheet-backdrop" onClick={onClose}>
+		<div className="mobile-action-sheet-backdrop fixed inset-0 z-[4000] bg-black/40" onClick={onClose}>
 			<div
-				className="mobile-action-sheet"
+				className="mobile-action-sheet fixed inset-x-0 bottom-0 z-[4001] rounded-t-[16px] bg-panel px-2.5 pt-1.5 pb-[calc(14px+env(safe-area-inset-bottom))] shadow-[0_-8px_30px_rgba(0,0,0,0.4)]"
 				style={drag.style}
 				{...drag.handlers}
 				onClick={(e) => e.stopPropagation()}
 			>
-				<div className="mobile-sheet-grip" />
-				<div className="mobile-sheet-title">{session.title}</div>
+				<div className="mobile-sheet-grip mx-auto my-2 h-1 w-9 rounded-sm bg-line-strong" />
+				<div className="mobile-sheet-title truncate px-3 py-1.5 pb-2 text-control-label text-faint">{session.title}</div>
 				<button
-					className="mobile-sheet-item"
+					className={MOBILE_SHEET_ITEM_CLASS}
 					onClick={() => {
 						onRename();
 						onClose();
@@ -7169,7 +7145,7 @@ function MobileActionSheet({
 				    state — the phone twin of the row's right-click action. */}
 				{onSetStatus && (!mine || isClaimed(session)) && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						onClick={() => {
 							onSetStatus(isClaimed(session) ? null : "mine");
 							onClose();
@@ -7186,7 +7162,7 @@ function MobileActionSheet({
 				    YOUR sidebar only. */}
 				{onSetStatus && (
 					<div className="px-4 py-2">
-						<div className="mb-1.5 text-[11px] font-semibold text-faint">
+						<div className="mb-1.5 text-label font-semibold text-faint">
 							Move to lane
 						</div>
 						<div className="flex flex-wrap gap-1.5">
@@ -7198,7 +7174,7 @@ function MobileActionSheet({
 										size="xs"
 										key={m.key}
 										type="button"
-										className="min-h-0 gap-1.5 whitespace-normal rounded-md px-2 py-1 text-control-label font-medium"
+									className="min-h-0 gap-1.5 whitespace-normal rounded-md px-2 py-1 text-control-label font-medium"
 										style={{
 											borderColor: on ? m.dotColor : "var(--border)",
 											color: on ? "var(--text)" : "var(--text-dim)",
@@ -7243,9 +7219,9 @@ function MobileActionSheet({
 						</div>
 					</div>
 				)}
-				<div className="mobile-sheet-sep" />
+				<div className="mobile-sheet-sep mx-2.5 my-1.5 h-px bg-line" />
 				<button
-					className="mobile-sheet-item mobile-sheet-item--danger"
+					className={`${MOBILE_SHEET_ITEM_CLASS} mobile-sheet-item--danger text-red [&_svg]:text-red`}
 					onClick={() => {
 						onArchive();
 						onClose();
@@ -7340,14 +7316,14 @@ function SessionHoverCard({
 	const card = (
 		<div
 			ref={cardRef}
-			className="sidebar-hovercard"
+			className="sidebar-hovercard fixed z-[200] rounded-[16px] border border-line-strong bg-panel px-[13px] pt-[11px] pb-3 text-fg shadow-[0_8px_30px_rgba(0,0,0,0.45)] max-[720px]:hidden"
 			style={{ left: pos.left, top: pos.top, width: CARD_W }}
 		>
-			<div className="hovercard-head">
+			<div className={HOVERCARD_HEAD_CLASS}>
 				<span
 					className={`sidebar-item-status hovercard-dot ${state.dotClass}`}
 				/>
-				<span className="hovercard-branch">
+				<span className={HOVERCARD_BRANCH_CLASS}>
 					{s.branch || s.title}
 				</span>
 				{s.prAdditions != null && s.prDeletions != null && (
@@ -7362,33 +7338,33 @@ function SessionHoverCard({
 				)}
 			</div>
 
-			<div className="hovercard-title">{s.title}</div>
+			<div className={HOVERCARD_TITLE_CLASS}>{s.title}</div>
 
-			<div className={`hovercard-state hovercard-state-${state.tone}`}>
+			<div className={`hovercard-state mt-[3px] text-label font-medium hovercard-state-${state.tone}`}>
 				{state.label}
 			</div>
 
 			{s.waitingForInput && (
-				<div className="hovercard-callout">
+				<div className={HOVERCARD_CALLOUT_CLASS}>
 					Blocked on a question — open the session to answer.
 				</div>
 			)}
 			{!s.waitingForInput && runNeedsAttention(s) && (
-				<div className="hovercard-callout">
+				<div className={HOVERCARD_CALLOUT_CLASS}>
 					Run failed: {s.lastRunError!.message.slice(0, 200)}
 				</div>
 			)}
 			{!s.waitingForInput && (s.queuedCount ?? 0) > 0 && (
-				<div className="hovercard-callout">
+				<div className={HOVERCARD_CALLOUT_CLASS}>
 					{s.queuedCount} prompt{s.queuedCount === 1 ? "" : "s"} queued.
 				</div>
 			)}
 
-			<div className="hovercard-rows">
+			<div className={HOVERCARD_ROWS_CLASS}>
 				{rows.map(([label, value], i) => (
-					<div className="hovercard-row" key={i}>
-						<span className="hovercard-label">{label}</span>
-						<span className="hovercard-value">{value}</span>
+					<div className={HOVERCARD_ROW_CLASS} key={i}>
+						<span className="hovercard-label w-[74px] shrink-0 text-faint">{label}</span>
+						<span className="hovercard-value min-w-0 truncate text-dim">{value}</span>
 					</div>
 				))}
 			</div>
@@ -7670,7 +7646,7 @@ function WsStatusMark({
 // Footer action button base — the color variant carries the status meaning
 // (green = ready to merge, purple = merged/archive, accent = needs an answer).
 const WS_ACTION =
-	"flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium no-underline";
+	"flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2.5 py-1 text-control-label font-medium no-underline";
 
 // Overview (description + thumbnails) for a workspace row. Same cache (and
 // key) as the right panel's WorkspaceInfo block, so a workspace that's been
@@ -7779,8 +7755,8 @@ function WsOverviewInfo({
 	const media = ov?.media || [];
 	return (
 		<>
-			<div className="hovercard-head">
-				<span className="hovercard-branch">
+			<div className={HOVERCARD_HEAD_CLASS}>
+				<span className={HOVERCARD_BRANCH_CLASS}>
 					{branch || row.chats[0]?.repo || DEFAULT_REPO_ID}
 				</span>
 				{prChat?.prAdditions != null && prChat?.prDeletions != null && (
@@ -7798,7 +7774,7 @@ function WsOverviewInfo({
 				</span>
 			</div>
 
-			<div className="hovercard-title">{row.name}</div>
+			<div className={HOVERCARD_TITLE_CLASS}>{row.name}</div>
 
 			{/* What os-review made of this PR — the question a Ready-to-merge row
 			    raises, answered without opening GitHub. */}
@@ -7811,11 +7787,11 @@ function WsOverviewInfo({
 
 			{row.status === "needsinput" &&
 				(row.chats.some((c) => c.waitingForInput) ? (
-					<div className="hovercard-callout">
+					<div className={HOVERCARD_CALLOUT_CLASS}>
 						Blocked on a question — open to answer.
 					</div>
 				) : (
-					<div className="hovercard-callout">
+					<div className={HOVERCARD_CALLOUT_CLASS}>
 						Run failed:{" "}
 						{row.chats
 							.find((c) => runNeedsAttention(c))
@@ -7824,7 +7800,7 @@ function WsOverviewInfo({
 				))}
 
 			{desc && (
-				<div className="selectable mt-1 text-xs leading-snug text-dim line-clamp-2">
+				<div className="selectable mt-1 text-meta leading-snug text-dim line-clamp-2">
 					{desc}
 				</div>
 			)}
@@ -7863,17 +7839,17 @@ function WsOverviewInfo({
 										preload="metadata"
 										className="h-full w-full object-contain"
 									/>
-									<span className="pointer-events-none absolute inset-0 grid place-items-center text-sm text-white drop-shadow">
+									<span className="pointer-events-none absolute inset-0 grid place-items-center text-item-title text-white drop-shadow">
 										▶
 									</span>
 								</>
 							)}
-							{i === MAX_HOVERCARD_MEDIA - 1 &&
-								media.length > MAX_HOVERCARD_MEDIA && (
-									<span className="absolute inset-0 grid place-items-center bg-black/55 text-xs font-semibold text-white">
-										+{media.length - MAX_HOVERCARD_MEDIA + 1}
-									</span>
-								)}
+						{i === MAX_HOVERCARD_MEDIA - 1 &&
+							media.length > MAX_HOVERCARD_MEDIA && (
+								<span className="absolute inset-0 grid place-items-center bg-black/55 text-label font-semibold text-white">
+									+{media.length - MAX_HOVERCARD_MEDIA + 1}
+								</span>
+							)}
 						</button>
 					))}
 				</div>
@@ -7946,7 +7922,7 @@ function WsHoverCard({
 	const card = (
 		<div
 			ref={cardRef}
-			className="sidebar-hovercard sidebar-hovercard--interactive pointer-events-auto"
+			className="sidebar-hovercard sidebar-hovercard--interactive pointer-events-auto fixed z-[200] rounded-[16px] border border-line-strong bg-panel px-[13px] pt-[11px] pb-3 text-fg shadow-[0_8px_30px_rgba(0,0,0,0.45)] max-[720px]:hidden"
 			data-side={pos.side}
 			style={
 				{
@@ -8016,18 +7992,18 @@ function WsHoverCard({
 						href={prChat.prUrl}
 						target="_blank"
 						rel="noopener noreferrer"
-						className={`shrink-0 text-xs no-underline hovercard-pr-${prTone(prChat)}`}
+						className={`shrink-0 text-control-label no-underline hovercard-pr-${prTone(prChat)}`}
 					>
 						{prChat.prNumber ? `#${prChat.prNumber}` : "PR"} ↗
 					</a>
 				)}
 				{prStatusBits.length > 0 && (
-					<span className="min-w-0 truncate text-[11px] text-faint">
+					<span className="min-w-0 truncate text-label text-faint">
 						{prStatusBits.join(" · ")}
 					</span>
 				)}
 				<span
-					className="ml-auto shrink-0 text-[11px] text-faint"
+					className="ml-auto shrink-0 text-label text-faint"
 					title={new Date(row.lastActivity).toLocaleString()}
 				>
 					{relativeTime(row.lastActivity)}
@@ -8116,18 +8092,18 @@ function WsMobileSheet({
 		</svg>
 	);
 	return createPortal(
-		<div className="mobile-action-sheet-backdrop" onClick={onClose}>
+		<div className="mobile-action-sheet-backdrop fixed inset-0 z-[4000] bg-black/40" onClick={onClose}>
 			<div
-				className="mobile-action-sheet"
+				className="mobile-action-sheet fixed inset-x-0 bottom-0 z-[4001] rounded-t-[16px] bg-panel px-2.5 pt-1.5 pb-[calc(14px+env(safe-area-inset-bottom))] shadow-[0_-8px_30px_rgba(0,0,0,0.4)]"
 				style={drag.style}
 				{...drag.handlers}
 				onClick={(e) => e.stopPropagation()}
 			>
-				<div className="mobile-sheet-grip" />
+				<div className="mobile-sheet-grip mx-auto my-2 h-1 w-9 rounded-sm bg-line-strong" />
 				<div className="px-2 pb-2.5 pt-1">
 					<WsOverviewInfo row={row} ov={ov} />
 					{(prStatusBits.length > 0 || row.lastActivity) && (
-						<div className="mt-2 flex min-w-0 items-center gap-2 text-[11px] text-faint">
+						<div className="mt-2 flex min-w-0 items-center gap-2 text-label text-faint">
 							{prChat?.prNumber != null && (
 								<span
 									className={`hovercard-mono shrink-0 hovercard-pr-${prTone(prChat)}`}
@@ -8152,7 +8128,7 @@ function WsMobileSheet({
 				{/* Main action, colored by what the workspace needs next. */}
 				{row.status === "needsinput" && row.chats.length > 0 && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						style={{ color: "var(--accent)", fontWeight: 600 }}
 						onClick={closing(() =>
 							onOpen(
@@ -8170,7 +8146,7 @@ function WsMobileSheet({
 				)}
 				{row.status === "review" && prChat?.prUrl && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						style={
 							prReady ? { color: "var(--green)", fontWeight: 600 } : undefined
 						}
@@ -8185,7 +8161,7 @@ function WsMobileSheet({
 				)}
 				{row.status === "merged" && row.chats.length > 0 && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						style={{ color: "var(--purple)", fontWeight: 600 }}
 						onClick={closing(onArchive)}
 					>
@@ -8195,7 +8171,7 @@ function WsMobileSheet({
 				)}
 				{prChat?.prUrl && row.status !== "review" && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						onClick={closing(() =>
 							window.open(prChat.prUrl, "_blank", "noopener"),
 						)}
@@ -8206,7 +8182,7 @@ function WsMobileSheet({
 				)}
 				{claimed !== null && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						onClick={closing(() => onSetStatus(claimed ? null : "mine"))}
 					>
 						<IconInbox size={22} />
@@ -8217,18 +8193,18 @@ function WsMobileSheet({
 				)}
 				{onToggleRead && (
 					<button
-						className="mobile-sheet-item"
+						className={MOBILE_SHEET_ITEM_CLASS}
 						onClick={closing(onToggleRead)}
 					>
 						<IconMail size={22} />
 						{unread ? "Mark as read" : "Mark as unread"}
 					</button>
 				)}
-				<button className="mobile-sheet-item" onClick={closing(onTogglePin)}>
+				<button className={MOBILE_SHEET_ITEM_CLASS} onClick={closing(onTogglePin)}>
 					<IconPin size={22} fill={pinned ? "currentColor" : "none"} />
 					{pinned ? "Unpin" : "Pin"}
 				</button>
-				<button className="mobile-sheet-item" onClick={closing(onRename)}>
+				<button className={MOBILE_SHEET_ITEM_CLASS} onClick={closing(onRename)}>
 					<svg
 						width="20"
 						height="20"
@@ -8242,7 +8218,7 @@ function WsMobileSheet({
 					Rename
 				</button>
 				{onCopyLink && (
-					<button className="mobile-sheet-item" onClick={closing(onCopyLink)}>
+					<button className={MOBILE_SHEET_ITEM_CLASS} onClick={closing(onCopyLink)}>
 						<IconLink size={22} />
 						Copy link
 					</button>
@@ -8261,7 +8237,7 @@ function WsMobileSheet({
 								: null;
 						return (
 							<div className="px-4 py-2">
-								<div className="mb-1.5 text-[11px] font-semibold text-faint">
+								<div className="mb-1.5 text-label font-semibold text-faint">
 									Move to lane
 								</div>
 								<div className="flex flex-wrap gap-1.5">
@@ -8271,9 +8247,9 @@ function WsMobileSheet({
 											<Button
 												variant="ghost"
 												size="xs"
-												key={m.key}
-												type="button"
-												className="min-h-0 gap-1.5 whitespace-normal rounded-md px-2 py-1 text-control-label font-medium"
+										key={m.key}
+										type="button"
+										className="min-h-0 gap-1.5 whitespace-normal rounded-md px-2 py-1 text-control-label font-medium"
 												style={{
 													borderColor: on ? m.dotColor : "var(--border)",
 													color: on ? "var(--text)" : "var(--text-dim)",
@@ -8321,7 +8297,7 @@ function WsMobileSheet({
 				    until the resolved time. */}
 				{row.chats.length > 0 && (
 					<div className="px-4 py-2">
-						<div className="mb-1.5 text-[11px] font-semibold text-faint">
+						<div className="mb-1.5 text-label font-semibold text-faint">
 							{snoozeUntil
 								? `Snoozed — wakes in ${formatRemaining(snoozeUntil)}`
 								: "Snooze"}

--- a/src/frontend/components/SidebarRowCards.tsx
+++ b/src/frontend/components/SidebarRowCards.tsx
@@ -20,7 +20,7 @@ import { IconGitMerge } from "./icons";
 
 /** Matches .sidebar-hovercard's width, padding, radius and shadow. */
 export const ROW_CARD_CLASS =
-	"w-[min(300px,calc(100vw-24px))] rounded-[16px] px-[13px] pt-[11px] pb-3 shadow-[0_8px_30px_rgba(0,0,0,0.45)]";
+	"w-[min(300px,calc(100vw-24px))] rounded-[16px] border border-line-strong bg-panel px-[13px] pt-[11px] pb-3 text-fg shadow-[0_8px_30px_rgba(0,0,0,0.45)] max-[720px]:hidden";
 
 /**
  * Hover-only card wiring for a sidebar row.
@@ -51,11 +51,11 @@ export function useRowHoverCard() {
 function CardRows({ rows }: { rows: Array<[string, React.ReactNode]> }) {
 	if (rows.length === 0) return null;
 	return (
-		<div className="hovercard-rows">
+		<div className="hovercard-rows mt-[9px] flex flex-col gap-[3px]">
 			{rows.map(([label, value], i) => (
-				<div className="hovercard-row" key={i}>
-					<span className="hovercard-label">{label}</span>
-					<span className="hovercard-value">{value}</span>
+				<div className="hovercard-row flex gap-2 text-label leading-[1.35]" key={i}>
+					<span className="hovercard-label w-[74px] shrink-0 text-faint">{label}</span>
+					<span className="hovercard-value min-w-0 truncate text-dim">{value}</span>
 				</div>
 			))}
 		</div>
@@ -74,7 +74,7 @@ function CardFooter({
 	return (
 		<div className="mt-2.5 flex min-w-0 items-center gap-2 border-t border-line pt-2">
 			{link}
-			<span className="ml-auto shrink-0 text-[11px] text-faint" title={timeTitle}>
+			<span className="ml-auto shrink-0 text-label text-faint" title={timeTitle}>
 				{time}
 			</span>
 		</div>
@@ -184,10 +184,10 @@ export function PrRowCard({ item }: { item: ReviewQueueItem }) {
 
 	return (
 		<>
-			<div className="hovercard-head">
-				<span className="hovercard-branch">{pr.branch}</span>
+			<div className="hovercard-head flex min-w-0 items-center gap-[7px]">
+				<span className="hovercard-branch min-w-0 flex-1 truncate text-label text-dim">{pr.branch}</span>
 				{pr.isDraft && (
-					<span className="shrink-0 text-[11px] text-faint">draft</span>
+					<span className="shrink-0 text-label text-faint">draft</span>
 				)}
 				<span className="flex shrink-0 items-center">
 					{item.bucket === "ready" ? (
@@ -202,20 +202,20 @@ export function PrRowCard({ item }: { item: ReviewQueueItem }) {
 				</span>
 			</div>
 
-			<div className="hovercard-title">{pr.title}</div>
+			<div className="hovercard-title mt-[5px] text-control-label font-semibold leading-[1.3]">{pr.title}</div>
 
 			{problem ? (
-				<div className="hovercard-callout">{problem}</div>
+				<div className="hovercard-callout mt-[7px] rounded-sm bg-accent-soft px-2 py-[5px] text-label text-dim">{problem}</div>
 			) : (
 				state && (
-					<div className={`hovercard-state hovercard-state-${state.tone}`}>
+					<div className={`hovercard-state mt-[3px] text-label font-medium hovercard-state-${state.tone}`}>
 						{state.label}
 					</div>
 				)
 			)}
 
 			{pr.reviewActive && (
-				<div className="hovercard-callout">
+				<div className="hovercard-callout mt-[7px] rounded-sm bg-accent-soft px-2 py-[5px] text-label text-dim">
 					An automated review is still running.
 				</div>
 			)}
@@ -229,7 +229,7 @@ export function PrRowCard({ item }: { item: ReviewQueueItem }) {
 						target="_blank"
 						rel="noopener noreferrer"
 						title={`Open on ${providerFromUrl(pr.url).name}`}
-						className="hovercard-mono shrink-0 text-xs text-dim hover:underline"
+						className="hovercard-mono shrink-0 text-meta text-dim hover:underline"
 					>
 						#{pr.number} ↗
 					</a>
@@ -283,17 +283,17 @@ export function SupportRowCard({
 
 	return (
 		<>
-			<div className="hovercard-head">
-				<span className="hovercard-branch">{customer}</span>
-				<span className={`shrink-0 text-[11px] ${priority.cls}`}>
+			<div className="hovercard-head flex min-w-0 items-center gap-[7px]">
+				<span className="hovercard-branch min-w-0 flex-1 truncate text-label text-dim">{customer}</span>
+				<span className={`shrink-0 text-label ${priority.cls}`}>
 					{priority.label}
 				</span>
 			</div>
 
-			<div className="hovercard-title">{t.title || customer}</div>
+			<div className="hovercard-title mt-[5px] text-control-label font-semibold leading-[1.3]">{t.title || customer}</div>
 
 			{preview && (
-				<div className="selectable mt-1 text-xs leading-snug text-dim line-clamp-3">
+				<div className="selectable mt-1 text-meta leading-snug text-dim line-clamp-3">
 					{preview}
 				</div>
 			)}
@@ -320,7 +320,7 @@ export function SupportRowCard({
 						href={plainThreadUrl(t.id)}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="shrink-0 text-xs text-dim hover:underline"
+						className="shrink-0 text-meta text-dim hover:underline"
 					>
 						Open in Plain ↗
 					</a>

--- a/src/frontend/components/SlackChannelPane.tsx
+++ b/src/frontend/components/SlackChannelPane.tsx
@@ -150,7 +150,7 @@ function MessageRow({
 					className="mt-0.5 h-7 w-7 flex-shrink-0 rounded-md"
 				/>
 			) : (
-				<span className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-active text-xs font-semibold text-dim">
+				<span className="mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-active text-label font-semibold text-dim">
 					{m.userName.charAt(0).toUpperCase()}
 				</span>
 			)}
@@ -176,7 +176,7 @@ function MessageRow({
 				{expanded && (
 					<div className="mt-1 border-l-2 border-line pl-3">
 						{loadingReplies ? (
-							<div className="py-1 text-xs text-faint">Loading thread…</div>
+							<div className="py-1 text-label text-faint">Loading thread…</div>
 						) : (
 							(replies || []).map((r) => (
 								<MessageRow
@@ -356,11 +356,11 @@ export function SlackChannelPane({
 						</div>
 					)}
 					{loading ? (
-						<div className="py-8 text-center text-sm text-faint">
+						<div className="py-8 text-center text-control-label text-faint">
 							Loading channel…
 						</div>
 					) : messages.length === 0 ? (
-						<div className="py-8 text-center text-sm text-faint">
+						<div className="py-8 text-center text-control-label text-faint">
 							No recent messages.
 						</div>
 					) : (
@@ -371,12 +371,12 @@ export function SlackChannelPane({
 				</div>
 			</div>
 			{error && (
-				<div className="mx-auto w-full max-w-[760px] px-5 py-2 text-xs text-red">
+				<div className="mx-auto w-full max-w-[760px] px-5 py-2 text-label text-red">
 					{error}
 				</div>
 			)}
 			{/* Same visual family as the sessions Composer (.composer classes from
-			    global.css) — rounded card, borderless textarea, circular accent
+			    adapters.css) — rounded card, borderless textarea, circular accent
 			    send — sized down for a chat channel. */}
 			<div className="composer-wrap shrink-0 px-5 pb-4 pt-1">
 				<div className={`composer ${!asUser ? "composer-disabled" : ""}`}>

--- a/src/frontend/components/SlackChannelPane.tsx
+++ b/src/frontend/components/SlackChannelPane.tsx
@@ -92,7 +92,7 @@ function ReactionPills({ reactions }: { reactions?: MessageReaction[] }) {
 					{r.url ? (
 						<img src={r.url} alt={r.name} className="h-[14px] w-[14px]" />
 					) : (
-						<span className="text-[13px]">{r.emoji || `:${r.name}:`}</span>
+						<span className="text-control-label">{r.emoji || `:${r.name}:`}</span>
 					)}
 					<span className="font-medium">{r.count}</span>
 				</span>

--- a/src/frontend/components/SpinOffMenu.tsx
+++ b/src/frontend/components/SpinOffMenu.tsx
@@ -145,17 +145,17 @@ export function SpinOffMenu({ session, entries, send, connected }: Props) {
         <Menu.Popup className="w-80 overflow-hidden p-0">
           {isAsk && (
             <Menu.Item closeOnClick={false} onClick={() => pick("build")} className={itemCls}>
-              <span className="text-[13px] font-semibold text-fg">Build this</span>
-              <span className="text-meta leading-[1.4] text-faint">Start a coding session with this conversation as context</span>
+				<span className="text-control-label font-semibold text-fg">Build this</span>
+				<span className="text-meta leading-snug text-faint">Start a coding session with this conversation as context</span>
             </Menu.Item>
           )}
           <Menu.Item closeOnClick={false} onClick={() => pick("learnings")} className={itemCls}>
-            <span className="text-[13px] font-semibold text-fg">Capture learnings → docs PR</span>
-            <span className="text-meta leading-[1.4] text-faint">{AGENT_NAME} adds what was learned here to {session.repo || "the repository"} docs</span>
+			<span className="text-control-label font-semibold text-fg">Capture learnings → docs PR</span>
+			<span className="text-meta leading-snug text-faint">{AGENT_NAME} adds what was learned here to {session.repo || "the repository"} docs</span>
           </Menu.Item>
           <Menu.Item closeOnClick={false} onClick={() => pick("analyze")} className={itemCls}>
-            <span className="text-[13px] font-semibold text-fg">Analyze session</span>
-            <span className="text-meta leading-[1.4] text-faint">What went well, what didn't, and a better prompt</span>
+			<span className="text-control-label font-semibold text-fg">Analyze session</span>
+			<span className="text-meta leading-snug text-faint">What went well, what didn't, and a better prompt</span>
           </Menu.Item>
         </Menu.Popup>
       </Menu.SubmenuRoot>
@@ -211,7 +211,7 @@ export function SpinOffMenu({ session, entries, send, connected }: Props) {
 
           <Modal.Footer>
             {starting && (
-              <span className="text-meta text-faint">
+				<span className="text-meta text-faint">
                 Starting the session. We'll take you there automatically.
               </span>
             )}

--- a/src/frontend/components/SpinOffMenu.tsx
+++ b/src/frontend/components/SpinOffMenu.tsx
@@ -115,9 +115,9 @@ export function SpinOffMenu({ session, entries, send, connected }: Props) {
   const itemCls =
     "flex-col items-start gap-0.5 rounded-none border-b border-line px-3.5 py-2.5 last:border-b-0";
 
-  const fieldLabelCls = "flex flex-col gap-1.5 text-sm font-medium text-fg";
+  const fieldLabelCls = "flex flex-col gap-1.5 text-control-label font-medium text-fg";
   const fieldCls =
-    "w-full rounded-md border border-line-strong bg-surface px-3 text-sm text-fg outline-none placeholder:text-faint focus:border-accent focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+    "w-full rounded-md border border-line-strong bg-surface px-3 text-control-label text-fg outline-none placeholder:text-faint focus:border-accent focus:shadow-[0_0_0_3px_var(--accent-soft)]";
 
   const flavorMeta: Record<Flavor, { title: string; description: string }> = {
     build: {

--- a/src/frontend/components/StagingLink.tsx
+++ b/src/frontend/components/StagingLink.tsx
@@ -100,7 +100,7 @@ export function StagingLink({
 	if (!staging) {
 		if (!deployPending) return null;
 		const shimmerGlobe = (size: number, className?: string) => (
-			<span className="staging-globe-wrap staging-shimmer" aria-hidden="true">
+			<span className="staging-globe-wrap staging-shimmer relative inline-flex animate-[staging-shimmer_1.4s_ease-in-out_infinite] items-center justify-center" aria-hidden="true">
 				<IconGlobe size={size} className={className} />
 			</span>
 		);
@@ -112,7 +112,7 @@ export function StagingLink({
 					multiline
 				>
 					<span
-						className="viewer-code-icon staging-icon is-pending"
+						className="viewer-code-icon staging-icon is-pending inline-flex cursor-default items-center justify-center rounded-md border border-transparent bg-transparent px-1 py-0.5 text-faint no-underline"
 						aria-disabled="true"
 					>
 						{shimmerGlobe(25)}
@@ -135,7 +135,7 @@ export function StagingLink({
 		}
 		return (
 			<span
-				className="staging-link staging-link-pending"
+				className="staging-link staging-link-pending inline-flex cursor-default items-center gap-1.5 whitespace-nowrap rounded-md border border-line px-2.5 py-1 text-control-label font-semibold text-dim no-underline"
 				title="Preview environment starting… the link appears once it's up"
 			>
 				{shimmerGlobe(15, "staging-globe")}
@@ -189,8 +189,8 @@ export function StagingLink({
 				idle={<IconGlobe size={size} className={className} />}
 			/>
 		) : (
-			<span className="staging-globe-wrap">
-				{spinning && <span className="staging-spinner" aria-hidden="true" />}
+			<span className="staging-globe-wrap relative inline-flex items-center justify-center">
+				{spinning && <span className="staging-spinner pointer-events-none absolute left-1/2 top-1/2 size-[22px] -translate-x-1/2 -translate-y-1/2 animate-spin rounded-full border-[1.5px] border-transparent border-t-current opacity-90" aria-hidden="true" />}
 				<IconGlobe size={size} className={className} />
 			</span>
 		);
@@ -218,7 +218,7 @@ export function StagingLink({
 					rel="noopener"
 					onClick={onClick}
 					aria-disabled={building || undefined}
-					className={`viewer-code-icon staging-icon ${stateClass}`}
+					className={`viewer-code-icon staging-icon inline-flex items-center justify-center rounded-md border border-transparent bg-transparent px-1 py-0.5 text-faint no-underline transition-colors hover:bg-accent-soft hover:text-accent ${stateClass} ${building ? "cursor-default text-yellow opacity-70 hover:bg-[rgba(210,153,34,0.13)] hover:text-yellow hover:opacity-100" : rebuilding ? "text-yellow opacity-70 hover:bg-[rgba(210,153,34,0.13)] hover:text-yellow hover:opacity-100" : "text-green hover:bg-green-soft hover:text-green"}`}
 				>
 					{/* The globe glyph only fills ~60% of its box (thin circle in a 24
 					    viewBox), so it still needs a hair more than the play/sidebar
@@ -254,12 +254,12 @@ export function StagingLink({
 			rel="noopener"
 			onClick={onClick}
 			aria-disabled={building || undefined}
-			className={`staging-link ${building ? "staging-link-building" : ""}`}
+			className={`staging-link inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-[rgba(210,153,34,0.45)] px-2.5 py-1 text-control-label font-semibold text-yellow no-underline transition-colors hover:bg-[rgba(210,153,34,0.12)] ${building ? "staging-link-building cursor-default opacity-55" : ""}`}
 			title={`${tooltip("⌘-click to copy the link")} — ${href}`}
 		>
 			{globe(15, "staging-globe")}
 			Preview environment
-			<IconArrowUpRight size={15} className="staging-ext" />
+			<IconArrowUpRight size={15} className="staging-ext -ml-px opacity-80" />
 		</a>
 	);
 }

--- a/src/frontend/components/SubagentPane.tsx
+++ b/src/frontend/components/SubagentPane.tsx
@@ -88,40 +88,40 @@ export function SubagentPane({ sessionId, stack, onOpenSubagent, onBack }: Props
     ? friendlyModelSlug(opencodeModelParts(meta.model)?.model ?? meta.model)
     : null;
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="subagent-head">
-        <div className="subagent-head-top">
-          <span className="subagent-chip">sub-agent</span>
-          <span className="subagent-title" title={meta?.description || current.label}>
+	return (
+		<div className="flex min-h-0 flex-1 flex-col">
+			<div className="subagent-head border-b border-line bg-raised px-2.5 pb-2.5 pt-2">
+				<div className="subagent-head-top flex items-center gap-2">
+					<span className="subagent-chip whitespace-nowrap rounded-sm bg-accent-soft px-1.5 py-0.5 text-meta font-semibold tracking-[-0.01em] text-accent">sub-agent</span>
+					<span className="subagent-title min-w-0 flex-1 truncate text-control-label font-semibold text-fg" title={meta?.description || current.label}>
             {title}
           </span>
           {modelLabel && (
             <span
-              className="shrink-0 rounded-sm bg-surface px-1.5 py-0.5 text-[11px] text-dim"
+              className="shrink-0 rounded-sm bg-surface px-1.5 py-0.5 text-meta text-dim"
               title={meta?.model}
             >
               {modelLabel}
             </span>
           )}
-          {/* No close button: the tab's × owns that, like Review and Assets. */}
-          {data?.sessionRunning && <span className="subagent-live-dot" title="Session running" />}
+					{/* No close button: the tab's × owns that, like Review and Assets. */}
+					{data?.sessionRunning && <span className="subagent-live-dot size-[7px] shrink-0 animate-pulse rounded-full bg-green" title="Session running" />}
         </div>
         {stack.length > 1 && (
-          <button className="subagent-back" onClick={onBack}>
+          <button className="subagent-back mt-2 block max-w-full truncate bg-transparent p-0 text-label text-dim hover:text-fg focus-ring" onClick={onBack}>
             ← {stack[stack.length - 2].label}
           </button>
         )}
-        {meta?.description && <div className="subagent-desc">{meta.description}</div>}
+        {meta?.description && <div className="subagent-desc mt-1.5 text-label leading-[1.4] text-dim">{meta.description}</div>}
       </div>
 
-      <div className="panel-body subagent-body" ref={bodyRef} onScroll={onScroll}>
+      <div className="panel-body subagent-body min-h-0 flex-1 overflow-y-auto px-3.5 py-3" ref={bodyRef} onScroll={onScroll}>
         {loading ? (
-          <div className="panel-placeholder">Loading sub-agent…</div>
+          <div className="panel-placeholder px-4 py-12 text-center text-control-label text-faint">Loading sub-agent…</div>
         ) : error ? (
-          <div className="panel-placeholder panel-error">{error}</div>
+          <div className="panel-placeholder panel-error px-4 py-12 text-center text-control-label text-red">{error}</div>
         ) : data && data.entries.length > 0 ? (
-          <div className="subagent-messages">
+          <div className="subagent-messages min-w-0">
             <TranscriptBlocks
               entries={data.entries}
               live={data.sessionRunning}
@@ -129,7 +129,7 @@ export function SubagentPane({ sessionId, stack, onOpenSubagent, onBack }: Props
             />
           </div>
         ) : (
-          <div className="panel-placeholder">No transcript yet for this sub-agent.</div>
+          <div className="panel-placeholder px-4 py-12 text-center text-control-label text-faint">No transcript yet for this sub-agent.</div>
         )}
       </div>
     </div>

--- a/src/frontend/components/SupportPreview.tsx
+++ b/src/frontend/components/SupportPreview.tsx
@@ -150,7 +150,7 @@ export function SupportPreview({
 					onModelChange={setModel}
 					modelTitle="Model for this session"
 				/>
-				{startError && <div className="ask-error">{startError}</div>}
+				{startError && <div className="ask-error mt-2.5 rounded-md bg-red-soft px-2.5 py-1.5 text-center text-supporting text-red">{startError}</div>}
 			</div>
 		</div>
 	);

--- a/src/frontend/components/TitleBar.tsx
+++ b/src/frontend/components/TitleBar.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "../ui/tooltip";
  * just the window-control buttons overlaid on our own content — which also
  * takes the browser's back/forward buttons with it. There is no dedicated
  * titlebar band: the window's first content row is the titlebar (drag regions
- * + traffic-light inset live in the `html.wco` rules in global.css). The
+ * + traffic-light inset live in the `html.wco` rules in adapters.css). The
  * cluster carries the in-app back/forward, wired to the same history the
  * router drives (pushState / popstate), and sits at the right edge of the
  * sidebar's top chrome row. The `pane` variant is a floating fallback in the

--- a/src/frontend/components/TitleBar.tsx
+++ b/src/frontend/components/TitleBar.tsx
@@ -26,11 +26,17 @@ export function TitleBar({
 	pane?: boolean;
 	onSearch?: () => void;
 }) {
+	const navClassName = pane
+		? "wco-nav wco-nav-pane absolute top-[calc((var(--desktop-header-h)-30px)/2)] left-[50px] z-20 items-center gap-0.5 [html.wco_&]:left-[calc(env(titlebar-area-x,78px)+42px)] [html.wco_&]:[-webkit-app-region:no-drag] [html.wco_&]:[app-region:no-drag]"
+		: "wco-nav ml-auto hidden items-center gap-0.5 [html.wco_&]:flex";
+	const buttonClassName =
+		"wco-nav-btn inline-flex size-[30px] items-center justify-center rounded-[calc(8px*var(--rf))] border-0 bg-transparent p-0 text-dim cursor-pointer [corner-shape:var(--cs)] [-webkit-app-region:no-drag] [app-region:no-drag] hover:bg-hover hover:text-fg";
+
 	return (
-		<div className={pane ? "wco-nav wco-nav-pane" : "wco-nav"}>
+		<div className={navClassName}>
 			<Tooltip label="Back" side="bottom">
 				<button
-					className="wco-nav-btn"
+					className={buttonClassName}
 					onClick={() => history.back()}
 					aria-label="Back"
 				>
@@ -39,7 +45,7 @@ export function TitleBar({
 			</Tooltip>
 			<Tooltip label="Forward" side="bottom">
 				<button
-					className="wco-nav-btn"
+					className={buttonClassName}
 					onClick={() => history.forward()}
 					aria-label="Forward"
 				>
@@ -49,7 +55,7 @@ export function TitleBar({
 			{onSearch && (
 				<Tooltip label="Command menu" side="bottom" shortcut={["⌘", "K"]}>
 					<button
-						className="wco-nav-btn"
+						className={buttonClassName}
 						onClick={onSearch}
 						aria-label="Open command menu"
 					>

--- a/src/frontend/components/ToolCallBlock.tsx
+++ b/src/frontend/components/ToolCallBlock.tsx
@@ -495,7 +495,7 @@ export function ToolCallBlock({ entry, result, pending, onOpenSubagent, sessionI
         aria-expanded={expanded}
         onClick={() => setExpanded(!expanded)}
         className={cn(
-          "group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-[3px] text-left font-sans transition-colors",
+            "group flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-[3px] text-left font-sans transition-colors focus-ring",
           "hover:bg-hover/40"
         )}
       >
@@ -518,14 +518,14 @@ export function ToolCallBlock({ entry, result, pending, onOpenSubagent, sessionI
         </span>
 
         {mcp ? (
-          <span className="flex min-w-0 flex-shrink-0 items-baseline gap-1.5 text-[14px] leading-5">
+			<span className="flex min-w-0 flex-shrink-0 items-baseline gap-1.5 text-body leading-5">
             <span className="rounded bg-panel px-1.5 py-px text-label leading-4 font-bold tracking-[-0.01em] text-dim">
               {mcp.server}
             </span>
             <span className="font-medium text-dim transition-colors group-hover:text-fg">{mcp.tool}</span>
           </span>
         ) : (
-          <span className="flex-shrink-0 text-[14px] leading-5 font-medium text-dim transition-colors group-hover:text-fg">{toolName}</span>
+          <span className="flex-shrink-0 text-body leading-5 font-medium text-dim transition-colors group-hover:text-fg">{toolName}</span>
         )}
 
         <span className="flex min-w-0 flex-1 items-center gap-2">
@@ -554,7 +554,7 @@ export function ToolCallBlock({ entry, result, pending, onOpenSubagent, sessionI
             role="button"
             tabIndex={0}
             className={cn(
-              "flex-shrink-0 rounded border border-line px-1.5 py-px text-meta text-dim opacity-100 transition-opacity hover:border-line-strong hover:text-fg focus:opacity-100",
+				"flex-shrink-0 rounded border border-line px-1.5 py-px text-meta text-dim opacity-100 transition-opacity hover:border-line-strong hover:text-fg focus:opacity-100 focus-ring",
               !subagentLive && "md:opacity-0 md:group-hover:opacity-100"
             )}
             onClick={(e) => {
@@ -683,7 +683,7 @@ function toolInputNode(toolName: string, input: unknown): React.ReactNode | null
 
   if (toolName === "Bash" && bashCommand(input)) {
     return (
-      <div className="tool-code-surface">
+      <div className="tool-code-surface overflow-x-auto rounded-md border border-white/6 bg-[#0d0f13] px-2.5 py-2 [tab-size:2] [html[data-theme=light]_&]:border-[#d8dee4] [html[data-theme=light]_&]:bg-[#f6f8fa] [&_.tool-pre]:text-[#b6bcc8] [html[data-theme=light]_&_.tool-pre]:text-[#57606a] [&_.shiki-gutter]:text-[#565d6b] [html[data-theme=light]_&_.shiki-gutter]:text-[#8c959f]">
         <CodeHighlight code={bashCommand(input)!} lang="bash" />
       </div>
     );
@@ -704,7 +704,7 @@ function toolInputNode(toolName: string, input: unknown): React.ReactNode | null
         : "");
     if (diff) {
       return (
-        <div className="tool-code-surface">
+        <div className="tool-code-surface overflow-x-auto rounded-md border border-white/6 bg-[#0d0f13] px-2.5 py-2 [tab-size:2] [html[data-theme=light]_&]:border-[#d8dee4] [html[data-theme=light]_&]:bg-[#f6f8fa] [&_.tool-pre]:text-[#b6bcc8] [html[data-theme=light]_&_.tool-pre]:text-[#57606a] [&_.shiki-gutter]:text-[#565d6b] [html[data-theme=light]_&_.shiki-gutter]:text-[#8c959f]">
           <CodeHighlight code={truncate(diff, 4000)} lang="diff" />
         </div>
       );
@@ -713,7 +713,7 @@ function toolInputNode(toolName: string, input: unknown): React.ReactNode | null
 
   if (toolName === "Write" && typeof inp.content === "string") {
     return (
-      <div className="tool-code-surface">
+        <div className="tool-code-surface overflow-x-auto rounded-md border border-white/6 bg-[#0d0f13] px-2.5 py-2 [tab-size:2] [html[data-theme=light]_&]:border-[#d8dee4] [html[data-theme=light]_&]:bg-[#f6f8fa] [&_.tool-pre]:text-[#b6bcc8] [html[data-theme=light]_&_.tool-pre]:text-[#57606a] [&_.shiki-gutter]:text-[#565d6b] [html[data-theme=light]_&_.shiki-gutter]:text-[#8c959f]">
         <CodeHighlight
           code={truncate(inp.content, 4000)}
           lang={langForFile(filePathOf(inp)) || "markdown"}

--- a/src/frontend/components/TurnBlock.tsx
+++ b/src/frontend/components/TurnBlock.tsx
@@ -155,7 +155,7 @@ export const TurnBlock = React.memo(function TurnBlock({
           userToggledRef.current = true;
           setExpanded(!expanded);
         }}
-        className="mx-auto flex w-full max-w-[var(--chat-col)] min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-1 text-left font-sans text-[14px] leading-5 text-dim transition-colors hover:bg-hover/40 hover:text-fg"
+        className="mx-auto flex w-full max-w-[var(--chat-col)] min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-1 text-left font-sans text-body leading-5 text-dim transition-colors hover:bg-hover/40 hover:text-fg"
       >
         <span
           className={cn(

--- a/src/frontend/components/TurnFooter.tsx
+++ b/src/frontend/components/TurnFooter.tsx
@@ -121,7 +121,7 @@ export const TurnFooter = React.memo(function TurnFooter({
           rather than mounted on hover (see .turn-footer-time), so its space is
           always reserved and revealing it never shifts the buttons out from
           under the cursor. */}
-      <span className="turn-footer-time ml-auto pl-3 text-xs font-medium text-faint">
+      <span className="turn-footer-time ml-auto hidden select-none whitespace-nowrap pl-3 text-meta font-medium text-faint [@media(hover:hover)]:block [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [&::selection]:bg-black/1">
         {fullTime(entry.timestamp)}
       </span>
     </div>
@@ -146,7 +146,7 @@ function turnFooterPropsEqual(prev: Props, next: Props): boolean {
 }
 
 const BTN =
-  "flex size-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-faint hover:bg-hover hover:text-dim";
+  "flex size-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-faint transition-colors hover:bg-hover hover:text-dim focus-ring";
 
 /** Friendly name for a per-message model id: opencode ids take their model
  * part, raw API ids drop the date suffix — "opencode/anthropic/claude-sonnet-5"
@@ -181,7 +181,7 @@ function FileChip({ file }: { file: TouchedFile }) {
       >
         <div className="flex items-center gap-2 border-b border-line px-2.5 py-2">
           <ExtBadge name={name} />
-          <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-dim">
+          <span className="min-w-0 flex-1 truncate font-mono text-meta text-dim">
             {tidyPath(file.path)}
           </span>
           <LineStats additions={file.additions} deletions={file.deletions} />
@@ -264,12 +264,12 @@ export function LineStats({
   className?: string;
 }) {
   return (
-    <span
-      className={cn(
-        "flex flex-shrink-0 items-center gap-1 text-[11px] font-medium",
-        className
-      )}
-    >
+		<span
+			className={cn(
+				"flex flex-shrink-0 items-center gap-1 text-meta font-medium",
+				className
+			)}
+		>
       <span className="text-green">+{additions}</span>
       <span className="text-red">-{deletions}</span>
     </span>

--- a/src/frontend/components/TurnFooter.tsx
+++ b/src/frontend/components/TurnFooter.tsx
@@ -71,7 +71,7 @@ export const TurnFooter = React.memo(function TurnFooter({
   return (
     <div className="mx-auto -mt-2.5 mb-[18px] flex w-full max-w-[var(--chat-col)] flex-wrap items-center gap-x-0.5 gap-y-1.5">
       {duration && (
-        <span className="mr-1.5 text-xs font-medium text-faint">{duration}</span>
+        <span className="mr-1.5 text-label font-medium text-faint">{duration}</span>
       )}
       <Tooltip label={copied ? "Copied" : "Copy message"}>
         <button type="button" onClick={doCopy} className={BTN}>
@@ -99,12 +99,12 @@ export const TurnFooter = React.memo(function TurnFooter({
           </Menu.Item>
           <Menu.Separator className="my-1" />
           {/* Touch has no hover, so the time also lives here — menus open on tap. */}
-          <div className="flex items-center gap-2 px-2.5 py-1.5 text-xs font-medium text-faint">
+          <div className="flex items-center gap-2 px-2.5 py-1.5 text-label font-medium text-faint">
             <IconClock size={20} />
             {fullTime(entry.timestamp)}
           </div>
           {entry.model && (
-            <div className="flex items-center gap-2 px-2.5 py-1.5 text-xs font-medium text-faint">
+            <div className="flex items-center gap-2 px-2.5 py-1.5 text-label font-medium text-faint">
               <IconSparkle size={20} />
               Written by {messageModelLabel(entry.model)}
             </div>
@@ -169,7 +169,7 @@ function FileChip({ file }: { file: TouchedFile }) {
         className="ml-1 flex h-6 min-w-0 cursor-pointer items-center gap-1.5 rounded-md bg-panel px-1.5"
       >
         <ExtBadge name={name} />
-        <span className="max-w-[180px] truncate text-xs font-medium text-dim">
+        <span className="max-w-[180px] truncate text-label font-medium text-dim">
           {name}
         </span>
         <LineStats additions={file.additions} deletions={file.deletions} />
@@ -188,7 +188,7 @@ function FileChip({ file }: { file: TouchedFile }) {
         </div>
         <div className="max-h-[min(360px,55vh)] overflow-y-auto p-1.5">
           {file.edits.length === 0 ? (
-            <div className="px-1.5 py-2 text-xs text-faint">
+            <div className="px-1.5 py-2 text-label text-faint">
               No captured changes for this file.
             </div>
           ) : (
@@ -245,7 +245,7 @@ function MoreChip({ files }: { files: TouchedFile[] }) {
         .join(", ") + (files.length > 12 ? ", …" : "")}
     >
       <span className="ml-1 flex h-6 items-center gap-1.5 rounded-md bg-panel px-1.5">
-        <span className="text-xs font-medium text-faint">
+        <span className="text-label font-medium text-faint">
           +{files.length} more
         </span>
         <LineStats additions={additions} deletions={deletions} />

--- a/src/frontend/components/UpdatePill.tsx
+++ b/src/frontend/components/UpdatePill.tsx
@@ -94,7 +94,7 @@ export function UpdatePill({ addHandler, variant = "toast" }: Props) {
   if (variant === "pill") {
     return (
       <button
-        className="update-pill"
+        className="update-pill inline-flex h-7 shrink-0 items-center rounded-full bg-red px-3 text-control-label font-semibold leading-none text-white transition-colors hover:bg-[color-mix(in_srgb,var(--red)_85%,black)] disabled:cursor-wait disabled:opacity-75 motion-reduce:animate-none"
         onClick={refresh}
         disabled={refreshing}
         role="status"
@@ -111,20 +111,20 @@ export function UpdatePill({ addHandler, variant = "toast" }: Props) {
   }
 
   return (
-    <div className="update-toast" role="status" aria-live="polite">
-      <div className="update-toast-body">
-        <span className="update-toast-text">
+    <div className="update-toast absolute inset-x-2 bottom-2 z-[9500] flex items-center justify-between gap-3 rounded-lg border border-line bg-panel py-2.5 pl-4 pr-2.5 [animation:update-toast-in_0.28s_cubic-bezier(0.16,1,0.3,1)] motion-reduce:animate-none" role="status" aria-live="polite">
+      <div className="update-toast-body flex min-w-0 flex-1 flex-col items-start gap-0.5">
+        <span className="update-toast-text max-w-full truncate text-control-label font-medium leading-[1.3] text-fg">
           {forced ? `Updating in ${secondsLeft}s…` : "New update available"}
         </span>
         {by && (
           <Tooltip label={by} side="top" multiline>
-            <span className="update-toast-by">{by}</span>
+            <span className="update-toast-by max-w-full truncate text-label font-medium leading-[1.3] text-dim">{by}</span>
           </Tooltip>
         )}
       </div>
-      <div className="update-toast-actions">
+      <div className="update-toast-actions flex shrink-0 items-center gap-1">
         <button
-          className="update-toast-refresh"
+          className="update-toast-refresh inline-flex h-[30px] items-center rounded-control bg-red px-3.5 text-control-label font-semibold leading-none text-white transition-colors hover:bg-[color-mix(in_srgb,var(--red)_85%,black)] disabled:cursor-wait disabled:opacity-75 focus-ring"
           onClick={refresh}
           disabled={refreshing}
         >

--- a/src/frontend/components/UserAvatar.tsx
+++ b/src/frontend/components/UserAvatar.tsx
@@ -46,7 +46,10 @@ export function UserAvatar({
 	useEffect(() => setFailed(false), [login]);
 	return (
 		<span
-			className={cn("user-avatar", className)}
+			className={cn(
+				"user-avatar relative inline-flex shrink-0 select-none items-center justify-center rounded-[32%] border border-line-strong bg-active font-bold text-dim [&>img]:absolute [&>img]:inset-0 [&>img]:size-full [&>img]:rounded-[inherit] [&>img]:object-cover",
+				className,
+			)}
 			style={{
 				width: size,
 				height: size,

--- a/src/frontend/components/UserPicker.tsx
+++ b/src/frontend/components/UserPicker.tsx
@@ -8,7 +8,7 @@ const GATE_CARD =
   "user-gate-card w-[380px] max-w-[calc(100vw-32px)] rounded-[calc(14px*var(--rf))] border border-line bg-raised p-8 text-center [corner-shape:var(--cs)]";
 const GATE_TITLE = "m-0 mb-5 text-[17px] font-semibold";
 const GATE_BUTTON =
-  "user-gate-btn flex flex-col items-center gap-2 rounded-[calc(8px*var(--rf))] border border-line-strong bg-panel p-3 text-sm text-fg [corner-shape:var(--cs)] transition-[background,border-color] hover:border-accent hover:bg-accent-soft disabled:cursor-default disabled:opacity-50";
+  "user-gate-btn flex flex-col items-center gap-2 rounded-[calc(8px*var(--rf))] border border-line-strong bg-panel p-3 text-control-label text-fg [corner-shape:var(--cs)] transition-[background,border-color] hover:border-accent hover:bg-accent-soft disabled:cursor-default disabled:opacity-50";
 
 /**
  * Mutable compatibility view for older consumers. `usePeople()` owns the
@@ -272,7 +272,7 @@ function GithubSignIn({
         <h2 className={GATE_TITLE}>Sign in</h2>
         {!flow ? (
           <>
-            <p className="my-2.5 mb-4 text-[13px] text-dim">
+            <p className="my-2.5 mb-4 text-control-label text-dim">
               This workspace uses GitHub sign-in. Your sessions will act as your
               own GitHub account (PRs are authored by you).
             </p>
@@ -301,7 +301,7 @@ function GithubSignIn({
             )}
           </>
         ) : (
-          <p className="mt-2.5 mb-0 text-sm leading-[1.7]">
+          <p className="mt-2.5 mb-0 text-control-label leading-[1.7]">
             Enter code{" "}
             <strong className="font-mono tracking-[0.12em]">
               {flow.userCode}

--- a/src/frontend/components/UserPicker.tsx
+++ b/src/frontend/components/UserPicker.tsx
@@ -3,6 +3,13 @@ import { UserAvatar } from "./UserAvatar";
 import { BASE_PATH } from "../lib/base";
 import { usePeople } from "../lib/people";
 
+const GATE_OVERLAY = "user-gate-overlay flex h-dvh items-center justify-center bg-bg";
+const GATE_CARD =
+  "user-gate-card w-[380px] max-w-[calc(100vw-32px)] rounded-[calc(14px*var(--rf))] border border-line bg-raised p-8 text-center [corner-shape:var(--cs)]";
+const GATE_TITLE = "m-0 mb-5 text-[17px] font-semibold";
+const GATE_BUTTON =
+  "user-gate-btn flex flex-col items-center gap-2 rounded-[calc(8px*var(--rf))] border border-line-strong bg-panel p-3 text-sm text-fg [corner-shape:var(--cs)] transition-[background,border-color] hover:border-accent hover:bg-accent-soft disabled:cursor-default disabled:opacity-50";
+
 /**
  * Mutable compatibility view for older consumers. `usePeople()` owns the
  * roster and updates this array in place after GET /api/people resolves.
@@ -140,15 +147,15 @@ export function UserGate({ children }: { children: React.ReactNode }) {
   if (user !== "Anonymous") return <>{children}</>;
 
   return (
-    <div className="user-gate-overlay">
-      <div className="user-gate-card">
-        <h2>Who are you?</h2>
-        <div className="user-gate-grid">
+    <div className={GATE_OVERLAY}>
+      <div className={GATE_CARD}>
+        <h2 className={GATE_TITLE}>Who are you?</h2>
+        <div className="user-gate-grid grid grid-cols-2 gap-2.5">
           {roster.length ? (
             roster.map(({ name }) => (
               <button
                 key={name}
-                className="user-gate-btn"
+                className={GATE_BUTTON}
                 onClick={() => setStoredUser(name)}
               >
                 <UserAvatar name={name} size={36} />
@@ -157,7 +164,7 @@ export function UserGate({ children }: { children: React.ReactNode }) {
             ))
           ) : (
             <button
-              className="user-gate-btn"
+              className={GATE_BUTTON}
               onClick={() => setStoredUser("Local User")}
             >
               <UserAvatar name="Local User" size={36} />
@@ -172,10 +179,10 @@ export function UserGate({ children }: { children: React.ReactNode }) {
 
 function LocalSessionExpired() {
   return (
-    <div className="user-gate-overlay">
-      <div className="user-gate-card">
-        <h2>GitHub sign-in expired</h2>
-        <p className="text-dim">
+    <div className={GATE_OVERLAY}>
+      <div className={GATE_CARD}>
+        <h2 className={GATE_TITLE}>GitHub sign-in expired</h2>
+        <p className="m-0 text-dim">
           Switch to cloud mode, sign in with GitHub, then restart local mode.
         </p>
       </div>
@@ -260,53 +267,43 @@ function GithubSignIn({
   }
 
   return (
-    <div className="user-gate-overlay">
-      <div className="user-gate-card" style={{ maxWidth: 380 }}>
-        <h2>Sign in</h2>
+    <div className={GATE_OVERLAY}>
+      <div className={GATE_CARD}>
+        <h2 className={GATE_TITLE}>Sign in</h2>
         {!flow ? (
           <>
-            <p style={{ margin: "10px 0 16px", fontSize: 13, opacity: 0.75 }}>
+            <p className="my-2.5 mb-4 text-[13px] text-dim">
               This workspace uses GitHub sign-in. Your sessions will act as your
               own GitHub account (PRs are authored by you).
             </p>
             {redirect ? (
               <>
                 <button
-                  className="user-gate-btn"
+                  className={`${GATE_BUTTON} w-full`}
                   onClick={() => {
                     window.location.href = `${BASE_PATH}/api/auth/login`;
                   }}
-                  style={{ width: "100%" }}
                 >
                   Sign in with GitHub
                 </button>
                 <button
                   onClick={start}
                   disabled={starting}
-                  style={{
-                    marginTop: 10,
-                    width: "100%",
-                    background: "none",
-                    border: "none",
-                    fontSize: 13,
-                    opacity: 0.6,
-                    textDecoration: "underline",
-                    cursor: "pointer",
-                  }}
+                  className="mt-2.5 w-full bg-transparent text-control-label text-dim underline disabled:cursor-default disabled:opacity-50"
                 >
                   {starting ? "Starting…" : "Use a device code instead"}
                 </button>
               </>
             ) : (
-              <button className="user-gate-btn" onClick={start} disabled={starting} style={{ width: "100%" }}>
+              <button className={`${GATE_BUTTON} w-full`} onClick={start} disabled={starting}>
                 {starting ? "Starting…" : "Sign in with GitHub"}
               </button>
             )}
           </>
         ) : (
-          <p style={{ margin: "10px 0 0", fontSize: 14, lineHeight: 1.7 }}>
+          <p className="mt-2.5 mb-0 text-sm leading-[1.7]">
             Enter code{" "}
-            <strong style={{ fontFamily: "var(--mono, monospace)", letterSpacing: "0.12em" }}>
+            <strong className="font-mono tracking-[0.12em]">
               {flow.userCode}
             </strong>{" "}
             at{" "}
@@ -314,11 +311,11 @@ function GithubSignIn({
               {flow.verificationUri.replace(/^https:\/\//, "")}
             </a>
             <br />
-            <span style={{ fontSize: 13, opacity: 0.7 }}>Waiting for GitHub…</span>
+            <span className="text-control-label text-dim">Waiting for GitHub…</span>
           </p>
         )}
         {error && (
-          <p style={{ marginTop: 10, fontSize: 13, color: "var(--red)" }}>{error}</p>
+          <p className="mt-2.5 text-control-label text-red">{error}</p>
         )}
       </div>
     </div>

--- a/src/frontend/components/VirtualTranscriptBlock.tsx
+++ b/src/frontend/components/VirtualTranscriptBlock.tsx
@@ -44,7 +44,7 @@ export const VirtualTranscriptBlock = React.memo(function VirtualTranscriptBlock
 		return (
 			<div
 				ref={ref}
-				className="transcript-window transcript-window-placeholder"
+				className="transcript-window transcript-window-placeholder pointer-events-none"
 				data-eid={anchorId}
 				aria-hidden
 				style={{ height: heightRef.current }}
@@ -55,7 +55,7 @@ export const VirtualTranscriptBlock = React.memo(function VirtualTranscriptBlock
 	return (
 		<div
 			ref={ref}
-			className={enabled ? "transcript-window transcript-settled" : "transcript-window"}
+			className={enabled ? "transcript-window transcript-settled [content-visibility:auto] [contain-intrinsic-size:auto_96px]" : "transcript-window"}
 		>
 			{children}
 		</div>

--- a/src/frontend/components/VoiceInput.tsx
+++ b/src/frontend/components/VoiceInput.tsx
@@ -3,6 +3,7 @@ import { transcribeClip } from "../lib/api";
 import { IconCheck, IconMic, IconPlus, IconX } from "./icons";
 import { Tooltip } from "../ui/tooltip";
 import { PRODUCT_NAME } from "../lib/brand";
+import { cn } from "../ui/cn";
 
 type Phase = "idle" | "recording" | "transcribing";
 
@@ -167,24 +168,31 @@ export function VoiceInput({
           <IconMic size={24} />
         </button>
       </Tooltip>
-      {error && phase === "idle" && <div className="voice-error">{error}</div>}
+      {error && phase === "idle" && (
+        <div className="voice-error absolute right-0 bottom-[calc(100%+8px)] z-[7] whitespace-nowrap rounded-[calc(10px*var(--rf))] border border-[color-mix(in_srgb,var(--red)_40%,transparent)] bg-red-soft px-[11px] py-[7px] text-[12.5px] font-medium text-red [corner-shape:var(--cs)]">
+          {error}
+        </div>
+      )}
       {phase !== "idle" && (
-        <div className="voice-overlay">
-          <span className="voice-lead" aria-hidden="true">
+        <div className="voice-overlay absolute inset-x-0 bottom-0 z-[6] flex h-[54px] items-center gap-2.5 rounded-b-[calc(16px*var(--rf))] border-t border-line bg-raised pr-3.5 pl-3 [corner-shape:var(--cs)]">
+          <span className="voice-lead inline-flex shrink-0 items-center text-faint" aria-hidden="true">
             <IconPlus size={22} />
           </span>
           {phase === "recording" ? (
             <>
               {/* Full-width track: baseline dots on the quiet/older left, live
                   bars accumulating on the right by the accept button. */}
-              <div className="voice-wave" aria-hidden="true">
+              <div className="voice-wave flex h-full min-w-0 flex-1 items-center gap-0.5 overflow-hidden" aria-hidden="true">
                 {Array.from({ length: BAR_COUNT }, (_, i) => {
                   const l = levels[levels.length - BAR_COUNT + i];
                   const active = l !== undefined;
                   return (
                     <span
                       key={i}
-                      className={active ? "is-live" : ""}
+                      className={cn(
+                        "mx-auto h-0.5 w-0.5 min-w-0 max-w-0.5 flex-[1_1_0] rounded-[calc(2px*var(--rf))] bg-faint [corner-shape:var(--cs)]",
+                        active && "is-live bg-dim transition-[height] duration-[90ms] ease-linear",
+                      )}
                       style={{ height: active ? `${16 + l * 84}%` : undefined }}
                     />
                   );
@@ -193,7 +201,7 @@ export function VoiceInput({
               <Tooltip label="Cancel">
                 <button
                   type="button"
-                  className="voice-glyph voice-cancel"
+                  className="voice-glyph voice-cancel inline-flex size-[34px] shrink-0 items-center justify-center rounded-[calc(8px*var(--rf))] bg-transparent text-dim transition-[color,background] duration-150 [corner-shape:var(--cs)] hover:bg-hover hover:text-fg"
                   onClick={() => stop(false)}
                   aria-label="Cancel dictation"
                 >
@@ -203,7 +211,7 @@ export function VoiceInput({
               <Tooltip label="Stop and transcribe">
                 <button
                   type="button"
-                  className="voice-glyph voice-accept"
+                  className="voice-glyph voice-accept inline-flex size-[34px] shrink-0 items-center justify-center rounded-[calc(8px*var(--rf))] bg-transparent text-fg transition-[color,background] duration-150 [corner-shape:var(--cs)] hover:bg-hover hover:text-accent"
                   onClick={() => stop(true)}
                   aria-label="Stop and transcribe"
                 >
@@ -213,9 +221,9 @@ export function VoiceInput({
             </>
           ) : (
             <>
-              <span className="voice-spinner" aria-hidden="true" />
-              <span className="voice-status">Transcribing…</span>
-              <span className="voice-wave-spacer" />
+              <span className="voice-spinner size-4 shrink-0 animate-spin rounded-full border-2 border-line-strong border-t-dim motion-reduce:animate-none" aria-hidden="true" />
+              <span className="voice-status shrink-0 text-[13.5px] font-medium text-dim">Transcribing…</span>
+              <span className="voice-wave-spacer flex-1" />
             </>
           )}
         </div>

--- a/src/frontend/components/VoiceInput.tsx
+++ b/src/frontend/components/VoiceInput.tsx
@@ -169,7 +169,7 @@ export function VoiceInput({
         </button>
       </Tooltip>
       {error && phase === "idle" && (
-        <div className="voice-error absolute right-0 bottom-[calc(100%+8px)] z-[7] whitespace-nowrap rounded-[calc(10px*var(--rf))] border border-[color-mix(in_srgb,var(--red)_40%,transparent)] bg-red-soft px-[11px] py-[7px] text-[12.5px] font-medium text-red [corner-shape:var(--cs)]">
+        <div className="voice-error absolute right-0 bottom-[calc(100%+8px)] z-[7] whitespace-nowrap rounded-[calc(10px*var(--rf))] border border-[color-mix(in_srgb,var(--red)_40%,transparent)] bg-red-soft px-[11px] py-[7px] text-supporting font-medium text-red [corner-shape:var(--cs)]">
           {error}
         </div>
       )}
@@ -222,7 +222,7 @@ export function VoiceInput({
           ) : (
             <>
               <span className="voice-spinner size-4 shrink-0 animate-spin rounded-full border-2 border-line-strong border-t-dim motion-reduce:animate-none" aria-hidden="true" />
-              <span className="voice-status shrink-0 text-[13.5px] font-medium text-dim">Transcribing…</span>
+              <span className="voice-status shrink-0 text-control-label font-medium text-dim">Transcribing…</span>
               <span className="voice-wave-spacer flex-1" />
             </>
           )}

--- a/src/frontend/components/WalkthroughCard.tsx
+++ b/src/frontend/components/WalkthroughCard.tsx
@@ -4,6 +4,7 @@ import { renderMarkdown } from "../lib/markdown";
 import { relativeTime } from "../lib/api";
 import { cn } from "../ui/cn";
 import { openLightbox, type LightboxItem } from "./MediaLightbox";
+import { MARKDOWN_STYLES } from "./MarkdownBody";
 
 /** Stream server-side media (staged under the uploads dir) through the
  *  existing scoped media route — same URL shape MessageBubble uses. */
@@ -74,7 +75,7 @@ export function WalkthroughCard({
 					Walkthrough
 				</span>
 				{chat && walkthrough.publishedAt && (
-					<span className="text-[11px] text-faint">
+					<span className="text-meta text-faint">
 						{relativeTime(walkthrough.publishedAt)}
 					</span>
 				)}
@@ -92,7 +93,7 @@ export function WalkthroughCard({
 						title={walkthrough.videoTitle || "Demo video"}
 					/>
 					{chat && walkthrough.videoTitle ? (
-						<div className="mb-2 mt-1 text-[11px] text-faint">
+						<div className="mb-2 mt-1 text-meta text-faint">
 							{walkthrough.videoTitle}
 						</div>
 					) : (
@@ -101,7 +102,7 @@ export function WalkthroughCard({
 				</>
 			)}
 			<div
-				className="markdown text-[13px]"
+				className={`markdown ${MARKDOWN_STYLES} text-control-label`}
 				dangerouslySetInnerHTML={{ __html: summaryHtml }}
 			/>
 			{(walkthrough.shots || []).map((shot, i) => (
@@ -114,7 +115,7 @@ export function WalkthroughCard({
 							(side) =>
 								shot[side] && (
 									<figure className="m-0 min-w-0 flex-1" key={side}>
-										<figcaption className="mb-1 text-[11px] font-medium text-dim">
+										<figcaption className="mb-1 text-meta font-medium text-dim">
 											{side === "before" ? "Before" : "After"}
 										</figcaption>
 										<img

--- a/src/frontend/components/WalkthroughCard.tsx
+++ b/src/frontend/components/WalkthroughCard.tsx
@@ -71,7 +71,7 @@ export function WalkthroughCard({
 			)}
 		>
 			<div className="mb-2 flex items-baseline gap-2">
-				<span className="text-xs font-semibold text-dim">
+				<span className="text-label font-semibold text-dim">
 					Walkthrough
 				</span>
 				{chat && walkthrough.publishedAt && (
@@ -108,7 +108,7 @@ export function WalkthroughCard({
 			{(walkthrough.shots || []).map((shot, i) => (
 				<div className="mt-3" key={i}>
 					{shot.caption && (
-						<div className="mb-1 text-xs text-dim">{shot.caption}</div>
+						<div className="mb-1 text-label text-dim">{shot.caption}</div>
 					)}
 					<div className="flex gap-2">
 						{(["before", "after"] as const).map(

--- a/src/frontend/components/WorkBlock.tsx
+++ b/src/frontend/components/WorkBlock.tsx
@@ -50,12 +50,12 @@ export const WorkBlock = React.memo(function WorkBlock({
   ).length;
 
   return (
-    <div className="mx-auto mb-3 max-w-[var(--chat-col)]">
+    <div className="mx-auto mb-3 w-full max-w-[var(--chat-col)]">
       <button
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-1 text-left font-sans text-supporting text-dim hover:bg-hover"
+        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-1 py-1 text-left font-sans text-supporting text-dim transition-colors hover:bg-hover focus-ring"
       >
         <span
           className={cn(
@@ -76,7 +76,7 @@ export const WorkBlock = React.memo(function WorkBlock({
           <span className="flex-shrink-0 text-meta text-red/80">· {failures} failed</span>
         )}
         {!expanded && last && (
-          <span className="min-w-0 truncate font-mono text-[11px] text-faint">
+          <span className="min-w-0 truncate font-mono text-meta text-faint">
             {toolDisplayName(last.toolName)}:{" "}
             {toolSummary(last.toolName || "Tool", last.toolInput, last.content, pathRoots)}
           </span>

--- a/src/frontend/components/WorkflowAgentTranscript.tsx
+++ b/src/frontend/components/WorkflowAgentTranscript.tsx
@@ -107,7 +107,7 @@ export function WorkflowAgentTranscript({ runId, agent, onBack }: Props) {
 					>
 						<path d="M7.5 2 3.5 6l4 4" />
 					</svg>
-					<span className="min-w-0 flex-1 truncate text-sm font-medium text-fg">
+					<span className="min-w-0 flex-1 truncate text-control-label font-medium text-fg">
 						{agent.label}
 					</span>
 					{agent.status === "running" && (
@@ -158,7 +158,7 @@ function Placeholder({
 	return (
 		<div
 			className={cn(
-				"px-1 py-3 text-xs leading-relaxed",
+				"px-1 py-3 text-label leading-relaxed",
 				tone === "error" ? "text-red" : "text-faint",
 			)}
 		>

--- a/src/frontend/components/WorkflowAgentTranscript.tsx
+++ b/src/frontend/components/WorkflowAgentTranscript.tsx
@@ -114,7 +114,7 @@ export function WorkflowAgentTranscript({ runId, agent, onBack }: Props) {
 						<span className="size-1.5 shrink-0 animate-pulse rounded-full bg-green" />
 					)}
 				</button>
-				<div className="mt-0.5 pl-[18px] text-[11px] text-faint tabular-nums">
+				<div className="mt-0.5 pl-[18px] text-meta text-faint tabular-nums">
 					{[
 						`agent ${agent.seq}`,
 						agent.status,

--- a/src/frontend/components/WorkspaceInfo.tsx
+++ b/src/frontend/components/WorkspaceInfo.tsx
@@ -146,7 +146,7 @@ const INFO_SECTION_CLASS = "grid gap-[5px]";
 const INFO_LIST_CLASS =
 	"grid gap-px overflow-hidden rounded-lg bg-panel p-1";
 const INFO_MORE_BUTTON_CLASS =
-	"cursor-pointer bg-panel px-[9px] py-[7px] text-left text-label font-semibold text-faint transition-colors hover:bg-hover hover:text-fg";
+	"cursor-pointer bg-panel px-[9px] py-[7px] text-left text-label font-semibold text-faint transition-colors hover:bg-hover hover:text-fg focus-ring";
 
 function statusBadgeClass(status: DiffFile["status"]): string {
 	switch (statusClass(status)) {
@@ -167,6 +167,27 @@ const ACTION_BUTTON_CLASS =
 	"flex min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left text-supporting font-semibold text-fg outline-none transition-colors hover:bg-hover focus-visible:bg-hover disabled:cursor-default disabled:opacity-50";
 const ACTION_ICON_CLASS =
 	"inline-flex size-5 shrink-0 items-center justify-center text-faint [&_svg]:block";
+const GIT_ROW_CLASS = "pr-git-row flex min-h-7 items-center gap-2.5 py-2";
+const GIT_DOT_CLASS = "pr-git-dot size-[7px] shrink-0 rounded-full";
+const GIT_LABEL_CLASS = "pr-git-label text-control-label leading-[1.3] text-dim";
+const GIT_ACTION_CLASS = "pr-git-action ml-auto min-h-7 rounded-sm border border-line-strong px-3 py-1 text-control-label text-dim transition-colors hover:bg-hover hover:text-fg disabled:cursor-default disabled:opacity-50 focus-ring";
+
+function gitDotClass(tone: "green" | "purple" | "yellow" | "muted" | "red" | "blue"): string {
+	switch (tone) {
+		case "green":
+			return `${GIT_DOT_CLASS} bg-green`;
+		case "purple":
+			return `${GIT_DOT_CLASS} bg-purple`;
+		case "red":
+			return `${GIT_DOT_CLASS} bg-red`;
+		case "blue":
+			return `${GIT_DOT_CLASS} bg-blue`;
+		case "muted":
+			return `${GIT_DOT_CLASS} bg-faint`;
+		default:
+			return `${GIT_DOT_CLASS} bg-yellow`;
+	}
+}
 
 function initial(name: string): string {
 	return (name.trim()[0] || "?").toUpperCase();
@@ -276,7 +297,7 @@ function CommentAvatar({ author }: { author: string }) {
 	}
 	return (
 		<span
-			className="grid size-6 shrink-0 place-items-center rounded-full border border-line bg-active text-[11px] font-semibold text-white"
+			className="grid size-6 shrink-0 place-items-center rounded-full border border-line bg-active text-meta font-semibold text-white"
 			style={{ background: `hsl(${hueFor(login || "?")} 52% 42%)` }}
 			aria-hidden
 		>
@@ -310,7 +331,7 @@ function CommentCard({
 	const addBtn = onAddToInput && (
 		<button
 			type="button"
-			className="absolute right-1.5 top-1/2 z-[1] -translate-y-1/2 rounded-md border border-line-strong bg-panel px-2 py-0.5 text-[11px] font-semibold text-dim opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:border-faint hover:bg-hover hover:text-fg"
+			className="absolute right-1.5 top-1/2 z-[1] -translate-y-1/2 rounded-md border border-line-strong bg-panel px-2 py-0.5 text-meta font-semibold text-dim opacity-0 transition-opacity duration-150 group-hover:opacity-100 hover:border-faint hover:bg-hover hover:text-fg"
 			onClick={(e) => {
 				e.stopPropagation();
 				onAddToInput(formatPrCommentPrompt(comment, pr));
@@ -416,7 +437,7 @@ function FileRow({
 		[theme],
 	);
 	const stats = (
-		<span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-semibold tabular-nums">
+		<span className="inline-flex shrink-0 items-center gap-1 text-meta font-semibold tabular-nums">
 			{file.additions > 0 && (
 				<span className="text-green">+{file.additions}</span>
 			)}
@@ -445,7 +466,7 @@ function FileRow({
 			>
 				<span
 					className={cn(
-						"inline-flex size-[18px] shrink-0 items-center justify-center rounded-[4px] text-[11px] font-bold",
+						"inline-flex size-[18px] shrink-0 items-center justify-center rounded-[4px] text-meta font-bold",
 						statusBadgeClass(file.status),
 					)}
 				>
@@ -662,7 +683,7 @@ function ChecksChip({
 								>
 									<CheckStatusIcon kind={status.kind} />
 								</span>
-								<span className="min-w-0 flex-1 truncate text-[13px] font-medium text-fg">
+								<span className="min-w-0 flex-1 truncate text-control-label font-medium text-fg">
 									{check.name}
 								</span>
 								<span className="shrink-0 text-label font-medium text-dim">
@@ -939,14 +960,14 @@ function MichaelReviewCard({
 								<div className="flex items-center gap-2.5 border-b border-line px-4 py-3">
 									<CommentAvatar author={reviewComment?.author || "tella-butler"} />
 									<div className="min-w-0 flex-1">
-										<div className="truncate text-[13px] font-semibold text-fg">
+										<div className="truncate text-control-label font-semibold text-fg">
 											{reviewComment?.author || "tella-butler"}
 										</div>
 										<div className="text-meta text-faint">
 											Automated review{reviewedAgo ? ` · reviewed ${reviewedAgo} ago` : ""}
 										</div>
 									</div>
-									<span className={cn("shrink-0 text-[13px] font-semibold", scoreTone)}>
+									<span className={cn("shrink-0 text-control-label font-semibold", scoreTone)}>
 										{score ?? "–"}/5
 									</span>
 								</div>
@@ -993,7 +1014,7 @@ function MichaelReviewCard({
 				)}
 			</div>
 			{done && (
-				<div className="px-1 text-[11px] font-medium text-dim">
+				<div className="px-1 text-meta font-medium text-dim">
 					Started {done.label.toLowerCase()} — {AGENT_NAME} will post results on{" "}
 					{pr.url ? (
 						<a
@@ -1021,7 +1042,7 @@ function MichaelReviewCard({
 				</div>
 			)}
 			{error && (
-				<div className="px-1 text-[11px] font-medium text-red">
+				<div className="px-1 text-meta font-medium text-red">
 					{error}
 				</div>
 			)}
@@ -1361,17 +1382,17 @@ function GitStatusRows({
 			<div className={INFO_LABEL_CLASS}>Git status</div>
 			<div className={INFO_LIST_CLASS}>
 				{prStatus && (
-					<div className="pr-git-row py-2">
-						<span className={`pr-git-dot pr-git-dot-${prTone}`} aria-hidden />
-						<span className="pr-git-label">{prStatus}</span>
+					<div className={GIT_ROW_CLASS}>
+						<span className={gitDotClass(prTone)} aria-hidden />
+						<span className={GIT_LABEL_CLASS}>{prStatus}</span>
 						{pr?.mergeable === "CONFLICTING" && send ? (
-							<button type="button" className="pr-git-action" onClick={resolveConflicts}>
+							<button type="button" className={GIT_ACTION_CLASS} onClick={resolveConflicts}>
 								Resolve
 							</button>
 						) : pr?.state === "OPEN" && !pr.isDraft ? (
 							<button
 								type="button"
-								className="pr-git-action"
+								className={GIT_ACTION_CLASS}
 								disabled={!!busy}
 								onClick={() => void merge()}
 								title="Squash and merge this pull request"
@@ -1386,14 +1407,14 @@ function GitStatusRows({
 					</div>
 				)}
 				{ahead > 0 && (
-					<div className="pr-git-row py-2">
-						<span className="pr-git-dot pr-git-dot-blue" aria-hidden />
-						<span className="pr-git-label">
+					<div className={GIT_ROW_CLASS}>
+						<span className={gitDotClass("blue")} aria-hidden />
+						<span className={GIT_LABEL_CLASS}>
 							{ahead} commit{ahead === 1 ? "" : "s"} ahead of remote
 						</span>
 						<button
 							type="button"
-							className="pr-git-action"
+							className={GIT_ACTION_CLASS}
 							disabled={!!busy}
 							onClick={() => run("push", () => gitPushApi(sessionId, repo))}
 						>
@@ -1402,15 +1423,15 @@ function GitStatusRows({
 					</div>
 				)}
 				{behindCount > 0 && (
-					<div className="pr-git-row py-2">
-						<span className="pr-git-dot pr-git-dot-yellow" aria-hidden />
-						<span className="pr-git-label">
+					<div className={GIT_ROW_CLASS}>
+						<span className={gitDotClass("yellow")} aria-hidden />
+						<span className={GIT_LABEL_CLASS}>
 							{behindCount} commit{behindCount === 1 ? "" : "s"} behind{" "}
 							{behindWhat}
 						</span>
 						<button
 							type="button"
-							className="pr-git-action"
+							className={GIT_ACTION_CLASS}
 							disabled={!!busy}
 							title={
 								behindWhat === "remote"
@@ -1426,15 +1447,15 @@ function GitStatusRows({
 					</div>
 				)}
 				{dirty > 0 && (
-					<div className="pr-git-row py-2">
-						<span className="pr-git-dot pr-git-dot-yellow" aria-hidden />
-						<span className="pr-git-label">
+					<div className={GIT_ROW_CLASS}>
+						<span className={gitDotClass("yellow")} aria-hidden />
+						<span className={GIT_LABEL_CLASS}>
 							{dirty} uncommitted file{dirty === 1 ? "" : "s"}
 						</span>
 						{send && (
 							<button
 								type="button"
-								className="pr-git-action"
+								className={GIT_ACTION_CLASS}
 								onClick={commit}
 								title={`Ask ${AGENT_NAME} to commit the uncommitted changes and push`}
 							>
@@ -1444,8 +1465,8 @@ function GitStatusRows({
 					</div>
 				)}
 			</div>
-			{prompted && <div className="pr-git-note">Asked {AGENT_NAME} to {prompted} ✓</div>}
-			{error && <div className="pr-git-note pr-git-note-error">{error}</div>}
+			{prompted && <div className="pr-git-note text-meta text-dim">Asked {AGENT_NAME} to {prompted} ✓</div>}
+			{error && <div className="pr-git-note pr-git-note-error text-meta text-red">{error}</div>}
 		</div>
 	);
 }
@@ -1669,7 +1690,7 @@ export function WorkspaceInfo({
 	return (
 		<div className="workspace-info-panel flex flex-col gap-4 px-2 pb-[22px] pt-3">
 			<div className="grid gap-1 px-1">
-				<div className="workspace-info-title selectable text-item-title font-[680] leading-[1.2] text-fg">
+				<div className="workspace-info-title selectable break-words text-item-title font-[680] leading-[1.2] text-fg">
 					{title}
 				</div>
 				{meta && <div className="text-label leading-[1.35] text-faint">{meta}</div>}
@@ -1720,7 +1741,7 @@ export function WorkspaceInfo({
 								{onAddToInput && (
 									<button
 										type="button"
-										className="rounded-md border border-line bg-surface px-2 py-0.5 text-[11px] font-semibold text-dim transition-colors hover:border-line-strong hover:bg-hover hover:text-fg"
+										className="rounded-md border border-line bg-surface px-2 py-0.5 text-meta font-semibold text-dim transition-colors hover:border-line-strong hover:bg-hover hover:text-fg"
 										onClick={() =>
 											onAddToInput(formatFixCommentsPrompt(comments, pr!))
 										}
@@ -1763,7 +1784,7 @@ export function WorkspaceInfo({
 								<span>
 									{changed.length} file{changed.length === 1 ? "" : "s"} changed
 								</span>
-								<span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-semibold tabular-nums">
+								<span className="inline-flex shrink-0 items-center gap-1 text-meta font-semibold tabular-nums">
 									{totalAdd > 0 && (
 										<span className="text-green">+{totalAdd}</span>
 									)}
@@ -1878,7 +1899,7 @@ export function WorkspaceInfo({
 									>
 										<IconFile size={14} className="shrink-0 text-faint" />
 										<span className="min-w-0 flex-1 truncate">{a.path}</span>
-										<span className="shrink-0 text-[11px] text-faint">
+										<span className="shrink-0 text-meta text-faint">
 											{fmtBytes(a.size)}
 										</span>
 									</button>

--- a/src/frontend/components/WorkspacePane.tsx
+++ b/src/frontend/components/WorkspacePane.tsx
@@ -159,12 +159,12 @@ export function WorkspacePane({
 	// surface, so it always shows one — even chat-less (Michiel 2026-07-24).
 	// Compact info: identity, linkage (repo/branch/PR/ticket), and its chats.
 	const infoPanel = !isPhone && (
-		<aside className="viewer-panel">
+		<aside className="viewer-panel relative flex min-h-0 w-[var(--panel-w,44%)] min-w-[320px] max-w-[max(480px,calc(100vw-620px))] shrink-0 flex-col border-l border-line bg-raised">
 			<div className="flex-1 min-h-0 overflow-y-auto p-4">
-				<div className="text-fg font-semibold text-item-title leading-snug">
+				<div className="text-item-title font-semibold leading-snug text-fg">
 					{workspace.name}
 				</div>
-				<div className="text-dim text-supporting mt-2 flex flex-col gap-1.5">
+				<div className="mt-2 flex flex-col gap-1.5 text-supporting text-dim">
 					{workspace.repo && (
 						<div className="flex items-center gap-2 min-w-0">
 							<span className="text-faint shrink-0">Repo</span>
@@ -174,7 +174,7 @@ export function WorkspacePane({
 					{workspace.branch && (
 						<div className="flex items-center gap-2 min-w-0">
 							<span className="text-faint shrink-0">Branch</span>
-							<span className="text-label truncate">
+							<span className="truncate text-label">
 								{workspace.branch}
 							</span>
 						</div>
@@ -211,7 +211,7 @@ export function WorkspacePane({
 						Chats
 					</div>
 					{chats.length === 0 ? (
-						<div className="text-dim text-supporting mt-1.5">
+						<div className="mt-1.5 text-supporting text-dim">
 							None yet — the composer below starts the first one
 							{workspace.branch ? " on the PR's branch" : ""}.
 						</div>
@@ -220,7 +220,7 @@ export function WorkspacePane({
 							{chats.map((c) => (
 								<button
 									key={c.id}
-									className="text-left text-[13px] text-dim hover:text-fg truncate py-1 cursor-pointer bg-transparent border-0 p-0"
+									className="cursor-pointer truncate border-0 bg-transparent py-1 text-left text-control-label text-dim hover:text-fg"
 									onClick={() => onOpenSession(c.id)}
 								>
 									{c.title || "Untitled chat"}
@@ -302,14 +302,14 @@ export function WorkspacePane({
 					<div className="text-section-title font-semibold text-fg">
 						{workspace.name}
 					</div>
-					<div className="text-dim text-supporting mt-1 flex items-center gap-2 flex-wrap">
+					<div className="mt-1 flex flex-wrap items-center gap-2 text-supporting text-dim">
 						{workspace.repo && <span>{workspace.repo}</span>}
 						{workspace.branch && (
 							<span className="text-label">{workspace.branch}</span>
 						)}
 					</div>
 					{chats.length === 0 && (
-						<div className="text-dim text-[13px] mt-5">
+						<div className="mt-5 text-control-label text-dim">
 							No chats in this workspace yet — start one below
 							{workspace.branch ? " on the PR's branch" : ""}.
 						</div>

--- a/src/frontend/components/useFileMentions.tsx
+++ b/src/frontend/components/useFileMentions.tsx
@@ -272,7 +272,7 @@ export function useFileMentions({ value, onChange, textareaRef, mentionFetch, sk
             role="option"
             aria-selected={i === activeIdx}
             className={cn(
-              "mention-item flex cursor-pointer items-baseline gap-2 overflow-hidden rounded-md px-[9px] py-1.5 text-[12.5px] leading-[1.3] whitespace-nowrap",
+              "mention-item flex cursor-pointer items-baseline gap-2 overflow-hidden rounded-md px-[9px] py-1.5 text-supporting leading-[1.3] whitespace-nowrap",
               i === activeIdx && "mention-item-active bg-pressed",
             )}
             onMouseDown={(e) => {
@@ -281,13 +281,13 @@ export function useFileMentions({ value, onChange, textareaRef, mentionFetch, sk
             }}
             onMouseEnter={() => setActiveIdx(i)}
           >
-            {isSession && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">session</span>}
-            {isPerson && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">person</span>}
-            {!isSession && !isSkill && !isPerson && item.repo && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">{item.repo}</span>}
+            {isSession && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-meta font-semibold text-accent">session</span>}
+            {isPerson && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-meta font-semibold text-accent">person</span>}
+            {!isSession && !isSkill && !isPerson && item.repo && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-meta font-semibold text-accent">{item.repo}</span>}
             <span className="mention-base shrink-0 font-medium text-fg">{isSkill ? `/${base}` : isDir ? `${base}/` : base}</span>
             {isSession || isSkill || isPerson
-              ? item.sub && <span className="mention-dir overflow-hidden text-[11.5px] text-ellipsis text-left text-faint [direction:rtl]">{item.sub}</span>
-              : dir && <span className="mention-dir overflow-hidden text-[11.5px] text-ellipsis text-left text-faint [direction:rtl]">{dir}</span>}
+              ? item.sub && <span className="mention-dir overflow-hidden text-meta text-ellipsis text-left text-faint [direction:rtl]">{item.sub}</span>
+              : dir && <span className="mention-dir overflow-hidden text-meta text-ellipsis text-left text-faint [direction:rtl]">{dir}</span>}
           </div>
         );
       })}

--- a/src/frontend/components/useFileMentions.tsx
+++ b/src/frontend/components/useFileMentions.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { FileMention } from "../lib/api";
+import { cn } from "../ui/cn";
 
 /**
  * Find the active "@"-mention being typed at the caret. Returns the index of
@@ -251,7 +252,11 @@ export function useFileMentions({ value, onChange, textareaRef, mentionFetch, sk
   }
 
   const popup = open && pos ? createPortal(
-    <div className="mention-popup" role="listbox" style={pos}>
+    <div
+      className="mention-popup fixed z-[10500] max-h-60 overflow-y-auto rounded-lg border border-line bg-control p-1 shadow-[0_8px_28px_rgba(0,0,0,0.28)]"
+      role="listbox"
+      style={pos}
+    >
       {suggestions.map((item, i) => {
         const isSession = item.kind === "session";
         const isSkill = item.kind === "skill";
@@ -266,20 +271,23 @@ export function useFileMentions({ value, onChange, textareaRef, mentionFetch, sk
             key={`${item.insert}-${i}`}
             role="option"
             aria-selected={i === activeIdx}
-            className={`mention-item ${i === activeIdx ? "mention-item-active" : ""}`}
+            className={cn(
+              "mention-item flex cursor-pointer items-baseline gap-2 overflow-hidden rounded-md px-[9px] py-1.5 text-[12.5px] leading-[1.3] whitespace-nowrap",
+              i === activeIdx && "mention-item-active bg-pressed",
+            )}
             onMouseDown={(e) => {
               e.preventDefault();
               applySuggestion(item);
             }}
             onMouseEnter={() => setActiveIdx(i)}
           >
-            {isSession && <span className="mention-repo">session</span>}
-            {isPerson && <span className="mention-repo">person</span>}
-            {!isSession && !isSkill && !isPerson && item.repo && <span className="mention-repo">{item.repo}</span>}
-            <span className="mention-base">{isSkill ? `/${base}` : isDir ? `${base}/` : base}</span>
+            {isSession && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">session</span>}
+            {isPerson && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">person</span>}
+            {!isSession && !isSkill && !isPerson && item.repo && <span className="mention-repo shrink-0 self-center rounded-sm bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] px-[5px] py-px text-[10.5px] font-semibold text-accent">{item.repo}</span>}
+            <span className="mention-base shrink-0 font-medium text-fg">{isSkill ? `/${base}` : isDir ? `${base}/` : base}</span>
             {isSession || isSkill || isPerson
-              ? item.sub && <span className="mention-dir">{item.sub}</span>
-              : dir && <span className="mention-dir">{dir}</span>}
+              ? item.sub && <span className="mention-dir overflow-hidden text-[11.5px] text-ellipsis text-left text-faint [direction:rtl]">{item.sub}</span>
+              : dir && <span className="mention-dir overflow-hidden text-[11.5px] text-ellipsis text-left text-faint [direction:rtl]">{dir}</span>}
           </div>
         );
       })}

--- a/src/frontend/hooks/useBackSwipe.ts
+++ b/src/frontend/hooks/useBackSwipe.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
  * iOS-style edge-swipe-to-go-back for the mobile page stack, plus a permanent
  * guard against the browser's own history-navigation gesture. On phones the
  * sidebar is the root page and a session/view is pushed over it (see the
- * `.mobile-detail` rules in global.css); overlays (the workspace/right panel,
+ * `.mobile-detail` rules in adapters.css); overlays (the workspace/right panel,
  * the session info page) stack further layers on top. A drag that STARTS near
  * the left edge pulls the topmost active layer's pane to the right under the
  * finger and, past the halfway point, pops it (calls its `onBack`).

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -74,7 +74,7 @@
         document.documentElement.classList.add("material-backdrop");
 
       // Window Controls Overlay detection → `html.wco` (drives the titlebar
-      // band + drag region in global.css). JS instead of the display-mode
+      // band + drag region in adapters.css). JS instead of the display-mode
       // media query because Electron (the OS¹ desktop shell) exposes the WCO
       // geometry while display-mode stays "browser". Re-evaluated on change so
       // fullscreen (controls auto-hide) drops the band, matching PWA behavior.

--- a/src/frontend/lib/theme.ts
+++ b/src/frontend/lib/theme.ts
@@ -1,7 +1,7 @@
 // Appearance theme: follow the OS ("system", the default) or force light/dark.
 // Stored per-browser in localStorage — it's an appearance/device preference, not
 // per-user cloud state like pins — and applied to <html data-theme>, which drives
-// the CSS-variable palette in styles/global.css. Kept in its own module so the
+// the CSS-variable palette in styles/adapters.css. Kept in its own module so the
 // pre-paint inline script in index.html and the React SettingsMenu share one
 // source of truth for the key and the resolution logic.
 

--- a/src/frontend/styles/adapters.css
+++ b/src/frontend/styles/adapters.css
@@ -1,3 +1,11 @@
+/* Non-utility contracts for the Tailwind entry.
+ *
+ * Component-owned presentation belongs in JSX utilities. This file is limited
+ * to document/theme foundations, generated-content and third-party adapters,
+ * native-shell hooks, responsive state coupling, and shared keyframes. It is
+ * pruned against the frontend source; keep new component styling out of here.
+ */
+
 /* ─────────────────────────────────────────────────────────────
    Michael — Tella's internal coding agent
    Devin-inspired dark theme
@@ -133,14 +141,6 @@ html[data-theme="light"] {
 }
 
 /* Spots that hardcode light-on-dark colors and would break on a light surface. */
-html[data-theme="light"] .diff-line-add {
-	background: rgba(26, 127, 55, 0.12);
-	color: #1a7f37;
-}
-html[data-theme="light"] .diff-line-del {
-	background: rgba(207, 34, 46, 0.1);
-	color: #b3261e;
-}
 html[data-theme="light"] .markdown code {
 	background: rgba(0, 0, 0, 0.06);
 	color: #953b39;
@@ -153,29 +153,8 @@ html[data-theme="light"] .markdown pre {
 html[data-theme="light"] .markdown pre code {
 	color: inherit;
 }
-html[data-theme="light"] .note-chip-session {
-	color: #c0322f;
-}
-html[data-theme="light"] .note-chip-note {
-	color: #1a7f37;
-}
-html[data-theme="light"] .note-chip-doc {
-	color: #6f42c1;
-}
 /* Source chips (.source-slack/.linear/.backstage/.ask) use light-on-dark
    colors for the dark theme; re-tone them to dark-on-light so they stay legible. */
-html[data-theme="light"] .source-slack {
-	background: rgba(122, 43, 124, 0.12);
-	color: #8a2b8c;
-}
-html[data-theme="light"] .source-linear {
-	background: rgba(94, 106, 210, 0.14);
-	color: #4650c0;
-}
-html[data-theme="light"] .source-backstage {
-	background: rgba(13, 148, 136, 0.14);
-	color: #0f766e;
-}
 html[data-theme="light"] .source-ask {
 	background: rgba(210, 153, 34, 0.16);
 	color: #9a6700;
@@ -290,8 +269,6 @@ select,
 .msg-system-text,
 .markdown,
 .markdown *,
-.diff-line,
-.diff-line *,
 code,
 pre,
 .selectable,
@@ -369,7 +346,6 @@ button {
 
 	.diff-file,
 	.pr-checks,
-	.pr-git,
 	.pr-body,
 	.composer-schedule-modal,
 	.composer-schedule-input,
@@ -379,32 +355,24 @@ button {
 	.composer-file-thumb,
 	.composer-queue-item,
 	.composer-queue-action,
-	.composer-queue-images img,
 	.mention-popup,
 	.mention-item,
 	.mention-repo,
 	.composer-menu,
 	.composer-menu-item,
-	.fork-banner,
 	.palette-card,
 	.palette-trigger,
 	.plain-entry,
 	.setting-card,
-	.ui-select,
 	.user-avatar,
 	.user-avatar img,
 	.rv-avatar,
-	.slack-avatar,
 	.viewer-branch-editable,
 	.viewer-branch-rename,
 	.session-info-list,
-	.btn-viewer-overflow,
 	.session-link,
 	.btn-panel-toggle,
-	.btn-viewer-delete,
-	.btn-viewer-archive,
 	.btn-viewer-newchat,
-	.btn-viewer-share,
 	.pr-num-chip,
 	.btn-viewer-pin,
 	.sidebar-nav-item,
@@ -658,23 +626,7 @@ html.wco .app-body.sidebar-collapsed
 	}
 }
 
-.app-title {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	font-size: 15px;
-	font-weight: 600;
-	color: var(--text);
-	text-decoration: none;
-	letter-spacing: -0.01em;
-}
-
 /* ── Settings dropdown (chevron behind the Michael title) ── */
-.settings-hint {
-	margin-top: 8px;
-	font-size: 11px;
-	color: var(--text-faint);
-}
 
 /* KITT scanner: black tile, glowing red M, a red beam sweeping across it */
 .app-logo {
@@ -881,16 +833,6 @@ html.wco .app-body.sidebar-collapsed
 	color: var(--text-dim);
 }
 
-.sidebar-section-label {
-	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: 0.02em;
-	color: var(--text-faint);
-	padding: 12px 16px 0;
-	border-top: 1px solid var(--border);
-	margin-top: 4px;
-}
-
 .app-body {
 	display: flex;
 	flex: 1;
@@ -919,28 +861,8 @@ html.wco .app-body.sidebar-collapsed
 	corner-shape: var(--cs);
 	box-shadow: -2px 1px 5px -1px rgba(0, 0, 0, 0.1);
 }
-html[data-platform="mac"] .workspace-shell {
-	--workspace-shell-radius: 8px;
-}
-html[data-platform="windows"] .workspace-shell {
-	--workspace-shell-radius: 8px;
-}
 .app-body.sidebar-collapsed .workspace-shell {
 	margin-left: 3px;
-}
-.hamburger {
-	display: none;
-	flex-direction: column;
-	gap: 4px;
-	background: none;
-	border: none;
-	padding: 6px;
-}
-.hamburger span {
-	width: 18px;
-	height: 2px;
-	background: var(--text-dim);
-	border-radius: calc(1px * var(--rf)); corner-shape: var(--cs);
 }
 
 /* ── Sidebar ─────────────────────────────────────────────── */
@@ -1113,13 +1035,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	display: none;
 }
 
-.sidebar-header {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 10px 18px 8px;
-}
-
 /* Workspace header: "My sessions" title row (+ optional repo chip + action
    icons), with the session search bar directly below it. */
 .sidebar-workspace {
@@ -1153,10 +1068,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	letter-spacing: -0.01em;
 	color: var(--text-faint);
 	flex-shrink: 0;
-}
-.sidebar-workspace-spacer {
-	flex: 1;
-	min-width: 0;
 }
 /* The filter + new-session buttons, grouped so their combined width can be
    measured when deciding whether the repo chip fits inline. */
@@ -1227,13 +1138,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	height: 17px;
 	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
 	font-size: 10px;
-}
-.sidebar-repo-chip-name {
-	color: var(--text-dim);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
 }
 .sidebar-repo-chip-x {
 	display: inline-flex;
@@ -1471,9 +1375,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	margin-right: 6px;
 	margin-left: 6px;
 }
-.sidebar-independent-section.sidebar-group--band-start {
-	margin-top: 28px;
-}
 .sidebar-independent-scroll {
 	overflow-y: visible;
 	min-width: 0;
@@ -1490,31 +1391,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 .sidebar-archived-row.active {
 	color: var(--text);
 	background: var(--bg-active);
-}
-.sidebar-archived-icon {
-	display: inline-flex;
-	align-items: center;
-	color: var(--text-faint);
-	flex-shrink: 0;
-}
-.sidebar-archived-row:hover .sidebar-archived-icon,
-.sidebar-archived-row.active .sidebar-archived-icon {
-	color: var(--text-dim);
-}
-
-.sidebar-empty {
-	color: var(--text-faint);
-	text-align: center;
-	padding: 24px 0;
-	font-size: 13px;
-}
-
-.sidebar-workspace-empty {
-	margin: 28px 16px;
-	text-align: center;
-	font-size: 13px;
-	line-height: 1.4;
-	color: var(--text-faint);
 }
 
 .sidebar-group {
@@ -1566,27 +1442,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 }
 /* Hover action at the far end: "+" that starts a session in this repo. Sits
    right, reveals on hover like the chevron, and never squeezes the name. */
-.sidebar-repo-new {
-	margin-left: auto;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
-	flex-shrink: 0;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-faint);
-	opacity: 0;
-	cursor: pointer;
-	transition: opacity 0.15s ease, color 0.12s ease, background 0.12s ease;
-}
-.sidebar-repo-head:hover .sidebar-repo-new {
-	opacity: 1;
-}
-.sidebar-repo-new:hover {
-	color: var(--text);
-	background: var(--hover);
-}
 .sidebar-repo-lanes {
 	margin-top: 2px;
 }
@@ -1639,7 +1494,7 @@ body:is(.resizing-sidebar, .resizing-panel) {
    inter-group margin leaves them floating far apart. Drop it so consecutive
    people/automation rows stack flush, like the session items above them. The
    band-start divider still separates the sections. */
-.sidebar-group--people,
+
 .sidebar-group--automations {
 	margin-bottom: 0;
 }
@@ -1649,16 +1504,12 @@ body:is(.resizing-sidebar, .resizing-panel) {
 
 /* Whitespace (not a divider line) separates one band from the next
    (personal → people → automations). */
-.sidebar-group--band-start {
-	margin-top: 28px;
-}
 
 /* Top-level band labels (Support / People / Automations) — small quiet labels
    that read like section kickers but behave like Notion's: the whole heading is
    a full-width hover row that toggles the band; the collapse chevron sits by the
    label (revealed on hover), and the count / any actions live on the right. */
-.sidebar-band-label,
-.sidebar-mine-label {
+.sidebar-band-label {
 	font-size: 12px;
 	font-weight: 600;
 	letter-spacing: -0.01em;
@@ -1931,8 +1782,7 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	.sidebar-status-group > .sidebar-group-header,
 	.sidebar-group--pinned > .sidebar-group-header,
 	.sidebar-group--review > .sidebar-group-header,
-	.sidebar-repo-group > .sidebar-repo-head,
-	.sidebar-folder-section > .sidebar-folder-header {
+	.sidebar-repo-group > .sidebar-repo-head {
 		position: sticky;
 		top: 44px;
 		z-index: 15;
@@ -1953,8 +1803,7 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	.sidebar-status-group > .sidebar-group-header:hover,
 	.sidebar-group--pinned > .sidebar-group-header:hover,
 	.sidebar-group--review > .sidebar-group-header:hover,
-	.sidebar-repo-group > .sidebar-repo-head:hover,
-	.sidebar-folder-section > .sidebar-folder-header:hover {
+	.sidebar-repo-group > .sidebar-repo-head:hover {
 		background: var(--hover);
 	}
 }
@@ -2134,19 +1983,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	/* No hover to reveal the row's new-session action on touch, so keep it
 	   visible, and give it a 44px hit target (iOS guideline) via a
 	   pseudo-element while the visual box stays 28px. */
-	.sidebar-repo-new {
-		opacity: 1;
-		position: relative;
-	}
-	.sidebar-repo-new::before {
-		content: "";
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		width: 44px;
-		height: 44px;
-		transform: translate(-50%, -50%);
-	}
 }
 @media (max-width: 720px) {
 	.sidebar-item:hover .sidebar-item-x,
@@ -2275,14 +2111,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	flex: 0 0 auto;
 	color: var(--text-faint);
 }
-.mobile-sheet-item-chevron {
-	margin-left: auto;
-	color: var(--text-faint);
-}
-.mobile-sheet-item-check {
-	margin-left: auto;
-	color: var(--accent);
-}
 .mobile-sheet-item--danger {
 	color: #e5484d;
 }
@@ -2293,11 +2121,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	height: 1px;
 	background: var(--border);
 	margin: 6px 10px;
-}
-.mobile-sheet-empty {
-	font-size: 14px;
-	color: var(--text-faint);
-	padding: 12px 14px;
 }
 .sidebar-item:hover {
 	background: var(--hover);
@@ -2340,9 +2163,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 }
 /* A completed session with unread activity — solid green means the result is
    ready; opening it returns the marker to the quiet gray idle state. */
-.sidebar-status-unread {
-	background: var(--green);
-}
 
 /* A session blocked on an AskUserQuestion — draw the eye so it gets answered. */
 .sidebar-item-waiting {
@@ -2537,24 +2357,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	font-size: 11.5px;
 	font-weight: 500;
 }
-.hovercard-state-accent {
-	color: var(--accent);
-}
-.hovercard-state-blue {
-	color: var(--blue);
-}
-.hovercard-state-green {
-	color: var(--green);
-}
-.hovercard-state-purple {
-	color: var(--purple);
-}
-.hovercard-state-yellow {
-	color: var(--yellow);
-}
-.hovercard-state-dim {
-	color: var(--text-faint);
-}
 
 .hovercard-callout {
 	margin-top: 7px;
@@ -2605,15 +2407,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 }
 .hovercard-pr-state {
 	font-weight: 600;
-}
-.hovercard-pr-open {
-	color: var(--green);
-}
-.hovercard-pr-merged {
-	color: var(--purple);
-}
-.hovercard-pr-closed {
-	color: var(--red);
 }
 .hovercard-pr-review {
 	color: var(--text-dim);
@@ -3084,14 +2877,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 
 /* A transient tab (the current session when it isn't pinned) reads as
    provisional: dashed top edge, like a Chrome tab that hasn't been pinned. */
-.session-tab-transient {
-	/* Dash only the visible edges — `border-style: dashed` would re-enable the
-     bottom border (reset to the 3px default width by `border-bottom: none`),
-     making transient tabs 3px taller than solid ones and the strip jumpy. */
-	border-top-style: dashed;
-	border-left-style: dashed;
-	border-right-style: dashed;
-}
 
 /* A user-colored tab: a colored top edge plus a faint tint of the chosen
    swatch (`--tab-color`, set inline). Lets a row of lookalike tabs be told
@@ -3112,9 +2897,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	border-color: color-mix(in srgb, var(--tab-color) 60%, transparent);
 }
 /* Keep the dashed top edge readable on a transient colored tab. */
-.session-tab-colored.session-tab-transient {
-	border-top-style: dashed;
-}
 
 /* Right-click swatch menu — a floating row of color chips anchored at the
    cursor. Fixed-position so it escapes the tab strip's overflow clipping. */
@@ -3171,38 +2953,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
    pins it. Always shown on touch; reveal-on-hover (or for the active tab) on
    desktop. The ☆ stays visible on transient tabs so the pin affordance is
    discoverable. */
-.session-tab-pin {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 16px;
-	height: 16px;
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	font-size: 11px;
-	line-height: 1;
-	color: var(--text-dim);
-	flex-shrink: 0;
-}
-.session-tab-pin-on {
-	color: var(--yellow);
-}
-.session-tab-pin:hover {
-	background: var(--hover-strong);
-	color: #e3b341;
-}
-
-@media (hover: hover) and (pointer: fine) {
-	.session-tab-pin {
-		opacity: 0;
-		pointer-events: none;
-		transition: opacity 0.12s ease;
-	}
-	.session-tab:hover .session-tab-pin,
-	.session-tab-active .session-tab-pin {
-		opacity: 1;
-		pointer-events: auto;
-	}
-}
 
 /* Per-tab close (×) — reset the <button> chrome, sit at the tab's trailing
    edge, and reveal on hover like the pin. Clicking archives the chat. */
@@ -3269,8 +3019,7 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	font-family: inherit;
 	align-items: center;
 }
-.session-tab-history:hover,
-.session-tab-history[data-popup-open] {
+.session-tab-history:hover {
 	color: var(--text);
 	background: var(--hover);
 }
@@ -3283,8 +3032,7 @@ body:is(.resizing-sidebar, .resizing-panel) {
 		transition: opacity 0.12s ease;
 	}
 	.session-tabs:hover .session-tab-new,
-	.session-tabs:hover .session-tab-history,
-	.session-tab-history[data-popup-open] {
+	.session-tabs:hover .session-tab-history {
 		opacity: 1;
 		pointer-events: auto;
 	}
@@ -3301,20 +3049,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	text-align: center;
 }
 
-.detail-empty-logo {
-	width: 56px;
-	height: 56px;
-	margin: 0 auto 14px;
-	border-radius: calc(16px * var(--rf)); corner-shape: var(--cs);
-	background: linear-gradient(135deg, #ff5a5a, #b00000);
-	color: #fff;
-	font-size: 30px;
-	font-weight: 700;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
 .detail-empty-title {
 	font-size: 19px;
 	font-weight: 600;
@@ -3324,20 +3058,6 @@ body:is(.resizing-sidebar, .resizing-panel) {
 	color: var(--text-dim);
 	margin-top: 6px;
 	font-size: 13.5px;
-}
-
-.btn-new-session {
-	margin-top: 18px;
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 9px 18px;
-	font-size: 13.5px;
-	font-weight: 500;
-}
-.btn-new-session:hover {
-	filter: brightness(1.1);
 }
 
 .loading,
@@ -3424,12 +3144,6 @@ body.resizing-tab-split {
 	background: color-mix(in srgb, var(--accent) 18%, transparent);
 	box-shadow: inset 0 0 0 1px color-mix(in srgb, white 16%, transparent);
 }
-.tab-split-drop-preview-left {
-	left: 8px;
-}
-.tab-split-drop-preview-right {
-	right: 8px;
-}
 
 .viewer-header {
 	display: flex;
@@ -3464,28 +3178,6 @@ body.resizing-tab-split {
 	padding: 2px 8px;
 	border-radius: 99px;
 	flex-shrink: 0;
-}
-.goal-phase-chip {
-	max-width: 340px;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	text-transform: none;
-	letter-spacing: 0;
-	flex-shrink: 1;
-}
-.source-slack {
-	background: rgba(74, 21, 75, 0.55);
-	color: #d9a8db;
-}
-.source-linear {
-	background: rgba(94, 106, 210, 0.25);
-	color: #9da6ee;
-}
-.source-backstage {
-	background: rgba(13, 148, 136, 0.22);
-	color: #5eead4;
 }
 .source-cli {
 	background: var(--bg-active);
@@ -3584,15 +3276,6 @@ html.wco .viewer-branch {
 	outline: none;
 }
 
-.viewer-started-by {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	color: var(--text-faint);
-	font-size: 12.5px;
-	flex-shrink: 0;
-}
-
 .working-pill {
 	display: inline-flex;
 	align-items: center;
@@ -3616,11 +3299,6 @@ html.wco .viewer-branch {
 
 /* Pixel spinner standing in for the pulsing dot inside the Working pill. It
    inherits the pill's green via currentColor; nudge it down to the text size. */
-.working-spinner {
-	flex-shrink: 0;
-	transform: scale(0.85);
-	transform-origin: center;
-}
 
 @keyframes pulse {
 	0%,
@@ -3656,12 +3334,6 @@ html.wco .viewer-branch {
 
 /* Narrow (non-phone) top bar: give the title room first. Drop the "by X" line
    and shrink the Working pill to just its dot before any action is hidden. */
-.viewer-header-compact .viewer-started-by {
-	display: none;
-}
-.viewer-header-compact .working-label {
-	display: none;
-}
 .viewer-header-compact .working-pill {
 	padding: 4px;
 }
@@ -3671,23 +3343,6 @@ html.wco .viewer-branch {
 .viewer-overflow {
 	position: relative;
 	display: inline-flex;
-}
-.btn-viewer-overflow {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	background: none;
-	border: 1px solid transparent;
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	padding: 3px 5px;
-	font-size: 20px;
-	line-height: 1;
-}
-.btn-viewer-overflow.active,
-.btn-viewer-overflow:hover {
-	color: var(--text);
-	background: var(--hover);
 }
 /* Squircle user picture (GitHub avatar, initial fallback) — see UserAvatar.tsx.
    Size + font-size come inline from the component; the count badge the
@@ -3727,23 +3382,6 @@ html.wco .viewer-branch {
 
 /* Small "reviewed" checkmark badge nested over the reviewer's avatar in the
    green Reviewed chip — bottom-right, ringed against the chip tint. */
-.wi-chip-avatar-check {
-	position: absolute;
-	right: -3px;
-	bottom: -3px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 13px;
-	height: 13px;
-	border-radius: 50%;
-	color: #fff;
-	background: var(--green, #16a34a);
-	box-shadow: 0 0 0 1.5px var(--bg-panel);
-}
-.wi-chip-avatar-check svg {
-	display: block;
-}
 
 /* presence facepile (the Figma/Notion-style user row before Share) */
 .presence {
@@ -3760,34 +3398,6 @@ html.wco .viewer-branch {
 }
 .presence-avatar:first-child {
 	margin-left: 0;
-}
-.presence-me {
-	background: var(--accent-soft);
-	color: var(--text-dim);
-}
-.presence-me::after {
-	content: "";
-	position: absolute;
-	left: 50%;
-	bottom: -4px;
-	z-index: 2;
-	width: 8px;
-	height: 3px;
-	border-radius: 99px;
-	background: var(--accent);
-	box-shadow: 0 0 0 2px var(--bg-raised);
-	transform: translateX(-50%);
-}
-.presence-count {
-	position: absolute;
-	bottom: -3px;
-	right: -3px;
-	background: var(--accent);
-	color: #fff;
-	font-size: 9px;
-	border-radius: 99px;
-	padding: 0 3.5px;
-	line-height: 1.3;
 }
 
 .session-link {
@@ -3917,33 +3527,13 @@ html.wco .viewer-branch {
    it doesn't balloon past the text buttons it sits next to. Borderless: the
    tint/icon color carries the affordance (the border stays on the text-y
    .btn-panel-toggle siblings like the PR button). */
-.btn-panel-toggle.btn-workspace {
-	padding: 3px 5px;
-	border-color: transparent;
-	/* Match the left sidebar toggle's rest tone (text-faint) — the base
-	   .btn-panel-toggle is text-dim, which read a shade darker than its mirror. */
-	color: var(--text-faint);
-}
 /* The Workspace toggle's affordance is neutral, not the red accent — hover
    leans toward the text color over a plain row-hover wash (same as the ⋯
    overflow button), so only genuinely alarming controls wear red. Note: no
    .active rule — an open panel is already visible beside the toggle, so
    highlighting the button too is redundant; only hover gets the wash. */
-.btn-panel-toggle.btn-workspace:hover {
-	border-color: transparent;
-	color: var(--text);
-	background: var(--hover);
-}
-.btn-panel-toggle-icon {
-	font-size: 14px;
-	line-height: 1;
-}
 /* PR button label stays visible everywhere (incl. mobile, where the generic
    .btn-panel-toggle-label is hidden) — the PR number is the point of it. */
-.btn-pr-label {
-	font-size: 13px;
-	line-height: 1;
-}
 .btn-panel-toggle:hover {
 	color: var(--accent);
 	border-color: var(--accent);
@@ -3959,11 +3549,6 @@ html.wco .viewer-branch {
    sized and padded to sit flush beside the .btn-workspace panel toggle. State
    is carried entirely by icon color (dim = off, amber = in flight, green =
    live), so no label is needed. */
-.viewer-code-icon-wrap {
-	position: relative;
-	display: inline-flex;
-	align-items: center;
-}
 .viewer-code-icon {
 	display: inline-flex;
 	align-items: center;
@@ -4021,36 +3606,8 @@ html.wco .viewer-branch {
 	color: var(--green);
 	background: var(--green-soft);
 }
-.btn-viewer-delete,
-.btn-viewer-archive {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	white-space: nowrap;
-	background: none;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-faint);
-	padding: 5px 12px;
-	font-size: 13px;
-}
 /* Archive is the safe, reversible action — it leans toward the text color on
    hover (not red), keeping Delete as the only alarming item in the menu. */
-.btn-viewer-archive:hover:not(:disabled) {
-	color: var(--text);
-	background: var(--hover);
-}
-.btn-viewer-archive:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
-.btn-viewer-shortcut {
-	margin-left: auto;
-	color: var(--text-faint);
-	font-size: 11px;
-	font-weight: 600;
-	letter-spacing: 0;
-}
 
 /* New-chat-in-workspace row (phone ⋯ menu). Matches the archive/delete rows:
    icon + label, neutral until hover. It's a create action, so hover leans to
@@ -4074,47 +3631,11 @@ html.wco .viewer-branch {
 
 /* Session name titling the phone ⋯ menu (WhatsApp/ChatGPT-style header). It's a
    label, not an action — dimmed, with a hairline rule under it. */
-.viewer-menu-title {
-	padding: 2px 6px 8px;
-	margin-bottom: 2px;
-	border-bottom: 1px solid var(--border);
-	color: var(--text-dim);
-	font-size: 12px;
-	font-weight: 600;
-	letter-spacing: -0.01em;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
 
 /* The workspace side panel (changes / terminal / PR / Plain) is reached from the
    ⋯ menu on phones, as a deeper page — a full-width row with a trailing chevron
    marking "opens another panel". It's the menu's primary destination, so it
    reads at full strength (accent glyph, real text). */
-.btn-viewer-panelrow {
-	display: inline-flex;
-	align-items: center;
-	gap: 9px;
-	white-space: nowrap;
-	background: none;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 8px 12px;
-	font-size: 13.5px;
-	font-weight: 500;
-}
-.btn-viewer-panelrow > svg:first-child {
-	color: var(--accent);
-	flex-shrink: 0;
-}
-.btn-viewer-panelrow-caret {
-	margin-left: auto;
-	color: var(--text-faint);
-}
-.btn-viewer-panelrow:hover {
-	background: var(--hover);
-}
 
 @keyframes preview-spin {
 	to {
@@ -4125,32 +3646,6 @@ html.wco .viewer-branch {
    the PR split-button beside it — same 32px height, 8px squircle radius, raised
    fill. The subtle fill + border reads as a solid, deliberate control instead of
    the thin ring it used to be. In the ⋯ menu the list styling overrides all this. */
-.btn-viewer-share {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	min-height: 32px;
-	background: var(--control-surface);
-	border: 1px solid var(--border);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	box-shadow: var(--control-shadow);
-	color: var(--text-dim);
-	padding: 0 13px;
-	font-size: 13px;
-	font-weight: 550;
-	white-space: nowrap;
-}
-.btn-viewer-share:hover {
-	color: var(--text);
-	border-color: var(--border-strong);
-	background: var(--hover);
-}
-.btn-viewer-share-done {
-	color: var(--green);
-	border-color: color-mix(in srgb, var(--green) 40%, transparent);
-	background: var(--green-soft);
-}
 
 .btn-viewer-pin {
 	display: inline-flex;
@@ -4173,29 +3668,6 @@ html.wco .viewer-branch {
 .viewer-delete-confirm {
 	display: flex;
 	gap: 6px;
-}
-
-.btn-delete-wt,
-.btn-delete-only,
-.btn-delete-cancel {
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	padding: 5px 12px;
-	font-size: 13px;
-	white-space: nowrap;
-	border: 1px solid var(--border-strong);
-	background: none;
-	color: var(--text-dim);
-}
-.btn-delete-wt {
-	color: var(--red);
-	border-color: var(--red);
-}
-.btn-delete-only {
-	color: var(--yellow);
-	border-color: var(--yellow);
-}
-.btn-delete-cancel:hover {
-	color: var(--text);
 }
 
 /* split layout: chat + workspace panel */
@@ -4249,17 +3721,6 @@ html.wco .viewer-branch {
    as a first-class "test this change" action, visible on every tab (tab-agnostic).
    Each child self-gates (renders null when N/A), so :empty collapses the row on
    sessions with no code affordances (e.g. Plain-only). */
-.panel-actions {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	gap: 8px;
-	padding: 10px 12px;
-	border-bottom: 1px solid var(--border);
-}
-.panel-actions:empty {
-	display: none;
-}
 
 /* Left-edge drag handle of the right panel — mirror of .sidebar-resize. */
 .panel-resize {
@@ -4348,29 +3809,8 @@ body.resizing-panel .panel-resize::after {
 	height: 7px;
 	border-radius: 50%;
 }
-.pr-dot-open {
-	background: var(--green);
-}
-.pr-dot-merged {
-	background: var(--purple);
-}
-.pr-dot-closed {
-	background: var(--red);
-}
 .pr-dot-conflict {
 	background: var(--yellow);
-}
-
-.panel-close {
-	background: none;
-	border: none;
-	color: var(--text-faint);
-	font-size: 13px;
-	padding: 4px 8px 8px;
-	margin-left: 6px;
-}
-.panel-close:hover {
-	color: var(--text);
 }
 
 .panel-overlay {
@@ -4390,19 +3830,6 @@ body.resizing-panel .panel-resize::after {
 	padding: 12px 12px 22px;
 }
 
-.workspace-info-head {
-	display: grid;
-	gap: 4px;
-}
-
-.workspace-info-kicker,
-.workspace-info-label {
-	color: var(--text-faint);
-	font-size: 12px;
-	font-weight: 650;
-	letter-spacing: -0.01em;
-}
-
 .workspace-info-title {
 	color: var(--text);
 	font-size: 17px;
@@ -4411,349 +3838,30 @@ body.resizing-panel .panel-resize::after {
 	overflow-wrap: anywhere;
 }
 
-.workspace-info-meta {
-	color: var(--text-faint);
-	font-size: 12px;
-	line-height: 1.35;
-}
-
 /* Status chips (checks / review / PR state) — compact, tinted by tone. */
-.workspace-info-status {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-	margin-top: 10px;
-}
-
-.wi-chip {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	/* Symmetric vertical padding — an earlier 5px/6px split shifted every
-	   icon/avatar 0.5px above the pill's center, which read as "riding high"
-	   and invited per-glyph margin nudges to compensate. Keep it symmetric and
-	   let flex centering do the work: iconic glyphs are drawn centered in
-	   their viewbox (sub-¼px offsets at most), so no nudges are needed. */
-	padding: 5.5px 11px;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	font-size: 12.5px;
-	font-weight: 600;
-	line-height: 1.35;
-	border: 1px solid transparent;
-	cursor: pointer;
-	white-space: nowrap;
-	transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
-}
-.wi-chip-icon {
-	display: inline-flex;
-	align-items: center;
-	/* De-emphasize the glyph so the label stays the dominant read (ported from
-	   tella-fusion's ButtonWithIcon, which dims leading icons to ~50-70%). */
-	opacity: 0.65;
-}
 /* Leading icon: pull the icon-side padding in 2px. Iconic glyphs only draw
    ~60% of their box, so with symmetric padding the icon side looks padded
    out — tella-fusion's buttons do the same px-3 → pl-2.5 tightening. */
-.wi-chip:has(> .wi-chip-icon:first-child) {
-	padding-left: 9px;
-}
-.wi-chip-icon svg {
-	display: block;
-}
-.wi-chip-green {
-	color: var(--green, #16a34a);
-	background: color-mix(in srgb, var(--green, #16a34a) 12%, transparent);
-	border-color: color-mix(in srgb, var(--green, #16a34a) 26%, transparent);
-}
-.wi-chip-red {
-	color: var(--red, #dc2626);
-	background: color-mix(in srgb, var(--red, #dc2626) 12%, transparent);
-	border-color: color-mix(in srgb, var(--red, #dc2626) 26%, transparent);
-}
-.wi-chip-yellow {
-	color: var(--yellow, #ca8a04);
-	background: color-mix(in srgb, var(--yellow, #ca8a04) 14%, transparent);
-	border-color: color-mix(in srgb, var(--yellow, #ca8a04) 30%, transparent);
-}
-.wi-chip-purple {
-	color: var(--purple, #7c3aed);
-	background: color-mix(in srgb, var(--purple, #7c3aed) 12%, transparent);
-	border-color: color-mix(in srgb, var(--purple, #7c3aed) 26%, transparent);
-}
-.wi-chip-muted {
-	color: var(--text-dim);
-	background: var(--bg-surface);
-	border-color: var(--border);
-}
 
 /* Hover feedback: deepen the tint a touch and pull the border in. */
-.wi-chip-green:hover {
-	background: color-mix(in srgb, var(--green, #16a34a) 20%, transparent);
-	border-color: color-mix(in srgb, var(--green, #16a34a) 40%, transparent);
-}
-.wi-chip-red:hover {
-	background: color-mix(in srgb, var(--red, #dc2626) 20%, transparent);
-	border-color: color-mix(in srgb, var(--red, #dc2626) 40%, transparent);
-}
-.wi-chip-yellow:hover {
-	background: color-mix(in srgb, var(--yellow, #ca8a04) 22%, transparent);
-	border-color: color-mix(in srgb, var(--yellow, #ca8a04) 44%, transparent);
-}
-.wi-chip-purple:hover {
-	background: color-mix(in srgb, var(--purple, #7c3aed) 20%, transparent);
-	border-color: color-mix(in srgb, var(--purple, #7c3aed) 40%, transparent);
-}
-.wi-chip-muted:hover {
-	color: var(--text);
-	background: var(--hover);
-	border-color: var(--border-strong);
-}
-
-.workspace-info-body {
-	display: grid;
-	gap: 16px;
-}
 
 /* Horizontal filmstrip — bigger thumbs, still one scrolling row so screenshots
    read clearly without pushing the text sections off-screen. */
-.workspace-info-media {
-	display: flex;
-	gap: 8px;
-	overflow-x: auto;
-	padding-bottom: 4px;
-	scrollbar-width: thin;
-}
-
-.workspace-info-thumb {
-	position: relative;
-	flex: none;
-	display: block;
-	width: 240px;
-	aspect-ratio: 16 / 10;
-	overflow: hidden;
-	border: 1px solid var(--border);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-surface);
-}
 
 /* Files changed — compact preview that drills into the Changes tab. */
-.workspace-info-files-label {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-}
-.workspace-info-files {
-	display: grid;
-	gap: 1px;
-	border: 1px solid var(--border);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	overflow: hidden;
-}
-.workspace-info-file {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 6px 9px;
-	background: var(--bg-panel);
-	border: none;
-	text-align: left;
-	cursor: pointer;
-	min-width: 0;
-}
-.workspace-info-file:hover {
-	background: var(--hover);
-}
-.workspace-info-file-path {
-	font-family: var(--mono);
-	font-size: 12px;
-	display: flex;
-	align-items: baseline;
-	min-width: 0;
-	flex: 1;
-}
-.workspace-info-file-dir {
-	color: var(--text-faint);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-}
-.workspace-info-file-base {
-	color: var(--text-dim);
-	white-space: nowrap;
-	flex: none;
-}
-.workspace-info-more {
-	padding: 7px 9px;
-	background: var(--bg-surface);
-	border: none;
-	color: var(--text-faint);
-	font-size: 12px;
-	font-weight: 600;
-	text-align: left;
-	cursor: pointer;
-}
-.workspace-info-more:hover {
-	color: var(--text);
-	background: var(--hover);
-}
 
 /* PR comments — an avatar beside a markdown body with a muted source/time
    footer. Clamped by default; hovering floats the full comment in a popover. */
-.workspace-info-comments {
-	display: grid;
-	gap: 8px;
-}
 /* Comments heading + its right-aligned "Fix" button. */
-.workspace-info-comments-label {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-}
-.workspace-info-fix {
-	flex: none;
-	padding: 2px 10px;
-	border-radius: 999px;
-	border: 1px solid var(--border-strong);
-	background: var(--bg-surface);
-	color: var(--text-dim);
-	font-size: 11.5px;
-	font-weight: 650;
-	letter-spacing: -0.01em;
-	cursor: pointer;
-	transition:
-		color 0.12s ease,
-		border-color 0.12s ease,
-		background 0.12s ease;
-}
-.workspace-info-fix:hover {
-	color: var(--text);
-	border-color: var(--text-faint);
-	background: var(--hover);
-}
 /* One-line row: avatar · title · time. Dense list — the full comment opens in
    the hover popover, never by growing the row. */
 /* Clean text rows — no outline/box. Avatar · title · time, aligned flush with
    the section heading above. Hovering floats the full comment popover. */
-.workspace-info-comment {
-	position: relative;
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 3px 0;
-	text-align: left;
-	cursor: pointer;
-	min-width: 0;
-}
-.workspace-info-comment:hover .workspace-info-comment-time {
-	color: var(--text-dim);
-}
-.workspace-info-comment-avatar {
-	flex: none;
-	width: 18px;
-	height: 18px;
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	display: grid;
-	place-items: center;
-	color: #fff;
-	font-size: 10px;
-	font-weight: 680;
-}
 /* Real GitHub avatar variant (author's logo) — fill the same 18px tile. */
-img.workspace-info-comment-avatar {
-	object-fit: cover;
-	background: var(--bg-active);
-}
-.workspace-info-comment-title {
-	flex: 1;
-	min-width: 0;
-	color: var(--text);
-	font-size: 12.5px;
-	font-weight: 550;
-	line-height: 1.35;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.workspace-info-comment-time {
-	flex: none;
-	color: var(--text-faint);
-	font-size: 11.5px;
-}
-.workspace-info-comment-author {
-	color: var(--text-faint);
-	font-size: 11.5px;
-	font-weight: 600;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-}
 /* Hover "Add to chat" — floats over the right end of the row (covers time). */
-.workspace-info-comment-add {
-	position: absolute;
-	top: 50%;
-	right: 6px;
-	transform: translateY(-50%);
-	z-index: 1;
-	padding: 2px 8px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	border: 1px solid var(--border-strong);
-	background: var(--bg-panel);
-	color: var(--text-dim);
-	font-size: 11px;
-	font-weight: 600;
-	cursor: pointer;
-	opacity: 0;
-	transition: opacity 0.12s ease;
-}
-.workspace-info-comment:hover .workspace-info-comment-add {
-	opacity: 1;
-}
-.workspace-info-comment-add:hover {
-	color: var(--text);
-	border-color: var(--text-faint);
-	background: var(--hover);
-}
 /* Popover-only: author/time header above the full markdown body. */
-.workspace-info-comment-main {
-	position: relative;
-	min-width: 0;
-	flex: 1;
-}
-.workspace-info-comment-pop-head {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	gap: 8px;
-	min-width: 0;
-	margin-bottom: 6px;
-}
 
 /* Hover popover — the full comment floated on top of the list. */
-.workspace-info-comment-pop {
-	position: fixed;
-	z-index: 60;
-	display: flex;
-	align-items: stretch;
-	gap: 9px;
-	padding: 11px 12px;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-panel);
-	overflow: hidden;
-	cursor: pointer;
-	box-shadow:
-		0 12px 40px -8px rgba(0, 0, 0, 0.5),
-		0 0 0 1px var(--border);
-}
-.workspace-info-comment-pop .workspace-info-comment-main {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
 .workspace-info-comment-pop-body {
 	flex: 1;
 	overflow-y: auto;
@@ -4763,140 +3871,11 @@ img.workspace-info-comment-avatar {
 
 /* Hover popover for a "file changed" row — the file's actual diff floated on
    top of the list, mirroring the comment popover's floated-card chrome. */
-.workspace-info-file-pop {
-	position: fixed;
-	z-index: 60;
-	display: flex;
-	flex-direction: column;
-	padding: 10px 12px;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-panel);
-	overflow: hidden;
-	cursor: pointer;
-	box-shadow:
-		0 12px 40px -8px rgba(0, 0, 0, 0.5),
-		0 0 0 1px var(--border);
-}
-.workspace-info-file-pop-head {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	gap: 8px;
-	min-width: 0;
-	margin-bottom: 8px;
-}
-.workspace-info-file-pop-body {
-	flex: 1;
-	overflow: auto;
-	min-height: 0;
-	font-size: 12px;
-}
 
 /* Checks hover overview — the full per-check list floated off the checks chip
    (GitHub-style: status icon · name · outcome word). Shares the comment-pop's
    floated-card chrome. */
-.workspace-info-checks-pop {
-	position: fixed;
-	z-index: 60;
-	display: flex;
-	flex-direction: column;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-panel);
-	overflow: hidden;
-	box-shadow:
-		0 12px 40px -8px rgba(0, 0, 0, 0.5),
-		0 0 0 1px var(--border);
-}
-.workspace-info-checks-head {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	gap: 10px;
-	padding: 9px 12px;
-	border-bottom: 1px solid var(--border);
-	background: var(--bg-surface);
-}
-.workspace-info-checks-title {
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--text);
-}
-.workspace-info-checks-summary {
-	display: inline-flex;
-	gap: 8px;
-	font-size: 11.5px;
-	font-weight: 600;
-}
-.workspace-info-checks-list {
-	overflow-y: auto;
-	padding: 4px;
-}
-.workspace-info-check-row {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	padding: 6px 8px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	text-decoration: none;
-}
-a.workspace-info-check-row {
-	cursor: pointer;
-}
-.workspace-info-check-row:hover {
-	background: var(--bg-surface);
-}
-.workspace-info-check-name {
-	flex: 1;
-	min-width: 0;
-	font-size: 13px;
-	font-weight: 500;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.workspace-info-check-status {
-	flex-shrink: 0;
-	font-size: 12px;
-	font-weight: 500;
-	color: var(--text-dim);
-}
-.wi-check-icon {
-	flex-shrink: 0;
-	display: inline-flex;
-	width: 16px;
-	height: 16px;
-}
-.wi-check-ico {
-	display: block;
-	width: 16px;
-	height: 16px;
-}
-.wi-check-success {
-	color: var(--green, #16a34a);
-}
-.wi-check-failure {
-	color: var(--red, #dc2626);
-}
-.wi-check-pending {
-	color: var(--yellow, #ca8a04);
-}
-.wi-check-skipped,
-.wi-check-neutral {
-	color: var(--text-dim);
-}
 /* Indeterminate running spinner (no determinate SVG) — centered in the 16px slot. */
-.wi-check-spin {
-	width: 13px;
-	height: 13px;
-	margin: 1.5px;
-	border-radius: 999px;
-	border: 1.6px solid color-mix(in srgb, currentColor 28%, transparent);
-	border-top-color: currentColor;
-	animation: wi-check-spin 0.7s linear infinite;
-}
 @keyframes wi-check-spin {
 	to {
 		transform: rotate(360deg);
@@ -4905,47 +3884,47 @@ a.workspace-info-check-row {
 
 /* Compact markdown scale (base .markdown is sized for chat) — shared by the
    inline card body and the popover body. */
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body) .markdown {
+:is( .workspace-info-comment-pop-body) .markdown {
 	font-size: 13px;
 	line-height: 1.45;
 	color: var(--text-dim);
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	> :first-child {
 	margin-top: 0;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	> :last-child {
 	margin-bottom: 0;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
-	:where(h1, h2, h3, h4, h5, h6) {
+	:where(h1, h2, h3) {
 	font-size: 12.5px;
 	font-weight: 700;
 	color: var(--text);
 	margin: 9px 0 3px;
 	letter-spacing: -0.01em;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	:where(p) {
 	margin: 5px 0;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	:where(ul, ol) {
 	margin: 5px 0;
 	padding-left: 18px;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	:where(li) {
 	margin: 2px 0;
 }
-:is(.workspace-info-comment-md, .workspace-info-comment-pop-body)
+:is( .workspace-info-comment-pop-body)
 	.markdown
 	:where(table) {
 	font-size: 12px;
@@ -4972,87 +3951,9 @@ a.workspace-info-check-row {
 	max-width: 100%;
 }
 
-.workspace-info-section {
-	display: grid;
-	gap: 5px;
-}
-
 /* Status section (info panel): the PR/branch state line + one row per
    outstanding git fact (ahead → Push, behind → Update, dirty → Commit). The
    Conductor-style status header, in the info panel's own idiom. */
-.wi-git-state {
-	display: flex;
-	align-items: center;
-	gap: 7px;
-	flex-wrap: wrap;
-}
-.wi-git-state-label {
-	font-size: 14px;
-	font-weight: 650;
-}
-.wi-git-state-green {
-	color: var(--green, #16a34a);
-}
-.wi-git-state-purple {
-	color: var(--purple, #7c3aed);
-}
-.wi-git-state-muted {
-	color: var(--text-dim);
-}
-.wi-git-badge {
-	margin-left: 1px;
-	cursor: default;
-	padding: 3px 8px;
-	font-size: 11.5px;
-}
-.wi-git-rows {
-	display: grid;
-	gap: 8px;
-	margin-top: 3px;
-}
-.wi-git-row {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	min-height: 28px;
-}
-.wi-git-dot {
-	flex: 0 0 auto;
-	width: 7px;
-	height: 7px;
-	border-radius: 50%;
-	background: var(--yellow, #ca8a04);
-}
-.wi-git-label {
-	color: var(--text-dim);
-	font-size: 13.5px;
-	line-height: 1.3;
-}
-.wi-git-row .wi-git-btn {
-	margin-left: auto;
-	min-height: 28px;
-	padding: 4px 12px;
-}
-.wi-git-prompted {
-	margin-left: auto;
-}
-.wi-git-error {
-	color: var(--red);
-	font-size: 11.5px;
-	margin-top: 2px;
-}
-
-.workspace-info-text {
-	color: var(--text-dim);
-	font-size: 14px;
-	line-height: 1.42;
-}
-
-.workspace-info-empty {
-	color: var(--text-faint);
-	font-size: 13px;
-	padding-top: 2px;
-}
 
 .panel-placeholder {
 	color: var(--text-faint);
@@ -5101,9 +4002,6 @@ a.workspace-info-check-row {
 	background: var(--green);
 	flex-shrink: 0;
 	animation: pulse 1.6s ease-in-out infinite;
-}
-.subagent-head-top .panel-close {
-	margin-left: auto;
 }
 .subagent-back {
 	margin-top: 8px;
@@ -5204,38 +4102,6 @@ a.workspace-info-check-row {
 	color: var(--text);
 }
 /* "Link PR" affordance: the + chip / inline paste-a-URL form. */
-.pr-link-form {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-}
-.pr-link-input {
-	font-size: 12px;
-	color: var(--text);
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 3px 10px;
-	width: min(280px, 50vw);
-}
-.pr-link-input:focus {
-	outline: none;
-	border-color: var(--accent);
-}
-.pr-link-submit {
-	font-size: 12px;
-	white-space: nowrap;
-	color: var(--text);
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 3px 10px;
-	cursor: pointer;
-}
-.pr-link-submit:disabled {
-	color: var(--text-dim);
-	cursor: default;
-}
 
 /* Per-repo tabs in a multi-repo session's diff */
 .diff-repo-tabs {
@@ -5285,20 +4151,6 @@ a.workspace-info-check-row {
 .diff-del {
 	color: var(--red);
 	font-weight: 600;
-}
-
-.btn-icon {
-	margin-left: auto;
-	background: none;
-	border: none;
-	color: var(--text-faint);
-	font-size: 14px;
-	padding: 2px 6px;
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-}
-.btn-icon:hover {
-	color: var(--text);
-	background: var(--hover);
 }
 
 .diff-truncated {
@@ -5579,10 +4431,6 @@ a.workspace-info-check-row {
 	justify-content: flex-end;
 	gap: 8px;
 }
-.diff-comment-actions .btn-send {
-	padding: 6px 14px;
-	font-size: 12.5px;
-}
 
 .diff-comment-error {
 	color: var(--red);
@@ -5698,109 +4546,6 @@ a.workspace-info-check-row {
 
 /* Floating "you have pending comments" bar — sticks to the bottom of whichever
    container scrolls the diff (the split drawer's diff pane, or the panel body). */
-.pr-review-bar {
-	position: sticky;
-	bottom: 0;
-	z-index: 5;
-	margin-top: 10px;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.35);
-	padding: 10px 12px;
-	padding-bottom: max(10px, env(safe-area-inset-bottom, 0px));
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-}
-.pr-review-bar-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 10px;
-}
-.pr-review-count {
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--text);
-}
-.pr-review-toggle {
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 7px 14px;
-	font-size: 13px;
-	font-weight: 600;
-	cursor: pointer;
-}
-.pr-review-toggle:hover {
-	filter: brightness(1.1);
-}
-.pr-review-form {
-	display: flex;
-	flex-direction: column;
-	gap: 9px;
-	border-top: 1px solid var(--border);
-	padding-top: 10px;
-}
-.pr-review-summary {
-	background: var(--bg-raised);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 8px 10px;
-	font-size: 13px;
-	font-family: var(--sans);
-	line-height: 1.45;
-	resize: vertical;
-	outline: none;
-}
-.pr-review-summary:focus {
-	border-color: var(--accent);
-}
-.pr-review-events {
-	display: flex;
-	gap: 6px;
-	flex-wrap: wrap;
-}
-.pr-review-event {
-	flex: 1 1 auto;
-	background: var(--bg-raised);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	padding: 7px 10px;
-	font-size: 12.5px;
-	font-weight: 500;
-	cursor: pointer;
-	white-space: nowrap;
-}
-.pr-review-event:hover {
-	color: var(--text);
-}
-.pr-review-event.active {
-	background: color-mix(in srgb, var(--accent) 16%, transparent);
-	border-color: var(--accent);
-	color: var(--text);
-}
-.pr-review-submit {
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 9px 12px;
-	font-size: 13.5px;
-	font-weight: 600;
-	cursor: pointer;
-}
-.pr-review-submit:disabled {
-	opacity: 0.5;
-	cursor: default;
-}
-.pr-review-submit:not(:disabled):hover {
-	filter: brightness(1.1);
-}
 
 .pr-diff-section {
 	display: flex;
@@ -5815,10 +4560,6 @@ a.workspace-info-check-row {
 	text-transform: none;
 	letter-spacing: 0;
 	font-weight: 500;
-}
-
-.diff-files {
-	padding: 8px 10px 24px;
 }
 
 .diff-file {
@@ -5844,87 +4585,11 @@ a.workspace-info-check-row {
 	background: var(--hover);
 }
 
-.diff-status {
-	font-family: var(--mono);
-	font-size: 11px;
-	font-weight: 700;
-	width: 18px;
-	height: 18px;
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	flex-shrink: 0;
-}
-.diff-status-added,
-.diff-status-untracked {
-	background: var(--green-soft);
-	color: var(--green);
-}
-.diff-status-modified {
-	background: rgba(210, 153, 34, 0.15);
-	color: var(--yellow);
-}
-.diff-status-deleted {
-	background: var(--red-soft);
-	color: var(--red);
-}
-.diff-status-renamed {
-	background: var(--accent-soft);
-	color: var(--accent);
-}
-
-.diff-file-path {
-	font-family: var(--mono);
-	font-size: 12px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-	flex: 1;
-	text-align: left;
-}
-
 .diff-file-stats {
 	display: flex;
 	gap: 6px;
 	font-size: 11.5px;
 	flex-shrink: 0;
-}
-
-.diff-chevron {
-	color: var(--text-faint);
-	font-size: 10px;
-	flex-shrink: 0;
-}
-
-.diff-patch {
-	margin: 0;
-	border-top: 1px solid var(--border);
-	font-family: var(--mono);
-	font-size: 11.5px;
-	line-height: 1.55;
-	overflow-x: auto;
-	max-height: 480px;
-	overflow-y: auto;
-}
-
-.diff-line {
-	padding: 0 10px;
-	white-space: pre;
-}
-.diff-line-add {
-	background: rgba(63, 185, 80, 0.13);
-	color: #7ee787;
-}
-.diff-line-del {
-	background: rgba(248, 81, 73, 0.12);
-	color: #ffa198;
-}
-.diff-line-hunk {
-	background: var(--accent-soft);
-	color: var(--text-dim);
-	padding: 2px 10px;
 }
 
 /* ── PR status bar (Conductor-style strip atop the right panel) ── */
@@ -5943,18 +4608,6 @@ a.workspace-info-check-row {
 .pr-bar > .staging-icon {
 	flex-shrink: 0;
 	margin-left: -2px;
-}
-.pr-bar-green {
-	background: var(--green-soft);
-}
-.pr-bar-purple {
-	background: rgba(163, 113, 247, 0.1);
-}
-.pr-bar-red {
-	background: var(--red-soft);
-}
-.pr-bar-yellow {
-	background: rgba(210, 153, 34, 0.09);
 }
 .pr-bar-muted {
 	/* Match the chat's top bar surface so the panel's top row reads as the same
@@ -6037,38 +4690,6 @@ a.workspace-info-check-row {
    as a green pill on the green strip, matching the Merge button, rather than a
    stark white pill. The tint stays subordinate to the solid-fill primary action;
    hover deepens it. */
-.pr-num-chip-green {
-	color: var(--green);
-	border-color: color-mix(in srgb, var(--green) 22%, transparent);
-	background: color-mix(in srgb, var(--green) 24%, var(--control-surface));
-}
-.pr-num-chip-purple {
-	color: var(--purple);
-	border-color: color-mix(in srgb, var(--purple) 22%, transparent);
-	background: color-mix(in srgb, var(--purple) 24%, var(--control-surface));
-}
-.pr-num-chip-red {
-	color: var(--red);
-	border-color: color-mix(in srgb, var(--red) 22%, transparent);
-	background: color-mix(in srgb, var(--red) 24%, var(--control-surface));
-}
-.pr-num-chip-yellow {
-	color: var(--yellow);
-	border-color: color-mix(in srgb, var(--yellow) 22%, transparent);
-	background: color-mix(in srgb, var(--yellow) 24%, var(--control-surface));
-}
-.pr-num-chip-green,
-.pr-num-chip-purple,
-.pr-num-chip-red,
-.pr-num-chip-yellow {
-	box-shadow: none;
-}
-.pr-num-chip-green:hover,
-.pr-num-chip-purple:hover,
-.pr-num-chip-red:hover,
-.pr-num-chip-yellow:hover {
-	background: color-mix(in srgb, currentColor 32%, var(--control-surface));
-}
 /* A session that shipped one feature as several PRs: the primary strip keeps
    its tone band and its action, and the other PRs stack under it as their own
    quiet rows (repo · number · title · state). Crammed into the primary line as
@@ -6178,18 +4799,6 @@ a.workspace-info-check-row {
 	flex-shrink: 0;
 	background: var(--text-dim);
 }
-.pr-sib-dot-green {
-	background: var(--green);
-}
-.pr-sib-dot-purple {
-	background: var(--purple);
-}
-.pr-sib-dot-red {
-	background: var(--red);
-}
-.pr-sib-dot-yellow {
-	background: var(--yellow);
-}
 /* In the panel's PR strip the chip sits next to the primary action button
    (Merge/Push/…) — size it to the same height so the two read as a matched
    pair, the way .pr-head already does for the header variant. */
@@ -6214,112 +4823,9 @@ a.workspace-info-check-row {
 .pr-bar-state:hover {
 	text-decoration: underline;
 }
-.pr-bar-state-green {
-	color: var(--green);
-}
-.pr-bar-state-purple {
-	color: var(--purple);
-}
-.pr-bar-state-red {
-	color: var(--red);
-}
-.pr-bar-state-yellow {
-	color: var(--yellow);
-}
-.pr-bar-state-muted {
-	color: var(--text-dim);
-}
 
 .pr-bar-spacer {
 	flex: 1;
-}
-
-.pr-bar-btn {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	min-height: 30px;
-	border: 1px solid transparent;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	font-size: 13px;
-	line-height: 1;
-	font-weight: 650;
-	padding: 5px 10px;
-	white-space: nowrap;
-	cursor: pointer;
-	color: #fff;
-	/* Same whisper as every other button — one shadow across the tool. */
-	box-shadow: var(--control-shadow);
-	transition:
-		background-color 150ms ease,
-		border-color 150ms ease,
-		color 150ms ease,
-		filter 150ms ease,
-		transform 150ms ease;
-	will-change: transform;
-}
-.pr-bar-btn-icon {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 18px;
-	height: 18px;
-	flex: 0 0 18px;
-}
-.pr-bar-btn-icon svg {
-	display: block;
-	stroke-width: 1.7;
-}
-.pr-bar-btn-label {
-	display: inline-flex;
-	align-items: center;
-}
-.pr-bar-btn:disabled {
-	opacity: 0.6;
-	cursor: default;
-	box-shadow: none;
-}
-.pr-bar-btn-green {
-	background: var(--green);
-	border-color: color-mix(in srgb, var(--green) 78%, black);
-}
-.pr-bar-btn-purple {
-	background: var(--purple);
-	border-color: color-mix(in srgb, var(--purple) 78%, black);
-}
-.pr-bar-btn-red {
-	background: var(--red);
-	border-color: color-mix(in srgb, var(--red) 78%, black);
-}
-.pr-bar-btn-solid {
-	background: var(--text);
-	color: var(--bg);
-	border-color: color-mix(in srgb, var(--text) 84%, transparent);
-}
-.pr-bar-btn-secondary {
-	background: var(--bg-raised);
-	color: var(--text);
-	border-color: var(--border-strong);
-}
-.pr-bar-btn-confirm {
-	outline: 2px solid color-mix(in srgb, var(--green) 45%, transparent);
-	outline-offset: 1px;
-}
-.pr-bar-btn:hover:not(:disabled) {
-	filter: brightness(1.08);
-}
-.pr-bar-btn-secondary:hover:not(:disabled) {
-	background: var(--hover);
-	filter: none;
-}
-.pr-bar-btn:active:not(:disabled) {
-	filter: brightness(0.98);
-	transform: translateY(0) scale(0.98);
-}
-.pr-bar-btn:focus-visible {
-	outline: 2px solid var(--accent);
-	outline-offset: 2px;
 }
 
 .pr-bar-error {
@@ -6355,12 +4861,6 @@ a.workspace-info-check-row {
 	width: 32px;
 	height: 32px;
 }
-.pr-head .pr-bar-btn {
-	min-height: 32px;
-	padding: 5px 11px;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	font-size: 13px;
-}
 /* Keep the shared split-button seam after the bar/header size overrides above,
    which otherwise restore the number chip's radius on all four corners. */
 .pr-num-chip-group .pr-num-chip {
@@ -6389,13 +4889,6 @@ a.workspace-info-check-row {
 }
 
 /* ── PR panel ────────────────────────────────────────────── */
-
-.pr-panel {
-	padding: 14px;
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
 /* The info region (header, checks, body, actions) keeps the vertical rhythm
    whether or not it's beside the diff. */
 .pr-panel-info {
@@ -6411,38 +4904,6 @@ a.workspace-info-check-row {
    panel can be as narrow as 320px). The PR tab bar sits ABOVE the split, so
    the row lives on .pr-panel-body (a plain wrapper — display:contents — in
    the stacked layout), not on the panel itself. */
-.pr-panel-split {
-	height: 100%;
-	padding: 0;
-	gap: 0;
-}
-.pr-panel-body {
-	display: contents;
-}
-.pr-panel-split .pr-panel-body {
-	display: flex;
-	flex-direction: row;
-	align-items: stretch;
-	flex: 1;
-	min-height: 0;
-}
-.pr-panel-split .pr-panel-info {
-	width: min(384px, 45%);
-	flex-shrink: 0;
-	overflow-y: auto;
-	padding: 16px 20px 22px;
-	border-right: 1px solid var(--border);
-}
-.pr-panel-split .pr-panel-diff {
-	flex: 1;
-	min-width: 0;
-	overflow-y: auto;
-	padding: 18px 20px;
-	background: var(--bg);
-}
-.pr-panel-split .pr-diff-section {
-	margin-top: 0;
-}
 
 .pr-head {
 	display: flex;
@@ -6516,15 +4977,6 @@ a.workspace-info-check-row {
 	text-transform: capitalize;
 	font-weight: 600;
 }
-.pr-review-approved {
-	color: var(--green);
-}
-.pr-review-changes_requested {
-	color: var(--red);
-}
-.pr-review-review_required {
-	color: var(--yellow);
-}
 
 .pr-checks {
 	border: 0;
@@ -6585,11 +5037,6 @@ a.workspace-info-check-row {
 .check-pending-text {
 	color: var(--yellow);
 }
-.pr-checks-chevron {
-	margin-left: auto;
-	color: var(--text-faint);
-	font-size: 11px;
-}
 
 .pr-check {
 	display: flex;
@@ -6622,9 +5069,6 @@ a.workspace-info-check-row {
 }
 .pr-check-mark-pending {
 	animation: pulse 1.4s infinite;
-}
-.check-neutral-text {
-	color: var(--text-faint);
 }
 
 .pr-checks-group {
@@ -6662,16 +5106,6 @@ a.workspace-info-check-row {
 	border-radius: 0;
 	background: transparent;
 	overflow: hidden;
-}
-.pr-comments-head {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	border-bottom: 0;
-}
-.pr-comments-title {
-	flex: 1;
-	padding-bottom: 6px;
 }
 .pr-comments-add-all,
 .pr-comment-add {
@@ -6759,12 +5193,6 @@ a.workspace-info-check-row {
 }
 
 /* Git status rows — one local/remote discrepancy per line, action on the right. */
-.pr-git {
-	border: 0;
-	border-radius: 0;
-	background: transparent;
-	padding-bottom: 0;
-}
 .pr-git-row {
 	display: flex;
 	align-items: center;
@@ -6783,21 +5211,6 @@ a.workspace-info-check-row {
 	border-radius: 50%;
 	background: var(--text-faint);
 	flex-shrink: 0;
-}
-.pr-git-dot-green {
-	background: var(--green);
-}
-.pr-git-dot-yellow {
-	background: var(--yellow);
-}
-.pr-git-dot-red {
-	background: var(--red);
-}
-.pr-git-dot-blue {
-	background: var(--blue);
-}
-.pr-git-dot-purple {
-	background: var(--purple);
 }
 .pr-git-label {
 	flex: 1;
@@ -6832,16 +5245,6 @@ a.workspace-info-check-row {
 }
 
 /* Placeholder identity for a branch with no PR yet (mirrors Conductor). */
-.pr-no-pr-title {
-	font-size: 15.5px;
-	font-weight: 600;
-	color: var(--text-faint);
-}
-.pr-no-pr-desc {
-	font-size: 12.5px;
-	color: var(--text-faint);
-	margin-top: -6px;
-}
 
 .pr-body {
 	border: 0;
@@ -6850,18 +5253,6 @@ a.workspace-info-check-row {
 }
 .pr-body-top {
 	margin-top: -6px;
-}
-
-.pr-body-text {
-	margin: 0;
-	padding: 4px 12px 12px;
-	font-family: var(--sans);
-	font-size: 12.5px;
-	color: var(--text-dim);
-	white-space: pre-wrap;
-	word-break: break-word;
-	max-height: 280px;
-	overflow-y: auto;
 }
 
 /* Markdown-rendered PR description (inherits .markdown for headings/lists/code). */
@@ -6986,10 +5377,6 @@ a.workspace-info-check-row {
 	justify-content: flex-end;
 	gap: 8px;
 }
-.selection-actions .btn-send {
-	padding: 6px 14px;
-	font-size: 12.5px;
-}
 .selection-sent {
 	padding: 8px 14px;
 	font-size: 12.5px;
@@ -6997,199 +5384,19 @@ a.workspace-info-check-row {
 	white-space: nowrap;
 }
 
-.btn-open-pr {
-	display: block;
-	text-align: center;
-	background: var(--accent);
-	color: #fff;
-	text-decoration: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 9px;
-	font-size: 13px;
-	font-weight: 500;
-}
-.btn-open-pr:hover {
-	filter: brightness(1.1);
-}
-
 /* PR action row (Open on GitHub / Squash & merge / Open session) */
-.pr-actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	align-items: stretch;
-}
-.pr-actions .btn-open-pr {
-	flex: 1;
-	min-width: 150px;
-}
-
-.btn-merge-pr {
-	flex: 1;
-	min-width: 150px;
-	text-align: center;
-	background: #238636;
-	color: #fff;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 9px;
-	font-size: 13px;
-	font-weight: 500;
-	cursor: pointer;
-}
-.btn-merge-pr:hover:not(:disabled) {
-	background: #2ea043;
-}
-.btn-merge-pr:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
-.btn-merge-confirm {
-	background: #cf222e;
-}
-.btn-merge-confirm:hover:not(:disabled) {
-	background: #e5484d;
-}
-
-.btn-open-session {
-	background: var(--bg-active);
-	color: var(--text);
-	border: 1px solid var(--border);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 9px 14px;
-	font-size: 13px;
-	cursor: pointer;
-}
-.btn-open-session:hover {
-	background: var(--hover);
-}
-
-.pr-merge-error {
-	color: var(--red);
-	font-size: 12.5px;
-	background: var(--red-soft);
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	padding: 8px 10px;
-}
 
 /* ── PR panel: Linear-style cards (Status / Reviewers / Checks / Files) ──── */
 
 /* Header: title + one meta line (author · #num · base ← head · +/−). */
-.prc-header {
-	display: flex;
-	flex-direction: column;
-	gap: 5px;
-}
-.prc-title {
-	font-size: 15px;
-	font-weight: 650;
-	letter-spacing: -0.012em;
-	line-height: 1.3;
-	color: var(--text);
-	text-decoration: none;
-}
-.prc-title:hover {
-	color: var(--accent);
-}
-.prc-meta {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	gap: 8px;
-	font-size: 12px;
-	color: var(--text-faint);
-	font-variant-numeric: tabular-nums;
-}
-.prc-meta-author {
-	color: var(--text-dim);
-	font-weight: 550;
-}
-.prc-meta-branches {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	min-width: 0;
-}
-.prc-branch {
-	font-family: var(--mono);
-	font-size: 11px;
-	color: var(--text-dim);
-	background: var(--bg-active);
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	padding: 1px 6px;
-	max-width: 130px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-.prc-branch-arrow {
-	color: var(--text-faint);
-}
-.prc-meta-diffstat {
-	display: inline-flex;
-	gap: 6px;
-	font-variant-numeric: tabular-nums;
-	font-weight: 600;
-}
-.prc-add {
-	color: var(--green);
-}
-.prc-del {
-	color: var(--red);
-}
 
 /* The card: a titled, bordered surface — the Linear right-rail module. */
-.prc-card {
-	border: 1px solid var(--border);
-	border-radius: calc(11px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-panel);
-	overflow: hidden;
-}
-.prc-card-head {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 9px 12px;
-	min-height: 22px;
-}
-.prc-card-title {
-	font-size: 12px;
-	font-weight: 600;
-	letter-spacing: -0.005em;
-	color: var(--text-faint);
-	white-space: nowrap;
-}
-.prc-card-body {
-	display: flex;
-	flex-direction: column;
-	padding: 0 6px 6px;
-	gap: 1px;
-}
 /* Card with no title-only content still needs its rows to breathe. */
-.prc-card-head + .prc-card-body:empty {
-	display: none;
-}
 
 /* A collapse toggle sitting on the right of a card head. */
-.prc-card-toggle {
-	margin-left: auto;
-	display: inline-flex;
-	align-items: center;
-	gap: 10px;
-	background: none;
-	border: none;
-	padding: 0;
-	cursor: pointer;
-	color: var(--text-dim);
-	font: inherit;
-}
 .prc-chevron {
 	color: var(--text-faint);
 	font-size: 10px;
-}
-.prc-checks-rollup {
-	font-size: 12px;
-	font-weight: 600;
 }
 .prc-checks-counts {
 	display: inline-flex;
@@ -7199,53 +5406,6 @@ a.workspace-info-check-row {
 }
 
 /* Compact action row at the top of the panel — primary merge + quiet pills. */
-.prc-actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-	align-items: center;
-}
-.prc-btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	border: 1px solid var(--border);
-	background: var(--bg-panel);
-	color: var(--text-dim);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 4px 10px;
-	font-size: 12px;
-	font-weight: 550;
-	line-height: 18px;
-	cursor: pointer;
-	text-decoration: none;
-	white-space: nowrap;
-}
-.prc-btn:hover {
-	background: var(--hover);
-	color: var(--text);
-}
-.prc-btn-primary {
-	background: var(--accent);
-	border-color: var(--accent);
-	color: #fff;
-}
-.prc-btn-primary:hover:not(:disabled) {
-	background: var(--accent);
-	color: #fff;
-	filter: brightness(1.08);
-}
-.prc-btn-primary:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
-.prc-btn-confirm {
-	background: var(--red);
-	border-color: var(--red);
-}
-.prc-btn-confirm:hover:not(:disabled) {
-	background: var(--red);
-}
 
 /* Checks rollup row — the whole card body when collapsed (Linear's "All passed"). */
 .prc-summary-row {
@@ -7288,10 +5448,6 @@ a.workspace-info-check-row {
 }
 
 /* Head-right diffstat label (not a button). */
-.prc-head-diffstat {
-	margin-left: auto;
-	font-size: 11.5px;
-}
 
 /* "Show all N files" expander at the foot of a long files card. */
 .prc-show-more {
@@ -7311,211 +5467,15 @@ a.workspace-info-check-row {
 }
 
 /* Check rows sit denser inside a card than in the legacy checks panel. */
-.prc-card-body .pr-check {
-	font-size: 12.5px;
-	padding: 3px 6px;
-}
-.prc-card-body .pr-checks-group {
-	font-size: 11px;
-	font-weight: 600;
-	padding: 8px 6px 3px;
-}
 
 /* Status card */
-.prc-status-row {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 4px 6px;
-}
-.prc-state {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 13.5px;
-	font-weight: 600;
-}
-.prc-state svg {
-	flex-shrink: 0;
-}
-.prc-state-green {
-	color: var(--green);
-}
-.prc-state-purple {
-	color: var(--purple);
-}
-.prc-state-red {
-	color: var(--red);
-}
-.prc-state-yellow {
-	color: var(--yellow);
-}
-.prc-state-muted {
-	color: var(--text-dim);
-}
-.prc-badge {
-	font-size: 11px;
-	font-weight: 600;
-	padding: 2px 8px;
-	border-radius: 99px;
-}
-.prc-badge-green {
-	background: var(--green-soft);
-	color: var(--green);
-}
-.prc-badge-red {
-	background: var(--red-soft);
-	color: var(--red);
-}
-.prc-badge-yellow {
-	background: rgba(210, 153, 34, 0.16);
-	color: var(--yellow);
-}
-.prc-badge-muted {
-	background: var(--bg-active);
-	color: var(--text-dim);
-}
 
 /* Git-status rows inside the Status card (Push / Create PR / Resolve / …). */
-.prc-git-row {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 5px 6px;
-	font-size: 13px;
-	color: var(--text-dim);
-}
 /* Attention row (e.g. behind main) — lift the label out of the dim tone. */
-.prc-git-row-strong .prc-git-label {
-	color: var(--text);
-	font-weight: 550;
-}
-.prc-git-dot {
-	width: 7px;
-	height: 7px;
-	border-radius: 50%;
-	flex-shrink: 0;
-	background: var(--text-faint);
-}
-.prc-git-label {
-	flex: 1;
-	min-width: 0;
-}
-.prc-action {
-	border: 1px solid var(--border-strong);
-	background: var(--bg-active);
-	color: var(--text);
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	padding: 3px 10px;
-	font-size: 12px;
-	font-weight: 550;
-	white-space: nowrap;
-	cursor: pointer;
-}
-.prc-action:hover:not(:disabled) {
-	background: var(--hover);
-	border-color: var(--text-faint);
-}
-.prc-action:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
-.prc-git-note {
-	padding: 4px 6px;
-	font-size: 12px;
-	color: var(--accent);
-}
-.prc-git-note-error {
-	color: var(--red);
-}
 
 /* Reviewers card */
-.prc-reviewer {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	padding: 5px 6px;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-}
-.prc-reviewer:hover {
-	background: var(--hover);
-}
-.prc-reviewer-avatar {
-	width: 20px;
-	height: 20px;
-	border-radius: 50%;
-	flex-shrink: 0;
-	object-fit: cover;
-}
-.prc-reviewer-avatar-fallback {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	background: var(--bg-active);
-	color: var(--text-dim);
-	font-size: 10px;
-	font-weight: 700;
-}
-.prc-reviewer-name {
-	flex: 1;
-	min-width: 0;
-	font-size: 13px;
-	color: var(--text);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.prc-reviewer-state {
-	display: inline-flex;
-	flex-shrink: 0;
-}
 
 /* Files-changed card */
-.prc-file {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	width: 100%;
-	padding: 4px 6px;
-	background: none;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	font: inherit;
-	text-align: left;
-	cursor: pointer;
-}
-.prc-file:disabled {
-	cursor: default;
-}
-.prc-file:not(:disabled):hover {
-	background: var(--hover);
-}
-.prc-file-icon {
-	flex-shrink: 0;
-	color: var(--text-faint);
-}
-.prc-file-name {
-	flex: 1;
-	min-width: 0;
-	font-size: 12.5px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	direction: rtl; /* keep the filename visible, clip the leading dirs */
-	text-align: left;
-}
-.prc-file-dir {
-	color: var(--text-faint);
-}
-.prc-file-stat {
-	display: inline-flex;
-	gap: 6px;
-	flex-shrink: 0;
-	font-size: 11.5px;
-	font-weight: 600;
-	font-variant-numeric: tabular-nums;
-}
 
 /* Tone helpers shared by reviewer state, git dots, check rollups. */
 .prc-tone-green {
@@ -7527,61 +5487,8 @@ a.workspace-info-check-row {
 .prc-tone-yellow {
 	color: var(--yellow);
 }
-.prc-tone-muted {
-	color: var(--text-faint);
-}
-.prc-git-dot.prc-tone-green {
-	background: var(--green);
-}
-.prc-git-dot.prc-tone-red {
-	background: var(--red);
-}
-.prc-git-dot.prc-tone-yellow {
-	background: var(--yellow);
-}
-.prc-git-dot.prc-tone-muted {
-	background: var(--text-faint);
-}
 
 /* Diff column head: Diff/Guide switcher + the pending-review hint. */
-.pr-diff-head {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	margin-bottom: 10px;
-}
-.pr-diff-head .pr-checks-title {
-	margin: 0;
-	min-width: 0;
-}
-.pr-diff-tabs {
-	display: inline-flex;
-	gap: 2px;
-	padding: 2px;
-	border-radius: var(--rf, 8px);
-	background: var(--surface);
-	flex-shrink: 0;
-}
-.pr-diff-tab {
-	appearance: none;
-	border: none;
-	background: transparent;
-	color: var(--text-dim);
-	font: inherit;
-	font-size: 12px;
-	font-weight: 600;
-	padding: 3px 10px;
-	border-radius: calc(var(--rf, 8px) - 2px);
-	cursor: pointer;
-}
-.pr-diff-tab:hover {
-	color: var(--text);
-}
-.pr-diff-tab.active {
-	background: var(--panel);
-	color: var(--text);
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-}
 
 /* AI review guide — narrative sections, each with its own diff slice. */
 .pr-guide-status {
@@ -7797,18 +5704,6 @@ a.workspace-info-check-row {
 .rv-state-label {
 	white-space: nowrap;
 }
-.rv-state-open {
-	color: var(--green);
-}
-.rv-state-draft {
-	color: var(--text-dim);
-}
-.rv-state-merged {
-	color: var(--purple);
-}
-.rv-state-closed {
-	color: var(--red);
-}
 
 .rv-c-title {
 	display: flex;
@@ -7931,16 +5826,6 @@ a.workspace-info-check-row {
 	border-radius: 99px;
 	flex-shrink: 0;
 }
-.rv-check-dot-pass {
-	background: var(--green);
-}
-.rv-check-dot-fail {
-	background: var(--red);
-}
-.rv-check-dot-pending {
-	background: #d9a23a;
-	animation: rv-pulse 1.4s ease-in-out infinite;
-}
 @keyframes rv-pulse {
 	0%,
 	100% {
@@ -7949,15 +5834,6 @@ a.workspace-info-check-row {
 	50% {
 		opacity: 0.35;
 	}
-}
-.rv-checks-pass .rv-checks-label {
-	color: var(--green);
-}
-.rv-checks-fail .rv-checks-label {
-	color: var(--red);
-}
-.rv-checks-pending .rv-checks-label {
-	color: #d9a23a;
 }
 .rv-checks-label {
 	white-space: nowrap;
@@ -8074,109 +5950,9 @@ a.workspace-info-check-row {
 }
 
 /* ── Detail drawer ──────────────────────────────────────── */
-.reviews-drawer {
-	flex: 1 1 auto;
-	min-width: 0;
-	border-left: 1px solid var(--border);
-	background: var(--bg-panel);
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-.reviews-drawer-head {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 12px 16px;
-	border-bottom: 1px solid var(--border);
-	flex-shrink: 0;
-}
-.reviews-drawer-close {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	background: none;
-	border: none;
-	color: var(--text-dim);
-	cursor: pointer;
-	flex-shrink: 0;
-}
-.reviews-drawer-close:hover {
-	background: var(--hover);
-	color: var(--text);
-}
-.reviews-drawer-back {
-	display: none;
-	align-items: center;
-	gap: 7px;
-	background: none;
-	border: none;
-	padding: 4px 6px;
-	margin: -4px 0 -4px -2px;
-	font: inherit;
-	font-size: 14px;
-	font-weight: 550;
-	color: var(--text);
-	cursor: pointer;
-}
-.reviews-drawer-back svg {
-	color: var(--text-dim);
-}
-.reviews-drawer-title {
-	flex: 1;
-	min-width: 0;
-	font-size: 13.5px;
-	font-weight: 600;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-.reviews-drawer-body {
-	flex: 1;
-	min-height: 0;
-	overflow: hidden;
-}
 
 /* When a PR is open the list collapses to a compact rail (GitHub split view):
    the diff is the hero, the list just keeps you oriented. */
-.reviews-has-detail .reviews-main {
-	flex: 0 0 360px;
-	border-right: 1px solid var(--border);
-}
-.reviews-has-detail .reviews-search {
-	display: none;
-}
-.reviews-has-detail .reviews-header {
-	padding: 14px 16px 0;
-}
-.reviews-has-detail .reviews-title {
-	font-size: 16px;
-}
-.reviews-has-detail .reviews-tabs {
-	overflow-x: auto;
-	margin: 0 -16px;
-	padding: 0 16px;
-}
-.reviews-has-detail .reviews-row {
-	grid-template-columns: 22px minmax(0, 1fr) auto;
-	gap: 10px;
-	padding: 10px 16px;
-}
-.reviews-has-detail .reviews-row-head,
-.reviews-has-detail .rv-state-label,
-.reviews-has-detail .rv-checks-bar,
-.reviews-has-detail .rv-c-review,
-.reviews-has-detail .rv-c-author,
-.reviews-has-detail .rv-c-changes,
-.reviews-has-detail .rv-c-updated {
-	display: none;
-}
-.reviews-has-detail .rv-checks-label {
-	font-size: 12px;
-}
 
 @media (max-width: 1180px) {
 	.reviews-row {
@@ -8263,43 +6039,8 @@ a.workspace-info-check-row {
 	}
 
 	/* the list and detail are separate screens, not a split */
-	.reviews-has-detail .reviews-main {
-		display: none;
-	}
-	.reviews-has-detail .reviews-drawer {
-		position: absolute;
-		inset: 0;
-		z-index: 20;
-		border-left: none;
-	}
-	.reviews-drawer-close,
-	.reviews-has-detail .reviews-drawer-title {
-		display: none;
-	}
-	.reviews-drawer-back {
-		display: inline-flex;
-	}
-	.reviews-drawer-body {
-		overflow-y: auto;
-	}
 
 	/* the PrPanel split stacks: info, then the diff below */
-	.pr-panel-split {
-		height: auto;
-	}
-	.pr-panel-split .pr-panel-body {
-		flex-direction: column;
-	}
-	.pr-panel-split .pr-panel-info {
-		width: auto;
-		flex-shrink: 1;
-		overflow-y: visible;
-		border-right: none;
-		border-bottom: 1px solid var(--border);
-	}
-	.pr-panel-split .pr-panel-diff {
-		overflow-y: visible;
-	}
 }
 
 /* ── Messages ────────────────────────────────────────────── */
@@ -8425,35 +6166,6 @@ a.workspace-info-check-row {
 /* "Load earlier history" — shown when the initial view is only the tail of a
    large transcript. Excluded from scroll anchoring so the click-to-expand keeps
    the reader's place via the content below it. */
-.load-history {
-	display: flex;
-	justify-content: center;
-	/* .viewer-messages already pads its top to clear the floating tab strip, so
-	   this only needs its own small breathing room as the first row. */
-	padding: 4px 0 14px;
-	overflow-anchor: none;
-}
-.load-history-btn {
-	font: inherit;
-	font-size: 12px;
-	color: var(--text-dim);
-	background: var(--bg-raised);
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	padding: 5px 14px;
-	cursor: pointer;
-	transition:
-		background 0.12s,
-		color 0.12s;
-}
-.load-history-btn:hover:not(:disabled) {
-	background: var(--hover);
-	color: var(--text);
-}
-.load-history-btn:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
 
 /* Bottom spacer that lets the latest turn reach the top of the viewport. Height is
    set imperatively by the scroll hook; no transition so it tracks streaming exactly. */
@@ -8466,48 +6178,7 @@ a.workspace-info-check-row {
 
 /* Make it easy to return to the latest reply (principles 8 & 9). Floats just
    above the composer; appears only when the reader has scrolled away. */
-.jump-latest {
-	position: absolute;
-	left: 50%;
-	/* Sit the pill above the composer's top edge with a little breathing room —
-	   a small fixed lift, not keyed to --chat-under (that pushed it too far up
-	   over the transcript). */
-	bottom: 24px;
-	transform: translateX(-50%);
-	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 14px;
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--text);
-	background: var(--bg-raised);
-	border: 1px solid var(--border);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	box-shadow: var(--control-shadow);
-	cursor: pointer;
-	z-index: 5;
-	animation: jump-rise 0.18s ease-out;
-	transition:
-		background 0.12s,
-		border-color 0.12s;
-}
-.jump-latest:hover {
-	border-color: var(--accent);
-	background: var(--hover);
-}
-.jump-latest-arrow {
-	font-size: 14px;
-	line-height: 1;
-}
 /* Content arrived out of view — draw the eye with the accent. */
-.jump-latest-new {
-	border-color: var(--accent);
-	color: var(--accent);
-}
-.jump-latest-new .jump-latest-arrow {
-	animation: pulse 1s ease-in-out infinite;
-}
 
 @keyframes jump-rise {
 	from {
@@ -8571,10 +6242,6 @@ a.workspace-info-check-row {
 .msg-user .msg-images,
 .msg-human .msg-images {
 	justify-content: flex-end;
-}
-.msg-label-assistant::before {
-	border-radius: 50%;
-	background: linear-gradient(135deg, #ff5a5a, #b00000);
 }
 
 .msg-body {
@@ -8674,10 +6341,6 @@ a.workspace-info-check-row {
 	height: 7px;
 }
 
-.msg-busy-inline .queue-count {
-	color: var(--text-faint);
-}
-
 .msg-system {
 	text-align: center;
 	/* `auto` left/right keeps this in the same centered column as user/assistant
@@ -8725,13 +6388,6 @@ a.workspace-info-check-row {
 .msg-system-text[data-tone="warn"] {
 	color: var(--yellow);
 	background: color-mix(in srgb, var(--yellow) 12%, transparent);
-}
-
-.app-title-wrap {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	min-width: 0;
 }
 
 /* "A new version is available" toast, docked to the sidebar bottom (see UpdatePill.tsx).
@@ -8924,17 +6580,6 @@ a.workspace-info-check-row {
 	background: color-mix(in srgb, var(--bg) 72%, transparent);
 	backdrop-filter: blur(2px);
 }
-.session-delete-card {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 14px;
-	padding: 26px 32px;
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
-}
 .session-delete-label {
 	font-size: 13px;
 	color: var(--text-dim);
@@ -9077,8 +6722,7 @@ a.workspace-info-check-row {
 
 .markdown h1,
 .markdown h2,
-.markdown h3,
-.markdown h4 {
+.markdown h3 {
 	margin: 6px 0 1px;
 	line-height: 1.3;
 	font-weight: 600;
@@ -9090,8 +6734,7 @@ a.workspace-info-check-row {
 .markdown h2 {
 	font-size: 14.5px;
 }
-.markdown h3,
-.markdown h4 {
+.markdown h3 {
 	font-size: 13.5px;
 }
 
@@ -9100,13 +6743,6 @@ a.workspace-info-check-row {
 }
 .markdown > :last-child {
 	margin-bottom: 0;
-}
-
-.markdown blockquote {
-	margin: 2px 0 8px;
-	padding: 3px 12px;
-	border-left: 2px solid rgba(255, 59, 59, 0.4);
-	color: var(--text-dim);
 }
 
 .markdown table {
@@ -9190,92 +6826,6 @@ a.workspace-info-check-row {
 	flex-direction: column;
 }
 
-.home-inner {
-	max-width: 760px;
-	width: 100%;
-	/* Center the start screen vertically, nudged up for optical balance. */
-	margin: auto;
-	padding: 24px 24px 10vh;
-}
-
-.home-hello {
-	font-size: 14px;
-	color: var(--text-dim);
-	margin-bottom: 6px;
-	text-align: center;
-}
-
-.home-greeting {
-	font-size: 24px;
-	font-weight: 600;
-	letter-spacing: -0.02em;
-	margin-bottom: 18px;
-	text-align: center;
-}
-
-.ask-box {
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(14px * var(--rf)); corner-shape: var(--cs);
-	padding: 12px;
-	transition: border-color 0.15s;
-}
-.ask-box:focus-within {
-	border-color: var(--accent);
-}
-
-.ask-input {
-	width: 100%;
-	background: none;
-	border: none;
-	color: var(--text);
-	font-size: 14.5px;
-	line-height: 1.5;
-	resize: none;
-	outline: none;
-	padding: 2px 4px 8px;
-}
-.ask-input::placeholder {
-	color: var(--text-faint);
-}
-
-.ask-actions {
-	display: flex;
-	justify-content: space-between;
-	gap: 10px;
-}
-
-.btn-task {
-	background: none;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	padding: 7px 14px;
-	font-size: 13px;
-	font-weight: 500;
-}
-.btn-task:hover {
-	color: var(--text);
-	border-color: var(--text-faint);
-}
-
-.btn-ask {
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 7px 22px;
-	font-size: 13px;
-	font-weight: 600;
-}
-.btn-ask:disabled {
-	opacity: 0.4;
-	cursor: default;
-}
-.btn-ask:not(:disabled):hover {
-	filter: brightness(1.1);
-}
-
 .ask-error {
 	margin-top: 10px;
 	padding: 7px 10px;
@@ -9286,89 +6836,7 @@ a.workspace-info-check-row {
 	text-align: center;
 }
 
-.ask-suggestions {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	gap: 7px;
-	margin-top: 12px;
-}
-
-.ask-suggestion {
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: 99px;
-	color: var(--text-dim);
-	font-size: 12px;
-	padding: 5px 12px;
-	max-width: 100%;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.ask-suggestion:hover {
-	color: var(--text);
-	border-color: var(--border-strong);
-	background: var(--hover);
-}
-
-.ask-suggestion-dot {
-	width: 6px;
-	height: 6px;
-	border-radius: 50%;
-	flex-shrink: 0;
-}
-
 /* Ambient status line under the start-screen suggestions. */
-.home-whisper {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	gap: 8px;
-	margin-top: 28px;
-	font-size: 12.5px;
-	color: var(--text-faint);
-}
-.home-whisper-part {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	color: inherit;
-	font-size: inherit;
-}
-.home-whisper-part + .home-whisper-part::before {
-	content: "·";
-	margin-right: 8px;
-	color: var(--text-faint);
-}
-.home-whisper-part .working-dot {
-	width: 6px;
-	height: 6px;
-}
-button.home-whisper-link {
-	background: none;
-	border: none;
-	padding: 0;
-	cursor: pointer;
-}
-button.home-whisper-link:hover {
-	color: var(--text);
-}
-
-.home-section {
-	margin-bottom: 26px;
-}
-
-.home-section-title {
-	font-size: 12px;
-	font-weight: 700;
-	letter-spacing: -0.01em;
-	color: var(--text-faint);
-	margin-bottom: 8px;
-}
 
 .home-rows {
 	display: flex;
@@ -9402,13 +6870,6 @@ button.home-whisper-link:hover {
 	gap: 4px;
 }
 
-.home-row-titleline {
-	display: flex;
-	align-items: center;
-	gap: 7px;
-	min-width: 0;
-}
-
 .home-row-title {
 	font-size: 13.5px;
 	font-weight: 500;
@@ -9419,17 +6880,6 @@ button.home-whisper-link:hover {
 
 /* Unread activity since you last opened the session — a solid iMessage/WhatsApp
    -style accent dot (no pulse; it's a marker, not a live-status indicator). */
-.home-row-unread-dot {
-	width: 8px;
-	height: 8px;
-	border-radius: 50%;
-	flex-shrink: 0;
-	background: var(--accent);
-}
-.home-row-unread .home-row-title {
-	font-weight: 600;
-	color: var(--text);
-}
 
 .home-row-meta {
 	display: flex;
@@ -9440,69 +6890,10 @@ button.home-whisper-link:hover {
 	min-width: 0;
 }
 
-.home-row-branch {
-	font-family: var(--mono);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 .home-empty {
 	color: var(--text-faint);
 	font-size: 13px;
 	padding: 14px 4px;
-}
-
-.status-pill {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 11px;
-	font-weight: 700;
-	padding: 3px 10px;
-	border-radius: 99px;
-	flex-shrink: 0;
-	min-width: 70px;
-	justify-content: center;
-}
-.status-green {
-	background: var(--green-soft);
-	color: var(--green);
-}
-.status-blue {
-	background: var(--accent-soft);
-	color: var(--accent);
-}
-.status-purple {
-	background: rgba(163, 113, 247, 0.16);
-	color: var(--purple);
-}
-.status-red {
-	background: var(--red-soft);
-	color: var(--red);
-}
-.status-yellow {
-	background: rgba(210, 153, 34, 0.15);
-	color: var(--yellow);
-}
-.status-gray {
-	background: var(--bg-active);
-	color: var(--text-faint);
-}
-
-.pin-btn {
-	color: var(--text-faint);
-	font-size: 15px;
-	padding: 4px 6px;
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	flex-shrink: 0;
-}
-.pin-btn:hover {
-	color: var(--yellow);
-	background: var(--hover-strong);
-}
-.pin-active {
-	color: var(--yellow);
 }
 
 /* Work blocks + tool calls are Tailwind-styled in WorkBlock.tsx /
@@ -9516,100 +6907,7 @@ button.home-whisper-link:hover {
 
 /* ── Spin-off menu ───────────────────────────────────────── */
 
-.spinoff {
-	position: relative;
-}
-
-.spinoff-form {
-	position: absolute;
-	top: calc(100% + 6px);
-	right: 0;
-	z-index: 50;
-	width: 380px;
-	max-width: 90vw;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
-	padding: 14px;
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-}
-
-.spinoff-form-title {
-	font-weight: 600;
-	font-size: 13.5px;
-}
-
-.spinoff-form label {
-	display: flex;
-	flex-direction: column;
-	gap: 5px;
-	font-size: 12px;
-	font-weight: 500;
-	color: var(--text-dim);
-}
-
-.spinoff-form input,
-.spinoff-form textarea {
-	background: var(--bg-raised);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 7px 10px;
-	font-size: 13px;
-	outline: none;
-}
-.spinoff-form input:focus,
-.spinoff-form textarea:focus {
-	border-color: var(--accent);
-}
-.spinoff-form textarea {
-	resize: vertical;
-	line-height: 1.45;
-}
-
-.spinoff-form-actions {
-	display: flex;
-	justify-content: flex-end;
-	gap: 8px;
-}
-
-.spinoff-note {
-	color: var(--text-faint);
-	font-size: 11.5px;
-}
-
 /* automation webhook row */
-.automation-webhook {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-top: 10px;
-	padding-top: 10px;
-	border-top: 1px solid var(--border);
-	min-width: 0;
-}
-
-.automation-webhook-label {
-	font-size: 10.5px;
-	font-weight: 700;
-	letter-spacing: -0.01em;
-	color: var(--text-faint);
-	flex-shrink: 0;
-}
-
-.automation-webhook-url {
-	font-family: var(--mono);
-	font-size: 11px;
-	color: var(--text-dim);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-	flex: 1;
-}
 
 /* ── Terminal panel ──────────────────────────────────────── */
 
@@ -9621,36 +6919,6 @@ button.home-whisper-link:hover {
 	font-size: 11.5px;
 	line-height: 1.55;
 	background: #08080a;
-}
-
-.terminal-entry {
-	margin-bottom: 12px;
-}
-
-.terminal-cmd {
-	color: var(--text);
-	white-space: pre-wrap;
-	word-break: break-word;
-	font-weight: 600;
-}
-
-.terminal-prompt {
-	color: var(--green);
-}
-
-.terminal-output {
-	margin: 4px 0 0;
-	color: var(--text-dim);
-	white-space: pre-wrap;
-	word-break: break-word;
-	max-height: 360px;
-	overflow-y: auto;
-}
-
-.terminal-running {
-	color: var(--yellow);
-	margin-top: 4px;
-	animation: pulse 1.4s infinite;
 }
 
 /* ── Tool calls (rows styled in ToolCallBlock.tsx) ───────── */
@@ -9673,9 +6941,6 @@ button.home-whisper-link:hover {
 
 /* Timeline icon chip: solid tint of the tool family's hue (currentColor) mixed
    into the page bg — solid so the timeline rail doesn't show through it. */
-.tool-chip {
-	background: color-mix(in oklab, currentColor 13%, var(--bg));
-}
 
 /* Code surface inside an expanded tool call. */
 .tool-code-surface {
@@ -9750,59 +7015,7 @@ html[data-theme="light"] .tool-code-surface .shiki-gutter {
 	padding: 4px 20px 14px;
 }
 
-.viewer-input-row {
-	display: flex;
-	gap: 10px;
-	align-items: flex-end;
-	max-width: var(--chat-col);
-	margin: 0 auto;
-}
-
 /* Live cost/context pill, aligned under the composer's right edge. */
-.viewer-usage-row {
-	display: flex;
-	justify-content: flex-end;
-	max-width: var(--chat-col);
-	margin: 4px auto 0;
-	padding: 0 2px;
-}
-
-.prompt-input {
-	flex: 1;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 10px 14px;
-	font-size: 13.5px;
-	line-height: 1.5;
-	resize: vertical;
-	min-height: 44px;
-	outline: none;
-}
-.prompt-input:focus {
-	border-color: var(--accent);
-}
-.prompt-input::placeholder {
-	color: var(--text-faint);
-}
-
-.btn-send {
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	padding: 10px 18px;
-	font-size: 13.5px;
-	font-weight: 500;
-}
-.btn-send:disabled {
-	opacity: 0.4;
-	cursor: default;
-}
-.btn-send:not(:disabled):hover {
-	filter: brightness(1.1);
-}
 
 /* ── Composer (shared chat input — Claude/Codex style) ─────────────── */
 
@@ -10248,9 +7461,6 @@ html[data-theme="light"] .tool-code-surface .shiki-gutter {
 .composer.composer-min .composer-voice-wrap {
 	order: 3;
 }
-.composer.composer-min .composer-send-queue {
-	order: 4;
-}
 .composer.composer-min .composer-send-split {
 	order: 5;
 }
@@ -10418,52 +7628,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	flex-shrink: 1;
 	min-width: 0;
 }
-.composer-toolbar .palette-effort-icon {
-	flex-shrink: 0;
-}
-
-.composer-model {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	position: relative;
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	padding: 3px 9px 3px 9px;
-	color: var(--text-dim);
-	font-size: 12px;
-	max-width: 240px;
-	transition:
-		border-color 0.15s,
-		color 0.15s;
-}
-.composer-model:hover {
-	border-color: var(--text-faint);
-	color: var(--text);
-}
-.composer-model select {
-	appearance: none;
-	-webkit-appearance: none;
-	background: none;
-	border: none;
-	outline: none;
-	color: inherit;
-	font-size: 12px;
-	font-weight: 500;
-	cursor: pointer;
-	max-width: 180px;
-	text-overflow: ellipsis;
-	padding-right: 2px;
-}
-.composer-model select:disabled {
-	cursor: default;
-	opacity: 0.7;
-}
-.composer-model-chevron {
-	font-size: 9px;
-	color: var(--text-faint);
-	pointer-events: none;
-}
 .composer-send {
 	width: 32px;
 	height: 32px;
@@ -10490,11 +7654,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	filter: brightness(1.12);
 	transform: scale(1.05);
 }
-.composer-send-queue {
-	background: var(--bg-raised);
-	color: var(--text-dim);
-	border: 1px solid var(--border-strong);
-}
 .composer-send-queue-main {
 	background: var(--bg-raised);
 	color: var(--accent);
@@ -10518,14 +7677,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	display: inline-flex;
 	align-items: stretch;
 	flex-shrink: 0;
-}
-.composer-send-split.has-menu .composer-send {
-	width: 34px;
-	border-radius: calc(14px * var(--rf)) 0 0 calc(14px * var(--rf)); corner-shape: var(--cs);
-}
-.composer-send-split.has-menu .composer-send:not(:disabled):hover {
-	/* No scale on a fused half — it would tear the seam open. */
-	transform: none;
 }
 .composer-schedule-wrap {
 	position: relative;
@@ -10586,13 +7737,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	transform: rotate(180deg);
 }
 /* Busy → the caret matches the interrupt-red send half. */
-.composer-send-split.is-interrupt .composer-send-caret {
-	background: var(--red-soft);
-	color: var(--red);
-}
-.composer-send-split.is-interrupt .composer-send-caret::before {
-	background: rgba(248, 81, 73, 0.4);
-}
 .composer-schedule-badge {
 	position: absolute;
 	top: -5px;
@@ -10793,26 +7937,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	margin-top: 7px;
 }
 
-.chip-fallback {
-	opacity: 0.65;
-}
-
-.prompt-hint {
-	color: var(--text-faint);
-	font-size: 11px;
-	margin-top: 5px;
-}
-
-.input-busy {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	color: var(--text-dim);
-	font-size: 13px;
-	max-width: var(--chat-col);
-	margin: 0 auto;
-}
-
 .pulse-dot {
 	width: 8px;
 	height: 8px;
@@ -10827,43 +7951,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	font-variant-numeric: tabular-nums;
 }
 
-.btn-cancel {
-	margin-left: auto;
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	background: none;
-	border: 1px solid transparent;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-faint);
-	padding: 5px 12px;
-	font-size: 12.5px;
-	font-weight: 500;
-	cursor: pointer;
-	transition:
-		color 0.12s ease,
-		background 0.12s ease,
-		border-color 0.12s ease;
-}
-.btn-cancel-icon {
-	width: 8px;
-	height: 8px;
-	border-radius: calc(2px * var(--rf)); corner-shape: var(--cs);
-	background: currentColor;
-}
-.btn-cancel:hover {
-	color: var(--red);
-	background: var(--red-soft);
-	border-color: var(--red-soft);
-}
-
-.input-disabled {
-	color: var(--text-faint);
-	font-size: 13px;
-	max-width: var(--chat-col);
-	margin: 0 auto;
-}
-
 /* ── New session form ────────────────────────────────────── */
 
 .new-session {
@@ -10876,91 +7963,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	overflow-y: auto;
 }
 
-.btn-back {
-	background: none;
-	border: none;
-	color: var(--text-dim);
-	font-size: 13px;
-	padding: 4px 8px;
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-}
-.btn-back:hover {
-	color: var(--text);
-	background: var(--hover);
-}
-
-.new-session-form {
-	max-width: 560px;
-	width: 100%;
-	margin: 32px auto;
-	padding: 0 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 18px;
-}
-
-.new-session-form label {
-	display: flex;
-	flex-direction: column;
-	gap: 7px;
-	font-size: 13px;
-	font-weight: 500;
-	color: var(--text-dim);
-}
-
-.new-session-form .label-row {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-.new-session-form .branch-suggesting {
-	font-weight: 500;
-	font-size: 12px;
-	color: var(--text-dim);
-	opacity: 0.8;
-}
-
-.new-session-form select,
-.new-session-form input,
-.new-session-form textarea {
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 10px 12px;
-	font-size: 13.5px;
-	outline: none;
-}
-.new-session-form select:focus,
-.new-session-form input:focus,
-.new-session-form textarea:focus {
-	border-color: var(--accent);
-}
-
-.new-session-form textarea {
-	resize: vertical;
-	line-height: 1.5;
-	width: 100%;
-	box-sizing: border-box;
-}
-
-.btn-create {
-	background: var(--accent);
-	color: #fff;
-	border: none;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	padding: 11px;
-	font-size: 14px;
-	font-weight: 500;
-}
-.btn-create:disabled {
-	opacity: 0.4;
-	cursor: default;
-}
-.btn-create:not(:disabled):hover {
-	filter: brightness(1.1);
-}
-
 .form-error {
 	background: var(--red-soft);
 	border: 1px solid rgba(248, 81, 73, 0.4);
@@ -10968,12 +7970,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
 	padding: 10px 12px;
 	font-size: 13px;
-}
-
-.create-note {
-	color: var(--text-faint);
-	font-size: 12.5px;
-	text-align: center;
 }
 
 /* ── Automations ─────────────────────────────────────────── */
@@ -11003,184 +7999,7 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	letter-spacing: -0.01em;
 }
 
-.page-sub {
-	color: var(--text-faint);
-	font-size: 12.5px;
-	margin-top: 4px;
-}
-
 /* Archived-page filter bar: segmented owner (Mine / Everyone) + repo controls. */
-.archived-filters {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 10px;
-	margin: -6px 0 18px;
-}
-.seg-control {
-	display: inline-flex;
-	background: var(--bg-hover);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	padding: 2px;
-	gap: 2px;
-}
-.seg-control-btn {
-	background: none;
-	border: none;
-	cursor: pointer;
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	padding: 4px 10px;
-	font-size: 12.5px;
-	font-weight: 500;
-	color: var(--text-faint);
-	white-space: nowrap;
-}
-.seg-control-btn:hover {
-	color: var(--text-dim);
-}
-.seg-control-btn.active {
-	background: var(--bg-active);
-	color: var(--text);
-}
-
-.automations-empty {
-	text-align: center;
-	color: var(--text-dim);
-	padding: 48px 16px;
-}
-.automations-empty p {
-	margin: 0 0 8px;
-}
-.automations-empty-sub {
-	color: var(--text-faint);
-	font-size: 13px;
-}
-
-.automation-list {
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-}
-
-.automation-card {
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	padding: 14px 16px;
-}
-.automation-disabled {
-	opacity: 0.55;
-}
-
-.automation-top {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	min-width: 0;
-}
-
-.automation-name {
-	font-weight: 600;
-	font-size: 14px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.automation-actions {
-	margin-left: auto;
-	display: flex;
-	gap: 6px;
-	flex-shrink: 0;
-}
-
-.btn-small {
-	background: none;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	padding: 3px 10px;
-	font-size: 12px;
-}
-.btn-small:hover {
-	color: var(--text);
-	border-color: var(--text-faint);
-}
-.btn-small:disabled {
-	opacity: 0.4;
-	cursor: default;
-}
-.btn-small-danger:hover {
-	color: var(--red);
-	border-color: var(--red);
-}
-
-.auto-toggle {
-	width: 34px;
-	height: 19px;
-	border-radius: 99px;
-	border: 1px solid var(--border-strong);
-	background: var(--bg-active);
-	position: relative;
-	flex-shrink: 0;
-	padding: 0;
-	transition: background 0.15s;
-}
-.auto-toggle-knob {
-	position: absolute;
-	top: 2px;
-	left: 2px;
-	width: 13px;
-	height: 13px;
-	border-radius: 50%;
-	background: var(--text-faint);
-	transition:
-		transform 0.15s,
-		background 0.15s;
-}
-.auto-toggle-on {
-	background: var(--green-soft);
-	border-color: var(--green);
-}
-.auto-toggle-on .auto-toggle-knob {
-	transform: translateX(15px);
-	background: var(--green);
-}
-
-.automation-prompt {
-	color: var(--text-dim);
-	font-size: 13px;
-	line-height: 1.5;
-	margin: 9px 0;
-	display: -webkit-box;
-	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;
-	overflow: hidden;
-}
-
-.automation-meta {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 6px 14px;
-	font-size: 12px;
-	color: var(--text-faint);
-}
-
-.automation-cron {
-	font-family: var(--mono);
-	background: var(--bg-active);
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	padding: 1px 7px;
-	font-size: 11px;
-}
-
-.auto-status-ok {
-	color: var(--green);
-}
-.auto-status-err {
-	color: var(--red);
-}
 
 .automation-session-link {
 	color: var(--accent);
@@ -11191,331 +8010,19 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	text-decoration: underline;
 }
 
-.automation-by {
-	margin-left: auto;
-}
-
-.automation-form {
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	padding: 18px;
-	margin-bottom: 18px;
-	display: flex;
-	flex-direction: column;
-	gap: 14px;
-}
-
-.automation-form-title {
-	font-weight: 600;
-	font-size: 14.5px;
-}
-
-.automation-form label {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-	font-size: 12.5px;
-	font-weight: 500;
-	color: var(--text-dim);
-	flex: 1;
-}
-
-.automation-form input,
-.automation-form textarea,
-.automation-form select {
-	background: var(--bg-raised);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 8px 11px;
-	font-size: 13.5px;
-	outline: none;
-}
-.automation-form input:focus,
-.automation-form textarea:focus,
-.automation-form select:focus {
-	border-color: var(--accent);
-}
-.automation-form textarea {
-	resize: vertical;
-	line-height: 1.5;
-}
-
-.automation-form-row {
-	display: flex;
-	gap: 14px;
-}
-
-.automation-form-actions {
-	display: flex;
-	justify-content: flex-end;
-	gap: 10px;
-}
-
 /* ── Automations: list + right detail drawer (mirrors Reviews) ──────────────
    The generic .automations/.automation-list/.automation-card classes above are
    shared by Goals/Security/Actions/Archived, so this page has its own set. */
 
-.automations-page {
-	flex: 1;
-	min-height: 0;
-	min-width: 0;
-	display: flex;
-	position: relative;
-}
-.automations-page-main {
-	flex: 1;
-	min-width: 0;
-	overflow-y: auto;
-	padding: 28px 24px 60px;
-}
-.automations-page-inner {
-	max-width: 860px;
-	margin: 0 auto;
-}
-
-.automations-table {
-	display: flex;
-	flex-direction: column;
-	border-top: 1px solid var(--border);
-}
-.automations-row {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	width: 100%;
-	min-width: 0;
-	text-align: left;
-	background: none;
-	border: none;
-	border-bottom: 1px solid var(--border);
-	padding: 11px 10px;
-	cursor: pointer;
-	color: var(--text);
-	font: inherit;
-}
-.automations-row:hover {
-	background: var(--hover);
-}
-.automations-row.active {
-	background: var(--bg-active);
-}
-.automations-row-off .automations-row-main {
-	opacity: 0.55;
-}
-.automations-row-main {
-	flex: 1;
-	min-width: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 3px;
-}
-.automations-row-name {
-	font-size: 14px;
-	font-weight: 600;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.automations-row-trigger {
-	font-size: 11.5px;
-	font-family: var(--mono);
-	color: var(--text-faint);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.automations-row-graph {
-	flex-shrink: 0;
-	display: flex;
-}
-.automations-row-next {
-	flex-shrink: 0;
-	width: 84px;
-	text-align: right;
-	font-size: 12px;
-	color: var(--text-faint);
-}
-
 /* Detail drawer (right side, Reviews-style). */
-.automations-drawer {
-	flex: 1 1 auto;
-	min-width: 0;
-	border-left: 1px solid var(--border);
-	background: var(--bg-panel);
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-.automations-drawer-head {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 12px 16px;
-	border-bottom: 1px solid var(--border);
-	flex-shrink: 0;
-}
-.automations-drawer-title {
-	min-width: 0;
-	font-size: 13.5px;
-	font-weight: 600;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-.automations-drawer-actions {
-	margin-left: auto;
-	display: flex;
-	gap: 6px;
-	flex-shrink: 0;
-}
-.automations-drawer-close {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	background: none;
-	border: none;
-	color: var(--text-dim);
-	cursor: pointer;
-	flex-shrink: 0;
-}
-.automations-drawer-close:hover {
-	background: var(--hover);
-	color: var(--text);
-}
-.automations-drawer-back {
-	display: none;
-	align-items: center;
-	gap: 7px;
-	background: none;
-	border: none;
-	padding: 4px 6px;
-	margin: -4px 0 -4px -2px;
-	font: inherit;
-	font-size: 14px;
-	font-weight: 550;
-	color: var(--text);
-	cursor: pointer;
-	flex-shrink: 0;
-}
-.automations-drawer-back svg {
-	color: var(--text-dim);
-}
-.automations-drawer-body {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-	padding: 18px 20px 40px;
-	display: flex;
-	flex-direction: column;
-	gap: 14px;
-}
-.automations-drawer-chips {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-.automations-drawer-section-label {
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--text-faint);
-}
 /* The card list clamps prompts to two lines — the drawer shows the whole thing. */
-.automation-prompt.automations-drawer-prompt {
-	display: block;
-	-webkit-line-clamp: unset;
-	white-space: pre-wrap;
-	overflow: visible;
-	margin: 0;
-}
 
 /* Inline edit hosted in the drawer: drop the form's card chrome — the drawer
    body already provides the panel background and its own padding. */
-.automation-form.automation-form-inline {
-	background: none;
-	border: none;
-	border-radius: 0;
-	padding: 0;
-	margin-bottom: 0;
-}
 
 /* Drawer open: the list compresses to a narrow rail (Reviews-style). */
-.automations-page-has-detail .automations-page-main {
-	flex: 0 0 340px;
-	border-right: 1px solid var(--border);
-	padding: 16px 14px 40px;
-}
-.automations-page-has-detail .automations-page-inner {
-	max-width: none;
-}
-.automations-page-has-detail .page-sub,
-.automations-page-has-detail .automations-row-graph,
-.automations-page-has-detail .automations-row-next {
-	display: none;
-}
-.automations-page-has-detail .page-title {
-	font-size: 16px;
-}
-.automations-page-has-detail .page-header {
-	align-items: center;
-	margin-bottom: 14px;
-}
 
 /* Phones: the drawer takes the full width; Back returns to the list. */
-@media (max-width: 900px) {
-	.automations-page-has-detail .automations-page-main {
-		display: none;
-	}
-	.automations-drawer {
-		border-left: none;
-	}
-	.automations-drawer-back {
-		display: inline-flex;
-	}
-	.automations-drawer-close {
-		display: none;
-	}
-}
-
-@media (max-width: 560px) {
-	.automations-page-main {
-		padding: 20px 16px 48px;
-	}
-	.automations-page .page-header {
-		align-items: flex-start;
-		flex-direction: column;
-		gap: 14px;
-		margin-bottom: 20px;
-	}
-	.automations-row {
-		gap: 10px;
-		padding: 12px 4px;
-	}
-	.automations-row-main {
-		order: -1;
-	}
-	.automations-row-name {
-		font-size: 14.5px;
-	}
-	.automations-row-graph,
-	.automations-row-next {
-		display: none;
-	}
-	.auto-toggle {
-		flex-shrink: 0;
-	}
-	.automations-row .working-pill,
-	.automations-row .source-chip {
-		max-width: 92px;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
-}
 
 /* ── Connections ─────────────────────────────────────────── */
 
@@ -11529,141 +8036,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	margin: 0 auto;
 }
 
-.conn-section-title {
-	font-size: 12px;
-	font-weight: 700;
-	letter-spacing: -0.01em;
-	color: var(--text-faint);
-	margin: 22px 0 10px;
-}
-
-.conn-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-	gap: 10px;
-}
-
-.conn-card {
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(12px * var(--rf)); corner-shape: var(--cs);
-	padding: 14px;
-	min-width: 0;
-}
-
-.conn-card-top {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	margin-bottom: 8px;
-}
-
-.conn-logo {
-	width: 28px;
-	height: 28px;
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	font-weight: 700;
-	font-size: 13px;
-	color: #fff;
-	background: var(--bg-active);
-	flex-shrink: 0;
-}
-.conn-logo-slack {
-	background: #4a154b;
-}
-.conn-logo-linear {
-	background: #5e6ad2;
-}
-.conn-logo-plain {
-	background: #0d9488;
-}
-.conn-logo-sentry {
-	background: #584774;
-}
-.conn-logo-workos {
-	background: #6363f1;
-}
-.conn-logo-tinybird {
-	background: #27f795;
-	color: #08080a;
-}
-
-.conn-name {
-	font-weight: 600;
-	font-size: 14px;
-	text-transform: capitalize;
-	flex: 1;
-	min-width: 0;
-}
-
-.conn-blurb {
-	color: var(--text-dim);
-	font-size: 12.5px;
-	line-height: 1.45;
-	margin-bottom: 8px;
-}
-
-.conn-detail {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-size: 11.5px;
-	color: var(--text-faint);
-	min-width: 0;
-}
-
-.conn-transport {
-	font-family: var(--mono);
-	background: var(--bg-active);
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	padding: 1px 6px;
-	flex-shrink: 0;
-}
-
-.conn-target {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
-}
-
-.conn-error {
-	margin-top: 8px;
-	color: var(--red);
-	font-size: 11.5px;
-	font-family: var(--mono);
-}
-
-.conn-remove {
-	margin-top: 10px;
-	background: none;
-	border: 1px solid var(--border-strong);
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-faint);
-	padding: 2px 9px;
-	font-size: 11.5px;
-}
-.conn-remove:hover {
-	color: var(--red);
-	border-color: var(--red);
-}
-
-.conn-footnote {
-	margin-top: 24px;
-	color: var(--text-faint);
-	font-size: 12.5px;
-}
-.conn-footnote code {
-	font-family: var(--mono);
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	padding: 1px 5px;
-}
-
 /* ── Wiki ────────────────────────────────────────────────── */
 
 .wiki {
@@ -11672,160 +8044,12 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	min-height: 0;
 }
 
-.wiki-nav {
-	width: 300px;
-	flex-shrink: 0;
-	border-right: 1px solid var(--border);
-	background: var(--bg-raised);
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-
-.wiki-search-wrap {
-	padding: 12px;
-	border-bottom: 1px solid var(--border);
-}
-
-.wiki-search {
-	width: 100%;
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	padding: 7px 10px;
-	font-size: 13px;
-	outline: none;
-}
-.wiki-search:focus {
-	border-color: var(--accent);
-}
-.wiki-search::placeholder {
-	color: var(--text-faint);
-}
-
-.wiki-tree,
-.wiki-results {
-	flex: 1;
-	overflow-y: auto;
-	padding: 8px 6px 24px;
-}
-
-.wiki-tree {
-	padding: 6px 4px 16px;
-}
-
 .wiki-filetree {
 	display: block;
 	height: 100%;
 	/* The tree's shadow styles use light-dark(); force the dark arm —
      the app is dark-only regardless of OS preference */
 	color-scheme: dark;
-}
-
-.wiki-dir,
-.wiki-file {
-	display: block;
-	width: 100%;
-	text-align: left;
-	background: none;
-	border: none;
-	border-radius: calc(5px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	font-size: 13px;
-	padding: 5px 8px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.wiki-dir {
-	font-weight: 600;
-	color: var(--text);
-}
-.wiki-dir:hover,
-.wiki-file:hover {
-	background: var(--hover);
-}
-.wiki-file-selected,
-.wiki-file-selected:hover {
-	background: var(--accent-soft);
-	color: var(--text);
-}
-
-.wiki-chevron {
-	display: inline-block;
-	width: 13px;
-	font-size: 9px;
-	color: var(--text-faint);
-}
-
-.wiki-empty {
-	color: var(--text-faint);
-	text-align: center;
-	padding: 24px 0;
-	font-size: 13px;
-}
-
-.wiki-result {
-	display: flex;
-	flex-direction: column;
-	gap: 3px;
-	width: 100%;
-	text-align: left;
-	background: none;
-	border: none;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	padding: 8px 10px;
-	min-width: 0;
-}
-.wiki-result:hover {
-	background: var(--hover);
-}
-
-.wiki-result-title {
-	color: var(--text);
-	font-size: 13px;
-	font-weight: 600;
-}
-.wiki-result-snippet {
-	color: var(--text-dim);
-	font-size: 12px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-.wiki-result-path {
-	color: var(--text-faint);
-	font-size: 11px;
-	font-family: var(--mono);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.wiki-content {
-	flex: 1;
-	overflow-y: auto;
-	min-width: 0;
-	padding: 24px 32px 80px;
-}
-
-.wiki-nav-toggle {
-	display: none;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	padding: 6px 12px;
-	font-size: 13px;
-	margin-bottom: 14px;
-}
-
-.wiki-doc-path {
-	font-family: var(--mono);
-	font-size: 11.5px;
-	color: var(--text-faint);
-	margin-bottom: 16px;
 }
 
 .wiki-doc {
@@ -11851,29 +8075,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 }
 .wiki-doc a {
 	color: var(--accent);
-}
-
-.wiki-welcome {
-	max-width: 560px;
-	margin: 60px auto;
-	text-align: center;
-	color: var(--text-dim);
-}
-.wiki-welcome h2 {
-	color: var(--text);
-	margin-bottom: 12px;
-}
-.wiki-welcome code {
-	font-family: var(--mono);
-	background: var(--bg-panel);
-	border: 1px solid var(--border);
-	border-radius: calc(4px * var(--rf)); corner-shape: var(--cs);
-	padding: 1px 5px;
-	font-size: 12.5px;
-}
-.wiki-welcome-hint {
-	font-size: 13px;
-	color: var(--text-faint);
 }
 
 /* ── User gate ───────────────────────────────────────────── */
@@ -11947,10 +8148,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		z-index: 25;
 	}
 
-	.panel-close {
-		display: block;
-	}
-
 	/* Chevron-back at the top of the workspace panel on phones — the panel is a
 	   deeper page reached from the ⋯ menu, so it carries its own way back to the
 	   chat (matching the top-bar back chevron, no "Back" word). */
@@ -11974,27 +8171,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 	.panel-back:active {
 		opacity: 0.4;
-	}
-
-	.wiki-nav {
-		position: fixed;
-		top: var(--header-h);
-		left: 0;
-		bottom: 0;
-		z-index: 30;
-		width: min(320px, 88vw);
-		transform: translateX(-100%);
-		transition: transform 0.18s ease;
-		box-shadow: 12px 0 32px rgba(0, 0, 0, 0.5);
-	}
-	.wiki-nav-open {
-		transform: translateX(0);
-	}
-	.wiki-nav-toggle {
-		display: inline-block;
-	}
-	.wiki-content {
-		padding: 16px 16px 60px;
 	}
 }
 
@@ -12135,10 +8311,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 
 	/* The drawer affordances are gone in the page model. */
-	.hamburger,
-	.sidebar-overlay {
-		display: none;
-	}
 
 	/* Back control on a pushed page: a floating circular bubble carrying just the
 	   chevron (no "Back" word) — matches the ⋯ / search bubbles so the pushed-page
@@ -12313,11 +8485,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		pointer-events: auto;
 		cursor: pointer;
 		-webkit-tap-highlight-color: transparent;
-	}
-	.app-header-title-caret {
-		flex-shrink: 0;
-		opacity: 0.5;
-		color: var(--text-dim);
 	}
 	.app-header-title-tappable:active .app-header-title-text {
 		opacity: 0.6;
@@ -12560,13 +8727,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		color: var(--text-dim);
 	}
 	/* Repo chip: tile + name, sized to the thin subtitle line. */
-	.header-chatbar-repo {
-		display: inline-flex;
-		align-items: center;
-		gap: 4px;
-		min-width: 0;
-		max-width: 45vw;
-	}
 	.header-chatbar-model {
 		min-width: 0;
 		max-width: 45vw;
@@ -12591,29 +8751,7 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	/* Model line as a tap target: a compact label + chevron with a full-bleed
 	   transparent native <select> over it (opens the OS picker). Kept tiny to
 	   read as a subtitle until tapped. */
-	.header-model-select {
-		position: relative;
-		display: inline-flex;
-		align-items: center;
-		gap: 3px;
-		max-width: 100%;
-		color: var(--text-dim);
-	}
-	.header-model-label {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	.header-model-chevron {
-		flex-shrink: 0;
-		opacity: 0.6;
-	}
 	/* Grow the touch area past the thin text line without shifting layout. */
-	.header-model-select .palette-select-overlay {
-		top: -8px;
-		bottom: -8px;
-		height: auto;
-	}
 	/* The title now lives in the top bar — the in-page copy under it is
 	   duplicate chrome. */
 	.detail-topbar-title {
@@ -12741,46 +8879,14 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	/* The ⋯ is the phone's main gateway to session actions, so give it a real
 	   iOS-style circular touch target (matching .mobile-search-btn) with a
 	   larger glyph — the tiny 18px text-only button read as an afterthought. */
-	.viewer-header-actions .btn-viewer-overflow {
-		width: 40px;
-		height: 40px;
-		min-height: 40px;
-		padding: 0;
-		font-size: 24px;
-		border-radius: 50%;
-		border-color: var(--border);
-		/* White floating bubble matching the Back bubble + title pill. */
-		background: var(--bg);
-		color: var(--accent);
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-	}
-	.viewer-header-actions .btn-viewer-overflow.active {
-		background: var(--accent-soft);
-		border-color: var(--accent-soft);
-	}
 	/* Icon-only workspace toggle on phones — the label is kept on desktop */
-	.btn-panel-toggle-label {
-		display: none;
-	}
 	/* Make the Workspace toggle the one standout control — it's how you reach the
      diff / terminal / PR on a phone. (Scoped to .btn-workspace so the Spin-off
      trigger, which shares .btn-panel-toggle, stays neutral.) */
-	.viewer-header-actions .btn-workspace {
-		order: 2;
-		color: var(--accent);
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
-		padding: 5px 7px;
-		font-size: 15px;
-	}
-	.viewer-header-actions .btn-workspace.active {
-		background: color-mix(in srgb, var(--accent) 12%, transparent);
-		color: var(--accent);
-	}
 
 	/* The keyboard-shortcut hint is irrelevant on touch and eats vertical space
      right where the keyboard appears — hide it. */
-	.composer-hint,
-	.prompt-hint {
+	.composer-hint {
 		display: none;
 	}
 
@@ -12792,9 +8898,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 	/* Sit the pill just above the composer's top edge — a small fixed lift, not
 	   keyed to --chat-under (that pushed it too far up over the transcript). */
-	.jump-latest {
-		bottom: 24px;
-	}
 
 	.viewer-messages {
 		/* Clear the floating pills at rest, then scroll under them: the top inset
@@ -12864,9 +8967,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	/* Team chat (Watercooler + session Chat tab): keyboard closed keeps its snug
      resting gap; keyboard up drops it flush to the keyboard so the maximum
      amount of the conversation stays visible while typing. */
-	body.kb-open .chat-input-bar {
-		padding-bottom: 0;
-	}
 
 	/* Immersive reading (Safari-style): SessionViewer toggles body.chrome-collapsed
 	   from the transcript's scroll direction — scrolling down slides the top bar
@@ -12896,21 +8996,10 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	   comfortable iOS body size. Includes the in-session composer textarea — the
 	   primary chat input — which otherwise zoomed on focus at 13.5px, and the
 	   Plain reply box now that Conversation is a primary phone surface. */
-	.prompt-input,
-	.composer-textarea,
-	.ask-input,
-	.plain-reply-textarea,
-	.new-session-form select,
-	.new-session-form input,
-	.new-session-form textarea {
-		font-size: 16px;
-	}
 
-	.home-inner {
-		padding: 24px 14px 8vh;
-	}
-	.home-greeting {
-		font-size: 21px;
+	.composer-textarea,
+	.plain-reply-textarea {
+		font-size: 16px;
 	}
 	.home-row {
 		padding: 12px 11px;
@@ -12921,10 +9010,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 	.home-row-meta {
 		font-size: 12.5px;
-	}
-	.status-pill {
-		min-width: 0;
-		padding: 3px 8px;
 	}
 
 	.automations {
@@ -12937,31 +9022,8 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		flex-direction: column;
 		gap: 10px;
 	}
-	.automation-form-row {
-		flex-direction: column;
-		gap: 14px;
-	}
-	.automation-by {
-		display: none;
-	}
-	.automation-form input,
-	.automation-form textarea,
-	.automation-form select,
-	.wiki-search {
-		font-size: 16px;
-	}
-
-	.btn-send {
-		padding: 10px 14px;
-	}
-	.prompt-hint {
-		display: none;
-	}
 
 	/* Keep the home Ask toolbar on one tidy row */
-	.btn-task {
-		white-space: nowrap;
-	}
 	.composer-toolbar {
 		gap: 6px;
 	}
@@ -12969,41 +9031,10 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	/* Automation cards: the single top row (toggle · name · chips · buttons)
      starves the title of width on phones — wrap it instead. Title gets the
      first line, chips flow after, actions drop to their own row. */
-	.automation-top {
-		flex-wrap: wrap;
-		row-gap: 8px;
-	}
-	.automation-name {
-		flex: 1 1 60%;
-		min-width: 0;
-		white-space: normal;
-		overflow-wrap: anywhere;
-	}
-	.automation-actions {
-		margin-left: 0;
-		width: 100%;
-	}
 
 	.msg-body {
 		font-size: 14px;
 		line-height: 24px;
-	}
-
-	.diff-patch {
-		font-size: 11px;
-	}
-	.diff-files {
-		padding: 6px 6px 20px;
-	}
-
-	.pr-panel {
-		padding: 10px;
-	}
-
-	.new-session-form {
-		margin: 16px auto;
-		/* Clear the home indicator / nav so the Start button isn't flush to the edge. */
-		padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
 	}
 
 	.user-gate-card {
@@ -13102,8 +9133,8 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	   transcript — so drop their white-bubble fill, border and shadow. The Back
 	   chevron, the title and the ⋯ read as flat bar controls instead of white
 	   chips on a white bar. (Single-chat keeps the floating bubbles.) */
-	.app:has(.session-tab-view) .app-header-overlay :is(.mobile-back, .app-header-title, .btn-viewer-overflow),
-	.app:has(.session-tab-reorder ~ .session-tab-reorder) .app-header-overlay :is(.mobile-back, .app-header-title, .btn-viewer-overflow) {
+	.app:has(.session-tab-view) .app-header-overlay :is(.mobile-back, .app-header-title),
+	.app:has(.session-tab-reorder ~ .session-tab-reorder) .app-header-overlay :is(.mobile-back, .app-header-title) {
 		background: transparent;
 		border-color: transparent;
 		box-shadow: none;
@@ -13122,13 +9153,7 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 
 	/* Brand logo in the top bar. */
-	.app-brand .app-title-wrap {
-		display: contents;
-	}
-	.app-brand .app-title {
-		order: 1;
-	}
-	.app-brand > button[aria-label="Account menu"],
+
 	.app-brand > button[aria-label="Settings"] {
 		position: relative;
 		z-index: 1;
@@ -13143,19 +9168,8 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		padding: 0 18px;
 		font-size: 15px;
 	}
-	.app-title {
-		font-size: 16px;
-	}
 
 	/* Hamburger: bigger bars and a 44px tap target. */
-	.hamburger {
-		gap: 5px;
-		padding: 10px;
-	}
-	.hamburger span {
-		width: 22px;
-		height: 2.5px;
-	}
 
 	/* Composer send / attach / toolbar icon buttons — larger circles and icons
 	   that clear the 44pt guideline once padding is counted. */
@@ -13168,10 +9182,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		width: 24px;
 		height: 24px;
 	}
-	.composer-attach-btn {
-		width: 36px;
-		height: 36px;
-	}
 	.palette-icon-btn {
 		width: 40px;
 		height: 40px;
@@ -13180,17 +9190,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 		width: 24px;
 		height: 24px;
 	}
-	.composer-model {
-		font-size: 13px;
-		padding: 5px 11px;
-	}
-	.composer-model select {
-		font-size: 13px;
-	}
-}
-
-.automation-event {
-	color: #e3b341;
 }
 
 /* ── Phone page-stack polish ─────────────────────────────────────
@@ -13306,20 +9305,8 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	}
 
 	/* Inline icon buttons (copy, expand, …) inside diff / message headers. */
-	.btn-icon {
-		padding: 8px 10px;
-		font-size: 15px;
-	}
-	.pin-btn {
-		padding: 8px 10px;
-		font-size: 16px;
-	}
 
 	/* Segmented pickers (Ask/Code mode, sort, …). */
-	.seg-control-btn {
-		padding: 9px 13px;
-		font-size: 14px;
-	}
 
 	/* The "+" new-chat and history tabs keep a comfortable square hit area. */
 	.session-tab-new,
@@ -13331,17 +9318,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	/* Toggle switches read larger and are easier to flick on a phone.
 	   Width/knob/offset move together so the on-state math stays right:
 	   44 − 20(knob) − 2(left) − 2(right) = 20 → knob travels 18px. */
-	.auto-toggle {
-		width: 44px;
-		height: 26px;
-	}
-	.auto-toggle-knob {
-		width: 20px;
-		height: 20px;
-	}
-	.auto-toggle-on .auto-toggle-knob {
-		transform: translateX(18px);
-	}
 
 }
 
@@ -13730,52 +9706,7 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	padding: 0;
 }
 
-.composer-attach-row {
-	margin-top: 8px;
-}
-.btn-attach {
-	background: none;
-	border: 1px solid var(--border-strong);
-	color: var(--text-dim);
-	font-size: 13px;
-	padding: 6px 12px;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	cursor: pointer;
-}
-.btn-attach:hover:not(:disabled) {
-	color: var(--text);
-	background: var(--hover);
-}
-.btn-attach:disabled {
-	opacity: 0.5;
-	cursor: default;
-}
-
 /* Round attach button in the in-session composer toolbar */
-.composer-attach-btn {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 28px;
-	height: 28px;
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	background: none;
-	color: var(--text-dim);
-	font-size: 14px;
-	line-height: 1;
-	cursor: pointer;
-	flex-shrink: 0;
-}
-.composer-attach-btn:hover:not(:disabled) {
-	color: var(--text);
-	border-color: var(--border-strong);
-	background: var(--hover);
-}
-.composer-attach-btn:disabled {
-	opacity: 0.5;
-	cursor: default;
-}
 
 /* Non-image file attachments: preview cards (type badge + name + remove) */
 .composer-files {
@@ -13911,95 +9842,8 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 /* The session-goal editor is now the shared <Modal> primitive (ui/modal.tsx). */
 
 /* Fork mode banner above the composer */
-.fork-banner {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 7px 12px;
-	margin-bottom: 8px;
-	border-radius: calc(14px * var(--rf)); corner-shape: var(--cs);
-	background: color-mix(in srgb, var(--accent) 12%, transparent);
-	border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
-	font-size: 12.5px;
-	color: var(--text);
-}
-.fork-banner-cancel {
-	border: none;
-	background: none;
-	color: var(--text-dim);
-	cursor: pointer;
-	font-size: 12px;
-}
-.fork-banner-cancel:hover {
-	color: var(--text);
-}
-
-.queue-count {
-	font-size: 11.5px;
-	color: var(--accent);
-	font-weight: 600;
-}
 
 /* ── Claude account pool (Connections page) ── */
-.conn-logo-claude {
-	background: #d97757;
-}
-
-.acct-usage-row {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	margin-top: 8px;
-	font-size: 11.5px;
-	color: var(--text-dim);
-}
-
-.acct-usage-label {
-	width: 18px;
-	flex-shrink: 0;
-	color: var(--text-faint);
-}
-
-.acct-usage-bar {
-	flex: 1;
-	height: 6px;
-	border-radius: calc(3px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-active);
-	overflow: hidden;
-	min-width: 40px;
-}
-
-.acct-usage-fill {
-	height: 100%;
-	border-radius: calc(3px * var(--rf)); corner-shape: var(--cs);
-	transition: width 0.3s ease;
-}
-.acct-usage-green {
-	background: #34d399;
-}
-.acct-usage-yellow {
-	background: #fbbf24;
-}
-.acct-usage-red {
-	background: #f87171;
-}
-.acct-usage-gray {
-	background: var(--border);
-}
-
-.acct-usage-pct {
-	width: 34px;
-	text-align: right;
-	flex-shrink: 0;
-	font-variant-numeric: tabular-nums;
-}
-
-.acct-usage-reset {
-	color: var(--text-faint);
-	white-space: nowrap;
-	flex-shrink: 0;
-}
 
 /* ─────────────────────────────────────────────────────────────
    Notes — shared collaborative editor (merged with the Docs wiki)
@@ -14011,169 +9855,15 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 }
 
 /* Left rail sections (Notes on top, Docs below) */
-.notes-section {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-.notes-section-docs {
-	flex: 1;
-	border-top: 1px solid var(--border);
-	margin-top: 6px;
-	padding-top: 4px;
-}
-.notes-section-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 10px 14px 4px;
-	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: -0.01em;
-	color: var(--text-faint);
-}
-.notes-add {
-	background: none;
-	border: none;
-	color: var(--text-dim);
-	font-size: 16px;
-	line-height: 1;
-	cursor: pointer;
-	padding: 2px 6px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-}
-.notes-add:hover {
-	background: var(--hover);
-	color: var(--text);
-}
-.notes-new-input {
-	margin: 2px 10px 6px;
-	padding: 7px 9px;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	font-size: 13px;
-	outline: none;
-}
-.notes-list {
-	overflow-y: auto;
-	max-height: 38vh;
-	padding: 0 6px 6px;
-}
-.notes-section-docs .notes-list {
-	max-height: none;
-}
-.notes-empty {
-	padding: 6px 14px;
-	color: var(--text-faint);
-	font-size: 12px;
-}
-.notes-item {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	padding: 7px 8px;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	cursor: pointer;
-	color: var(--text-dim);
-}
-.notes-item:hover {
-	background: var(--hover);
-	color: var(--text);
-}
-.notes-item-active {
-	background: var(--bg-active);
-	color: var(--text);
-}
-.notes-item-title {
-	flex: 1;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	font-size: 13px;
-}
-.notes-item-pin,
-.notes-item-del {
-	opacity: 0;
-	font-size: 12px;
-	color: var(--text-faint);
-	padding: 0 2px;
-}
-.notes-item-pin.on {
-	opacity: 1;
-	color: var(--yellow);
-}
-.notes-item:hover .notes-item-pin,
-.notes-item:hover .notes-item-del {
-	opacity: 0.8;
-}
-.notes-item-del:hover {
-	color: var(--red);
-}
 
 /* Right pane: presence bar + editor + collapsible prompt */
 /* When a note is open the right pane is the editor, which manages its own
    scroll + a flush bottom prompt bar — so drop the article padding/scroll that
    wiki-content adds for read-only docs and let .note-pane fill edge to edge. */
-.notes-editing {
-	padding: 0 !important;
-	overflow: hidden !important;
-}
-.note-pane {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-	height: 100%;
-}
-.note-pane-bar {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 8px 14px;
-	border-bottom: 1px solid var(--border);
-	flex-shrink: 0;
-}
-.note-pane-id {
-	font-family: var(--mono);
-	font-size: 12px;
-	color: var(--text-faint);
-}
-.note-presence {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-}
-.note-presence-dot {
-	width: 18px;
-	height: 18px;
-	border-radius: 50%;
-	background: var(--purple);
-	color: #fff;
-	font-size: 10px;
-	font-weight: 700;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-}
-.note-presence-label {
-	font-size: 11px;
-	color: var(--text-dim);
-	margin-left: 2px;
-}
-.note-editor-wrap {
-	flex: 1;
-	min-height: 0;
-	overflow: hidden;
-	display: flex;
-}
 .note-cm {
 	flex: 1;
 	min-height: 0;
 	overflow: hidden;
-}
-.note-cm .cm-editor {
-	height: 100%;
 }
 
 /* Inline @-mention chips */
@@ -14191,125 +9881,15 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	vertical-align: baseline;
 	border: 1px solid transparent;
 }
-.note-chip-session {
-	background: var(--accent-soft);
-	color: #ff8f8f;
-	border-color: rgba(255, 59, 59, 0.3);
-}
-.note-chip-note {
-	background: var(--green-soft);
-	color: #7ee094;
-	border-color: rgba(63, 185, 80, 0.3);
-}
-.note-chip-doc {
-	background: rgba(163, 113, 247, 0.14);
-	color: #c4a6ff;
-	border-color: rgba(163, 113, 247, 0.3);
-}
 .note-chip:hover {
 	filter: brightness(1.15);
 }
 
 /* Share button (copy link to a note) */
-.note-share {
-	margin-left: auto;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	color: var(--text-dim);
-	font-size: 12px;
-	font-family: var(--sans);
-	padding: 4px 10px;
-	border-radius: calc(7px * var(--rf)); corner-shape: var(--cs);
-	cursor: pointer;
-	white-space: nowrap;
-}
-.note-share:hover {
-	background: var(--hover);
-	color: var(--text);
-}
 
 /* Collapsible Haiku prompt bar */
-.note-prompt {
-	border-top: 1px solid var(--border);
-	background: var(--bg-raised);
-	flex-shrink: 0;
-	padding: 5px 10px 8px;
-}
-.note-prompt-toggle {
-	display: inline-flex;
-	align-items: center;
-	gap: 5px;
-	background: none;
-	border: none;
-	color: var(--text-faint);
-	font-size: 11px;
-	cursor: pointer;
-	padding: 1px 0 3px;
-}
-.note-prompt-toggle:hover {
-	color: var(--text-dim);
-}
-.note-prompt-caret {
-	display: inline-block;
-	transition: transform 0.12s ease;
-}
-.note-prompt-caret.open {
-	transform: rotate(90deg);
-}
-.note-prompt-input {
-	display: block;
-	width: 100%;
-	resize: none;
-	min-height: 30px;
-	height: 30px;
-	max-height: 140px;
-	padding: 6px 10px;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text);
-	font-size: 13px;
-	line-height: 1.4;
-	outline: none;
-	field-sizing: content;
-}
-.note-prompt-input:focus {
-	border-color: var(--accent);
-}
-.note-prompt-loading {
-	display: flex;
-	align-items: center;
-	gap: 9px;
-	padding: 8px 11px;
-	background: var(--bg-panel);
-	border: 1px solid var(--border-strong);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	color: var(--text-dim);
-	font-size: 13px;
-}
-.note-prompt-running .note-prompt-toggle {
-	color: var(--accent);
-}
-.note-prompt-error {
-	color: var(--red);
-	font-size: 12px;
-	margin-top: 4px;
-}
 
 /* Spinner used in the prompt bar */
-.note-spinner {
-	display: inline-block;
-	width: 11px;
-	height: 11px;
-	border: 2px solid var(--border-strong);
-	border-top-color: var(--accent);
-	border-radius: 50%;
-	animation: note-spin 0.6s linear infinite;
-}
-.note-spinner-lg {
-	width: 15px;
-	height: 15px;
-}
 @keyframes note-spin {
 	to {
 		transform: rotate(360deg);
@@ -14317,16 +9897,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 }
 
 /* Note tabs in the tab bar + drag-reorder affordances */
-.session-tab-note .session-tab-glyph {
-	font-size: 12px;
-	margin-right: 2px;
-}
-.session-tab-dragging {
-	opacity: 0.45;
-}
-.session-tab-dragover {
-	box-shadow: inset 2px 0 0 var(--accent);
-}
 
 /* ── Plain conversation sidebar ──────────────────────────────────
    Read-only timeline of a session's linked Plain support thread, shown
@@ -14370,18 +9940,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	flex-shrink: 0;
 	background: var(--bg-active);
 	color: var(--text-faint);
-}
-.plain-status-todo {
-	background: color-mix(in srgb, var(--accent) 18%, transparent);
-	color: var(--accent);
-}
-.plain-status-done {
-	background: color-mix(in srgb, var(--green, #3fb950) 18%, transparent);
-	color: var(--green, #3fb950);
-}
-.plain-status-snoozed {
-	background: color-mix(in srgb, var(--amber, #d29922) 20%, transparent);
-	color: var(--amber, #d29922);
 }
 .plain-open {
 	font-size: 11.5px;
@@ -14428,16 +9986,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	background: var(--bg-panel);
 }
 /* Customer messages on the left, our replies on the right — like a chat. */
-.plain-entry-in {
-	align-self: flex-start;
-	border-bottom-left-radius: 3px;
-}
-.plain-entry-out {
-	align-self: flex-end;
-	background: color-mix(in srgb, var(--accent) 9%, var(--bg-panel));
-	border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
-	border-bottom-right-radius: 3px;
-}
 .plain-entry-note {
 	align-self: stretch;
 	max-width: 100%;
@@ -14709,20 +10257,6 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-.palette-effort-icon {
-	display: inline-flex;
-	align-items: flex-end;
-	gap: 2px;
-	height: 15px;
-}
-.palette-effort-icon span {
-	width: 3.5px;
-	background: currentColor;
-	border-radius: calc(1px * var(--rf)); corner-shape: var(--cs);
-}
-.palette-effort-icon span:nth-child(1) { height: 6px; }
-.palette-effort-icon span:nth-child(2) { height: 10px; }
-.palette-effort-icon span:nth-child(3) { height: 15px; }
 
 /* Connected-services picker (footer icon button). Desktop opens the shared
    Base UI Menu; the popover below is the phone-only full-width sheet. */
@@ -15366,40 +10900,16 @@ html.wco .settings-sidenav {
 	padding: 0;
 	min-height: 0;
 }
-.settings-panel {
-	width: 100%;
-	max-width: 720px;
-}
 .settings-panel-frame {
 	width: 100%;
 	max-width: 720px;
 	padding-bottom: 88px;
 	align-self: flex-start;
 }
-.settings-title {
-	font-size: 24px;
-	font-weight: 700;
-	letter-spacing: -0.02em;
-	color: var(--text);
-	margin: 0 0 20px;
-	padding: 0 10px;
-}
-.settings-group-label {
-	font-size: 12px;
-	font-weight: 600;
-	color: var(--text-faint);
-	margin: 22px 0 8px;
-	padding: 0 10px;
-}
 /* Panel-level intro/description text and hints sit directly on the surface (not
    inside a card), so they'd otherwise butt against the rounded card edge — give
    them the same 6px inset as the labels. In-card descriptions are padded by
    .setting-row, so scope this to direct children of the panel only. */
-.settings-panel > .setting-row-desc,
-.settings-panel > .settings-hint {
-	padding-left: 10px;
-	padding-right: 10px;
-}
 
 /* On phones Settings renders as a bottom sheet (Settings.tsx MobileSettings)
    with its own paged header — the legacy panel classes adapt inside it: the
@@ -15411,9 +10921,6 @@ html.wco .settings-sidenav {
 .settings-sheet .settings-panel-frame {
 	padding-bottom: 48px;
 }
-.settings-sheet .settings-title {
-	display: none;
-}
 
 .setting-card {
 	background: var(--bg-panel);
@@ -15421,102 +10928,10 @@ html.wco .settings-sidenav {
 	border-radius: calc(20px * var(--rf)); corner-shape: var(--cs);
 	overflow: hidden;
 }
-.setting-row {
-	display: flex;
-	align-items: center;
-	gap: 16px;
-	padding: 14px 16px;
-}
-.setting-row + .setting-row {
-	border-top: 1px solid var(--border);
-}
-.setting-row-text {
-	flex: 1;
-	min-width: 0;
-}
-.setting-row-title {
-	font-size: 14px;
-	font-weight: 500;
-	color: var(--text);
-}
-.setting-row-desc {
-	font-size: 12.5px;
-	color: var(--text-dim);
-	margin-top: 2px;
-}
-.setting-row-control {
-	flex-shrink: 0;
-}
-.setting-inline {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
 
 /* Toggle switch */
-.ui-switch {
-	width: 38px;
-	height: 22px;
-	flex-shrink: 0;
-	padding: 0;
-	border: none;
-	border-radius: 999px;
-	corner-shape: round;
-	background: var(--bg-active);
-	position: relative;
-	cursor: pointer;
-	transition: background 0.15s ease;
-}
-.ui-switch.on {
-	background: var(--accent);
-}
-.ui-switch-knob {
-	position: absolute;
-	top: 2px;
-	left: 2px;
-	width: 18px;
-	height: 18px;
-	border-radius: 50%;
-	background: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-	transition: transform 0.15s ease;
-}
-.ui-switch.on .ui-switch-knob {
-	transform: translateX(16px);
-}
 
 /* Native-ish select + Test button */
-.ui-select {
-	background: var(--bg-raised);
-	color: var(--text);
-	border: 1px solid var(--border);
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	padding: 6px 10px;
-	font-size: 13px;
-	font-family: inherit;
-	cursor: pointer;
-}
-.ui-testbtn {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	background: none;
-	border: none;
-	cursor: pointer;
-	color: var(--text-dim);
-	font-size: 13px;
-	font-family: inherit;
-	padding: 6px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-}
-.ui-testbtn:hover:not(:disabled) {
-	color: var(--text);
-	background: var(--hover);
-}
-.ui-testbtn:disabled {
-	opacity: 0.4;
-	cursor: default;
-}
 
 /* "Settings" entry in the Michael-menu dropdown */
 /* Theme picker — three preview cards (System / Light / Dark) */
@@ -15568,18 +10983,6 @@ html.wco .settings-sidenav {
 
 /* The miniature app mockup rendered inside a swatch. Fixed palettes (not theme
    vars) so each swatch always shows its own tone regardless of the active theme. */
-.mk-light {
-	--mk-bg: #e9e9e9;
-	--mk-panel: #ffffff;
-	--mk-line: #d5d5d5;
-	--mk-pill: #cbcbcb;
-}
-.mk-dark {
-	--mk-bg: #565656;
-	--mk-panel: #3e3e3e;
-	--mk-line: #c4c4c4;
-	--mk-pill: #8a8a8a;
-}
 .theme-mock {
 	position: absolute;
 	inset: 0;
@@ -15657,50 +11060,10 @@ html.wco .settings-sidenav {
 	background: var(--hover);
 }
 /* Promote button on ask chats (header, next to the ask chip). */
-.viewer-promote-btn {
-	flex: 0 0 auto;
-	font-size: 12px;
-	padding: 2px 8px;
-	border-radius: calc(6px * var(--rf)); corner-shape: var(--cs);
-	border: 1px solid var(--border-strong);
-	background: var(--bg-panel);
-	color: var(--text);
-	cursor: pointer;
-	white-space: nowrap;
-}
-.viewer-promote-btn:hover {
-	border-color: var(--accent);
-	color: var(--accent);
-}
-.viewer-promote-btn:disabled {
-	opacity: 0.6;
-	cursor: default;
-}
 
 /* Lone-chat "+ New tab" beside the session title — the tab strip's + relocated
    here while the workspace has a single chat. A quiet plus-only icon button, same
    weight/footprint as the header ⋯ menu: no label, no border, hover-lit. */
-.viewer-newtab-btn {
-	flex: 0 0 auto;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	/* Tighter than the 3px 5px of its ▶/▐ row-mates: the plus glyph is drawn
-	   larger (size 28 — see SessionViewer) to match their visible weight, so the
-	   box is trimmed to keep the hover pill the same ~34px height as the sidebar
-	   toggle rather than ballooning taller. */
-	padding: 2px 4px;
-	border-radius: calc(10px * var(--rf)); corner-shape: var(--cs);
-	border: 1px solid transparent;
-	background: none;
-	color: var(--text-dim);
-	line-height: 1;
-	cursor: pointer;
-}
-.viewer-newtab-btn:hover {
-	color: var(--text);
-	background: var(--hover);
-}
 
 /* Hover-revealed real timestamps. A message's time is a detail you go looking
    for, not something to read past on every turn — so it fades in while the
@@ -15798,27 +11161,6 @@ html.wco .settings-sidenav {
 	top: 7px;
 	width: 7px;
 	height: 7px;
-	border-radius: 50%;
-	background: var(--green);
-}
-.sidebar-workspace-attention--trailing {
-	position: relative;
-	left: auto;
-	top: auto;
-	flex: 0 0 28px;
-	width: 28px;
-	height: 22px;
-	margin-left: auto;
-	background: transparent;
-}
-.sidebar-workspace-attention--trailing::after {
-	content: "";
-	position: absolute;
-	left: 50%;
-	top: 50%;
-	width: 7px;
-	height: 7px;
-	transform: translate(-50%, -50%);
 	border-radius: 50%;
 	background: var(--green);
 }
@@ -16009,36 +11351,9 @@ html.wco .settings-sidenav {
    PR size, "+adds -dels", resting in the right slot the idle time badge would
    occupy (the time drops to hover-reveal while this shows). Yields to the
    hover actions like the count/time do. */
-.sidebar-ws-diff {
-	flex: 0 0 auto;
-	margin-left: auto;
-	display: inline-flex;
-	gap: 5px;
-	padding-right: 16px;
-	font-size: 10.5px;
-	font-variant-numeric: tabular-nums;
-}
-.sidebar-ws-diff-add {
-	color: var(--green);
-}
-.sidebar-ws-diff-del {
-	color: var(--red);
-}
 /* A count/ticker already pushed the cluster to the right edge — keep a small
    fixed gap instead of a second auto margin (two autos would split the free
    space and strand a badge mid-row). Same for the badges after the stat. */
-.sidebar-group-count + .sidebar-ws-diff,
-.sidebar-ws-ticker + .sidebar-ws-diff {
-	margin-left: 6px;
-}
-.sidebar-ws-diff ~ .sidebar-ws-draft {
-	margin-left: 6px;
-}
-@media (hover: hover) {
-	.sidebar-ws-row:hover .sidebar-ws-diff {
-		display: none;
-	}
-}
 
 /* Wake countdown on a snoozed workspace row (moon + "1h"): it stands in for
    the idle time badge, so it rests in that same right-edge slot and matches
@@ -16060,7 +11375,7 @@ html.wco .settings-sidenav {
 .sidebar-ws-ticker + .sidebar-ws-snooze {
 	margin-left: 6px;
 }
-.sidebar-ws-snooze ~ .sidebar-ws-diff,
+
 .sidebar-ws-snooze ~ .sidebar-ws-draft {
 	margin-left: 6px;
 }
@@ -16908,131 +12223,14 @@ html.wco .settings-sidenav {
 /* ===== PIXEL SPINNER PATTERNS ===== */
 
 /* Wave Left-Right */
-.pixel-spinner.wave-lr .pixel:nth-child(1),
-.pixel-spinner.wave-lr .pixel:nth-child(4),
-.pixel-spinner.wave-lr .pixel:nth-child(7) {
-  animation-name: pixel-wave-trail-1;
-}
-.pixel-spinner.wave-lr .pixel:nth-child(2),
-.pixel-spinner.wave-lr .pixel:nth-child(5),
-.pixel-spinner.wave-lr .pixel:nth-child(8) {
-  animation-name: pixel-wave-trail-2;
-}
-.pixel-spinner.wave-lr .pixel:nth-child(3),
-.pixel-spinner.wave-lr .pixel:nth-child(6),
-.pixel-spinner.wave-lr .pixel:nth-child(9) {
-  animation-name: pixel-wave-trail-3;
-}
 
 /* Wave Top-Bottom */
-.pixel-spinner.wave-tb .pixel:nth-child(1),
-.pixel-spinner.wave-tb .pixel:nth-child(2),
-.pixel-spinner.wave-tb .pixel:nth-child(3) {
-  animation-name: pixel-wave-trail-1;
-}
-.pixel-spinner.wave-tb .pixel:nth-child(4),
-.pixel-spinner.wave-tb .pixel:nth-child(5),
-.pixel-spinner.wave-tb .pixel:nth-child(6) {
-  animation-name: pixel-wave-trail-2;
-}
-.pixel-spinner.wave-tb .pixel:nth-child(7),
-.pixel-spinner.wave-tb .pixel:nth-child(8),
-.pixel-spinner.wave-tb .pixel:nth-child(9) {
-  animation-name: pixel-wave-trail-3;
-}
 
 /* Ripple Out */
-.pixel-spinner.ripple-out .pixel:nth-child(5) {
-  animation-name: pixel-ripple-out-center;
-}
-.pixel-spinner.ripple-out .pixel:nth-child(2),
-.pixel-spinner.ripple-out .pixel:nth-child(4),
-.pixel-spinner.ripple-out .pixel:nth-child(6),
-.pixel-spinner.ripple-out .pixel:nth-child(8) {
-  animation-name: pixel-ripple-out-mid;
-}
-.pixel-spinner.ripple-out .pixel:nth-child(1),
-.pixel-spinner.ripple-out .pixel:nth-child(3),
-.pixel-spinner.ripple-out .pixel:nth-child(7),
-.pixel-spinner.ripple-out .pixel:nth-child(9) {
-  animation-name: pixel-ripple-out-outer;
-}
 
 /* Snake */
-.pixel-spinner.snake .pixel:nth-child(1) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 0ms;
-}
-.pixel-spinner.snake .pixel:nth-child(2) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 133ms;
-}
-.pixel-spinner.snake .pixel:nth-child(3) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 266ms;
-}
-.pixel-spinner.snake .pixel:nth-child(6) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 400ms;
-}
-.pixel-spinner.snake .pixel:nth-child(5) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 533ms;
-}
-.pixel-spinner.snake .pixel:nth-child(4) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 666ms;
-}
-.pixel-spinner.snake .pixel:nth-child(7) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 800ms;
-}
-.pixel-spinner.snake .pixel:nth-child(8) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 933ms;
-}
-.pixel-spinner.snake .pixel:nth-child(9) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 1066ms;
-}
 
 /* Spiral Clockwise */
-.pixel-spinner.spiral-cw .pixel:nth-child(1) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 0ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(2) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 133ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(3) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 266ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(6) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 400ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(9) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 533ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(8) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 666ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(7) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 800ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(4) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 933ms;
-}
-.pixel-spinner.spiral-cw .pixel:nth-child(5) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 1066ms;
-}
 
 /* Cross */
 .pixel-spinner.cross .pixel:nth-child(2),
@@ -17044,13 +12242,6 @@ html.wco .settings-sidenav {
 }
 
 /* X-Shape */
-.pixel-spinner.x-shape .pixel:nth-child(1),
-.pixel-spinner.x-shape .pixel:nth-child(3),
-.pixel-spinner.x-shape .pixel:nth-child(5),
-.pixel-spinner.x-shape .pixel:nth-child(7),
-.pixel-spinner.x-shape .pixel:nth-child(9) {
-  animation-name: pixel-pulse-trail;
-}
 
 /* Corners */
 .pixel-spinner.corners .pixel:nth-child(1) {
@@ -17071,109 +12262,14 @@ html.wco .settings-sidenav {
 }
 
 /* Diamond */
-.pixel-spinner.diamond .pixel:nth-child(2) {
-  animation-name: pixel-corner-trail;
-  animation-delay: 0ms;
-}
-.pixel-spinner.diamond .pixel:nth-child(6) {
-  animation-name: pixel-corner-trail;
-  animation-delay: 300ms;
-}
-.pixel-spinner.diamond .pixel:nth-child(8) {
-  animation-name: pixel-corner-trail;
-  animation-delay: 600ms;
-}
-.pixel-spinner.diamond .pixel:nth-child(4) {
-  animation-name: pixel-corner-trail;
-  animation-delay: 900ms;
-}
 
 /* Checkerboard */
-.pixel-spinner.checkerboard .pixel:nth-child(1),
-.pixel-spinner.checkerboard .pixel:nth-child(3),
-.pixel-spinner.checkerboard .pixel:nth-child(5),
-.pixel-spinner.checkerboard .pixel:nth-child(7),
-.pixel-spinner.checkerboard .pixel:nth-child(9) {
-  animation-name: pixel-checker-a-trail;
-}
-.pixel-spinner.checkerboard .pixel:nth-child(2),
-.pixel-spinner.checkerboard .pixel:nth-child(4),
-.pixel-spinner.checkerboard .pixel:nth-child(6),
-.pixel-spinner.checkerboard .pixel:nth-child(8) {
-  animation-name: pixel-checker-b-trail;
-}
 
 /* Stripes Horizontal */
-.pixel-spinner.stripes-h .pixel:nth-child(1),
-.pixel-spinner.stripes-h .pixel:nth-child(2),
-.pixel-spinner.stripes-h .pixel:nth-child(3) {
-  animation-name: pixel-wave-trail-1;
-}
-.pixel-spinner.stripes-h .pixel:nth-child(4),
-.pixel-spinner.stripes-h .pixel:nth-child(5),
-.pixel-spinner.stripes-h .pixel:nth-child(6) {
-  animation-name: pixel-wave-trail-2;
-}
-.pixel-spinner.stripes-h .pixel:nth-child(7),
-.pixel-spinner.stripes-h .pixel:nth-child(8),
-.pixel-spinner.stripes-h .pixel:nth-child(9) {
-  animation-name: pixel-wave-trail-3;
-}
 
 /* Stripes Vertical */
-.pixel-spinner.stripes-v .pixel:nth-child(1),
-.pixel-spinner.stripes-v .pixel:nth-child(4),
-.pixel-spinner.stripes-v .pixel:nth-child(7) {
-  animation-name: pixel-wave-trail-1;
-}
-.pixel-spinner.stripes-v .pixel:nth-child(2),
-.pixel-spinner.stripes-v .pixel:nth-child(5),
-.pixel-spinner.stripes-v .pixel:nth-child(8) {
-  animation-name: pixel-wave-trail-2;
-}
-.pixel-spinner.stripes-v .pixel:nth-child(3),
-.pixel-spinner.stripes-v .pixel:nth-child(6),
-.pixel-spinner.stripes-v .pixel:nth-child(9) {
-  animation-name: pixel-wave-trail-3;
-}
 
 /* Rain */
-.pixel-spinner.rain .pixel:nth-child(1) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 0ms;
-}
-.pixel-spinner.rain .pixel:nth-child(4) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 133ms;
-}
-.pixel-spinner.rain .pixel:nth-child(7) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 266ms;
-}
-.pixel-spinner.rain .pixel:nth-child(2) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 400ms;
-}
-.pixel-spinner.rain .pixel:nth-child(5) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 533ms;
-}
-.pixel-spinner.rain .pixel:nth-child(8) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 666ms;
-}
-.pixel-spinner.rain .pixel:nth-child(3) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 800ms;
-}
-.pixel-spinner.rain .pixel:nth-child(6) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 933ms;
-}
-.pixel-spinner.rain .pixel:nth-child(9) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 1066ms;
-}
 
 /* Diagonal */
 .pixel-spinner.diagonal-br .pixel:nth-child(1) {
@@ -17262,103 +12358,14 @@ html.wco .settings-sidenav {
 }
 
 /* Breathe */
-.pixel-spinner.breathe .pixel {
-  animation-name: pixel-breathe-trail;
-}
 
 /* Orbit */
-.pixel-spinner.orbit .pixel:nth-child(1) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 0ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(2) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 150ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(3) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 300ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(6) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 450ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(9) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 600ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(8) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 750ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(7) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 900ms;
-}
-.pixel-spinner.orbit .pixel:nth-child(4) {
-  animation-name: pixel-snake-trail;
-  animation-delay: 1050ms;
-}
 
 /* Scan Horizontal */
-.pixel-spinner.scan-h .pixel:nth-child(1),
-.pixel-spinner.scan-h .pixel:nth-child(2),
-.pixel-spinner.scan-h .pixel:nth-child(3) {
-  animation-name: pixel-scan-line;
-  animation-delay: 0ms;
-}
-.pixel-spinner.scan-h .pixel:nth-child(4),
-.pixel-spinner.scan-h .pixel:nth-child(5),
-.pixel-spinner.scan-h .pixel:nth-child(6) {
-  animation-name: pixel-scan-line;
-  animation-delay: 400ms;
-}
-.pixel-spinner.scan-h .pixel:nth-child(7),
-.pixel-spinner.scan-h .pixel:nth-child(8),
-.pixel-spinner.scan-h .pixel:nth-child(9) {
-  animation-name: pixel-scan-line;
-  animation-delay: 800ms;
-}
 
 /* Scan Vertical */
-.pixel-spinner.scan-v .pixel:nth-child(1),
-.pixel-spinner.scan-v .pixel:nth-child(4),
-.pixel-spinner.scan-v .pixel:nth-child(7) {
-  animation-name: pixel-scan-line;
-  animation-delay: 0ms;
-}
-.pixel-spinner.scan-v .pixel:nth-child(2),
-.pixel-spinner.scan-v .pixel:nth-child(5),
-.pixel-spinner.scan-v .pixel:nth-child(8) {
-  animation-name: pixel-scan-line;
-  animation-delay: 400ms;
-}
-.pixel-spinner.scan-v .pixel:nth-child(3),
-.pixel-spinner.scan-v .pixel:nth-child(6),
-.pixel-spinner.scan-v .pixel:nth-child(9) {
-  animation-name: pixel-scan-line;
-  animation-delay: 800ms;
-}
 
 /* Loading Bar */
-.pixel-spinner.loading-bar .pixel:nth-child(1),
-.pixel-spinner.loading-bar .pixel:nth-child(4),
-.pixel-spinner.loading-bar .pixel:nth-child(7) {
-  animation-name: pixel-bar-fill;
-  animation-delay: 0ms;
-}
-.pixel-spinner.loading-bar .pixel:nth-child(2),
-.pixel-spinner.loading-bar .pixel:nth-child(5),
-.pixel-spinner.loading-bar .pixel:nth-child(8) {
-  animation-name: pixel-bar-fill;
-  animation-delay: 200ms;
-}
-.pixel-spinner.loading-bar .pixel:nth-child(3),
-.pixel-spinner.loading-bar .pixel:nth-child(6),
-.pixel-spinner.loading-bar .pixel:nth-child(9) {
-  animation-name: pixel-bar-fill;
-  animation-delay: 400ms;
-}
 
 /* Heartbeat */
 .pixel-spinner.heartbeat .pixel:nth-child(5) {
@@ -17457,35 +12464,8 @@ html.wco .settings-sidenav {
 	display: flex;
 	flex-direction: column;
 }
-.viewer-review-main > .pr-panel {
-	flex: 1;
-	min-height: 0;
-}
 
 /* Prominent Review button in the Info panel head. */
-.workspace-info-review-btn {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 7px;
-	width: 100%;
-	margin-top: 10px;
-	padding: 9px 12px;
-	border: 1px solid var(--border);
-	border-radius: calc(8px * var(--rf)); corner-shape: var(--cs);
-	background: var(--bg-active);
-	color: var(--text);
-	font-size: 13px;
-	font-weight: 600;
-	cursor: pointer;
-	transition:
-		background 0.14s ease,
-		border-color 0.14s ease;
-}
-.workspace-info-review-btn:hover {
-	background: var(--hover);
-	border-color: var(--text-faint);
-}
 .transcript-settled {
 	content-visibility: auto;
 	contain-intrinsic-size: auto 96px;

--- a/src/frontend/styles/tailwind.css
+++ b/src/frontend/styles/tailwind.css
@@ -1,24 +1,24 @@
 /* ─────────────────────────────────────────────────────────────
    Tailwind v4 entry (CSS-first config — there is no tailwind.config.js).
 
-   Compiled by the @tailwindcss/cli step inside buildFrontend() (backstage.ts),
-   NOT by Bun — do not import this file from App.tsx; Bun's bundler would ship
-   the raw directives without running the Tailwind compiler. The compiled sheet
-   is linked AFTER global.css, and utilities are imported *unlayered* below, so
-   a utility class wins a tie against legacy unlayered global.css rules by
-   source order. (Preflight is deliberately not imported: global.css was
-   written against browser defaults and a global reset would reskin the app.)
+   Compiled by the @tailwindcss/cli step inside buildFrontend(), not by Bun.
+   adapters.css contains the non-utility contracts that still need authored
+   CSS: theme/base rules, generated-content and third-party adapters, native
+   shell hooks, responsive state coupling, and keyframes. Component-owned
+   presentation lives in Tailwind utilities and is intentionally loaded after
+   those adapters so utilities win equal-specificity ties.
 
-   BACKSTAGE_DEV=1 (HTML-import dev mode) doesn't run this compile step and
-   gets no utilities — the prod path with in-process rebuilds is the dev loop.
+   Preflight remains disabled because the app explicitly owns its document and
+   form-control reset in adapters.css.
    ───────────────────────────────────────────────────────────── */
+@import "./adapters.css";
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" source(none);
 
 /* Only scan the frontend tree for class names (not agents/server/prompts). */
 @source "../";
 
-/* Design tokens: map the existing global.css variables (which already carry
+/* Design tokens: map the adapter variables (which already carry
    dark/light theming via html[data-theme]) into Tailwind's namespace, so
    `bg-panel text-dim border-line` and legacy CSS read the same values and
    re-theme together. `inline` makes utilities emit var(--bg) directly. */
@@ -83,17 +83,17 @@
 	--font-sans: var(--sans);
 	--font-mono: var(--mono);
 	--radius-panel: var(--radius);
-	/* The corner every button and chip in the chrome shares. global.css authors
+	/* The corner every button and chip in the chrome shares. adapters.css authors
 	   it as `calc(10px * var(--rf))` on .btn-viewer-pin / .btn-panel-toggle /
 	   .btn-viewer-newchat and friends; naming it here lets the Button primitive
 	   and any Tailwind-authored control land on the same corner instead of
 	   re-deriving it with an arbitrary value. Because it is built from --rf it
 	   tracks the squircle bump on its own (8.5px round → 13.5px squircle), and
-	   global.css gives every `rounded-*` class `corner-shape: squircle`, so it
+	   adapters.css gives every `rounded-*` class `corner-shape: squircle`, so it
 	   needs no entry in the @supports block below. */
 	--radius-control: calc(10px * var(--rf));
 
-	/* global.css sets html { font-size: 14px }, which silently shrinks every
+	/* adapters.css sets html { font-size: 14px }, which silently shrinks every
 	   rem-based utility to 87.5% of its px design value (p-3 → 10.5px). Anchor
 	   the scales this codebase designs in px so utilities mean what they say. */
 	--spacing: 4px;

--- a/src/frontend/ui/button.tsx
+++ b/src/frontend/ui/button.tsx
@@ -3,7 +3,7 @@ import { cn } from "./cn";
 
 /**
  * Button primitive — the shared optics for text, icon+label, and icon-only
- * buttons. New buttons go through this; legacy `.btn-*` classes in global.css
+ * buttons. New buttons go through this; compatibility `.btn-*` adapters
  * migrate here opportunistically when touched (strangler pattern).
  *
  * The icon/spacing rules are ported from tella-fusion's button system
@@ -39,7 +39,7 @@ const sizes: Record<Size, string> = {
 	// header buttons, 26px the chip/inline tier.
 	//
 	// One radius across every size: `rounded-control`, the corner the rest of
-	// the chrome already uses (global.css authors it as `calc(10px*var(--rf))`
+	// the chrome already uses (adapters.css authors it as `calc(10px*var(--rf))`
 	// on .btn-viewer-pin / .btn-panel-toggle / .btn-viewer-newchat). The
 	// `rounded-xs`/`rounded-sm` this used to ship read visibly squarer than the
 	// buttons it sat beside — enough that call sites kept patching it back out

--- a/src/frontend/ui/modal.tsx
+++ b/src/frontend/ui/modal.tsx
@@ -189,7 +189,7 @@ function Header({
 			)}
 			<div className="min-w-0 flex-1">
 				{/* Base UI renders Title as <h2> and Description as <p>; preflight
-				    isn't imported (global.css owns resets), so zero their UA margins
+				    isn't imported (adapters.css owns resets), so zero their UA margins
 				    or the <h2> top margin reads as phantom padding above the head. */}
 				<BaseDialog.Title className="m-0 text-balance text-section-title font-semibold leading-tight tracking-[-0.01em] text-fg">
 					{title}

--- a/src/frontend/ui/settings.tsx
+++ b/src/frontend/ui/settings.tsx
@@ -79,7 +79,7 @@ export function SettingsGroupLabel({
  * quiet blocks rather than a stack of outlined boxes.
  *
  * The corner is authored in the chrome's own language — `calc(Npx * var(--rf))`,
- * which global.css bumps under `corner-shape: squircle` — rather than the flat
+ * which adapters.css bumps under `corner-shape: squircle` — rather than the flat
  * `rounded-lg` Card ships. A squircle at a flat radius reads visibly squarer
  * than the panels around it; 12px × --rf lands these blocks on the same softness
  * as the rest of the app's large surfaces. */

--- a/src/server/frontend-build.ts
+++ b/src/server/frontend-build.ts
@@ -68,25 +68,6 @@ export async function buildFrontend(): Promise<string> {
 	if (!entry) throw new Error("frontend build produced no entry point");
 	const entryName = entry.path.split("/").pop()!;
 
-	// Bun 1.3.14's CSS minifier strips the space after var(...) and breaks the
-	// .panel-overlay / .sidebar-overlay inset (and a few color-mix percentages),
-	// which knocks out the mobile overlay layer. Bypass it: write the source CSS
-	// unmodified with a content-hashed name and serve it ourselves.
-	let cssSrc = await Bun.file(`${FRONTEND_SRC}/styles/global.css`).text();
-	// xterm stylesheet (the Shell tab) rides along in the same file, vendored
-	// straight from the installed package so it can't drift from the JS.
-	try {
-		const xtermCss = await Bun.file(
-			`${REPO_ROOT}/node_modules/@xterm/xterm/css/xterm.css`,
-		).text();
-		cssSrc += `\n\n/* ── vendored @xterm/xterm/css/xterm.css (Shell tab) ── */\n${xtermCss}`;
-	} catch {}
-	const cssHash = Bun.hash(cssSrc).toString(36);
-	const cssName = `global-${cssHash}.css`;
-	// Atomic: a mid-write bundle file has shipped corrupt before ("useState is
-	// not defined") — never serve a torn asset.
-	writeFileAtomic(`${FRONTEND_DIST}/${cssName}`, cssSrc);
-
 	// ghostty-web's WASM VT engine (the Shell tab's terminal) rides along too:
 	// the bundled chunk can't resolve the package-relative wasm, so it's copied
 	// out and served at a stable name (static-assets.ts; the shell passes the
@@ -105,13 +86,10 @@ export async function buildFrontend(): Promise<string> {
 		);
 	}
 
-	// Tailwind pass (see styles/tailwind.css). Bun can't compile Tailwind, so
-	// the real compiler runs as a subprocess (~50ms); its lightningcss minifier
-	// doesn't have the var() bug above. Linked after global.css so utilities win
-	// source-order ties against legacy rules. Fail-soft: a broken Tailwind
-	// compile ships the bundle without utilities rather than taking down the
-	// whole server (this build also runs at boot, before Bun.serve).
-	let twName: string | null = null;
+	// Tailwind owns the complete stylesheet (see styles/tailwind.css). Bun can't
+	// compile it, so the real compiler runs as a subprocess. A CSS failure must
+	// fail the rebuild now: there is no second legacy sheet to fall back to.
+	let twName: string;
 	try {
 		const twTmp = `${FRONTEND_DIST}/.tailwind-build.css`;
 		const twProc = Bun.spawn(
@@ -128,14 +106,20 @@ export async function buildFrontend(): Promise<string> {
 		if ((await twProc.exited) !== 0) {
 			throw new Error(await new Response(twProc.stderr).text());
 		}
-		const twCss = await Bun.file(twTmp).text();
+		let twCss = await Bun.file(twTmp).text();
+		// The Shell tab's xterm stylesheet is vendored from the installed package
+		// so its CSS cannot drift from the JS version.
+		try {
+			const xtermCss = await Bun.file(
+				`${REPO_ROOT}/node_modules/@xterm/xterm/css/xterm.css`,
+			).text();
+			twCss += `\n\n/* vendored @xterm/xterm/css/xterm.css */\n${xtermCss}`;
+		} catch {}
 		twName = `tailwind-${Bun.hash(twCss).toString(36)}.css`;
 		writeFileAtomic(`${FRONTEND_DIST}/${twName}`, twCss);
 	} catch (e) {
-		console.error(
-			"[frontend] Tailwind build FAILED — serving without utilities:",
-			e,
-		);
+		console.error("[frontend] Tailwind build FAILED:", e);
+		throw e;
 	}
 
 	let indexHtml = await Bun.file(`${FRONTEND_SRC}/index.html`).text();
@@ -163,14 +147,11 @@ export async function buildFrontend(): Promise<string> {
 		'<script type="module" src="./App.tsx"></script>',
 		`<script type="module" crossorigin src="/${entryName}"></script>`,
 	);
-	const twLink = twName
-		? `\n  <link rel="stylesheet" href="/${twName}">`
-		: "";
 	indexHtml = indexHtml.replace(
 		"</head>",
-		`  <link rel="stylesheet" href="/${cssName}">${twLink}\n</head>`,
+		`  <link rel="stylesheet" href="/${twName}">\n</head>`,
 	);
-	const version = `${entryName}|${cssName}|${twName ?? "no-tw"}`;
+	const version = `${entryName}|${twName}`;
 
 	const store: FrontendBundle = (g.__backstageFrontend ??= {
 		indexHtml: "",
@@ -183,7 +164,7 @@ export async function buildFrontend(): Promise<string> {
 	try {
 		writeFileAtomic(
 			BUNDLE_META,
-			JSON.stringify({ inputsHash, version, indexHtml, assets: [entryName, cssName, twName].filter(Boolean) }),
+			JSON.stringify({ inputsHash, version, indexHtml, assets: [entryName, twName] }),
 		);
 	} catch {}
 	console.log(


### PR DESCRIPTION
## Summary

- Move component-owned presentation from the monolithic global stylesheet into colocated Tailwind utilities across the frontend.
- Replace `global.css` with a pruned `adapters.css` containing only document/theme foundations, generated-content and third-party adapters, native-shell hooks, responsive state coupling, and shared keyframes.
- Make Tailwind the single production stylesheet, including vendored xterm CSS, and fail frontend builds when CSS compilation fails.
- Preserve concurrent main-branch behavior, including the right-click sidebar tool removal interaction and recent typography corrections.
- Fix the mobile page stack by making the workspace shell `contents` at phone widths in the same utility cascade.

## Verification

- `bun run typecheck`
- `bun test src/frontend` — 206 pass, 0 fail
- `bunx @tailwindcss/cli -i src/frontend/styles/tailwind.css -o /tmp/opencode/opensession-tailwind.css --minify`
- Production `buildFrontend()` — 368 output files with one hashed Tailwind stylesheet
- Desktop and mobile static production-bundle smoke renders; mobile tool-card/root-page layout verified after the responsive cascade fix
- `git diff --check`
- No remaining source/build references to `global.css`

## Session

https://os.tella.dev/session/bks-019fb3ad-3c25-7000-aff6-1b0ed6cdf652