### PR TITLE
Stop the shared oc McpServer instance killing turns mid-flight

### DIFF
--- a/patches/@rynfar%2Fmeridian@1.51.0.patch
+++ b/patches/@rynfar%2Fmeridian@1.51.0.patch
@@ -1,5 +1,8 @@
+diff --git a/node_modules/@rynfar/meridian/.bun-tag-30ff0bd920d93449 b/.bun-tag-30ff0bd920d93449
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/cli-7df5eg5d.js b/dist/cli-7df5eg5d.js
-index ca4a412a41d803ca72f6fea0f143dadd88cced50..6c2acb7e99f1a7654deddc49f4f07e4e9349134a 100644
+index ca4a412a41d803ca72f6fea0f143dadd88cced50..8f02fc11c9c5d8f7701ba73396480083fe49eede 100644
 --- a/dist/cli-7df5eg5d.js
 +++ b/dist/cli-7df5eg5d.js
 @@ -17890,11 +17890,11 @@ function buildQueryOptions(ctx, abortController) {
@@ -16,3 +19,21 @@ index ca4a412a41d803ca72f6fea0f143dadd88cced50..6c2acb7e99f1a7654deddc49f4f07e4e
            mcpServers: { [PASSTHROUGH_MCP_NAME]: passthroughMcp.server }
          } : {}
        } : {
+@@ -19478,7 +19478,16 @@ function createProxyServer(config = {}) {
+           const toolSetKey = computeToolSetKey(requestTools);
+           const cachedMcp = profileSessionId ? sessionMcpCache.get(profileSessionId) : undefined;
+           if (cachedMcp && cachedMcp.key === toolSetKey) {
+-            passthroughMcp = cachedMcp.mcp;
++            // Same tool set, but NEVER reuse the cached McpServer instance: one
++            // instance can only serve one SDK query's transport, and a finished
++            // query's async teardown races the next query's connect on the shared
++            // instance. When connect loses, the SDK deletes the transport and every
++            // later mcp_message fails "SDK MCP server not found: oc" -- the CLI
++            // then strips all passthrough tools mid-session (cold prompt rewrite,
++            // model announces-and-stops or returns empty). 252 hits in mcp-logs-oc
++            // since 2026-07-16. The stable toolSetKey still preserves the prompt
++            // cache: identical tools serialize to an identical prefix.
++            passthroughMcp = createPassthroughMcpServer(requestTools, pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined);
+           } else {
+             passthroughMcp = createPassthroughMcpServer(requestTools, pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined);
+             if (profileSessionId) {

--- a/src/server/auto-continue.test.ts
+++ b/src/server/auto-continue.test.ts
@@ -42,6 +42,23 @@ describe("announcesNextAction", () => {
 		).toBe(true);
 	});
 
+	test("matches noun-phrase step announcements (observed bks-019fc72d tail)", () => {
+		expect(
+			announcesNextAction(
+				"The MCP tools dropped; continuing with native tools. Next: where the render path turns `audio_source: Enhanced` into an actual file, and whether it silently falls back.",
+			),
+		).toBe(true);
+		expect(announcesNextAction("Then: the fallback readiness check in segment.rs.")).toBe(true);
+		expect(announcesNextAction("Next step: wire the frontend half of the flag.")).toBe(true);
+	});
+
+	test("does not match non-step colon tails", () => {
+		expect(
+			announcesNextAction("Summary: the cache key never included the audio source."),
+		).toBe(false);
+		expect(announcesNextAction("Result: all four tests pass.")).toBe(false);
+	});
+
 	test("matches bare gerund announcements (observed bks-019f54f8 tail)", () => {
 		expect(
 			announcesNextAction("Fetching the review comments on #4791."),

--- a/src/server/auto-continue.ts
+++ b/src/server/auto-continue.ts
@@ -88,6 +88,11 @@ export function announcesNextAction(text: string): boolean {
 		)
 	)
 		return true;
+	// Noun-phrase step announcements ("Next: where the render path turns X
+	// into Y.", "Then: the fallback check.") — 2026-08-03 bks-019fc72d ended
+	// its turn on one after a mid-turn tool loss and parked; no first-person
+	// verb and no gerund, so every pattern above misses the shape.
+	if (/^(?:next(?:\s+step|\s+up)?|then|after that)\s*:\s+\S/i.test(last)) return true;
 	// Bare gerund announcements ("Fetching the review comments on #4791.",
 	// "Now running the tests.") — seen 2026-07-12 in bks-019f54f8, where the
 	// first-person patterns above missed and the session parked. The verb must

--- a/src/server/opencode-runner.ts
+++ b/src/server/opencode-runner.ts
@@ -2472,6 +2472,49 @@ async function meridianLineageForStep(
 }
 
 /**
+ * Did the Claude CLI just fail to (re)connect Meridian's in-process "oc" MCP
+ * server? At that moment the CLI strips every mcp__oc__* tool from the session
+ * (cold prompt rewrite; the model then announces-and-stops or returns empty)
+ * and leaves a one-line jsonl under ~/.cache/claude-cli-nodejs/<cwd-slug>/
+ * mcp-logs-oc/. A hit inside the window turns a generic context_rebuild into a
+ * diagnosed tool-drop (2026-08-03: bks-019fc72d/-72e/-75f all died on this;
+ * root cause patched in patches/@rynfar%2Fmeridian, this is the tripwire in
+ * case it resurfaces). Matches on the SDK session id when lineage produced
+ * one; otherwise any fresh error in the window is attributed.
+ */
+function recentOcMcpDropError(sdkSessionId: string | undefined, windowMs = 180_000): string | undefined {
+  const root = `${HOME}/.cache/claude-cli-nodejs`;
+  let cwdSlugs: string[];
+  try {
+    cwdSlugs = readdirSync(root);
+  } catch {
+    return undefined;
+  }
+  for (const slug of cwdSlugs) {
+    const logDir = `${root}/${slug}/mcp-logs-oc`;
+    let names: string[];
+    try {
+      names = readdirSync(logDir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      try {
+        const path = `${logDir}/${name}`;
+        if (Date.now() - statSync(path).mtimeMs > windowMs) continue;
+        const lines = readFileSync(path, "utf-8").trim().split("\n");
+        const entry = JSON.parse(lines[lines.length - 1] || "{}");
+        if (sdkSessionId && entry.sessionId && entry.sessionId !== sdkSessionId) continue;
+        if (typeof entry.error === "string" && entry.error) return entry.error;
+      } catch {
+        // Unreadable/partial log line — skip; this is best-effort diagnosis.
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
  * Per-attempt watcher for silent context rebuilds under the engine (see
  * isContextRebuildStep). Fed every `message.updated`; fires at most once per
  * completed step, and never on an attempt's first step (no warm predecessor →
@@ -2506,6 +2549,15 @@ function makeContextRebuildWatcher(opts: {
     opts.onDetected(notice);
     // The verdict costs a loopback round-trip, so it rides after the notice.
     void meridianLineageForStep(current.cacheCreationTokens).then((lineage) => {
+      // Third rebuild cause besides compaction and replay: the CLI lost the
+      // "oc" SDK MCP server and stripped every tool (also lineage
+      // "continuation" — lineage alone can't tell the shapes apart).
+      const mcpDropError = recentOcMcpDropError(lineage?.sdkSessionId);
+      if (mcpDropError)
+        opts.onDetected(
+          "The rebuild coincides with the engine losing its tool bridge " +
+            `(${mcpDropError}) — the model was left without tools for the rest of the turn.`,
+        );
       opts.turnEvent({
         direction: "out",
         kind: "context_rebuild",
@@ -2519,6 +2571,7 @@ function makeContextRebuildWatcher(opts: {
         sdk_session_id: lineage?.sdkSessionId,
         engine_message_count: lineage?.messageCount,
         tool_count: lineage?.toolCount,
+        ...(mcpDropError ? { mcp_drop_error: mcpDropError.slice(0, 300) } : {}),
       });
     });
   };

--- a/src/server/run-session.ts
+++ b/src/server/run-session.ts
@@ -1275,8 +1275,21 @@ export function maybeQueueAutoContinue(opts: {
 	session?: UnifiedSession | null;
 }): boolean {
 	const { sessionId, assistantText, toolUseCount, endedWithError, runFailure } = opts;
+	// When a turn that plainly announced a next step is NOT nudged, record why:
+	// 2026-08-03 bks-019fc75f ended on "Now let me correlate…" with no nudge and
+	// no trace of which condition vetoed it, which made the miss undebuggable.
+	const suppressed = (reason: string): false => {
+		if (announcesNextAction(assistantText))
+			audit({
+				msg: "auto_continue_suppressed",
+				bks_session_id: sessionId,
+				reason,
+				tail: assistantText.trim().slice(-200),
+			});
+		return false;
+	};
 	const session = opts.session ?? findSession(sessionId);
-	if (!session) return false;
+	if (!session) return suppressed("session_not_found");
 	const queuedBehind = (promptQueues.get(sessionId) || []).filter(
 		(m) => m.user !== AUTO_CONTINUE_USER,
 	).length;
@@ -1289,16 +1302,13 @@ export function maybeQueueAutoContinue(opts: {
 	const endedOnFabricatedTranscript = looksLikeFabricatedToolTranscript(
 		assistantText.slice(-2000),
 	);
-	if (
-		endedWithError ||
-		runFailure ||
-		session.source !== "backstage" ||
-		session.automation ||
-		stoppedSessions.has(sessionId) ||
-		autoContinueNudged.has(sessionId) ||
-		!(announcesNextAction(assistantText) || endedOnFabricatedTranscript)
-	)
-		return false;
+	if (endedWithError) return suppressed("ended_with_error");
+	if (runFailure) return suppressed("run_failure");
+	if (session.source !== "backstage") return suppressed(`source_${session.source}`);
+	if (session.automation) return suppressed("automation_session");
+	if (stoppedSessions.has(sessionId)) return suppressed("user_stop");
+	if (autoContinueNudged.has(sessionId)) return suppressed("already_nudged");
+	if (!(announcesNextAction(assistantText) || endedOnFabricatedTranscript)) return false;
 	autoContinueNudged.add(sessionId);
 	audit({
 		msg: "auto_continue_nudge",


### PR DESCRIPTION
## What happened

Three sessions died mid-turn today (bks-019fc72d, bks-019fc72e, bks-019fc75f — the ones Michiel linked): the new context-rebuild detector fired (110k → 122k, cache cold, lineage `continuation`), the model said "The MCP tools dropped", announced a next step or returned empty completions, and the turn ended.

## Root cause

Meridian's proxy caches the passthrough MCP bundle per session (`sessionMcpCache`) and reuses **one `McpServer` instance** across sequential SDK queries. An MCP server instance serves one transport; a finished query's async teardown races the next query's connect on the shared instance. When connect loses, the SDK deletes the transport and every later `mcp_message` fails **"SDK MCP server not found: oc"** — the CLI strips all 564 `mcp__oc__*` tools, rewrites the prompt cold, and injects a 558-name `deferred_tools_delta` telling the model its tools are gone. The model then announces-and-stops (fc72d, fc75f) or returns empty completions until the run fails (fc72e).

Evidence: `~/.cache/claude-cli-nodejs/…/mcp-logs-oc/` has **252** of these errors since 2026-07-16, timestamped to the second against each incident; 21 today alone once f2bce2fa (ToolSearch fix) started surfacing the loss to the model. Drops hit fresh SDK sessions 42–250s in; the link reconnects on the next query (re-add delta observed), so only the in-flight turn dies.

## The fix

- **patches/@rynfar%2Fmeridian**: on a toolset-cache hit, build a fresh `McpServer` instance per request instead of reusing the cached one. The stable `toolSetKey` keeps the serialized tool list — and therefore the prompt cache — identical, so the reuse bought nothing but the race.

## Tripwires (in case it resurfaces in another costume)

- `context_rebuild` audit events + transcript notice now diagnose the tool-drop shape via `mcp-logs-oc` (`mcp_drop_error`) — lineage alone can't tell compaction from a tool drop.
- `announcesNextAction` learns noun-phrase step announcements ("Next: where the render path turns X into Y") — the fc72d tail every existing pattern missed.
- `maybeQueueAutoContinue` audits **why** it declined (`auto_continue_suppressed`) whenever the turn plainly announced a next step — fc75f matched the detector yet silently got no nudge.

## Deploy notes

- Engine servers pick up the patched Meridian on their next respawn (config change or idle reap); a forced respawn sweep isn't necessary but accelerates coverage.
- Runner + run-session changes need the usual `systemctl restart opensession` after merge.
- Full test suite: 1287 pass; the one failure (`os1-tui/test/app.test.tsx`, missing `@opentui/react/test-utils`) is a worktree-deps gap unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wn31EBHw4vkHCfuZJkzJC