### PR TITLE
Align sidebar popover pointer

### DIFF
--- a/src/frontend/ui/popover.tsx
+++ b/src/frontend/ui/popover.tsx
@@ -126,7 +126,7 @@ function Popup({
 						<BasePopover.Arrow
 							className={cn(
 								"size-[10px] rotate-45 border-line-strong bg-panel",
-								"data-[side=right]:left-[-6px] data-[side=right]:border-b data-[side=right]:border-l",
+								"data-[side=right]:left-[-5px] data-[side=right]:border-b data-[side=right]:border-l",
 								"data-[side=left]:right-[-6px] data-[side=left]:border-t data-[side=left]:border-r",
 								"data-[side=top]:bottom-[-6px] data-[side=top]:border-r data-[side=top]:border-b",
 								"data-[side=bottom]:top-[-6px] data-[side=bottom]:border-t data-[side=bottom]:border-l",


### PR DESCRIPTION
## Summary

- shift the right-side sidebar popover pointer 1px toward the container
- leave pointer positioning for the other popover sides unchanged

## Verification

- `bun run typecheck`

Started by Grant Shaddick in [this Michael session](https://os.tella.dev/session/os-019fd68b-bb9f-7000-ae71-61fbe63c6dea)