### PR TITLE
Scheduler: catch up cron minutes a tick never landed in

### DIFF
--- a/src/server/automations.ts
+++ b/src/server/automations.ts
@@ -13,7 +13,7 @@ import {
   webhookBodyTooLargeResponse,
 } from "./shared/bounded-body";
 import { labelIdentity } from "./shared/user-mappings";
-import { parseCron, cronMatches, nextRun } from "./cron";
+import { parseCron, cronMatches, nextRun, minuteKey, pendingMinutes } from "./cron";
 import {
   STRIPE_CONFIRM_TOOLS,
   declaredRunFailure,
@@ -1650,9 +1650,15 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
 
   schedulerInterval = setInterval(() => {
     const now = new Date();
-    const minuteKey = now.toISOString().slice(0, 16);
-    if (minuteKey === lastFiredMinute) return;
-    lastFiredMinute = minuteKey;
+    const currentMinute = minuteKey(now);
+    if (currentMinute === lastFiredMinute) return;
+
+    // Every whole minute this tick is responsible for, not just the one it woke
+    // up in: a minute that no tick lands in would otherwise skip its automations
+    // until the cron's next occurrence, 24 hours later for a daily. Bounded by
+    // MAX_CATCHUP_MINUTES, and a fresh scheduler catches up nothing.
+    const minutes = pendingMinutes(lastFiredMinute, now);
+    lastFiredMinute = currentMinute;
 
     for (const automation of listAutomations()) {
       if (!automation.enabled) continue;
@@ -1671,8 +1677,13 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
         continue;
       }
 
-      if (!automation.schedule) continue;
-      if (cronMatches(automation.schedule, now)) {
+      const schedule = automation.schedule;
+      if (!schedule) continue;
+      // `some`, not a loop over `minutes`: one tick is at most one run per
+      // automation, so a caught-up gap that spans several matching minutes
+      // (a "* * * * *" schedule, say) never fires a burst. Consecutive ticks
+      // own disjoint minute ranges, so no minute is ever evaluated twice.
+      if (minutes.some((minute) => cronMatches(schedule, minute))) {
         // Fire and forget — runner guards against overlap per automation
         void runAutomation(automation, onSessionCreated, { trigger: "cron" });
       }

--- a/src/server/cron.test.ts
+++ b/src/server/cron.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { cronMatches, nextRun, parseCron } from "./cron";
+import {
+  MAX_CATCHUP_MINUTES,
+  cronMatches,
+  minuteKey,
+  nextRun,
+  parseCron,
+  pendingMinutes,
+} from "./cron";
 
 // Helper: build a UTC date. Month is 1-based here for readability.
 function utc(
@@ -243,5 +250,132 @@ describe("nextRun", () => {
     const copy = new Date(from.getTime());
     nextRun("* * * * *", from);
     expect(from.getTime()).toBe(copy.getTime());
+  });
+});
+
+describe("pendingMinutes", () => {
+  it("returns just the current minute when no minute was missed", () => {
+    const now = utc(2026, 8, 17, 14, 3, 12);
+    expect(pendingMinutes("2026-08-17T14:02", now)).toEqual([utc(2026, 8, 17, 14, 3)]);
+  });
+
+  it("returns every whole minute a tick missed, oldest first", () => {
+    // Last tick landed in 13:59, next one not until 14:02: 14:00 and 14:01 had
+    // no tick in them at all.
+    const minutes = pendingMinutes("2026-08-17T13:59", utc(2026, 8, 17, 14, 2, 6));
+    expect(minutes).toEqual([
+      utc(2026, 8, 17, 14, 0),
+      utc(2026, 8, 17, 14, 1),
+      utc(2026, 8, 17, 14, 2),
+    ]);
+  });
+
+  it("catches up nothing on a fresh scheduler", () => {
+    // lastMinute "" means "no history", not "replay the last five minutes":
+    // a restart must never fire a burst of backdated automations.
+    const minutes = pendingMinutes("", utc(2026, 8, 17, 14, 2, 6));
+    expect(minutes).toEqual([utc(2026, 8, 17, 14, 2)]);
+  });
+
+  it("clamps a long gap to MAX_CATCHUP_MINUTES, keeping the newest", () => {
+    const minutes = pendingMinutes("2026-08-17T13:30", utc(2026, 8, 17, 14, 2, 6));
+    expect(minutes.length).toBe(MAX_CATCHUP_MINUTES);
+    expect(minutes[0]).toEqual(utc(2026, 8, 17, 13, 58));
+    expect(minutes[minutes.length - 1]).toEqual(utc(2026, 8, 17, 14, 2));
+  });
+
+  it("returns nothing when the clock has not advanced past the last minute", () => {
+    expect(pendingMinutes("2026-08-17T14:02", utc(2026, 8, 17, 14, 2, 30))).toEqual([]);
+    expect(pendingMinutes("2026-08-17T14:05", utc(2026, 8, 17, 14, 2, 30))).toEqual([]);
+  });
+
+  it("falls back to the current minute for an unparseable last minute", () => {
+    expect(pendingMinutes("not-a-minute", utc(2026, 8, 17, 14, 2, 6))).toEqual([
+      utc(2026, 8, 17, 14, 2),
+    ]);
+  });
+
+  it("does not mutate `now`", () => {
+    const now = utc(2026, 8, 17, 14, 2, 6);
+    const copy = now.getTime();
+    pendingMinutes("2026-08-17T13:59", now);
+    expect(now.getTime()).toBe(copy);
+  });
+});
+
+// Mirrors the decision the automations scheduler makes on each 20s tick
+// (startScheduler in automations.ts): skip a repeat of the same minute, take
+// the minutes this tick owns, fire at most once per automation per tick.
+function runTicks(schedule: string, ticks: Date[], seed = ""): string[] {
+  let lastFiredMinute = seed;
+  const fired: string[] = [];
+  for (const now of ticks) {
+    const currentMinute = minuteKey(now);
+    if (currentMinute === lastFiredMinute) continue;
+    const minutes = pendingMinutes(lastFiredMinute, now);
+    lastFiredMinute = currentMinute;
+    if (minutes.some((minute) => cronMatches(schedule, minute))) fired.push(currentMinute);
+  }
+  return fired;
+}
+
+describe("scheduler catch-up", () => {
+  it("fires an hourly automation whose minute fell inside a tick gap", () => {
+    // The 2026-08-17 incident: ticks stop at 13:59:37 and resume at 14:01:42,
+    // so nothing ever woke up inside 14:00 and the hourly slot was lost.
+    const fired = runTicks(
+      "0 * * * *",
+      [utc(2026, 8, 17, 13, 59, 37), utc(2026, 8, 17, 14, 1, 42)],
+      "2026-08-17T13:59"
+    );
+    expect(fired).toEqual(["2026-08-17T14:01"]);
+  });
+
+  it("fires nothing retroactively on a fresh boot", () => {
+    // Booting at 14:01:46 with the first tick at 14:02:06 must NOT resurrect
+    // the 14:00 slot the dead process missed.
+    const fired = runTicks("0 * * * *", [
+      utc(2026, 8, 17, 14, 2, 6),
+      utc(2026, 8, 17, 14, 2, 26),
+      utc(2026, 8, 17, 14, 2, 46),
+    ]);
+    expect(fired).toEqual([]);
+  });
+
+  it("still fires the boot minute's own slot", () => {
+    // Booting at 14:00:03 with the first tick at 14:00:23: the current minute
+    // is always evaluated, so no-catch-up-on-boot does not itself skip a slot.
+    const fired = runTicks("0 * * * *", [utc(2026, 8, 17, 14, 0, 23)]);
+    expect(fired).toEqual(["2026-08-17T14:00"]);
+  });
+
+  it("does not fire every skipped occurrence after a long gap", () => {
+    // A per-minute schedule with a 30-minute gap: one catch-up run, not 30.
+    const fired = runTicks(
+      "* * * * *",
+      [utc(2026, 8, 17, 13, 30, 5), utc(2026, 8, 17, 14, 0, 5)],
+      "2026-08-17T13:29"
+    );
+    expect(fired).toEqual(["2026-08-17T13:30", "2026-08-17T14:00"]);
+  });
+
+  it("does not double-fire a slot covered by both catch-up and the next tick", () => {
+    // 14:00 is caught up by the 14:01 tick; the ticks that follow own only
+    // later minutes, so the hourly runs exactly once for the hour.
+    const ticks = [
+      utc(2026, 8, 17, 13, 59, 40),
+      utc(2026, 8, 17, 14, 1, 0),
+      utc(2026, 8, 17, 14, 1, 20),
+      utc(2026, 8, 17, 14, 1, 40),
+      utc(2026, 8, 17, 14, 2, 0),
+      utc(2026, 8, 17, 14, 2, 20),
+    ];
+    expect(runTicks("0 * * * *", ticks, "2026-08-17T13:59")).toEqual(["2026-08-17T14:01"]);
+  });
+
+  it("fires an hourly exactly once when ticks land normally", () => {
+    const ticks: Date[] = [];
+    for (let s = 0; s < 60 * 5; s += 20) ticks.push(new Date(utc(2026, 8, 17, 13, 58, 0).getTime() + s * 1000));
+    expect(runTicks("0 * * * *", ticks, "2026-08-17T13:57")).toEqual(["2026-08-17T14:00"]);
   });
 });

--- a/src/server/cron.ts
+++ b/src/server/cron.ts
@@ -87,6 +87,54 @@ function fieldMatches(spec: FieldSpec, value: number): boolean {
   return spec.any || spec.values.has(value);
 }
 
+/** How far back one scheduler tick will look for minutes that went by untick'd. */
+export const MAX_CATCHUP_MINUTES = 5;
+
+/** The minute key a scheduler records for `date`, e.g. "2026-08-17T14:00". */
+export function minuteKey(date: Date): string {
+  return date.toISOString().slice(0, 16);
+}
+
+/**
+ * The whole minutes a scheduler tick is responsible for: the minute containing
+ * `now`, plus any minute after `lastMinute` that no tick landed in, capped at
+ * the newest `max`.
+ *
+ * A tick-based scheduler only evaluates the minute it happens to wake up in, so
+ * a minute with no tick in it (event-loop stall, suspended host, tick drift)
+ * skips every automation scheduled for it until the cron's next occurrence,
+ * which for a daily is 24 hours later.
+ *
+ * A fresh scheduler (`lastMinute` empty) catches up NOTHING: it gets the
+ * current minute only. Replaying the minutes a process was down for would fire
+ * a burst of automations on every restart, which is worse than the miss it
+ * would paper over. The current minute is still included, exactly as before,
+ * so booting early in a minute does not itself skip that minute's slot.
+ *
+ * Returned oldest first; empty if the clock has not advanced past `lastMinute`.
+ */
+export function pendingMinutes(
+  lastMinute: string,
+  now: Date,
+  max: number = MAX_CATCHUP_MINUTES
+): Date[] {
+  const current = new Date(now.getTime());
+  current.setUTCSeconds(0, 0);
+  if (!lastMinute) return [current];
+
+  // Shape-check before parsing: Date.parse is lenient enough to turn a garbled
+  // key into a finite, very old timestamp, which would replay the full window.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(lastMinute)) return [current];
+  const last = Date.parse(`${lastMinute}:00Z`);
+  if (!Number.isFinite(last)) return [current];
+
+  const minutes: Date[] = [];
+  for (let t = current.getTime(); t > last && minutes.length < max; t -= 60_000) {
+    minutes.push(new Date(t));
+  }
+  return minutes.reverse();
+}
+
 /** Next matching minute strictly after `from`, scanning up to ~1 year. */
 export function nextRun(expr: string, from: Date = new Date()): Date | null {
   if (!parseCron(expr)) return null;


### PR DESCRIPTION
## The bug

`startScheduler` runs a 20s tick and evaluates only the minute that tick happened to wake up in. A minute that no tick lands in skips every automation scheduled for it until that cron's next occurrence, which for a daily is 24 hours later. There was no catch-up.

Measured on 2026-08-17: a self-restart at 14:01:46 left a 125 second gap in the audit log, 13:59:37 to 14:01:42. The 14:00 minute was never evaluated, so both hourly automations (`0 * * * *`, "Michael Health Monitor" and "Cassandra") recorded 23 of 24 hours that day. "Production Watchdog" at `20 * * * *` was unaffected because its minute came later. Same shape on 2026-08-14. Four sightings total.

## The fix

`pendingMinutes(lastMinute, now, max)` in `cron.ts` returns every whole minute after the one the scheduler last recorded, up to and including the current minute, capped at `MAX_CATCHUP_MINUTES = 5`, oldest first. The tick fires when any of them matches:

```ts
if (minutes.some((minute) => cronMatches(schedule, minute)))
```

`some`, not a loop, so one tick is at most one run per automation: a caught-up gap spanning several matching minutes (a `* * * * *` schedule) never fires a burst. Consecutive ticks own disjoint minute ranges, so no minute is evaluated twice and a slot cannot double-fire.

`runOnceAt` still fires against `now`, never against a caught-up minute.

## A fresh boot catches up nothing

This is the part worth reviewing. On a fresh scheduler (`lastFiredMinute === ""`) `pendingMinutes` returns the current minute only. Replaying the last 5 minutes on boot would fire a burst of backdated automations on every restart, which is a worse bug than the miss it papers over. The current minute is still evaluated exactly as it is today, so booting early in a minute does not itself skip that minute's slot. Both behaviours are pinned by tests.

**Honest limitation:** the measured incidents were all process restarts, and a restart resets `lastFiredMinute`, so this change does **not** recover the 14:00 slot in the 2026-08-17 sighting. That case is excluded by the no-replay-on-boot rule above, deliberately. What this fixes is every other cause of a missing tick within a live process: event-loop stalls, a suspended or overloaded host, and tick drift, where a 20s interval and a 60s window leave no margin. Closing the restart case properly needs a durable record of the last evaluated minute plus a policy for how stale a slot may be before it is dropped, which is a larger change than this one.

## Tests

Seven cases over `pendingMinutes` and six over the scheduler's tick decision, in `cron.test.ts` (`bun test src/server/cron.test.ts`: 46 pass, 0 fail):

- a 2 to 3 minute gap fires a `0 * * * *` automation whose minute fell in the gap
- a fresh boot fires nothing retroactively, and still fires the boot minute's own slot
- a gap longer than `MAX_CATCHUP_MINUTES` is clamped to the newest 5 and a `* * * * *` schedule fires once, not 30 times
- no double-fire: a slot covered by both catch-up and the following ticks runs exactly once
- an unparseable stored minute falls back to the current minute rather than replaying the window (a shape check, because `Date.parse` is lenient enough to turn a garbled key into a finite very old timestamp; caught by the test)

## Verification

- `bunx tsc --noEmit`: byte-identical to the baseline at the base commit, 0 errors both sides.
- `bun test src/server`: failure lists diffed against a detached worktree at the base commit. Baseline fluctuates between 31 and 32 failures run to run; the 32-failure baseline list is **identical** to this branch's. The mover is `report signals > persists urgency, confidence, and bounded structured highlights`, which fails in the unmodified baseline too and passes when its file is run alone. `reports.test.ts` writes into the live `~/.opensession-reports/`, shared with the running server and other sessions' test runs. No new failures from this change.

Started by Dreaming (nightly reflection) in [this OS session](https://os.tella.dev/session/os-01a01327-fe28-7000-b9f8-f5138044a420)
