### PR TITLE
Align transcript history controls across clients

### DIFF
--- a/os1-ios/OS1/Views/SessionView.swift
+++ b/os1-ios/OS1/Views/SessionView.swift
@@ -845,7 +845,7 @@ struct SessionView: View {
     /// The web transcript's floating Load all pill, kept out of the transcript
     /// layout so loading older messages never looks like another message.
     private var historyLoader: some View {
-        Group {
+        HStack(spacing: 0) {
             if viewModel.loadingEarlier {
                 HStack(spacing: 7) {
                     ProgressView()

--- a/os1-ios/OS1/Views/SessionView.swift
+++ b/os1-ios/OS1/Views/SessionView.swift
@@ -250,9 +250,6 @@ struct SessionView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 10) {
-                            if viewModel.canLoadEarlier || viewModel.loadingEarlier {
-                                historyLoader
-                            }
                             // Nothing on screen: the caller may own this space
                             // (the Desk puts its board here). Rendered inside
                             // the transcript rather than in place of it, so the
@@ -460,7 +457,17 @@ struct SessionView: View {
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
                     }
+                    // Match the web transcript: history is one floating action,
+                    // not a row that participates in the conversation layout.
+                    .overlay(alignment: .top) {
+                        if viewModel.canLoadEarlier || viewModel.loadingEarlier {
+                            historyLoader
+                                .padding(.top, 12)
+                                .transition(.opacity.combined(with: .move(edge: .top)))
+                        }
+                    }
                     .animation(.snappy(duration: 0.22, extraBounce: 0), value: pinnedToBottom)
+                    .animation(.snappy(duration: 0.22, extraBounce: 0), value: viewModel.loadingEarlier)
                     // A scroll gesture is the reader taking over: the
                     // opening hold ends the moment they touch the transcript.
                     .onScrollPhaseChange { _, phase in
@@ -835,40 +842,38 @@ struct SessionView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    /// Sits above the oldest rendered entry; scrolling it into view pages in
-    /// the previous window of history (with a button as the manual fallback).
+    /// The web transcript's floating Load all pill, kept out of the transcript
+    /// layout so loading older messages never looks like another message.
     private var historyLoader: some View {
-        HStack(spacing: 6) {
-            if viewModel.jumpingToStart {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Loading full history…")
-            } else if viewModel.loadingEarlier {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Loading earlier…")
-            } else {
-                Button("Load earlier history") { requestEarlier() }
-                    .buttonStyle(.borderless)
-                Divider()
-                    .frame(height: 14)
-                // The whole backlog in one tap, for readers who'd otherwise
-                // page a hundred times to reach the first message.
-                Button { requestJumpToStart() } label: {
-                    Image(systemName: "arrow.up.to.line")
+        Group {
+            if viewModel.loadingEarlier {
+                HStack(spacing: 7) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(viewModel.jumpingToStart
+                        ? "Loading all messages…"
+                        : "Loading older messages…")
                 }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("Jump to the start of the session")
+                .historyPillSurface()
+            } else {
+                Button { requestJumpToStart() } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "arrow.up")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Load all")
+                    }
+                    .historyPillSurface()
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Load all earlier messages")
             }
         }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 6)
+        .font(.caption.weight(.medium))
+        .foregroundStyle(OS1VisualStyle.textDim)
         .onAppear {
-            // A jump that stopped at its ceiling leaves this control on screen
-            // right under the reader; auto-paging there would yank the view
-            // they were just placed in. The next appearance loads as usual.
+            // Preserve the native prefetch: one page loads when this control
+            // first enters, while the visible action handles the full backlog.
             if suppressAutoEarlier {
                 suppressAutoEarlier = false
             } else {
@@ -1531,6 +1536,19 @@ private struct ScrollToLatestButton: View {
         .accessibilityLabel(
             hasNewOutput ? "New messages below. Scroll to latest" : "Scroll to latest"
         )
+    }
+}
+
+private extension View {
+    /// The shared floating transcript-control surface. History and return-to-
+    /// latest actions travel over arbitrary content, so they stay opaque.
+    func historyPillSurface() -> some View {
+        self
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(OS1VisualStyle.panel, in: Capsule())
+            .overlay { Capsule().stroke(OS1VisualStyle.border, lineWidth: 0.5) }
+            .shadow(color: .black.opacity(0.12), radius: 6, y: 1)
     }
 }
 

--- a/src/frontend/components/SessionViewer.tsx
+++ b/src/frontend/components/SessionViewer.tsx
@@ -1037,7 +1037,6 @@ export function SessionViewer({
 		loaded: number;
 		cursor: number | null;
 	} | null>(null);
-	const [loadingAllHistory, setLoadingAllHistory] = useState(false);
 	// Byte offset the loaded history begins at — the "load earlier" pagination
 	// cursor (server: parseTranscriptTail/parseTranscriptWindow startOffset).
 	// null = unknown (old server) → load_history falls back to the full resend.
@@ -1565,7 +1564,6 @@ export function SessionViewer({
 	useEffect(() => {
 		return () => {
 			historyWalkRef.current = null;
-			setLoadingAllHistory(false);
 		};
 	}, [session.id]);
 
@@ -2199,7 +2197,6 @@ export function SessionViewer({
 					if (historyWalkRef.current?.sessionId === session.id) {
 						if (msg.truncated) {
 							historyWalkRef.current = null;
-							setLoadingAllHistory(false);
 						} else {
 							finishHistoryWalk();
 						}
@@ -2844,7 +2841,6 @@ export function SessionViewer({
 			loaded: 0,
 			cursor: null,
 		};
-		setLoadingAllHistory(true);
 		beginHistoryLoad(60_000);
 		requestHistoryPage(true);
 	}, [beginHistoryLoad, historyTruncated, requestHistoryPage, session.id]);
@@ -2855,7 +2851,6 @@ export function SessionViewer({
 	const finishHistoryWalk = useCallback(() => {
 		if (!historyWalkRef.current) return;
 		historyWalkRef.current = null;
-		setLoadingAllHistory(false);
 		stopHistoryHold();
 	}, [stopHistoryHold]);
 
@@ -5606,11 +5601,7 @@ export function SessionViewer({
 												className={TRANSCRIPT_PILL_SPINNER}
 												aria-hidden
 											/>
-											<span>
-												{loadingAllHistory
-													? "Loading all messages…"
-													: "Loading older messages…"}
-											</span>
+											<span>Loading</span>
 										</div>
 									) : (
 										<button

--- a/src/frontend/lib/session-viewer-classes.ts
+++ b/src/frontend/lib/session-viewer-classes.ts
@@ -286,7 +286,7 @@ export const SESSION_DELETE_LABEL = "text-label text-dim";
 const PILL_BASE =
 	"inline-flex h-[26px] items-center rounded-full bg-panel pr-2.5 pl-2 " +
 	"text-xs font-medium text-dim " +
-	"[--smooth-ring-color:var(--line)] smooth-shadow-ring-sm";
+	"[--smooth-ring-width:0.5px] [--smooth-ring-color:var(--line)] smooth-shadow-ring-sm";
 
 export const TRANSCRIPT_PILL = `${PILL_BASE} gap-1.5`;
 

--- a/src/frontend/lib/session-viewer-classes.ts
+++ b/src/frontend/lib/session-viewer-classes.ts
@@ -268,8 +268,9 @@ export const SESSION_DELETE_LABEL = "text-label text-dim";
  *
  * "Load all" at the top of the transcript, "Scroll to bottom" at its foot, and
  * the loading state each of them swaps to. They float over live content, so
- * they are glass rather than a panel, and they stay small: this is chrome the
- * eye should pass over, not a primary action.
+ * they use the same compact opaque capsule as the native app: this is chrome
+ * the eye should pass over, not a primary action. `rounded-full` is deliberate
+ * here. Unlike the app's squircle radii, it keeps the ends truly round.
  *
  * The padding is asymmetric on purpose. Every one of these carries a leading
  * icon, and an icon brings its own whitespace to the edge, so matching the
@@ -283,9 +284,9 @@ export const SESSION_DELETE_LABEL = "text-label text-dim";
  *  one element resolve by Tailwind's output order, not by the order they are
  *  written in. */
 const PILL_BASE =
-	"inline-flex min-h-8 items-center rounded-[999px] bg-popup-glass pr-3.5 pl-2.5 " +
-	"text-label font-semibold text-fg [backdrop-filter:var(--popup-blur)] " +
-	"[--smooth-ring-color:var(--popup-ring)] smooth-shadow-ring-sm";
+	"inline-flex h-[26px] items-center rounded-full bg-panel pr-2.5 pl-2 " +
+	"text-xs font-medium text-dim " +
+	"[--smooth-ring-color:var(--line)] smooth-shadow-ring-sm";
 
 export const TRANSCRIPT_PILL = `${PILL_BASE} gap-1.5`;
 
@@ -298,15 +299,14 @@ export const TRANSCRIPT_PILL = `${PILL_BASE} gap-1.5`;
  * with a pale sliver showing at each corner. `corner-shape: inherit` follows
  * whatever the pill resolved to, including the PWA's round-cornered phone case.
  *
- * `after` is the hit target, held a few pixels out past the visible edge so a
- * small pill is still easy to hit; it must not paint anything, or it would
- * square off the corners it extends past.
+ * `after` is the 40px hit target around the 26px visible capsule; it must not
+ * paint anything, or it would square off the corners it extends past.
  */
 export const TRANSCRIPT_PILL_BUTTON =
 	`group relative cursor-pointer ${TRANSCRIPT_PILL} transition-[scale] ` +
 	"before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] " +
 	"before:[corner-shape:inherit] before:bg-transparent before:transition-colors before:content-[''] " +
-	"after:absolute after:-inset-1 after:content-[''] hover:before:bg-hover " +
+	"after:absolute after:-inset-x-1 after:-inset-y-[7px] after:content-[''] hover:before:bg-hover " +
 	"focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fg active:scale-[0.96]";
 
 /** The loading state's leading spinner, and the wider gap it asks for: an arrow


### PR DESCRIPTION
## Summary
- move native history loading out of the transcript and into a floating top-center pill
- replace the separate native paging and jump actions with one `Load all` action
- match the web `Load all`, loading, and `Scroll to bottom` controls to the compact native capsule
- preserve automatic prefetch, scroll behavior, hover, focus, press feedback, and a 40px web hit target

## Verification
- iOS simulator build
- OS1Mac build
- full OS1Mac test suite
- iPhone 17 Pro simulator: `Load all` reached the first session messages
- frontend production build: 483 files
- computed web geometry at desktop and phone widths: 85×26px, round capsule, 13px medium text
- `git diff --check`

## CI
Current repository CI failures are unrelated to this diff: type-check fails in `src/server/codex-usage.ts`, and installer jobs intentionally omit OpenCode before requiring `doctor` to report no errors.

Started by Kent de Bruin in [this Michael session](https://os.tella.dev/session/os-019ff574-3c87-7000-8e50-a779d221a22f)