### PR TITLE
Capture UI: drive the page before the screenshot

### DIFF
--- a/scripts/capture-ui.ts
+++ b/scripts/capture-ui.ts
@@ -1,24 +1,68 @@
 #!/usr/bin/env bun
 /** Capture the running app with Mac/Retina-quality desktop defaults. */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import {
-  acquireCdpBrowser,
-  closeCdpTarget,
-  releaseCdpBrowser,
-} from "./lib/cdp-browser";
+import { openCdpSession } from "./lib/cdp-session";
 import { localAutomationToken } from "./lib/local-auth";
 import { captureInitScript, captureViewport } from "./lib/visual-capture";
 
 const argv = process.argv.slice(2);
-const outputArg = argv.find((value) => !value.startsWith("--"));
+
+// Flags that consume the next argument. Tracking them is what keeps a selector
+// or a route from being read as the output path.
+const VALUE_FLAGS = new Set([
+  "route",
+  "width",
+  "height",
+  "theme",
+  "wait",
+  "step-wait",
+  "seek",
+  "click",
+  "hover",
+  "eval",
+  "script",
+]);
+type StepKind = "click" | "hover" | "eval" | "script";
+const STEP_FLAGS = new Set<string>(["click", "hover", "eval", "script"]);
+
+// Steps run in the order they were written, so --hover x --click y is a
+// sequence rather than a set.
+const steps: { kind: StepKind; value: string }[] = [];
+const consumed = new Set<number>();
+for (let index = 0; index < argv.length; index++) {
+  const arg = argv[index]!;
+  if (!arg.startsWith("--")) continue;
+  const name = arg.slice(2);
+  if (!VALUE_FLAGS.has(name)) continue;
+  const value = argv[index + 1];
+  if (value === undefined) throw new Error(`--${name} needs a value`);
+  consumed.add(index + 1);
+  if (STEP_FLAGS.has(name)) steps.push({ kind: name as StepKind, value });
+}
+
+const outputArg = argv.find(
+  (value, index) => !value.startsWith("--") && !consumed.has(index),
+);
 const flag = (name: string, fallback?: string) => {
   const index = argv.indexOf(`--${name}`);
   return index >= 0 ? argv[index + 1] : fallback;
 };
 if (!outputArg) {
   console.error(
-    "usage: bun scripts/capture-ui.ts <output.png> [--route /] [--width 1440] [--height 900] [--theme light|dark] [--web] [--wait 3000]",
+    [
+      "usage: bun scripts/capture-ui.ts <output.png> [--route /] [--width 1440] [--height 900]",
+      "         [--theme light|dark] [--web] [--wait 3000]",
+      "  drive the page before capturing (repeatable, runs in the order written):",
+      "         [--hover <selector>] [--click <selector>] [--eval <js>] [--script <file.js>]",
+      "         [--step-wait 500]",
+      "  keep motion alive instead of freezing it:",
+      "         [--motion] [--seek <ms>]",
+      "",
+      "  --eval and --script run in page context inside an async wrapper, so they can",
+      "  await, and `return` prints the value.",
+      "  --seek pauses document.getAnimations() at <ms> and implies --motion.",
+    ].join("\n"),
   );
   process.exit(2);
 }
@@ -33,8 +77,15 @@ const theme = flag("theme", "light");
 // mid-"Checking sign-in". Give slow routes a longer settle rather than a
 // screenshot of the loading state.
 const settleMs = Number(flag("wait", "3000"));
+const stepWaitMs = Number(flag("step-wait", "500"));
+const seekArg = flag("seek");
+const seekMs = seekArg === undefined ? undefined : Number(seekArg);
 if (!Number.isFinite(settleMs) || settleMs < 0)
   throw new Error("wait must be a non-negative number of milliseconds");
