### PR TITLE
Spin off: hand the link to the composer

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -5088,6 +5088,7 @@ export function SessionViewer({
 						entries={entries}
 						send={send}
 						connected={connected}
+						onOpenNewSession={onOpenNewSession}
 					/>
 				);
 				// Archive is the reversible primary "done with this" action — it sits

--- a/packages/core/opensession-server/src/frontend/components/SpinOffMenu.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SpinOffMenu.tsx
@@ -8,6 +8,8 @@ import type { UnifiedSession, TranscriptEntry } from "../lib/types";
 import { getCurrentUser } from "./UserPicker";
 import { Field, fieldClasses } from "../ui/input";
 import { noAutofill } from "../lib/composer-autofill";
+import { composerSessionRef } from "../lib/share-link";
+import type { NewSessionPrefill } from "../lib/new-session-link";
 
 type Flavor = "build" | "learnings" | "analyze";
 
@@ -16,6 +18,9 @@ interface Props {
   entries: TranscriptEntry[];
   send: (msg: any) => void;
   connected: boolean;
+  /** Open the new-session composer prefilled — the one flavor that writes no
+      prompt of its own. */
+  onOpenNewSession: (prefill: NewSessionPrefill) => void;
 }
 
 /**
@@ -23,8 +28,18 @@ interface Props {
  *  - build:     ask → code handoff with conversation context (Devin's "spin-off")
  *  - learnings: code session that feeds durable learnings back into the repo's docs as a PR
  *  - analyze:   ask session reviewing what went well/wrong + better prompt
+ *
+ * A fourth row spins nothing off itself: it opens the new-session composer with
+ * a link to this session already in the draft, for when the handoff is one the
+ * person wants to word themselves.
  */
-export function SpinOffMenu({ session, entries, send, connected }: Props) {
+export function SpinOffMenu({
+  session,
+  entries,
+  send,
+  connected,
+  onOpenNewSession,
+}: Props) {
   const [flavor, setFlavor] = useState<Flavor | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [branch, setBranch] = useState("");
@@ -46,6 +61,17 @@ export function SpinOffMenu({ session, entries, send, connected }: Props) {
       setBranch(`opensession-learnings-${dateStamp()}`);
       setTask("");
     }
+  }
+
+  function openLinkedSession() {
+    onOpenNewSession({
+      // A reference, not a transcript: the new session reads this one through
+      // the link when it needs to, instead of carrying a copy that goes stale.
+      // The trailing space parks the caret clear of the chip.
+      prompt: `${composerSessionRef(session)} `,
+      mode: session.mode ?? "code",
+      ...(session.repo ? { repo: session.repo } : {}),
+    });
   }
 
   function start() {
@@ -164,6 +190,12 @@ export function SpinOffMenu({ session, entries, send, connected }: Props) {
           <Menu.Item closeOnClick={false} onClick={() => pick("analyze")} className={itemCls}>
             <span className="text-label font-semibold text-fg">Analyze session</span>
             <span className="text-supporting leading-[1.4] text-faint">What went well, what didn't, and a better prompt</span>
+          </Menu.Item>
+          {/* Closes the whole menu rather than opening the form above: there is
+              nothing to fill in here, the composer IS the form. */}
+          <Menu.Item onClick={openLinkedSession} className={itemCls}>
+            <span className="text-label font-semibold text-fg">Reference this session</span>
+            <span className="text-supporting leading-[1.4] text-faint">Opens the new-session composer with a link to this one — you write the prompt</span>
           </Menu.Item>
         </Menu.Popup>
       </Menu.SubmenuRoot>

--- a/packages/core/opensession-server/src/frontend/lib/session-url.ts
+++ b/packages/core/opensession-server/src/frontend/lib/session-url.ts
@@ -25,6 +25,15 @@ export const UUIDV7 =
  */
 const MINTED_SESSION_ID = new RegExp(`^(?:os|bks)-${UUIDV7}$`, "i");
 
+/**
+ * Whether an id stands on its own as a reference — see `MINTED_SESSION_ID`.
+ * The question anyone WRITING a reference has to ask, which is the mirror of
+ * the one `pastedSessionId` asks when reading one.
+ */
+export function isMintedSessionId(id: string): boolean {
+	return MINTED_SESSION_ID.test(id);
+}
+
 // Links into OS1 itself must not open a new window — it's the same app. Known
 // public hosts cover links pasted as absolute URLs viewed from another origin
 // (e.g. the ts.net entry); same-origin covers everything else, prefix included
@@ -101,7 +110,7 @@ export function pastedSessionId(pasted: string): string | undefined {
 	const text = pasted.trim();
 	if (!text || /\s/.test(text)) return undefined;
 	const id = internalUrlTarget(text)?.sessionId;
-	return id && MINTED_SESSION_ID.test(id) ? id : undefined;
+	return id && isMintedSessionId(id) ? id : undefined;
 }
 
 /**

--- a/packages/core/opensession-server/src/frontend/lib/share-link.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/share-link.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	composerSessionRef,
 	sessionPath,
 	splitSessionRef,
 	subagentSuffix,
@@ -90,6 +91,22 @@ describe("workspacePanePath", () => {
 		);
 		expect(workspacePanePath("ws 1", "conversation")).toBe(
 			"/workspace/ws%201/conversation",
+		);
+	});
+});
+
+describe("composerSessionRef", () => {
+	const MINTED = "os-01a01ae5-ce77-7000-8874-98ded6c9208f";
+
+	test("writes a minted session as the bare id the composer chips", () => {
+		expect(composerSessionRef({ id: MINTED, workspaceId: "ws-1" })).toBe(MINTED);
+	});
+
+	test("keeps the whole URL for an id that has no bare form", () => {
+		// @ts-expect-error — jsdom-less test env; absoluteLink only reads origin.
+		globalThis.location = { origin: "https://os.tella.dev" };
+		expect(composerSessionRef({ id: "bks-ghpr-5099-review" })).toBe(
+			"https://os.tella.dev/session/bks-ghpr-5099-review",
 		);
 	});
 });

--- a/packages/core/opensession-server/src/frontend/lib/share-link.ts
+++ b/packages/core/opensession-server/src/frontend/lib/share-link.ts
@@ -4,6 +4,7 @@
 // textarea + execCommand, the same trick the viewer's share button uses.
 
 import { BASE_PATH } from "./base";
+import { isMintedSessionId } from "./session-url";
 
 /**
  * Canonical session/workspace URL path — workspace-scoped when the session has
@@ -70,6 +71,27 @@ export function prPath(repo: string, branch: string): string {
 /** Absolute link for a path built above. */
 export function absoluteLink(path: string): string {
   return `${location.origin}${path}`;
+}
+
+/**
+ * How to write a reference to a session INTO a composer draft.
+ *
+ * The bare id, because that is the form the composer settles on anyway: a
+ * pasted session URL is rewritten to its id the moment it lands
+ * (`insertPastedSessionId` in lib/session-url.ts), and the id is what paints
+ * as a chip carrying the session's title. Handing the composer a URL it would
+ * immediately shorten would be taking the long way round on purpose.
+ *
+ * An id older than the minted shape has no bare form that chips, so it keeps
+ * its whole URL — the renderer reads that too.
+ */
+export function composerSessionRef(session: {
+  id: string;
+  workspaceId?: string | null;
+}): string {
+  return isMintedSessionId(session.id)
+    ? session.id
+    : absoluteLink(sessionPath(session));
 }
 
 /**


### PR DESCRIPTION
"Spin off" had three rows and all of them write the prompt for you: Build this, Capture learnings, Analyze session. There was no way to say "start something new, but from here" in your own words.

This adds a fourth row that spins nothing off itself — it opens the new-session composer with a reference to this session already in the draft, caret parked after it. No modal, no branch field, no generated prompt: the composer *is* the form.

The reference written into the draft is the bare session id rather than the URL, because that is the form the composer settles on anyway — a pasted session link is rewritten to its id the moment it lands (`insertPastedSessionId`), and the id is what paints as a chip carrying the session's title. Handing the composer a URL it would immediately shorten would be taking the long way round on purpose. A session whose id predates the minted shape has no bare form that chips, so it keeps its whole URL, which the renderer reads too.

`composerSessionRef` in `lib/share-link.ts` is the new helper (covered by tests); `isMintedSessionId` is now exported from `lib/session-url.ts` so the write side asks the same question the read side already did.

Created by [this OS session](https://os.tella.dev/session/os-01a01ae5-ce77-7000-8874-98ded6c9208f)