### PR TITLE
Stop the review canvas scrolling sideways on a phone

### DIFF
--- a/src/frontend/components/PrPanel.tsx
+++ b/src/frontend/components/PrPanel.tsx
@@ -1228,7 +1228,7 @@ export function PrPanel({
             inside the one scroll container so the identity scrolls away with
             the diff. Only the tab row sticks, so the reviewer keeps a way back
             to Conversation/Commits/Checks once they're deep in a file. */}
-        <main className="min-h-0 flex-1 overflow-y-auto bg-surface pb-24 [--review-file-header-top:106px]">
+        <main className="min-h-0 flex-1 overflow-y-auto bg-surface pb-24 [--review-file-header-top:106px] phone:pb-36">
           <header className="flex min-h-[96px] shrink-0 items-center gap-5 px-6 py-4 phone:min-h-[78px] phone:px-3">
             <div className="min-w-0 flex-1">
               <a
@@ -1644,7 +1644,10 @@ export function PrPanel({
           </>
         )}
 
-        <div className="pointer-events-none absolute bottom-4 left-4 right-4 z-10 flex min-h-[54px] items-center rounded-md border border-line-strong bg-panel/95 px-3 py-2 smooth-shadow-soft backdrop-blur">
+        {/* Caption and actions share a row until the actions need the whole
+            width — on a phone the three buttons alone are wider than the bar,
+            so side-by-side pushed them off its right edge. */}
+        <div className="pointer-events-none absolute bottom-4 left-4 right-4 z-10 flex min-h-[54px] items-center gap-3 rounded-md border border-line-strong bg-panel/95 px-3 py-2 smooth-shadow-soft backdrop-blur phone:flex-col phone:items-stretch phone:gap-2">
           <div className="min-w-0 flex-1">
             <div className="text-xs font-medium text-fg">
               {reviewDone === "merged"
@@ -1667,7 +1670,7 @@ export function PrPanel({
                   : `${provider.name} has no reviews. Merge or close when you're done.`)}
             </div>
           </div>
-          <div className="pointer-events-auto ml-3 flex shrink-0 gap-2">
+          <div className="pointer-events-auto flex shrink-0 flex-wrap justify-end gap-2">
             {onOpenSession && (
               <Button className="text-xs" onClick={onOpenSession}>
                 Open workspace

--- a/src/frontend/components/pr/PrViews.tsx
+++ b/src/frontend/components/pr/PrViews.tsx
@@ -17,7 +17,7 @@ function PrDescriptionCard({
       </div>
     );
   return (
-    <article className="rounded-md border border-line bg-panel">
+    <article className="min-w-0 rounded-md border border-line bg-panel">
       <div className="flex items-center gap-2 border-b border-line px-4 py-3">
         <span className="flex size-7 items-center justify-center rounded-full bg-active text-[11px] font-semibold text-fg">
           {author.slice(0, 1).toUpperCase()}
@@ -60,7 +60,7 @@ export function ChecksView({
       ) : (
         <div className="grid gap-4">
           {checks.length > 0 && (
-            <section className="rounded-md border border-line bg-panel p-3">
+            <section className="min-w-0 rounded-md border border-line bg-panel p-3">
               <h3 className="m-0 px-2 pb-2 text-xs font-semibold text-fg">CI checks</h3>
               {checks.map((check, index) => (
                 <CheckRow key={`${check.name}-${index}`} check={check} />
@@ -68,7 +68,7 @@ export function ChecksView({
             </section>
           )}
           {deployments.length > 0 && (
-            <section className="rounded-md border border-line bg-panel p-3">
+            <section className="min-w-0 rounded-md border border-line bg-panel p-3">
               <h3 className="m-0 px-2 pb-2 text-xs font-semibold text-fg">Deployments</h3>
               {deployments.map((check, index) => (
                 <CheckRow key={`${check.name}-${index}`} check={check} />
@@ -163,7 +163,11 @@ export function ConversationView({
   repo?: string;
 }) {
   return (
-    <div className="mx-auto max-w-[760px]">
+    /* `w-full` is load-bearing, not belt-and-braces: this column is a flex item
+       and `mx-auto` (an auto cross-axis margin) opts it out of stretching, so
+       without it the box sizes to its content and `max-w` becomes a fixed 760px
+       that a phone can't fit. */
+    <div className="mx-auto w-full min-w-0 max-w-[760px]">
       <div className="mb-6">
         <h2 className="m-0 text-section-title font-semibold tracking-[-0.01em] text-fg">
           Conversation
@@ -190,7 +194,10 @@ export function ConversationView({
               : null;
             return (
               <article
-                className="rounded-md border border-line bg-panel"
+                /* A grid item's automatic minimum size is its min-content
+                   width, so a wide comment (a deploy table, a long path) would
+                   otherwise stretch the track past the viewport. */
+                className="min-w-0 rounded-md border border-line bg-panel"
                 key={`${comment.url || comment.createdAt || index}`}
               >
                 <div className="flex items-center gap-2 border-b border-line px-4 py-3">

--- a/src/frontend/styles/base.css
+++ b/src/frontend/styles/base.css
@@ -1158,7 +1158,6 @@ html.wco .app-body.sidebar-collapsed
 	font-size: 14px;
 	line-height: 1.5;
 	color: var(--text-dim);
-	overflow-wrap: anywhere;
 }
 .review-preview-markdown.markdown > h3:first-child {
 	margin: 0 0 12px;
@@ -1174,6 +1173,17 @@ html.wco .app-body.sidebar-collapsed
 }
 
 /* markdown content */
+/* Model and GitHub output carries tokens no line break can fall inside — a
+   module path, a query string, a bare URL. Left to default `normal` wrapping
+   those set the block's min-content width, so on a phone they don't just
+   overflow their own line: any flex/grid ancestor sized off min-content grows
+   with them and the whole surface scrolls sideways. `anywhere` both wraps them
+   and takes them out of the intrinsic width. `pre` is unaffected — it never
+   wraps, and keeps its own horizontal scroll. */
+.markdown {
+	overflow-wrap: anywhere;
+}
+
 .markdown p {
 	/* 8px on a 14px/24px body ≈ the 0.47em block rhythm the native app uses
 	   (blockSpacing 8 against 17pt). 6px left paragraphs reading as one slab. */


### PR DESCRIPTION
## Why

On a phone the `/workspace/<id>/review` Conversation tab put the whole review surface into horizontal scroll — the sticky sub-tab row, the PR title and the comment bodies all slid off-screen together. Measured over CDP at 390x844: `main` scrollWidth **930** against a 390 client width.

## What

Three causes, each measured rather than guessed:

- **The conversation column never shrank.** It's a flex item with `mx-auto`; an auto cross-axis margin opts an item out of stretching, so the box sized to its content and `max-w-[760px]` became a *fixed* 760px width — wider than the phone before a single comment rendered. `w-full` restores stretch and leaves `max-w` as the cap it reads as.
- **Comment cards and check sections are grid items**, whose automatic minimum size is their min-content width. One Vercel deploy table was enough to widen the track to 916px and drag the scroller with it. `min-w-0` lets them shrink; the table keeps its own `overflow-x`.
- **`.markdown` wrapped at `normal`**, so a module path or a bare URL both overflowed its line and fed the min-content width driving the above. `overflow-wrap: anywhere` fixes both. `pre` is unaffected — it never wraps and keeps its horizontal scroll. (This subsumes the same declaration that `.review-preview-markdown` already carried, which is removed.)

Also stacks the bottom review bar on phones: `Open workspace` / `Close` / `Finish review` are together wider than the bar, so they overflowed its right edge and squashed the pending-comment caption to roughly one word per line.

## Verification

CDP at 390x844 against a real PR. `main` scrollWidth vs clientWidth:

| tab | before | after |
| --- | --- | --- |
| Conversation | 930 / 390 | 390 / 390 |
| Commits | 390 / 390 | 390 / 390 |
| Checks | 397 / 390 | 390 / 390 |
| Files changed | 390 / 390 | 390 / 390 |

Desktop 1440x900 re-shot and unchanged; the session transcript (which shares `.markdown`) re-shot at phone width with no regression. `bun test src/frontend` and `tsc --noEmit` show the same pre-existing failures as `main`, nothing new.

## Not covered

Web UI only. `os1-ios/` renders its own transcript and PR surfaces, so nothing here reaches the native app; I didn't find an equivalent overflow there, but I also didn't audit it.