### PR TITLE
Fix outward-effect tool identifiers

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/admin-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/admin-tools.ts
@@ -443,9 +443,9 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
           let mcpServers = args.mcpServers;
           if (replyInThread) {
             prompt +=
-              `\n\nDeliver this by posting to Slack channel \`${ctx.channel}\` in thread \`${ctx.threadTs}\` ` +
-              "via the Slack MCP `conversations_add_message` (content_type text/markdown). Open with \"⏰ \", " +
-              `say it's you, ${personaName()}, and keep it concise.`;
+              `\n\nDeliver this with the Slack MCP \`slack_reply_to_thread\`: pass \`channel_id\` ` +
+              `\`${ctx.channel}\`, \`thread_ts\` \`${ctx.threadTs}\`, and the reminder as \`text\`. ` +
+              `Open with "⏰ ", say it's you, ${personaName()}, and keep it concise.`;
             // Make sure the run can reach Slack even if the caller restricted servers.
             if (mcpServers) mcpServers = Array.from(new Set([...mcpServers, "slack"]));
           }

--- a/packages/core/opensession-server/src/server/turn-outcome.test.ts
+++ b/packages/core/opensession-server/src/server/turn-outcome.test.ts
@@ -13,11 +13,18 @@ import {
 describe("isReachTool", () => {
   test("matches the mcp__server__tool spelling", () => {
     expect(isReachTool("mcp__plain__create_note")).toBe(true);
-    expect(isReachTool("mcp__slack__conversations_add_message")).toBe(true);
+    expect(isReachTool("mcp__slack__slack_post_message")).toBe(true);
+    expect(isReachTool("mcp__slack__slack_reply_to_thread")).toBe(true);
+    expect(isReachTool("mcp__linear__save_comment")).toBe(true);
+    expect(isReachTool("mcp__linear__save_issue")).toBe(true);
   });
 
   test("matches the pi <server>_<tool> spelling the engine reports", () => {
     expect(isReachTool("plain_create_note")).toBe(true);
+    expect(isReachTool("slack_slack_post_message")).toBe(true);
+    expect(isReachTool("slack_slack_reply_to_thread")).toBe(true);
+    expect(isReachTool("linear_save_comment")).toBe(true);
+    expect(isReachTool("linear_save_issue")).toBe(true);
     expect(isReachTool("opensession-report_publish_report")).toBe(true);
   });
 
@@ -27,6 +34,9 @@ describe("isReachTool", () => {
 
   test("does not match reads, unrelated tools, or nothing at all", () => {
     expect(isReachTool("mcp__plain__get_thread")).toBe(false);
+    expect(isReachTool("slack_slack_get_thread_replies")).toBe(false);
+    expect(isReachTool("linear_get_issue")).toBe(false);
+    expect(isReachTool("linear_save_customer")).toBe(false);
     expect(isReachTool("bash")).toBe(false);
     expect(isReachTool("mcp__gmail__draft_email")).toBe(false);
     expect(isReachTool(undefined)).toBe(false);
@@ -97,10 +107,10 @@ describe("ledger", () => {
     beginTurn({ key: "bks-effects", kind: "automation" });
     recordEffect("bks-effects", "mcp__plain__create_note");
     recordEffect("bks-effects", "mcp__plain__create_note");
-    recordEffect("bks-effects", "mcp__linear__create_issue");
+    recordEffect("bks-effects", "mcp__linear__save_issue");
     expect(getTurn("bks-effects")!.effects).toEqual([
       "mcp__plain__create_note",
-      "mcp__linear__create_issue",
+      "mcp__linear__save_issue",
     ]);
     expect(endTurn("bks-effects")!.verdict).toBe("reached");
   });

--- a/packages/core/opensession-server/src/server/turn-outcome.ts
+++ b/packages/core/opensession-server/src/server/turn-outcome.ts
@@ -70,10 +70,11 @@ const REACH_TOOLS = [
   "mcp__plain__create_note",
   "mcp__plain__reply_to_thread",
   // Slack — a message in a channel or DM.
-  "mcp__slack__conversations_add_message",
-  // Linear — a comment or a new issue on the team's board.
-  "mcp__linear__create_comment",
-  "mcp__linear__create_issue",
+  "mcp__slack__slack_post_message",
+  "mcp__slack__slack_reply_to_thread",
+  // Linear — a comment or an issue created or updated on the team's board.
+  "mcp__linear__save_comment",
+  "mcp__linear__save_issue",
   // Gmail — outbound mail (a draft is not delivery; sending is).
   "mcp__gmail__send_email",
   // Our own in-process servers: a published report, and asking a teammate.


### PR DESCRIPTION
## Summary
- replace stale Slack reach-tool identifiers with the mounted post and thread-reply tools
- recognize Linear's catalog-backed `save_comment` and `save_issue` writes
- update one-off Slack reminder instructions to call `slack_reply_to_thread` with its current arguments
- pin the exact Pi event spellings while keeping reads and unrelated `save_*` tools excluded

## Evidence
- `scripts/mcp-slack.ts` and the mounted tool catalog expose `slack_post_message` and `slack_reply_to_thread`
- Pi mounts MCP tools as `<server>_<tool>`, producing `slack_slack_post_message` and `slack_slack_reply_to_thread`
- Linear's mounted catalog describes `save_comment` and `save_issue` as create-or-update writes

## Tests
- `bun test packages/core/opensession-server/src/server/turn-outcome.test.ts`
- `bunx tsc --noEmit --pretty false` (blocked by a pre-existing `Setup.tsx` `compact` prop error outside this change)

Started by Dreaming (nightly reflection) in [this OS session](https://os.tella.dev/session/os-01a01d7c-40ae-7000-a380-524b468ca0a9)