+if (!Number.isFinite(stepWaitMs) || stepWaitMs < 0)
+  throw new Error("step-wait must be a non-negative number of milliseconds");
+if (seekMs !== undefined && (!Number.isFinite(seekMs) || seekMs < 0))
+  throw new Error("seek must be a non-negative number of milliseconds");
 if (
   !Number.isInteger(width) ||
   !Number.isInteger(height) ||
@@ -46,6 +97,9 @@ if (theme !== "light" && theme !== "dark")
   throw new Error("theme must be light or dark");
 const viewport = captureViewport(width, height);
 const electronMaterial = !viewport.mobile && !argv.includes("--web");
+// Seeking a paused animation is meaningless once the freeze stylesheet has set
+// `animation: none`, so --seek turns motion back on by itself.
+const liveMotion = argv.includes("--motion") || seekMs !== undefined;
 
 const FREEZE = `
   *, *::before, *::after {
@@ -55,46 +109,87 @@ const FREEZE = `
   }
   html { scroll-behavior: auto !important; }
 `;
+// A caret is neither a transition nor an animation, and it blinks into the
+// frame at random, so a motion capture still hides it.
+const HIDE_CARET = `
+  *, *::before, *::after { caret-color: transparent !important; }
+`;
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const lease = await acquireCdpBrowser();
-let target: { id?: string; webSocketDebuggerUrl?: string } | undefined;
-let socket: WebSocket | undefined;
+const session = await openCdpSession();
+const { send, evaluate } = session;
+
+/**
+ * Centre of the first match that actually occupies space. Several controls are
+ * rendered twice (a phone bar and a desktop rail), and the copy the reader
+ * cannot see is regularly first in document order.
+ */
+async function pointAt(selector: string) {
+  const found = await evaluate(`(() => {
+    const nodes = [...document.querySelectorAll(${JSON.stringify(selector)})];
+    const visible = nodes.find((node) => {
+      const rect = node.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+    if (!visible) return { count: nodes.length };
+    visible.scrollIntoView({ block: "center", inline: "nearest", behavior: "instant" });
+    const rect = visible.getBoundingClientRect();
+    return {
+      count: nodes.length,
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  })()`);
+  if (typeof found?.x !== "number")
+    throw new Error(
+      `no element with a visible box matched ${selector} (${found?.count ?? 0} matched the selector)`,
+    );
+  if (found.x < 0 || found.y < 0 || found.x > width || found.y > height)
+    throw new Error(
+      `${selector} sits outside the ${width}x${height} viewport at ${Math.round(found.x)},${Math.round(found.y)}`,
+    );
+  return found as { x: number; y: number };
+}
+
+// A synthetic .click() does not navigate this app, so drive the real input
+// pipeline instead.
+async function movePointer(selector: string) {
+  const { x, y } = await pointAt(selector);
+  await send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y, buttons: 0 });
+  return { x, y };
+}
+
+async function clickAt(selector: string) {
+  const { x, y } = await movePointer(selector);
+  const button = { button: "left", buttons: 1, clickCount: 1 };
+  await send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, ...button });
+  await send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x,
+    y,
+    ...button,
+    buttons: 0,
+  });
+}
+
+async function runSource(kind: "eval" | "script", value: string) {
+  const source = kind === "script" ? readFileSync(resolve(value), "utf8") : value;
+  // The wrapper lets a step await, and lets a file hold statements rather than
+  // one expression. The newline keeps a trailing line comment from eating it.
+  const result = await evaluate(`(async () => { ${source}\n})()`);
+  if (result !== undefined) console.log(`--${kind} returned ${JSON.stringify(result)}`);
+}
 
 try {
-  target = await fetch(
-    `http://127.0.0.1:${lease.port}/json/new?url=about:blank`,
-    {
-      method: "PUT",
-    },
-  ).then((response) => response.json());
-  const debuggerUrl = target?.webSocketDebuggerUrl;
-  if (!debuggerUrl) throw new Error("CDP target has no debugger URL");
-  socket = new WebSocket(debuggerUrl);
-  await new Promise<void>((resolveOpen, reject) => {
-    socket!.onopen = () => resolveOpen();
-    socket!.onerror = () => reject(new Error("CDP connection failed"));
-  });
-
-  let commandId = 0;
-  const pending = new Map<number, (result: any) => void>();
-  socket.onmessage = (event) => {
-    const message = JSON.parse(String(event.data));
-    if (!message.id) return;
-    pending.get(message.id)?.(message.result);
-    pending.delete(message.id);
-  };
-  const send = (method: string, params: Record<string, unknown> = {}) =>
-    new Promise<any>((resolveResult) => {
-      const id = ++commandId;
-      pending.set(id, resolveResult);
-      socket!.send(JSON.stringify({ id, method, params }));
-    });
-
   await send("Page.enable");
   await send("Network.enable");
   await send("Runtime.enable");
   await send("Emulation.setEmulatedMedia", {
-    features: [{ name: "prefers-reduced-motion", value: "reduce" }],
+    features: [
+      {
+        name: "prefers-reduced-motion",
+        value: liveMotion ? "no-preference" : "reduce",
+      },
+    ],
   });
   const token = localAutomationToken();
   if (token) {
@@ -106,7 +201,11 @@ try {
     });
   }
   await send("Page.addScriptToEvaluateOnNewDocument", {
-    source: captureInitScript({ theme, electronMaterial, freezeCss: FREEZE }),
+    source: captureInitScript({
+      theme,
+      electronMaterial,
+      freezeCss: liveMotion ? HIDE_CARET : FREEZE,
+    }),
   });
   await send("Emulation.setDeviceMetricsOverride", viewport);
   await send("Page.navigate", { url: new URL(route, APP).href });
@@ -124,36 +223,79 @@ try {
     returnByValue: true,
   });
   const actual = probe?.result?.value;
