### PR TITLE
Durable publish: agent-built internal apps that outlive their session

### DIFF
--- a/opensession.ts
+++ b/opensession.ts
@@ -345,7 +345,13 @@ const server: import("bun").Server<WSClientData> = hotServe({
 					!openKeychainBroker &&
 					((path.startsWith("/backstage/api/") &&
 						!path.startsWith("/backstage/api/auth/")) ||
-						path === "/backstage/ws")
+						path === "/backstage/ws" ||
+						// Agent-published apps (src/server/deploys.ts). Explicitly
+						// listed because /d/ is a page-ish path, and page loads are
+						// otherwise left open so the sign-in screen can render — a
+						// published app must get OpenSession's audience, not a
+						// wider one.
+						/^\/(?:backstage\/)?d\//.test(path))
 				) {
 					return Response.json({ error: "Sign in required" }, { status: 401 });
 				}
@@ -513,6 +519,16 @@ if (!g.__backstageBooted) {
 		} catch (e) {
 			console.error("[seeds] Failed to seed instance actions/automations:", e);
 		}
+	}
+
+	// Published internal apps (src/server/deploys.ts) are supervised child
+	// processes, so a restart of this server takes them with it — bring back
+	// everything that wasn't deliberately stopped.
+	try {
+		const { relaunchDeploys } = await import("./src/server/deploys");
+		relaunchDeploys();
+	} catch (e) {
+		console.error("[deploys] relaunch on boot failed:", e);
 	}
 
 	// Cron-scheduled automations + internal event bus (agents → automations)

--- a/src/agents/slack/publish-tools.ts
+++ b/src/agents/slack/publish-tools.ts
@@ -1,0 +1,160 @@
+/**
+ * opensession-publish — turn a directory in this session's worktree into a
+ * durable internal web app (src/server/deploys.ts).
+ *
+ * Interactive runs only. A deploy is arbitrary agent-authored code that keeps
+ * running after the session ends; automation runs process untrusted text and
+ * must never be able to leave a persistent process behind.
+ */
+
+import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
+import { z } from "zod";
+import { isAbsolute, resolve } from "node:path";
+import {
+  deployUrl,
+  getDeploy,
+  listDeploys,
+  publishDeploy,
+  rollbackDeploy,
+  stopDeploy,
+} from "../../server/deploys";
+
+export interface PublishToolContext {
+  sessionId: string;
+  user: string;
+  /** The session's worktree — publishable paths must resolve inside it. */
+  worktreeDir: () => string | undefined;
+}
+
+function text(s: string) {
+  return { content: [{ type: "text" as const, text: s }] };
+}
+
+export function createPublishMcpServer(ctx: PublishToolContext) {
+  const tools = [
+    tool(
+      "publish_app",
+      "Publish a directory from this session's worktree as a durable internal web app: it keeps running after this session ends and gets a stable link at /d/<name>/. The app MUST listen on the port in the PORT env var. Every publish creates a new immutable version; pass `name` again to update an existing app in place. IMPORTANT — durability: only $DATA_DIR survives a restart or redeploy; the rest of the app's disk is reset from the published snapshot every time it relaunches. Keep any state the app writes (a SQLite file, uploads, caches you care about) under $DATA_DIR. The app runs with a minimal environment — no OpenSession tokens — so pass anything it needs via `env`, and remember node_modules/.git/dist are NOT copied: vendor what you need or keep the app dependency-free. Everyone who can reach OpenSession can reach the app; don't publish anything that needs per-person privacy.",
+      {
+        dir: z
+          .string()
+          .describe(
+            "Directory to publish, absolute or relative to the session's worktree. Its contents become the app root."
+          ),
+        entrypoint: z
+          .string()
+          .describe(
+            'Shell command that starts the server, run from the app root, e.g. "bun server.ts" or "node index.js". It must bind $PORT.'
+          ),
+        name: z
+          .string()
+          .describe(
+            "Stable handle → the link becomes /d/<name>/. Lowercase letters, digits and hyphens. Reuse the same name to ship a new version of an existing app."
+          ),
+        description: z
+          .string()
+          .optional()
+          .describe("One line on what the app is, shown in the Deploys list."),
+        env: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe("Environment variables baked into this version. Never put a real secret here."),
+        renameFrom: z
+          .string()
+          .optional()
+          .describe("Rename the app currently called this to `name` instead of creating a new one."),
+      },
+      async (args: {
+        dir: string;
+        entrypoint: string;
+        name: string;
+        description?: string;
+        env?: Record<string, string>;
+        renameFrom?: string;
+      }) => {
+        const worktree = ctx.worktreeDir();
+        const dir = isAbsolute(args.dir)
+          ? resolve(args.dir)
+          : resolve(worktree || process.cwd(), args.dir);
+        // A session may only publish out of its own checkout — otherwise
+        // "publish /home/ubuntu" is a one-call exfiltration of the whole box
+        // onto a team-visible URL.
+        if (worktree && !dir.startsWith(resolve(worktree))) {
+          return text(
+            `Refused: ${dir} is outside this session's worktree (${worktree}). Publish a directory you built inside the session.`
+          );
+        }
+        try {
+          const r = publishDeploy({
+            dir,
+            entrypoint: args.entrypoint,
+            name: args.name,
+            owner: ctx.user,
+            sessionId: ctx.sessionId,
+            ...(args.description ? { description: args.description } : {}),
+            ...(args.env ? { env: args.env } : {}),
+            ...(args.renameFrom ? { renameFrom: args.renameFrom } : {}),
+          });
+          return text(
+            `Published **${r.deploy.name}** v${r.version} → ${r.url}\n` +
+              `State: ${r.deploy.state}. Durable data path: $DATA_DIR (everything else resets on relaunch).\n` +
+              `Check it responds before telling anyone it's ready — if the app fails to bind $PORT it will crash-loop and the link will 503.`
+          );
+        } catch (e: any) {
+          return text(`Publish failed: ${e?.message || String(e)}`);
+        }
+      }
+    ),
+    tool(
+      "list_apps",
+      "List the published internal apps — name, link, running state, current version and owner. Use it before publishing to see whether the app you're about to create already exists (reuse its name to ship a new version rather than making a near-duplicate).",
+      {},
+      async () => {
+        const all = listDeploys();
+        if (!all.length) return text("No apps are published yet.");
+        return text(
+          all
+            .map(
+              (d) =>
+                `- **${d.name}** (v${d.currentVersion}, ${d.state}) — ${deployUrl(d.name)}` +
+                (d.description ? ` — ${d.description}` : "") +
+                ` — owner ${d.owner}` +
+                (d.lastError ? `\n  last error: ${d.lastError}` : "")
+            )
+            .join("\n")
+        );
+      }
+    ),
+    tool(
+      "rollback_app",
+      "Flip a published app back to an earlier version, e.g. when the version you just shipped is broken. list_apps shows the current version; the last 10 versions are retained.",
+      {
+        name: z.string().describe("The app's handle."),
+        version: z.number().int().describe("Version number to make live again."),
+      },
+      async (args: { name: string; version: number }) => {
+        try {
+          const d = rollbackDeploy(args.name, args.version);
+          return text(`Rolled ${d.name} back to v${d.currentVersion} (${d.state}).`);
+        } catch (e: any) {
+          return text(`Rollback failed: ${e?.message || String(e)}`);
+        }
+      }
+    ),
+    tool(
+      "stop_app",
+      "Stop a published app. It stays registered with its versions intact and can be started again from Settings → Deploys, but its link returns 503 until then. Use it when an app is superseded or misbehaving — don't leave broken apps crash-looping.",
+      {
+        name: z.string().describe("The app's handle."),
+      },
+      async (args: { name: string }) => {
+        const d = getDeploy(args.name);
+        if (!d) return text(`No app named "${args.name}".`);
+        await stopDeploy(d.id);
+        return text(`Stopped ${d.name}. Its link now returns 503 until someone starts it again.`);
+      }
+    ),
+  ];
+
+  return createSdkMcpServer({ name: "opensession-publish", tools });
+}

