### PR TITLE
Keychain: borrow a teammate's credential, with their approval, through a broker

### DIFF
--- a/opensession.ts
+++ b/opensession.ts
@@ -77,6 +77,7 @@ import "./src/server/goal-runner"; // goals ticker
 import "./src/server/session-index"; // session search index sweeper
 import "./src/server/session-control-wiring"; // opensession-sessions MCP + Slack-link bridge
 import "./src/server/preview-pool"; // warm dev-server pool sweeper
+import "./src/server/keychain"; // registers the keychain human-ask domain handler
 import { websocketHandlers } from "./src/server/ws-handlers";
 import {
 	routeHandlers,
@@ -326,12 +327,22 @@ const server: import("bun").Server<WSClientData> = hotServe({
 					(path === "/backstage/api/nodes/register" ||
 						path === "/backstage/api/nodes/heartbeat") &&
 					req.method === "POST";
+				// The keychain broker's caller is an agent subprocess on
+				// loopback with no browser session. Its own credential is the
+				// grant id in the path: unguessable, scoped to one credential
+				// and one session's approved purpose, method/path-limited,
+				// expiring, revocable and audited per call (src/server/
+				// keychain.ts). Same reasoning as the node routes above.
+				const openKeychainBroker = path.startsWith(
+					"/backstage/api/keychain/broker/",
+				);
 				if (
 					!authUser &&
 					!openHealth &&
 					!keypadBearer &&
 					!openOs1Update &&
 					!openNodeAuth &&
+					!openKeychainBroker &&
 					((path.startsWith("/backstage/api/") &&
 						!path.startsWith("/backstage/api/auth/")) ||
 						path === "/backstage/ws")

--- a/src/agents/slack/keychain-tools.ts
+++ b/src/agents/slack/keychain-tools.ts
@@ -1,0 +1,141 @@
+/**
+ * opensession-keychain — borrow a teammate's credential for a stated purpose.
+ *
+ * Three tools, no secret-handling among them: list what exists, ask an owner
+ * for a scoped grant, list this session's grants. Approved calls go through
+ * the broker (routes/keychain.ts) with the credential injected server-side, so
+ * the model never holds the secret and cannot leak one it never had.
+ *
+ * Interactive runs ONLY — same boundary as opensession-humans. An ask is a DM
+ * to a teammate carrying a model-authored "purpose" string; letting untrusted
+ * ticket text reach it would turn Michael into a social-engineering proxy
+ * against our own team ("I need the Stripe key to process this refund").
+ *
+ * Registration is deliberately not a tool: a secret pasted into a session
+ * prompt is a secret in the transcript. Credentials are added over HTTP.
+ */
+
+import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
+import { z } from "zod";
+import {
+  listCredentials,
+  listGrants,
+  listKeychainAsks,
+  requestCredential,
+} from "../../server/keychain";
+
+export interface KeychainToolContext {
+  sessionId: string;
+  /** Who is driving — recorded on the ask so the owner sees who is asking. */
+  user: string;
+}
+
+function text(s: string) {
+  return { content: [{ type: "text" as const, text: s }] };
+}
+
+export function createKeychainMcpServer(ctx: KeychainToolContext) {
+  const tools = [
+    tool(
+      "list_credentials",
+      "List the credentials teammates have registered in the keychain — service, owner, target host, and any method/path limits. Secrets are never included. Use this to find out whether the access you need already exists before asking anyone for a token.",
+      {},
+      async () => {
+        const creds = listCredentials();
+        if (!creds.length) {
+          return text(
+            "The keychain is empty. Credentials are registered by their owner in the OpenSession UI (Settings → Keychain) — never paste a secret into a session."
+          );
+        }
+        const lines = creds.map((c) => {
+          const limits = [
+            c.allowedMethods?.length ? `methods ${c.allowedMethods.join("/")}` : null,
+            c.allowedPathPrefixes?.length ? `paths ${c.allowedPathPrefixes.join(", ")}` : null,
+          ]
+            .filter(Boolean)
+            .join("; ");
+          return (
+            `- **${c.service}** (${c.host}) — owner ${c.owner}` +
+            (c.description ? `: ${c.description}` : "") +
+            (limits ? ` [${limits}]` : "")
+          );
+        });
+        return text(`Credentials in the keychain:\n${lines.join("\n")}`);
+      }
+    ),
+    tool(
+      "request_credential",
+      "Ask a credential's owner to lend it to THIS session for a stated purpose. They get a DM (or a card, if they're driving a session) with Approve once / Approve standing / Decline, and this call blocks until they answer. On approval you receive broker instructions — a URL that injects the credential server-side; you never see the secret itself. Ask only when you actually need the access now, state the real purpose (the owner is approving that sentence, and every call is audited against it), and prefer 'once' unless the task genuinely needs repeated calls. If they decline, don't re-ask.",
+      {
+        credential: z
+          .string()
+          .describe("Service slug (from list_credentials) or a credential id."),
+        purpose: z
+          .string()
+          .describe(
+            "What you need it for, one specific sentence the owner can judge — e.g. 'read the tella-fusion project's latest deployment status to diagnose the failing preview'."
+          ),
+        mode: z
+          .enum(["once", "standing"])
+          .optional()
+          .describe(
+            "'once' (default) = a single broker call, expires in an hour. 'standing' = repeated calls for up to 7 days; the owner can approve either regardless of what you request."
+          ),
+      },
+      async (args: { credential: string; purpose: string; mode?: "once" | "standing" }) => {
+        const result = requestCredential({
+          credential: args.credential,
+          sessionId: ctx.sessionId,
+          requestedBy: ctx.user,
+          purpose: args.purpose,
+          ...(args.mode ? { mode: args.mode } : {}),
+        });
+        if ("error" in result) return text(`Couldn't ask: ${result.error}`);
+        // The human-asks transport owns the wait; the keychain domain handler
+        // swaps the owner's button label for grant instructions, so whatever
+        // comes back here is already the text the model should act on.
+        const { awaitBlockingAnswer } = await import("../../server/human-asks");
+        const answer = await awaitBlockingAnswer(result.transport.id);
+        if (answer === null) {
+          return text(
+            `${result.ask.owner} hasn't answered yet — the ask stays open (${result.ask.id}) and their reply will arrive in this session as a message. Carry on with what doesn't need this credential, or stop and say what you're blocked on.`
+          );
+        }
+        return text(answer);
+      }
+    ),
+    tool(
+      "list_grants",
+      "List the keychain grants this session holds — which credential, once or standing, active/used/expired/revoked, and when each expires. Use it to check whether a grant you were given is still usable before relying on it.",
+      {},
+      async () => {
+        const grants = listGrants({ sessionId: ctx.sessionId });
+        const pending = listKeychainAsks({ sessionId: ctx.sessionId }).filter(
+          (a) => a.status === "pending"
+        );
+        if (!grants.length && !pending.length) {
+          return text("This session holds no keychain grants and has no pending asks.");
+        }
+        const creds = new Map(listCredentials().map((c) => [c.id, c]));
+        const lines = grants.map((g) => {
+          const service = creds.get(g.credentialId)?.service || g.credentialId;
+          const when = g.status === "active" ? `expires ${g.expiresAt}` : g.status;
+          return `- ${service} (${g.mode}) — ${when} — grant \`${g.id}\` — purpose: ${g.purpose}`;
+        });
+        const pendingLines = pending.map(
+          (a) => `- ${a.id}: awaiting ${a.owner}'s answer — purpose: ${a.purpose}`
+        );
+        return text(
+          [
+            grants.length ? `Grants:\n${lines.join("\n")}` : "",
+            pendingLines.length ? `Pending asks:\n${pendingLines.join("\n")}` : "",
+          ]
+            .filter(Boolean)
+            .join("\n\n")
+        );
+      }
+    ),
+  ];
+
+  return createSdkMcpServer({ name: "opensession-keychain", tools });
+}

--- a/src/frontend/components/Settings.tsx
+++ b/src/frontend/components/Settings.tsx
@@ -1,5 +1,5 @@
 import { BASE_PATH } from "../lib/base";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
 	getNotifSettings,
 	setNotifSettings,
@@ -81,6 +81,10 @@ import {
 	deleteMemoryEntryApi,
 	fetchPapercuts,
 	setPapercutsRepoEnabled,
+	fetchKeychain,
+	addKeychainCredential,
+	deleteKeychainCredential,
+	revokeKeychainGrant,
 	fetchPersonalPrompt,
 	savePersonalPrompt,
 	relativeTime,
@@ -92,6 +96,9 @@ import {
 	type MemoryEntryDto,
 	type PapercutDto,
 	type PapercutsRepoConfig,
+	type KeychainCredentialDto,
+	type KeychainGrantDto,
+	type KeychainAskDto,
 } from "../lib/api";
 import type { FeedDescriptor } from "../lib/types";
 import { getPushState, enablePush, disablePush, type PushState } from "../lib/push";
@@ -181,6 +188,7 @@ export type SettingsSectionKey =
 	| "warmPreviews"
 	| "previewPool"
 	| "papercuts"
+	| "keychain"
 	| "audit"
 	| ToolSectionKey;
 
@@ -514,6 +522,24 @@ const SECTIONS: {
 		),
 	},
 	{
+		key: "keychain",
+		label: "Keychain",
+		group: "Workspace",
+		icon: (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.4"
+			>
+				<circle cx="5.4" cy="8" r="2.6" />
+				<path d="M8 8h6M12 8v2.2M10 8v1.6" strokeLinecap="round" />
+			</svg>
+		),
+	},
+	{
 		key: "papercuts",
 		label: "Papercuts",
 		group: "Workspace",
@@ -585,6 +611,7 @@ function SectionPanel({
 			{section === "warmPreviews" && <WarmPreviewsPanel />}
 			{section === "previewPool" && <PreviewPoolPanel />}
 			{section === "papercuts" && <PapercutsPanel />}
+			{section === "keychain" && <KeychainPanel />}
 		</>
 	);
 }
@@ -1805,6 +1832,253 @@ function PreviewPoolPanel() {
 					);
 				})}
 			</SettingCard>
+		</SettingsPanel>
+	);
+}
+
+// ── Keychain: per-person credentials sessions can BORROW with your approval
+// (src/server/keychain.ts). Registration lives here rather than in a tool
+// because a secret pasted into a session prompt is a secret in the transcript. ──
+function KeychainPanel() {
+	const [data, setData] = useState<{
+		credentials: KeychainCredentialDto[];
+		grants: KeychainGrantDto[];
+		asks: KeychainAskDto[];
+	} | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [adding, setAdding] = useState(false);
+	const [service, setService] = useState("");
+	const [host, setHost] = useState("");
+	const [secret, setSecret] = useState("");
+	const [description, setDescription] = useState("");
+	const [header, setHeader] = useState("");
+	const [methods, setMethods] = useState("");
+	const [prefixes, setPrefixes] = useState("");
+	const [busy, setBusy] = useState(false);
+
+	const reload = useCallback(() => {
+		fetchKeychain()
+			.then(setData)
+			.catch((e) => setError(e.message));
+	}, []);
+	useEffect(reload, [reload]);
+
+	const submit = () => {
+		setBusy(true);
+		addKeychainCredential({
+			service: service.trim(),
+			host: host.trim(),
+			secret,
+			...(description.trim() ? { description: description.trim() } : {}),
+			...(header.trim() ? { injection: { header: header.trim() } } : {}),
+			...(methods.trim()
+				? { allowedMethods: methods.split(",").map((m) => m.trim()).filter(Boolean) }
+				: {}),
+			...(prefixes.trim()
+				? { allowedPathPrefixes: prefixes.split(",").map((p) => p.trim()).filter(Boolean) }
+				: {}),
+		})
+			.then(() => {
+				// Clear the secret first and always — it must not survive a
+				// failed reload in a React state a devtools user can read back.
+				setSecret("");
+				setService("");
+				setHost("");
+				setDescription("");
+				setHeader("");
+				setMethods("");
+				setPrefixes("");
+				setAdding(false);
+				reload();
+			})
+			.catch((e) => setError(e.message))
+			.finally(() => setBusy(false));
+	};
+
+	const panelHeader = (
+		<SettingsHeader
+			title="Keychain"
+			description="Credentials you own that a session can borrow — with your approval, for a stated purpose. Approved calls go through a broker that injects the secret server-side, so the agent never sees it. Grants are scoped to one session, expire, and are revocable."
+		/>
+	);
+
+	if (!data)
+		return (
+			<SettingsPanel>
+				{panelHeader}
+				{error ? <InlineAlert>{error}</InlineAlert> : <LoadingState>Loading keychain…</LoadingState>}
+			</SettingsPanel>
+		);
+
+	const byId = new Map(data.credentials.map((c) => [c.id, c]));
+	const activeGrants = data.grants.filter((g) => g.status === "active");
+	const pendingAsks = data.asks.filter((a) => a.status === "pending");
+
+	return (
+		<SettingsPanel>
+			{panelHeader}
+			{error && <InlineAlert onDismiss={() => setError(null)}>{error}</InlineAlert>}
+
+			<SettingsGroupLabel className="flex items-center justify-between gap-2">
+				Credentials
+				<Button size="sm" variant="ghost" onClick={() => setAdding((v) => !v)}>
+					{adding ? "Cancel" : "Add credential"}
+				</Button>
+			</SettingsGroupLabel>
+
+			{adding && (
+				<SettingCard>
+					<div className="flex flex-col gap-2 p-4">
+						<input
+							className={settingsInputClass}
+							value={service}
+							onChange={(e) => setService(e.target.value)}
+							placeholder="service slug, e.g. vercel"
+							aria-label="Service slug"
+						/>
+						<input
+							className={settingsInputClass}
+							value={host}
+							onChange={(e) => setHost(e.target.value)}
+							placeholder="api host, e.g. api.vercel.com"
+							aria-label="API host"
+						/>
+						<input
+							className={settingsInputClass}
+							type="password"
+							value={secret}
+							onChange={(e) => setSecret(e.target.value)}
+							placeholder="secret (never shown again, never sent to a model)"
+							aria-label="Secret"
+						/>
+						<input
+							className={settingsInputClass}
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							placeholder="what it's for (optional)"
+							aria-label="Description"
+						/>
+						<input
+							className={settingsInputClass}
+							value={header}
+							onChange={(e) => setHeader(e.target.value)}
+							placeholder="header (optional, default: Authorization: Bearer)"
+							aria-label="Injection header"
+						/>
+						<input
+							className={settingsInputClass}
+							value={methods}
+							onChange={(e) => setMethods(e.target.value)}
+							placeholder="allowed methods, comma-separated (optional — e.g. GET)"
+							aria-label="Allowed methods"
+						/>
+						<input
+							className={settingsInputClass}
+							value={prefixes}
+							onChange={(e) => setPrefixes(e.target.value)}
+							placeholder="allowed path prefixes, comma-separated (optional — e.g. /v1/deployments)"
+							aria-label="Allowed path prefixes"
+						/>
+						<SettingsHint>
+							Narrow the methods and paths where you can — a grant can only ever reach what the
+							credential allows, so this is the ceiling on anything you approve later.
+						</SettingsHint>
+						<Button
+							size="sm"
+							disabled={busy || !service.trim() || !host.trim() || !secret}
+							onClick={submit}
+						>
+							{busy ? "Saving…" : "Save credential"}
+						</Button>
+					</div>
+				</SettingCard>
+			)}
+
+			{data.credentials.length === 0 ? (
+				<EmptyState placement="card">
+					No credentials yet. Add one to let sessions ask you for scoped access instead of going
+					without — or instead of a token ending up in a prompt.
+				</EmptyState>
+			) : (
+				<SettingCard>
+					{data.credentials.map((c) => (
+						<SettingRow
+							key={c.id}
+							title={`${c.service} · ${c.host}`}
+							desc={[
+								`owner ${c.owner}`,
+								c.description,
+								c.allowedMethods?.length ? `methods ${c.allowedMethods.join("/")}` : null,
+								c.allowedPathPrefixes?.length
+									? `paths ${c.allowedPathPrefixes.join(", ")}`
+									: null,
+							]
+								.filter(Boolean)
+								.join(" · ")}
+							control={
+								<Button
+									size="sm"
+									variant="ghost"
+									onClick={() =>
+										deleteKeychainCredential(c.id)
+											.then(reload)
+											.catch((e) => setError(e.message))
+									}
+								>
+									Delete
+								</Button>
+							}
+						/>
+					))}
+				</SettingCard>
+			)}
+
+			{pendingAsks.length > 0 && (
+				<>
+					<SettingsGroupLabel>Awaiting your answer</SettingsGroupLabel>
+					<SettingCard>
+						{pendingAsks.map((a) => (
+							<SettingRow
+								key={a.id}
+								title={`${byId.get(a.credentialId)?.service ?? a.credentialId} — ${a.requestedBy}`}
+								desc={`${a.requestedMode} · ${a.purpose}`}
+								control={null}
+							/>
+						))}
+					</SettingCard>
+					<SettingsHint>
+						Answer these where they were asked — the Slack DM, or the card in the session.
+					</SettingsHint>
+				</>
+			)}
+
+			<SettingsGroupLabel>Active grants</SettingsGroupLabel>
+			{activeGrants.length === 0 ? (
+				<EmptyState placement="card">No session currently holds a keychain grant.</EmptyState>
+			) : (
+				<SettingCard>
+					{activeGrants.map((g) => (
+						<SettingRow
+							key={g.id}
+							title={`${byId.get(g.credentialId)?.service ?? g.credentialId} → ${g.requestedBy}`}
+							desc={`${g.mode} · expires ${new Date(g.expiresAt).toLocaleString()} · ${g.purpose}`}
+							control={
+								<Button
+									size="sm"
+									variant="ghost"
+									onClick={() =>
+										revokeKeychainGrant(g.id)
+											.then(reload)
+											.catch((e) => setError(e.message))
+									}
+								>
+									Revoke
+								</Button>
+							}
+						/>
+					))}
+				</SettingCard>
+			)}
 		</SettingsPanel>
 	);
 }

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -2007,6 +2007,78 @@ export async function setPapercutsRepoEnabled(
 	});
 }
 