-  if (
-    actual?.width !== width ||
-    actual?.height !== height ||
-    actual?.dpr !== viewport.deviceScaleFactor ||
-    (electronMaterial &&
-      (!actual?.material || !actual?.wco || actual?.platform !== "mac"))
-  ) {
+  const expected: [string, unknown, unknown][] = [
+    ["width", actual?.width, width],
+    ["height", actual?.height, height],
+    ["dpr", actual?.dpr, viewport.deviceScaleFactor],
+  ];
+  if (electronMaterial)
+    expected.push(
+      ["material", actual?.material, true],
+      ["wco", actual?.wco, true],
+      ["platform", actual?.platform, "mac"],
+    );
+  // Name the field that tripped: printing every value made a missing shell
+  // class read as a viewport problem.
+  const wrong = expected.filter(([, got, want]) => got !== want);
+  if (wrong.length) {
     throw new Error(
-      `capture emulation did not apply: ${JSON.stringify(actual)}`,
+      `capture emulation did not apply: ${wrong
+        .map(
+          ([name, got, want]) =>
+            `${name} is ${JSON.stringify(got)}, expected ${JSON.stringify(want)}`,
+        )
+        .join("; ")} (probe ${JSON.stringify(actual)})`,
     );
   }
 
-  let previous = "";
+  for (const step of steps) {
+    if (step.kind === "hover") await movePointer(step.value);
+    else if (step.kind === "click") await clickAt(step.value);
+    else await runSource(step.kind, step.value);
+    await sleep(stepWaitMs);
+  }
+
+  if (seekMs !== undefined) {
+    const count = await evaluate(`(() => {
+      const animations = document.getAnimations();
+      for (const animation of animations) {
+        animation.pause();
+        try { animation.currentTime = ${seekMs}; } catch (error) {}
+      }
+      return animations.length;
+    })()`);
+    console.log(`paused ${count} animations at ${seekMs}ms`);
+    await sleep(50);
+  }
+  if (steps.length || seekMs !== undefined) await send("Page.bringToFront");
+
   let screenshot = "";
-  const deadline = Date.now() + 20_000;
-  while (Date.now() < deadline) {
+  // Waiting for two identical frames is how a still capture avoids a loading
+  // state, but live motion never repeats a frame, so seek or take one shot.
+  if (liveMotion && seekMs === undefined) {
     const result = await send("Page.captureScreenshot", { format: "png" });
     screenshot = result?.data ?? "";
-    if (screenshot && screenshot === previous) break;
-    previous = screenshot;
-    await sleep(600);
+  } else {
+    let previous = "";
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      const result = await send("Page.captureScreenshot", { format: "png" });
+      screenshot = result?.data ?? "";
+      if (screenshot && screenshot === previous) break;
+      previous = screenshot;
+      await sleep(600);
+    }
   }
   if (!screenshot) throw new Error("Chrome returned no screenshot data");
   mkdirSync(dirname(output), { recursive: true });
   writeFileSync(output, Buffer.from(screenshot, "base64"));
+  const drove = [
+    steps.length ? `${steps.length} step${steps.length > 1 ? "s" : ""}` : "",
+    liveMotion ? (seekMs === undefined ? "motion live" : `motion at ${seekMs}ms`) : "",
+  ].filter(Boolean);
   console.log(
-    `${output}\nCSS viewport ${width}x${height}; PNG ${width * viewport.deviceScaleFactor}x${height * viewport.deviceScaleFactor}; DPR ${viewport.deviceScaleFactor}; ${electronMaterial ? "Electron material" : "web"}`,
+    `${output}\nCSS viewport ${width}x${height}; PNG ${width * viewport.deviceScaleFactor}x${height * viewport.deviceScaleFactor}; DPR ${viewport.deviceScaleFactor}; ${electronMaterial ? "Electron material" : "web"}${drove.length ? `; ${drove.join("; ")}` : ""}`,
   );
 } finally {
-  socket?.close();
-  await closeCdpTarget(lease.port, target?.id);
-  await releaseCdpBrowser(lease);
+  await session.close();
 }

