### PR TITLE
Give automations a read of the audit digest

### DIFF
--- a/packages/core/opensession-server/src/server/audit-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/audit-mcp.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import { type AuditDigestDeps, auditDigestPayload } from "./audit-mcp";
+
+/** A digest stub with the fields the payload caps or reports on. `build`
+ *  records what it was asked for, so a rejected date can be shown never to
+ *  reach the filename. */
+function deps(
+  digest: Record<string, unknown> | null,
+  asked: string[] = []
+): AuditDigestDeps & { asked: string[] } {
+  return {
+    asked,
+    build: (date: string) => {
+      asked.push(date);
+      return digest ? structuredClone(digest) : null;
+    },
+    dates: () => ["2026-08-18", "2026-08-17"],
+  };
+}
+
+const DIGEST = {
+  date: "2026-08-18",
+  totals: { events: 12, sessions: 2, turns: 3, errors: 1 },
+  papercuts: [{ text: "one" }],
+  sessions: [{ id: "os-1", turns: 3 }],
+};
+
+describe("auditDigestPayload", () => {
+  it("returns the digest for a valid date", () => {
+    const d = deps(DIGEST);
+    const out = auditDigestPayload("2026-08-18", d);
+    expect(d.asked).toEqual(["2026-08-18"]);
+    expect(out.ok).toBe(true);
+    expect(out.totals).toEqual(DIGEST.totals);
+    expect(out.papercuts).toEqual(DIGEST.papercuts);
+    expect(out.truncated).toBeUndefined();
+  });
+
+  it("defaults to yesterday (UTC) when no date is given", () => {
+    const d = deps(DIGEST);
+    auditDigestPayload(undefined, d);
+    expect(d.asked).toEqual([new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)]);
+  });
+
+  it("rejects malformed dates without reaching the log", () => {
+    for (const bad of [
+      "../../etc/passwd",
+      "2026-08-18/../secret",
+      "2026-8-1",
+      "2026-08-18.jsonl",
+      "*",
+      "2026-08-18..2026-08-19",
+      "2026-08-18 2026-08-19",
+      "yesterday",
+    ]) {
+      const d = deps(DIGEST);
+      const out = auditDigestPayload(bad, d);
+      expect(out.ok).toBe(false);
+      expect(String(out.error)).toContain("YYYY-MM-DD");
+      // The rejected value must never have become a filename.
+      expect(d.asked).toEqual([]);
+    }
+  });
+
+  it("treats a blank date as an omitted one", () => {
+    const d = deps(DIGEST);
+    expect(auditDigestPayload("  ", d).ok).toBe(true);
+    expect(d.asked).toEqual([new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)]);
+  });
+
+  it("says so, with the days it does have, when there is no log", () => {
+    const out = auditDigestPayload("2020-01-01", deps(null));
+    expect(out.ok).toBe(false);
+    expect(out.date).toBe("2020-01-01");
+    expect(String(out.error)).toContain("no audit log for 2020-01-01");
+    expect(out.availableDates).toEqual(["2026-08-18", "2026-08-17"]);
+  });
+
+  it("caps the lists that grow with the day and says what it dropped", () => {
+    const big = {
+      ...DIGEST,
+      papercuts: Array.from({ length: 90 }, (_, i) => ({ text: `p${i}` })),
+      sessions: Array.from({ length: 60 }, (_, i) => ({ id: `os-${i}` })),
+    };
+    const out = auditDigestPayload("2026-08-18", deps(big));
+    expect(out.ok).toBe(true);
+    expect((out.papercuts as unknown[]).length).toBe(40);
+    expect((out.sessions as unknown[]).length).toBe(40);
+    expect(out.truncated).toEqual({
+      papercuts: { kept: 40, dropped: 50 },
+      sessions: { kept: 40, dropped: 20 },
+    });
+    expect(String(out.truncatedNote)).toContain("Totals");
+  });
+
+  it("drops detail sections when the capped digest is still outsized", () => {
+    const huge = {
+      ...DIGEST,
+      sessions: Array.from({ length: 40 }, (_, i) => ({ id: `os-${i}`, firstPrompt: "x".repeat(4000) })),
+    };
+    const out = auditDigestPayload("2026-08-18", deps(huge));
+    expect(JSON.stringify(out).length).toBeLessThan(120_000);
+    expect(out.sessions).toEqual([]);
+    expect((out.truncated as Record<string, { kept: number }>).sessions.kept).toBe(0);
+    // Totals survive whatever gets dropped.
+    expect(out.totals).toEqual(DIGEST.totals);
+  });
+});