--- a/src/frontend/components/Settings.tsx
+++ b/src/frontend/components/Settings.tsx
@@ -81,6 +81,10 @@ import {
 	deleteMemoryEntryApi,
 	fetchPapercuts,
 	setPapercutsRepoEnabled,
+	fetchDeploys,
+	setDeployRunning,
+	rollbackDeployTo,
+	deleteDeployApp,
 	fetchKeychain,
 	addKeychainCredential,
 	deleteKeychainCredential,
@@ -96,6 +100,7 @@ import {
 	type MemoryEntryDto,
 	type PapercutDto,
 	type PapercutsRepoConfig,
+	type DeployDto,
 	type KeychainCredentialDto,
 	type KeychainGrantDto,
 	type KeychainAskDto,
@@ -189,6 +194,7 @@ export type SettingsSectionKey =
 	| "previewPool"
 	| "papercuts"
 	| "keychain"
+	| "deploys"
 	| "audit"
 	| ToolSectionKey;
 
@@ -522,6 +528,25 @@ const SECTIONS: {
 		),
 	},
 	{
+		key: "deploys",
+		label: "Deploys",
+		group: "Workspace",
+		icon: (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.4"
+			>
+				<rect x="2" y="2.4" width="12" height="4" rx="1" />
+				<rect x="2" y="9.6" width="12" height="4" rx="1" />
+				<path d="M4.6 4.4h.01M4.6 11.6h.01" strokeLinecap="round" />
+			</svg>
+		),
+	},
+	{
 		key: "keychain",
 		label: "Keychain",
 		group: "Workspace",
@@ -612,6 +637,7 @@ function SectionPanel({
 			{section === "previewPool" && <PreviewPoolPanel />}
 			{section === "papercuts" && <PapercutsPanel />}
 			{section === "keychain" && <KeychainPanel />}
+			{section === "deploys" && <DeploysPanel />}
 		</>
 	);
 }
@@ -2079,6 +2105,116 @@ function KeychainPanel() {
 					))}
 				</SettingCard>
 			)}
+		</SettingsPanel>
+	);
+}
+
+// ── Deploys: internal web apps agents published with opensession-publish.
+// They outlive the session that made them, so this is where a human sees what
+// is running and turns it off. ──
+function DeploysPanel() {
+	const [deploys, setDeploys] = useState<DeployDto[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const reload = useCallback(() => {
+		fetchDeploys()
+			.then((r) => setDeploys(r.deploys))
+			.catch((e) => setError(e.message));
+	}, []);
+	useEffect(reload, [reload]);
+
+	const act = (p: Promise<unknown>) =>
+		p.then(reload).catch((e) => setError(e.message));
+
+	const header = (
+		<SettingsHeader
+			title="Deploys"
+			description="Internal web apps published from sessions with the publish_app tool. Each keeps running after its session ends, is served at /d/<name>/ behind the same sign-in as OpenSession, and is supervised — restarted on crash and after a server restart. Only $DATA_DIR survives a redeploy; everything else is reset from the published snapshot."
+		/>
+	);
+
+	if (!deploys)
+		return (
+			<SettingsPanel>
+				{header}
+				{error ? <InlineAlert>{error}</InlineAlert> : <LoadingState>Loading deploys…</LoadingState>}
+			</SettingsPanel>
+		);
+
+	return (
+		<SettingsPanel>
+			{header}
+			{error && <InlineAlert onDismiss={() => setError(null)}>{error}</InlineAlert>}
+
+			{deploys.length === 0 ? (
+				<EmptyState placement="card">
+					Nothing published yet. Ask a session to build a small internal tool and publish it.
+				</EmptyState>
+			) : (
+				<SettingCard>
+					{deploys.map((d) => (
+						<SettingRow
+							key={d.id}
+							title={`${d.name} — v${d.currentVersion} · ${d.state}`}
+							desc={
+								<>
+									{d.description ? `${d.description} · ` : ""}
+									owner {d.owner} · port {d.port}
+									{d.lastError ? ` · last error: ${d.lastError}` : ""}
+									<br />
+									<a
+										className="underline"
+										href={`/d/${d.name}/`}
+										target="_blank"
+										rel="noreferrer"
+									>
+										/d/{d.name}/
+									</a>
+									{d.sessionId ? (
+										<>
+											{" · "}
+											<a className="underline" href={`/session/${d.sessionId}`}>
+												published from this session
+											</a>
+										</>
+									) : null}
+								</>
+							}
+							control={
+								<div className="flex items-center gap-1">
+									{d.currentVersion > 1 && (
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() => act(rollbackDeployTo(d.name, d.currentVersion - 1))}
+										>
+											Roll back
+										</Button>
+									)}
+									<Button
+										size="sm"
+										variant="ghost"
+										onClick={() => act(setDeployRunning(d.name, d.state !== "running"))}
+									>
+										{d.state === "running" ? "Stop" : "Start"}
+									</Button>
+									<Button
+										size="sm"
+										variant="ghost"
+										onClick={() => act(deleteDeployApp(d.name))}
+									>
+										Delete
+									</Button>
+								</div>
+							}
+						/>
+					))}
+				</SettingCard>
+			)}
+			<SettingsHint>
+				A deploy is agent-authored code running unsandboxed on this box for as long as it is
+				started. Delete anything you don't recognise.
+			</SettingsHint>
 		</SettingsPanel>
 	);
 }

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -2079,6 +2079,58 @@ export async function revokeKeychainGrant(id: string): Promise<{ ok: true }> {
 	});
 }
 