--- a/scripts/lib/cdp-session.ts
+++ b/scripts/lib/cdp-session.ts
@@ -1,0 +1,114 @@
+/**
+ * One CDP page target on a private, resource-bounded browser.
+ *
+ * Every visual script needs the same preamble before it can do anything: lease
+ * a browser, open a target, connect to its debugger socket, and wrap the
+ * id-keyed request/response protocol in a promise. Copying that preamble is
+ * what made people copy the whole of capture-ui.ts into /tmp, so it lives here
+ * where a throwaway script can import it.
+ */
+import {
+  acquireCdpBrowser,
+  closeCdpTarget,
+  releaseCdpBrowser,
+} from "./cdp-browser";
+
+export type CdpSend = (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<any>;
+
+export type CdpSession = {
+  port: number;
+  targetId?: string;
+  send: CdpSend;
+  /** Evaluate source in the page, awaiting a promise it returns. */
+  evaluate: (source: string) => Promise<any>;
+  close: () => Promise<void>;
+};
+
+export async function openCdpSession(
+  url = "about:blank",
+): Promise<CdpSession> {
+  const lease = await acquireCdpBrowser();
+  let target: { id?: string; webSocketDebuggerUrl?: string } | undefined;
+  let socket: WebSocket | undefined;
+
+  try {
+    target = await fetch(
+      `http://127.0.0.1:${lease.port}/json/new?url=${encodeURIComponent(url)}`,
+      { method: "PUT" },
+    ).then((response) => response.json());
+    const debuggerUrl = target?.webSocketDebuggerUrl;
+    if (!debuggerUrl) throw new Error("CDP target has no debugger URL");
+    socket = new WebSocket(debuggerUrl);
+    await new Promise<void>((resolveOpen, reject) => {
+      socket!.onopen = () => resolveOpen();
+      socket!.onerror = () => reject(new Error("CDP connection failed"));
+    });
+
+    let commandId = 0;
+    const pending = new Map<
+      number,
+      { method: string; resolve: (result: any) => void; reject: (error: Error) => void }
+    >();
+    socket.onmessage = (event) => {
+      const message = JSON.parse(String(event.data));
+      if (!message.id) return;
+      const entry = pending.get(message.id);
+      if (!entry) return;
+      pending.delete(message.id);
+      // A dropped error reads as a command that silently did nothing, which is
+      // then blamed on whatever asserts the page state next.
+      if (message.error)
+        entry.reject(
+          new Error(
+            `${entry.method} failed: ${message.error.message ?? JSON.stringify(message.error)}`,
+          ),
+        );
+      else entry.resolve(message.result);
+    };
+    socket.onclose = () => {
+      for (const entry of pending.values())
+        entry.reject(new Error(`${entry.method} failed: CDP socket closed`));
+      pending.clear();
+    };
+
+    const send: CdpSend = (method, params = {}) =>
+      new Promise<any>((resolveResult, reject) => {
+        const id = ++commandId;
+        pending.set(id, { method, resolve: resolveResult, reject });
+        socket!.send(JSON.stringify({ id, method, params }));
+      });
+
+    const evaluate = async (source: string) => {
+      const result = await send("Runtime.evaluate", {
+        expression: source,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      const details = result?.exceptionDetails;
+      if (details)
+        throw new Error(
+          details.exception?.description ?? details.text ?? "page evaluation failed",
+        );
+      return result?.result?.value;
+    };
+
+    let closed = false;
+    const close = async () => {
+      if (closed) return;
+      closed = true;
+      socket?.close();
+      await closeCdpTarget(lease.port, target?.id);
+      await releaseCdpBrowser(lease);
+    };
+
+    return { port: lease.port, targetId: target?.id, send, evaluate, close };
+  } catch (error) {
+    socket?.close();
+    await closeCdpTarget(lease.port, target?.id);
+    await releaseCdpBrowser(lease);
+    throw error;
+  }
+}


### PR DESCRIPTION
`scripts/capture-ui.ts` can navigate and screenshot, but there was no hook to drive the page in between. Six sessions each hand-copied 100 to 150 lines of it into /tmp in a single day, always for the same reason: to add a click, a hover, or to undo the freeze stylesheet. 15 of 64 agent-logged papercuts on 2026-08-15 name this one script.

### What is new

**Page-driving steps, repeatable and ordered.** `--click <selector>`, `--hover <selector>`, `--eval <js>`, `--script <file.js>` run after navigation and the emulation check, in the order written, so `--hover x --click y` is a sequence. Clicks and hovers go through `Input.dispatchMouseEvent` because a synthetic `.click()` does not navigate this app. `--eval` and `--script` run inside an async wrapper, so a step can `await`, and a `return` prints the value. `--step-wait` (default 500ms) paces them; the existing settle loop still runs before the capture.

Selector resolution takes the first match with a non-zero box, not the first match. Several controls render twice here (a phone bar and a desktop rail) and the copy the reader cannot see is regularly first in document order: `[aria-label="Open settings"]` matches 2 elements on `/`, and the off-screen one is first.

**`--motion`** skips the injected freeze stylesheet and emulates `prefers-reduced-motion: no-preference` instead of `reduce`. It still hides the caret, which is neither a transition nor an animation and otherwise blinks into the frame at random. **`--seek <ms>`** pauses `document.getAnimations()` at a fixed point and implies `--motion`, since seeking is meaningless once the freeze has set `animation: none`. With live motion and no seek the two-identical-frames settle loop can never converge, so that combination takes a single shot.

**The emulation assert names the failing field.** It printed all six values when one tripped, which reads as a viewport problem; one session lost a round-trip to it. Now: `capture emulation did not apply: width is 1441, expected 1440 (probe {...})`.

**The CDP preamble moved to `scripts/lib/cdp-session.ts`.** Two papercuts asked for this directly. `openCdpSession()` leases the bounded browser, opens a target, connects the socket and returns `{ send, evaluate, close }`, so a genuine one-off no longer has to copy 60 lines to get a `send()`. It also rejects on a CDP `message.error` rather than resolving `undefined`, which is what let a failed command surface as whatever asserted the page state next. No other script was touched.

Argument parsing now tracks which values belong to a flag, so `--click button out.png` no longer reads `button` as the output path.

### Deviations from the brief

- The brief said `tellahq/backstage`; the remote is `tellahq/opensession` (renamed), so the PR is there.
- The brief offered the `cdp-session` extraction as optional. I did it, because it is the other half of the same papercut and it is what makes `send()` reject on error.
- No walkthrough: this is a developer script with no user-visible surface.

### Verified

`bunx tsc --noEmit` in a detached worktree at `615160d6`: **0 errors before, 0 errors after** (baseline measured on the same clean tree, not assumed).

Every command below was run from the worktree against the live server. Default mode is unchanged when no new flag is passed.

```
# 1. default, unchanged
bun scripts/capture-ui.ts /tmp/capture-hooks-shots/default.png --route /
#   -> CSS viewport 1440x900; PNG 2880x1800; DPR 2; Electron material

# 2. click + eval (proves the click navigated, and picked the visible duplicate)
bun scripts/capture-ui.ts /tmp/capture-hooks-shots/clicked.png --route / \
  --click '[aria-label="Open settings"]' --eval 'return location.pathname'
#   -> --eval returned "/settings"
#   -> ...; Electron material; 2 steps

# 3. motion + seek
bun scripts/capture-ui.ts /tmp/capture-hooks-shots/seek.png --route /settings \
  --wait 400 --motion --seek 120
#   -> paused 12 animations at 120ms
#   -> ...; motion at 120ms

# 4. hover + script file (statements, await, return)
bun scripts/capture-ui.ts /tmp/capture-hooks-shots/hovered.png --route / \
  --hover '[aria-label="Open settings"]' --script /tmp/capture-hooks-step.js
#   -> --script returned 2

# 5. a selector that matches nothing fails loudly
bun scripts/capture-ui.ts /tmp/x.png --route / --click '.does-not-exist'
#   -> error: no element with a visible box matched .does-not-exist (0 matched the selector)

# 6. emulation assert, forced with a throwaway copy patched to report innerWidth + 1
#   -> error: capture emulation did not apply: width is 1441, expected 1440 (probe {...})
```

All four PNGs are 2880x1800 with 9k to 14k distinct colours (not a flat frame from a dead app), and `default.png` vs `clicked.png` differ in 2,104,561 pixels, i.e. home versus settings.

Started by Dreaming (nightly reflection) in [this Michael session](https://os.tella.dev/session/os-01a008db-577a-7000-bef9-0cbd04043bf3)