--- a/packages/core/opensession-server/src/server/audit-mcp.ts
+++ b/packages/core/opensession-server/src/server/audit-mcp.ts
@@ -1,0 +1,132 @@
+/**
+ * `opensession-audit`: read one day of this instance's own audit log, rolled
+ * up. One tool, one optional date, no writes.
+ *
+ * It returns what GET /api/audit/digest serves: buildAuditDigest(date), the
+ * compact roll-up of a day's ~10-20MB jsonl that the nightly Dreaming
+ * reflection reads.
+ *
+ * Why a tool and not a fetch, same story as opensession-health. Dreaming is an
+ * unattended automation, and an automation cannot reach its own host over
+ * HTTP: web-fetch.ts refuses loopback and private addresses by design, and no
+ * engine gives an unattended ask run a shell to curl with. Nor can it read the
+ * files: Pi's ask tool list is read/grep/find/ls (pi-runner.ts) and those are
+ * sandboxed to the session workspace, so ~/.opensession-audit is out of reach.
+ * Moving automations to Pi (aeb73d59f) took the last path away, and the
+ * reflection ran blind.
+ *
+ * Held to the automation in-process bar, same as opensession-health and
+ * opensession-turn: the only argument is a date, validated against
+ * YYYY-MM-DD before it becomes a filename component, so untrusted text cannot
+ * steer it at a path, a glob or a range. It reads aggregate counters and
+ * already-redacted event fields, writes nothing, and there is nothing here to
+ * escalate with. Never grow this server past that: no raw event reads, no
+ * arbitrary file paths.
+ */
+
+import { z } from "zod";
+import { buildAuditDigest, listAuditDates } from "./audit";
+import { createSdkMcpServer, tool } from "./inprocess-mcp";
+
+/** A date is a filename component here, so nothing but a plain ISO day. */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Detail arrays are capped harder than the endpoint caps them: a busy day's
+ *  digest runs 50-70KB, which trips the engines' large-tool-output truncation
+ *  and lands as a cut inline view. Better to hand back a whole document that
+ *  says what it left out. */
+const MAX_PAPERCUTS = 40;
+const MAX_SESSIONS = 40;
+/** Last-resort ceiling if the capped digest is still outsized (many error
+ *  groups, long prompts). Detail sections drop until it fits. */
+const MAX_CHARS = 120_000;
+
+function yesterdayUtc(): string {
+  return new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+}
+
+export interface AuditDigestDeps {
+  build: (date: string) => Record<string, unknown> | null;
+  dates: () => string[];
+}
+
+/**
+ * The tool's whole answer, as data. Split out from the handler so the date
+ * validation, the missing-log case and the size caps are testable without a
+ * live audit directory (deps are injected in audit-mcp.test.ts).
+ */
+export function auditDigestPayload(
+  date: string | undefined,
+  deps: AuditDigestDeps = { build: buildAuditDigest, dates: listAuditDates }
+): Record<string, unknown> {
+  const day = date?.trim() || yesterdayUtc();
+  if (!DATE_RE.test(day)) {
+    return {
+      ok: false,
+      error: `invalid date ${JSON.stringify(day)}. Pass a single day as YYYY-MM-DD, or omit it for yesterday (UTC).`,
+    };
+  }
+
+  const digest = deps.build(day);
+  if (!digest) {
+    return {
+      ok: false,
+      date: day,
+      error: `no audit log for ${day}`,
+      availableDates: deps.dates().slice(0, 7),
+    };
+  }
+
+  const truncated: Record<string, { kept: number; dropped: number }> = {};
+  const cap = (key: string, max: number) => {
+    const list = digest[key];
+    if (!Array.isArray(list) || list.length <= max) return;
+    truncated[key] = { kept: max, dropped: list.length - max };
+    digest[key] = list.slice(0, max);
+  };
+  // Papercuts and sessions are the two that grow with the day's volume; every
+  // other section is already capped by buildAuditDigest.
+  cap("papercuts", MAX_PAPERCUTS);
+  cap("sessions", MAX_SESSIONS);
+
+  const payload: Record<string, unknown> = { ok: true, ...digest };
+  const size = () => JSON.stringify(payload).length;
+  // Drop whole detail sections, least useful first, until the document fits.
+  for (const key of ["sessions", "papercuts", "toolErrorGroups"]) {
+    if (size() <= MAX_CHARS) break;
+    const list = payload[key];
+    if (!Array.isArray(list) || list.length === 0) continue;
+    truncated[key] = { kept: 0, dropped: list.length + (truncated[key]?.dropped || 0) };
+    payload[key] = [];
+  }
+  if (Object.keys(truncated).length > 0) {
+    payload.truncated = truncated;
+    payload.truncatedNote =
+      "Some detail lists were shortened to keep this response readable. Totals above cover the whole day.";
+  }
+  return payload;
+}
+
+export function createAuditMcpServer() {
+  const tools = [
+    tool(
+      "read_audit_digest",
+      "Read one day of this instance's audit log, rolled up: totals (events, sessions, turns, errors, tool errors, cost), turn verdicts including silent drops, per-run-kind breakdown, model usage, the top recurring error and tool-error groups, top tools, one-shot counts, logged papercuts, and the most troubled sessions. Defaults to yesterday (UTC). Use this instead of trying to read ~/.opensession-audit or fetch the server over HTTP. Neither is reachable from an unattended run.",
+      {
+        date: z
+          .string()
+          .optional()
+          .describe("Day to read, as YYYY-MM-DD. Defaults to yesterday (UTC). One day only."),
+      },
+      async ({ date }) => ({
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(auditDigestPayload(date), null, 2),
+          },
+        ],
+      })
+    ),
+  ];
+  return createSdkMcpServer({ name: "opensession-audit", version: "1.0.0", tools });
+}

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -42,6 +42,7 @@ import { createPapercutsMcpServer } from "../agents/slack/papercuts-tools";
 import { createReportMcpServer } from "../agents/slack/report-tools";
 import { createWorkflowsMcpServer } from "../agents/slack/workflow-tools";
 import { createTurnMcpServer } from "../agents/slack/turn-tools";