+// ── Deploys (Settings → Deploys: agent-published internal apps) ──
+
+export interface DeployVersionDto {
+	version: number;
+	createdAt: string;
+	createdBy: string;
+	sessionId?: string;
+	entrypoint: string;
+}
+
+export interface DeployDto {
+	id: string;
+	name: string;
+	owner: string;
+	sessionId?: string;
+	description?: string;
+	port: number;
+	currentVersion: number;
+	versions: DeployVersionDto[];
+	state: "running" | "stopped" | "crashed";
+	lastError?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export async function fetchDeploys(): Promise<{ deploys: DeployDto[] }> {
+	return request("/deploys", { label: "Failed to fetch deploys" });
+}
+
+export async function setDeployRunning(
+	name: string,
+	running: boolean,
+): Promise<{ deploy: DeployDto }> {
+	return request(`/deploys/${encodeURIComponent(name)}/${running ? "start" : "stop"}`, {
+		method: "POST",
+	});
+}
+
+export async function rollbackDeployTo(
+	name: string,
+	version: number,
+): Promise<{ deploy: DeployDto }> {
+	return request(`/deploys/${encodeURIComponent(name)}/rollback`, {
+		method: "POST",
+		body: { version },
+	});
+}
+
+export async function deleteDeployApp(name: string): Promise<{ ok: true }> {
+	return request(`/deploys/${encodeURIComponent(name)}`, { method: "DELETE" });
+}
+
 // ── Personal system prompt (Settings → Personal prompt) ──
 
 export async function fetchPersonalPrompt(

--- a/src/server/deploys.test.ts
+++ b/src/server/deploys.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Point the registry and version store at a throwaway tree BEFORE importing —
+// the real ~/.opensession-deploys holds published apps.
+const ROOT = mkdtempSync(join(tmpdir(), "deploys-test-"));
+process.env.OPENSESSION_DEPLOYS_DIR = ROOT;
+process.env.OPENSESSION_DEPLOYS_REGISTRY = join(ROOT, "registry.json");
+
+let dp: typeof import("./deploys");
+let src: string;
+
+beforeEach(async () => {
+  process.env.OPENSESSION_DEPLOYS_DIR = ROOT;
+  process.env.OPENSESSION_DEPLOYS_REGISTRY = join(ROOT, "registry.json");
+  dp = await import("./deploys");
+  dp.__resetDeploysForTest();
+  if (existsSync(join(ROOT, "registry.json"))) rmSync(join(ROOT, "registry.json"));
+  src = mkdtempSync(join(tmpdir(), "deploys-src-"));
+  writeFileSync(join(src, "server.ts"), "// app\n");
+});
+
+afterEach(() => {
+  rmSync(src, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  // Nothing in this suite launches a process (publish is exercised through
+  // publishDeploy's bookkeeping only when the entrypoint is a no-op `true`),
+  // but make sure nothing is left registered.
+  dp.__resetDeploysForTest();
+});
+
+describe("names", () => {
+  test("accepts handles that make sane URL segments", () => {
+    for (const ok of ["a", "counter", "my-tool-2", "x9"]) {
+      expect(dp.isValidDeployName(ok)).toBe(true);
+    }
+  });
+
+  test("rejects anything that would break /d/<name>/ or read as a path", () => {
+    for (const bad of ["", "-lead", "trail-", "Upper", "has space", "a/b", "a".repeat(41), "a_b"]) {
+      expect(dp.isValidDeployName(bad), bad).toBe(false);
+    }
+  });
+});
+
+describe("entrypoint validation", () => {
+  test("single commands are accepted", () => {
+    for (const ok of ["bun server.ts", "node index.js", "python3 -u app.py", "sh start.sh"]) {
+      expect(dp.compoundEntrypointError(ok), ok).toBeNull();
+    }
+  });
+
+  test("compound commands are rejected with a fix, since exec cannot supervise them", () => {
+    for (const bad of [
+      "cd app && node index.js",
+      "node a.js; node b.js",
+      "cat x | node -",
+      "node a.js || node b.js",
+    ]) {
+      const err = dp.compoundEntrypointError(bad);
+      expect(err, bad).toBeTruthy();
+      expect(err).toContain("start script");
+    }
+  });
+
+  test("redirections are not compound", () => {
+    expect(dp.compoundEntrypointError("node index.js 2>&1")).toBeNull();
+    expect(dp.compoundEntrypointError("node index.js >log.txt")).toBeNull();
+  });
+});
+
+describe("snapshot filter", () => {
+  test("skips build detritus and git, keeps everything else", () => {
+    expect(dp.snapshotFilter("/x/app/node_modules")).toBe(false);
+    expect(dp.snapshotFilter("/x/app/.git")).toBe(false);
+    expect(dp.snapshotFilter("/x/app/dist")).toBe(false);
+    expect(dp.snapshotFilter("/x/app/server.ts")).toBe(true);
+    expect(dp.snapshotFilter("/x/app/public")).toBe(true);
+  });
+});
+
+describe("publish bookkeeping", () => {
+  const publish = (over: Partial<Parameters<typeof dp.publishDeploy>[0]> = {}) =>
+    dp.publishDeploy({
+      dir: src,
+      // `true` exits 0 immediately: enough to exercise versioning and the
+      // registry without leaving a server bound to a port in CI.
+      entrypoint: "true",
+      name: "tool",
+      owner: "Michiel",
+      ...over,
+    });
+
+  test("first publish creates v1, a snapshot, and a port in the deploy range", () => {
+    const r = publish();
+    expect(r.version).toBe(1);
+    expect(r.deploy.port).toBeGreaterThanOrEqual(7100);
+    expect(r.deploy.port).toBeLessThanOrEqual(7899);
+    expect(existsSync(join(dp.versionDir(r.deploy.id, 1), "server.ts"))).toBe(true);
+    expect(dp.listDeploys()).toHaveLength(1);
+  });
+
+  test("republishing the same name adds a version instead of a second app", () => {
+    publish();
+    const r2 = publish();
+    expect(r2.version).toBe(2);
+    expect(r2.deploy.currentVersion).toBe(2);
+    expect(dp.listDeploys()).toHaveLength(1);
+    expect(existsSync(dp.versionDir(r2.deploy.id, 1))).toBe(true);
+  });
+
+  test("each app gets its own port", () => {
+    const a = publish({ name: "one" });
+    const b = publish({ name: "two" });
+    expect(a.deploy.port).not.toBe(b.deploy.port);
+  });
+
+  test("rollback moves the live version and refuses versions that aren't retained", () => {
+    const r = publish();
+    publish();
+    const rolled = dp.rollbackDeploy("tool", 1);
+    expect(rolled.currentVersion).toBe(1);
+    expect(() => dp.rollbackDeploy("tool", 99)).toThrow(/isn't retained/);
+    expect(r.deploy.id).toBe(rolled.id);
+  });
+
+  test("renameFrom moves an existing app rather than creating one", () => {
+    publish({ name: "old-name" });
+    const r = publish({ name: "new-name", renameFrom: "old-name" });
+    expect(dp.listDeploys()).toHaveLength(1);
+    expect(r.deploy.name).toBe("new-name");
+    expect(r.version).toBe(2);
+    expect(dp.getDeploy("old-name")).toBeUndefined();
+    expect(dp.getDeploy("new-name")).toBeDefined();
+  });
+
+  test("renaming onto a name another app already holds is refused", () => {
+    publish({ name: "one" });
+    publish({ name: "two" });
+    expect(() => publish({ name: "one", renameFrom: "two" })).toThrow(/already taken/);
+  });
+
+  test("bad input is rejected before anything is written", () => {
+    expect(() => publish({ name: "Bad Name" })).toThrow(/name must be/);
+    expect(() => publish({ entrypoint: "  " })).toThrow(/entrypoint is required/);
+    expect(() => publish({ entrypoint: "cd x && node y" })).toThrow(/single command/);
+    expect(() => publish({ dir: join(ROOT, "does-not-exist") })).toThrow(/does not exist/);
+    expect(dp.listDeploys()).toHaveLength(0);
+  });
+
+  test("lookup works by name and by id, and is case-insensitive on the name", () => {
+    const r = publish();
+    expect(dp.getDeploy("tool")?.id).toBe(r.deploy.id);
+    expect(dp.getDeploy("TOOL")?.id).toBe(r.deploy.id);
+    expect(dp.getDeploy(r.deploy.id)?.name).toBe("tool");
+    expect(dp.getDeploy("nope")).toBeUndefined();
+  });
+
+  test("only the last 10 versions are retained", () => {
+    let last: ReturnType<typeof publish> | undefined;
+    for (let i = 0; i < 12; i++) last = publish();
+    expect(last!.version).toBe(12);
+    const d = dp.getDeploy("tool")!;
+    expect(d.versions).toHaveLength(10);
+    expect(d.versions[0]!.version).toBe(3);
+    expect(existsSync(dp.versionDir(d.id, 1))).toBe(false);
+    expect(existsSync(dp.versionDir(d.id, 12))).toBe(true);
+  });
+
+  test("data dir is separate from every version snapshot", () => {
+    const r = publish();
+    mkdirSync(dp.dataDir(r.deploy.id), { recursive: true });
+    writeFileSync(join(dp.dataDir(r.deploy.id), "app.db"), "state");
+    publish();
+    // The redeploy created a new snapshot; durable data is untouched by it.
+    expect(existsSync(join(dp.dataDir(r.deploy.id), "app.db"))).toBe(true);
+    expect(dp.dataDir(r.deploy.id)).not.toContain("/versions/");
+  });
+});

--- a/src/server/deploys.ts
+++ b/src/server/deploys.ts
@@ -1,0 +1,519 @@
+/**
+ * Deploys — durable, agent-published internal web apps, modelled on qm's
+ * `publish` tool (MIT).
+ *
+ * A session's preview (src/server/preview.ts) is a dev server tied to a
+ * worktree: it dies with the session and points at a checkout that will be
+ * deleted. That makes "the agent built us a small internal tool" a demo rather
+ * than something the team uses on Monday. A deploy is the durable half:
+ *
+ *   - the published directory is COPIED into an immutable version snapshot
+ *     (~/.opensession-deploys/<id>/versions/<n>/), so it survives the worktree
+ *   - it gets a stable link at /d/<name>/ on the main server, behind the same
+ *     tailnet + sign-in gate as everything else
+ *   - it is supervised: relaunched on crash (with backoff) and on boot
+ *   - $DATA_DIR (~/.opensession-deploys/<id>/data) is the ONE durable path;
+ *     everything else is reset from the snapshot on every relaunch, so state
+ *     that isn't in $DATA_DIR is state you will lose
+ *   - rollbackTo flips the live version back to an earlier snapshot
+ *
+ * Deliberately NOT ported from qm: per-scope share grants. Reaching a deploy
+ * requires reaching OpenSession, which is already tailnet- and team-gated —
+ * an ACL lattice on top would be the scope machinery the qm analysis
+ * explicitly recommended against at our size. Deploys are visible to the team;
+ * that is stated in the tool description so nobody publishes secrets expecting
+ * per-person privacy.
+ *
+ * Security posture, stated plainly: a deploy is arbitrary agent-authored code
+ * running unsandboxed and persistently as the OpenSession user. Sessions
+ * already run arbitrary code — what is new is that it outlives the session. So
+ * publishing is interactive-only (never automations, whose input is untrusted
+ * text), every publish/relaunch/stop is audited, and the Deploys UI lists what
+ * is running so nothing accumulates unseen.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, cpSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { Subprocess } from "bun";
+import { writeJsonAtomic } from "./shared/atomic-write";
+import { audit } from "./audit";
+import { stateDir } from "./rename-compat";
+
+export const DEPLOYS_DIR = stateDir("deploys");
+const REGISTRY = join(DEPLOYS_DIR, "registry.json");
+
+/** Host ports for deploys. Kept clear of the webapp dev range (3100-3999) and
+ *  its +6000 preview mirror (9100-9999). */
+const PORT_MIN = 7100;
+const PORT_MAX = 7899;
+
+const MAX_VERSIONS = 10;
+/** A deploy that dies this fast, this often, is broken — stop restarting it. */
+const CRASH_WINDOW_MS = 60_000;
+const MAX_CRASHES_IN_WINDOW = 5;
+const RESTART_DELAY_MS = 1_000;
+
+export interface DeployVersion {
+  version: number;
+  createdAt: string;
+  createdBy: string;
+  sessionId?: string;
+  entrypoint: string;
+  env?: Record<string, string>;
+}
+
+export interface Deploy {
+  id: string;
+  /** URL handle: /d/<name>/. Globally unique, lowercase. */
+  name: string;
+  owner: string;
+  /** The session that last published it — the UI links back to its history. */
+  sessionId?: string;
+  description?: string;
+  port: number;
+  currentVersion: number;
+  versions: DeployVersion[];
+  state: "running" | "stopped" | "crashed";
+  lastError?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Stored {
+  deploys: Deploy[];
+}
+
+const g = globalThis as any;
+const deploys: Map<string, Deploy> = (g.__deploys ??= new Map());
+/** Live child processes, by deploy id. Never persisted. */
+const procs: Map<string, Subprocess> = (g.__deployProcs ??= new Map());
+/** Crash timestamps per deploy, for the restart circuit-breaker. */
+const crashes: Map<string, number[]> = (g.__deployCrashes ??= new Map());
+/**
+ * Processes we are killing on purpose. Without this, a redeploy's own teardown
+ * looks like a crash to onExit, which schedules a restart of the OLD version a
+ * second later; that restart races the new version for the port, kills it,
+ * which looks like another crash… a cascade that trips the breaker while the
+ * original process is somehow still serving.
+ *
+ * Keyed on the PROCESS, not the deploy id, and deliberately so: onExit fires
+ * independently of the `exited` promise, so a deploy-id flag cleared when
+ * `exited` resolves can still be gone by the time onExit runs. The process
+ * object is the one thing both closures agree on.
+ */
+const intentionalKills = new WeakSet<Subprocess>();
+let loaded = false;
+
+function registryPath(): string {
+  return process.env.OPENSESSION_DEPLOYS_REGISTRY || REGISTRY;
+}
+
+function rootDir(): string {
+  return process.env.OPENSESSION_DEPLOYS_DIR || DEPLOYS_DIR;
+}
+
+export function deployDir(id: string): string {
+  return join(rootDir(), id);
+}
+export function versionDir(id: string, version: number): string {
+  return join(deployDir(id), "versions", String(version));
+}
+export function dataDir(id: string): string {
+  return join(deployDir(id), "data");
+}
+
+function persist(): void {
+  mkdirSync(rootDir(), { recursive: true });
+  writeJsonAtomic(registryPath(), { deploys: [...deploys.values()] } satisfies Stored);
+}
+
+function load(): void {
+  if (loaded) return;
+  loaded = true;
+  if (!existsSync(registryPath())) return;
+  try {
+    const data: Stored = JSON.parse(readFileSync(registryPath(), "utf-8"));
+    for (const d of data.deploys || []) deploys.set(d.id, d);
+  } catch (e) {
+    console.error("[deploys] failed to read registry:", e);
+  }
+}
+
+export function listDeploys(): Deploy[] {
+  load();
+  return [...deploys.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function getDeploy(ref: string): Deploy | undefined {
+  load();
+  return deploys.get(ref) || [...deploys.values()].find((d) => d.name === ref.toLowerCase());
+}
+
+export function isValidDeployName(name: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/.test(name);
+}
+
+function allocatePort(): number {
+  load();
+  const taken = new Set([...deploys.values()].map((d) => d.port));
+  for (let p = PORT_MIN; p <= PORT_MAX; p++) if (!taken.has(p)) return p;
+  throw new Error("no free deploy port — stop an unused deploy first");
+}
+
+// ── Supervision ─────────────────────────────────────────────────────────────
+
+function crashLooping(id: string): boolean {
+  const now = Date.now();
+  const recent = (crashes.get(id) || []).filter((t) => now - t < CRASH_WINDOW_MS);
+  crashes.set(id, recent);
+  return recent.length >= MAX_CRASHES_IN_WINDOW;
+}
+
+function noteCrash(id: string): void {
+  const recent = crashes.get(id) || [];
+  recent.push(Date.now());
+  crashes.set(id, recent);
+}
+
+/**
+ * Stop a deploy's process and WAIT for the port to actually be released.
+ *
+ * Both halves matter. The wait is why a redeploy works at all: spawning the
+ * new version while the old one still holds the port makes the new process die
+ * on EADDRINUSE, five times in a row, into the crash-loop breaker — leaving
+ * the OLD version serving while the registry claims the new one is live. And
+ * SIGKILL after a grace period is what makes "stopped" mean stopped for an app
+ * that ignores SIGTERM.
+ */
+async function killProcess(id: string, graceMs = 3_000): Promise<void> {
+  const proc = procs.get(id);
+  if (!proc) return;
+  procs.delete(id);
+  intentionalKills.add(proc);
+  try {
+    proc.kill();
+  } catch {
+    return; // already gone
+  }
+  const exited = await Promise.race([
+    proc.exited.then(() => true),
+    new Promise<false>((r) => setTimeout(() => r(false), graceMs).unref?.()),
+  ]);
+  if (exited) return;
+  try {
+    proc.kill("SIGKILL");
+    await proc.exited;
+  } catch {
+    // nothing left to signal
+  }
+}
+
+/**
+ * Launch (or relaunch) a deploy's current version. Idempotent: a live process
+ * is left alone unless `force` is set, which is what a publish/rollback wants.
+ */
+export async function launchDeploy(
+  id: string,
+  opts?: { force?: boolean }
+): Promise<Deploy | undefined> {
+  load();
+  const d = deploys.get(id);
+  if (!d) return undefined;
+  const existing = procs.get(id);
+  if (existing && !existing.killed && !opts?.force) return d;
+  await killProcess(id);
+
+  const version = d.versions.find((v) => v.version === d.currentVersion);
+  if (!version) {
+    d.state = "crashed";
+    d.lastError = `version ${d.currentVersion} is missing from disk`;
+    persist();
+    return d;
+  }
+  const cwd = versionDir(id, d.currentVersion);
+  if (!existsSync(cwd)) {
+    d.state = "crashed";
+    d.lastError = `snapshot for version ${d.currentVersion} is missing`;
+    persist();
+    return d;
+  }
+  mkdirSync(dataDir(id), { recursive: true });
+
+  let proc: Subprocess;
+  try {
+    // `exec` so the pid we hold IS the app, not a shell wrapping it — killing
+    // the wrapper leaves the real server running and holding the port, which
+    // is exactly how "stopped" apps stayed up. publishDeploy rejects compound
+    // entrypoints so exec always applies.
+    proc = Bun.spawn(["/bin/sh", "-c", `exec ${version.entrypoint}`], {
+      cwd,
+      env: {
+        // A deliberately minimal environment, like agent subprocesses get:
+        // a published app must never inherit the server's tokens.
+        PATH: process.env.PATH || "/usr/bin:/bin",
+        HOME: process.env.HOME || "/home/ubuntu",
+        LANG: process.env.LANG || "C.UTF-8",
+        PORT: String(d.port),
+        DATA_DIR: dataDir(id),
+        NODE_ENV: "production",
+        ...(version.env || {}),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      onExit(_proc, exitCode, signalCode) {
+        if (procs.get(id) === proc) procs.delete(id);
+        const current = deploys.get(id);
+        // A deliberate teardown (redeploy, rollback, stop) is not a crash and
+        // must not schedule a restart — the caller is already launching the
+        // replacement, and a second launcher would fight it for the port.
+        if (!current || current.state === "stopped" || intentionalKills.has(proc)) return;
+        noteCrash(id);
+        current.lastError = `exited (code ${exitCode ?? "null"}${signalCode ? `, signal ${signalCode}` : ""})`;
+        if (crashLooping(id)) {
+          current.state = "crashed";
+          persist();
+          audit({ kind: "deploy_crash_looping", deploy: current.name, error: current.lastError });
+          console.error(`[deploys] ${current.name} is crash-looping — not restarting`);
+          return;
+        }
+        persist();
+        setTimeout(() => {
+          if (deploys.get(id)?.state !== "stopped") void launchDeploy(id, { force: true });
+        }, RESTART_DELAY_MS).unref?.();
+      },
+    });
+  } catch (e: any) {
+    d.state = "crashed";
+    d.lastError = `spawn failed: ${e?.message || String(e)}`;
+    persist();
+    return d;
+  }
+
+  procs.set(id, proc);
+  d.state = "running";
+  delete d.lastError;
+  d.updatedAt = new Date().toISOString();
+  persist();
+  audit({ kind: "deploy_launched", deploy: d.name, version: d.currentVersion, port: d.port });
+  return d;
+}
+
+export async function stopDeploy(id: string): Promise<Deploy | undefined> {
+  load();
+  const d = deploys.get(id);
+  if (!d) return undefined;
+  // Set the state BEFORE killing: the onExit handler reads it to decide
+  // whether an exit is a crash worth restarting or a deliberate stop.
+  d.state = "stopped";
+  d.updatedAt = new Date().toISOString();
+  await killProcess(id);
+  crashes.delete(id);
+  persist();
+  audit({ kind: "deploy_stopped", deploy: d.name });
+  return d;
+}
+
+export async function deleteDeploy(id: string): Promise<boolean> {
+  load();
+  const d = deploys.get(id);
+  if (!d) return false;
+  await stopDeploy(id);
+  deploys.delete(id);
+  persist();
+  try {
+    rmSync(deployDir(id), { recursive: true, force: true });
+  } catch (e) {
+    console.error(`[deploys] failed to remove ${d.name}'s files:`, e);
+  }
+  audit({ kind: "deploy_deleted", deploy: d.name });
+  return true;
+}
+
+export function deployPort(name: string): number | undefined {
+  const d = getDeploy(name);
+  return d && d.state === "running" ? d.port : undefined;
+}
+
+/** Relaunch everything that should be running. Called once at boot. */
+export async function relaunchDeploys(): Promise<void> {
+  load();
+  for (const d of deploys.values()) {
+    if (d.state === "stopped") continue;
+    await launchDeploy(d.id, { force: true });
+  }
+}
+
+// ── Publishing ──────────────────────────────────────────────────────────────
+
+export interface PublishInput {
+  /** Absolute directory to snapshot. */
+  dir: string;
+  entrypoint: string;
+  name: string;
+  owner: string;
+  sessionId?: string;
+  description?: string;
+  env?: Record<string, string>;
+  /** Rename the deploy currently called this to `name`. */
+  renameFrom?: string;
+}
+
+export interface PublishResult {
+  deploy: Deploy;
+  version: number;
+  url: string;
+}
+
+/** Files a snapshot never carries: build detritus and anything git. */
+const SNAPSHOT_SKIP = new Set([".git", "node_modules", ".next", "dist", ".turbo", ".cache"]);
+
+export function snapshotFilter(src: string): boolean {
+  const base = src.split("/").pop() || "";
+  return !SNAPSHOT_SKIP.has(base);
+}
+
+/**
+ * The entrypoint is run as `sh -c "exec <entrypoint>"` so the supervised pid
+ * is the app itself (see launchDeploy). `exec` only takes effect on a single
+ * command, so a compound one would silently reintroduce the shell wrapper that
+ * made "stop" fail to stop anything. Reject it with a fix rather than accept a
+ * deploy we cannot reliably kill.
+ */
+export function compoundEntrypointError(entrypoint: string): string | null {
+  if (!/(^|[^&|>])(&&|\|\||[;|])/.test(entrypoint)) return null;
+  return (
+    "entrypoint must be a single command so it can be supervised directly " +
+    `(got "${entrypoint}"). Put the sequence in a start script in the published ` +
+    'directory and use that, e.g. entrypoint "sh start.sh".'
+  );
+}
+
+export function publishDeploy(input: PublishInput): PublishResult {
+  load();
+  const name = input.name.trim().toLowerCase();
+  if (!isValidDeployName(name)) {
+    throw new Error(
+      "name must be 1-40 lowercase letters, digits or hyphens, starting and ending alphanumeric"
+    );
+  }
+  if (!input.entrypoint.trim()) throw new Error("entrypoint is required");
+  const compound = compoundEntrypointError(input.entrypoint.trim());
+  if (compound) throw new Error(compound);
+  if (!existsSync(input.dir)) throw new Error(`directory does not exist: ${input.dir}`);
+
+  let d = input.renameFrom ? getDeploy(input.renameFrom) : getDeploy(name);
+  if (input.renameFrom && !d) throw new Error(`no deploy named "${input.renameFrom}" to rename`);
+  const clash = getDeploy(name);
+  if (clash && d && clash.id !== d.id) throw new Error(`the name "${name}" is already taken`);
+
+  const now = new Date().toISOString();
+  if (!d) {
+    d = {
+      id: `dep-${crypto.randomUUID()}`,
+      name,
+      owner: input.owner,
+      port: allocatePort(),
+      currentVersion: 0,
+      versions: [],
+      state: "stopped",
+      createdAt: now,
+      updatedAt: now,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.description ? { description: input.description } : {}),
+    };
+    deploys.set(d.id, d);
+  } else {
+    d.name = name;
+    if (input.sessionId) d.sessionId = input.sessionId;
+    if (input.description) d.description = input.description;
+  }
+
+  const version = d.currentVersion + 1;
+  const dest = versionDir(d.id, version);
+  mkdirSync(dest, { recursive: true });
+  cpSync(input.dir, dest, { recursive: true, dereference: true, filter: snapshotFilter });
+
+  d.versions.push({
+    version,
+    createdAt: now,
+    createdBy: input.owner,
+    entrypoint: input.entrypoint.trim(),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.env ? { env: input.env } : {}),
+  });
+  d.currentVersion = version;
+  d.updatedAt = now;
+
+  // Prune old snapshots, keeping the tail rollbackTo can reach.
+  const prunable = d.versions.slice(0, Math.max(0, d.versions.length - MAX_VERSIONS));
+  for (const v of prunable) {
+    try {
+      rmSync(versionDir(d.id, v.version), { recursive: true, force: true });
+    } catch {
+      // a snapshot we can't remove is disk we leak, not a failed publish
+    }
+  }
+  d.versions = d.versions.slice(-MAX_VERSIONS);
+
+  persist();
+  audit({
+    kind: "deploy_published",
+    deploy: d.name,
+    version,
+    by: input.owner,
+    session_id: input.sessionId,
+  });
+  crashes.delete(d.id);
+  void launchDeploy(d.id, { force: true });
+  return { deploy: deploys.get(d.id)!, version, url: deployUrl(d.name) };
+}
+
+export function rollbackDeploy(ref: string, toVersion: number): Deploy {
+  load();
+  const d = getDeploy(ref);
+  if (!d) throw new Error(`no deploy named "${ref}"`);
+  if (!d.versions.some((v) => v.version === toVersion)) {
+    throw new Error(
+      `version ${toVersion} isn't retained — available: ${d.versions.map((v) => v.version).join(", ")}`
+    );
+  }
+  d.currentVersion = toVersion;
+  d.updatedAt = new Date().toISOString();
+  persist();
+  audit({ kind: "deploy_rolled_back", deploy: d.name, version: toVersion });
+  crashes.delete(d.id);
+  void launchDeploy(d.id, { force: true });
+  return deploys.get(d.id)!;
+}
+
+export function deployUrl(name: string): string {
+  const base = (process.env.OPENSESSION_PUBLIC_BASE_URL || "").replace(/\/+$/, "");
+  return `${base}/d/${name}/`;
+}
+
+/** Recent stdout/stderr for the UI — a crashed app's reason to live. */
+export async function deployLogs(id: string, limit = 4000): Promise<string> {
+  const proc = procs.get(id);
+  if (!proc) return "";
+  const chunks: string[] = [];
+  for (const stream of [proc.stdout, proc.stderr]) {
+    if (!stream || typeof stream === "number") continue;
+    try {
+      const reader = (stream as ReadableStream<Uint8Array>).getReader();
+      const { value } = await reader.read();
+      reader.releaseLock();
+      if (value) chunks.push(new TextDecoder().decode(value));
+    } catch {
+      // a stream we can't drain just contributes nothing
+    }
+  }
+  return chunks.join("\n").slice(-limit);
+}
+
+/** Test seam — drops in-memory state so a suite starts clean. */
+export function __resetDeploysForTest(): void {
+  deploys.clear();
+  procs.clear();
+  crashes.clear();
+  loaded = false;
+}

--- a/src/server/interactive-mcp.ts
+++ b/src/server/interactive-mcp.ts
@@ -18,6 +18,7 @@ import { createNodesMcpServer } from "../agents/slack/nodes-tools";
 import { createAdminMcpServer } from "../agents/slack/admin-tools";
 import { createHumansMcpServer } from "../agents/slack/humans-tools";
 import { createKeychainMcpServer } from "../agents/slack/keychain-tools";
+import { createPublishMcpServer } from "../agents/slack/publish-tools";
 import { createAskUserMcpServer } from "../agents/slack/ask-tools";
 import { createReposMcpServer } from "../agents/slack/repos-tools";
 import { createPreviewMcpServer } from "../agents/slack/preview-tools";
@@ -124,6 +125,15 @@ export function interactiveMcpServers(
 					"opensession-keychain": createKeychainMcpServer({
 						sessionId,
 						user: createdBy,
+					}),
+					// Publish a directory as a durable internal web app that
+					// outlives this session (src/server/deploys.ts). Interactive
+					// only: a deploy is arbitrary code that keeps running, so
+					// untrusted automation text must never reach it.
+					"opensession-publish": createPublishMcpServer({
+						sessionId,
+						user: createdBy,
+						worktreeDir: () => findSession(sessionId)?.worktreeDir || undefined,
 					}),
 					// Cross-repo: attach secondary repos as isolated worktrees.
 					"opensession-repos": createReposMcpServer({

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -517,6 +517,7 @@ export const SHARED_INPROCESS_SERVERS = [
   "opensession-goals",
   "opensession-humans",
   "opensession-keychain",
+  "opensession-publish",
   "opensession-repos",
   "opensession-memory",
   "opensession-preview",

--- a/src/server/routes/deploys.ts
+++ b/src/server/routes/deploys.ts
@@ -1,0 +1,131 @@
+/**
+ * Deploy routes: the public-ish surface for agent-published apps
+ * (src/server/deploys.ts) and the management API behind Settings → Deploys.
+ *
+ *   /d/<name>/<path>   →  reverse proxy to 127.0.0.1:<the deploy's port>
+ *   /api/deploys       →  list / stop / relaunch / rollback / delete
+ *
+ * The proxy sits INSIDE the sign-in gate on purpose: a published app is
+ * whatever an agent wrote, so it gets exactly the audience OpenSession itself
+ * has (tailnet + team), never a wider one. `/d/` is a page-ish path rather than
+ * `/api/`, so the gate's own carve-out for page loads does not apply to it —
+ * see the explicit check in opensession.ts.
+ */
+
+import type { RouteContext } from "./context";
+import { requestUser } from "./context";
+import {
+  deleteDeploy,
+  deployLogs,
+  getDeploy,
+  launchDeploy,
+  listDeploys,
+  rollbackDeploy,
+  stopDeploy,
+} from "../deploys";
+
+const PROXY_TIMEOUT_MS = 30_000;
+
+/** Hop-by-hop headers a proxy must not forward verbatim. */
+const STRIPPED = new Set(["host", "connection", "content-length", "accept-encoding"]);
+
+export async function handleDeployRoutes(
+  ctx: RouteContext
+): Promise<Response | undefined> {
+  const { req, url, path } = ctx;
+
+  // ── /d/<name>/… reverse proxy ────────────────────────────────────────────
+  const proxied = path.match(/^\/(?:backstage\/)?d\/([a-z0-9-]+)(\/.*)?$/);
+  if (proxied) {
+    const name = proxied[1]!;
+    const rest = proxied[2] ?? "";
+    const deploy = getDeploy(name);
+    if (!deploy) return new Response(`No deploy named "${name}"`, { status: 404 });
+    if (deploy.state !== "running") {
+      return new Response(
+        `"${name}" is ${deploy.state}${deploy.lastError ? `: ${deploy.lastError}` : ""}`,
+        { status: 503 }
+      );
+    }
+    // A bare /d/<name> must become /d/<name>/ before the app sees it, or its
+    // relative asset links resolve one level too high.
+    if (!rest) {
+      return Response.redirect(`${url.origin}${path}/${url.search}`, 308);
+    }
+
+    const headers = new Headers();
+    req.headers.forEach((value, key) => {
+      if (!STRIPPED.has(key.toLowerCase())) headers.set(key, value);
+    });
+    // Apps that build absolute links need to know where they really live.
+    headers.set("X-Forwarded-Prefix", `/d/${name}`);
+    headers.set("X-Forwarded-Host", url.host);
+    headers.set("X-Forwarded-Proto", url.protocol.replace(":", ""));
+
+    try {
+      const upstream = await fetch(
+        `http://127.0.0.1:${deploy.port}${rest}${url.search}`,
+        {
+          method: req.method,
+          headers,
+          body:
+            req.method === "GET" || req.method === "HEAD"
+              ? undefined
+              : await req.arrayBuffer(),
+          redirect: "manual",
+          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+        }
+      );
+      const out = new Headers(upstream.headers);
+      out.delete("content-encoding");
+      out.delete("content-length");
+      return new Response(upstream.body, { status: upstream.status, headers: out });
+    } catch (e: any) {
+      return new Response(
+        `"${name}" did not respond (${e?.message || String(e)}). It may still be starting.`,
+        { status: 502 }
+      );
+    }
+  }
+
+  // ── Management ───────────────────────────────────────────────────────────
+  if (path === "/backstage/api/deploys" && req.method === "GET") {
+    return Response.json({ deploys: listDeploys() });
+  }
+
+  const m = path.match(/^\/backstage\/api\/deploys\/([^/]+)(?:\/(logs|stop|start|rollback))?$/);
+  if (!m) return undefined;
+  const ref = decodeURIComponent(m[1]!);
+  const action = m[2];
+  const deploy = getDeploy(ref);
+  if (!deploy) return Response.json({ error: "no such deploy" }, { status: 404 });
+
+  if (action === "logs" && req.method === "GET") {
+    return Response.json({ logs: await deployLogs(deploy.id) });
+  }
+  if (action === "stop" && req.method === "POST") {
+    return Response.json({ deploy: await stopDeploy(deploy.id) });
+  }
+  if (action === "start" && req.method === "POST") {
+    return Response.json({ deploy: await launchDeploy(deploy.id, { force: true }) });
+  }
+  if (action === "rollback" && req.method === "POST") {
+    const body = await req.json().catch(() => null);
+    const version = Number(body?.version);
+    if (!Number.isInteger(version)) {
+      return Response.json({ error: "expected { version: number }" }, { status: 400 });
+    }
+    try {
+      return Response.json({ deploy: rollbackDeploy(deploy.id, version) });
+    } catch (e: any) {
+      return Response.json({ error: e?.message || String(e) }, { status: 400 });
+    }
+  }
+  if (!action && req.method === "DELETE") {
+    const by = requestUser(ctx);
+    await deleteDeploy(deploy.id);
+    return Response.json({ ok: true, by });
+  }
+
+  return undefined;
+}

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -30,6 +30,7 @@ import { handleLocalReposRoutes } from "./local-repos";
 import { handleAutomationsRoutes } from "./automations";
 import { handleHumanAsksRoutes } from "./human-asks";
 import { handleKeychainRoutes } from "./keychain";
+import { handleDeployRoutes } from "./deploys";
 import { handleChatRoutes } from "./chat";
 import { handlePeopleRoutes } from "./people";
 import { handlePrefsRoutes } from "./prefs";
@@ -84,6 +85,7 @@ export const routeHandlers: RouteHandler[] = [
 	handleAutomationsRoutes,
 	handleHumanAsksRoutes,
 	handleKeychainRoutes,
+	handleDeployRoutes,
 	handleChatRoutes,
 	handlePeopleRoutes,
 	handlePrefsRoutes,


### PR DESCRIPTION
Item 5 from the qm analysis. Independent of #85 and #86.

## Why

`preview.ts` gives a session a dev server tied to its worktree — it dies with the session and points at a checkout that gets deleted. So "the agent built us a small internal tool" is a demo, not something the team opens on Monday. This is the durable half.

## What

`publish_app` (new `opensession-publish` MCP) snapshots a directory into an **immutable version**, serves it at **`/d/<name>/`** behind OpenSession's own sign-in gate, and supervises it:

- restarted on crash, with a circuit breaker (5 crashes/min ⇒ stop trying)
- relaunched after a server restart (boot hook)
- `rollback_app` to any of the last 10 versions
- **`$DATA_DIR` is the one durable path** — everything else is reset from the snapshot on every relaunch, and the tool description says so plainly
- minimal env: a published app inherits none of the server's tokens

Plus `list_apps` / `stop_app`, and a **Settings → Deploys** panel so a human can see what's running, roll back, stop and delete.

**Not ported:** qm's per-scope share grants. Reaching a deploy already means reaching OpenSession (tailnet + team gated); an ACL lattice on top is exactly the scope machinery the analysis said to leave behind at our size. Deploys are team-visible, and the tool description says that so nobody publishes something expecting per-person privacy.

## Three supervisor bugs the e2e found — none of which unit tests would have caught

I wrote a real app (an HTTP server with a `$DATA_DIR`-backed counter), published it, redeployed it, rolled it back and stopped it. That found:

1. **`kill()` reaped a shell, not the app.** The spawned pid was `sh -c "<entrypoint>"`, so stopping a deploy left the real server running and holding its port — "stopped" apps stayed up. Entrypoints now run under `exec`, and publishing **rejects compound commands** (`cd x && node y`) with the fix, since `exec` can only supervise a single command.
2. **Redeploy raced the port.** The new version spawned before the old one released its port, died on `EADDRINUSE` five times into the breaker — while the old version kept serving and the registry claimed the new one was live. Teardown now waits for exit, escalating to `SIGKILL` after a grace period.
3. **A deliberate kill looked like a crash.** `onExit` counted redeploy teardown as a crash and scheduled a restart of the *old* version, which then fought the new one for the port — a cascade that tripped the breaker. Intentional kills are marked on the **process object**, not the deploy id: `onExit` fires independently of the `exited` promise, so an id-keyed flag was already cleared by the time it ran.

Final verified run:

```
v1 GET /   → hello from the deploy, path=/
bump/bump  → count=1 count=2
v2 GET /   → VERSION TWO, path=/          ← redeploy took effect
rollback   → hello from the deploy, path=/ ← rollback took effect
DATA_DIR   → count=3                       ← state survived both
state      → running v1
after stop → down (good)
```

## Security posture (stated in the module, not just here)

A deploy is arbitrary agent-authored code running unsandboxed and persistently as the OpenSession user. Sessions already run arbitrary code — what's new is that it *outlives the session*. So: interactive-only (never automations), publishing confined to the session's own worktree (otherwise `publish /home/ubuntu` is one call to a team-visible URL), every publish/launch/stop audited, and the Deploys panel exists so nothing accumulates unseen.

## Notes

- 16 deploy tests, `bun test src/` green (1239), `tsc --noEmit` clean, frontend builds.
- Boot hook + routes + auth gate ⇒ needs a real `systemctl restart opensession` after merge.
- Ports 7100-7899, clear of the webapp dev range and its preview mirror.

Started by Michiel in this Michael session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
