### PR TITLE
Simple mode 3/5: bring your own GitHub App, with optional org sign-in

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -116,6 +116,7 @@
       "enabled": false,
       "userPrAuth": false,
       "oauthClientId": "",
+      "appSlug": "",
       "mentionHandles": [
         "assistant",
         "acme-automation"

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -233,47 +233,46 @@ What turns on (`packages/core/opensession-server/src/server/github-auth.ts`, `we
 
 A **simple-mode install** is one person on their own box: no operator config, no
 bot machine-user, no `gh auth login`, and no sign-in gate. Such a user still
-needs their **private** repos available — to list them in the repo picker, clone
-them, and open PRs as themselves. Connect a **personal access token**, pasted
-once, with nothing to provision:
+needs their **private** repos available, to list them in the repo picker, clone
+them, and open PRs as themselves. Simple mode connects with a **GitHub App you
+create**, configured entirely in the UI: no file editing, no restart.
 
-1. Create a token. A **fine-grained** token is the recommendation:
-   [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new).
-   Scope it to the repositories you want to expose and grant permissions
-   **Contents: Read and write** and **Pull requests: Read and write** (Metadata:
-   Read is added automatically). A **classic** token with the `repo` scope also
-   works — you get a bearer token either way.
-2. Settings → Connections → **GitHub**: paste the token and **Save**. It is
-   validated with `GET /user`, and stored server-side under the login GitHub
-   reports (`~/.opensession-github-auth.json`, 0600) with no expiry — never
-   shown again. That single account becomes *the* account for this install
-   (there is no roster in simple mode; the one connected account is the acting
-   identity). **Disconnect** removes it.
+1. **Create the app.** Settings → Connections → **GitHub App** opens a wizard
+   whose link lands on `github.com/settings/apps/new` pre-filled: a generated,
+   likely-unique name, private, no webhook, **Device Flow enabled**, permissions
+   **Contents: Read & write** and **Pull requests: Read & write** (Metadata: Read
+   is automatic). Pick the owner: your personal account, or an organization (a
+   team's app should be org-owned so the org owns it and can reach org repos).
+   On that page, **generate a client secret** and copy it, then create the app.
+2. **Paste the details.** Back in the wizard, paste the **Client ID**, the app
+   **slug** (from the app's URL), and the **client secret**. All three are
+   required. The secret is stored 0600 so Open Session can refresh the ~8h
+   user-to-server token; without it the connection would lapse.
+3. **Install on your repositories.** Follow the install link and pick the repos
+   to expose. A user-to-server token only reaches repos the app is installed on.
+4. **Connect.** Enter the one-time code at `github.com/login/device`. The token
+   is stored under the login GitHub reports (`~/.opensession-github-auth.json`,
+   0600, never shown again). Private clones use it through a temporary
+   `GIT_ASKPASS` (never written into the remote), and a per-checkout credential
+   helper keeps later `fetch`/`push` authenticated. No `gh` CLI or
+   `GITHUB_API_TOKEN` is involved.
 
-Private clones use the connected token without ever writing it into the remote:
-the clone runs with a temporary `GIT_ASKPASS` helper, and `origin` is left as the
-plain `https://github.com/<owner>/<repo>.git`. No `gh` CLI or `GITHUB_API_TOKEN`
-is involved.
+The single connected account is *the* account for this install (there is no
+roster in simple mode; the one connected account is the acting identity).
+**Disconnect** removes it; **Remove app** clears the configured client id, slug,
+and secret and returns the section to unconfigured. There is no personal-access-
+token path: the App is the only simple-mode connect.
 
-This is entirely decoupled from [per-user GitHub auth](#per-user-github-auth-prs-as-the-session-owner)
-above: connecting a token in simple mode does **not** turn on the sign-in gate.
-That gate is still governed solely by `integrations.github.userPrAuth`.
+### Graduating to per-user sign-in
 
-### Operator override: bring your own GitHub App
-
-No App is shipped and none is required. An operator who prefers an
-**installable** connect — a user-to-server token scoped to selected repos rather
-than a pasted PAT — can register their own public GitHub App and configure its
-client id. The simple-mode card then also offers GitHub's device flow.
-
-Set `OPENSESSION_GITHUB_CLIENT_ID` (env) or `integrations.github.oauthClientId`
-(config), plus `OPENSESSION_GITHUB_APP_SLUG` / `integrations.github.appSlug` for
-the install URL. The App wants **Device Flow: ON**, **Expire user authorization
-tokens: OFF** (so the `ghu_` token is non-expiring and no client secret is ever
-needed — the device flow is a public-client flow), permissions **Contents: Read
-& write**, **Pull requests: Read & write**, **Metadata: Read**, no webhook, and
-no callback URL. Absent a configured client id this path stays hidden; the PAT
-field is always present.
+Connecting the app does **not** by itself turn on the sign-in gate (governed
+solely by `integrations.github.userPrAuth`). Because the App's client id is the
+*same* key sign-in reads, graduating a team to
+[per-user GitHub auth](#per-user-github-auth-prs-as-the-session-owner) is a
+one-flag change, or automatic for an org-owned app: `install.sh --org <name>`
+(or choosing the Organization owner in the wizard) records the org, and at the
+connect step rosters the connecting account as the first admin and enables
+sign-in in one locked write. A personal app stays single-user with no gate.
 
 ## Deploy script
 

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -240,8 +240,10 @@ create**, configured entirely in the UI: no file editing, no restart.
 1. **Create the app.** Settings → Connections → **GitHub App** opens a wizard
    whose link lands on `github.com/settings/apps/new` pre-filled: a generated,
    likely-unique name, private, no webhook, **Device Flow enabled**, permissions
-   **Contents: Read & write** and **Pull requests: Read & write** (Metadata: Read
-   is automatic). Pick the owner: your personal account, or an organization (a
+   **Contents: Read & write**, **Pull requests: Read & write**, and organization
+   **Members: Read** (Metadata: Read is automatic). The Members permission lets
+   org setup import private memberships into the sign-in roster. Pick the owner:
+   your personal account, or an organization (a
    team's app should be org-owned so the org owns it and can reach org repos).
    On that page, **generate a client secret** and copy it, then create the app.
 2. **Paste the details.** Back in the wizard, paste the **Client ID**, the app

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -229,6 +229,52 @@ What turns on (`packages/core/opensession-server/src/server/github-auth.ts`, `we
   connections (per-teammate status, disconnect) in the Connections UI.
 - `GET /api/health` stays un-gated (deploy polls / restart detection).
 
+## Connecting GitHub in simple mode
+
+A **simple-mode install** is one person on their own box: no operator config, no
+bot machine-user, no `gh auth login`, and no sign-in gate. Such a user still
+needs their **private** repos available — to list them in the repo picker, clone
+them, and open PRs as themselves. Connect a **personal access token**, pasted
+once, with nothing to provision:
+
+1. Create a token. A **fine-grained** token is the recommendation:
+   [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new).
+   Scope it to the repositories you want to expose and grant permissions
+   **Contents: Read and write** and **Pull requests: Read and write** (Metadata:
+   Read is added automatically). A **classic** token with the `repo` scope also
+   works — you get a bearer token either way.
+2. Settings → Connections → **GitHub**: paste the token and **Save**. It is
+   validated with `GET /user`, and stored server-side under the login GitHub
+   reports (`~/.opensession-github-auth.json`, 0600) with no expiry — never
+   shown again. That single account becomes *the* account for this install
+   (there is no roster in simple mode; the one connected account is the acting
+   identity). **Disconnect** removes it.
+
+Private clones use the connected token without ever writing it into the remote:
+the clone runs with a temporary `GIT_ASKPASS` helper, and `origin` is left as the
+plain `https://github.com/<owner>/<repo>.git`. No `gh` CLI or `GITHUB_API_TOKEN`
+is involved.
+
+This is entirely decoupled from [per-user GitHub auth](#per-user-github-auth-prs-as-the-session-owner)
+above: connecting a token in simple mode does **not** turn on the sign-in gate.
+That gate is still governed solely by `integrations.github.userPrAuth`.
+
+### Operator override: bring your own GitHub App
+
+No App is shipped and none is required. An operator who prefers an
+**installable** connect — a user-to-server token scoped to selected repos rather
+than a pasted PAT — can register their own public GitHub App and configure its
+client id. The simple-mode card then also offers GitHub's device flow.
+
+Set `OPENSESSION_GITHUB_CLIENT_ID` (env) or `integrations.github.oauthClientId`
+(config), plus `OPENSESSION_GITHUB_APP_SLUG` / `integrations.github.appSlug` for
+the install URL. The App wants **Device Flow: ON**, **Expire user authorization
+tokens: OFF** (so the `ghu_` token is non-expiring and no client secret is ever
+needed — the device flow is a public-client flow), permissions **Contents: Read
+& write**, **Pull requests: Read & write**, **Metadata: Read**, no webhook, and
+no callback URL. Absent a configured client id this path stays hidden; the PAT
+field is always present.
+
 ## Deploy script
 
 `deploy/deploy.sh` updates a running box in place. There is no deploy workflow

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,11 @@
 #                                              sign-in); off by default
 #   --tailscale           WITH_TAILSCALE=1     also install Tailscale (off by
 #                                              default; --no-tailscale still accepted)
+#   --org <name>          OPENSESSION_ORG      set this instance up for a GitHub
+#                                              org: an org-owned GitHub App plus
+#                                              per-user sign-in, turned on when
+#                                              the first admin connects. Omit for
+#                                              a single-user install.
 #   --advanced                                 interactive onboarding (all the
 #                                              questions); default writes defaults
 #                                              and asks nothing
@@ -58,6 +63,10 @@ RELEASE_BASE="${OPENSESSION_RELEASE_BASE:-https://github.com/tellahq/opensession
 FROM_SOURCE=0
 [ -n "${OPENSESSION_REPO:-}${OPENSESSION_CHANNEL:-}" ] && FROM_SOURCE=1
 CHANNEL="${OPENSESSION_CHANNEL:-}"
+# The GitHub org this instance is for. Set = onboarding writes an org App owner
+# and the intent to turn on per-user sign-in at first connect; unset = today's
+# single-user install.
+ORG="${OPENSESSION_ORG:-}"
 NO_MODIFY_PATH="${NO_MODIFY_PATH:-0}"
 NO_ONBOARD="${NO_ONBOARD:-0}"
 NO_ENGINE="${NO_ENGINE:-0}"
@@ -75,6 +84,7 @@ while [ $# -gt 0 ]; do
     --channel) CHANNEL="$2"; FROM_SOURCE=1; shift 2 ;;
     --repo) REPO="$2"; FROM_SOURCE=1; shift 2 ;;
     --artifact) ARTIFACT="$2"; shift 2 ;;
+    --org) ORG="$2"; shift 2 ;;
     --source) FROM_SOURCE=1; shift ;;
     --no-modify-path) NO_MODIFY_PATH=1; shift ;;
     --no-onboard) NO_ONBOARD=1; shift ;;
@@ -795,12 +805,27 @@ if [ -n "${OPENSESSION_CLAUDE_TOKEN:-}" ]; then
   good "Claude token staged in ~/.opensession-claude-token (imported at first start)"
 fi
 
-# Default: write defaults, start the service, print the URL.
+# The one question the simple install asks: an organization sets up a shared,
+# org-owned GitHub app and per-user sign-in; blank keeps it single-user with no
+# sign-in. Default path only (advanced onboarding asks it itself), only when
+# nothing set it already, and only with a real terminal — a piped `curl | bash`
+# reads the answer from /dev/tty, and a non-interactive run (CI, --yes) stays
+# single-user.
+if [ "$ADVANCED" != "1" ] && [ -z "$ORG" ] && [ "$NO_PROMPT" != "1" ] && [ "$STDIN_PATH" = "/dev/tty" ]; then
+  step "GitHub organization"
+  printf '  Enter your GitHub org name or leave blank for a personal install: ' >/dev/tty
+  read -r ORG </dev/tty || ORG=""
+  ORG="$(printf '%s' "$ORG" | tr -d '[:space:]')"
+fi
+
+# Default: write defaults (and the org above), start the service, print the URL.
 # --advanced is the operator path with every question.
+# --org, when given, records the App owner and per-user sign-in intent (never a
+# live gate flip — nobody is signed in yet). Onboard ignores it on a re-run.
 if [ "$ADVANCED" = "1" ]; then
-  run_interactive "$BIN_DIR/opensession" onboard || true
+  run_interactive "$BIN_DIR/opensession" onboard ${ORG:+--org "$ORG"} || true
 else
-  run_interactive "$BIN_DIR/opensession" onboard --defaults || true
+  run_interactive "$BIN_DIR/opensession" onboard --defaults ${ORG:+--org "$ORG"} || true
 fi
 
 # Ensure the service independently of onboarding. On a re-run onboard sees an

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -1,10 +1,12 @@
 import { BASE_PATH } from "../lib/base";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import { Menu } from "../ui/menu";
 import { OptionSelect } from "../ui/select";
 import { cn } from "../ui/cn";
 import { Button } from "../ui/button";
 import { DeviceCode } from "../ui/device-code";
+import { Modal } from "../ui/modal";
+import { Segmented, SegmentedOption } from "../ui/segmented";
 import { InlineAlert, Skeleton, SkeletonBar } from "../ui/state";
 import { PulseDot } from "../ui/status";
 import {
@@ -490,6 +492,25 @@ export function Connections() {
 interface GithubAuthData {
   enabled: boolean;
   clientIdConfigured: boolean;
+  /** A client id resolves (shipped app, env, or config) — connect is on offer
+   *  even when the sign-in gate (webAuthRequired) is off. */
+  connectAvailable: boolean;
+  /** Where that App client id came from, so the blocked-PAT note can name the
+   *  exact thing to unset. null when no App is configured. */
+  appConfigSource?: "env" | "config" | null;
+  /** The workspace is behind GitHub sign-in (operator mode). False = simple
+   *  mode: one user, no session, the single connected account is the identity. */
+  webAuthRequired: boolean;
+  /** github.com/apps/<slug>/installations/new, or null until the app slug ships. */
+  appInstallUrl: string | null;
+  /** Captured install/app-setup intent: the org the App is owned by, so the
+   *  wizard prefills the org owner. null for a single-user install. */
+  appOrg?: string | null;
+  /** Connecting should also turn on per-user sign-in (set at install with an
+   *  org). Inert until the connect handler consumes it. */
+  authOnConnect?: boolean;
+  /** Simple mode: the single connected login, if exactly one. */
+  soleLogin?: string | null;
   accounts: { login: string; name?: string; connectedAt: string; scopes?: string }[];
   team: {
     name: string;
@@ -515,6 +536,477 @@ interface DeviceFlow {
  * device flow: show a code, the person enters it on github.com, we poll until
  * GitHub hands over their token (stored server-side, never shown here).
  */
+// The create-app form on GitHub can be pre-filled with URL query parameters
+// (docs.github.com/apps/sharing-github-apps/registering-a-github-app-using-url-parameters).
+// `device_flow_enabled` is undocumented but pre-ticks the Enable Device Flow
+// box — so the only thing left to do by hand is generate a client secret. It
+// is treated as best-effort: the wizard still asks the user to confirm Device
+// Flow is on, in case GitHub ever drops the param. GitHub ignores unknown
+// params, so this can only under-fill, never error.
+// Blank org creates the app under the signed-in personal account; an org login
+// creates it under that organization (so the org owns it and it can reach org
+// repos). Same query params either way.
+function buildGithubAppCreateUrl(name: string, org: string): string {
+  const params = new URLSearchParams({
+    name,
+    url: "http://localhost:3850",
+    public: "false",
+    webhook_active: "false",
+    contents: "write",
+    pull_requests: "write",
+    metadata: "read",
+    device_flow_enabled: "true",
+  }).toString();
+  const base = org.trim()
+    ? `https://github.com/organizations/${encodeURIComponent(org.trim())}/settings/apps/new`
+    : "https://github.com/settings/apps/new";
+  return `${base}?${params}`;
+}
+
+// GitHub derives the app slug from its name: lowercased, every run of
+// non-alphanumerics collapsed to one hyphen. Previewed so the user recognises
+// their slug on the settings page before it exists.
+function deriveGithubAppSlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// App names are unique across all of GitHub, so a bare "Open Session" is almost
+// always taken. A short random suffix in parens makes the pre-filled name land
+// first try and reads as a deliberate tag rather than a typo; still editable,
+// well under GitHub's 34-char cap, and slugifies to open-session-<suffix>.
+function generateGithubAppName(): string {
+  const suffix = Math.random().toString(36).slice(2, 6);
+  return `Open Session (${suffix})`;
+}
+
+function WizardCheck({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2 text-supporting leading-snug text-dim">
+      <span className="mt-[3px] shrink-0 text-green">✓</span>
+      <span className="min-w-0">{children}</span>
+    </li>
+  );
+}
+
+/**
+ * Guided setup for a bring-your-own GitHub App: create it on GitHub (form
+ * pre-filled), paste its id/slug/secret, install it on the repos you pick, then
+ * connect. It lives outside the card so saving the client id — which re-renders
+ * the card from "no app" to "app configured" — doesn't unmount it mid-flow.
+ */
+function GithubAppWizard({
+  open,
+  onOpenChange,
+  clientId,
+  setClientId,
+  slug,
+  setSlug,
+  secret,
+  setSecret,
+  onSaveApp,
+  saving,
+  configured,
+  connected,
+  installUrl,
+  onConnect,
+  error,
+  flow,
+  onCancelFlow,
+  intentOrg,
+  onClearIntent,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  clientId: string;
+  setClientId: (v: string) => void;
+  slug: string;
+  setSlug: (v: string) => void;
+  secret: string;
+  setSecret: (v: string) => void;
+  onSaveApp: (appOrg: string) => void;
+  saving: boolean;
+  configured: boolean;
+  connected: boolean;
+  installUrl: string | null;
+  onConnect: () => void;
+  error: string | null;
+  flow: DeviceFlow | null;
+  onCancelFlow: () => void;
+  /** Org captured at install (config appOrg): prefills the owner and shows the
+   *  wizard is finishing sign-in setup. null for a single-user install. */
+  intentOrg?: string | null;
+  /** Clear the captured org intent (switch the owner back to single-user). */
+  onClearIntent: () => void;
+}) {
+  const [step, setStep] = useState(1);
+  // A likely-unique app name, minted once per open so the pre-filled name and
+  // the slug we preview stay in step.
+  const [appName, setAppName] = useState("Open Session");
+  // Where the app is created: the person's own account, or an org they name.
+  const [appOwner, setAppOwner] = useState<"you" | "org">("you");
+  // The org login, used only when appOwner is "org".
+  const [appOrg, setAppOrg] = useState("");
+  // Opening jumps to where the user actually is (an already-configured app
+  // resumes at install, a fresh start begins at create) and mints a fresh name.
+  useEffect(() => {
+    if (open) {
+      setStep(configured ? 3 : 1);
+      setAppName(generateGithubAppName());
+      // An org install/app-setup prefills the owner and the org login, so the
+      // wizard resumes finishing the sign-in setup it was told to do.
+      setAppOwner(intentOrg ? "org" : "you");
+      setAppOrg(intentOrg ?? "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+  // Saving the client id flips `configured`; carry the user from paste to
+  // install without a manual step.
+  useEffect(() => {
+    if (open && configured && step === 2) setStep(3);
+  }, [open, configured, step]);
+  // Connected is the finish line — nothing left to guide.
+  useEffect(() => {
+    if (open && connected) onOpenChange(false);
+  }, [open, connected, onOpenChange]);
+
+  // The last step needs no preamble: arriving on it starts the device flow once
+  // and drops the user straight on the code. The ref stops a re-render (or
+  // strict mode's double invoke) from opening a second flow; leaving the step
+  // rearms it, so Back → Next or a retry can start again.
+  const connectStartedRef = useRef(false);
+  useEffect(() => {
+    if (step !== 4) {
+      connectStartedRef.current = false;
+      return;
+    }
+    if (!open || connectStartedRef.current) return;
+    connectStartedRef.current = true;
+    if (!flow) onConnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, step]);
+
+  // Focus each step's primary control as the user arrives on it (and on open).
+  const stepFocusRef = useRef<HTMLElement | null>(null);
+  const setStepFocus = useCallback((el: HTMLElement | null) => {
+    stepFocusRef.current = el;
+  }, []);
+  useEffect(() => {
+    if (open) stepFocusRef.current?.focus();
+  }, [open, step]);
+
+  const createUrl = buildGithubAppCreateUrl(appName, appOwner === "org" ? appOrg : "");
+  // Creating in an org needs its login to build the URL, so block until it's given.
+  const createReady = appOwner === "you" || !!appOrg.trim();
+  const previewSlug = deriveGithubAppSlug(appName);
+  const canSave = !!clientId.trim() && !!slug.trim() && !!secret.trim();
+  const titles = ["Create the app", "Paste the details", "Install on your repos", "Connect"];
+
+  return (
+    <Modal.Root open={open} onOpenChange={(next) => !saving && onOpenChange(next)}>
+      <Modal.Content widthClassName="max-w-[34rem]" initialFocus={stepFocusRef}>
+        <Modal.Header
+          title="Set up a GitHub App"
+          description={`Step ${step} of 4 · ${titles[step - 1]}`}
+        />
+
+        {step === 1 && (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <span className="text-supporting text-dim">Create under</span>
+              <Segmented
+                label="Create under"
+                size="sm"
+                value={appOwner}
+                onValueChange={(next) => {
+                  // Switching back to single-user drops the captured org intent:
+                  // no org App, no sign-in. Confirm it, then clear it upstream.
+                  if (next === "you" && intentOrg) {
+                    if (!confirm("Stays single-user, no sign-in.")) return;
+                    onClearIntent();
+                  }
+                  setAppOwner(next as "you" | "org");
+                }}
+              >
+                <SegmentedOption value="you">You</SegmentedOption>
+                <SegmentedOption value="org">Organization</SegmentedOption>
+              </Segmented>
+              {appOwner === "org" && (
+                <>
+                  <input
+                    type="text"
+                    className={cn(settingsInputClass, "font-mono")}
+                    value={appOrg}
+                    onChange={(e) => setAppOrg(e.target.value)}
+                    placeholder="my-org"
+                    autoCapitalize="none"
+                    autoComplete="off"
+                    spellCheck={false}
+                    aria-label="Organization login"
+                  />
+                  {intentOrg && (
+                    <div className="text-meta leading-snug text-dim">
+                      Finishing sign-in setup for {intentOrg}.
+                    </div>
+                  )}
+                  <div className="text-meta leading-snug text-faint">
+                    For a team, create it in your organization so the org owns
+                    the app and it can reach org repos. You need permission to
+                    create apps in the org.
+                  </div>
+                </>
+              )}
+            </div>
+            {createReady ? (
+              <a href={createUrl} target="_blank" rel="noreferrer">
+                <Button
+                  ref={setStepFocus}
+                  variant="primary"
+                  icon={<IconArrowUpRight size={20} />}
+                >
+                  Create app on GitHub
+                </Button>
+              </a>
+            ) : (
+              <Button
+                ref={setStepFocus}
+                variant="primary"
+                disabled
+                icon={<IconArrowUpRight size={20} />}
+              >
+                Create app on GitHub
+              </Button>
+            )}
+            <div className="text-supporting leading-snug text-dim">
+              Opens a pre-filled form. On that page:
+            </div>
+            {/* An annotated screenshot could slot in here, but GitHub's settings
+                UI changes, so the text carries the flow and stays correct. */}
+            <ul className="flex flex-col gap-2">
+              <WizardCheck>
+                Confirm <span className="text-fg">Device Flow</span> is checked.
+              </WizardCheck>
+              <WizardCheck>
+                Click <span className="text-fg">Create GitHub App</span>.
+              </WizardCheck>
+            </ul>
+            <div className="text-meta leading-snug text-faint">
+              Pre-filled: name{" "}
+              <span className="font-mono text-dim">{appName}</span>, permissions
+              (Contents + Pull requests, read &amp; write), private, no webhook.
+              Names are unique on GitHub, so tweak it if it's taken.
+            </div>
+            <Modal.Footer>
+              <button
+                type="button"
+                className="mr-auto text-supporting text-dim underline hover:text-fg"
+                onClick={() => setStep(2)}
+              >
+                I already have an app
+              </button>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  if (!slug.trim()) setSlug(previewSlug);
+                  setStep(2);
+                }}
+              >
+                Next
+              </Button>
+            </Modal.Footer>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="flex flex-col gap-4">
+            <div className="text-supporting leading-snug text-dim">
+              On your new app's settings page:
+            </div>
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-supporting text-fg">Client ID</label>
+                <input
+                  ref={setStepFocus}
+                  type="text"
+                  className={cn(settingsInputClass, "font-mono")}
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                  placeholder="Iv23…"
+                  aria-label="GitHub App client ID"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <span className="text-meta leading-snug text-faint">
+                  In <span className="text-dim">About</span> at the top: the{" "}
+                  <span className="text-dim">Client ID</span>, not the App ID above
+                  it.
+                </span>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-supporting text-fg">App slug</label>
+                <input
+                  type="text"
+                  className={cn(settingsInputClass, "font-mono")}
+                  value={slug}
+                  onChange={(e) => setSlug(e.target.value)}
+                  placeholder={previewSlug}
+                  aria-label="GitHub App slug"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <span className="text-meta leading-snug text-faint">
+                  From the app's URL{" "}
+                  <span className="font-mono text-dim">
+                    github.com/settings/apps/{previewSlug}
+                  </span>
+                  . Pre-filled, so fix it only if you renamed the app.
+                </span>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-supporting text-fg">Client secret</label>
+                <input
+                  type="password"
+                  className={cn(settingsInputClass, "font-mono")}
+                  value={secret}
+                  onChange={(e) => setSecret(e.target.value)}
+                  placeholder="Client secret"
+                  aria-label="GitHub App client secret"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <span className="text-meta leading-snug text-faint">
+                  In <span className="text-dim">Client secrets</span>, click{" "}
+                  <span className="text-dim">Generate a new client secret</span>, then
+                  copy it (shown once). Required.
+                </span>
+              </div>
+            </div>
+            <div className="text-meta leading-snug text-faint">
+              Ignore GitHub's “generate a private key” banner. Open Session uses
+              device flow and doesn't need one.
+            </div>
+            <Modal.Footer>
+              <Button
+                variant="ghost"
+                onClick={() => setStep(1)}
+                className="mr-auto"
+              >
+                Back
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => onSaveApp(appOwner === "org" ? appOrg.trim() : "")}
+                disabled={!canSave || saving}
+              >
+                {saving ? "Saving…" : "Save and continue"}
+              </Button>
+            </Modal.Footer>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="flex flex-col gap-4">
+            <div className="text-supporting leading-snug text-dim">
+              Install the app on the repositories you want to use. Its access
+              reaches only the repos you pick here.
+            </div>
+            {installUrl && (
+              <a href={installUrl} target="_blank" rel="noreferrer">
+                <Button
+                  ref={setStepFocus}
+                  variant="primary"
+                  icon={<IconArrowUpRight size={20} />}
+                >
+                  Install on your repositories
+                </Button>
+              </a>
+            )}
+            <Modal.Footer>
+              <Button
+                variant="ghost"
+                onClick={() => setStep(2)}
+                className="mr-auto"
+              >
+                Back
+              </Button>
+              <Button variant="primary" onClick={() => setStep(4)}>
+                Next
+              </Button>
+            </Modal.Footer>
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="flex flex-col gap-4">
+            {appOwner === "org" && (
+              <div className="text-supporting leading-snug text-dim">
+                This turns on GitHub sign-in for this workspace. You'll be signed
+                in as the first admin.
+              </div>
+            )}
+            {flow ? (
+              <div className="flex flex-col gap-2.5">
+                <div className="text-supporting text-dim">
+                  Enter this code at{" "}
+                  <span className="font-medium text-fg">
+                    {flow.verificationUri.replace(/^https:\/\//, "")}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2.5">
+                  <DeviceCode code={flow.userCode} />
+                  <a href={flow.verificationUri} target="_blank" rel="noreferrer">
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      icon={<IconArrowUpRight size={20} />}
+                    >
+                      Open GitHub
+                    </Button>
+                  </a>
+                </div>
+                <div className="flex items-center gap-2 text-supporting text-dim">
+                  <PulseDot size={7} />
+                  <span>Waiting for GitHub…</span>
+                </div>
+              </div>
+            ) : error ? (
+              <InlineAlert onRetry={onConnect} retryLabel="Try again">
+                {error}
+              </InlineAlert>
+            ) : (
+              <div className="flex items-center gap-2 text-supporting text-dim">
+                <PulseDot size={7} />
+                <span>Starting…</span>
+              </div>
+            )}
+            <Modal.Footer>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  if (flow) onCancelFlow();
+                  setStep(3);
+                }}
+                className="mr-auto"
+              >
+                Back
+              </Button>
+            </Modal.Footer>
+          </div>
+        )}
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
 /** `personal`: only the signed-in user's own row (the Account page);
  *  default shows the whole team roster (admin overview). */
 export function GithubAccounts({ personal = false }: { personal?: boolean } = {}) {
@@ -522,7 +1014,16 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
   const [flow, setFlow] = useState<DeviceFlow | null>(null);
   const [flowState, setFlowState] = useState<"idle" | "starting" | "waiting">("idle");
   const [error, setError] = useState<string | null>(null);
-  const [justConnected, setJustConnected] = useState<string | null>(null);
+  // Simple-mode "bring your own GitHub App" form: client id + slug (+ secret)
+  // written to config.json, so the device flow lights up with no env var and no
+  // restart.
+  const [appClientId, setAppClientId] = useState("");
+  const [appSlug, setAppSlug] = useState("");
+  const [appSecret, setAppSecret] = useState("");
+  const [savingApp, setSavingApp] = useState(false);
+  // The guided "create your app on GitHub, then paste + install + connect"
+  // wizard, launched from the App option below.
+  const [wizardOpen, setWizardOpen] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -553,7 +1054,14 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
         if (body.status === "ok") {
           setFlow(null);
           setFlowState("idle");
-          setJustConnected(body.login);
+          // authEnabled: this connect flipped the workspace into sign-in mode and
+          // the browser now holds the session cookie. A full reload re-runs the
+          // app's auth bootstrap so every panel reflects operator mode, rather
+          // than patching one card's state.
+          if (body.authEnabled) {
+            window.location.reload();
+            return;
+          }
           load();
           return;
         }
@@ -576,7 +1084,6 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
 
   async function startConnect() {
     setError(null);
-    setJustConnected(null);
     setFlowState("starting");
     try {
       const res = await fetch(`${BASE_PATH}/api/connections/github/device`, { method: "POST" });
@@ -587,6 +1094,76 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
     } catch (e: any) {
       setError(e.message);
       setFlowState("idle");
+    }
+  }
+
+  async function saveApp(appOrg: string) {
+    const clientId = appClientId.trim();
+    const slug = appSlug.trim();
+    const secret = appSecret.trim();
+    // The secret is required: the device-flow token expires and is refreshed
+    // with it, so without one the connection would stop after ~8h.
+    if (!clientId || !slug || !secret) return;
+    setError(null);
+    setSavingApp(true);
+    try {
+      const res = await fetch(`${BASE_PATH}/api/connections/github/app`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // An org owner also records the sign-in intent server-side; a blank org
+        // is a personal, single-user App.
+        body: JSON.stringify({ clientId, slug, secret, appOrg }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+      setAppClientId("");
+      setAppSlug("");
+      setAppSecret("");
+      // getConfig() re-reads on the file change, so the reload shows the App as
+      // configured and switches the card to its device-flow connect.
+      load();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSavingApp(false);
+    }
+  }
+
+  async function removeApp() {
+    if (
+      !confirm(
+        "Remove the GitHub App? You'll be able to paste a personal access token instead.",
+      )
+    )
+      return;
+    setError(null);
+    try {
+      const res = await fetch(`${BASE_PATH}/api/connections/github/app`, {
+        method: "DELETE",
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+      load();
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  // Switching the wizard owner back to "You" clears the captured org intent
+  // (appOrg + authOnConnect) so a later connect stays single-user. The DELETE
+  // /app route clears both; at intent stage there are no App keys yet to remove.
+  async function clearOrgIntent() {
+    try {
+      const res = await fetch(`${BASE_PATH}/api/connections/github/app`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error || `Failed: ${res.status}`);
+      }
+      load();
+    } catch (e: any) {
+      setError(e.message);
     }
   }
 
@@ -606,6 +1183,258 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
   }
 
   if (!data) return null;
+
+  // The device-flow well and the just-connected note render the same in both
+  // the operator roster and the simple-mode card, so they're built once here.
+  const deviceFlowWell = flow ? (
+    // A well, not a sentence: the code, the link and the status used to run
+    // together on one line that overflowed the card on anything narrower than a
+    // desktop. Three short stacked lines — what to do, the two controls, what
+    // we're waiting for — never wrap badly and let the code be the thing the eye
+    // lands on.
+    <div className="flex flex-col gap-2.5 px-5 py-3.5">
+      <div className="text-supporting text-dim">
+        Enter this code at{" "}
+        <span className="font-medium text-fg">
+          {flow.verificationUri.replace(/^https:\/\//, "")}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2.5">
+        <DeviceCode code={flow.userCode} />
+        <a href={flow.verificationUri} target="_blank" rel="noreferrer">
+          <Button size="sm" variant="primary" icon={<IconArrowUpRight size={20} />}>
+            Open GitHub
+          </Button>
+        </a>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-supporting text-dim">
+        {/* Dot and status are one item: as two siblings of a wrapping row, a
+            phone breaks between them and leaves the dot orphaned on its own
+            line. */}
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          <PulseDot size={7} />
+          <span className="min-w-0">
+            Waiting for GitHub. Sign in as the account you want to connect.
+          </span>
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="ml-auto"
+          onClick={() => {
+            setFlow(null);
+            setFlowState("idle");
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  ) : null;
+
+  // ── Simple mode ──
+  // No web sign-in, so no roster and no authUser: the card is one shared account
+  // (the install's single user), and every session acts as it. Connect is a
+  // GitHub App device flow, available once an app's client id is configured
+  // (data.connectAvailable) via the setup wizard or an env var. The operator
+  // roster below is untouched.
+  if (!data.webAuthRequired) {
+    const account = data.accounts[0];
+    const connected = !!account;
+    return (
+      <>
+        <SectionHeading>GitHub</SectionHeading>
+        {error && <InlineAlert onDismiss={() => setError(null)}>{error}</InlineAlert>}
+        <SettingCard>
+          <SettingRow className="items-start gap-x-3">
+            {connected ? (
+              <span className="flex size-[30px] shrink-0 items-center justify-center">
+                <UserAvatar
+                  name={account.name || account.login}
+                  login={account.login}
+                  size={28}
+                />
+              </span>
+            ) : (
+              <IconTile name="github" size={30} />
+            )}
+            <SettingRowText>
+              <SettingRowTitle className="truncate">
+                {connected ? account.name || account.login : "GitHub"}
+                {connected && (
+                  <span className="ml-2 text-label font-normal text-faint">
+                    @{account.login}
+                  </span>
+                )}
+              </SettingRowTitle>
+              <SettingRowDescription className="leading-snug">
+                {connected
+                  ? `All sessions clone and open pull requests as @${account.login}.`
+                  : "Connect a GitHub App to clone your private repositories and open pull requests."}
+              </SettingRowDescription>
+            </SettingRowText>
+            <SettingRowControl className="flex items-center gap-3">
+              <StatusChip
+                label={connected ? "Connected" : "Not connected"}
+                dot={
+                  connected
+                    ? "var(--green)"
+                    : "var(--line-strong, var(--text-faint))"
+                }
+              />
+              {connected && (
+                <Menu.Root>
+                  <Menu.Trigger
+                    className={rowMenuTriggerClasses}
+                    aria-label={`Manage @${account.login}`}
+                  >
+                    <IconDotsHorizontal size={18} />
+                  </Menu.Trigger>
+                  <Menu.Popup align="end" sideOffset={4}>
+                    {/* Reconnect re-runs the device flow, which exists only with
+                        a configured App. */}
+                    {data.connectAvailable && (
+                      <Menu.Item onClick={startConnect} disabled={flowState !== "idle"}>
+                        <IconPlug size={16} className="text-faint" />
+                        Reconnect
+                      </Menu.Item>
+                    )}
+                    <Menu.Item
+                      onClick={() => disconnect(account.login)}
+                      className="text-red data-[highlighted]:bg-red-soft"
+                    >
+                      <IconTrash size={16} />
+                      Disconnect
+                    </Menu.Item>
+                  </Menu.Popup>
+                </Menu.Root>
+              )}
+            </SettingRowControl>
+          </SettingRow>
+
+          {/* Not connected: the GitHub App device flow. The connect button
+              appears once an app client id is configured (data.connectAvailable,
+              set by the wizard or an env var); before that the setup wizard is
+              the entry point. */}
+          {!connected &&
+            (data.connectAvailable
+              ? flowState !== "waiting" && (
+                  <div className="flex flex-col gap-2.5 px-5 py-3.5">
+                    <div className="flex flex-wrap items-center gap-2.5">
+                      <Button
+                        variant="primary"
+                        onClick={startConnect}
+                        disabled={flowState !== "idle"}
+                      >
+                        {flowState === "starting" ? "Starting…" : "Connect GitHub App"}
+                      </Button>
+                      {data.appInstallUrl && (
+                        <a href={data.appInstallUrl} target="_blank" rel="noreferrer">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            icon={<IconArrowUpRight size={20} />}
+                          >
+                            Install on your repositories
+                          </Button>
+                        </a>
+                      )}
+                    </div>
+                    <div className="text-meta leading-snug text-faint">
+                      Authorize with a one-time code. No sign-in here, so every
+                      session shares the connected account.
+                    </div>
+                    {/* A config-set app can be cleared live; an env-set one only
+                        gets named, since it needs a restart to change. */}
+                    {data.appConfigSource === "config" ? (
+                      <button
+                        type="button"
+                        className="self-start text-meta text-dim underline hover:text-fg"
+                        onClick={removeApp}
+                      >
+                        Remove app
+                      </button>
+                    ) : (
+                      <div className="text-meta leading-snug text-faint">
+                        Set via{" "}
+                        <code className="rounded-sm bg-surface px-1 py-0.5 font-mono text-[0.92em] text-dim">
+                          OPENSESSION_GITHUB_CLIENT_ID
+                        </code>
+                        . Unset and restart to change.
+                      </div>
+                    )}
+                  </div>
+                )
+              : (
+                  <div className="flex flex-col gap-4 px-5 py-3.5">
+                    <div className="text-meta leading-snug text-faint">
+                      No sign-in here, so every session shares one GitHub account.
+                      Turn on GitHub sign-in for per-person accounts.
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <div className="text-label font-medium text-fg">GitHub App</div>
+                      <div className="text-meta leading-snug text-faint">
+                        Install your own app on the repos you choose and authorize
+                        with a one-time code. Nothing secret to paste.
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2.5">
+                        <Button variant="primary" onClick={() => setWizardOpen(true)}>
+                          Set up GitHub App
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+
+          {deviceFlowWell}
+
+          {/* A configured App's user-to-server token reaches only repos the App
+              is installed on, so managing the install is ongoing. A quiet link
+              once connected, not a pending step. */}
+          {connected && data.appInstallUrl && (
+            <div className="px-5 py-3.5">
+              <a
+                href={data.appInstallUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-meta text-dim underline hover:text-fg"
+              >
+                Manage which repositories the app can access
+                <IconArrowUpRight size={14} />
+              </a>
+            </div>
+          )}
+        </SettingCard>
+        {/* Rendered outside the card so it survives the card re-rendering from
+            "no app" to "app configured" the moment the client id is saved. */}
+        <GithubAppWizard
+          open={wizardOpen}
+          onOpenChange={setWizardOpen}
+          clientId={appClientId}
+          setClientId={setAppClientId}
+          slug={appSlug}
+          setSlug={setAppSlug}
+          secret={appSecret}
+          setSecret={setAppSecret}
+          onSaveApp={saveApp}
+          saving={savingApp}
+          configured={data.connectAvailable}
+          connected={connected}
+          installUrl={data.appInstallUrl}
+          onConnect={startConnect}
+          error={error}
+          flow={flow}
+          onCancelFlow={() => {
+            setFlow(null);
+            setFlowState("idle");
+          }}
+          intentOrg={data.appOrg}
+          onClearIntent={clearOrgIntent}
+        />
+      </>
+    );
+  }
+
   const active = data.enabled && data.clientIdConfigured;
   // The only account this card can hold is your own. GitHub's device flow is
   // rejected unless the login that authorizes matches the signed-in user, so
@@ -746,58 +1575,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
           </SettingRowControl>
         </SettingRow>
 
-        {flow && (
-          // A well, not a sentence: the code, the link and the status used to
-          // run together on one line that overflowed the card on anything
-          // narrower than a desktop. Three short stacked lines — what to do,
-          // the two controls, what we're waiting for — never wrap badly and
-          // let the code be the thing the eye lands on.
-          <div className="flex flex-col gap-2.5 px-5 py-3.5">
-            <div className="text-supporting text-dim">
-              Enter this code at{" "}
-              <span className="font-medium text-fg">
-                {flow.verificationUri.replace(/^https:\/\//, "")}
-              </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-2.5">
-              <DeviceCode code={flow.userCode} />
-              <a href={flow.verificationUri} target="_blank" rel="noreferrer">
-                <Button size="sm" variant="primary" icon={<IconArrowUpRight size={20} />}>
-                  Open GitHub
-                </Button>
-              </a>
-            </div>
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-supporting text-dim">
-              {/* Dot and status are one item: as two siblings of a wrapping
-                  row, a phone breaks between them and leaves the dot orphaned
-                  on its own line. */}
-              <span className="flex min-w-0 flex-1 items-center gap-2">
-                <PulseDot size={7} />
-                <span className="min-w-0">
-                  Waiting for GitHub. Sign in as the account you want to connect.
-                </span>
-              </span>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="ml-auto"
-                onClick={() => {
-                  setFlow(null);
-                  setFlowState("idle");
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {justConnected && (
-          <div className="px-5 py-2.5 text-label text-dim">
-            Connected <span className="font-medium text-fg">@{justConnected}</span>. Their new
-            session runs now open PRs as this account.
-          </div>
-        )}
+        {deviceFlowWell}
 
         {active &&
           !personal &&

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -554,6 +554,7 @@ function buildGithubAppCreateUrl(name: string, org: string): string {
     webhook_active: "false",
     contents: "write",
     pull_requests: "write",
+    members: "read",
     metadata: "read",
     device_flow_enabled: "true",
   }).toString();
@@ -796,7 +797,8 @@ function GithubAppWizard({
             <div className="text-meta leading-snug text-faint">
               Pre-filled: name{" "}
               <span className="font-mono text-dim">{appName}</span>, permissions
-              (Contents + Pull requests, read &amp; write), private, no webhook.
+              (Contents + Pull requests, read &amp; write; Members, read), private,
+              no webhook.
               Names are unique on GitHub, so tweak it if it's taken.
             </div>
             <Modal.Footer>

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -1133,7 +1133,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
   async function removeApp() {
     if (
       !confirm(
-        "Remove the GitHub App? You'll be able to paste a personal access token instead.",
+        "Remove the GitHub App configuration? You'll need to set up an app again before you can connect GitHub.",
       )
     )
       return;

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -1383,8 +1383,8 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
                     <div className="flex flex-col gap-2">
                       <div className="text-label font-medium text-fg">GitHub App</div>
                       <div className="text-meta leading-snug text-faint">
-                        Install your own app on the repos you choose and authorize
-                        with a one-time code. Nothing secret to paste.
+                        Install your own app on the repos you choose, then authorize
+                        with a one-time code.
                       </div>
                       <div className="flex flex-wrap items-center gap-2.5">
                         <Button variant="primary" onClick={() => setWizardOpen(true)}>

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -762,15 +762,14 @@ function GithubAppWizard({
               )}
             </div>
             {createReady ? (
-              <a href={createUrl} target="_blank" rel="noreferrer">
-                <Button
-                  ref={setStepFocus}
-                  variant="primary"
-                  icon={<IconArrowUpRight size={20} />}
-                >
-                  Create app on GitHub
-                </Button>
-              </a>
+              <Button
+                ref={setStepFocus}
+                variant="primary"
+                icon={<IconArrowUpRight size={20} />}
+                render={<a href={createUrl} target="_blank" rel="noreferrer" />}
+              >
+                Create app on GitHub
+              </Button>
             ) : (
               <Button
                 ref={setStepFocus}
@@ -922,15 +921,14 @@ function GithubAppWizard({
               reaches only the repos you pick here.
             </div>
             {installUrl && (
-              <a href={installUrl} target="_blank" rel="noreferrer">
-                <Button
-                  ref={setStepFocus}
-                  variant="primary"
-                  icon={<IconArrowUpRight size={20} />}
-                >
-                  Install on your repositories
-                </Button>
-              </a>
+              <Button
+                ref={setStepFocus}
+                variant="primary"
+                icon={<IconArrowUpRight size={20} />}
+                render={<a href={installUrl} target="_blank" rel="noreferrer" />}
+              >
+                Install on your repositories
+              </Button>
             )}
             <Modal.Footer>
               <Button
@@ -965,15 +963,16 @@ function GithubAppWizard({
                 </div>
                 <div className="flex flex-wrap items-center gap-2.5">
                   <DeviceCode code={flow.userCode} />
-                  <a href={flow.verificationUri} target="_blank" rel="noreferrer">
-                    <Button
-                      size="sm"
-                      variant="primary"
-                      icon={<IconArrowUpRight size={20} />}
-                    >
-                      Open GitHub
-                    </Button>
-                  </a>
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    icon={<IconArrowUpRight size={20} />}
+                    render={
+                      <a href={flow.verificationUri} target="_blank" rel="noreferrer" />
+                    }
+                  >
+                    Open GitHub
+                  </Button>
                 </div>
                 <div className="flex items-center gap-2 text-supporting text-dim">
                   <PulseDot size={7} />
@@ -1203,11 +1202,14 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
       </div>
       <div className="flex flex-wrap items-center gap-2.5">
         <DeviceCode code={flow.userCode} />
-        <a href={flow.verificationUri} target="_blank" rel="noreferrer">
-          <Button size="sm" variant="primary" icon={<IconArrowUpRight size={20} />}>
-            Open GitHub
-          </Button>
-        </a>
+        <Button
+          size="sm"
+          variant="primary"
+          icon={<IconArrowUpRight size={20} />}
+          render={<a href={flow.verificationUri} target="_blank" rel="noreferrer" />}
+        >
+          Open GitHub
+        </Button>
       </div>
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-supporting text-dim">
         {/* Dot and status are one item: as two siblings of a wrapping row, a
@@ -1331,15 +1333,20 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
                         {flowState === "starting" ? "Starting…" : "Connect GitHub App"}
                       </Button>
                       {data.appInstallUrl && (
-                        <a href={data.appInstallUrl} target="_blank" rel="noreferrer">
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            icon={<IconArrowUpRight size={20} />}
-                          >
-                            Install on your repositories
-                          </Button>
-                        </a>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          icon={<IconArrowUpRight size={20} />}
+                          render={
+                            <a
+                              href={data.appInstallUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            />
+                          }
+                        >
+                          Install on your repositories
+                        </Button>
                       )}
                     </div>
                     <div className="text-meta leading-snug text-faint">

--- a/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
@@ -592,11 +592,12 @@ function AddRepoPicker({
 						) : (
 							<>
 								No GitHub credential yet, so the repo list can&rsquo;t be browsed.
-								Connect your account under Workspace → Connections, or set{" "}
+								Connect your GitHub account under Settings → Connections to list
+								your private repos here. (Operators can instead set{" "}
 								<code className="rounded-sm bg-surface px-1.5 py-0.5 font-mono text-[0.92em] text-fg">
 									GITHUB_API_TOKEN
 								</code>{" "}
-								via the GitHub integration card below.
+								via the GitHub integration card below.)
 							</>
 						)}{" "}
 						You can still register a repo by name:

--- a/packages/core/opensession-server/src/server/git-status.test.ts
+++ b/packages/core/opensession-server/src/server/git-status.test.ts
@@ -3,7 +3,8 @@ import { $ } from "bun";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { gitPull, porcelainPaths } from "./git-status";
+import { gitPull, gitPush, porcelainPaths } from "./git-status";
+import type { WorkspaceExec } from "./sandbox/workspace-exec";
 
 const roots: string[] = [];
 
@@ -114,5 +115,22 @@ describe("porcelainPaths", () => {
 
   test("ignores blank and truncated lines", () => {
     expect(porcelainPaths("\n\nM  src/a.ts\nM\n")).toEqual(["src/a.ts"]);
+  });
+});
+
+
+describe("scoped Git credentials", () => {
+  test("passes a credential only to the explicit server-owned operation", async () => {
+    const envs: Array<Record<string, string> | undefined> = [];
+    const exec = Object.assign(
+      async (_cmd: string[], opts?: { env?: Record<string, string> }) => {
+        envs.push(opts?.env);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      { sandboxed: false, remote: false },
+    ) as WorkspaceExec;
+
+    expect(await gitPush("/repo", "feature", exec, { GH_TOKEN: "scoped" })).toEqual({ ok: true });
+    expect(envs).toEqual([{ GH_TOKEN: "scoped" }]);
   });
 });

--- a/packages/core/opensession-server/src/server/git-status.test.ts
+++ b/packages/core/opensession-server/src/server/git-status.test.ts
@@ -133,4 +133,18 @@ describe("scoped Git credentials", () => {
     expect(await gitPush("/repo", "feature", exec, { GH_TOKEN: "scoped" })).toEqual({ ok: true });
     expect(envs).toEqual([{ GH_TOKEN: "scoped" }]);
   });
+
+  test("does not send host credentials to a Runner executor", async () => {
+    const envs: Array<Record<string, string> | undefined> = [];
+    const exec = Object.assign(
+      async (_cmd: string[], opts?: { env?: Record<string, string> }) => {
+        envs.push(opts?.env);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      { sandboxed: false, remote: true },
+    ) as WorkspaceExec;
+
+    expect(await gitPush("/runner/repo", "feature", exec, { GH_TOKEN: "host-only" })).toEqual({ ok: true });
+    expect(envs).toEqual([undefined]);
+  });
 });

--- a/packages/core/opensession-server/src/server/git-status.test.ts
+++ b/packages/core/opensession-server/src/server/git-status.test.ts
@@ -147,4 +147,33 @@ describe("scoped Git credentials", () => {
     expect(await gitPush("/runner/repo", "feature", exec, { GH_TOKEN: "host-only" })).toEqual({ ok: true });
     expect(envs).toEqual([undefined]);
   });
+
+  test("uses the in-container helper for local Docker pull and push", async () => {
+    const envs: Array<Record<string, string> | undefined> = [];
+    const exec = Object.assign(
+      async (_cmd: string[], opts?: { env?: Record<string, string> }) => {
+        envs.push(opts?.env);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      { sandboxed: true, remote: false },
+    ) as WorkspaceExec;
+    const hostEnv = {
+      GH_TOKEN: "scoped",
+      GITHUB_TOKEN: "scoped",
+      GIT_CONFIG_VALUE_1: "!/home/user/.opensession/bin/opensession github-credential",
+    };
+
+    expect(await gitPull("/repo", undefined, exec, hostEnv)).toEqual({ ok: true });
+    expect(await gitPush("/repo", "feature", exec, hostEnv)).toEqual({ ok: true });
+    expect(envs).toHaveLength(2);
+    for (const env of envs) {
+      expect(env).toMatchObject({
+        GH_TOKEN: "scoped",
+        GITHUB_TOKEN: "scoped",
+        GIT_CONFIG_VALUE_0: "",
+        GIT_CONFIG_VALUE_1: "!gh auth git-credential",
+      });
+      expect(JSON.stringify(env)).not.toContain("/home/user");
+    }
+  });
 });

--- a/packages/core/opensession-server/src/server/git-status.ts
+++ b/packages/core/opensession-server/src/server/git-status.ts
@@ -83,6 +83,31 @@ export function porcelainPaths(status: string): string[] {
   return out;
 }
 
+/** Select the credential transport for the process that will run Git. Host
+ * calls use the stable Open Session helper supplied by github-auth. Local
+ * Docker calls cannot reach that host path, so they use gh inside the
+ * container. Remote sandboxes and Runners keep their own projected transport. */
+export function gitCredentialEnvForExec(
+  env?: Record<string, string>,
+  exec?: WorkspaceExec,
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+  if (exec?.remote) return undefined;
+  if (!exec?.sandboxed) return env;
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+  if (!token) return undefined;
+  return {
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token,
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
+    GIT_CONFIG_VALUE_0: "",
+    GIT_CONFIG_KEY_1: "credential.https://github.com.helper",
+    GIT_CONFIG_VALUE_1: "!gh auth git-credential",
+  };
+}
+
 const FETCH_TTL = 90_000;
 const lastFetch = new Map<string, number>();
 
@@ -198,13 +223,14 @@ export async function gitPull(
       args: { dir, fromBase: fromBase || null, sandboxed: exec?.sandboxed || undefined },
     },
     async () => {
+      const operationEnv = gitCredentialEnvForExec(env, exec);
       async function run(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
         if (exec) {
-          const r = await exec(args, env && !exec.remote ? { env } : undefined);
+          const r = await exec(args, operationEnv ? { env: operationEnv } : undefined);
           return { stdout: r.stdout, stderr: r.stderr, code: r.exitCode };
         }
         const proc = Bun.spawn(args, {
-          env: { ...process.env, ...env },
+          env: { ...process.env, ...operationEnv },
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -285,16 +311,17 @@ export async function gitPush(
       args: { dir, branch, sandboxed: exec?.sandboxed || undefined },
     },
     async () => {
+      const operationEnv = gitCredentialEnvForExec(env, exec);
       const args = ["git", "-C", dir, "push", "-u", "origin", "HEAD"];
       let err: string;
       let code: number;
       if (exec) {
-        const r = await exec(args, env && !exec.remote ? { env } : undefined);
+        const r = await exec(args, operationEnv ? { env: operationEnv } : undefined);
         err = r.stderr;
         code = r.exitCode;
       } else {
         const proc = Bun.spawn(args, {
-          env: { ...process.env, ...env },
+          env: { ...process.env, ...operationEnv },
           stdout: "pipe",
           stderr: "pipe",
         });

--- a/packages/core/opensession-server/src/server/git-status.ts
+++ b/packages/core/opensession-server/src/server/git-status.ts
@@ -189,6 +189,7 @@ export async function gitPull(
   dir: string,
   fromBase?: string,
   exec?: WorkspaceExec,
+  env?: Record<string, string>,
 ): Promise<{ ok: true } | { error: string }> {
   return audited(
     {
@@ -199,10 +200,14 @@ export async function gitPull(
     async () => {
       async function run(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
         if (exec) {
-          const r = await exec(args);
+          const r = await exec(args, env ? { env } : undefined);
           return { stdout: r.stdout, stderr: r.stderr, code: r.exitCode };
         }
-        const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+        const proc = Bun.spawn(args, {
+          env: { ...process.env, ...env },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
         const [stdout, stderr, code] = await Promise.all([
           new Response(proc.stdout).text(),
           new Response(proc.stderr).text(),
@@ -271,6 +276,7 @@ export async function gitPush(
   dir: string,
   branch: string,
   exec?: WorkspaceExec,
+  env?: Record<string, string>,
 ): Promise<{ ok: true } | { error: string }> {
   return audited(
     {
@@ -283,11 +289,15 @@ export async function gitPush(
       let err: string;
       let code: number;
       if (exec) {
-        const r = await exec(args);
+        const r = await exec(args, env ? { env } : undefined);
         err = r.stderr;
         code = r.exitCode;
       } else {
-        const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+        const proc = Bun.spawn(args, {
+          env: { ...process.env, ...env },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
         [err, code] = await Promise.all([
           new Response(proc.stderr).text(),
           proc.exited,

--- a/packages/core/opensession-server/src/server/git-status.ts
+++ b/packages/core/opensession-server/src/server/git-status.ts
@@ -200,7 +200,7 @@ export async function gitPull(
     async () => {
       async function run(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
         if (exec) {
-          const r = await exec(args, env ? { env } : undefined);
+          const r = await exec(args, env && !exec.remote ? { env } : undefined);
           return { stdout: r.stdout, stderr: r.stderr, code: r.exitCode };
         }
         const proc = Bun.spawn(args, {
@@ -289,7 +289,7 @@ export async function gitPush(
       let err: string;
       let code: number;
       if (exec) {
-        const r = await exec(args, env ? { env } : undefined);
+        const r = await exec(args, env && !exec.remote ? { env } : undefined);
         err = r.stderr;
         code = r.exitCode;
       } else {

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -323,8 +323,9 @@ describe("token lookups + runner env", () => {
   });
 
   test("builds a credential only for the exact connected login", () => {
-    enableFeature();
     seedToken("Alice");
+    expect(githubCredentialForLogin("alice")?.principal).toBe("user:alice");
+    enableFeature();
     expect(githubCredentialForLogin("alice")).toEqual({
       kind: "user",
       principal: "user:alice",

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -323,9 +323,8 @@ describe("token lookups + runner env", () => {
   });
 
   test("builds a credential only for the exact connected login", () => {
-    seedToken("Alice");
-    expect(githubCredentialForLogin("alice")?.principal).toBe("user:alice");
     enableFeature();
+    seedToken("Alice");
     expect(githubCredentialForLogin("alice")).toEqual({
       kind: "user",
       principal: "user:alice",

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -17,6 +17,7 @@ import {
   githubAuthEnv,
   githubRunEnv,
   githubCredentialForLogin,
+  githubCredentialForPrincipal,
   githubReconnectRequired,
   githubUserAuthActive,
   githubUserAuthSettings,
@@ -325,12 +326,34 @@ describe("token lookups + runner env", () => {
   test("builds a credential only for the exact connected login", () => {
     enableFeature();
     seedToken("Alice");
-    expect(githubCredentialForLogin("alice")).toEqual({
+    const credential = githubCredentialForLogin("alice");
+    expect(credential).toMatchObject({
       kind: "user",
       principal: "user:alice",
-      env: { GH_TOKEN: "gho_test123", GITHUB_TOKEN: "gho_test123" },
+      env: {
+        GH_TOKEN: "gho_test123",
+        GITHUB_TOKEN: "gho_test123",
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_CONFIG_COUNT: "2",
+        GIT_CONFIG_VALUE_0: "",
+      },
     });
+    expect(credential?.env.GIT_CONFIG_VALUE_1).toContain("credential");
+    expect(credential?.env.GIT_CONFIG_VALUE_1).not.toContain("gho_test123");
     expect(githubCredentialForLogin("bob")).toBeNull();
+  });
+
+  test("durable principals resolve the current token without changing identity", () => {
+    enableFeature();
+    seedToken("Alice", "gho_old");
+    expect(githubCredentialForPrincipal("user:alice")?.env.GH_TOKEN).toBe("gho_old");
+
+    seedToken("Alice", "gho_refreshed");
+    const recovered = githubCredentialForPrincipal("user:alice");
+    expect(recovered?.principal).toBe("user:alice");
+    expect(recovered?.env.GH_TOKEN).toBe("gho_refreshed");
+    expect(JSON.stringify(recovered)).not.toContain("gho_old");
+    expect(githubCredentialForPrincipal("user:bob")).toBeNull();
   });
 
   test("rejects a device-flow login that differs from the signed-in user", () => {

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -21,7 +21,11 @@ import {
   githubUserAuthActive,
   githubUserAuthSettings,
   githubUserLoginForRun,
+  pollGithubDeviceFlow,
+  refreshExpiringGithubTokens,
   removeGithubAccount,
+  soleGithubAccount,
+  soleGithubLogin,
   startGithubDeviceFlow,
   validateGithubTokenLogin,
 } from "./github-auth";
@@ -154,9 +158,14 @@ describe("token lookups + runner env", () => {
     }
   });
 
-  test("empty when the feature is off, the user is unknown, or not connected", () => {
+  test("simple mode uses the sole account; operator mode empty for unknown/unconnected", () => {
     seedToken();
-    expect(githubAuthEnv("Alice")).toEqual({}); // feature off
+    // Feature off (simple mode): the single connected account is the identity
+    // for every interactive run, regardless of the passed user.
+    expect(githubAuthEnv("Alice")).toEqual({
+      GH_TOKEN: "gho_test123",
+      GITHUB_TOKEN: "gho_test123",
+    });
     enableFeature();
     expect(githubAuthEnv("Some Randomer")).toEqual({}); // unknown user
     expect(githubAuthEnv(null)).toEqual({});
@@ -588,5 +597,97 @@ describe("keypad bearer auth", () => {
     expect(keypadBearerAuthorized(request("bearer keypad-test-secret"))).toBe(true);
     expect(keypadBearerAuthorized(request("Bearer wrong-secret"))).toBe(false);
     expect(keypadBearerAuthorized(request())).toBe(false);
+  });
+});
+
+describe("simple-mode credential (App connected, sign-in off)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  // A personal App: client id + secret configured, but userPrAuth stays off, so
+  // githubUserAuthActive()/webAuthRequired() are both false.
+  function simpleModeApp(): void {
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        integrations: {
+          github: { oauthClientId: "cid", oauthClientSecret: "csecret" },
+        },
+      }),
+    );
+    process.env.OPENSESSION_CONFIG = path;
+  }
+
+  function writeStore(users: Record<string, unknown>): void {
+    writeFileSync(
+      process.env.OPENSESSION_GITHUB_AUTH_STORE!,
+      JSON.stringify({ users }),
+    );
+  }
+
+  test("refreshes a personal-app token even with sign-in off", async () => {
+    simpleModeApp();
+    expect(githubUserAuthActive()).toBe(false);
+    const soon = new Date(Date.now() + 60_000).toISOString(); // inside the skew window
+    writeStore({
+      alice: {
+        login: "alice",
+        token: "old-token",
+        refreshToken: "rt-1",
+        expiresAt: soon,
+        connectedAt: "2026-07-18T00:00:00.000Z",
+      },
+    });
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("login/oauth/access_token"))
+        return new Response(
+          JSON.stringify({
+            access_token: "new-token",
+            refresh_token: "rt-2",
+            expires_in: 28800,
+            refresh_token_expires_in: 15552000,
+            token_type: "bearer",
+          }),
+          { status: 200 },
+        );
+      return new Response("{}", { status: 404 });
+    }) as unknown as typeof fetch;
+    await refreshExpiringGithubTokens();
+    const after = JSON.parse(
+      readFileSync(process.env.OPENSESSION_GITHUB_AUTH_STORE!, "utf-8"),
+    );
+    expect(after.users.alice.token).toBe("new-token");
+    expect(after.users.alice.refreshToken).toBe("rt-2");
+  });
+
+  test("reconnect authorizing a different account replaces, never strands two", async () => {
+    simpleModeApp();
+    writeStore({
+      alice: { login: "alice", token: "tok-alice", connectedAt: "2026-07-18T00:00:00.000Z" },
+    });
+    // Simple-mode reconnect passes no expected login; GitHub reports @bob.
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("login/oauth/access_token"))
+        return new Response(
+          JSON.stringify({ access_token: "tok-bob", token_type: "bearer" }),
+          { status: 200 },
+        );
+      if (url.includes("api.github.com/user"))
+        return new Response(JSON.stringify({ login: "bob", name: "Bob" }), { status: 200 });
+      return new Response("{}", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await pollGithubDeviceFlow("device-code");
+    expect(res.status).toBe("ok");
+    const after = JSON.parse(
+      readFileSync(process.env.OPENSESSION_GITHUB_AUTH_STORE!, "utf-8"),
+    );
+    expect(Object.keys(after.users)).toEqual(["bob"]); // one account, not two
+    expect(soleGithubLogin()).toBe("bob"); // recoverable: DELETE can find it
+    expect(soleGithubAccount()).not.toBeNull(); // repo ops resolve, no fallback to bot
   });
 });

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -166,6 +166,18 @@ describe("token lookups + runner env", () => {
       GH_TOKEN: "gho_test123",
       GITHUB_TOKEN: "gho_test123",
     });
+    // The caller may pass a null or unmatched user (simple mode has no per-user
+    // login); the sole account is still returned, so an interactive run gets
+    // GH_TOKEN. The pi-runner gate keys on interactivity, not on a non-null
+    // login — see the githubInteractive boolean.
+    expect(githubAuthEnv(null)).toEqual({
+      GH_TOKEN: "gho_test123",
+      GITHUB_TOKEN: "gho_test123",
+    });
+    expect(githubAuthEnv("Some Randomer")).toEqual({
+      GH_TOKEN: "gho_test123",
+      GITHUB_TOKEN: "gho_test123",
+    });
     enableFeature();
     expect(githubAuthEnv("Some Randomer")).toEqual({}); // unknown user
     expect(githubAuthEnv(null)).toEqual({});

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -848,11 +848,9 @@ export const serviceGithubCredential: GithubCredential = {
   env: {},
 };
 
-/**
- * Exact-login lookup for an authenticated request or a checkout whose local
- * credential config records the non-secret login that registered it.
- */
+/** Exact-login lookup for an already authenticated web request. */
 export function githubCredentialForLogin(login: string): GithubCredential | null {
+  if (!githubUserAuthActive()) return null;
   const account = readStore().users[login.toLowerCase()];
   if (!account?.token || !tokenUsable(account)) return null;
   return {

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -526,7 +526,7 @@ async function identifyAndStoreToken(
   if (!ownership.ok) return { status: "error", error: ownership.error };
 
   const store = readStore();
-  store.users[login.toLowerCase()] = {
+  const record: StoredAccount = {
     login,
     token,
     ...(typeof user.name === "string" && user.name ? { name: user.name } : {}),
@@ -535,6 +535,16 @@ async function identifyAndStoreToken(
     connectedAt: new Date().toISOString(),
     ...grantExpiryFields(grant),
   };
+  // Simple mode holds exactly one account: soleGithubAccount()/soleGithubLogin()
+  // are one-account-or-nothing, so a reconnect that authorizes a DIFFERENT login
+  // must REPLACE the previous record, not accumulate. Two usable accounts strand
+  // both getters at null, which also leaves the DELETE route no way to recover.
+  // Operator mode keeps one record per signed-in team member.
+  if (githubUserAuthActive()) {
+    store.users[login.toLowerCase()] = record;
+  } else {
+    store.users = { [login.toLowerCase()]: record };
+  }
   writeStore(store);
   audit({ kind: "github_auth_connect", login, scopes: scope });
   return { status: "ok", login, ...(user.name ? { name: user.name } : {}) };
@@ -622,7 +632,14 @@ export async function refreshGithubToken(login: string): Promise<boolean> {
  *  Kept cheap (no-op for legacy tokens and far-from-expiry ones) so it can
  *  run on boot and on a short interval. */
 export async function refreshExpiringGithubTokens(): Promise<void> {
-  if (!githubUserAuthActive()) return;
+  // Gate on the App credentials the refresh grant itself needs, NOT on web
+  // sign-in. A personal App in simple mode keeps userPrAuth (and so
+  // githubUserAuthActive) off, yet still mints ~8h user-to-server tokens and
+  // stores a client secret for exactly this refresh. Bailing on
+  // githubUserAuthActive() left those tokens to expire and drop out of
+  // soleGithubAccount() until a manual reconnect.
+  const { clientId, clientSecret } = githubUserAuthSettings();
+  if (!clientId || !clientSecret) return;
   for (const account of Object.values(readStore().users)) {
     if (!account.refreshToken || !account.expiresAt) continue;
     if (account.refreshFailedAt) continue; // dead grant — only a reconnect fixes it
@@ -769,10 +786,16 @@ export function githubUserLoginForRun(user?: string | null): string | null {
  */
 export function githubAuthEnv(user?: string | null): Record<string, string> {
   const login = githubUserLoginForRun(user);
-  if (!login) return {};
-  const account = readStore().users[login.toLowerCase()];
-  if (!account || !tokenUsable(account)) return {};
-  return { GH_TOKEN: account.token, GITHUB_TOKEN: account.token };
+  if (login) {
+    const account = readStore().users[login.toLowerCase()];
+    if (account && tokenUsable(account))
+      return { GH_TOKEN: account.token, GITHUB_TOKEN: account.token };
+  }
+  // Simple mode has no per-user mapping (githubUserLoginForRun returns null when
+  // sign-in is off), but the single connected account IS the identity for every
+  // interactive run. soleGithubAccount() is null in operator mode, so the two
+  // paths never overlap.
+  return soleGithubAccount()?.env ?? {};
 }
 
 /** A remote sandbox cannot read the server's per-user grant store. Its trusted

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -45,6 +45,7 @@ import { audit } from "./audit";
 import { configuredIdentity, getConfig } from "./config";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import { fetchWithTimeout } from "./shared/fetch-with-timeout";
+import { githubGitCredentialEnv } from "./github-git-credential";
 
 const HOME = homeDir();
 
@@ -785,17 +786,9 @@ export function githubUserLoginForRun(user?: string | null): string | null {
  * for the trust gate (interactive, non-least-privilege runs only).
  */
 export function githubAuthEnv(user?: string | null): Record<string, string> {
-  const login = githubUserLoginForRun(user);
-  if (login) {
-    const account = readStore().users[login.toLowerCase()];
-    if (account && tokenUsable(account))
-      return { GH_TOKEN: account.token, GITHUB_TOKEN: account.token };
-  }
-  // Simple mode has no per-user mapping (githubUserLoginForRun returns null when
-  // sign-in is off), but the single connected account IS the identity for every
-  // interactive run. soleGithubAccount() is null in operator mode, so the two
-  // paths never overlap.
-  return soleGithubAccount()?.env ?? {};
+  const credential = githubCredentialForRun(user);
+  const token = credential?.env.GH_TOKEN;
+  return token ? { GH_TOKEN: token, GITHUB_TOKEN: token } : {};
 }
 
 /** A remote sandbox cannot read the server's per-user grant store. Its trusted
@@ -838,7 +831,9 @@ export function githubRunEnv(user?: string | null): Record<string, string> {
 
 export interface GithubCredential {
   kind: "service" | "user";
+  /** Durable, non-secret selector. Raw tokens must never be persisted. */
   principal: string;
+  /** Ephemeral child-process capability, including a process-local Git helper. */
   env: Record<string, string>;
 }
 
@@ -848,16 +843,50 @@ export const serviceGithubCredential: GithubCredential = {
   env: {},
 };
 
-/** Exact-login lookup for an already authenticated web request. */
-export function githubCredentialForLogin(login: string): GithubCredential | null {
-  if (!githubUserAuthActive()) return null;
-  const account = readStore().users[login.toLowerCase()];
-  if (!account?.token || !tokenUsable(account)) return null;
+function credentialForAccount(account: StoredAccount): GithubCredential {
   return {
     kind: "user",
     principal: `user:${account.login.toLowerCase()}`,
-    env: { GH_TOKEN: account.token, GITHUB_TOKEN: account.token },
+    env: githubGitCredentialEnv(account.token),
   };
+}
+
+function usableAccountForLogin(login: string): StoredAccount | null {
+  const account = readStore().users[login.toLowerCase()];
+  return account?.token && tokenUsable(account) ? account : null;
+}
+
+/** Exact-login lookup for an already authenticated web request. */
+export function githubCredentialForLogin(login: string): GithubCredential | null {
+  if (!githubUserAuthActive()) return null;
+  const account = usableAccountForLogin(login);
+  return account ? credentialForAccount(account) : null;
+}
+
+/** Resolve the current token for a server-minted durable selector. This lookup
+ * deliberately ignores the current simple/operator mode: recovery must retain
+ * the exact original identity, never switch to whichever account is sole now. */
+export function githubCredentialForPrincipal(
+  principal?: string | null,
+): GithubCredential | null {
+  if (principal === "service") return serviceGithubCredential;
+  if (!principal?.startsWith("user:")) return null;
+  const login = principal.slice("user:".length);
+  if (!login) return null;
+  const account = usableAccountForLogin(login);
+  return account ? credentialForAccount(account) : null;
+}
+
+/** Credential for a trusted interactive run. Callers still own the trust gate. */
+export function githubCredentialForRun(
+  user?: string | null,
+): GithubCredential | null {
+  const login = githubUserLoginForRun(user);
+  if (login) {
+    const account = usableAccountForLogin(login);
+    return account ? credentialForAccount(account) : null;
+  }
+  return soleGithubAccount();
 }
 
 /** The usable stored accounts (token present and not expired). */
@@ -880,11 +909,7 @@ export function soleGithubAccount(): GithubCredential | null {
   const usable = usableAccounts();
   if (usable.length !== 1) return null;
   const account = usable[0]!;
-  return {
-    kind: "user",
-    principal: `user:${account.login.toLowerCase()}`,
-    env: { GH_TOKEN: account.token, GITHUB_TOKEN: account.token },
-  };
+  return credentialForAccount(account);
 }
 
 /** The sole connected login in simple mode (for routes that manage it by

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -6,7 +6,7 @@
  * Opt-in via config (`integrations.github` in ~/.opensession/config.json):
  *
  *   "integrations": {
- *     "github": { "userPrAuth": true, "oauthClientId": "<OAuth app client id>" }
+ *     "github": { "userPrAuth": true, "oauthClientId": "<GitHub App client id>" }
  *   }
  *
  * Both keys are required for the feature to activate; absent/false = today's
@@ -73,6 +73,9 @@ export interface GithubConnectedAccount {
   /** GitHub profile display name at connect time. */
   name?: string;
   scopes?: string;
+  /** How the token was obtained: the device flow ("device") or a pasted
+   *  personal access token ("pat"). Absent on records predating the field. */
+  source?: "device" | "pat";
   connectedAt: string;
   /** GitHub has permanently rejected the stored refresh token, so the access
    *  token can no longer be renewed. Nothing server-side can revive it — the
@@ -107,11 +110,19 @@ function tokenUsable(account: StoredAccount): boolean {
   return Date.parse(account.expiresAt) > Date.now();
 }
 
-export function githubUserAuthSettings(): GithubUserAuthSettings {
+/** `integrations.github` as a plain object (the config value is untyped). */
+function githubIntegrationConfig(): Record<string, unknown> {
   const raw = getConfig().integrations?.github;
-  const o = raw && typeof raw === "object" && !Array.isArray(raw)
+  return raw && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : {};
+}
+
+export function githubUserAuthSettings(): GithubUserAuthSettings {
+  const o = githubIntegrationConfig();
+  // env → config: this client id feeds githubUserAuthActive()/webAuthRequired().
+  // It mirrors githubAppIdentity()'s client id resolution, kept separate so the
+  // two never drift into changing each other's meaning.
   const clientId =
     process.env.OPENSESSION_GITHUB_CLIENT_ID ||
     (typeof o.oauthClientId === "string" && o.oauthClientId.trim()
@@ -129,6 +140,101 @@ export function githubUserAuthSettings(): GithubUserAuthSettings {
 export function githubUserAuthActive(): boolean {
   const s = githubUserAuthSettings();
   return s.enabled && !!s.clientId;
+}
+
+// ── The GitHub App device flow ───────────────────────────────────────────────
+//
+// Simple-mode connect is a user's own GitHub App: they create one (the setup
+// wizard, or an operator env var), and the device flow issues a user-to-server
+// token scoped to the repos the app is installed on. It is opt-in: NO app is
+// shipped and there is no baked client id, so this path stays invisible until a
+// client id is configured.
+//
+// The client id and slug are public identifiers, not credentials. A client
+// secret is configured alongside them: the device flow itself needs none (its
+// token exchange takes client_id + device_code), but refreshing the ~8h
+// user-to-server token does, so without a secret the connection would lapse.
+export interface GithubAppIdentity {
+  /** Public OAuth client id; null = not configured (device flow unavailable). */
+  clientId: string | null;
+  /** App slug, for the install URL; null = not configured. */
+  slug: string | null;
+}
+
+function trimmedEnv(name: string): string | null {
+  const v = process.env[name];
+  return v && v.trim() ? v.trim() : null;
+}
+
+function trimmedConfig(o: Record<string, unknown>, key: string): string | null {
+  const v = o[key];
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * The operator's configured GitHub App identity, resolved env → config, with no
+ * baked default (nothing ships). Deliberately does NOT feed
+ * githubUserAuthActive() / webAuthRequired(): configuring an App must never flip
+ * an operator's sign-in gate. It is the client id for the device flow and the
+ * slug for the install URL only.
+ */
+export function githubAppIdentity(): GithubAppIdentity {
+  const o = githubIntegrationConfig();
+  return {
+    clientId:
+      trimmedEnv("OPENSESSION_GITHUB_CLIENT_ID") ?? trimmedConfig(o, "oauthClientId"),
+    slug: trimmedEnv("OPENSESSION_GITHUB_APP_SLUG") ?? trimmedConfig(o, "appSlug"),
+  };
+}
+
+/**
+ * The device-flow connect path is on offer — only when an operator has
+ * configured a GitHub App client id, and INDEPENDENT of
+ * webAuthRequired()/userPrAuth. Simple mode's always-available connect is the
+ * pasted token, not this.
+ */
+export function githubConnectAvailable(): boolean {
+  return !!githubAppIdentity().clientId;
+}
+
+/**
+ * The org an install was told to set the App up under (install `--org`, or the
+ * setup wizard with owner=Organization). Config-only — it is captured intent,
+ * not a live credential, and NEVER feeds githubUserAuthActive()/webAuthRequired().
+ * Null when the install was single-user (no org).
+ */
+export function githubAppOrg(): string | null {
+  return trimmedConfig(githubIntegrationConfig(), "appOrg");
+}
+
+/**
+ * The install/app-setup recorded that connecting should also turn on per-user
+ * sign-in (config `integrations.github.authOnConnect`). This is INTENT only: it
+ * has zero effect until the simple-mode device-connect handler consumes it and
+ * clears it (routes/connections.ts), so a box carrying it set-but-unconsumed
+ * behaves exactly like one without it. It deliberately does not touch
+ * userPrAuth, so it can never gate the app on its own.
+ */
+export function githubAuthOnConnect(): boolean {
+  return githubIntegrationConfig().authOnConnect === true;
+}
+
+/**
+ * Where the App client id came from, so the UI can name the exact thing to
+ * unset when it explains that the PAT field is blocked by an App. env wins over
+ * config, mirroring githubAppIdentity()'s resolution; null when no App is set.
+ */
+export function githubAppConfigSource(): "env" | "config" | null {
+  if (trimmedEnv("OPENSESSION_GITHUB_CLIENT_ID")) return "env";
+  if (trimmedConfig(githubIntegrationConfig(), "oauthClientId")) return "config";
+  return null;
+}
+
+/** Where a user picks which repos the App (and so their user-to-server token)
+ *  may reach. Null unless a configured App's slug is known. */
+export function githubAppInstallUrl(): string | null {
+  const { slug } = githubAppIdentity();
+  return slug ? `https://github.com/apps/${slug}/installations/new` : null;
 }
 
 function readStore(): Store {
@@ -172,9 +278,13 @@ const DEVICE_FLOW_DISABLED =
   'Tick "Enable Device Flow" in the app\'s settings on GitHub, then try again.';
 
 export async function startGithubDeviceFlow(): Promise<DeviceFlowStart | { error: string }> {
-  const { enabled, clientId } = githubUserAuthSettings();
-  if (!enabled) return { error: "GitHub user auth is not enabled (config integrations.github.userPrAuth)" };
-  if (!clientId) return { error: "No OAuth client id configured (integrations.github.oauthClientId)" };
+  // The device flow is the operator-App override (simple mode's default connect
+  // is a pasted PAT), so its client id comes from githubAppIdentity — env/config
+  // only, absent unless an App is configured. Who may reach this is the route's
+  // job (operator mode: signed in; simple mode: App configured), not the
+  // flow's — starting a device code is a read-only call to GitHub.
+  const clientId = githubAppIdentity().clientId;
+  if (!clientId) return { error: "GitHub connect is not configured (no client id)" };
   const res = await fetchWithTimeout("https://github.com/login/device/code", {
     method: "POST",
     headers: { Accept: "application/json", "Content-Type": "application/json" },
@@ -239,7 +349,7 @@ export async function pollGithubDeviceFlow(
   deviceCode: string,
   expectedLogin?: string | null
 ): Promise<DeviceFlowPoll> {
-  const { clientId } = githubUserAuthSettings();
+  const { clientId } = githubAppIdentity();
   if (!clientId) return { status: "error", error: "No OAuth client id configured" };
   const res = await fetchWithTimeout("https://github.com/login/oauth/access_token", {
     method: "POST",
@@ -387,7 +497,8 @@ function grantExpiryFields(body: TokenGrant): Partial<StoredAccount> {
 async function identifyAndStoreToken(
   token: string,
   grant: TokenGrant,
-  expectedLogin?: string | null
+  expectedLogin?: string | null,
+  source: "device" | "pat" = "device"
 ): Promise<DeviceFlowPoll> {
   const scope = grant.scope;
   const userRes = await fetchWithTimeout("https://api.github.com/user", {
@@ -400,7 +511,15 @@ async function identifyAndStoreToken(
   const user: any = await userRes.json().catch(() => null);
   const login: string | undefined = user?.login;
   if (!userRes.ok || !login) {
-    return { status: "error", error: "Token issued but GET /user failed — not stored" };
+    return {
+      status: "error",
+      // A pasted token is the user's own input to fix, so the error names the
+      // likely cause; the device-flow message reflects a token we just minted.
+      error:
+        source === "pat"
+          ? "GitHub rejected that token. Check it hasn't expired and grants repo access (Contents + Pull requests read-write, or a classic `repo` token)."
+          : "Token issued but GET /user failed — not stored",
+    };
   }
 
   const ownership = validateGithubTokenLogin(login, expectedLogin);
@@ -412,6 +531,7 @@ async function identifyAndStoreToken(
     token,
     ...(typeof user.name === "string" && user.name ? { name: user.name } : {}),
     ...(typeof scope === "string" && scope ? { scopes: scope } : {}),
+    source,
     connectedAt: new Date().toISOString(),
     ...grantExpiryFields(grant),
   };
@@ -419,6 +539,17 @@ async function identifyAndStoreToken(
   audit({ kind: "github_auth_connect", login, scopes: scope });
   return { status: "ok", login, ...(user.name ? { name: user.name } : {}) };
 }
+
+/**
+ * Store a user-pasted personal access token as the simple-mode account. The PAT
+ * is already the bearer credential — there is no grant to exchange — so it is
+ * validated and attributed exactly like a minted token (GET /user is ground
+ * truth for the login, never client-supplied) and stored with no `expiresAt`:
+ * classic and fine-grained PATs are treated as long-lived, and a 401 at use
+ * time is what surfaces a needed reconnect. Accepts both PAT kinds (both are
+ * just a bearer token). The route gates this to simple mode; storing here does
+ * not, so nothing depends on a client id being configured.
+ */
 
 // ── Token refresh (GitHub App user tokens) ───────────────────────────────────
 
@@ -704,4 +835,39 @@ export function githubCredentialForLogin(login: string): GithubCredential | null
     principal: `user:${account.login.toLowerCase()}`,
     env: { GH_TOKEN: account.token, GITHUB_TOKEN: account.token },
   };
+}
+
+/** The usable stored accounts (token present and not expired). */
+function usableAccounts(): StoredAccount[] {
+  return Object.values(readStore().users).filter((a) => a.token && tokenUsable(a));
+}
+
+/**
+ * The acting GitHub identity in SIMPLE MODE — one install, one user, so the
+ * single connected account (a pasted PAT, or a device-flow token) IS the
+ * identity, resolved without any web session (there is none: webAuthRequired()
+ * is false, so no authUser exists to scope by). Null when sign-in is active
+ * (operator mode resolves by authUser via githubCredentialForLogin instead) or
+ * when the usable-account count isn't exactly one — zero (nobody connected) and
+ * more than one (ambiguous) both fail closed so a caller never guesses whose
+ * token to act with.
+ */
+export function soleGithubAccount(): GithubCredential | null {
+  if (githubUserAuthActive()) return null; // operator mode scopes by authUser
+  const usable = usableAccounts();
+  if (usable.length !== 1) return null;
+  const account = usable[0]!;
+  return {
+    kind: "user",
+    principal: `user:${account.login.toLowerCase()}`,
+    env: { GH_TOKEN: account.token, GITHUB_TOKEN: account.token },
+  };
+}
+
+/** The sole connected login in simple mode (for routes that manage it by
+ *  name), on the same one-account-or-nothing rule as soleGithubAccount. */
+export function soleGithubLogin(): string | null {
+  if (githubUserAuthActive()) return null;
+  const usable = usableAccounts();
+  return usable.length === 1 ? usable[0]!.login : null;
 }

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -848,9 +848,11 @@ export const serviceGithubCredential: GithubCredential = {
   env: {},
 };
 
-/** Exact-login lookup for an already authenticated web request. */
+/**
+ * Exact-login lookup for an authenticated request or a checkout whose local
+ * credential config records the non-secret login that registered it.
+ */
 export function githubCredentialForLogin(login: string): GithubCredential | null {
-  if (!githubUserAuthActive()) return null;
   const account = readStore().users[login.toLowerCase()];
   if (!account?.token || !tokenUsable(account)) return null;
   return {

--- a/packages/core/opensession-server/src/server/github-git-credential.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.ts
@@ -1,0 +1,49 @@
+/** Process-local Git credential wiring for trusted server-owned Git calls. */
+
+import { existsSync } from "fs";
+import { resolve } from "path";
+import { SHIM_PATH } from "../../../../../scripts/lib/paths";
+
+const GH_CREDENTIAL_SCRIPT = resolve(
+  import.meta.dir,
+  "../../../../../scripts/gh-credential.ts",
+);
+
+function shellQuoteWord(word: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(word)) return word;
+  return `'${word.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * Use the stable installed command so compiled releases need neither Bun nor a
+ * scripts sidecar. The source-tree fallback keeps direct development runs
+ * useful before install.sh creates the shim.
+ */
+export function githubCredentialHelperCommand(
+  shimPath = SHIM_PATH,
+  shimExists = existsSync(shimPath),
+): string {
+  if (shimExists) return `!${shellQuoteWord(shimPath)} github-credential`;
+  return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
+}
+
+/**
+ * Authentication for one trusted server-owned Git subprocess. The token stays
+ * in the child environment. Git receives only a process-local, non-secret
+ * helper command, so existing checkouts work without mutating .git/config.
+ */
+export function githubGitCredentialEnv(
+  token: string,
+  helper = githubCredentialHelperCommand(),
+): Record<string, string> {
+  return {
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token,
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
+    GIT_CONFIG_VALUE_0: "",
+    GIT_CONFIG_KEY_1: "credential.https://github.com.helper",
+    GIT_CONFIG_VALUE_1: helper,
+  };
+}

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -36,7 +36,7 @@ import { createSelfDeployMcpServer } from "./self-deploy";
 import { createWebMcpServer } from "./web-mcp";
 import { papercutsEnabledForRepo } from "./papercuts";
 import { defaultRepo, productName } from "./config";
-import { githubAuthEnv } from "./github-auth";
+import { githubCredentialForRun } from "./github-auth";
 import { REPOS, sessionRepoId } from "./worktree";
 import { registerInteractiveMcpBuilder } from "./run-rpc";
 import { automationRunMcpForSession, selfImproveMcpForSession } from "./automations";
@@ -197,9 +197,19 @@ export function interactiveMcpServers(
 					"opensession-repos": createReposMcpServer({
 						sessionId,
 						attach: (repo, branch) =>
-							attachRepo(sessionId, repo, branch, githubAuthEnv(createdBy)),
+							attachRepo(
+								sessionId,
+								repo,
+								branch,
+								githubCredentialForRun(createdBy)?.env,
+							),
 						switchPrimary: (repo) =>
-							switchPrimaryRepo(sessionId, repo, false, githubAuthEnv(createdBy)),
+							switchPrimaryRepo(
+								sessionId,
+								repo,
+								false,
+								githubCredentialForRun(createdBy)?.env,
+							),
 						snapshot: () => {
 							const s = findSession(sessionId);
 							if (!s) return null;

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -36,6 +36,7 @@ import { createSelfDeployMcpServer } from "./self-deploy";
 import { createWebMcpServer } from "./web-mcp";
 import { papercutsEnabledForRepo } from "./papercuts";
 import { defaultRepo, productName } from "./config";
+import { githubAuthEnv } from "./github-auth";
 import { REPOS, sessionRepoId } from "./worktree";
 import { registerInteractiveMcpBuilder } from "./run-rpc";
 import { automationRunMcpForSession, selfImproveMcpForSession } from "./automations";
@@ -195,8 +196,10 @@ export function interactiveMcpServers(
 					// Cross-repo: attach secondary repos as isolated worktrees.
 					"opensession-repos": createReposMcpServer({
 						sessionId,
-						attach: (repo, branch) => attachRepo(sessionId, repo, branch),
-						switchPrimary: (repo) => switchPrimaryRepo(sessionId, repo),
+						attach: (repo, branch) =>
+							attachRepo(sessionId, repo, branch, githubAuthEnv(createdBy)),
+						switchPrimary: (repo) =>
+							switchPrimaryRepo(sessionId, repo, false, githubAuthEnv(createdBy)),
 						snapshot: () => {
 							const s = findSession(sessionId);
 							if (!s) return null;

--- a/packages/core/opensession-server/src/server/pr-viewed.test.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { getPrViewedFiles } from "./pr-viewed";
+import type { RouteContext } from "./routes/context";
+
+const savedConfig = process.env.OPENSESSION_CONFIG;
+const savedStore = process.env.OPENSESSION_GITHUB_AUTH_STORE;
+const realFetch = globalThis.fetch;
+let dir = "";
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "os-pr-viewed-test-"));
+  process.env.OPENSESSION_CONFIG = join(dir, "config.json");
+  process.env.OPENSESSION_GITHUB_AUTH_STORE = join(dir, "github-auth.json");
+  writeFileSync(
+    process.env.OPENSESSION_CONFIG,
+    JSON.stringify({ integrations: { github: { userPrAuth: false } } }),
+  );
+  writeFileSync(
+    process.env.OPENSESSION_GITHUB_AUTH_STORE,
+    JSON.stringify({
+      users: {
+        alice: {
+          login: "alice",
+          token: "ghu_simple_alice",
+          connectedAt: "2026-08-20T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  rmSync(dir, { recursive: true, force: true });
+  if (savedConfig === undefined) delete process.env.OPENSESSION_CONFIG;
+  else process.env.OPENSESSION_CONFIG = savedConfig;
+  if (savedStore === undefined) delete process.env.OPENSESSION_GITHUB_AUTH_STORE;
+  else process.env.OPENSESSION_GITHUB_AUTH_STORE = savedStore;
+});
+
+describe("PR viewed state credential", () => {
+  test("uses the sole connected account in simple mode", async () => {
+    let authorization = "";
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      authorization = String((init?.headers as Record<string, string>)?.Authorization || "");
+      return Response.json({
+        data: {
+          repository: {
+            pullRequest: {
+              id: "PR_node",
+              files: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{ path: "README.md", viewerViewedState: "VIEWED" }],
+              },
+            },
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    const req = new Request("http://localhost/api/pr-viewed-files");
+    const ctx: RouteContext = {
+      req,
+      url: new URL(req.url),
+      path: "/api/pr-viewed-files",
+      publicPrefix: "",
+      authUser: null,
+    };
+    const result = await getPrViewedFiles(ctx, "", "tellahq/opensession", 112);
+
+    expect(authorization).toBe("Bearer ghu_simple_alice");
+    expect(result).toEqual({ prId: "PR_node", viewed: ["README.md"] });
+  });
+});

--- a/packages/core/opensession-server/src/server/pr-viewed.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.ts
@@ -13,6 +13,7 @@
 import type { RouteContext } from "./routes/context";
 import { githubCredentialForLogin, githubUserLoginForRun } from "./github-auth";
 import { botGhToken } from "./github-limit";
+import { githubMutationCredential } from "./routes/github-credential";
 import { fetchWithTimeout } from "./shared/fetch-with-timeout";
 
 export interface PrViewedFiles {
@@ -27,10 +28,19 @@ async function viewerToken(
 	ctx: RouteContext,
 	claimedUser?: string | null,
 ): Promise<string | null> {
+	// Use the same request-scoped resolver as the other human-triggered PR
+	// actions. In simple mode this selects the sole connected account; with
+	// sign-in enabled it selects only the verified requester's account.
+	const requestCredential = githubMutationCredential(ctx);
+	if (requestCredential?.env.GH_TOKEN)
+		return requestCredential.env.GH_TOKEN;
+
+	// Preserve the older identity-table lookup for deployments that still send
+	// a claimed user without web sign-in, then retain the historical bot fallback.
 	const login = ctx.authUser?.login ?? githubUserLoginForRun(claimedUser);
 	if (login) {
-		const cred = githubCredentialForLogin(login);
-		if (cred?.env.GH_TOKEN) return cred.env.GH_TOKEN;
+		const credential = githubCredentialForLogin(login);
+		if (credential?.env.GH_TOKEN) return credential.env.GH_TOKEN;
 	}
 	return botGhToken();
 }

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -333,6 +333,34 @@ describe("connect-time auth bootstrap", () => {
     }
   });
 
+  test("refuses to flip when a concurrent connect replaced the stored account", async () => {
+    // The finding: token storage happens before this lock. If a racing poll
+    // authorized a different account, the simple-mode store now holds Bob, so
+    // enabling sign-in for Alice would roster an admin whose token is gone
+    // (githubCredentialForLogin("alice") is null). The in-lock revalidation must
+    // refuse and leave the gate + intent untouched.
+    const cfg = writeGithubConfig({ oauthClientId: "cid", authOnConnect: true });
+    const storePath = join(dir, `gh-auth-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        users: {
+          bob: { login: "bob", token: "tok-bob", connectedAt: "2020-01-01T00:00:00.000Z" },
+        },
+      }),
+    );
+    process.env.OPENSESSION_GITHUB_AUTH_STORE = storePath;
+    try {
+      const boot = await bootstrapUserAuthOnConnect("alice", "Alice");
+      expect("error" in boot).toBe(true);
+      const written = JSON.parse(readFileSync(cfg, "utf-8"));
+      expect(written.integrations.github.userPrAuth).toBeUndefined(); // gate NOT flipped
+      expect(written.integrations.github.authOnConnect).toBe(true); // intent NOT consumed
+    } finally {
+      delete process.env.OPENSESSION_GITHUB_AUTH_STORE;
+    }
+  });
+
   test("no authOnConnect: simple mode is unchanged (no cookie, no flip, no roster)", async () => {
     const cfg = writeGithubConfig({ oauthClientId: "cid" });
     const restore = stubGithubDeviceFetch("octocat", "Octo Cat");
@@ -375,17 +403,33 @@ describe("connect-time auth bootstrap", () => {
 
   test("refuses a second bootstrap once the intent is consumed (TOCTOU)", async () => {
     const cfg = writeGithubConfig({ oauthClientId: "cid", authOnConnect: true });
-    // First connect consumes authOnConnect: rosters @alice, flips the gate.
-    const first = await bootstrapUserAuthOnConnect("alice", "Alice");
-    expect("error" in first).toBe(false);
-    // A second poll that also passed the pre-lock check must be refused INSIDE
-    // the lock, or it would roster @bob as a second admin and mint a session.
-    const second = await bootstrapUserAuthOnConnect("bob", "Bob");
-    expect("error" in second).toBe(true);
-    const written = JSON.parse(readFileSync(cfg, "utf-8"));
-    const admins = written.identity.team.filter((m: any) => m.admin === true);
-    expect(admins.length).toBe(1); // @bob was never rostered
-    expect(admins[0].github.toLowerCase()).toBe("alice");
-    expect(written.integrations.github.authOnConnect).toBeUndefined();
+    // The connecting account is in the store (pollGithubDeviceFlow stored it
+    // before the lock), so the in-lock revalidation passes for @alice.
+    const storePath = join(dir, `gh-auth-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        users: {
+          alice: { login: "alice", token: "tok-alice", connectedAt: "2020-01-01T00:00:00.000Z" },
+        },
+      }),
+    );
+    process.env.OPENSESSION_GITHUB_AUTH_STORE = storePath;
+    try {
+      // First connect consumes authOnConnect: rosters @alice, flips the gate.
+      const first = await bootstrapUserAuthOnConnect("alice", "Alice");
+      expect("error" in first).toBe(false);
+      // A second poll that also passed the pre-lock check must be refused INSIDE
+      // the lock, or it would roster @bob as a second admin and mint a session.
+      const second = await bootstrapUserAuthOnConnect("bob", "Bob");
+      expect("error" in second).toBe(true);
+      const written = JSON.parse(readFileSync(cfg, "utf-8"));
+      const admins = written.identity.team.filter((m: any) => m.admin === true);
+      expect(admins.length).toBe(1); // @bob was never rostered
+      expect(admins[0].github.toLowerCase()).toBe("alice");
+      expect(written.integrations.github.authOnConnect).toBeUndefined();
+    } finally {
+      delete process.env.OPENSESSION_GITHUB_AUTH_STORE;
+    }
   });
 });

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -1,15 +1,72 @@
-import { describe, expect, test } from "bun:test";
-import { handleConnectionsRoutes } from "./connections";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { bootstrapUserAuthOnConnect, handleConnectionsRoutes } from "./connections";
 import type { RouteContext } from "./context";
+
+// The GitHub connect routes behave differently by mode: operator mode (web
+// sign-in on) gates on the signed-in identity; simple mode (no sign-in) drives
+// connect off a resolvable client id and manages the single connected account.
+// Every test isolates config + the token/session stores via their env overrides
+// so nothing reads the machine's real ~/.opensession.
+
+const ENV_KEYS = [
+  "OPENSESSION_CONFIG",
+  "OPENSESSION_GITHUB_CLIENT_ID",
+  "OPENSESSION_GITHUB_APP_SLUG",
+  "OPENSESSION_GITHUB_AUTH_STORE",
+  "OPENSESSION_WEB_SESSIONS_STORE",
+] as const;
+const saved: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) saved[k] = process.env[k];
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "os-connections-test-"));
+  for (const k of ENV_KEYS) delete process.env[k];
+  // Missing config = simple mode (sign-in off, feature off, no client id).
+  process.env.OPENSESSION_CONFIG = join(dir, "config.json");
+  process.env.OPENSESSION_GITHUB_AUTH_STORE = join(dir, "github-auth.json");
+  process.env.OPENSESSION_WEB_SESSIONS_STORE = join(dir, "web-sessions.json");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k]!;
+  }
+});
+
+/** Operator mode: userPrAuth + a client id makes webAuthRequired() true. A
+ *  fresh path each call sidesteps getConfig's mtime cache. */
+function enableOperatorMode(): void {
+  const path = join(dir, `operator-${Math.random().toString(36).slice(2)}.json`);
+  writeFileSync(
+    path,
+    JSON.stringify({
+      integrations: { github: { userPrAuth: true, oauthClientId: "test-client-id" } },
+    }),
+  );
+  process.env.OPENSESSION_CONFIG = path;
+}
 
 function context(
   path: string,
   method: string,
   authUser?: RouteContext["authUser"],
+  body?: unknown,
 ): RouteContext {
   const url = new URL(`http://localhost${path}`);
   return {
-    req: new Request(url, { method }),
+    req: new Request(url, {
+      method,
+      ...(body !== undefined
+        ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }
+        : {}),
+    }),
     url,
     path,
     publicPrefix: "",
@@ -17,25 +74,302 @@ function context(
   };
 }
 
-describe("GitHub connection ownership", () => {
-  test("requires sign-in before starting a connection", async () => {
-    const response = await handleConnectionsRoutes(
-      context("/api/connections/github/device", "POST", null),
-    );
-    expect(response?.status).toBe(403);
+const DEVICE = "/api/connections/github/device";
+
+describe("GitHub connect gating", () => {
+  test("simple mode without a configured app rejects the connect (400)", async () => {
+    const response = await handleConnectionsRoutes(context(DEVICE, "POST", null));
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error: "GitHub connect is not configured",
+    });
   });
 
-  test("cannot disconnect another signed-in user's account", async () => {
+  test("operator mode requires sign-in before starting a connection (403)", async () => {
+    enableOperatorMode();
+    const response = await handleConnectionsRoutes(context(DEVICE, "POST", null));
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toEqual({ error: "Sign in to connect GitHub" });
+  });
+
+  test("connect is decoupled from the sign-in gate", async () => {
+    // A resolvable client id (env) with sign-in still OFF: connect is available
+    // without putting the workspace behind sign-in.
+    process.env.OPENSESSION_GITHUB_CLIENT_ID = "simple-client-id";
     const response = await handleConnectionsRoutes(
-      context(
-        "/api/connections/github/account/happylinks",
-        "DELETE",
-        { login: "9ranty", name: "Grant" },
-      ),
+      context("/api/connections/github", "GET", null),
+    );
+    const body = await response?.json();
+    expect(body.connectAvailable).toBe(true);
+    expect(body.webAuthRequired).toBe(false);
+    // The client id came from the env var, so the UI names that to unset.
+    expect(body.appConfigSource).toBe("env");
+  });
+
+  test("no configured app: connect unavailable and no config source", async () => {
+    const response = await handleConnectionsRoutes(
+      context("/api/connections/github", "GET", null),
+    );
+    const body = await response?.json();
+    expect(body.connectAvailable).toBe(false);
+    expect(body.appConfigSource).toBe(null);
+  });
+
+  test("app configured via config file reports a config source", async () => {
+    const path = join(dir, `app-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(
+      path,
+      JSON.stringify({ integrations: { github: { oauthClientId: "cfg-client-id" } } }),
+    );
+    process.env.OPENSESSION_CONFIG = path;
+    const response = await handleConnectionsRoutes(
+      context("/api/connections/github", "GET", null),
+    );
+    const body = await response?.json();
+    expect(body.connectAvailable).toBe(true);
+    // userPrAuth is off, so a client id alone must not flip the sign-in gate.
+    expect(body.webAuthRequired).toBe(false);
+    expect(body.appConfigSource).toBe("config");
+  });
+});
+
+describe("GitHub disconnect ownership", () => {
+  test("operator mode: cannot disconnect another signed-in user's account", async () => {
+    enableOperatorMode();
+    const response = await handleConnectionsRoutes(
+      context("/api/connections/github/account/happylinks", "DELETE", {
+        login: "9ranty",
+        name: "Grant",
+      }),
     );
     expect(response?.status).toBe(403);
     expect(await response?.json()).toEqual({
       error: "You can only disconnect your own GitHub account",
     });
+  });
+
+  test("simple mode: only the single connected account is manageable", async () => {
+    // Nobody connected, so there is no sole account to disconnect.
+    const response = await handleConnectionsRoutes(
+      context("/api/connections/github/account/happylinks", "DELETE", null),
+    );
+    expect(response?.status).toBe(403);
+    expect(await response?.json()).toEqual({
+      error: "You can only disconnect the connected GitHub account",
+    });
+  });
+});
+
+
+const APP = "/api/connections/github/app";
+const GET = "/api/connections/github";
+
+describe("GitHub App config (simple mode)", () => {
+  test("POST writes client id + slug + secret to config, connect goes live, and userPrAuth is untouched", async () => {
+    const res = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),
+    );
+    expect(res?.status).toBe(200);
+    expect(await res?.json()).toEqual({ ok: true });
+
+    // On disk: the three keys are set and userPrAuth was never introduced —
+    // configuring the repo App must not flip the sign-in gate.
+    const written = JSON.parse(readFileSync(process.env.OPENSESSION_CONFIG!, "utf-8"));
+    expect(written.integrations.github.oauthClientId).toBe("Iv1.abc");
+    expect(written.integrations.github.appSlug).toBe("my-app");
+    expect(written.integrations.github.oauthClientSecret).toBe("shh");
+    expect(written.integrations.github.userPrAuth).toBeUndefined();
+
+    // Live, no restart: the App now reads as configured-from-config, and the
+    // workspace is still not behind sign-in.
+    const get = await handleConnectionsRoutes(context(GET, "GET", null));
+    const body = await get?.json();
+    expect(body.connectAvailable).toBe(true);
+    expect(body.appConfigSource).toBe("config");
+    expect(body.webAuthRequired).toBe(false);
+  });
+
+  test("POST without a client id, slug, or secret is rejected (400)", async () => {
+    // Missing client id.
+    expect(
+      (
+        await handleConnectionsRoutes(
+          context(APP, "POST", null, { clientId: "", slug: "my-app", secret: "shh" }),
+        )
+      )?.status,
+    ).toBe(400);
+    // Missing secret: required on the UI config path (the token is refreshed
+    // with it), so a blank one is refused rather than silently stored.
+    expect(
+      (
+        await handleConnectionsRoutes(
+          context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app" }),
+        )
+      )?.status,
+    ).toBe(400);
+  });
+
+  test("DELETE clears the App keys but leaves other github config intact", async () => {
+    await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),
+    );
+    // An unrelated github key, to prove the clear is surgical.
+    const path = process.env.OPENSESSION_CONFIG!;
+    const cfg = JSON.parse(readFileSync(path, "utf-8"));
+    cfg.integrations.github.userPrAuth = false;
+    writeFileSync(path, JSON.stringify(cfg));
+
+    const res = await handleConnectionsRoutes(context(APP, "DELETE", null));
+    expect(res?.status).toBe(200);
+
+    const after = JSON.parse(readFileSync(path, "utf-8"));
+    expect(after.integrations.github.oauthClientId).toBeUndefined();
+    expect(after.integrations.github.appSlug).toBeUndefined();
+    expect(after.integrations.github.userPrAuth).toBe(false);
+
+    const get = await handleConnectionsRoutes(context(GET, "GET", null));
+    expect((await get?.json()).connectAvailable).toBe(false);
+  });
+
+  test("POST is gated to simple mode (operator mode → 403)", async () => {
+    enableOperatorMode();
+    const res = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app" }),
+    );
+    expect(res?.status).toBe(403);
+  });
+
+  test("an env-set App cannot be overridden from the UI (409)", async () => {
+    process.env.OPENSESSION_GITHUB_CLIENT_ID = "env-client";
+    const res = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app" }),
+    );
+    expect(res?.status).toBe(409);
+  });
+});
+
+// ── The connect-time auth bootstrap (authOnConnect) ──────────────────────────
+// Simple-mode connect turning the workspace into operator mode in one request:
+// the just-authorized GitHub login is rostered as the first admin BEFORE
+// userPrAuth is flipped (single atomic write), a session cookie is set on the
+// response, and the intent is cleared. This is auth-critical — a wrong ordering
+// would leave the gate on with nobody able to sign in. GitHub is stubbed; the
+// login is ground truth from GET /user.
+
+const POLL = "/api/connections/github/device/poll";
+
+function writeGithubConfig(github: Record<string, unknown>): string {
+  const path = join(dir, `boot-${Math.random().toString(36).slice(2)}.json`);
+  writeFileSync(path, JSON.stringify({ integrations: { github } }));
+  process.env.OPENSESSION_CONFIG = path;
+  return path;
+}
+
+/** Stub the two calls a device poll makes: the token exchange, then GET /user
+ *  (which reports WHO authorized). Returns a restore fn. */
+function stubGithubDeviceFetch(login: string, name?: string): () => void {
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/login/oauth/access_token"))
+      return new Response(
+        JSON.stringify({ access_token: "tok-123", scope: "repo" }),
+        { status: 200 },
+      );
+    if (u.includes("api.github.com/user"))
+      return new Response(JSON.stringify({ login, ...(name ? { name } : {}) }), {
+        status: 200,
+      });
+    return new Response("{}", { status: 404 });
+  }) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = real;
+  };
+}
+
+describe("connect-time auth bootstrap", () => {
+  test("authOnConnect: rosters admin, flips userPrAuth, sets a session cookie, clears the intent", async () => {
+    const cfg = writeGithubConfig({
+      oauthClientId: "cid",
+      appOrg: "acme-inc",
+      authOnConnect: true,
+    });
+    const restore = stubGithubDeviceFetch("octocat", "Octo Cat");
+    try {
+      const res = await handleConnectionsRoutes(
+        context(POLL, "POST", null, { deviceCode: "dc-1" }),
+      );
+      expect(res?.status).toBe(200);
+      const body = await res?.json();
+      expect(body.status).toBe("ok");
+      expect(body.login).toBe("octocat");
+      expect(body.authEnabled).toBe(true);
+      expect(body.admin).toBe(true);
+      // The browser is signed in on this very response.
+      expect(res?.headers.get("set-cookie") || "").toContain("opensession_auth=");
+
+      const written = JSON.parse(readFileSync(cfg, "utf-8"));
+      // Rostered admin AND the flip live in the SAME persisted file — a single
+      // atomic write, so no readable state ever had the gate on without the
+      // admin present (the no-locked-out-window property).
+      const admin = written.identity.team.find(
+        (m: any) => m.github?.toLowerCase() === "octocat",
+      );
+      expect(admin.admin).toBe(true);
+      expect(admin.name).toBe("Octo Cat");
+      expect(written.integrations.github.userPrAuth).toBe(true);
+      // Intent consumed; the App identity survives.
+      expect(written.integrations.github.authOnConnect).toBeUndefined();
+      expect(written.integrations.github.appOrg).toBe("acme-inc");
+      expect(written.integrations.github.oauthClientId).toBe("cid");
+
+      // A web session exists for the just-connected login.
+      const store = JSON.parse(
+        readFileSync(process.env.OPENSESSION_WEB_SESSIONS_STORE!, "utf-8"),
+      );
+      expect(store.sessions.some((s: any) => s.login === "octocat")).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  test("no authOnConnect: simple mode is unchanged (no cookie, no flip, no roster)", async () => {
+    const cfg = writeGithubConfig({ oauthClientId: "cid" });
+    const restore = stubGithubDeviceFetch("octocat", "Octo Cat");
+    try {
+      const res = await handleConnectionsRoutes(
+        context(POLL, "POST", null, { deviceCode: "dc-2" }),
+      );
+      expect(res?.status).toBe(200);
+      const body = await res?.json();
+      expect(body.status).toBe("ok");
+      expect(body.login).toBe("octocat");
+      // None of the bootstrap fired.
+      expect(body.authEnabled).toBeUndefined();
+      expect(body.admin).toBeUndefined();
+      expect(res?.headers.get("set-cookie")).toBeNull();
+
+      const written = JSON.parse(readFileSync(cfg, "utf-8"));
+      expect(written.integrations.github.userPrAuth).toBeUndefined();
+      expect(written.identity).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("preflight refuses the flip when no rostered github login results", async () => {
+    const cfg = writeGithubConfig({
+      oauthClientId: "cid",
+      appOrg: "acme-inc",
+      authOnConnect: true,
+    });
+    // An empty login can't become a sign-in-capable admin, so the preflight
+    // fails closed: nothing is persisted, the gate stays off, intent intact.
+    const result = await bootstrapUserAuthOnConnect("", undefined);
+    expect("error" in result).toBe(true);
+    const written = JSON.parse(readFileSync(cfg, "utf-8"));
+    expect(written.integrations.github.userPrAuth).toBeUndefined();
+    expect(written.integrations.github.authOnConnect).toBe(true);
+    expect(written.identity).toBeUndefined();
   });
 });

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -372,4 +372,20 @@ describe("connect-time auth bootstrap", () => {
     expect(written.integrations.github.authOnConnect).toBe(true);
     expect(written.identity).toBeUndefined();
   });
+
+  test("refuses a second bootstrap once the intent is consumed (TOCTOU)", async () => {
+    const cfg = writeGithubConfig({ oauthClientId: "cid", authOnConnect: true });
+    // First connect consumes authOnConnect: rosters @alice, flips the gate.
+    const first = await bootstrapUserAuthOnConnect("alice", "Alice");
+    expect("error" in first).toBe(false);
+    // A second poll that also passed the pre-lock check must be refused INSIDE
+    // the lock, or it would roster @bob as a second admin and mint a session.
+    const second = await bootstrapUserAuthOnConnect("bob", "Bob");
+    expect("error" in second).toBe(true);
+    const written = JSON.parse(readFileSync(cfg, "utf-8"));
+    const admins = written.identity.team.filter((m: any) => m.admin === true);
+    expect(admins.length).toBe(1); // @bob was never rostered
+    expect(admins[0].github.toLowerCase()).toBe("alice");
+    expect(written.integrations.github.authOnConnect).toBeUndefined();
+  });
 });

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -83,6 +83,18 @@ export async function bootstrapUserAuthOnConnect(
 				return {
 					error: "GitHub sign-in was already enabled by another connection",
 				};
+			// The token was stored by pollGithubDeviceFlow BEFORE this lock, and
+			// simple mode keeps only one account. A concurrent poll that authorized
+			// a DIFFERENT account would have replaced the store, so flipping sign-in
+			// for `login` now would roster an admin whose token is gone
+			// (githubCredentialForLogin(login) would be null). Confirm the stored
+			// sole identity still matches before enabling the gate.
+			const { soleGithubLogin } = await import("../github-auth");
+			if (soleGithubLogin()?.toLowerCase() !== key)
+				return {
+					error:
+						"A different GitHub account connected before setup finished; reconnect to enable sign-in",
+				};
 			const team = rawTeam(config);
 			// (b) roster-upsert the login as admin, matched by github login.
 			const existing = team.find(

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -13,6 +13,122 @@ import { refreshPickerModels } from "../models";
 import { BRIDGE_PROVIDER_IDS, PROVIDER_ID_RE, addPickerModel, defaultPickerModelsForProvider, maskProviderKey, modelProviders, readModelProviderConfig, removeModelProvider, removePickerModel, setModelProvider } from "../model-providers";
 import { isPiModelId, piEngineEnabled, readPiEngineConfig, setPiEnabled, setPiPickerModels } from "../pi-config";
 
+/** Navigate `integrations.github` in a raw parsed config object so the App
+ *  routes can set or drop its keys without disturbing anything else the file
+ *  holds. `create` mints the objects on the way down; otherwise a missing
+ *  section returns undefined. */
+function githubIntegrationSection(
+	config: Record<string, unknown>,
+	create: boolean,
+): Record<string, unknown> | undefined {
+	const asObj = (v: unknown): Record<string, unknown> | undefined =>
+		v && typeof v === "object" && !Array.isArray(v)
+			? (v as Record<string, unknown>)
+			: undefined;
+	let integrations = asObj(config.integrations);
+	if (!integrations) {
+		if (!create) return undefined;
+		integrations = {};
+		config.integrations = integrations;
+	}
+	let github = asObj(integrations.github);
+	if (!github) {
+		if (!create) return undefined;
+		github = {};
+		integrations.github = github;
+	}
+	return github;
+}
+
+/**
+ * Turn a simple-mode device connect into operator mode, inside the ONE request,
+ * when the install or app-setup recorded that intent
+ * (integrations.github.authOnConnect). Ordering is the whole safety property:
+ * the just-authorized GitHub login is rostered as the first admin BEFORE
+ * userPrAuth is flipped, and both land in a single atomic config write, so no
+ * persisted state ever has the sign-in gate on with nobody able to pass it. A
+ * web session for that login is then minted and returned as the auth cookie
+ * (mirrors routes/auth.ts), and the intent is cleared so it never re-runs.
+ *
+ * `login`/`name` are GitHub ground truth from the device-flow poll
+ * (github-auth.ts GET /user), never client-supplied. The token itself is already
+ * stored by pollGithubDeviceFlow, so after the flip soleGithubAccount() returns
+ * null and githubCredentialForLogin(login) — the same store, keyed by login —
+ * silently becomes this person's per-user credential; nothing is deleted.
+ *
+ * The break-glass recovery is untouched: editing config `userPrAuth:false` on the
+ * box restores access (opensession.ts), because webAuthRequired() keys on it.
+ */
+export async function bootstrapUserAuthOnConnect(
+	login: string,
+	name: string | undefined,
+): Promise<{ token: string; cookie: string; name: string } | { error: string }> {
+	const { rawTeam } = await import("./setup-team");
+	const { rawConfig, persistRawConfig, withConfigMutationLock } = await import(
+		"../config-mutation"
+	);
+	const { createWebSession, webAuthSetCookie } = await import("../web-auth");
+	const key = login.trim().toLowerCase();
+
+	const flip = await withConfigMutationLock(
+		async (): Promise<{ ok: true } | { error: string }> => {
+			const config = rawConfig();
+			const team = rawTeam(config);
+			// (b) roster-upsert the login as admin, matched by github login.
+			const existing = team.find(
+				(m) => typeof m.github === "string" && m.github.toLowerCase() === key,
+			);
+			if (existing) {
+				existing.github = login;
+				existing.admin = true;
+				if (typeof existing.name !== "string" || !existing.name.trim())
+					existing.name = name?.trim() || login;
+			} else {
+				team.push({ name: name?.trim() || login, github: login, admin: true });
+			}
+			(config.identity as Record<string, unknown>).team = team;
+			// Preflight: refuse to flip the gate unless a rostered admin github
+			// login now exists. Ground-truth login is non-empty so this should
+			// always hold — it is the guarantee that step (c) never runs without
+			// step (b) having produced a sign-in-capable admin, and it fails closed
+			// (no persist) on an empty/unusable login rather than gating the app
+			// on a member nobody can sign in as.
+			const rostered =
+				!!key &&
+				team.some(
+					(m) =>
+						m.admin === true &&
+						typeof m.github === "string" &&
+						m.github.trim().toLowerCase() === key,
+				);
+			if (!rostered)
+				return {
+					error: "Could not roster the connected GitHub account as admin",
+				};
+			// (c) flip the sign-in gate — atomically with the roster write above.
+			const github = githubIntegrationSection(config, true)!;
+			github.userPrAuth = true;
+			// Consumed — clear the intent so a later connect is a plain reconnect.
+			delete github.authOnConnect;
+			persistRawConfig(config);
+			return { ok: true };
+		},
+	);
+	if ("error" in flip) return flip;
+
+	// (d) mint the session for the just-rostered login. getConfig() re-reads on
+	// the file change (mtime+size guard), so teamMemberForLogin inside
+	// createWebSession sees the fresh roster.
+	const session = createWebSession(login);
+	if (!session)
+		return { error: "Signed in with GitHub but could not create a session" };
+	return {
+		token: session.token,
+		cookie: webAuthSetCookie(session.token),
+		name: session.name,
+	};
+}
+
 export async function handleConnectionsRoutes(
 	ctx: RouteContext,
 ): Promise<Response | undefined> {
@@ -358,6 +474,7 @@ export async function handleConnectionsRoutes(
 
 	// ── Pi engine settings ──
 
+
 	if (path === "/api/settings/pi-engine" && req.method === "GET") {
 		return Response.json(
 			readPiEngineConfig() ?? { enabled: false, pickerModels: [] },
@@ -429,9 +546,18 @@ export async function handleConnectionsRoutes(
 	// Device-flow connect per teammate; tokens live server-side (0600) and are
 	// never returned here. See src/server/github-auth.ts.
 	if (path === "/api/connections/github" && req.method === "GET") {
-		const { githubUserAuthSettings, connectedGithubAccount, connectedGithubAccounts } = await import(
-			"../github-auth"
-		);
+		const {
+			githubUserAuthSettings,
+			connectedGithubAccount,
+			connectedGithubAccounts,
+			githubConnectAvailable,
+			githubAppConfigSource,
+			githubAppInstallUrl,
+			githubAppOrg,
+			githubAuthOnConnect,
+			soleGithubLogin,
+		} = await import("../github-auth");
+		const { webAuthRequired } = await import("../web-auth");
 		const { configuredIdentity } = await import("../config");
 		const settings = githubUserAuthSettings();
 		const all = connectedGithubAccounts();
@@ -441,10 +567,24 @@ export async function handleConnectionsRoutes(
 		);
 		const ownLogin = ctx.authUser?.login || "";
 		const ownAccount = ownLogin ? connectedGithubAccount(ownLogin) : null;
+		// Simple mode (no web sign-in): there is no authUser to scope by, so the
+		// card shows the single connected account directly and drives connect off
+		// githubConnectAvailable() rather than the userPrAuth switch.
+		const simpleMode = !webAuthRequired();
 		return Response.json({
 			enabled: settings.enabled,
 			clientIdConfigured: !!settings.clientId,
-			accounts: ownAccount ? [ownAccount] : [],
+			connectAvailable: githubConnectAvailable(),
+			appConfigSource: githubAppConfigSource(),
+			webAuthRequired: !simpleMode,
+			appInstallUrl: githubAppInstallUrl(),
+			// Captured install/app-setup intent, so the wizard can prefill the org
+			// owner and show it is finishing sign-in setup. Inert until a connect
+			// consumes authOnConnect.
+			appOrg: githubAppOrg(),
+			authOnConnect: githubAuthOnConnect(),
+			soleLogin: simpleMode ? soleGithubLogin() : null,
+			accounts: simpleMode ? all : ownAccount ? [ownAccount] : [],
 			team: configuredIdentity()
 				.team.filter((m) => m.github)
 				.map((m) => ({
@@ -462,9 +602,18 @@ export async function handleConnectionsRoutes(
 		path === "/api/connections/github/device" &&
 		req.method === "POST"
 	) {
-		if (!ctx.authUser?.login)
+		const { startGithubDeviceFlow, githubConnectAvailable } = await import(
+			"../github-auth"
+		);
+		const { webAuthRequired } = await import("../web-auth");
+		if (!githubConnectAvailable())
+			return Response.json({ error: "GitHub connect is not configured" }, { status: 400 });
+		// Operator mode stores the token under the signed-in identity, so it
+		// still needs a session. Simple mode has neither session nor authUser —
+		// the sole install user connects the one account, and GitHub's /user tells
+		// us who that is (identifyAndStoreToken), never the client.
+		if (webAuthRequired() && !ctx.authUser?.login)
 			return Response.json({ error: "Sign in to connect GitHub" }, { status: 403 });
-		const { startGithubDeviceFlow } = await import("../github-auth");
 		const result = await startGithubDeviceFlow();
 		if ("error" in result) return Response.json(result, { status: 400 });
 		return Response.json(result);
@@ -474,17 +623,56 @@ export async function handleConnectionsRoutes(
 		path === "/api/connections/github/device/poll" &&
 		req.method === "POST"
 	) {
-		if (!ctx.authUser?.login)
+		const { pollGithubDeviceFlow, githubConnectAvailable } = await import(
+			"../github-auth"
+		);
+		const { webAuthRequired } = await import("../web-auth");
+		if (!githubConnectAvailable())
+			return Response.json({ error: "GitHub connect is not configured" }, { status: 400 });
+		if (webAuthRequired() && !ctx.authUser?.login)
 			return Response.json({ error: "Sign in to connect GitHub" }, { status: 403 });
 		const body = await req.json().catch(() => null);
 		const deviceCode =
 			typeof body?.deviceCode === "string" ? body.deviceCode : "";
 		if (!deviceCode)
 			return Response.json({ error: "deviceCode required" }, { status: 400 });
-		const { pollGithubDeviceFlow } = await import("../github-auth");
-		return Response.json(
-			await pollGithubDeviceFlow(deviceCode, ctx.authUser.login),
+		// Simple mode passes no expected login (authUser is null): the token is
+		// stored under whichever login GitHub reports authorized it.
+		const result = await pollGithubDeviceFlow(
+			deviceCode,
+			ctx.authUser?.login ?? undefined,
 		);
+		// The auth bootstrap: a simple-mode connect the install/app-setup marked
+		// as also turning on sign-in (authOnConnect). This is the first moment a
+		// real GitHub login exists to become the admin and hold a session, so it
+		// is the only safe moment to flip the gate — never at install, where doing
+		// so would lock the operator out. webAuthRequired() is still false here
+		// (userPrAuth not yet set); once this runs, later connects are operator
+		// mode and take the branch above. authOnConnect absent ⇒ this is skipped
+		// and the simple-mode path is byte-identical.
+		if (result.status === "ok" && !webAuthRequired()) {
+			const { githubAuthOnConnect } = await import("../github-auth");
+			if (githubAuthOnConnect()) {
+				const boot = await bootstrapUserAuthOnConnect(result.login, result.name);
+				if ("error" in boot)
+					return Response.json({ status: "error", error: boot.error });
+				// Native clients can't hold the HttpOnly cookie — they ask for the
+				// token in the body (native:true) and send it back as Bearer.
+				const native = body?.native === true;
+				return Response.json(
+					{
+						...result,
+						// The workspace is now behind sign-in and the browser holds the
+						// session cookie; the client reloads to reflect operator mode.
+						authEnabled: true,
+						admin: true,
+						...(native ? { token: boot.token } : {}),
+					},
+					{ headers: { "Set-Cookie": boot.cookie } },
+				);
+			}
+		}
+		return Response.json(result);
 	}
 
 	const ghAccountMatch = path.match(
@@ -492,17 +680,138 @@ export async function handleConnectionsRoutes(
 	);
 	if (ghAccountMatch && req.method === "DELETE") {
 		const login = decodeURIComponent(ghAccountMatch[1]);
-		if (!ctx.authUser?.login || ctx.authUser.login.toLowerCase() !== login.toLowerCase()) {
-			return Response.json(
-				{ error: "You can only disconnect your own GitHub account" },
-				{ status: 403 },
-			);
+		const { removeGithubAccount, soleGithubLogin } = await import("../github-auth");
+		const { webAuthRequired } = await import("../web-auth");
+		if (webAuthRequired()) {
+			// Operator mode: you manage only your own signed-in account.
+			if (!ctx.authUser?.login || ctx.authUser.login.toLowerCase() !== login.toLowerCase()) {
+				return Response.json(
+					{ error: "You can only disconnect your own GitHub account" },
+					{ status: 403 },
+				);
+			}
+		} else {
+			// Simple mode: the only manageable account is the single connected one.
+			const sole = soleGithubLogin();
+			if (!sole || sole.toLowerCase() !== login.toLowerCase()) {
+				return Response.json(
+					{ error: "You can only disconnect the connected GitHub account" },
+					{ status: 403 },
+				);
+			}
 		}
-		const { removeGithubAccount } = await import("../github-auth");
 		const removed = removeGithubAccount(login);
 		if (!removed)
 			return Response.json({ error: "Not connected" }, { status: 404 });
 		return Response.json({ ok: true });
+	}
+
+	// ── Bring-your-own GitHub App (simple mode) ──────────────────────────────
+	// Persist the App's public client id + slug to config.json so the device
+	// flow lights up with no env var and no restart: githubAppIdentity() reads
+	// getConfig() per call, and getConfig() re-reads on the file's mtime change.
+	// Deliberately never writes userPrAuth — configuring the repo App must not
+	// flip the sign-in gate. Gated to simple mode; an env-set App can't be
+	// overridden here (env wins), so it is refused with the reason.
+	if (path === "/api/connections/github/app" && req.method === "POST") {
+		const { webAuthRequired } = await import("../web-auth");
+		if (webAuthRequired())
+			return Response.json(
+				{ error: "Not available while GitHub sign-in is on" },
+				{ status: 403 },
+			);
+		const { githubAppConfigSource } = await import("../github-auth");
+		if (githubAppConfigSource() === "env")
+			return Response.json(
+				{
+					error:
+						"A GitHub App is set via OPENSESSION_GITHUB_CLIENT_ID; unset it to configure one here",
+				},
+				{ status: 409 },
+			);
+		const body = (await req.json().catch(() => null)) as {
+			clientId?: unknown;
+			slug?: unknown;
+			secret?: unknown;
+			appOrg?: unknown;
+		} | null;
+		const clientId =
+			typeof body?.clientId === "string" ? body.clientId.trim() : "";
+		const slug = typeof body?.slug === "string" ? body.slug.trim() : "";
+		const secret = typeof body?.secret === "string" ? body.secret.trim() : "";
+		// Present ⇒ the App is owned by an org (owner=Organization); empty/absent ⇒
+		// a personal App (single-user).
+		const appOrg = typeof body?.appOrg === "string" ? body.appOrg.trim() : "";
+		// The secret is required on the UI config path: the device-flow token
+		// expires and Open Session refreshes it with the secret, so without one
+		// the connection would silently stop working after ~8h. (Env-configured
+		// Apps are governed separately and may omit it — an ops choice.)
+		if (!clientId || !slug || !secret)
+			return Response.json(
+				{ error: "clientId, slug and secret are required" },
+				{ status: 400 },
+			);
+		const { rawConfig, persistRawConfig, withConfigMutationLock } =
+			await import("../config-mutation");
+		return withConfigMutationLock(async () => {
+			const config = rawConfig();
+			const github = githubIntegrationSection(config, true)!;
+			github.oauthClientId = clientId;
+			github.appSlug = slug;
+			github.oauthClientSecret = secret;
+			// An org-owned App also records the intent to turn on per-user sign-in
+			// at the first connect; a personal App is single-user, so any stale
+			// intent is cleared. Deliberately never writes userPrAuth — the gate is
+			// flipped only when someone actually connects (device/poll below), so a
+			// box carrying authOnConnect set-but-unconsumed still behaves as simple
+			// mode.
+			if (appOrg) {
+				github.appOrg = appOrg;
+				github.authOnConnect = true;
+			} else {
+				delete github.appOrg;
+				delete github.authOnConnect;
+			}
+			persistRawConfig(config);
+			return Response.json({ ok: true });
+		});
+	}
+
+	if (path === "/api/connections/github/app" && req.method === "DELETE") {
+		const { webAuthRequired } = await import("../web-auth");
+		if (webAuthRequired())
+			return Response.json(
+				{ error: "Not available while GitHub sign-in is on" },
+				{ status: 403 },
+			);
+		const { githubAppConfigSource } = await import("../github-auth");
+		if (githubAppConfigSource() === "env")
+			return Response.json(
+				{
+					error:
+						"The GitHub App is set via OPENSESSION_GITHUB_CLIENT_ID; unset the variable and restart to remove it",
+				},
+				{ status: 409 },
+			);
+		const { rawConfig, persistRawConfig, withConfigMutationLock } =
+			await import("../config-mutation");
+		return withConfigMutationLock(async () => {
+			const config = rawConfig();
+			const github = githubIntegrationSection(config, false);
+			if (github) {
+				// Drop the repo-App keys and the captured sign-in intent
+				// (appOrg/authOnConnect) — removing the App is also how the wizard
+				// clears the org intent when the owner is switched back to "You".
+				// userPrAuth and anything else the github integration holds survive.
+				delete github.oauthClientId;
+				delete github.appSlug;
+				delete github.oauthClientSecret;
+				delete github.appOrg;
+				delete github.authOnConnect;
+			}
+			persistRawConfig(config);
+			return Response.json({ ok: true });
+		});
 	}
 
 	// ── Plain triage router (spam gate + model routing for new tickets) ──

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -73,6 +73,16 @@ export async function bootstrapUserAuthOnConnect(
 	const flip = await withConfigMutationLock(
 		async (): Promise<{ ok: true } | { error: string }> => {
 			const config = rawConfig();
+			// (a) Re-check the intent INSIDE the lock. The route checked
+			// githubAuthOnConnect() before acquiring it, but a concurrent device
+			// poll may have already consumed authOnConnect (rostered its own admin,
+			// flipped the gate). Without this the queued second poll would roster a
+			// second admin and mint a session against an already-enabled instance.
+			const github = githubIntegrationSection(config, true)!;
+			if (github.authOnConnect !== true)
+				return {
+					error: "GitHub sign-in was already enabled by another connection",
+				};
 			const team = rawTeam(config);
 			// (b) roster-upsert the login as admin, matched by github login.
 			const existing = team.find(
@@ -106,7 +116,6 @@ export async function bootstrapUserAuthOnConnect(
 					error: "Could not roster the connected GitHub account as admin",
 				};
 			// (c) flip the sign-in gate — atomically with the roster write above.
-			const github = githubIntegrationSection(config, true)!;
 			github.userPrAuth = true;
 			// Consumed — clear the intent so a later connect is a plain reconnect.
 			delete github.authOnConnect;

--- a/packages/core/opensession-server/src/server/routes/github-credential.ts
+++ b/packages/core/opensession-server/src/server/routes/github-credential.ts
@@ -1,6 +1,7 @@
 import {
   githubCredentialForLogin,
   serviceGithubCredential,
+  soleGithubAccount,
   type GithubCredential,
 } from "../github-auth";
 import { webAuthRequired } from "../web-auth";
@@ -12,7 +13,10 @@ import type { RouteContext } from "./context";
  * that would attribute a deliberate human action to the bot.
  */
 export function githubMutationCredential(ctx: RouteContext): GithubCredential | null {
-  if (!webAuthRequired()) return serviceGithubCredential;
+  // Simple mode: the single connected account is the identity, so a PR the sole
+  // user opens is authored by them, not the bot. Fall back to the service
+  // credential only when nobody has connected (soleGithubAccount() is null).
+  if (!webAuthRequired()) return soleGithubAccount() ?? serviceGithubCredential;
   return ctx.authUser?.login ? githubCredentialForLogin(ctx.authUser.login) : null;
 }
 

--- a/packages/core/opensession-server/src/server/routes/session-git.ts
+++ b/packages/core/opensession-server/src/server/routes/session-git.ts
@@ -25,6 +25,7 @@ import { defaultRepo } from "../config";
 import { $ } from "bun";
 import { existsSync } from "fs";
 import { resolve } from "path";
+import { githubMutationCredential } from "./github-credential";
 
 function isDiffGroupFile(file: unknown): file is DiffGroupFile {
 	if (typeof file !== "object" || file === null) return false;
@@ -423,6 +424,7 @@ export async function handleSessionGitRoutes(
 			target.dir,
 			session.branch || "HEAD",
 			target.primary ? await workspaceExecFor(session, target.dir) : undefined,
+			githubMutationCredential(ctx)?.env,
 		);
 		if ("error" in result) return Response.json(result, { status: 502 });
 		return Response.json(result);
@@ -453,6 +455,7 @@ export async function handleSessionGitRoutes(
 			target.dir,
 			body?.base ? target.defaultBranch : undefined,
 			target.primary ? await workspaceExecFor(session, target.dir) : undefined,
+			githubMutationCredential(ctx)?.env,
 		);
 		if ("error" in result) return Response.json(result, { status: 502 });
 		return Response.json(result);

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -55,3 +55,52 @@ describe("workspace setup authorization", () => {
 		});
 	});
 });
+
+/** A simple-mode config carrying the captured org intent (userPrAuth absent, so
+ *  sign-in is off and any caller administers the workspace). */
+function orgIntentConfig(): void {
+	const dir = mkdtempSync(join(tmpdir(), "opensession-setup-intent-"));
+	dirs.push(dir);
+	const path = join(dir, "config.json");
+	writeFileSync(
+		path,
+		JSON.stringify({
+			integrations: {
+				github: { appOrg: "acme-inc", authOnConnect: true },
+			},
+		}),
+	);
+	process.env.OPENSESSION_CONFIG = path;
+	delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+}
+
+function singleUserConfig(): void {
+	const dir = mkdtempSync(join(tmpdir(), "opensession-setup-single-"));
+	dirs.push(dir);
+	const path = join(dir, "config.json");
+	writeFileSync(path, JSON.stringify({ integrations: {} }));
+	process.env.OPENSESSION_CONFIG = path;
+	delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+}
+
+describe("setup status github snapshot exposes install intent", () => {
+	test("appOrg + authOnConnect ride the snapshot", async () => {
+		orgIntentConfig();
+		const response = await handleSetupRoutes(context("anyone"));
+		expect(response?.status).toBe(200);
+		const body = await response?.json();
+		expect(body.github.appOrg).toBe("acme-inc");
+		expect(body.github.authOnConnect).toBe(true);
+		// The intent is inert: it must not have flipped the sign-in gate.
+		expect(body.github.userPrAuth).toBe(false);
+	});
+
+	test("a single-user install exposes no intent", async () => {
+		singleUserConfig();
+		const response = await handleSetupRoutes(context("anyone"));
+		const body = await response?.json();
+		expect(body.github.appOrg).toBe(null);
+		expect(body.github.authOnConnect).toBe(false);
+		expect(body.github.userPrAuth).toBe(false);
+	});
+});

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { validGithubFullName } from "./setup-repos";
+import { githubCredentialHelperCommand, validGithubFullName } from "./setup-repos";
 
 describe("validGithubFullName", () => {
   test("accepts ordinary owner/name pairs", () => {
@@ -35,5 +35,20 @@ describe("validGithubFullName", () => {
     // Matches the regex, but is harmless: the clone always receives the full
     // https URL via array spawn, so a "-"-prefixed owner can't become a flag.
     expect(validGithubFullName("--flag/repo")).toBe(true);
+  });
+});
+
+
+describe("githubCredentialHelperCommand", () => {
+  test("uses the stable installed command for compiled releases", () => {
+    expect(
+      githubCredentialHelperCommand("/home/alice/Open Session/bin/opensession", true),
+    ).toBe("!'/home/alice/Open Session/bin/opensession' github-credential");
+  });
+
+  test("falls back to the source script before the shim is installed", () => {
+    const command = githubCredentialHelperCommand("/missing/opensession", false);
+    expect(command).toStartWith("!bun ");
+    expect(command).toEndWith("scripts/gh-credential.ts");
   });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -1,17 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
-import {
-  configureGithubCredentialHelper,
-  githubCredentialHelperCommand,
-  validGithubFullName,
-} from "./setup-repos";
-
-const tempDirs: string[] = [];
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
-});
+import { describe, expect, test } from "bun:test";
+import { githubCredentialHelperCommand, validGithubFullName } from "./setup-repos";
 
 describe("validGithubFullName", () => {
   test("accepts ordinary owner/name pairs", () => {
@@ -64,26 +52,4 @@ describe("githubCredentialHelperCommand", () => {
     expect(command).toEndWith("scripts/gh-credential.ts");
   });
 
-  test("records the registering login for later server-side Git operations", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "github-helper-"));
-    tempDirs.push(dir);
-    const init = Bun.spawnSync(["git", "init", "-q", dir]);
-    expect(init.exitCode).toBe(0);
-
-    await configureGithubCredentialHelper(dir, {
-      kind: "user",
-      principal: "user:alice",
-      env: { GH_TOKEN: "secret", GITHUB_TOKEN: "secret" },
-    });
-
-    const username = Bun.spawnSync([
-      "git", "-C", dir, "config", "--get", "credential.https://github.com.username",
-    ]);
-    expect(username.stdout.toString().trim()).toBe("alice");
-    const helper = Bun.spawnSync([
-      "git", "-C", dir, "config", "--get-all", "credential.https://github.com.helper",
-    ]).stdout.toString();
-    expect(helper).toContain("gh-credential");
-    expect(helper).not.toContain("secret");
-  });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, test } from "bun:test";
-import { githubCredentialHelperCommand, validGithubFullName } from "./setup-repos";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  configureGithubCredentialHelper,
+  githubCredentialHelperCommand,
+  validGithubFullName,
+} from "./setup-repos";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("validGithubFullName", () => {
   test("accepts ordinary owner/name pairs", () => {
@@ -50,5 +62,28 @@ describe("githubCredentialHelperCommand", () => {
     const command = githubCredentialHelperCommand("/missing/opensession", false);
     expect(command).toStartWith("!bun ");
     expect(command).toEndWith("scripts/gh-credential.ts");
+  });
+
+  test("records the registering login for later server-side Git operations", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "github-helper-"));
+    tempDirs.push(dir);
+    const init = Bun.spawnSync(["git", "init", "-q", dir]);
+    expect(init.exitCode).toBe(0);
+
+    await configureGithubCredentialHelper(dir, {
+      kind: "user",
+      principal: "user:alice",
+      env: { GH_TOKEN: "secret", GITHUB_TOKEN: "secret" },
+    });
+
+    const username = Bun.spawnSync([
+      "git", "-C", dir, "config", "--get", "credential.https://github.com.username",
+    ]);
+    expect(username.stdout.toString().trim()).toBe("alice");
+    const helper = Bun.spawnSync([
+      "git", "-C", dir, "config", "--get-all", "credential.https://github.com.helper",
+    ]).stdout.toString();
+    expect(helper).toContain("gh-credential");
+    expect(helper).not.toContain("secret");
   });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -333,18 +333,10 @@ export function githubCredentialHelperCommand(
   return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
 }
 
-export async function configureGithubCredentialHelper(
-  checkoutPath: string,
-  credential: GithubCredential,
-): Promise<void> {
+async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {
   const helperKey = "credential.https://github.com.helper";
   await $`git -C ${checkoutPath} config --replace-all ${helperKey} ${""}`.quiet();
   await $`git -C ${checkoutPath} config --add ${helperKey} ${githubCredentialHelperCommand()}`.quiet();
-  if (credential.kind === "user") {
-    const login = credential.principal.replace(/^user:/, "");
-    const usernameKey = "credential.https://github.com.username";
-    await $`git -C ${checkoutPath} config --replace-all ${usernameKey} ${login}`.quiet();
-  }
 }
 
 async function registerGithubRepo(input: {
@@ -372,7 +364,7 @@ async function registerGithubRepo(input: {
     // it leaves is tokenless, so wire the credential helper for future
     // fetch/push. No-op for a public (tokenless) clone — the helper simply has
     // nothing to answer with.
-    if (input.credential) await configureGithubCredentialHelper(dest, input.credential);
+    if (input.credential) await configureGithubCredentialHelper(dest);
     const inspected = await inspectRepo(dest);
     const config = rawConfig();
     const repos = {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -8,9 +8,10 @@
  *                                   config.repos.
  */
 
+import { $ } from "bun";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve as resolvePath } from "path";
 import { audit } from "../audit";
 import { codeStorageConfig, configuredRepos, type RepoSection } from "../config";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
@@ -300,6 +301,25 @@ function checkoutsRoot(): string {
   return `${homeDir()}/checkouts`;
 }
 
+const GH_CREDENTIAL_SCRIPT = resolvePath(
+  import.meta.dir,
+  "../../../../../../scripts/gh-credential.ts",
+);
+
+/**
+ * Wire a URL-scoped git credential helper on a github.com checkout so ambient
+ * `git fetch`/`git push` resolve the currently connected token at use time,
+ * without the token ever persisting in the remote. Mirrors
+ * configureCsCredentialHelper: an empty value first resets any inherited helper
+ * list for this URL scope, then the minting helper. `--replace-all` keeps
+ * re-runs from stacking duplicates.
+ */
+async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {
+  const key = "credential.https://github.com.helper";
+  await $`git -C ${checkoutPath} config --replace-all ${key} ${""}`.quiet();
+  await $`git -C ${checkoutPath} config --add ${key} ${`!bun ${GH_CREDENTIAL_SCRIPT}`}`.quiet();
+}
+
 async function registerGithubRepo(input: {
   fullName: string;
   id?: string;
@@ -321,6 +341,11 @@ async function registerGithubRepo(input: {
   mkdirSync(root, { recursive: true });
   try {
     await cloneGithubRepo(input.fullName, dest, input.userToken);
+    // A private clone authenticated through a one-shot GIT_ASKPASS; the remote
+    // it leaves is tokenless, so wire the credential helper for future
+    // fetch/push. No-op for a public (tokenless) clone — the helper simply has
+    // nothing to answer with.
+    if (input.userToken) await configureGithubCredentialHelper(dest);
     const inspected = await inspectRepo(dest);
     const config = rawConfig();
     const repos = {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -8,7 +8,9 @@
  *                                   config.repos.
  */
 
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { audit } from "../audit";
 import { codeStorageConfig, configuredRepos, type RepoSection } from "../config";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
@@ -18,7 +20,7 @@ import {
   rawConfig,
   withConfigMutationLock,
 } from "../config-mutation";
-import { githubCredentialForLogin } from "../github-auth";
+import { githubCredentialForLogin, soleGithubAccount, type GithubCredential } from "../github-auth";
 import { homeDir } from "../paths";
 import { fetchWithTimeout } from "../shared/fetch-with-timeout";
 import type { RouteContext } from "./context";
@@ -30,6 +32,19 @@ export const GITHUB_FULL_NAME_RE = /^[\w.-]+\/[\w.-]+$/;
 
 export function validGithubFullName(value: unknown): value is string {
   return typeof value === "string" && GITHUB_FULL_NAME_RE.test(value);
+}
+
+/**
+ * The GitHub credential to act with for listing and cloning: the signed-in
+ * user's stored token when web sign-in is active (operator mode), else the
+ * single connected account in simple mode (soleGithubAccount — no authUser to
+ * scope by there). Null falls back to the bot PAT / anonymous access.
+ */
+function actingGithubCredential(ctx: RouteContext): GithubCredential | null {
+  return (
+    (ctx.authUser?.login ? githubCredentialForLogin(ctx.authUser.login) : null) ??
+    soleGithubAccount()
+  );
 }
 
 // ── GitHub repo listing ──────────────────────────────────────────────────────
@@ -191,6 +206,7 @@ async function listCodestorageRepos(): Promise<PickerRepo[]> {
 async function runCommand(
   argv: string[],
   timeoutMs: number,
+  extraEnv?: Record<string, string>,
 ): Promise<{ exitCode: number; stderr: string }> {
   const proc = Bun.spawn(argv, {
     env: {
@@ -198,6 +214,7 @@ async function runCommand(
       GIT_SSH_COMMAND:
         process.env.GIT_SSH_COMMAND ||
         "ssh -o ConnectTimeout=20 -o ServerAliveInterval=10 -o ServerAliveCountMax=3",
+      ...extraEnv,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -210,15 +227,69 @@ async function runCommand(
   return { exitCode, stderr: stderr.trim() };
 }
 
-/** Prefer `gh repo clone` (brings its own auth, leaves a clean tokenless
- *  remote); fall back to plain https `git clone`. NEVER embeds a credential
- *  in the persisted remote URL. Both paths get the full https URL (never the
- *  bare owner/name) so a `-`-prefixed name can't be parsed as a CLI flag. */
-async function cloneGithubRepo(fullName: string, dest: string): Promise<void> {
-  const url = `https://github.com/${fullName}.git`;
+/** Replace every occurrence of a secret in text bound for a log or an API
+ *  error. Cheap and total, so a token can't ride out on a clone failure. */
+function scrubSecret(text: string, secret?: string): string {
+  return secret ? text.split(secret).join("***") : text;
+}
+
+/**
+ * Clone `owner/name` to `dest`, NEVER embedding a credential in the persisted
+ * remote URL. Both paths take the full https URL (never the bare owner/name) so
+ * a `-`-prefixed name can't be read as a CLI flag.
+ *
+ * With a connected user token, clone privately and secretlessly: the token
+ * reaches git only through a 0700 GIT_ASKPASS helper that echoes it for the
+ * password prompt — never in argv (ps-visible), never in .git/config. The URL
+ * carries the username `x-access-token` (GitHub's app-token username, not a
+ * secret) so git skips the username prompt; origin is normalized to the
+ * tokenless URL afterward, holding the "no credential in the persisted remote"
+ * invariant. Without a token: `gh` (brings its own auth) if present, else an
+ * anonymous https clone — still enough for public repos.
+ */
+async function cloneGithubRepo(
+  fullName: string,
+  dest: string,
+  userToken?: string,
+): Promise<void> {
+  const cleanUrl = `https://github.com/${fullName}.git`;
+  if (userToken) {
+    const askpassDir = mkdtempSync(join(tmpdir(), "os-gh-askpass-"));
+    const askpass = join(askpassDir, "askpass.sh");
+    // The script body is static and secret-free: git passes the prompt text as
+    // $1, and the helper echoes the username or the token from the environment
+    // (which only this child and its git subprocess can read).
+    writeFileSync(
+      askpass,
+      '#!/bin/sh\ncase "$1" in\n*[Uu]sername*) printf %s "$GIT_USERNAME" ;;\n*) printf %s "$GIT_PASSWORD" ;;\nesac\n',
+      { mode: 0o700 },
+    );
+    chmodSync(askpass, 0o700); // belt against a permissive umask on create
+    try {
+      const result = await runCommand(
+        ["git", "clone", "--", `https://x-access-token@github.com/${fullName}.git`, dest],
+        5 * 60_000,
+        {
+          GIT_ASKPASS: askpass,
+          GIT_TERMINAL_PROMPT: "0",
+          GIT_USERNAME: "x-access-token",
+          GIT_PASSWORD: userToken,
+        },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(scrubSecret(result.stderr, userToken) || "git clone failed");
+      }
+      // The token never touched the persisted remote (it lived only in the
+      // askpass env), but drop the username too so origin is the plain URL.
+      await runCommand(["git", "-C", dest, "remote", "set-url", "origin", cleanUrl], 30_000);
+    } finally {
+      rmSync(askpassDir, { recursive: true, force: true });
+    }
+    return;
+  }
   const argv = Bun.which("gh")
-    ? ["gh", "repo", "clone", url, dest]
-    : ["git", "clone", "--", url, dest];
+    ? ["gh", "repo", "clone", cleanUrl, dest]
+    : ["git", "clone", "--", cleanUrl, dest];
   const result = await runCommand(argv, 5 * 60_000);
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || `${argv[0]} clone failed`);
@@ -232,6 +303,8 @@ function checkoutsRoot(): string {
 async function registerGithubRepo(input: {
   fullName: string;
   id?: string;
+  /** Connected user token to clone private repos with (secretlessly). */
+  userToken?: string;
 }): Promise<RepoSection & { id: string }> {
   const name = input.fullName.split("/")[1];
   const id = repoIdFromName(input.id?.trim() || name);
@@ -247,7 +320,7 @@ async function registerGithubRepo(input: {
   }
   mkdirSync(root, { recursive: true });
   try {
-    await cloneGithubRepo(input.fullName, dest);
+    await cloneGithubRepo(input.fullName, dest, input.userToken);
     const inspected = await inspectRepo(dest);
     const config = rawConfig();
     const repos = {
@@ -344,11 +417,10 @@ export async function handleSetupRepoRoutes(
   const { req, path } = ctx;
 
   if (path === "/api/setup/github/repos" && req.method === "GET") {
-    // Credential preference: the signed-in user's stored GitHub token, else
+    // Credential preference: the acting user's stored GitHub token (signed-in
+    // user in operator mode, the sole connected account in simple mode), else
     // the bot PAT, else an empty (but well-formed) answer.
-    const userCredential = ctx.authUser?.login
-      ? githubCredentialForLogin(ctx.authUser.login)
-      : null;
+    const userCredential = actingGithubCredential(ctx);
     const token = userCredential?.env.GH_TOKEN || process.env.GITHUB_API_TOKEN;
     const source: "user" | "bot" | null = userCredential
       ? "user"
@@ -460,11 +532,15 @@ export async function handleSetupRepoRoutes(
     if (body?.id !== undefined && (typeof body.id !== "string" || !body.id.trim())) {
       return Response.json({ error: "id must be a non-empty string" }, { status: 400 });
     }
+    // The acting token lets a private clone succeed without ambient gh /
+    // credential-helper auth; absent, the clone stays anonymous (public repos).
+    const userToken = actingGithubCredential(ctx)?.env.GH_TOKEN;
     try {
       const repo = await withConfigMutationLock(() =>
         registerGithubRepo({
           fullName: body!.fullName as string,
           ...(typeof body!.id === "string" ? { id: body!.id } : {}),
+          ...(userToken ? { userToken } : {}),
         }),
       );
       return Response.json(repo, { status: 201 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -12,6 +12,7 @@ import { $ } from "bun";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve as resolvePath } from "path";
+import { SHIM_PATH } from "../../../../../../scripts/lib/paths";
 import { audit } from "../audit";
 import { codeStorageConfig, configuredRepos, type RepoSection } from "../config";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
@@ -314,10 +315,28 @@ const GH_CREDENTIAL_SCRIPT = resolvePath(
  * list for this URL scope, then the minting helper. `--replace-all` keeps
  * re-runs from stacking duplicates.
  */
+function shellQuoteWord(word: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(word)) return word;
+  return `'${word.replaceAll("'", `'\''`)}'`;
+}
+
+/**
+ * Use the stable installed command so a compiled release needs neither Bun nor
+ * a scripts sidecar. The source-tree fallback keeps direct development runs
+ * useful before install.sh has created the shim.
+ */
+export function githubCredentialHelperCommand(
+  shimPath = SHIM_PATH,
+  shimExists = existsSync(shimPath),
+): string {
+  if (shimExists) return `!${shellQuoteWord(shimPath)} github-credential`;
+  return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
+}
+
 async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {
   const key = "credential.https://github.com.helper";
   await $`git -C ${checkoutPath} config --replace-all ${key} ${""}`.quiet();
-  await $`git -C ${checkoutPath} config --add ${key} ${`!bun ${GH_CREDENTIAL_SCRIPT}`}`.quiet();
+  await $`git -C ${checkoutPath} config --add ${key} ${githubCredentialHelperCommand()}`.quiet();
 }
 
 async function registerGithubRepo(input: {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -11,8 +11,7 @@
 import { $ } from "bun";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join, resolve as resolvePath } from "path";
-import { SHIM_PATH } from "../../../../../../scripts/lib/paths";
+import { join } from "path";
 import { audit } from "../audit";
 import { codeStorageConfig, configuredRepos, type RepoSection } from "../config";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
@@ -23,6 +22,7 @@ import {
   withConfigMutationLock,
 } from "../config-mutation";
 import { githubCredentialForLogin, soleGithubAccount, type GithubCredential } from "../github-auth";
+import { githubCredentialHelperCommand } from "../github-git-credential";
 import { homeDir } from "../paths";
 import { fetchWithTimeout } from "../shared/fetch-with-timeout";
 import type { RouteContext } from "./context";
@@ -31,6 +31,8 @@ import { inspectRepo, repoIdFromName } from "./repo-inspection";
 /** Strict: this value reaches a spawn argv (always array-spawned, never a
  *  shell string — the regex is belt AND suspenders). */
 export const GITHUB_FULL_NAME_RE = /^[\w.-]+\/[\w.-]+$/;
+
+export { githubCredentialHelperCommand };
 
 export function validGithubFullName(value: unknown): value is string {
   return typeof value === "string" && GITHUB_FULL_NAME_RE.test(value);
@@ -300,37 +302,6 @@ async function cloneGithubRepo(
 
 function checkoutsRoot(): string {
   return `${homeDir()}/checkouts`;
-}
-
-const GH_CREDENTIAL_SCRIPT = resolvePath(
-  import.meta.dir,
-  "../../../../../../scripts/gh-credential.ts",
-);
-
-/**
- * Wire a URL-scoped git credential helper on a github.com checkout so ambient
- * `git fetch`/`git push` resolve the currently connected token at use time,
- * without the token ever persisting in the remote. Mirrors
- * configureCsCredentialHelper: an empty value first resets any inherited helper
- * list for this URL scope, then the minting helper. `--replace-all` keeps
- * re-runs from stacking duplicates.
- */
-function shellQuoteWord(word: string): string {
-  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(word)) return word;
-  return `'${word.replaceAll("'", `'\''`)}'`;
-}
-
-/**
- * Use the stable installed command so a compiled release needs neither Bun nor
- * a scripts sidecar. The source-tree fallback keeps direct development runs
- * useful before install.sh has created the shim.
- */
-export function githubCredentialHelperCommand(
-  shimPath = SHIM_PATH,
-  shimExists = existsSync(shimPath),
-): string {
-  if (shimExists) return `!${shellQuoteWord(shimPath)} github-credential`;
-  return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
 }
 
 async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -333,17 +333,25 @@ export function githubCredentialHelperCommand(
   return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
 }
 
-async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {
-  const key = "credential.https://github.com.helper";
-  await $`git -C ${checkoutPath} config --replace-all ${key} ${""}`.quiet();
-  await $`git -C ${checkoutPath} config --add ${key} ${githubCredentialHelperCommand()}`.quiet();
+export async function configureGithubCredentialHelper(
+  checkoutPath: string,
+  credential: GithubCredential,
+): Promise<void> {
+  const helperKey = "credential.https://github.com.helper";
+  await $`git -C ${checkoutPath} config --replace-all ${helperKey} ${""}`.quiet();
+  await $`git -C ${checkoutPath} config --add ${helperKey} ${githubCredentialHelperCommand()}`.quiet();
+  if (credential.kind === "user") {
+    const login = credential.principal.replace(/^user:/, "");
+    const usernameKey = "credential.https://github.com.username";
+    await $`git -C ${checkoutPath} config --replace-all ${usernameKey} ${login}`.quiet();
+  }
 }
 
 async function registerGithubRepo(input: {
   fullName: string;
   id?: string;
-  /** Connected user token to clone private repos with (secretlessly). */
-  userToken?: string;
+  /** Connected user credential for the private clone and later Git operations. */
+  credential?: GithubCredential;
 }): Promise<RepoSection & { id: string }> {
   const name = input.fullName.split("/")[1];
   const id = repoIdFromName(input.id?.trim() || name);
@@ -359,12 +367,12 @@ async function registerGithubRepo(input: {
   }
   mkdirSync(root, { recursive: true });
   try {
-    await cloneGithubRepo(input.fullName, dest, input.userToken);
+    await cloneGithubRepo(input.fullName, dest, input.credential?.env.GH_TOKEN);
     // A private clone authenticated through a one-shot GIT_ASKPASS; the remote
     // it leaves is tokenless, so wire the credential helper for future
     // fetch/push. No-op for a public (tokenless) clone — the helper simply has
     // nothing to answer with.
-    if (input.userToken) await configureGithubCredentialHelper(dest);
+    if (input.credential) await configureGithubCredentialHelper(dest, input.credential);
     const inspected = await inspectRepo(dest);
     const config = rawConfig();
     const repos = {
@@ -578,13 +586,13 @@ export async function handleSetupRepoRoutes(
     }
     // The acting token lets a private clone succeed without ambient gh /
     // credential-helper auth; absent, the clone stays anonymous (public repos).
-    const userToken = actingGithubCredential(ctx)?.env.GH_TOKEN;
+    const credential = actingGithubCredential(ctx);
     try {
       const repo = await withConfigMutationLock(() =>
         registerGithubRepo({
           fullName: body!.fullName as string,
           ...(typeof body!.id === "string" ? { id: body!.id } : {}),
-          ...(userToken ? { userToken } : {}),
+          ...(credential ? { credential } : {}),
         }),
       );
       return Response.json(repo, { status: 201 });

--- a/packages/core/opensession-server/src/server/routes/setup-team.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.test.ts
@@ -28,7 +28,9 @@ function writeConfig(): string {
   writeFileSync(
     path,
     JSON.stringify({
-      integrations: { github: { installationOwner: "acme" } },
+      // The App wizard records its organization as appOrg before this
+      // first-mile import runs.
+      integrations: { github: { appOrg: "acme" } },
       identity: { team: [{ name: "Ada Lovelace", github: "ada" }] },
     }),
   );

--- a/packages/core/opensession-server/src/server/routes/setup-team.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.ts
@@ -102,11 +102,9 @@ function memberGithub(entry: MemberPatch): string {
  * people step, so a normal first-mile flow has this by the time it needs it. */
 function githubOrganization(): string | null {
   const integration = configuredIntegration("github");
-  const explicit =
-    typeof integration.installationOwner === "string"
-      ? integration.installationOwner.trim()
-      : "";
-  if (explicit) return explicit;
+  const explicit = [integration.installationOwner, integration.appOrg]
+    .find((owner): owner is string => typeof owner === "string" && !!owner.trim());
+  if (explicit) return explicit.trim();
 
   const counts = new Map<string, { owner: string; count: number }>();
   for (const repo of Object.values(configuredRepos())) {

--- a/packages/core/opensession-server/src/server/routes/setup-team.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.ts
@@ -73,8 +73,10 @@ function validateMemberFields(
 }
 
 /** The raw `identity.team` array (unknown keys preserved), plus the raw
- *  config it lives in — mutate the array, then persist the config. */
-function rawTeam(config: Record<string, unknown>): MemberPatch[] {
+ *  config it lives in — mutate the array, then persist the config. Exported so
+ *  the connect-time auth bootstrap (routes/connections.ts) upserts the first
+ *  admin through the same array the team CRUD uses. */
+export function rawTeam(config: Record<string, unknown>): MemberPatch[] {
   const identity =
     config.identity && typeof config.identity === "object" && !Array.isArray(config.identity)
       ? (config.identity as Record<string, unknown>)

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -104,7 +104,8 @@ async function primaryGithubOrg(): Promise<string | undefined> {
 }
 
 async function githubSnapshot() {
-  const { githubUserAuthSettings } = await import("../github-auth");
+  const { githubUserAuthSettings, githubAppOrg, githubAuthOnConnect } =
+    await import("../github-auth");
   const github = githubUserAuthSettings();
   const org = await primaryGithubOrg();
   return {
@@ -112,6 +113,11 @@ async function githubSnapshot() {
     clientIdConfigured: !!github.clientId,
     clientSecretConfigured: !!github.clientSecret,
     botTokenPresent: !!process.env.GITHUB_API_TOKEN,
+    // Captured install/app-setup intent: the org the App is owned by, and
+    // whether connecting should turn on per-user sign-in. Both are inert until
+    // the simple-mode connect handler consumes authOnConnect.
+    appOrg: githubAppOrg(),
+    authOnConnect: githubAuthOnConnect(),
     appCreateUrl: org
       ? `https://github.com/organizations/${org}/settings/apps/new`
       : "https://github.com/settings/apps/new",

--- a/packages/core/opensession-server/src/server/routes/workspace.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.ts
@@ -48,6 +48,7 @@ import { REPOS, createWorktree, createWorktreeForExistingBranch, ensureScratchDi
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "fs";
 import { isClientSessionId, isNativeSessionId, newSessionId } from "../paths";
 import { isReusableEmptySession } from "../empty-session";
+import { githubMutationCredential } from "./github-credential";
 
 /**
  * Validate a `draft` field from a workspace create/patch body. `null` (clear)
@@ -672,6 +673,7 @@ export async function handleWorkspaceRoutes(
 				branch = `${src.branch}-stack-${bksId.slice(4, 10)}`;
 				worktreeDir = await createWorktree(branch, repo.id, {
 					base: src.branch,
+					gitEnv: githubMutationCredential(ctx)?.env,
 				});
 				mode = "code";
 				// Remember the layer underneath so this session's PR bases on it and
@@ -699,7 +701,11 @@ export async function handleWorkspaceRoutes(
 				// create_session's fromPr path), and stamp it as the workspace's
 				// owned worktree for later siblings.
 				branch = ws.branch;
-				worktreeDir = await createWorktreeForExistingBranch(ws.branch, ws.repo);
+				worktreeDir = await createWorktreeForExistingBranch(
+					ws.branch,
+					ws.repo,
+					githubMutationCredential(ctx)?.env,
+				);
 				mode = "code";
 				repoId = getRepo(ws.repo).id;
 				updateWorkspace(ws.id, { worktreeDir });
@@ -857,7 +863,9 @@ export async function handleWorkspaceRoutes(
 				`session-${sessionId.slice(4, 10)}`
 			).trim();
 			const oldCwd = current || repo.repo;
-			worktreeDir = await createWorktree(branch, repo.id);
+			worktreeDir = await createWorktree(branch, repo.id, {
+				gitEnv: githubMutationCredential(ctx)?.env,
+			});
 			// Best-effort: copy the ask rollout into the new worktree's hash dir
 			// so SDK resume (keyed by cwd) finds the prior conversation.
 			try {

--- a/packages/core/opensession-server/src/server/routes/workspace.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.ts
@@ -936,6 +936,7 @@ export async function handleWorkspaceRoutes(
 				sessionId,
 				body.repo,
 				body.branch,
+				githubMutationCredential(ctx)?.env,
 			);
 			return Response.json({ ok: true, attached, attachedRepos: all });
 		} catch (e: any) {
@@ -993,6 +994,7 @@ export async function handleWorkspaceRoutes(
 				sessionId,
 				body.repo,
 				!!body.force,
+				githubMutationCredential(ctx)?.env,
 			);
 			return Response.json({ ok: true, ...result });
 		} catch (e: any) {

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -156,7 +156,7 @@ setJournalSetListener((record) =>
 	acknowledgePromptDispatch(record.osSessionId, record.promptEntryId),
 );
 import { audit } from "./audit";
-import { githubAuthEnv, githubCredentialForLogin } from "./github-auth";
+import { githubCredentialForLogin, githubCredentialForRun } from "./github-auth";
 import {
 	announcesNextAction,
 	AUTO_CONTINUE_FABRICATED_PROMPT,
@@ -1192,7 +1192,7 @@ export async function autoPushSessionBranches(session: UnifiedSession): Promise<
 		? undefined
 		: session.createdByLogin
 			? githubCredentialForLogin(session.createdByLogin)?.env
-			: githubAuthEnv(session.createdBy || session.startedBy);
+			: githubCredentialForRun(session.createdBy || session.startedBy)?.env;
 	// Repo-less sessions (scratch, repo-less ask) have no primary branch to
 	// push, and their worktreeDir is a plain dir repoForPath would throw on.
 	// Attached repos still push: those carry their own repo and branch.

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -156,6 +156,7 @@ setJournalSetListener((record) =>
 	acknowledgePromptDispatch(record.osSessionId, record.promptEntryId),
 );
 import { audit } from "./audit";
+import { githubAuthEnv, githubCredentialForLogin } from "./github-auth";
 import {
 	announcesNextAction,
 	AUTO_CONTINUE_FABRICATED_PROMPT,
@@ -1187,6 +1188,11 @@ export function foldSessionUsage(
  * refetch the instant the push lands.
  */
 export async function autoPushSessionBranches(session: UnifiedSession): Promise<void> {
+	const githubGitEnv = session.automation || session.automationId
+		? undefined
+		: session.createdByLogin
+			? githubCredentialForLogin(session.createdByLogin)?.env
+			: githubAuthEnv(session.createdBy || session.startedBy);
 	// Repo-less sessions (scratch, repo-less ask) have no primary branch to
 	// push, and their worktreeDir is a plain dir repoForPath would throw on.
 	// Attached repos still push: those carry their own repo and branch.
@@ -1224,7 +1230,7 @@ export async function autoPushSessionBranches(session: UnifiedSession): Promise<
 			continue;
 		}
 		if (!git.hasUpstream || git.ahead <= 0 || git.behind > 0) continue;
-		const result = await gitPush(dir, branch, exec);
+		const result = await gitPush(dir, branch, exec, githubGitEnv);
 		if ("error" in result) {
 			console.warn(
 				`[auto-push] ${session.id} ${repoId}/${branch}: ${result.error}`,

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -58,7 +58,11 @@ import {
 	snapshotResolvedCreate,
 	updateCreatePlan,
 } from "./session-create-plan";
-import { githubAuthEnv, githubCredentialForLogin } from "./github-auth";
+import {
+	githubCredentialForLogin,
+	githubCredentialForPrincipal,
+	githubCredentialForRun,
+} from "./github-auth";
 import { existsSync, watch } from "fs";
 import { branchNameFromPrompt } from "./suggest-branch";
 
@@ -472,11 +476,12 @@ registerSessionControl({
 		const parentSession = parentSessionId ? findSession(parentSessionId) : null;
 		// opensession-sessions is withheld from automation-owned runs. Scope the
 		// server-owned worktree fetch to this trusted interactive creator.
-		const githubGitEnv = parentSession?.automation
-			? undefined
+		const githubCredential = parentSession?.automation
+			? null
 			: parentSession?.createdByLogin
-				? githubCredentialForLogin(parentSession.createdByLogin)?.env
-				: githubAuthEnv(user || parentSession?.createdBy);
+				? githubCredentialForLogin(parentSession.createdByLogin)
+				: githubCredentialForRun(user || parentSession?.createdBy);
+		const githubGitEnv = githubCredential?.env;
 		// Attribution only (CreateSessionInput.spawnedBy): the session whose agent
 		// asked for this one, recorded even when the create was standalone and
 		// carries no parent link. It is what lets the sidebar keep an agent's own
@@ -853,6 +858,7 @@ ${createMentionsNote}`;
 			openingPromptEntryId: `create-${requestId}`,
 			// Persist the full decision before git creates anything. The opening
 			// setup materializes this deterministic path after announcement.
+			gitPrincipal: githubCredential?.principal,
 			gitEnv: githubGitEnv,
 			needsWorktree: !!materializeWorktree,
 			worktreeKind: "new",
@@ -869,6 +875,9 @@ ${createMentionsNote}`;
 		const restoredSpec = createPlan.resolved
 			? restoreResolvedCreate<ResolvedCreate>(createPlan.resolved)
 			: undefined;
+		const restoredGitEnv = githubCredentialForPrincipal(
+			restoredSpec?.gitPrincipal,
+		)?.env;
 		const restoredWorktreeReady =
 			restoredSpec?.needsWorktree &&
 			typeof restoredSpec.wtPath === "string" &&
@@ -893,7 +902,7 @@ ${createMentionsNote}`;
 							);
 						return createWorktree(restoredSpec.branch!, restoredSpec.repoId!, {
 							...(isolatedWorktree ? { isolated: true } : {}),
-							...(restoredSpec.gitEnv ? { gitEnv: restoredSpec.gitEnv } : {}),
+							...(restoredGitEnv ? { gitEnv: restoredGitEnv } : {}),
 						});
 					}
 				: undefined;
@@ -902,6 +911,7 @@ ${createMentionsNote}`;
 					...computedSpec,
 					...restoredSpec,
 					images: computedSpec.images,
+					gitEnv: restoredGitEnv,
 					materializeWorktree: restoredMaterializer,
 					needsWorktree: !!restoredMaterializer,
 				}

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -893,6 +893,7 @@ ${createMentionsNote}`;
 							);
 						return createWorktree(restoredSpec.branch!, restoredSpec.repoId!, {
 							...(isolatedWorktree ? { isolated: true } : {}),
+							...(restoredSpec.gitEnv ? { gitEnv: restoredSpec.gitEnv } : {}),
 						});
 					}
 				: undefined;

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -58,6 +58,7 @@ import {
 	snapshotResolvedCreate,
 	updateCreatePlan,
 } from "./session-create-plan";
+import { githubAuthEnv, githubCredentialForLogin } from "./github-auth";
 import { existsSync, watch } from "fs";
 import { branchNameFromPrompt } from "./suggest-branch";
 
@@ -469,6 +470,13 @@ registerSessionControl({
 			: resolvePinnedAccountId(model, accountIdInput, user);
 		const images = parseImageDataUrls(imageUrls);
 		const parentSession = parentSessionId ? findSession(parentSessionId) : null;
+		// opensession-sessions is withheld from automation-owned runs. Scope the
+		// server-owned worktree fetch to this trusted interactive creator.
+		const githubGitEnv = parentSession?.automation
+			? undefined
+			: parentSession?.createdByLogin
+				? githubCredentialForLogin(parentSession.createdByLogin)?.env
+				: githubAuthEnv(user || parentSession?.createdBy);
 		// Attribution only (CreateSessionInput.spawnedBy): the session whose agent
 		// asked for this one, recorded even when the create was standalone and
 		// carries no parent link. It is what lets the sidebar keep an agent's own
@@ -609,7 +617,10 @@ registerSessionControl({
 				// is the difference between this session getting a tree of its own
 				// and joining every other session in the live main checkout.
 				if (!wtPath) {
-					const worktreeOptions = isolatedWorktree ? { isolated: true } : {};
+					const worktreeOptions = {
+						...(isolatedWorktree ? { isolated: true } : {}),
+						...(githubGitEnv ? { gitEnv: githubGitEnv } : {}),
+					};
 					wtPath = worktreePathFor(sessionBranch, repo.id, worktreeOptions);
 					materializeWorktree = () =>
 						createWorktree(sessionBranch, repo.id, worktreeOptions);

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -853,6 +853,7 @@ ${createMentionsNote}`;
 			openingPromptEntryId: `create-${requestId}`,
 			// Persist the full decision before git creates anything. The opening
 			// setup materializes this deterministic path after announcement.
+			gitEnv: githubGitEnv,
 			needsWorktree: !!materializeWorktree,
 			worktreeKind: "new",
 			worktreeIsolated: isolatedWorktree === true,

--- a/packages/core/opensession-server/src/server/session-create-plan.test.ts
+++ b/packages/core/opensession-server/src/server/session-create-plan.test.ts
@@ -20,6 +20,21 @@ afterEach(() => {
 });
 
 describe("durable create plan", () => {
+  test("never persists ephemeral GitHub bearer tokens", () => {
+    const snapshot = snapshotResolvedCreate({
+      gitPrincipal: "user:alice",
+      gitEnv: {
+        GH_TOKEN: "gho_secret",
+        GITHUB_TOKEN: "gho_secret",
+        GIT_CONFIG_VALUE_1: "!opensession github-credential",
+      },
+      branch: "feature/private",
+    });
+    expect(snapshot.gitPrincipal).toBe("user:alice");
+    expect(snapshot.gitEnv).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain("gho_secret");
+  });
+
   test("preserves explicitly absent resolved decisions", () => {
     const snapshot = snapshotResolvedCreate({
       model: "pi/openai/gpt-5.5",

--- a/packages/core/opensession-server/src/server/session-create-plan.ts
+++ b/packages/core/opensession-server/src/server/session-create-plan.ts
@@ -143,7 +143,10 @@ function restoreValue(value: unknown): unknown {
 export function snapshotResolvedCreate(
   value: Record<string, unknown>,
 ): Record<string, unknown> {
-  return snapshotValue(value) as Record<string, unknown>;
+  // gitEnv carries short-lived bearer tokens. A durable plan keeps only the
+  // non-secret gitPrincipal and resolves its current token during recovery.
+  const { gitEnv: _ephemeralGitEnv, ...durable } = value;
+  return snapshotValue(durable) as Record<string, unknown>;
 }
 
 export function restoreResolvedCreate<T>(

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -81,7 +81,11 @@ import {
 	snapshotResolvedCreate,
 	updateCreatePlan,
 } from "./session-create-plan";
-import { githubCredentialForLogin, soleGithubAccount } from "./github-auth";
+import {
+	githubCredentialForLogin,
+	githubCredentialForPrincipal,
+	soleGithubAccount,
+} from "./github-auth";
 
 
 /**
@@ -229,7 +233,9 @@ export interface ResolvedCreate {
    * so its system note and any sandbox mounts already know about them.
    */
 	attachRepos?: { repos: string[]; branch: string };
-	/** Credential scoped to trusted server-owned worktree fetches. */
+	/** Durable, non-secret selector for trusted server-owned worktree fetches. */
+	gitPrincipal?: string;
+	/** Ephemeral capability. snapshotResolvedCreate always strips this field. */
 	gitEnv?: Record<string, string>;
 	stackedOn?: { repo: string; branch: string };
 	/** Workspace recorded on the session file. */
@@ -368,6 +374,7 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 	const dispatch = promptDispatches.get(sessionId);
 	if (!plan?.resolved || dispatch?.kind !== "create") return false;
 	const restored = restoreResolvedCreate<ResolvedCreate>(plan.resolved);
+	const restoredGitEnv = githubCredentialForPrincipal(restored.gitPrincipal)?.env;
 	if (
 		typeof restored.wtPath !== "string" ||
 		typeof restored.branch !== "string" ||
@@ -386,14 +393,14 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 					? createWorktreeForExistingBranch(
 							restored.branch!,
 							restored.repoId!,
-							restored.gitEnv,
+							restoredGitEnv,
 						)
 					: createWorktree(restored.branch!, restored.repoId!, {
 							...(restored.stackedOn?.branch
 								? { base: restored.stackedOn.branch }
 								: {}),
 							...(restored.worktreeIsolated ? { isolated: true } : {}),
-							...(restored.gitEnv ? { gitEnv: restored.gitEnv } : {}),
+							...(restoredGitEnv ? { gitEnv: restoredGitEnv } : {}),
 						});
 			}
 		: undefined;
@@ -403,6 +410,7 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 		id: sessionId,
 		openingPromptEntryId: dispatch.promptEntryId,
 		images: parseImageDataUrls(imageUrls),
+		gitEnv: restoredGitEnv,
 		materializeWorktree,
 		needsWorktree: !!materializeWorktree,
 	};
@@ -1123,13 +1131,14 @@ export async function handleCreateSessionMessage(
 		finishCreate();
 		return response;
 	}
-	// This WebSocket create is interactive. Pass its credential only to the
-	// server-owned worktree materializer; unattended processes cannot recover it.
-	const githubGitEnv = ws.data.authLogin
-		? githubCredentialForLogin(ws.data.authLogin)?.env
+	// This WebSocket create is interactive. The raw credential reaches only the
+	// server-owned materializer; recovery persists and resolves its principal.
+	const githubCredential = ws.data.authLogin
+		? githubCredentialForLogin(ws.data.authLogin)
 		: ws.data.authAutomation
-			? undefined
-			: soleGithubAccount()?.env;
+			? null
+			: soleGithubAccount();
+	const githubGitEnv = githubCredential?.env;
 	// Mutable: a brand-new code branch is made collision-free below (a
 	// name clashing with an existing `name/...` ref — or vice versa —
 	// makes `git worktree add -b` fail, killing the session).
@@ -1723,6 +1732,7 @@ export async function handleCreateSessionMessage(
 			volumeWorkspace,
 			remoteSandbox,
 			openingPromptEntryId: `create-${requestId || bksId}`,
+			gitPrincipal: githubCredential?.principal,
 			gitEnv: githubGitEnv,
 			needsWorktree,
 			worktreeKind: fromPr ? "existing" : "new",
@@ -1746,6 +1756,9 @@ export async function handleCreateSessionMessage(
 		const restoredSpec = createPlan.resolved
 			? restoreResolvedCreate<ResolvedCreate>(createPlan.resolved)
 			: undefined;
+		const restoredGitEnv = githubCredentialForPrincipal(
+			restoredSpec?.gitPrincipal,
+		)?.env;
 		const restoredWorktreeReady =
 			restoredSpec?.needsWorktree &&
 			typeof restoredSpec.wtPath === "string" &&
@@ -1772,7 +1785,7 @@ export async function handleCreateSessionMessage(
 							? createWorktreeForExistingBranch(
 									restoredSpec.branch!,
 									restoredSpec.repoId!,
-									restoredSpec.gitEnv,
+									restoredGitEnv,
 								)
 							: createWorktree(
 									restoredSpec.branch!,
@@ -1781,8 +1794,8 @@ export async function handleCreateSessionMessage(
 										...(restoredSpec.stackedOn?.branch
 											? { base: restoredSpec.stackedOn.branch }
 											: {}),
-										...(restoredSpec.gitEnv
-											? { gitEnv: restoredSpec.gitEnv }
+										...(restoredGitEnv
+											? { gitEnv: restoredGitEnv }
 											: {}),
 									},
 								);
@@ -1793,6 +1806,7 @@ export async function handleCreateSessionMessage(
 					...computedSpec,
 					...restoredSpec,
 					images: computedSpec.images,
+					gitEnv: restoredGitEnv,
 					materializeWorktree: restoredMaterializer,
 					needsWorktree: !!restoredMaterializer,
 				}

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -81,6 +81,8 @@ import {
 	snapshotResolvedCreate,
 	updateCreatePlan,
 } from "./session-create-plan";
+import { githubCredentialForLogin, soleGithubAccount } from "./github-auth";
+
 
 /**
  * The `create_session` client message fields the flow reads. Fields typed
@@ -1112,6 +1114,13 @@ export async function handleCreateSessionMessage(
 		finishCreate();
 		return response;
 	}
+	// This WebSocket create is interactive. Pass its credential only to the
+	// server-owned worktree materializer; unattended processes cannot recover it.
+	const githubGitEnv = ws.data.authLogin
+		? githubCredentialForLogin(ws.data.authLogin)?.env
+		: ws.data.authAutomation
+			? undefined
+			: soleGithubAccount()?.env;
 	// Mutable: a brand-new code branch is made collision-free below (a
 	// name clashing with an existing `name/...` ref — or vice versa —
 	// makes `git worktree add -b` fail, killing the session).
@@ -1710,12 +1719,11 @@ export async function handleCreateSessionMessage(
 			materializeWorktree: needsWorktree
 				? () =>
 						fromPr
-							? createWorktreeForExistingBranch(branch, repo.id)
-							: createWorktree(
-									branch,
-									repo.id,
-									stackBase ? { base: stackBase } : undefined,
-								)
+							? createWorktreeForExistingBranch(branch, repo.id, githubGitEnv)
+							: createWorktree(branch, repo.id, {
+									...(stackBase ? { base: stackBase } : {}),
+									...(githubGitEnv ? { gitEnv: githubGitEnv } : {}),
+								})
 				: undefined,
 			fork: canFork
 				? {

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -229,6 +229,8 @@ export interface ResolvedCreate {
    * so its system note and any sandbox mounts already know about them.
    */
 	attachRepos?: { repos: string[]; branch: string };
+	/** Credential scoped to trusted server-owned worktree fetches. */
+	gitEnv?: Record<string, string>;
 	stackedOn?: { repo: string; branch: string };
 	/** Workspace recorded on the session file. */
 	workspaceId?: string;
@@ -326,11 +328,12 @@ async function attachCreateRepos(
 	sessionId: string,
 	plan: { repos: string[]; branch: string },
 	io: CreateSessionIO,
+	gitEnv?: Record<string, string>,
 ): Promise<string[]> {
 	const attached: string[] = [];
 	for (const repoId of plan.repos) {
 		try {
-			await attachRepo(sessionId, repoId, plan.branch);
+			await attachRepo(sessionId, repoId, plan.branch, gitEnv);
 			attached.push(repoId);
 		} catch (e) {
 			io.emit({
@@ -635,7 +638,8 @@ export async function openCreatedSession(
 						attachedRepoIds = await attachCreateRepos(
 							bksId,
 							pendingAttach,
-							io
+							io,
+							spec.gitEnv,
 						);
 				} finally {
 					// Ready (or failed — the error surfaces separately): flip the
@@ -1714,6 +1718,7 @@ export async function handleCreateSessionMessage(
 			volumeWorkspace,
 			remoteSandbox,
 			openingPromptEntryId: `create-${requestId || bksId}`,
+			gitEnv: githubGitEnv,
 			needsWorktree,
 			worktreeKind: fromPr ? "existing" : "new",
 			materializeWorktree: needsWorktree

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -383,12 +383,17 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 						`Incomplete worktree exists at ${restored.wtPath}; refusing to resume the session`,
 					);
 				return restored.worktreeKind === "existing"
-					? createWorktreeForExistingBranch(restored.branch!, restored.repoId!)
+					? createWorktreeForExistingBranch(
+							restored.branch!,
+							restored.repoId!,
+							restored.gitEnv,
+						)
 					: createWorktree(restored.branch!, restored.repoId!, {
 							...(restored.stackedOn?.branch
 								? { base: restored.stackedOn.branch }
 								: {}),
 							...(restored.worktreeIsolated ? { isolated: true } : {}),
+							...(restored.gitEnv ? { gitEnv: restored.gitEnv } : {}),
 						});
 			}
 		: undefined;
@@ -1767,13 +1772,19 @@ export async function handleCreateSessionMessage(
 							? createWorktreeForExistingBranch(
 									restoredSpec.branch!,
 									restoredSpec.repoId!,
+									restoredSpec.gitEnv,
 								)
 							: createWorktree(
 									restoredSpec.branch!,
 									restoredSpec.repoId!,
-									restoredSpec.stackedOn?.branch
-										? { base: restoredSpec.stackedOn.branch }
-										: undefined,
+									{
+										...(restoredSpec.stackedOn?.branch
+											? { base: restoredSpec.stackedOn.branch }
+											: {}),
+										...(restoredSpec.gitEnv
+											? { gitEnv: restoredSpec.gitEnv }
+											: {}),
+									},
 								);
 					}
 				: undefined;

--- a/packages/core/opensession-server/src/server/session-repos.ts
+++ b/packages/core/opensession-server/src/server/session-repos.ts
@@ -444,6 +444,7 @@ export async function attachRepo(
 	sessionId: string,
 	repoId: string,
 	branch?: string,
+	gitEnv?: Record<string, string>,
 ): Promise<{ attached: AttachedRepo; all: AttachedRepo[] }> {
 	const session = findSession(sessionId);
 	if (!session) throw new Error("Session not found");
@@ -462,7 +463,7 @@ export async function attachRepo(
 		throw new Error("No branch to attach on — pass a branch name");
 	}
 
-	const attached = await prepareAttachedWorktree(repoId, effectiveBranch);
+	const attached = await prepareAttachedWorktree(repoId, effectiveBranch, gitEnv);
 	// Read-modify-write inside the session-file lock rather than from the
 	// snapshot above: cutting the worktree takes as long as a fetch, and a
 	// create attaching several repos in a row must not have the last one's list
@@ -560,6 +561,7 @@ export async function switchPrimaryRepo(
 	sessionId: string,
 	repoId: string,
 	force = false,
+	gitEnv?: Record<string, string>,
 ): Promise<{ repo: string; branch: string; worktreeDir: string }> {
 	const session = findSession(sessionId);
 	if (!session) throw new Error("Session not found");
@@ -596,7 +598,11 @@ export async function switchPrimaryRepo(
 		const worktrees = await listWorktrees(target.id);
 		wtPath =
 			worktrees.find((w) => w.branch === branch)?.path ||
-			(await createWorktree(branch, target.id));
+			(await createWorktree(
+				branch,
+				target.id,
+				gitEnv ? { gitEnv } : undefined,
+			));
 	}
 
 	// Drop the target from attached repos if it was attached — it's the primary now.

--- a/packages/core/opensession-server/src/server/worktree.ts
+++ b/packages/core/opensession-server/src/server/worktree.ts
@@ -998,13 +998,16 @@ export async function createWorktree(
  */
 export async function prepareAttachedWorktree(
   repoId: string,
-  branch: string
+  branch: string,
+  gitEnv?: Record<string, string>,
 ): Promise<{ repo: string; branch: string; dir: string }> {
   const repo = getRepo(repoId);
   if (sharedCheckoutForNewSessions(repo)) {
     throw new Error(`${repo.id} is a shared-checkout repo and can't be attached as an isolated worktree`);
   }
   const existing = (await listWorktrees(repo.id)).find((w) => w.branch === branch);
-  const dir = existing?.path || (await createWorktree(branch, repo.id));
+  const dir =
+    existing?.path ||
+    (await createWorktree(branch, repo.id, gitEnv ? { gitEnv } : undefined));
   return { repo: repo.id, branch, dir };
 }

--- a/packages/core/opensession-server/src/server/worktree.ts
+++ b/packages/core/opensession-server/src/server/worktree.ts
@@ -774,8 +774,10 @@ export async function createWorktreeForFollowup(
 export async function createWorktreeForExistingBranch(
   branch: string,
   repoId?: string,
+  gitEnv?: Record<string, string>,
 ): Promise<string> {
   const repo = getRepo(repoId);
+  const shell = gitEnv ? $.env({ ...process.env, ...gitEnv }) : $;
   const existing = (await listWorktrees(repo.id)).find((w) => w.branch === branch);
   if (existing) return existing.path;
 
@@ -783,7 +785,7 @@ export async function createWorktreeForExistingBranch(
   await withGitLock(async () => {
     await $`git -C ${repo.repo} worktree prune`.quiet();
     if (existsSync(wtPath)) return; // pruned stale registration; dir already usable
-    await $`git -C ${repo.repo} fetch origin ${branch} --quiet`.nothrow();
+    await shell`git -C ${repo.repo} fetch origin ${branch} --quiet`.nothrow();
     const hasLocal =
       (await $`git -C ${repo.repo} show-ref --verify --quiet refs/heads/${branch}`.nothrow())
         .exitCode === 0;
@@ -913,9 +915,10 @@ export async function resolveUniqueBranch(
 export async function createWorktree(
   branch: string,
   repoId?: string,
-  opts?: { base?: string; isolated?: boolean },
+  opts?: { base?: string; isolated?: boolean; gitEnv?: Record<string, string> },
 ): Promise<string> {
   const repo = getRepo(repoId);
+  const shell = opts?.gitEnv ? $.env({ ...process.env, ...opts.gitEnv }) : $;
 
   // Shared-checkout repos (opensession) don't get a per-session worktree: the
   // session works in the live main checkout on the default branch so its edits
@@ -932,11 +935,11 @@ export async function createWorktree(
   const base = opts?.base;
 
   await withGitLock(async () => {
-    await $`git -C ${repo.repo} fetch origin ${repo.defaultBranch} --quiet`.nothrow();
+    await shell`git -C ${repo.repo} fetch origin ${repo.defaultBranch} --quiet`.nothrow();
     let startPoint = await defaultStartPoint(repo);
     if (base) {
       // Stacked worktree: fetch the base (it may be remote-only), then branch off it.
-      await $`git -C ${repo.repo} fetch origin ${base} --quiet`.nothrow();
+      await shell`git -C ${repo.repo} fetch origin ${base} --quiet`.nothrow();
       startPoint = await resolveStartPoint(repo.repo, base, repo.defaultBranch);
     }
     const add =

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -375,6 +375,14 @@ async function main(): Promise<number> {
       if (positional[0] === "remove") return await runnersRemove(positional[1] ?? "");
       return await runnersList();
 
+    // Internal git credential-helper entrypoint. It stays out of --help, but is
+    // routed through the installed command so compiled releases need no Bun or
+    // source-tree sidecar.
+    case "github-credential": {
+      const { githubCredentialHelper } = await import("./lib/github-credential");
+      return await githubCredentialHelper(positional[0]);
+    }
+
     case "version":
     case "--version":
     case "-v":

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -47,6 +47,7 @@ ${bold("opensession")} — self-hosted agent infrastructure
 ${bold("Setup")}
   onboard [--force]        configure this box (writes config + env + service)
                            --defaults: no questions, the installer's path
+                           --org <name>: set up an org App + per-user sign-in
   bind [address]           move the server to a new bind address and restart
                            (no address: this box's tailnet IP)
   team [add|remove]        manage the identity roster (attribution, sign-in)
@@ -276,6 +277,7 @@ async function main(): Promise<number> {
       return await onboard({
         force: flags.has("--force"),
         defaults: flags.has("--defaults"),
+        org: flagValue("--org"),
       });
 
     case "bind":

--- a/scripts/gh-credential.ts
+++ b/scripts/gh-credential.ts
@@ -1,39 +1,6 @@
 #!/usr/bin/env bun
-/**
- * Git credential helper for github.com remotes in simple mode.
- *
- * Wired per-checkout by configureGithubCredentialHelper (src/server/routes/
- * setup-repos.ts) so ambient `git fetch`/`git push` after a private clone
- * authenticate with the currently connected account's token, resolved at use
- * time and never persisted in `.git/config`. The clone's own GIT_ASKPASS covers
- * only the clone itself; without this helper the tokenless remote left behind
- * fails every later fetch/push, since simple mode has no `gh auth login` and git
- * does not read GH_TOKEN.
- *
- * Helper contract: key=value lines on stdin until a blank line. For `get` on
- * github.com we answer username `x-access-token` (the App/user-token username)
- * plus the sole account's token; store/erase are no-ops (the password is
- * derived, nothing to persist). Anything foreign — a non-github host, operator
- * mode where `soleGithubAccount()` is null, or no connected account — prints
- * nothing and exits 0 so git falls through to its other helpers rather than
- * failing the whole operation.
- */
+/** Source-tree entrypoint for the GitHub git credential helper. */
 
-import { soleGithubAccount } from "../packages/core/opensession-server/src/server/github-auth";
+import { githubCredentialHelper } from "./lib/github-credential";
 
-const action = process.argv[2];
-if (action !== "get") process.exit(0);
-
-const attrs: Record<string, string> = {};
-for (const line of (await Bun.stdin.text()).split("\n")) {
-  if (!line) break;
-  const eq = line.indexOf("=");
-  if (eq > 0) attrs[line.slice(0, eq)] = line.slice(eq + 1);
-}
-
-if (attrs.protocol !== "https" || attrs.host !== "github.com") process.exit(0);
-
-const token = soleGithubAccount()?.env.GH_TOKEN;
-if (!token) process.exit(0);
-
-process.stdout.write(`username=x-access-token\npassword=${token}\n`);
+process.exit(await githubCredentialHelper(process.argv[2]));

--- a/scripts/gh-credential.ts
+++ b/scripts/gh-credential.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+/**
+ * Git credential helper for github.com remotes in simple mode.
+ *
+ * Wired per-checkout by configureGithubCredentialHelper (src/server/routes/
+ * setup-repos.ts) so ambient `git fetch`/`git push` after a private clone
+ * authenticate with the currently connected account's token, resolved at use
+ * time and never persisted in `.git/config`. The clone's own GIT_ASKPASS covers
+ * only the clone itself; without this helper the tokenless remote left behind
+ * fails every later fetch/push, since simple mode has no `gh auth login` and git
+ * does not read GH_TOKEN.
+ *
+ * Helper contract: key=value lines on stdin until a blank line. For `get` on
+ * github.com we answer username `x-access-token` (the App/user-token username)
+ * plus the sole account's token; store/erase are no-ops (the password is
+ * derived, nothing to persist). Anything foreign — a non-github host, operator
+ * mode where `soleGithubAccount()` is null, or no connected account — prints
+ * nothing and exits 0 so git falls through to its other helpers rather than
+ * failing the whole operation.
+ */
+
+import { soleGithubAccount } from "../packages/core/opensession-server/src/server/github-auth";
+
+const action = process.argv[2];
+if (action !== "get") process.exit(0);
+
+const attrs: Record<string, string> = {};
+for (const line of (await Bun.stdin.text()).split("\n")) {
+  if (!line) break;
+  const eq = line.indexOf("=");
+  if (eq > 0) attrs[line.slice(0, eq)] = line.slice(eq + 1);
+}
+
+if (attrs.protocol !== "https" || attrs.host !== "github.com") process.exit(0);
+
+const token = soleGithubAccount()?.env.GH_TOKEN;
+if (!token) process.exit(0);
+
+process.stdout.write(`username=x-access-token\npassword=${token}\n`);

--- a/scripts/lib/github-credential.test.ts
+++ b/scripts/lib/github-credential.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { githubCredentialResponse } from "./github-credential";
+
+const savedToken = process.env.GH_TOKEN;
+afterEach(() => {
+  if (savedToken === undefined) delete process.env.GH_TOKEN;
+  else process.env.GH_TOKEN = savedToken;
+});
+
+describe("GitHub credential helper", () => {
+  test("prefers the run-scoped token used by org-mode sessions", () => {
+    process.env.GH_TOKEN = "ghu_run_scoped";
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
+    ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
+  });
+
+  test("ignores writes and non-GitHub hosts", () => {
+    process.env.GH_TOKEN = "ghu_run_scoped";
+    expect(githubCredentialResponse("store", "protocol=https\nhost=github.com\n\n")).toBe("");
+    expect(githubCredentialResponse("get", "protocol=https\nhost=example.com\n\n")).toBe("");
+  });
+});

--- a/scripts/lib/github-credential.test.ts
+++ b/scripts/lib/github-credential.test.ts
@@ -15,6 +15,25 @@ describe("GitHub credential helper", () => {
     ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
   });
 
+  test("resolves the checkout's recorded login without a run-scoped token", () => {
+    delete process.env.GH_TOKEN;
+    const seen: string[] = [];
+    const response = githubCredentialResponse(
+      "get",
+      "protocol=https\nhost=github.com\nusername=alice\n\n",
+      (login) => {
+        seen.push(login);
+        return {
+          kind: "user",
+          principal: `user:${login}`,
+          env: { GH_TOKEN: "ghu_stored", GITHUB_TOKEN: "ghu_stored" },
+        };
+      },
+    );
+    expect(seen).toEqual(["alice"]);
+    expect(response).toBe("username=x-access-token\npassword=ghu_stored\n");
+  });
+
   test("ignores writes and non-GitHub hosts", () => {
     process.env.GH_TOKEN = "ghu_run_scoped";
     expect(githubCredentialResponse("store", "protocol=https\nhost=github.com\n\n")).toBe("");

--- a/scripts/lib/github-credential.test.ts
+++ b/scripts/lib/github-credential.test.ts
@@ -15,23 +15,14 @@ describe("GitHub credential helper", () => {
     ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
   });
 
-  test("resolves the checkout's recorded login without a run-scoped token", () => {
+  test("does not resolve a recorded login without a run-scoped token", () => {
     delete process.env.GH_TOKEN;
-    const seen: string[] = [];
-    const response = githubCredentialResponse(
-      "get",
-      "protocol=https\nhost=github.com\nusername=alice\n\n",
-      (login) => {
-        seen.push(login);
-        return {
-          kind: "user",
-          principal: `user:${login}`,
-          env: { GH_TOKEN: "ghu_stored", GITHUB_TOKEN: "ghu_stored" },
-        };
-      },
-    );
-    expect(seen).toEqual(["alice"]);
-    expect(response).toBe("username=x-access-token\npassword=ghu_stored\n");
+    expect(
+      githubCredentialResponse(
+        "get",
+        "protocol=https\nhost=github.com\nusername=alice\n\n",
+      ),
+    ).toBe("");
   });
 
   test("ignores writes and non-GitHub hosts", () => {

--- a/scripts/lib/github-credential.ts
+++ b/scripts/lib/github-credential.ts
@@ -2,14 +2,22 @@
  * Git credential helper for github.com remotes.
  *
  * Registered per checkout by setup-repos.ts and reached through the stable
- * `opensession github-credential` command. The run-scoped GH_TOKEN wins in
- * operator mode; personal simple mode falls back to its sole stored account.
- * Neither credential is written to git config or a remote URL.
+ * `opensession github-credential` command. A run-scoped GH_TOKEN wins. Without
+ * one, the checkout's recorded non-secret username selects its stored account;
+ * personal simple mode can also fall back to its sole account. No token is
+ * written to git config or a remote URL.
  */
 
-import { soleGithubAccount } from "../../packages/core/opensession-server/src/server/github-auth";
+import {
+  githubCredentialForLogin,
+  soleGithubAccount,
+} from "../../packages/core/opensession-server/src/server/github-auth";
 
-export function githubCredentialResponse(action: string | undefined, input: string): string {
+export function githubCredentialResponse(
+  action: string | undefined,
+  input: string,
+  credentialForLogin = githubCredentialForLogin,
+): string {
   if (action !== "get") return "";
 
   const attrs: Record<string, string> = {};
@@ -20,7 +28,11 @@ export function githubCredentialResponse(action: string | undefined, input: stri
   }
   if (attrs.protocol !== "https" || attrs.host !== "github.com") return "";
 
-  const token = process.env.GH_TOKEN || soleGithubAccount()?.env.GH_TOKEN;
+  const login = attrs.username?.trim();
+  const token =
+    process.env.GH_TOKEN ||
+    (login ? credentialForLogin(login)?.env.GH_TOKEN : undefined) ||
+    soleGithubAccount()?.env.GH_TOKEN;
   return token ? `username=x-access-token\npassword=${token}\n` : "";
 }
 

--- a/scripts/lib/github-credential.ts
+++ b/scripts/lib/github-credential.ts
@@ -1,0 +1,30 @@
+/**
+ * Git credential helper for github.com remotes.
+ *
+ * Registered per checkout by setup-repos.ts and reached through the stable
+ * `opensession github-credential` command. The run-scoped GH_TOKEN wins in
+ * operator mode; personal simple mode falls back to its sole stored account.
+ * Neither credential is written to git config or a remote URL.
+ */
+
+import { soleGithubAccount } from "../../packages/core/opensession-server/src/server/github-auth";
+
+export function githubCredentialResponse(action: string | undefined, input: string): string {
+  if (action !== "get") return "";
+
+  const attrs: Record<string, string> = {};
+  for (const line of input.split("\n")) {
+    if (!line) break;
+    const eq = line.indexOf("=");
+    if (eq > 0) attrs[line.slice(0, eq)] = line.slice(eq + 1);
+  }
+  if (attrs.protocol !== "https" || attrs.host !== "github.com") return "";
+
+  const token = process.env.GH_TOKEN || soleGithubAccount()?.env.GH_TOKEN;
+  return token ? `username=x-access-token\npassword=${token}\n` : "";
+}
+
+export async function githubCredentialHelper(action: string | undefined): Promise<number> {
+  process.stdout.write(githubCredentialResponse(action, await Bun.stdin.text()));
+  return 0;
+}

--- a/scripts/lib/github-credential.ts
+++ b/scripts/lib/github-credential.ts
@@ -2,22 +2,13 @@
  * Git credential helper for github.com remotes.
  *
  * Registered per checkout by setup-repos.ts and reached through the stable
- * `opensession github-credential` command. A run-scoped GH_TOKEN wins. Without
- * one, the checkout's recorded non-secret username selects its stored account;
- * personal simple mode can also fall back to its sole account. No token is
- * written to git config or a remote URL.
+ * `opensession github-credential` command. It answers only from GH_TOKEN in
+ * this process. Trusted interactive runs and explicit server-side Git calls
+ * inject that value; unattended runs receive neither the token nor a way to
+ * resolve one from the server-side account store.
  */
 
-import {
-  githubCredentialForLogin,
-  soleGithubAccount,
-} from "../../packages/core/opensession-server/src/server/github-auth";
-
-export function githubCredentialResponse(
-  action: string | undefined,
-  input: string,
-  credentialForLogin = githubCredentialForLogin,
-): string {
+export function githubCredentialResponse(action: string | undefined, input: string): string {
   if (action !== "get") return "";
 
   const attrs: Record<string, string> = {};
@@ -28,11 +19,7 @@ export function githubCredentialResponse(
   }
   if (attrs.protocol !== "https" || attrs.host !== "github.com") return "";
 
-  const login = attrs.username?.trim();
-  const token =
-    process.env.GH_TOKEN ||
-    (login ? credentialForLogin(login)?.env.GH_TOKEN : undefined) ||
-    soleGithubAccount()?.env.GH_TOKEN;
+  const token = process.env.GH_TOKEN;
   return token ? `username=x-access-token\npassword=${token}\n` : "";
 }
 

--- a/scripts/lib/onboard.test.ts
+++ b/scripts/lib/onboard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Onboard config construction: an org install (`--org`) records the App owner
+ * and the intent to turn on per-user sign-in at first connect, and NEVER writes
+ * userPrAuth (nobody is signed in at install — flipping the gate here would lock
+ * the operator out). A single-user install writes neither key, byte-identical to
+ * before. buildConfig is the pure config-writing half, tested directly so the
+ * assertion doesn't run the installer's service/scratch-repo side effects.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildConfig, type Answers } from "./onboard";
+
+function answers(org?: string): Answers {
+  return {
+    productName: "Open Session",
+    host: "127.0.0.1",
+    port: 3850,
+    publicBaseUrl: "http://127.0.0.1:3850",
+    repoId: "scratch",
+    repoPath: "/tmp/scratch",
+    repoBranch: "main",
+    worktreesDir: "/tmp/worktrees",
+    enabled: [],
+    ...(org ? { org } : {}),
+  };
+}
+
+/** integrations.github as a plain object. */
+function github(config: Record<string, unknown>): Record<string, unknown> {
+  const integrations = config.integrations as Record<string, unknown>;
+  return (integrations.github as Record<string, unknown>) ?? {};
+}
+
+describe("onboard buildConfig org intent", () => {
+  test("--org writes appOrg + authOnConnect, never userPrAuth", () => {
+    const gh = github(buildConfig(answers("acme-inc")));
+    expect(gh.appOrg).toBe("acme-inc");
+    expect(gh.authOnConnect).toBe(true);
+    // The gate flip happens only at connect, with a live session — never here.
+    expect(gh.userPrAuth).toBeUndefined();
+    // The github integration is still written explicitly off (registry default).
+    expect(gh.enabled).toBe(false);
+  });
+
+  test("no --org writes neither appOrg nor authOnConnect (single-user, unchanged)", () => {
+    const gh = github(buildConfig(answers()));
+    expect(gh.appOrg).toBeUndefined();
+    expect(gh.authOnConnect).toBeUndefined();
+    expect(gh.userPrAuth).toBeUndefined();
+    expect(gh.enabled).toBe(false);
+  });
+});

--- a/scripts/lib/onboard.ts
+++ b/scripts/lib/onboard.ts
@@ -53,6 +53,15 @@ export type OnboardOptions = {
   force?: boolean;
   /** Write every default and ask nothing (the installer's default path). */
   defaults?: boolean;
+  /**
+   * The GitHub org this instance is for (install `--org`). Its presence is what
+   * turns a single-user install into an org one: it records the App's owning org
+   * AND the intent to turn on per-user sign-in at first connect (config
+   * `integrations.github.appOrg` + `authOnConnect`). It never writes userPrAuth —
+   * nobody is signed in at install time, so flipping the gate here would lock the
+   * operator out. Absent = today's single-user install, byte-identical.
+   */
+  org?: string;
 };
 
 /** "Open Session" -> "OS". Falls back to the first two characters. */
@@ -73,9 +82,12 @@ export type Answers = {
   repoGhRepo?: string;
   worktreesDir: string;
   enabled: string[];
+  /** The GitHub org this install is for (from `--org`), or undefined for a
+   *  single-user install. Set from OnboardOptions, never prompted. */
+  org?: string;
 };
 
-function collect(): Answers {
+function collect(orgFlag?: string): Answers {
   heading("Instance configuration");
   info(
     dim(
@@ -84,6 +96,16 @@ function collect(): Answers {
         "  restart, and `opensession bind` handles that one on its own.",
     ),
   );
+
+  // The one answer that changes the install's shape: an organization sets up a
+  // shared org-owned GitHub App and per-user GitHub sign-in; blank keeps it
+  // single-user with no sign-in. `--org` answers it without asking; on the
+  // defaults path (no tty) it stays blank.
+  const org =
+    orgFlag?.trim() ||
+    (canPrompt()
+      ? ask("GitHub organization (blank for a personal, single-user install)", "").trim()
+      : "");
 
   const productName = ask("Product name", "Open Session");
 
@@ -152,6 +174,7 @@ function collect(): Answers {
     repoGhRepo: detectGhRepo(repoPath),
     worktreesDir,
     enabled,
+    org: org || undefined,
   };
 }
 
@@ -177,16 +200,30 @@ function detectGhRepo(dir: string): string | undefined {
   }
 }
 
-/** Exported for tests: the config.json object onboarding writes, so it can be
- *  asserted without running the full installer side effects. */
+/** Exported for tests: the config.json object onboarding writes, so the org
+ *  intent mapping (appOrg + authOnConnect, never userPrAuth) can be asserted
+ *  without running the full installer side effects. */
 export function buildConfig(a: Answers): Record<string, unknown> {
-  // Every non-`always` integration written explicitly off.
+  // Every non-`always` integration written explicitly off. An org install also
+  // records its intent on the github section: the App's owning org and a flag to
+  // turn on per-user sign-in at the first connect. NEVER userPrAuth — nobody is
+  // signed in yet, so gating the app here would lock the operator out. The flip
+  // happens at the connect step, in a request that also mints their session
+  // (routes/connections.ts). A single-user install writes neither key, so its
+  // config is byte-identical to before.
   const integrations = Object.fromEntries(
     INTEGRATIONS.filter((i) => !i.always).map((i) => [
       i.id,
       { enabled: a.enabled.includes(i.id) } as Record<string, unknown>,
     ]),
   );
+  if (a.org) {
+    integrations.github = {
+      ...(integrations.github ?? {}),
+      appOrg: a.org,
+      authOnConnect: true,
+    };
+  }
   return {
     server: {
       host: a.host,
@@ -274,6 +311,16 @@ export async function onboard(opts: OnboardOptions = {}): Promise<number> {
   // defaults. Backups make that recoverable, not harmless.
   if (existsSync(CONFIG_PATH) && !opts.force) {
     warn(`${CONFIG_PATH} already exists — this box is already onboarded.`);
+    // `--org` sets up the App owner and per-user sign-in intent, but only on a
+    // FIRST onboard: re-running here would silently change an existing
+    // instance's auth posture, so it is ignored and said so.
+    if (opts.org) {
+      info(
+        dim(
+          `--org is a first-onboard setting; this box already has a config, so it is ignored.`,
+        ),
+      );
+    }
     info(
       dim(
         `Smaller changes have their own commands: ${bold("opensession bind")} (move to the\n` +
@@ -290,7 +337,7 @@ export async function onboard(opts: OnboardOptions = {}): Promise<number> {
     }
   }
 
-  const answers = collect();
+  const answers = collect(opts.org);
 
   heading("Writing configuration");
   mkdirSync(OPENSESSION_HOME, { recursive: true });


### PR DESCRIPTION
Connect GitHub in simple mode by bringing your own GitHub App, with optional per-user sign-in for a team.

Settings → Connections has a guided wizard: create a GitHub App (personal or org, via a pre-filled `settings/apps/new` link with Device Flow already enabled), paste its client id, slug and secret, install it on the repos you choose, then connect by device code. It stores a user-to-server token; private clones inject it through a temp `GIT_ASKPASS` and never write it to the persisted remote.

- App only, no personal-access-token path. The app config is applied live from `config.json`, no restart.
- Org path: `install.sh --org <name>` / `OPENSESSION_ORG`, or the wizard's owner control, records the org and an intent marker. Connecting an org app then, in one locked write, rosters the connecting account as admin and turns on GitHub sign-in, minting its session in the same request. There is no window where the gate is on but nobody can sign in. A personal app stays single-user with no auth.
- Sign-in reuses the same app's client id, so moving from single-user to per-user is a one-flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