+import { createAuditMcpServer } from "./audit-mcp";
 import { createHealthMcpServer } from "./health-mcp";
 import { papercutsEnabledForRepo } from "./papercuts";
 import {
@@ -942,6 +943,14 @@ function automationRunInProcessMcp(
     // refuses loopback, and an unattended ask run has no shell on either
     // engine (src/server/health-mcp.ts).
     "opensession-health": createHealthMcpServer(),
+    // And once more: one read of a single day's rolled-up audit log, whose
+    // only argument is a date validated as YYYY-MM-DD before it becomes a
+    // filename component. Nothing to steer, nothing to escalate with. Here
+    // for the same reason as its neighbour, and it is the nightly reflection
+    // that cannot read the log any other way: web-fetch.ts refuses loopback,
+    // and Pi's ask tools are sandboxed to the session workspace, so
+    // ~/.opensession-audit is unreachable (src/server/audit-mcp.ts).
+    "opensession-audit": createAuditMcpServer(),
   };
 }
 


### PR DESCRIPTION
## Why

Every automation runs on the Pi engine since aeb73d59f. Pi ask mode's local tool list is `["read","grep","find","ls"]` (`pi-runner.ts:1907`), those tools are sandboxed to the session workspace, and `automationRunInProcessMcp` does not mount `opensession-web` (which refuses loopback anyway, `web-fetch.ts`). Net effect: the nightly Dreaming reflection, whose entire job is to read yesterday's audit log, has no path to `~/.opensession-audit/*.jsonl` at all. It ran blind.

I verified each of those claims against the code before writing anything; they all hold at `faae15e2e`.

## What

`packages/core/opensession-server/src/server/audit-mcp.ts`, in the shape of the existing `health-mcp.ts` precedent: one in-process MCP server, `opensession-audit`, with one tool, `read_audit_digest`. It takes one optional `date` and returns `buildAuditDigest(date)`, the same roll-up `GET /api/audit/digest` serves. Mounted in `automationRunInProcessMcp` next to `opensession-health`. Automations only, nothing added to interactive runs or any other server set.

The bar it is held to, same as its neighbours: read-only, no writes, no shell, no network, no new env, and the only argument is a date.

- `date` is validated against `/^\d{4}-\d{2}-\d{2}$/` before it becomes a filename component, and a rejected value never reaches the log. Not a path, not a glob, not a range. A blank date reads as an omitted one (yesterday, UTC).
- A missing log returns `ok: false` with the days that do exist, rather than throwing.
- `papercuts` and `sessions` are capped, with a `truncated` block saying what was dropped. If the capped document is still outsized, whole detail sections drop until it fits, and the totals always survive. A busy day cannot return megabytes.

`audit-mcp.test.ts` covers the valid date, the default date, eight malformed dates (including `../../etc/passwd` and a range), the missing-log case, and both truncation paths.

## Checks

- `bun run typecheck`: clean, 0 errors.
- `bun test packages/core/opensession-server/src/server/audit-mcp.test.ts`: 7 pass, 0 fail.
- `bun scripts/check-module-side-effects.ts`: ok, 345 modules import cleanly.

This is a runner/automation-layer change, so it needs a deliberate `systemctl restart opensession` after merge.

**No reviewer was requested automatically. A human needs to be asked directly.**

Started by Dreaming (nightly reflection) in [this OS session](https://os.tella.dev/session/os-01a019ed-3395-7000-b641-92a222bca6d5)