### PR TITLE
Fix Pi audit digest turn aggregation

### DIFF
--- a/packages/core/opensession-server/src/server/audit.test.ts
+++ b/packages/core/opensession-server/src/server/audit.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { buildAuditDigestFromLines } from "./audit";
+
+const digest = (...events: Array<Record<string, unknown>>) =>
+  buildAuditDigestFromLines("2026-08-19", events.map((event) => JSON.stringify(event)).join("\n"));
+
+function totals(value: Record<string, unknown>): Record<string, unknown> {
+  return value.totals as Record<string, unknown>;
+}
+
+function byRunKind(value: Record<string, unknown>): Record<string, Record<string, unknown>> {
+  return value.byRunKind as Record<string, Record<string, unknown>>;
+}
+
+describe("buildAuditDigest", () => {
+  test("keeps historical generic terminals and learns metadata from later events", () => {
+    const value = digest(
+      { msg: "session_created", session_id: "legacy" },
+      {
+        kind: "user_prompt",
+        session_id: "legacy",
+        run_kind: "automation",
+        mode: "ask",
+        model: "opencode/anthropic/claude-fable-5",
+        text_snippet: "check the queue",
+      },
+      {
+        kind: "result",
+        session_id: "legacy",
+        run_kind: "automation",
+        mode: "ask",
+        duration_ms: 120,
+        total_cost_usd: 1.25,
+      },
+      {
+        kind: "error",
+        session_id: "legacy-error",
+        run_kind: "prompt",
+        mode: "code",
+        error: "historical failure",
+      },
+    );
+
+    expect(totals(value)).toMatchObject({ turns: 1, errors: 1, costUsd: 1.25 });
+    expect(byRunKind(value).automation).toMatchObject({ sessions: 1, turns: 1, costUsd: 1.25 });
+    expect(byRunKind(value).prompt).toMatchObject({ sessions: 1, errors: 1 });
+    expect(byRunKind(value)["?"]).toBeUndefined();
+  });
+
+  test("counts each terminal Pi turn once across retries, fallbacks, and mixed generic events", () => {
+    const value = digest(
+      { msg: "session_created", session_id: "pi-session" },
+      {
+        msg: "pi_turn",
+        direction: "out",
+        session: "pi-session",
+        request_id: "attempt-1",
+        run_key: "native-session",
+        run_kind: "prompt",
+        mode: "code",
+        model: "pi/anthropic/claude-fable-5",
+        ok: false,
+        error: "primary exhausted",
+        total_cost_usd: 0.25,
+      },
+      {
+        kind: "error",
+        session_id: "pi-session",
+        run_kind: "prompt",
+        mode: "code",
+        error: "mirrored attempt failure",
+      },
+      {
+        msg: "pi_turn",
+        kind: "account_switch",
+        direction: "out",
+        session: "pi-session",
+        request_id: "attempt-1",
+        run_kind: "prompt",
+        model: "pi/openai/gpt-5.6-sol",
+        total_cost_usd: 20,
+      },
+      {
+        msg: "pi_turn",
+        direction: "out",
+        session: "pi-session",
+        request_id: "attempt-2",
+        run_key: "fallback-native-session",
+        run_kind: "prompt-fallback",
+        mode: "code",
+        model: "pi/openai/gpt-5.6-sol",
+        ok: true,
+        total_cost_usd: 0.75,
+      },
+      {
+        kind: "result",
+        session_id: "pi-session",
+        run_kind: "prompt-fallback",
+        total_cost_usd: 99,
+      },
+      {
+        kind: "session_turn_metric",
+        session_id: "pi-session",
+        duration_ms: 500,
+        outcome: "ok",
+      },
+      {
+        msg: "pi_turn",
+        direction: "out",
+        session: "pi-session",
+        request_id: "attempt-3",
+        run_kind: "prompt",
+        mode: "code",
+        model: "pi/openai/gpt-5.6-sol",
+        ok: false,
+        error: "terminal Pi failure",
+        total_cost_usd: 0.5,
+      },
+      {
+        kind: "error",
+        session_id: "pi-session",
+        run_kind: "prompt",
+        error: "mirrored terminal failure",
+      },
+      {
+        kind: "session_turn_metric",
+        session_id: "pi-session",
+        duration_ms: 200,
+        outcome: "failed",
+      },
+      // Utility Pi calls have no Open Session id and never join session totals.
+      {
+        msg: "pi_turn",
+        direction: "out",
+        run_key: "oneshot-title",
+        run_kind: "prompt",
+        model: "pi/openai/gpt-5.6-sol",
+        ok: true,
+        total_cost_usd: 40,
+      },
+      { msg: "pi_oneshot", status: "ok", run_key: "oneshot-title" },
+    );
+
+    expect(totals(value)).toMatchObject({
+      sessions: 1,
+      turns: 2,
+      errors: 1,
+      costUsd: 1.5,
+    });
+    expect(byRunKind(value).prompt).toMatchObject({
+      sessions: 1,
+      turns: 2,
+      errors: 1,
+      costUsd: 1.5,
+    });
+    expect(byRunKind(value)["?"]).toBeUndefined();
+    expect(value.oneshots).toEqual({ total: 1, failed: 0 });
+    expect(value.errorGroups).toEqual([
+      expect.objectContaining({ count: 1, sample: "terminal Pi failure", runKinds: ["prompt"] }),
+    ]);
+  });
+});