+// ── Keychain (Settings → Keychain: per-person credentials + grants) ──
+
+export interface KeychainCredentialDto {
+	id: string;
+	owner: string;
+	service: string;
+	description?: string;
+	host: string;
+	injection?: { header?: string; scheme?: string };
+	allowedMethods?: string[];
+	allowedPathPrefixes?: string[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface KeychainGrantDto {
+	id: string;
+	credentialId: string;
+	owner: string;
+	sessionId: string;
+	requestedBy: string;
+	purpose: string;
+	mode: "once" | "standing";
+	status: "active" | "used" | "revoked" | "expired";
+	createdAt: string;
+	expiresAt: string;
+}
+
+export interface KeychainAskDto {
+	id: string;
+	credentialId: string;
+	owner: string;
+	sessionId: string;
+	requestedBy: string;
+	purpose: string;
+	requestedMode: "once" | "standing";
+	status: "pending" | "approved" | "declined" | "expired";
+	createdAt: string;
+}
+
+export async function fetchKeychain(): Promise<{
+	credentials: KeychainCredentialDto[];
+	grants: KeychainGrantDto[];
+	asks: KeychainAskDto[];
+}> {
+	return request("/keychain", { label: "Failed to fetch the keychain" });
+}
+
+export async function addKeychainCredential(input: {
+	service: string;
+	host: string;
+	secret: string;
+	description?: string;
+	injection?: { header?: string; scheme?: string };
+	allowedMethods?: string[];
+	allowedPathPrefixes?: string[];
+}): Promise<{ credential: KeychainCredentialDto }> {
+	return request("/keychain/credentials", { method: "POST", body: input });
+}
+
+export async function deleteKeychainCredential(id: string): Promise<{ ok: true }> {
+	return request(`/keychain/credentials/${encodeURIComponent(id)}`, {
+		method: "DELETE",
+	});
+}
+
+export async function revokeKeychainGrant(id: string): Promise<{ ok: true }> {
+	return request(`/keychain/grants/${encodeURIComponent(id)}`, {
+		method: "DELETE",
+	});
+}
+
 // ── Personal system prompt (Settings → Personal prompt) ──
 
 export async function fetchPersonalPrompt(

--- a/src/server/human-asks.ts
+++ b/src/server/human-asks.ts
@@ -91,6 +91,15 @@ export interface HumanAsk {
   state: HumanAskState;
   /** Set once delivered: the DM channel and the question message's ts (thread root). */
   slack?: { channel: string; rootTs: string };
+  /**
+   * Domain hook: a server-side module owns this ask's meaning (e.g. the
+   * keychain's approve/decline). When set, the registered handler for `kind`
+   * runs at resolution — whichever channel answered — and may replace the
+   * text delivered to the session (a grant token instead of the raw button
+   * label). Persisted with the ask, so a restart between question and answer
+   * still resolves through the domain (handlers re-register at module load).
+   */
+  domain?: { kind: string; ref: string };
   answer?: string;
   answeredBy?: string;
   createdAt: string;
@@ -231,6 +240,48 @@ export interface CreateAskInput {
   options?: string[];
   mode: "block" | "async";
   deliver: DeliverWhen;
+  domain?: { kind: string; ref: string };
+}
+
+// ---------------------------------------------------------------------------
+// Domain handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * A domain handler runs inside resolveAsk when a domain-tagged ask is
+ * answered, and may return replacement text for what the session receives
+ * (both the block resolver's return value and the async steer) — e.g. the
+ * keychain swaps "Approve once" for grant instructions. Returning null keeps
+ * the raw answer. A throwing handler must not eat the answer: the raw text
+ * still goes through.
+ *
+ * Registry lives on globalThis so hot reloads keep it; owning modules
+ * re-register at module load, so the newest code answers.
+ */
+export type AskDomainHandler = (ask: HumanAsk, answer: string) => string | null;
+
+const domainHandlers: Map<string, AskDomainHandler> = ((globalThis as any).__humanAskDomainHandlers ??=
+  new Map());
+
+export function registerAskDomainHandler(kind: string, handler: AskDomainHandler): void {
+  domainHandlers.set(kind, handler);
+}
+
+function applyDomainHandler(a: HumanAsk, answer: string): string {
+  if (!a.domain) return answer;
+  const handler = domainHandlers.get(a.domain.kind);
+  if (!handler) {
+    console.error(
+      `[human-asks] ask ${a.id} carries domain "${a.domain.kind}" but no handler is registered — delivering the raw answer`
+    );
+    return answer;
+  }
+  try {
+    return handler(a, answer) ?? answer;
+  } catch (e) {
+    console.error(`[human-asks] domain handler ${a.domain.kind} failed for ${a.id}:`, e);
+    return answer;
+  }
 }
 
 /**
@@ -352,6 +403,7 @@ export function registerAsk(input: CreateAskInput): HumanAsk {
     mode: input.mode,
     deliver: input.deliver,
     uiFirst: shouldAskInUiFirst(input) || undefined,
+    domain: input.domain,
     state: "scheduled",
     createdAt: new Date().toISOString(),
   };
@@ -543,9 +595,15 @@ function resolveAsk(
     answer_len: answer.length,
   });
 
+  // A domain-tagged ask (keychain approvals, …) resolves through its owning
+  // module FIRST — server-side effects (minting a grant) happen exactly once
+  // here, whichever channel answered, and the session receives the domain's
+  // text (grant instructions) rather than the raw button label.
+  const delivered = applyDomainHandler(a, answer);
+
   const resolver = resolvers.get(a.id);
   if (resolver) {
-    resolver(answer); // live block — the awaiting tool call returns the answer
+    resolver(delivered); // live block — the awaiting tool call returns the answer
     return;
   }
   // Async (or a block whose wait already timed out / lost its process): steer
@@ -559,7 +617,7 @@ function resolveAsk(
   // and a structured header the web UI keys on to render this as a distinct
   // "human reply" bubble rather than one of the session driver's own messages.
   const who = via === "ui" ? answeredBy || a.person.name : a.person.name;
-  const msg = `💬 **${who}** answered${via === "ui" ? "" : " (via Slack)"} — "${shortQ(a)}":\n\n${answer}`;
+  const msg = `💬 **${who}** answered${via === "ui" ? "" : " (via Slack)"} — "${shortQ(a)}":\n\n${delivered}`;
   void ctrl
     .deliverToSession(a.sessionId, msg, who)
     .catch((e) => console.error(`[human-asks] deliver answer to ${a.sessionId} failed:`, e));

--- a/src/server/interactive-mcp.ts
+++ b/src/server/interactive-mcp.ts
@@ -17,6 +17,7 @@ import { createSessionsMcpServer } from "../agents/slack/sessions-tools";
 import { createNodesMcpServer } from "../agents/slack/nodes-tools";
 import { createAdminMcpServer } from "../agents/slack/admin-tools";
 import { createHumansMcpServer } from "../agents/slack/humans-tools";
+import { createKeychainMcpServer } from "../agents/slack/keychain-tools";
 import { createAskUserMcpServer } from "../agents/slack/ask-tools";
 import { createReposMcpServer } from "../agents/slack/repos-tools";
 import { createPreviewMcpServer } from "../agents/slack/preview-tools";
@@ -114,6 +115,15 @@ export function interactiveMcpServers(
 						sessionId,
 						createdBy,
 						isAdmin: true,
+					}),
+					// Borrow a teammate's credential for a stated purpose, with
+					// their approval, through the broker (src/server/keychain.ts).
+					// Interactive-only for the same reason as its sibling above:
+					// an ask is a DM carrying a model-authored purpose string, and
+					// untrusted ticket text must never be able to compose one.
+					"opensession-keychain": createKeychainMcpServer({
+						sessionId,
+						user: createdBy,
 					}),
 					// Cross-repo: attach secondary repos as isolated worktrees.
 					"opensession-repos": createReposMcpServer({

--- a/src/server/keychain.test.ts
+++ b/src/server/keychain.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Point the store at a throwaway path BEFORE importing the module — the real
+// ~/.opensession-keychain.json holds registered credentials, and a suite that
+// truncated it would destroy them.
+const STORE = join(mkdtempSync(join(tmpdir(), "keychain-test-")), "keychain.json");
+process.env.OPENSESSION_KEYCHAIN_STORE = STORE;
+
+function resetKeychain(): void {
+  if (existsSync(STORE)) rmSync(STORE);
+  const g = globalThis as any;
+  g.__keychainCredentials?.clear();
+  g.__keychainGrants?.clear();
+  g.__keychainAsks?.clear();
+}
+
+let kc: typeof import("./keychain");
+
+beforeEach(async () => {
+  // Re-assert the override: another suite in this process may have imported
+  // the module first, and the path is resolved per call precisely so this
+  // still wins (and so no test can write to a real keychain).
+  process.env.OPENSESSION_KEYCHAIN_STORE = STORE;
+  resetKeychain();
+  kc = await import("./keychain");
+});
+
+afterEach(() => resetKeychain());
+
+const cred = (over: Partial<Parameters<typeof kc.addCredential>[0]> = {}) =>
+  kc.addCredential({
+    owner: "Michiel",
+    service: "vercel",
+    host: "api.vercel.com",
+    secret: "sk-live-secret",
+    ...over,
+  });
+
+describe("credentials", () => {
+  test("registering returns metadata and never the secret", () => {
+    const meta = cred();
+    expect(meta.service).toBe("vercel");
+    expect(meta.host).toBe("api.vercel.com");
+    expect(JSON.stringify(meta)).not.toContain("sk-live-secret");
+    expect(JSON.stringify(kc.listCredentials())).not.toContain("sk-live-secret");
+    expect(JSON.stringify(kc.findCredential("vercel"))).not.toContain("sk-live-secret");
+  });
+
+  test("normalizes host and service, rejects malformed input", () => {
+    const meta = cred({ service: "  Vercel  ", host: "https://api.vercel.com/v1?x=1" });
+    expect(meta.service).toBe("vercel");
+    expect(meta.host).toBe("api.vercel.com");
+    expect(() => cred({ service: "has space" })).toThrow(/slug/);
+    expect(() => cred({ service: "ahrefs", host: "api.ahrefs.com:8443" })).toThrow(/host/);
+    expect(() => cred({ service: "ahrefs", secret: "   " })).toThrow(/secret/);
+    expect(() => cred({ service: "ahrefs", allowedPathPrefixes: ["v1/x"] })).toThrow(/start with/);
+  });
+
+  test("service slugs are unique", () => {
+    cred();
+    expect(() => cred()).toThrow(/already exists/);
+  });
+
+  test("only the owner may delete, and deleting revokes live grants", () => {
+    const meta = cred();
+    expect(() => kc.deleteCredential(meta.id, "Grant")).toThrow(/owner/);
+    expect(kc.deleteCredential(meta.id, "Michiel")).toBe(true);
+    expect(kc.listCredentials()).toHaveLength(0);
+    expect(kc.deleteCredential(meta.id, "Michiel")).toBe(false);
+  });
+
+  test("findCredential resolves by id or service slug", () => {
+    const meta = cred();
+    expect(kc.findCredential(meta.id)?.id).toBe(meta.id);
+    expect(kc.findCredential("VERCEL")?.id).toBe(meta.id);
+    expect(kc.findCredential("nope")).toBeUndefined();
+  });
+});
+
+describe("owner answers", () => {
+  test("button labels map to their modes", () => {
+    expect(kc.parseOwnerAnswer("Approve once", "standing")).toEqual({
+      approve: true,
+      mode: "once",
+    });
+    expect(kc.parseOwnerAnswer("Approve standing", "once")).toEqual({
+      approve: true,
+      mode: "standing",
+    });
+    expect(kc.parseOwnerAnswer("Decline", "once")).toEqual({ approve: false });
+  });
+
+  test("free text approves only on an explicit yes, keeping the requested mode", () => {
+    expect(kc.parseOwnerAnswer("yes go ahead", "once")).toEqual({ approve: true, mode: "once" });
+    expect(kc.parseOwnerAnswer("ok, standing is fine", "once")).toEqual({
+      approve: true,
+      mode: "standing",
+    });
+    expect(kc.parseOwnerAnswer("no", "once")).toEqual({ approve: false });
+  });
+
+  test("anything ambiguous fails closed, keeping the text as the owner's note", () => {
+    const r = kc.parseOwnerAnswer("what do you need it for?", "once");
+    expect(r.approve).toBe(false);
+    expect((r as { note?: string }).note).toBe("what do you need it for?");
+  });
+});
+
+describe("broker", () => {
+  test("rejects unknown, revoked and expired grants", () => {
+    const r = kc.consumeGrantForBroker("kg-nope", "GET", "/v1/x");
+    expect(r).toMatchObject({ status: 404 });
+  });
+
+  test("injects Authorization: Bearer by default and honors a custom header", () => {
+    expect(
+      kc.brokerHeaders({ secret: "s3cr3t" } as Parameters<typeof kc.brokerHeaders>[0])
+    ).toEqual({ Authorization: "Bearer s3cr3t" });
+    expect(
+      kc.brokerHeaders({
+        secret: "s3cr3t",
+        injection: { header: "X-Api-Key" },
+      } as Parameters<typeof kc.brokerHeaders>[0])
+    ).toEqual({ "X-Api-Key": "s3cr3t" });
+    expect(
+      kc.brokerHeaders({
+        secret: "s3cr3t",
+        injection: { header: "Authorization", scheme: "token" },
+      } as Parameters<typeof kc.brokerHeaders>[0])
+    ).toEqual({ Authorization: "token s3cr3t" });
+  });
+
+  test("scrubs a secret the upstream echoed back", () => {
+    expect(kc.scrubSecret('{"key":"s3cr3t","ok":true}', "s3cr3t")).toBe(
+      '{"key":"[redacted]","ok":true}'
+    );
+    expect(kc.scrubSecret("nothing here", "s3cr3t")).toBe("nothing here");
+    expect(kc.scrubSecret("body", "")).toBe("body");
+  });
+});
+
+describe("grant lifecycle", () => {
+  // requestCredential needs the identity roster + the human-asks transport, so
+  // the ask path is covered by the route/tool layers. The lifecycle below
+  // exercises the parts that own the security properties.
+  test("listGrants is empty for a fresh session", () => {
+    expect(kc.listGrants({ sessionId: "bks-none" })).toEqual([]);
+  });
+
+  test("revoking an unknown grant reports it rather than throwing", () => {
+    expect(kc.revokeGrant("kg-missing", "Michiel")).toEqual({ error: "no such grant" });
+  });
+
+  test("requesting an unknown credential names what exists", () => {
+    cred();
+    const r = kc.requestCredential({
+      credential: "stripe",
+      sessionId: "bks-1",
+      requestedBy: "Michiel",
+      purpose: "test",
+    });
+    expect(r).toHaveProperty("error");
+    expect((r as { error: string }).error).toContain("vercel");
+  });
+
+  test("a purpose is required — it is what the owner approves", () => {
+    cred();
+    const r = kc.requestCredential({
+      credential: "vercel",
+      sessionId: "bks-1",
+      requestedBy: "Michiel",
+      purpose: "   ",
+    });
+    expect((r as { error: string }).error).toMatch(/purpose/);
+  });
+});
+
+describe("grant enforcement", () => {
+  test("a once grant is consumed by its first call and dead thereafter", () => {
+    const meta = cred();
+    const gr = kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "once",
+    });
+    const first = kc.consumeGrantForBroker(gr.id, "GET", "/v1/deployments");
+    expect(first).toHaveProperty("credential");
+    expect((first as { credential: { secret: string } }).credential.secret).toBe("sk-live-secret");
+    const second = kc.consumeGrantForBroker(gr.id, "GET", "/v1/deployments");
+    expect(second).toMatchObject({ status: 403 });
+    expect((second as { error: string }).error).toContain("used");
+  });
+
+  test("a standing grant survives repeated calls until revoked", () => {
+    const meta = cred();
+    const gr = kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "standing",
+    });
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/x")).toHaveProperty("credential");
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/x")).toHaveProperty("credential");
+    expect(kc.revokeGrant(gr.id, "Michiel")).toEqual({ ok: true });
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/x")).toMatchObject({ status: 403 });
+  });
+
+  test("an expired grant is refused and settles to expired", () => {
+    const meta = cred();
+    const gr = kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "standing",
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/x")).toMatchObject({ status: 403 });
+    expect(kc.listGrants({ sessionId: "bks-1" })[0]!.status).toBe("expired");
+  });
+
+  test("the credential's method and path limits bound every grant", () => {
+    const meta = cred({ allowedMethods: ["GET"], allowedPathPrefixes: ["/v1/deployments"] });
+    const grant = () =>
+      kc.__mintGrantForTest({
+        credentialId: meta.id,
+        sessionId: "bks-1",
+        requestedBy: "Grant",
+        mode: "standing",
+      });
+    const gr = grant();
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/deployments/abc")).toHaveProperty(
+      "credential"
+    );
+    expect(kc.consumeGrantForBroker(gr.id, "DELETE", "/v1/deployments/abc")).toMatchObject({
+      status: 403,
+    });
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/teams")).toMatchObject({ status: 403 });
+  });
+
+  test("deleting the credential kills its live grants", () => {
+    const meta = cred();
+    const gr = kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "standing",
+    });
+    kc.deleteCredential(meta.id, "Michiel");
+    expect(kc.consumeGrantForBroker(gr.id, "GET", "/v1/x")).toMatchObject({ status: 403 });
+  });
+
+  test("either side may revoke, nobody else", () => {
+    const meta = cred();
+    const gr = kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "standing",
+    });
+    expect(kc.revokeGrant(gr.id, "Kent")).toHaveProperty("error");
+    expect(kc.revokeGrant(gr.id, "Grant")).toEqual({ ok: true });
+  });
+
+  test("grants are listed per session, so one session cannot see another's", () => {
+    const meta = cred();
+    kc.__mintGrantForTest({
+      credentialId: meta.id,
+      sessionId: "bks-1",
+      requestedBy: "Grant",
+      mode: "standing",
+    });
+    expect(kc.listGrants({ sessionId: "bks-1" })).toHaveLength(1);
+    expect(kc.listGrants({ sessionId: "bks-2" })).toHaveLength(0);
+  });
+});
+
+describe("grant instructions", () => {
+  test("name the broker URL, the limits and the single-use rule", () => {
+    const meta = cred({ allowedMethods: ["GET"], allowedPathPrefixes: ["/v1/deployments"] });
+    const text = kc.grantInstructions(
+      {
+        id: "kg-abc",
+        credentialId: meta.id,
+        owner: "Michiel",
+        sessionId: "bks-1",
+        requestedBy: "Grant",
+        purpose: "check the failing preview deploy",
+        mode: "once",
+        status: "active",
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      },
+      meta
+    );
+    expect(text).toContain("kg-abc");
+    expect(text).toContain("api.vercel.com");
+    expect(text).toContain("SINGLE-USE");
+    expect(text).toContain("GET");
+    expect(text).toContain("/v1/deployments");
+    expect(text).toContain("check the failing preview deploy");
+    expect(text).not.toContain("sk-live-secret");
+  });
+});

--- a/src/server/keychain.ts
+++ b/src/server/keychain.ts
@@ -1,0 +1,665 @@
+/**
+ * Keychain — per-person credentials with an ask→grant flow, modelled on
+ * yc-software/qm's keychain (MIT) and built on our human-asks transport.
+ *
+ * Today a credential is either instance-wide (~/.opensession.env, mcp-config
+ * `env`) or absent. There is no way for a session to say "I need Michiel's
+ * Vercel token for this one task" and for Michiel to say "fine, once". This
+ * module adds exactly that:
+ *
+ *   credential — owned by a PERSON (identity roster name). The secret lives
+ *                here 0600 and is never returned by any API or tool.
+ *   ask        — a session's request to borrow one: purpose + once/standing.
+ *                Delivered to the owner through human-asks (Slack DM with
+ *                Approve once / Approve standing / Decline buttons, UI-first
+ *                card when the owner is driving a session). 24h TTL.
+ *   grant      — the approval: scoped to the REQUESTING SESSION only,
+ *                once (single broker call, 1h) or standing (7d), revocable,
+ *                audited.
+ *
+ * Delivery is broker-only: the agent never sees the secret, it gets a grant
+ * token and calls
+ *
+ *   http://127.0.0.1:<port>/backstage/api/keychain/broker/<grantId>/<path>
+ *
+ * (routes/keychain.ts) which injects the credential's header server-side and
+ * proxies to the credential's host — constrained by the credential's
+ * allowedMethods / allowedPathPrefixes, and with the secret scrubbed from any
+ * text response that echoes it. A leaked grant token is scoped (one
+ * credential, one session's purpose, method/path-limited, short-lived,
+ * revocable, fully audited) where a leaked secret is forever — that
+ * asymmetry is the whole design, same as qm's.
+ *
+ * Trust boundary: the opensession-keychain MCP server is interactive-only
+ * (same bar as opensession-humans — never automation runs), so untrusted
+ * ticket text cannot social-engineer an owner with a plausible "purpose".
+ * Registration is HTTP-only (routes/keychain.ts, web-auth gated): a secret
+ * typed into a session prompt would land in the transcript, so there is
+ * deliberately no add_credential tool.
+ *
+ * Two limitations, stated rather than papered over:
+ *
+ *  1. The broker rides loopback, so grants work for runs on this box
+ *     (worktrees, the shared checkout) but not inside remote sandboxes —
+ *     those would need the dial-back channel, out of scope here.
+ *  2. The grant id is a bearer token that lands in the requesting session's
+ *     transcript, and transcripts are searchable across sessions
+ *     (opensession-search). So a grant is scoped to a session by INTENT and
+ *     by audit, not by cryptographic isolation: another session on this box
+ *     that went looking could find and replay it inside its TTL. What bounds
+ *     the damage is everything else — the credential's method/path ceiling,
+ *     once-grants dying on first use, short TTLs, revocation, and an audit
+ *     line per call recording the session a grant was issued to (so a replay
+ *     from elsewhere is visible after the fact). Binding the broker to the
+ *     calling run would need per-run identity on the loopback call, which the
+ *     agent's shell does not have today.
+ */
+
+import { existsSync, readFileSync, chmodSync } from "node:fs";
+import { writeJsonAtomic } from "./shared/atomic-write";
+import { audit } from "./audit";
+import { resolveTeammate } from "./shared/user-mappings";
+import { registerAsk, registerAskDomainHandler, type HumanAsk } from "./human-asks";
+
+const HOME = process.env.HOME || "/home/ubuntu";
+
+/**
+ * Resolved per call, never captured at module load. Tests point
+ * OPENSESSION_KEYCHAIN_STORE at a temp file, and this module is imported
+ * transitively (interactive-mcp → keychain-tools → here) by other suites — a
+ * const captured at first import would silently ignore the override and let a
+ * test suite write to, or truncate, the real keychain.
+ */
+function storePath(): string {
+  return process.env.OPENSESSION_KEYCHAIN_STORE || `${HOME}/.opensession-keychain.json`;
+}
+
+export const ONCE_GRANT_TTL_MS = 60 * 60 * 1000;
+export const STANDING_GRANT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** Terminal asks/grants older than this are pruned on load. */
+const TERMINAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type GrantMode = "once" | "standing";
+
+export interface KeychainCredential {
+  id: string;
+  /** Owner's roster first name — the person who approves asks for it. */
+  owner: string;
+  /** Lookup + display key, e.g. "vercel", "ahrefs". Unique per keychain. */
+  service: string;
+  description?: string;
+  /** Broker target host (https assumed), e.g. "api.vercel.com". */
+  host: string;
+  /** How the secret rides the proxied request. Default Authorization: Bearer. */
+  injection?: { header?: string; scheme?: string };
+  /** Empty/undefined = all methods. */
+  allowedMethods?: string[];
+  /** Empty/undefined = all paths. */
+  allowedPathPrefixes?: string[];
+  secret: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Everything about a credential except the secret — the only shape any
+ *  list/API/tool ever returns. */
+export type KeychainCredentialMeta = Omit<KeychainCredential, "secret">;
+
+export interface KeychainGrant {
+  /** The id IS the broker bearer token — unguessable, scoped, expiring. */
+  id: string;
+  credentialId: string;
+  owner: string;
+  /** Audience: only this backstage session was granted anything. */
+  sessionId: string;
+  requestedBy: string;
+  purpose: string;
+  mode: GrantMode;
+  status: "active" | "used" | "revoked" | "expired";
+  createdAt: string;
+  expiresAt: string;
+  usedAt?: string;
+  revokedAt?: string;
+  askId?: string;
+}
+
+export interface KeychainAskRecord {
+  id: string;
+  credentialId: string;
+  owner: string;
+  sessionId: string;
+  requestedBy: string;
+  purpose: string;
+  requestedMode: GrantMode;
+  status: "pending" | "approved" | "declined" | "expired";
+  /** The human-asks transport record carrying the owner's buttons. */
+  humanAskId?: string;
+  grantId?: string;
+  createdAt: string;
+  resolvedAt?: string;
+  note?: string;
+}
+
+interface Stored {
+  credentials: KeychainCredential[];
+  grants: KeychainGrant[];
+  asks: KeychainAskRecord[];
+}
+
+const g = globalThis as any;
+const credentials: Map<string, KeychainCredential> = (g.__keychainCredentials ??= new Map());
+const grants: Map<string, KeychainGrant> = (g.__keychainGrants ??= new Map());
+const keychainAsks: Map<string, KeychainAskRecord> = (g.__keychainAsks ??= new Map());
+/** The path we last loaded from — a change (only tests do this) reloads. */
+let loadedFrom: string | null = null;
+
+function persist(): void {
+  const path = storePath();
+  writeJsonAtomic(path, {
+    credentials: [...credentials.values()],
+    grants: [...grants.values()],
+    asks: [...keychainAsks.values()],
+  } satisfies Stored);
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // best-effort — the file holds secrets, but a chmod failure must not
+    // lose the write (the box is single-tenant either way)
+  }
+}
+
+function load(): void {
+  const path = storePath();
+  if (loadedFrom === path) return;
+  loadedFrom = path;
+  if (!existsSync(path)) return;
+  try {
+    const data: Stored = JSON.parse(readFileSync(path, "utf-8"));
+    const cutoff = Date.now() - TERMINAL_RETENTION_MS;
+    for (const c of data.credentials || []) credentials.set(c.id, c);
+    for (const gr of data.grants || []) {
+      if (gr.status !== "active" && new Date(gr.createdAt).getTime() < cutoff) continue;
+      grants.set(gr.id, gr);
+    }
+    for (const a of data.asks || []) {
+      if (a.status !== "pending" && new Date(a.createdAt).getTime() < cutoff) continue;
+      keychainAsks.set(a.id, a);
+    }
+  } catch (e) {
+    console.error("[keychain] failed to load store:", e);
+  }
+}
+
+function meta(c: KeychainCredential): KeychainCredentialMeta {
+  const { secret: _secret, ...rest } = c;
+  return rest;
+}
+
+/** Lazy expiry — checked on every read/use, no sweeper to keep alive. */
+function settleExpiry(gr: KeychainGrant): KeychainGrant {
+  if (gr.status === "active" && Date.now() > new Date(gr.expiresAt).getTime()) {
+    gr.status = "expired";
+    grants.set(gr.id, gr);
+    persist();
+    audit({ kind: "keychain_grant_expired", grant_id: gr.id, credential_id: gr.credentialId });
+  }
+  return gr;
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+/** The roster first name for an identity, or the trimmed input as-is. */
+function ownerName(user: string): string {
+  return resolveTeammate(user)?.name || user.trim();
+}
+
+function sameOwner(a: string, b: string): boolean {
+  return norm(ownerName(a)) === norm(ownerName(b));
+}
+
+// ── Credentials ──────────────────────────────────────────────────────────────
+
+export interface AddCredentialInput {
+  owner: string;
+  service: string;
+  host: string;
+  secret: string;
+  description?: string;
+  injection?: { header?: string; scheme?: string };
+  allowedMethods?: string[];
+  allowedPathPrefixes?: string[];
+}
+
+export function addCredential(input: AddCredentialInput): KeychainCredentialMeta {
+  load();
+  const service = norm(input.service);
+  const host = input.host
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/[/?#].*$/, "");
+  if (!service || !/^[a-z0-9][a-z0-9._-]*$/.test(service)) {
+    throw new Error("service must be a short lowercase slug (letters, digits, . _ -)");
+  }
+  if (!host || !/^[a-z0-9][a-z0-9.-]*$/.test(host) || host.includes(":")) {
+    throw new Error("host must be a bare host name (no scheme, port, or path)");
+  }
+  if (!input.secret.trim()) throw new Error("secret is empty");
+  if ([...credentials.values()].some((c) => c.service === service)) {
+    throw new Error(`a credential for service "${service}" already exists`);
+  }
+  const methods = (input.allowedMethods || []).map((m) => m.trim().toUpperCase()).filter(Boolean);
+  const prefixes = (input.allowedPathPrefixes || []).map((p) => p.trim()).filter(Boolean);
+  for (const p of prefixes) {
+    if (!p.startsWith("/")) throw new Error(`path prefix must start with /: ${p}`);
+  }
+  const now = new Date().toISOString();
+  const cred: KeychainCredential = {
+    id: `kc-${crypto.randomUUID()}`,
+    owner: ownerName(input.owner),
+    service,
+    host,
+    secret: input.secret.trim(),
+    ...(input.description ? { description: input.description } : {}),
+    ...(input.injection ? { injection: input.injection } : {}),
+    ...(methods.length ? { allowedMethods: methods } : {}),
+    ...(prefixes.length ? { allowedPathPrefixes: prefixes } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+  credentials.set(cred.id, cred);
+  persist();
+  audit({
+    kind: "keychain_credential_added",
+    credential_id: cred.id,
+    owner: cred.owner,
+    service: cred.service,
+    host: cred.host,
+  });
+  return meta(cred);
+}
+
+export function deleteCredential(id: string, by: string): boolean {
+  load();
+  const cred = credentials.get(id);
+  if (!cred) return false;
+  if (!sameOwner(cred.owner, by)) throw new Error("only the credential's owner can delete it");
+  credentials.delete(id);
+  // A deleted credential takes its live grants with it — the broker would
+  // otherwise 404 on the credential with an "active" grant lying around.
+  for (const gr of grants.values()) {
+    if (gr.credentialId === id && gr.status === "active") {
+      gr.status = "revoked";
+      gr.revokedAt = new Date().toISOString();
+      grants.set(gr.id, gr);
+    }
+  }
+  persist();
+  audit({ kind: "keychain_credential_deleted", credential_id: id, by });
+  return true;
+}
+
+export function listCredentials(): KeychainCredentialMeta[] {
+  load();
+  return [...credentials.values()].map(meta);
+}
+
+export function findCredential(ref: string): KeychainCredentialMeta | undefined {
+  load();
+  const key = norm(ref);
+  const cred =
+    credentials.get(ref) || [...credentials.values()].find((c) => c.service === key);
+  return cred ? meta(cred) : undefined;
+}
+
+// ── Grants ───────────────────────────────────────────────────────────────────
+
+export function listGrants(opts?: { sessionId?: string; owner?: string }): KeychainGrant[] {
+  load();
+  return [...grants.values()]
+    .map(settleExpiry)
+    .filter(
+      (gr) =>
+        (!opts?.sessionId || gr.sessionId === opts.sessionId) &&
+        (!opts?.owner || sameOwner(gr.owner, opts.owner))
+    )
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function revokeGrant(id: string, by: string): { ok: true } | { error: string } {
+  load();
+  const gr = grants.get(id);
+  if (!gr) return { error: "no such grant" };
+  settleExpiry(gr);
+  if (gr.status !== "active") return { error: `grant is already ${gr.status}` };
+  // The owner lent it, the requester borrowed it — either may end it.
+  if (!sameOwner(gr.owner, by) && norm(gr.requestedBy) !== norm(by)) {
+    return { error: "only the grant's owner or requester can revoke it" };
+  }
+  gr.status = "revoked";
+  gr.revokedAt = new Date().toISOString();
+  grants.set(gr.id, gr);
+  persist();
+  audit({ kind: "keychain_grant_revoked", grant_id: id, credential_id: gr.credentialId, by });
+  return { ok: true };
+}
+
+function mintGrant(ask: KeychainAskRecord, mode: GrantMode): KeychainGrant {
+  const now = Date.now();
+  const gr: KeychainGrant = {
+    id: `kg-${crypto.randomUUID()}`,
+    credentialId: ask.credentialId,
+    owner: ask.owner,
+    sessionId: ask.sessionId,
+    requestedBy: ask.requestedBy,
+    purpose: ask.purpose,
+    mode,
+    status: "active",
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(
+      now + (mode === "once" ? ONCE_GRANT_TTL_MS : STANDING_GRANT_TTL_MS)
+    ).toISOString(),
+    askId: ask.id,
+  };
+  grants.set(gr.id, gr);
+  persist();
+  audit({
+    kind: "keychain_grant_minted",
+    grant_id: gr.id,
+    credential_id: gr.credentialId,
+    session_id: gr.sessionId,
+    mode,
+    owner: gr.owner,
+  });
+  return gr;
+}
+
+/**
+ * Test seam: mint a grant without the human-asks transport, so the lifecycle
+ * that carries the security properties (once-consumption, expiry, revocation,
+ * method/path enforcement) is testable without sending a real Slack DM.
+ * Never call outside tests — a grant minted here had no owner approval.
+ */
+export function __mintGrantForTest(input: {
+  credentialId: string;
+  sessionId: string;
+  requestedBy: string;
+  mode: GrantMode;
+  expiresAt?: string;
+}): KeychainGrant {
+  load();
+  const gr = mintGrant(
+    {
+      id: `ka-test-${crypto.randomUUID()}`,
+      credentialId: input.credentialId,
+      owner: credentials.get(input.credentialId)?.owner || "test",
+      sessionId: input.sessionId,
+      requestedBy: input.requestedBy,
+      purpose: "test",
+      requestedMode: input.mode,
+      status: "approved",
+      createdAt: new Date().toISOString(),
+    },
+    input.mode
+  );
+  if (input.expiresAt) {
+    gr.expiresAt = input.expiresAt;
+    grants.set(gr.id, gr);
+    persist();
+  }
+  return gr;
+}
+
+// ── The broker's server side ────────────────────────────────────────────────
+
+export interface BrokerUse {
+  credential: KeychainCredential;
+  grant: KeychainGrant;
+}
+
+/**
+ * Validate a broker call and — for a once grant — consume it. Returns an
+ * error string (safe to show the caller) or the credential+grant to use.
+ * Consuming BEFORE the upstream call is deliberate: a once grant whose
+ * upstream fetch fails is spent, not retryable — err on the side of the
+ * owner's intent.
+ */
+export function consumeGrantForBroker(
+  grantId: string,
+  method: string,
+  path: string
+): BrokerUse | { error: string; status: number } {
+  load();
+  const gr = grants.get(grantId);
+  if (!gr) return { error: "unknown grant", status: 404 };
+  settleExpiry(gr);
+  if (gr.status !== "active") return { error: `grant is ${gr.status}`, status: 403 };
+  const cred = credentials.get(gr.credentialId);
+  if (!cred) return { error: "credential no longer exists", status: 404 };
+  const m = method.toUpperCase();
+  if (cred.allowedMethods?.length && !cred.allowedMethods.includes(m)) {
+    return {
+      error: `method ${m} is not allowed for this credential (allowed: ${cred.allowedMethods.join(", ")})`,
+      status: 403,
+    };
+  }
+  if (
+    cred.allowedPathPrefixes?.length &&
+    !cred.allowedPathPrefixes.some((p) => path.startsWith(p))
+  ) {
+    return {
+      error: `path is outside this credential's allowed prefixes (${cred.allowedPathPrefixes.join(", ")})`,
+      status: 403,
+    };
+  }
+  if (gr.mode === "once") {
+    gr.status = "used";
+    gr.usedAt = new Date().toISOString();
+    grants.set(gr.id, gr);
+    persist();
+  }
+  return { credential: cred, grant: gr };
+}
+
+export function brokerHeaders(cred: KeychainCredential): Record<string, string> {
+  const header = cred.injection?.header || "Authorization";
+  const scheme = cred.injection?.scheme ?? (header === "Authorization" ? "Bearer" : "");
+  return { [header]: scheme ? `${scheme} ${cred.secret}` : cred.secret };
+}
+
+/** Scrub the secret from a text body the remote echoed back. */
+export function scrubSecret(body: string, secret: string): string {
+  return secret && body.includes(secret) ? body.split(secret).join("[redacted]") : body;
+}
+
+// ── Asks (through the human-asks transport) ─────────────────────────────────
+
+const APPROVE_ONCE = "Approve once";
+const APPROVE_STANDING = "Approve standing";
+const DECLINE = "Decline";
+
+export const KEYCHAIN_ASK_DOMAIN = "keychain-ask";
+
+function brokerBaseUrl(): string {
+  const port = parseInt(process.env.PORT || "3850");
+  return `http://127.0.0.1:${port}/backstage/api/keychain/broker`;
+}
+
+/** The steer/tool text a session gets when its ask is approved. This is the
+ *  agent's entire manual for the grant, so it names every constraint. */
+export function grantInstructions(gr: KeychainGrant, credMeta: KeychainCredentialMeta): string {
+  const limits = [
+    credMeta.allowedMethods?.length ? `methods: ${credMeta.allowedMethods.join(", ")}` : null,
+    credMeta.allowedPathPrefixes?.length
+      ? `paths: ${credMeta.allowedPathPrefixes.join(", ")}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join("; ");
+  return (
+    `${gr.owner} approved your keychain ask for **${credMeta.service}** ` +
+    `(${gr.mode === "once" ? "one single call" : `standing until ${gr.expiresAt}`}).\n` +
+    `Call the service through the broker — the secret itself is never exposed to you:\n\n` +
+    "```\n" +
+    `curl -sS -X GET '${brokerBaseUrl()}/${gr.id}/<path-on-${credMeta.host}>'\n` +
+    "```\n" +
+    `The broker injects the credential server-side and proxies to https://${credMeta.host}. ` +
+    (limits ? `Limits: ${limits}. ` : "") +
+    (gr.mode === "once"
+      ? "The grant is SINGLE-USE — the first call consumes it, so make it the right one. "
+      : "") +
+    `Stay within the approved purpose ("${gr.purpose}"); every call is audited.`
+  );
+}
+
+export interface RequestCredentialInput {
+  /** Credential id or service slug. */
+  credential: string;
+  sessionId: string;
+  requestedBy: string;
+  purpose: string;
+  mode?: GrantMode;
+}
+
+export function requestCredential(
+  input: RequestCredentialInput
+): { ask: KeychainAskRecord; transport: HumanAsk } | { error: string } {
+  load();
+  const credMeta = findCredential(input.credential);
+  if (!credMeta) {
+    const known = listCredentials()
+      .map((c) => c.service)
+      .join(", ");
+    return { error: `no credential matches "${input.credential}"${known ? ` (known: ${known})` : ""}` };
+  }
+  const purpose = input.purpose.trim();
+  if (!purpose) return { error: "a purpose is required — the owner approves that, not the tool" };
+  const owner = resolveTeammate(credMeta.owner);
+  if (!owner) return { error: `credential owner "${credMeta.owner}" is not in the identity roster` };
+
+  const pending = [...keychainAsks.values()].find(
+    (a) =>
+      a.status === "pending" &&
+      a.credentialId === credMeta.id &&
+      a.sessionId === input.sessionId
+  );
+  if (pending) return { error: `an ask for this credential is already pending (${pending.id})` };
+
+  const record: KeychainAskRecord = {
+    id: `ka-${crypto.randomUUID()}`,
+    credentialId: credMeta.id,
+    owner: credMeta.owner,
+    sessionId: input.sessionId,
+    requestedBy: input.requestedBy,
+    purpose,
+    requestedMode: input.mode || "once",
+    status: "pending",
+    createdAt: new Date().toISOString(),
+  };
+
+  const transport = registerAsk({
+    sessionId: input.sessionId,
+    createdBy: input.requestedBy,
+    person: { slackId: owner.slackId, name: owner.name },
+    question:
+      `May this session borrow your **${credMeta.service}** credential ` +
+      `(${credMeta.host})?\nPurpose: ${purpose}\nRequested: ${record.requestedMode} ` +
+      `(once = a single API call through the broker; standing = 7 days, revocable).`,
+    context:
+      "_The secret is never shown to the session — approved calls go through the " +
+      "keychain broker with method/path limits, and every call is audited._",
+    options: [APPROVE_ONCE, APPROVE_STANDING, DECLINE],
+    mode: "block",
+    deliver: "now",
+    domain: { kind: KEYCHAIN_ASK_DOMAIN, ref: record.id },
+  });
+
+  record.humanAskId = transport.id;
+  keychainAsks.set(record.id, record);
+  persist();
+  audit({
+    kind: "keychain_ask_created",
+    ask_id: record.id,
+    credential_id: credMeta.id,
+    session_id: input.sessionId,
+    requested_by: input.requestedBy,
+    mode: record.requestedMode,
+    owner: credMeta.owner,
+  });
+  return { ask: record, transport };
+}
+
+export function listKeychainAsks(opts?: { sessionId?: string }): KeychainAskRecord[] {
+  load();
+  return [...keychainAsks.values()]
+    .filter((a) => !opts?.sessionId || a.sessionId === opts.sessionId)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** Parse the owner's answer (button label or free text). Fail closed: only an
+ *  explicit approval approves; anything unrecognized declines with the text
+ *  kept as the owner's note. */
+export function parseOwnerAnswer(
+  answer: string,
+  requestedMode: GrantMode
+): { approve: true; mode: GrantMode } | { approve: false; note?: string } {
+  const t = answer.trim().toLowerCase();
+  if (t === APPROVE_ONCE.toLowerCase()) return { approve: true, mode: "once" };
+  if (t === APPROVE_STANDING.toLowerCase()) return { approve: true, mode: "standing" };
+  if (/^(approve|yes|ok|sure|go ahead)\b/.test(t)) {
+    return { approve: true, mode: /standing/.test(t) ? "standing" : requestedMode };
+  }
+  if (t === DECLINE.toLowerCase() || /^(no|deny|decline|reject)\b/.test(t)) {
+    return { approve: false };
+  }
+  return { approve: false, note: answer.trim() };
+}
+
+/**
+ * The human-asks domain handler: runs inside resolveAsk when the owner
+ * answers, whatever channel the answer came from (Slack button, free-text
+ * DM reply, UI card). Mints or declines, and returns the steer text the
+ * requesting session receives in place of the generic "X answered" line.
+ */
+export function resolveKeychainAsk(ask: HumanAsk, answer: string): string | null {
+  load();
+  const ref = ask.domain?.ref;
+  const record = ref ? keychainAsks.get(ref) : undefined;
+  if (!record || record.status !== "pending") return null;
+
+  const verdict = parseOwnerAnswer(answer, record.requestedMode);
+  record.resolvedAt = new Date().toISOString();
+
+  if (!verdict.approve) {
+    record.status = "declined";
+    if (verdict.note) record.note = verdict.note;
+    keychainAsks.set(record.id, record);
+    persist();
+    audit({
+      kind: "keychain_ask_declined",
+      ask_id: record.id,
+      credential_id: record.credentialId,
+      ...(record.note ? { note_len: record.note.length } : {}),
+    });
+    return (
+      `${record.owner} declined the keychain ask for this credential` +
+      (verdict.note ? ` — "${verdict.note}"` : "") +
+      ". Don't retry the same ask; either work without it, or tell the user why you need it " +
+      "and let them take it up with the owner."
+    );
+  }
+
+  record.status = "approved";
+  const grant = mintGrant(record, verdict.mode);
+  record.grantId = grant.id;
+  keychainAsks.set(record.id, record);
+  persist();
+  audit({ kind: "keychain_ask_approved", ask_id: record.id, grant_id: grant.id, mode: verdict.mode });
+  const credMeta = findCredential(record.credentialId);
+  return credMeta ? grantInstructions(grant, credMeta) : null;
+}
+
+/** Module-load side effect (re-runs on hot reload, overwriting the handler —
+ *  that's the point: the newest code answers). Registered here, next to the
+ *  handler, so importing the keychain anywhere wires the resolution path. */
+registerAskDomainHandler(KEYCHAIN_ASK_DOMAIN, resolveKeychainAsk);

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -514,6 +514,7 @@ export const SHARED_INPROCESS_SERVERS = [
   "opensession-admin",
   "opensession-goals",
   "opensession-humans",
+  "opensession-keychain",
   "opensession-repos",
   "opensession-memory",
   "opensession-preview",

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -29,6 +29,7 @@ import { handleWorkspaceRoutes } from "./workspace";
 import { handleLocalReposRoutes } from "./local-repos";
 import { handleAutomationsRoutes } from "./automations";
 import { handleHumanAsksRoutes } from "./human-asks";
+import { handleKeychainRoutes } from "./keychain";
 import { handleChatRoutes } from "./chat";
 import { handlePeopleRoutes } from "./people";
 import { handlePrefsRoutes } from "./prefs";
@@ -82,6 +83,7 @@ export const routeHandlers: RouteHandler[] = [
 	handleWorkspaceRoutes,
 	handleAutomationsRoutes,
 	handleHumanAsksRoutes,
+	handleKeychainRoutes,
 	handleChatRoutes,
 	handlePeopleRoutes,
 	handlePrefsRoutes,

--- a/src/server/routes/keychain.ts
+++ b/src/server/routes/keychain.ts
@@ -1,0 +1,198 @@
+/**
+ * Keychain routes: credential registration/inspection for humans (Settings →
+ * Keychain), and the credential broker the agent calls with a grant token.
+ *
+ * The management endpoints are ordinary API routes behind the web-auth gate.
+ * The broker is the interesting one:
+ *
+ *   ANY /api/keychain/broker/:grantId/*  →  https://<credential host>/*
+ *
+ * It validates the grant (active, not expired, method+path within the
+ * credential's limits), consumes it if it is a once grant, injects the
+ * credential's header server-side and proxies. The agent supplies only the
+ * grant id, so the secret never enters a model's context, a transcript, or a
+ * sandbox env.
+ *
+ * The broker is exempt from the sign-in gate: its caller is an agent
+ * subprocess on loopback with no browser session, and the grant id IS the
+ * credential — unguessable, single-session-scoped, expiring and revocable.
+ * That is the same reasoning the node register/heartbeat routes use.
+ */
+
+import type { RouteContext } from "./context";
+import { requestUser } from "./context";
+import {
+  addCredential,
+  brokerHeaders,
+  consumeGrantForBroker,
+  deleteCredential,
+  listCredentials,
+  listGrants,
+  listKeychainAsks,
+  revokeGrant,
+  scrubSecret,
+} from "../keychain";
+import { audit } from "../audit";
+
+/** Hop-by-hop and identity headers we never forward upstream. */
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "host",
+  "connection",
+  "authorization",
+  "cookie",
+  "content-length",
+  "accept-encoding",
+]);
+
+const BROKER_TIMEOUT_MS = 30_000;
+/** Bound what we buffer to scrub. Larger bodies stream through unscrubbed —
+ *  a credential echoed past 2MB of JSON is not a realistic shape. */
+const MAX_SCRUB_BYTES = 2 * 1024 * 1024;
+
+export async function handleKeychainRoutes(
+  ctx: RouteContext
+): Promise<Response | undefined> {
+  const { req, url, path } = ctx;
+
+  // ── Broker ────────────────────────────────────────────────────────────────
+  if (path.startsWith("/backstage/api/keychain/broker/")) {
+    const rest = path.slice("/backstage/api/keychain/broker/".length);
+    const slash = rest.indexOf("/");
+    const grantId = slash === -1 ? rest : rest.slice(0, slash);
+    const upstreamPath = slash === -1 ? "/" : rest.slice(slash);
+    if (!grantId) return Response.json({ error: "missing grant id" }, { status: 400 });
+
+    const use = consumeGrantForBroker(grantId, req.method, upstreamPath);
+    if ("error" in use) {
+      audit({
+        kind: "keychain_broker_denied",
+        grant_id: grantId,
+        method: req.method,
+        path: upstreamPath,
+        reason: use.error,
+      });
+      return Response.json({ error: use.error }, { status: use.status });
+    }
+
+    const target = new URL(`https://${use.credential.host}${upstreamPath}${url.search}`);
+    const headers = new Headers();
+    req.headers.forEach((value, key) => {
+      if (!STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) headers.set(key, value);
+    });
+    for (const [k, v] of Object.entries(brokerHeaders(use.credential))) headers.set(k, v);
+
+    audit({
+      kind: "keychain_broker_call",
+      grant_id: use.grant.id,
+      credential_id: use.credential.id,
+      session_id: use.grant.sessionId,
+      owner: use.grant.owner,
+      service: use.credential.service,
+      method: req.method,
+      host: use.credential.host,
+      path: upstreamPath,
+      mode: use.grant.mode,
+    });
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(target, {
+        method: req.method,
+        headers,
+        body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.arrayBuffer(),
+        signal: AbortSignal.timeout(BROKER_TIMEOUT_MS),
+        // A redirect's Location can point at any host; following it would send
+        // the credential somewhere the owner never approved. Surface the 3xx
+        // to the caller instead.
+        redirect: "manual",
+      });
+    } catch (e: any) {
+      return Response.json(
+        { error: `broker request to ${use.credential.host} failed: ${e?.message || String(e)}` },
+        { status: 502 }
+      );
+    }
+
+    const outHeaders = new Headers(upstream.headers);
+    outHeaders.delete("content-encoding");
+    outHeaders.delete("content-length");
+    const contentType = upstream.headers.get("content-type") || "";
+    const scrubbable =
+      /text\/|json|xml|x-www-form-urlencoded/i.test(contentType) &&
+      Number(upstream.headers.get("content-length") || 0) <= MAX_SCRUB_BYTES;
+    if (!scrubbable) {
+      return new Response(upstream.body, { status: upstream.status, headers: outHeaders });
+    }
+    const body = await upstream.text();
+    return new Response(scrubSecret(body, use.credential.secret), {
+      status: upstream.status,
+      headers: outHeaders,
+    });
+  }
+
+  // ── Management ────────────────────────────────────────────────────────────
+  if (path === "/backstage/api/keychain" && req.method === "GET") {
+    return Response.json({
+      credentials: listCredentials(),
+      grants: listGrants(),
+      asks: listKeychainAsks(),
+    });
+  }
+
+  if (path === "/backstage/api/keychain/credentials" && req.method === "POST") {
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body.service !== "string" || typeof body.secret !== "string") {
+      return Response.json(
+        { error: "expected { service, host, secret, ... }" },
+        { status: 400 }
+      );
+    }
+    const owner = requestUser(ctx, body.owner);
+    if (!owner) {
+      return Response.json(
+        { error: "no signed-in identity — a credential must have an owner who can approve asks" },
+        { status: 400 }
+      );
+    }
+    try {
+      return Response.json({
+        credential: addCredential({
+          owner,
+          service: body.service,
+          host: String(body.host || ""),
+          secret: body.secret,
+          description: typeof body.description === "string" ? body.description : undefined,
+          injection: body.injection,
+          allowedMethods: Array.isArray(body.allowedMethods) ? body.allowedMethods : undefined,
+          allowedPathPrefixes: Array.isArray(body.allowedPathPrefixes)
+            ? body.allowedPathPrefixes
+            : undefined,
+        }),
+      });
+    } catch (e: any) {
+      return Response.json({ error: e?.message || String(e) }, { status: 400 });
+    }
+  }
+
+  const credMatch = path.match(/^\/backstage\/api\/keychain\/credentials\/([^/]+)$/);
+  if (credMatch && req.method === "DELETE") {
+    try {
+      const ok = deleteCredential(decodeURIComponent(credMatch[1]!), requestUser(ctx));
+      return ok
+        ? Response.json({ ok: true })
+        : Response.json({ error: "no such credential" }, { status: 404 });
+    } catch (e: any) {
+      return Response.json({ error: e?.message || String(e) }, { status: 403 });
+    }
+  }
+
+  const grantMatch = path.match(/^\/backstage\/api\/keychain\/grants\/([^/]+)$/);
+  if (grantMatch && req.method === "DELETE") {
+    const result = revokeGrant(decodeURIComponent(grantMatch[1]!), requestUser(ctx));
+    return "error" in result
+      ? Response.json(result, { status: 403 })
+      : Response.json({ ok: true });
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Item 4 from the qm analysis — the biggest architectural gap it surfaced. Independent of #85.

## The problem

A credential today is instance-wide (`~/.opensession.env`, `mcp-config.json` `env`) or absent. There's no way for a session to say *"I need Michiel's Vercel token for this one task"* and for Michiel to answer *"fine, once."* The alternatives are both bad: widen an instance credential for everyone forever, or paste a token into a prompt (where it lives in the transcript).

## The model (ported from qm, MIT)

| | |
|---|---|
| **credential** | owned by a *person*. Registered over HTTP (Settings → Keychain). Deliberately **not** a tool — a secret pasted into a prompt is a secret in the transcript. |
| **ask** | a session's request to borrow it: purpose + once/standing. Delivered through our existing human-asks transport — Slack DM with **Approve once / Approve standing / Decline**, UI card first when the owner is driving a session. Blocks the asking tool call. |
| **grant** | scoped to the requesting session. `once` = one broker call, 1h. `standing` = 7d. Revocable by owner *or* requester. Audited per use. |

**Delivery is broker-only.** The agent receives a grant id, never a secret, and calls `/api/keychain/broker/<grantId>/<path>`. The broker injects the credential server-side and proxies to the credential's host — bounded by the credential's `allowedMethods`/`allowedPathPrefixes`, `redirect: "manual"` (a `Location` could point off-host and take the credential with it), and the secret scrubbed from any text response echoing it back.

The asymmetry is the point: a leaked grant is one credential, one session's approved purpose, method/path-limited, short-lived, revocable, fully audited. A leaked secret is forever.

## `human-asks` grows a `domain` hook

Small, general addition: an ask can carry `{ kind, ref }`, and the owning module's registered handler runs inside `resolveAsk`. So the grant is minted **exactly once** whichever channel answered (Slack button, free-text DM reply, UI card), and the session receives broker instructions in place of the raw button label. Handler failures fall back to delivering the raw answer rather than eating it.

## Trust boundaries

- `opensession-keychain` is **interactive-only** — same bar as `opensession-humans`. An ask is a DM carrying a model-authored "purpose" string; letting untrusted ticket text compose one would turn Michael into a social-engineering proxy against our own team.
- The broker route is exempt from the sign-in gate for the same reason the node register/heartbeat routes are: the caller is an agent subprocess on loopback with no browser session, and the grant id *is* its credential.
- Owner-only delete; deleting a credential revokes its live grants.

## Documented limitations (in the module, not just here)

1. Broker is loopback-only — works for worktrees and the shared checkout, not remote sandboxes (would need the dial-back channel).
2. The grant id lands in the requesting session's transcript, and transcripts are searchable across sessions. So session scoping is **intent + audit, not cryptographic isolation** — another session that went looking could replay a grant inside its TTL. What bounds it: the credential's method/path ceiling, once-grants dying on first use, short TTLs, revocation, and a per-call audit line naming the session the grant was issued to.

## Notes

- 23 keychain tests covering the security-critical lifecycle (once-consumption, expiry, revocation, method/path enforcement, credential deletion cascading, cross-session listing). `bun test src/` green (1246), `tsc --noEmit` clean, frontend builds.
- **Bug caught by the full-suite run and fixed:** the store path was captured at module load, and this module is imported transitively (`interactive-mcp` → `keychain-tools` → here), so the test override could be defeated by import order — one run wrote its fixture into the real `~/.opensession-keychain.json`. Path now resolves per call; the leaked file held only the fake `sk-live-secret` and was removed.
- Runner + route + auth-gate changes ⇒ needs a real `systemctl restart opensession` after merge.

Started by Michiel in this Michael session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