--- a/packages/core/opensession-server/src/server/audit.ts
+++ b/packages/core/opensession-server/src/server/audit.ts
@@ -225,7 +225,14 @@ export function buildAuditDigest(date: string): Record<string, unknown> | null {
   ensureAuditDir();
   const path = `${AUDIT_DIR}/audit-${date}.jsonl`;
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !existsSync(path)) return null;
+  return buildAuditDigestFromLines(date, readFileSync(path, "utf-8"));
+}
 
+/** Pure digest builder used by focused mixed-format fixtures. */
+export function buildAuditDigestFromLines(
+  date: string,
+  contents: string,
+): Record<string, unknown> {
   interface SessionAgg {
     id: string;
     runKind: string;
@@ -241,15 +248,22 @@ export function buildAuditDigest(date: string): Record<string, unknown> | null {
     costUsd: number;
   }
   const sessions = new Map<string, SessionAgg>();
+  const eventSessionId = (e: Record<string, unknown>): string =>
+    String(
+      e.session_id ||
+        e.bks_session_id ||
+        (e.msg === "pi_turn" ? e.session : "") ||
+        "",
+    );
   const sessionOf = (e: Record<string, unknown>): SessionAgg | null => {
-    const id = String(e.session_id || e.bks_session_id || "");
+    const id = eventSessionId(e);
     if (!id) return null;
     let s = sessions.get(id);
     if (!s) {
       s = {
         id,
-        runKind: String(e.run_kind || "?"),
-        mode: String(e.mode || "?"),
+        runKind: "?",
+        mode: "?",
         models: new Set(),
         firstPrompt: "",
         turns: 0,
@@ -262,6 +276,10 @@ export function buildAuditDigest(date: string): Record<string, unknown> | null {
       };
       sessions.set(id, s);
     }
+    // Session creation and queue events often arrive before runner metadata.
+    // Keep the first useful identity rather than freezing those early blanks.
+    if (s.runKind === "?" && e.run_kind) s.runKind = String(e.run_kind);
+    if (s.mode === "?" && e.mode) s.mode = String(e.mode);
     if (e.model) s.models.add(String(e.model));
     return s;
   };
@@ -302,14 +320,56 @@ export function buildAuditDigest(date: string): Record<string, unknown> | null {
   let engineRetries = 0;
   let costUsd = 0;
 
-  for (const line of readFileSync(path, "utf-8").split("\n")) {
+  const parsedEvents: Array<Record<string, unknown>> = [];
+  for (const line of contents.split("\n")) {
     if (!line) continue;
-    let e: Record<string, unknown>;
     try {
-      e = JSON.parse(line);
+      parsedEvents.push(JSON.parse(line));
     } catch {
-      continue;
+      // A partially-written final line must not discard the rest of the day.
     }
+  }
+
+  interface PiLogicalTurn {
+    attempts: Array<Record<string, unknown>>;
+  }
+  const piTurns = new Map<Record<string, unknown>, PiLogicalTurn>();
+  const genericTerminalsToSkip = new Set<Record<string, unknown>>();
+  const pendingPi = new Map<string, Array<Record<string, unknown>>>();
+  const pendingGeneric = new Map<string, Array<Record<string, unknown>>>();
+
+  // `pi_turn` is an attempt, not a person's turn: account retries and model
+  // fallbacks each close one, and continuation/utility runs may use the same
+  // shape. `session_turn_metric` is emitted once, after the outer runner walk
+  // settles. Pair only session-bearing attempts with that terminal marker.
+  // This excludes one-shots and lets mixed-format deployments prefer Pi's
+  // logical terminal without also counting their mirrored generic terminal.
+  for (const e of parsedEvents) {
+    const id = eventSessionId(e);
+    if (!id) continue;
+    if (e.msg === "pi_turn" && e.direction === "out" && !e.kind) {
+      const attempts = pendingPi.get(id) || [];
+      attempts.push(e);
+      pendingPi.set(id, attempts);
+    }
+    if ((e.kind === "result" || e.kind === "error") && pendingPi.has(id)) {
+      const terminals = pendingGeneric.get(id) || [];
+      terminals.push(e);
+      pendingGeneric.set(id, terminals);
+    }
+    if (e.kind === "session_turn_metric") {
+      const attempts = pendingPi.get(id) || [];
+      const genericTerminals = pendingGeneric.get(id) || [];
+      if (attempts.length) {
+        piTurns.set(e, { attempts });
+        for (const terminal of genericTerminals) genericTerminalsToSkip.add(terminal);
+      }
+      pendingPi.delete(id);
+      pendingGeneric.delete(id);
+    }
+  }
+
+  for (const e of parsedEvents) {
     events++;
     if (e.msg === "pi_oneshot") {
       oneshots.total++;
@@ -321,6 +381,45 @@ export function buildAuditDigest(date: string): Record<string, unknown> | null {
       continue;
     }
     const s = sessionOf(e);
+    const piTurn = piTurns.get(e);
+    if (piTurn) {
+      turns++;
+      const failed = e.outcome === "failed";
+      const cost = piTurn.attempts.reduce(
+        (sum, attempt) => sum + (Number(attempt.total_cost_usd) || 0),
+        0,
+      );
+      costUsd += cost;
+      if (s) {
+        s.turns++;
+        s.durationMs += Number(e.duration_ms) || 0;
+        s.costUsd += cost;
+      }
+      const terminalModel = [...piTurn.attempts].reverse().find((attempt) => attempt.model)?.model;
+      if (terminalModel) {
+        models.set(String(terminalModel), (models.get(String(terminalModel)) || 0) + 1);
+      }
+      if (failed) {
+        errors++;
+        if (s) s.errors++;
+        const failedAttempt = [...piTurn.attempts]
+          .reverse()
+          .find((attempt) => attempt.ok === false || attempt.error);
+        const raw = String(failedAttempt?.error || "Pi turn failed");
+        const g = errorGroups.get(normalize(raw)) || {
+          count: 0,
+          runKinds: new Set<string>(),
+          sample: raw.slice(0, 300),
+          sampleSession: s?.id || "",
+        };
+        g.count++;
+        g.runKinds.add(s?.runKind || "?");
+        errorGroups.set(normalize(raw), g);
+      }
+      continue;
+    }
+    if (genericTerminalsToSkip.has(e)) continue;
+
     switch (String(e.kind || "")) {
       case "user_prompt":
         if (e.model) models.set(String(e.model), (models.get(String(e.model)) || 0) + 1);


### PR DESCRIPTION
## Summary
- treat `session_turn_metric` as the logical Pi turn terminal and aggregate the session-bearing `pi_turn` attempts that precede it
- exclude one-shots, continuation-only records, and non-terminal account-switch records from session turn totals
- prefer the Pi logical terminal over mirrored generic result/error events during mixed-format periods
- enrich session run kind and mode when runner metadata first appears instead of freezing early unknown values

## Evidence
- `bun test packages/core/opensession-server/src/server/audit.test.ts packages/core/opensession-server/src/server/audit-mcp.test.ts`
- `bunx tsc --noEmit --pretty false` (the only reported error is the pre-existing `Setup.tsx:343` compact prop mismatch outside this PR)
- replaying `audit-2026-08-19.jsonl` changes unknown run-kind sessions from 499/501 to 14/501 and reports 641 logical turns, 68 terminal errors, and $2,399.48 after including Pi turns

Started by Dreaming (nightly reflection) in [this OS session](https://os.tella.dev/session/os-01a01d7c-1c84-7000-808d-0149dff0d00e)
