### PR TITLE
Simple mode 5/5: rotate service logs and warn on low disk

### DIFF
--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -11,6 +11,7 @@ import {
 import { startAccountHealthMonitor } from "./src/server/account-health";
 import { startAnalyticsPrewarm } from "./src/server/analytics";
 import { startDiskGc } from "./src/server/disk-gc";
+import { startMaintenance } from "./src/server/maintenance";
 import { startWorktreeReaper } from "./src/server/worktree-reaper";
 import { startPortalReaper } from "./src/server/portal-supervisor";
 import { startRunnerPortalReaper } from "./src/server/runner-portals";
@@ -690,6 +691,11 @@ if (!g.__opensessionBooted) {
 
 	// Reclaim rust target/ build caches from idle worktrees we keep (disk-gc.ts)
 	startDiskGc();
+
+	// Rotate the unbounded service logs and warn on low disk (maintenance.ts) —
+	// launchd/systemd never rotate their redirected stdout, so a long-running
+	// simple-mode install grows server.log until the disk fills.
+	startMaintenance();
 
 	// Keep the Analytics presets' summaries warm so the view opens instantly
 	// (analytics.ts — gh fetches + composed summaries are disk-cached too)

--- a/packages/core/opensession-server/src/server/maintenance.test.ts
+++ b/packages/core/opensession-server/src/server/maintenance.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rotateLog, serviceLogDirFromDefinition } from "./maintenance";
@@ -16,6 +24,25 @@ describe("rotateLog", () => {
     expect(freed).toBe(2048);
     expect(statSync(log).size).toBe(0); // live log truncated
     expect(readFileSync(`${log}.1`, "utf8")).toBe(body); // rotation preserved
+  });
+
+  test("truncates without a rotation when the copy runs out of space", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-maint-"));
+    const log = join(dir, "server.log");
+    writeFileSync(log, "x".repeat(2048));
+
+    const freed = rotateLog(log, 1024, {
+      copy: (_source, destination) => {
+        writeFileSync(destination, "partial");
+        throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      },
+      truncate: (path) => truncateSync(path, 0),
+      remove: (path) => rmSync(path, { force: true }),
+    });
+
+    expect(freed).toBe(2048);
+    expect(statSync(log).size).toBe(0);
+    expect(existsSync(`${log}.1`)).toBe(false);
   });
 
   test("leaves a log under the cap untouched", () => {

--- a/packages/core/opensession-server/src/server/maintenance.test.ts
+++ b/packages/core/opensession-server/src/server/maintenance.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { rotateLog } from "./maintenance";
+import { rotateLog, serviceLogDirFromDefinition } from "./maintenance";
 
 describe("rotateLog", () => {
   test("rotates a log over the cap: truncates in place and keeps .1", () => {
@@ -33,5 +33,43 @@ describe("rotateLog", () => {
   test("no-ops on a missing log", () => {
     const dir = mkdtempSync(join(tmpdir(), "os-maint-"));
     expect(rotateLog(join(dir, "nope.log"), 1024)).toBe(0);
+  });
+});
+
+describe("serviceLogDirFromDefinition", () => {
+  test("reads an existing systemd file log path", () => {
+    expect(
+      serviceLogDirFromDefinition(
+        "[Service]\nStandardOutput=append:/srv/os/logs/server.log\n",
+      ),
+    ).toBe("/srv/os/logs");
+  });
+
+  test("uses a valid systemd error path when stdout is not a file", () => {
+    expect(
+      serviceLogDirFromDefinition(
+        "[Service]\nStandardOutput=journal\nStandardError=append:/srv/os/logs/server.err.log\n",
+      ),
+    ).toBe("/srv/os/logs");
+  });
+
+  test("reads and decodes an existing launchd log path", () => {
+    expect(
+      serviceLogDirFromDefinition(
+        "<key>StandardOutPath</key><string>/srv/Open &amp; Session/logs/server.log</string>",
+      ),
+    ).toBe("/srv/Open & Session/logs");
+  });
+
+  test("derives a custom release home from an older unit executable", () => {
+    expect(
+      serviceLogDirFromDefinition(
+        "[Service]\nExecStart=/srv/os/bin/opensession server\n",
+      ),
+    ).toBe("/srv/os/logs");
+  });
+
+  test("ignores unrelated service files", () => {
+    expect(serviceLogDirFromDefinition("[Service]\nExecStart=/usr/bin/other\n")).toBeNull();
   });
 });

--- a/packages/core/opensession-server/src/server/maintenance.test.ts
+++ b/packages/core/opensession-server/src/server/maintenance.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rotateLog } from "./maintenance";
+
+describe("rotateLog", () => {
+  test("rotates a log over the cap: truncates in place and keeps .1", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-maint-"));
+    const log = join(dir, "server.log");
+    const body = "x".repeat(2048);
+    writeFileSync(log, body);
+
+    const freed = rotateLog(log, 1024); // cap below current size
+
+    expect(freed).toBe(2048);
+    expect(statSync(log).size).toBe(0); // live log truncated
+    expect(readFileSync(`${log}.1`, "utf8")).toBe(body); // rotation preserved
+  });
+
+  test("leaves a log under the cap untouched", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-maint-"));
+    const log = join(dir, "server.log");
+    writeFileSync(log, "small");
+
+    const freed = rotateLog(log, 1024);
+
+    expect(freed).toBe(0);
+    expect(statSync(log).size).toBe(5);
+    expect(() => statSync(`${log}.1`)).toThrow(); // no rotation created
+  });
+
+  test("no-ops on a missing log", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-maint-"));
+    expect(rotateLog(join(dir, "nope.log"), 1024)).toBe(0);
+  });
+});

--- a/packages/core/opensession-server/src/server/maintenance.ts
+++ b/packages/core/opensession-server/src/server/maintenance.ts
@@ -21,6 +21,7 @@ import {
   copyFileSync,
   existsSync,
   readFileSync,
+  rmSync,
   statSync,
   truncateSync,
 } from "node:fs";
@@ -151,10 +152,28 @@ const SERVICE_LOGS = ["server.log", "server.err.log"];
  * Rotate an oversized service log in place. launchd and systemd open the log
  * for append, so the running server's next write lands at the new end of file
  * rather than at a stale offset: copy-then-truncate is safe and leaves no
- * sparse hole. One generation is kept as `<name>.1` for a post-mortem; the
- * previous `.1` is overwritten. Returns the freed size, or 0 if nothing to do.
+ * sparse hole. One generation is kept as `<name>.1` for a post-mortem when
+ * space permits. On ENOSPC the partial rotation is removed and the live log is
+ * truncated as a last resort: recovering the filesystem is more important than
+ * preserving the copy. Returns the freed size, or 0 if nothing to do.
  */
-export function rotateLog(path: string, capBytes = LOG_CAP_BYTES): number {
+export interface LogRotationOps {
+  copy: (source: string, destination: string) => void;
+  truncate: (path: string) => void;
+  remove: (path: string) => void;
+}
+
+const DEFAULT_LOG_ROTATION_OPS: LogRotationOps = {
+  copy: (source, destination) => copyFileSync(source, destination),
+  truncate: (path) => truncateSync(path, 0),
+  remove: (path) => rmSync(path, { force: true }),
+};
+
+export function rotateLog(
+  path: string,
+  capBytes = LOG_CAP_BYTES,
+  ops: LogRotationOps = DEFAULT_LOG_ROTATION_OPS,
+): number {
   let size = 0;
   try {
     size = statSync(path).size;
@@ -162,12 +181,29 @@ export function rotateLog(path: string, capBytes = LOG_CAP_BYTES): number {
     return 0; // no such log yet
   }
   if (size <= capBytes) return 0;
+  const rotatedPath = `${path}.1`;
   try {
-    copyFileSync(path, `${path}.1`);
-    truncateSync(path, 0);
+    ops.copy(path, rotatedPath);
+    ops.truncate(path);
     return size;
-  } catch (e) {
-    console.error(`[maintenance] could not rotate ${path}:`, e);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOSPC") {
+      try {
+        ops.remove(rotatedPath);
+        ops.truncate(path);
+        console.warn(
+          `[maintenance] disk full while rotating ${path}; truncated without keeping .1`,
+        );
+        return size;
+      } catch (fallbackError) {
+        console.error(
+          `[maintenance] could not recover disk space from ${path}:`,
+          fallbackError,
+        );
+        return 0;
+      }
+    }
+    console.error(`[maintenance] could not rotate ${path}:`, error);
     return 0;
   }
 }
@@ -189,7 +225,7 @@ export function runMaintenance(): MaintenanceResult {
   }
   for (const r of rotated) {
     console.log(
-      `[maintenance] rotated ${r.path} (${(r.wasBytes / MB).toFixed(0)}MB -> 0, kept .1)`,
+      `[maintenance] rotated ${r.path} (${(r.wasBytes / MB).toFixed(0)}MB -> 0)`,
     );
   }
   if (rotated.length) audit({ event: "maintenance_log_rotate", rotated: rotated.length });

--- a/packages/core/opensession-server/src/server/maintenance.ts
+++ b/packages/core/opensession-server/src/server/maintenance.ts
@@ -17,8 +17,14 @@
  * scope; the sweep is armed from the boot block via startMaintenance().
  */
 
-import { copyFileSync, existsSync, statSync, truncateSync } from "node:fs";
-import { join } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  truncateSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { audit } from "./audit";
 import { diskUsagePct } from "./disk-gc";
 import { homeDir } from "./paths";
@@ -38,27 +44,105 @@ const FIRST_SWEEP_DELAY_MS = 2 * 60 * 1000;
 /** Warn the operator once free space is this tight — before writes start failing. */
 const DISK_WARN_PCT = num(process.env.OPENSESSION_DISK_WARN_PCT, 90);
 
-/** The install's home, honoring the OPENSESSION_HOME override the installer
- *  uses (scripts/lib/paths.ts), so maintenance inspects the same tree launchd
- *  and systemd actually write to rather than a stale `~/.opensession`. */
+/** The install's home, honoring the override used by scripts/lib/paths.ts. */
 function opensessionHome(): string {
   return process.env.OPENSESSION_HOME || join(homeDir(), ".opensession");
 }
 
-/** The install's log directory (service.ts points the unit's log output here). */
-export function serviceLogDir(): string {
-  return join(opensessionHome(), "logs");
+function xmlText(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
-/** An existing path ON the log filesystem, for the free-space check. The log
- *  dir may not be created yet, so fall back to the install home, then $HOME.
- *  Probing `/` would miss a nearly full `/home` on a split-filesystem box. */
+function logParent(path: string): string | null {
+  const clean = path.trim();
+  return /^(server|server\.err)\.log$/.test(basename(clean))
+    ? dirname(clean)
+    : null;
+}
+
+/**
+ * Recover the log directory from a rendered systemd unit or launchd plist.
+ * Older custom-home services do not carry OPENSESSION_HOME in their process
+ * environment, but their installed definition still names the real log path or
+ * stable executable. Reading it lets an upgraded server protect those logs on
+ * its first restart, without requiring a separate service reinstall.
+ */
+export function serviceLogDirFromDefinition(text: string): string | null {
+  for (const match of text.matchAll(
+    /^Standard(?:Output|Error)=append:(.+)$/gm,
+  )) {
+    const dir = logParent(match[1] || "");
+    if (dir) return dir;
+  }
+
+  for (const match of text.matchAll(
+    /<key>Standard(?:Out|Error)Path<\/key>\s*<string>([^<]+)<\/string>/g,
+  )) {
+    const dir = logParent(xmlText(match[1] || ""));
+    if (dir) return dir;
+  }
+
+  const systemdHome = text.match(
+    /^Environment=["']?OPENSESSION_HOME=([^"'\n]+)["']?$/m,
+  )?.[1];
+  if (systemdHome) return join(systemdHome.trim(), "logs");
+
+  const plistHome = text.match(
+    /<key>OPENSESSION_HOME<\/key>\s*<string>([^<]+)<\/string>/,
+  )?.[1];
+  if (plistHome) return join(xmlText(plistHome), "logs");
+
+  const binaryHome = text.match(
+    /^ExecStart=["']?(.+?)[\/]bin[\/]opensession(?:\s|["'])/m,
+  )?.[1];
+  return binaryHome ? join(binaryHome, "logs") : null;
+}
+
+function installedServiceLogDir(): string | null {
+  const home = homeDir();
+  const definitions = process.platform === "darwin"
+    ? [join(home, "Library", "LaunchAgents", "dev.opensession.server.plist")]
+    : [
+        join(
+          process.env.XDG_CONFIG_HOME || join(home, ".config"),
+          "systemd",
+          "user",
+          "opensession.service",
+        ),
+        "/etc/systemd/system/opensession.service",
+      ];
+  for (const path of definitions) {
+    try {
+      const dir = serviceLogDirFromDefinition(readFileSync(path, "utf8"));
+      if (dir) return dir;
+    } catch {}
+  }
+  return null;
+}
+
+/** The directory the active service writes, including pre-upgrade definitions. */
+export function serviceLogDir(): string {
+  if (process.env.OPENSESSION_HOME)
+    return join(process.env.OPENSESSION_HOME, "logs");
+  return installedServiceLogDir() || join(opensessionHome(), "logs");
+}
+
+/** The nearest existing path on the log filesystem for the free-space check.
+ * The log directory may not exist yet, so walk through its install home before
+ * reaching the filesystem root. */
 export function diskProbePath(): string {
-  const dir = serviceLogDir();
-  if (existsSync(dir)) return dir;
-  const home = opensessionHome();
-  if (existsSync(home)) return home;
-  return homeDir();
+  let candidate = serviceLogDir();
+  while (true) {
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(candidate);
+    if (parent === candidate) return homeDir();
+    candidate = parent;
+  }
 }
 
 const SERVICE_LOGS = ["server.log", "server.err.log"];

--- a/packages/core/opensession-server/src/server/maintenance.ts
+++ b/packages/core/opensession-server/src/server/maintenance.ts
@@ -1,0 +1,130 @@
+/**
+ * Simple-mode maintenance: keep a long-running single-user install from
+ * silently filling its disk.
+ *
+ * The service logs are the one piece of state that grows with no bound of its
+ * own. launchd and the systemd unit redirect the server's stdout/stderr into
+ * `server.log` / `server.err.log` and rotate nothing, so a laptop or small VPS
+ * left running for weeks grows those files until the disk is full, and the
+ * failures that follow (writes erroring, sessions wedging) read as a baffling
+ * outage rather than "your log ate the disk". Everything else that grows is
+ * already bounded: the worktree reaper and disk-gc reclaim worktrees and their
+ * caches, and audit files prune past a retention window. This fills the log
+ * gap and warns before free space runs out.
+ *
+ * Conservative by construction: it only truncates its own service logs, never
+ * user data, and keeps one rotation for a post-mortem. Nothing runs at module
+ * scope; the sweep is armed from the boot block via startMaintenance().
+ */
+
+import { copyFileSync, existsSync, statSync, truncateSync } from "node:fs";
+import { join } from "node:path";
+import { audit } from "./audit";
+import { diskUsagePct } from "./disk-gc";
+import { homeDir } from "./paths";
+
+const MB = 1024 * 1024;
+const HOUR = 60 * 60 * 1000;
+
+function num(raw: string | undefined, fallback: number): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Cap each service log here; above it, rotate to `.1` and truncate in place. */
+const LOG_CAP_BYTES = num(process.env.OPENSESSION_LOG_CAP_MB, 25) * MB;
+const SWEEP_INTERVAL_MS = num(process.env.OPENSESSION_MAINTENANCE_INTERVAL_MS, 6 * HOUR);
+const FIRST_SWEEP_DELAY_MS = 2 * 60 * 1000;
+/** Warn the operator once free space is this tight — before writes start failing. */
+const DISK_WARN_PCT = num(process.env.OPENSESSION_DISK_WARN_PCT, 90);
+
+/** The install's log directory (service.ts points the unit's log output here). */
+export function serviceLogDir(): string {
+  return join(homeDir(), ".opensession", "logs");
+}
+
+const SERVICE_LOGS = ["server.log", "server.err.log"];
+
+/**
+ * Rotate an oversized service log in place. launchd and systemd open the log
+ * for append, so the running server's next write lands at the new end of file
+ * rather than at a stale offset: copy-then-truncate is safe and leaves no
+ * sparse hole. One generation is kept as `<name>.1` for a post-mortem; the
+ * previous `.1` is overwritten. Returns the freed size, or 0 if nothing to do.
+ */
+export function rotateLog(path: string, capBytes = LOG_CAP_BYTES): number {
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return 0; // no such log yet
+  }
+  if (size <= capBytes) return 0;
+  try {
+    copyFileSync(path, `${path}.1`);
+    truncateSync(path, 0);
+    return size;
+  } catch (e) {
+    console.error(`[maintenance] could not rotate ${path}:`, e);
+    return 0;
+  }
+}
+
+export interface MaintenanceResult {
+  rotated: { path: string; wasBytes: number }[];
+  diskPct: number;
+}
+
+/** One maintenance pass. Safe to call repeatedly; never touches user data. */
+export function runMaintenance(): MaintenanceResult {
+  const dir = serviceLogDir();
+  const rotated: { path: string; wasBytes: number }[] = [];
+  if (existsSync(dir)) {
+    for (const name of SERVICE_LOGS) {
+      const wasBytes = rotateLog(join(dir, name));
+      if (wasBytes) rotated.push({ path: join(dir, name), wasBytes });
+    }
+  }
+  for (const r of rotated) {
+    console.log(
+      `[maintenance] rotated ${r.path} (${(r.wasBytes / MB).toFixed(0)}MB -> 0, kept .1)`,
+    );
+  }
+  if (rotated.length) audit({ event: "maintenance_log_rotate", rotated: rotated.length });
+
+  const diskPct = diskUsagePct();
+  if (diskPct >= DISK_WARN_PCT) {
+    console.warn(
+      `[maintenance] free disk is low — filesystem at ${diskPct.toFixed(0)}%. ` +
+        `Old sessions/worktrees are the usual culprit; \`opensession doctor\` reports state size.`,
+    );
+  }
+  return { rotated, diskPct };
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Arm the periodic maintenance sweep. Idempotent, so a `bun --hot` reload never
+ * stacks a second one. Call once from the __opensessionBooted block.
+ */
+export function startMaintenance(): void {
+  if (timer) return;
+  if (process.env.OPENSESSION_MAINTENANCE === "0") {
+    console.log("[maintenance] disabled (OPENSESSION_MAINTENANCE=0)");
+    return;
+  }
+  const run = () => {
+    try {
+      runMaintenance();
+    } catch (e) {
+      console.error("[maintenance] sweep failed:", e);
+    }
+  };
+  setTimeout(run, FIRST_SWEEP_DELAY_MS);
+  timer = setInterval(run, SWEEP_INTERVAL_MS);
+  console.log(
+    `[maintenance] started (every ${Math.round(SWEEP_INTERVAL_MS / HOUR)}h; ` +
+      `service-log cap ${(LOG_CAP_BYTES / MB).toFixed(0)}MB, disk warn at ${DISK_WARN_PCT}%)`,
+  );
+}

--- a/packages/core/opensession-server/src/server/maintenance.ts
+++ b/packages/core/opensession-server/src/server/maintenance.ts
@@ -38,9 +38,27 @@ const FIRST_SWEEP_DELAY_MS = 2 * 60 * 1000;
 /** Warn the operator once free space is this tight — before writes start failing. */
 const DISK_WARN_PCT = num(process.env.OPENSESSION_DISK_WARN_PCT, 90);
 
+/** The install's home, honoring the OPENSESSION_HOME override the installer
+ *  uses (scripts/lib/paths.ts), so maintenance inspects the same tree launchd
+ *  and systemd actually write to rather than a stale `~/.opensession`. */
+function opensessionHome(): string {
+  return process.env.OPENSESSION_HOME || join(homeDir(), ".opensession");
+}
+
 /** The install's log directory (service.ts points the unit's log output here). */
 export function serviceLogDir(): string {
-  return join(homeDir(), ".opensession", "logs");
+  return join(opensessionHome(), "logs");
+}
+
+/** An existing path ON the log filesystem, for the free-space check. The log
+ *  dir may not be created yet, so fall back to the install home, then $HOME.
+ *  Probing `/` would miss a nearly full `/home` on a split-filesystem box. */
+export function diskProbePath(): string {
+  const dir = serviceLogDir();
+  if (existsSync(dir)) return dir;
+  const home = opensessionHome();
+  if (existsSync(home)) return home;
+  return homeDir();
 }
 
 const SERVICE_LOGS = ["server.log", "server.err.log"];
@@ -92,7 +110,7 @@ export function runMaintenance(): MaintenanceResult {
   }
   if (rotated.length) audit({ event: "maintenance_log_rotate", rotated: rotated.length });
 
-  const diskPct = diskUsagePct();
+  const diskPct = diskUsagePct(diskProbePath());
   if (diskPct >= DISK_WARN_PCT) {
     console.warn(
       `[maintenance] free disk is low — filesystem at ${diskPct.toFixed(0)}%. ` +

--- a/packages/core/opensession-server/src/server/system-stats.ts
+++ b/packages/core/opensession-server/src/server/system-stats.ts
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync, readdirSync, statfsSync } from "node:fs";
-import { cpus, freemem, loadavg, totalmem } from "node:os";
+import { cpus, loadavg, totalmem } from "node:os";
 
 const isLinux = process.platform === "linux";
 
@@ -51,10 +51,10 @@ export function systemStats(): Record<string, unknown> {
 
 /**
  * Memory totals, portable across platforms. Linux reads /proc/meminfo for the
- * kernel's own "available" estimate and swap accounting; elsewhere
- * os.totalmem()/freemem() stand in. Swap is null off Linux because there is no
- * cheap read for it there, and null (not 0) keeps "no swap pressure" distinct
- * from "not measured".
+ * kernel's own "available" estimate and swap accounting. Other platforms
+ * expose only the total: os.freemem() is strictly unused RAM and excludes
+ * reclaimable cache, so labelling it "available" would produce false low-memory
+ * alarms on macOS. Null keeps "not measured" distinct from real zero pressure.
  */
 function memoryStats(): Record<string, unknown> {
 	if (isLinux) {
@@ -72,12 +72,10 @@ function memoryStats(): Record<string, unknown> {
 			swapUsedGb: +(((mem.SwapTotal || 0) - (mem.SwapFree || 0)) / 1e9).toFixed(2),
 		};
 	}
-	const total = totalmem();
-	const free = freemem();
 	return {
-		totalGb: +(total / 1e9).toFixed(2),
-		availableGb: +(free / 1e9).toFixed(2),
-		availablePct: total ? +((free / total) * 100).toFixed(1) : null,
+		totalGb: +(totalmem() / 1e9).toFixed(2),
+		availableGb: null,
+		availablePct: null,
 		swapUsedGb: null,
 	};
 }

--- a/packages/core/opensession-server/src/server/system-stats.ts
+++ b/packages/core/opensession-server/src/server/system-stats.ts
@@ -13,7 +13,9 @@
  */
 
 import { readFileSync, readdirSync, statfsSync } from "node:fs";
-import { cpus, loadavg } from "node:os";
+import { cpus, freemem, loadavg, totalmem } from "node:os";
+
+const isLinux = process.platform === "linux";
 
 /** Host metrics for /api/health and the `read_host_metrics` tool. The
  *  health-monitor automation reads these numbers through the tool: it runs
@@ -22,37 +24,62 @@ import { cpus, loadavg } from "node:os";
  *  these fields stable, and keep both readers on this one builder. */
 export function systemStats(): Record<string, unknown> {
 	try {
-		const mem: Record<string, number> = {};
-		for (const line of readFileSync("/proc/meminfo", "utf-8").split("\n")) {
-			const m = line.match(/^(\w+):\s+(\d+) kB/);
-			if (m) mem[m[1]] = Number(m[2]) * 1024;
-		}
 		const s = statfsSync("/");
 		const totalBytes = s.blocks * s.bsize;
 		const availBytes = s.bavail * s.bsize;
 		const [load1, load5, load15] = loadavg();
-		return {
+		const stats: Record<string, unknown> = {
 			disk: {
 				mount: "/",
 				totalGb: +(totalBytes / 1e9).toFixed(1),
 				availGb: +(availBytes / 1e9).toFixed(1),
 				usedPct: +((1 - availBytes / totalBytes) * 100).toFixed(1),
 			},
-			memory: {
-				totalGb: +((mem.MemTotal || 0) / 1e9).toFixed(2),
-				availableGb: +((mem.MemAvailable || 0) / 1e9).toFixed(2),
-				availablePct: mem.MemTotal
-					? +(((mem.MemAvailable || 0) / mem.MemTotal) * 100).toFixed(1)
-					: null,
-				swapUsedGb: +(((mem.SwapTotal || 0) - (mem.SwapFree || 0)) / 1e9).toFixed(2),
-			},
+			memory: memoryStats(),
 			load: { "1m": load1, "5m": load5, "15m": load15, cores: cpus().length },
 			processes: processCensus(),
-			cgroups: cgroupCensus(),
 		};
+		// The /proc census and the cgroup v2 tree are Linux-only. On macOS and
+		// elsewhere the process census returns {} and the cgroup fleet is omitted,
+		// so the host still reports disk, memory, and load instead of nothing.
+		if (isLinux) stats.cgroups = cgroupCensus();
+		return stats;
 	} catch (e) {
 		return { error: String((e as Error)?.message || e) };
 	}
+}
+
+/**
+ * Memory totals, portable across platforms. Linux reads /proc/meminfo for the
+ * kernel's own "available" estimate and swap accounting; elsewhere
+ * os.totalmem()/freemem() stand in. Swap is null off Linux because there is no
+ * cheap read for it there, and null (not 0) keeps "no swap pressure" distinct
+ * from "not measured".
+ */
+function memoryStats(): Record<string, unknown> {
+	if (isLinux) {
+		const mem: Record<string, number> = {};
+		for (const line of readFileSync("/proc/meminfo", "utf-8").split("\n")) {
+			const m = line.match(/^(\w+):\s+(\d+) kB/);
+			if (m) mem[m[1]] = Number(m[2]) * 1024;
+		}
+		return {
+			totalGb: +((mem.MemTotal || 0) / 1e9).toFixed(2),
+			availableGb: +((mem.MemAvailable || 0) / 1e9).toFixed(2),
+			availablePct: mem.MemTotal
+				? +(((mem.MemAvailable || 0) / mem.MemTotal) * 100).toFixed(1)
+				: null,
+			swapUsedGb: +(((mem.SwapTotal || 0) - (mem.SwapFree || 0)) / 1e9).toFixed(2),
+		};
+	}
+	const total = totalmem();
+	const free = freemem();
+	return {
+		totalGb: +(total / 1e9).toFixed(2),
+		availableGb: +(free / 1e9).toFixed(2),
+		availablePct: total ? +((free / total) * 100).toFixed(1) : null,
+		swapUsedGb: null,
+	};
 }
 
 interface CgroupMemorySnapshot {
@@ -185,6 +212,7 @@ function cgroupCensus(): Record<string, unknown> {
  *  incidents. */
 let censusCache: { at: number; data: Record<string, number> } | null = null;
 function processCensus(): Record<string, number> {
+	if (!isLinux) return {}; // the fleet census scans /proc, which is Linux-only
 	if (censusCache && Date.now() - censusCache.at < 60_000) return censusCache.data;
 	const counts = {
 		mcpProxies: 0,

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -12,10 +12,13 @@
  */
 
 import { existsSync, statSync } from "fs";
+import { join } from "path";
 import { tailnetIp } from "./config-edit";
 import { CONFIG_PATH, ENV_PATH, REPO_ROOT } from "./paths";
 import { isCompiledBinary } from "../../packages/core/opensession-server/src/runner-host/exe";
 import { INTEGRATIONS } from "../../packages/core/opensession-server/src/server/integrations/registry";
+import { diskUsagePct } from "../../packages/core/opensession-server/src/server/disk-gc";
+import { serviceLogDir } from "../../packages/core/opensession-server/src/server/maintenance";
 import * as service from "./service";
 import { dim, fail, heading, info, ok, run, warn } from "./ui";
 
@@ -272,6 +275,41 @@ async function checkEngine(t: Tally): Promise<void> {
   if (e.piEnabled) info(dim(`Pi enabled, ${pool}`));
 }
 
+/**
+ * Disk headroom and the one piece of state that grows without a bound of its
+ * own: the service logs. Maintenance rotates them at a cap, but surface the
+ * numbers here so "why did my laptop fill up" has an answer before it bites.
+ */
+function checkDisk(t: Tally): void {
+  heading("Disk");
+  const pct = diskUsagePct();
+  if (pct >= 95) {
+    fail(`disk ${pct.toFixed(0)}% full`, "free space now — old sessions and worktrees are the usual cause");
+    t.errors++;
+  } else if (pct >= 90) {
+    warn(`disk ${pct.toFixed(0)}% full`, "getting tight; prune old sessions/worktrees");
+    t.warnings++;
+  } else {
+    ok(`disk ${pct.toFixed(0)}% used`);
+  }
+  const dir = serviceLogDir();
+  for (const name of ["server.log", "server.err.log"]) {
+    let size = 0;
+    try {
+      size = statSync(join(dir, name)).size;
+    } catch {
+      continue; // no log yet (foreground run, or fresh install)
+    }
+    const mb = size / (1024 * 1024);
+    if (mb > 100) {
+      warn(`${name} is ${mb.toFixed(0)}MB`, "maintenance rotates it; this is unusually large");
+      t.warnings++;
+    } else if (size > 0) {
+      ok(name, `${mb.toFixed(0)}MB`);
+    }
+  }
+}
+
 export async function doctor(): Promise<number> {
   const t: Tally = { errors: 0, warnings: 0 };
 
@@ -281,6 +319,7 @@ export async function doctor(): Promise<number> {
   await checkEngine(t);
   await checkIntegrations(t, config);
   await checkService(t, config);
+  checkDisk(t);
 
   heading("Summary");
   if (!t.errors && !t.warnings) ok("everything looks healthy");

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -18,7 +18,7 @@ import { CONFIG_PATH, ENV_PATH, REPO_ROOT } from "./paths";
 import { isCompiledBinary } from "../../packages/core/opensession-server/src/runner-host/exe";
 import { INTEGRATIONS } from "../../packages/core/opensession-server/src/server/integrations/registry";
 import { diskUsagePct } from "../../packages/core/opensession-server/src/server/disk-gc";
-import { serviceLogDir } from "../../packages/core/opensession-server/src/server/maintenance";
+import { diskProbePath, serviceLogDir } from "../../packages/core/opensession-server/src/server/maintenance";
 import * as service from "./service";
 import { dim, fail, heading, info, ok, run, warn } from "./ui";
 
@@ -282,7 +282,7 @@ async function checkEngine(t: Tally): Promise<void> {
  */
 function checkDisk(t: Tally): void {
   heading("Disk");
-  const pct = diskUsagePct();
+  const pct = diskUsagePct(diskProbePath());
   if (pct >= 95) {
     fail(`disk ${pct.toFixed(0)}% full`, "free space now — old sessions and worktrees are the usual cause");
     t.errors++;

--- a/scripts/lib/service.test.ts
+++ b/scripts/lib/service.test.ts
@@ -183,8 +183,10 @@ describe("custom OPENSESSION_HOME", () => {
   test("persistedHomeEnv keeps a moved home and drops the default", () => {
     // A default install ($HOME/.opensession) needs no entry; a moved home does,
     // or the server's runtime opensessionHome() tends ~/.opensession instead.
-    expect(persistedHomeEnv("/srv/os-home", "/home/bob")).toBe("/srv/os-home");
-    expect(persistedHomeEnv("/home/bob/.opensession", "/home/bob")).toBeNull();
+    const homeRoot = join("/", "home", "bob");
+    const movedHome = join("/", "srv", "os-home");
+    expect(persistedHomeEnv(movedHome, homeRoot)).toBe(movedHome);
+    expect(persistedHomeEnv(join(homeRoot, ".opensession"), homeRoot)).toBeNull();
   });
 
   // OPENSESSION_HOME is read once at import, so exercise the rendered output in

--- a/scripts/lib/service.test.ts
+++ b/scripts/lib/service.test.ts
@@ -14,9 +14,11 @@
 
 import { describe, expect, test } from "bun:test";
 import { platform } from "os";
+import { join } from "path";
 import {
   LAUNCHD_LABEL,
   LAUNCHD_LAUNCHER,
+  persistedHomeEnv,
   renderExecutorUnit,
   renderLauncher,
   renderPlist,
@@ -174,5 +176,45 @@ describe.skipIf(!onServiceHost)("launchd plist", () => {
     const plist = renderPlist();
     expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
     expect(plist).toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+  });
+});
+
+describe("custom OPENSESSION_HOME", () => {
+  test("persistedHomeEnv keeps a moved home and drops the default", () => {
+    // A default install ($HOME/.opensession) needs no entry; a moved home does,
+    // or the server's runtime opensessionHome() tends ~/.opensession instead.
+    expect(persistedHomeEnv("/srv/os-home", "/home/bob")).toBe("/srv/os-home");
+    expect(persistedHomeEnv("/home/bob/.opensession", "/home/bob")).toBeNull();
+  });
+
+  // OPENSESSION_HOME is read once at import, so exercise the rendered output in
+  // a child process with the env set, and confirm a default install omits it.
+  function renderInChild(home: string | undefined): { unit: string; plist: string } {
+    const mod = join(import.meta.dir, "service.ts");
+    const script =
+      `const s = await import(${JSON.stringify(mod)});` +
+      `process.stdout.write(await s.renderUnit("system"));` +
+      `process.stdout.write("\\n@@PLIST@@\\n");` +
+      `process.stdout.write(s.renderPlist());`;
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v;
+    if (home === undefined) delete env.OPENSESSION_HOME;
+    else env.OPENSESSION_HOME = home;
+    const proc = Bun.spawnSync(["bun", "-e", script], { env });
+    const [unit, plist] = proc.stdout.toString().split("@@PLIST@@");
+    return { unit, plist };
+  }
+
+  test.skipIf(platform() === "win32")("a moved home is stamped into the unit and plist", () => {
+    const home = "/tmp/opensession-custom-home-test";
+    const { unit, plist } = renderInChild(home);
+    expect(unit).toContain(`Environment="OPENSESSION_HOME=${home}"`);
+    expect(plist).toContain(`<key>OPENSESSION_HOME</key><string>${home}</string>`);
+  });
+
+  test.skipIf(platform() === "win32")("a default home leaves no OPENSESSION_HOME entry", () => {
+    const { unit, plist } = renderInChild(undefined);
+    expect(unit).not.toContain("OPENSESSION_HOME");
+    expect(plist).not.toContain("OPENSESSION_HOME");
   });
 });

--- a/scripts/lib/service.ts
+++ b/scripts/lib/service.ts
@@ -111,6 +111,23 @@ export function serviceWorkdir(): string {
   return existsSync(link) ? link : REPO_ROOT;
 }
 
+/**
+ * The OPENSESSION_HOME to persist into a rendered service, or null when it is
+ * the default. A custom home (install.sh OPENSESSION_HOME=…) bakes the unit's
+ * log and state paths under itself, but the launched server reads
+ * OPENSESSION_HOME from its own env to resolve that same home at runtime (log
+ * rotation, disk probe). Without carrying it, the server falls back to
+ * ~/.opensession and tends the wrong tree, so stamp it into the unit and plist.
+ * A default install needs no entry. Args default to the frozen module paths and
+ * are injectable for tests.
+ */
+export function persistedHomeEnv(
+  home: string = OPENSESSION_HOME,
+  homeRoot: string = HOME,
+): string | null {
+  return home !== join(homeRoot, ".opensession") ? home : null;
+}
+
 export function supervisor(): Supervisor {
   if (process.platform === "darwin") return "launchd";
   if (Bun.which("systemctl") && existsSync("/run/systemd/system"))
@@ -331,6 +348,13 @@ export async function renderUnit(
     "# EXECUTOR_CREDENTIAL: rendered installs replace this marker. Keeping the\n" +
     "# source template optional lets the previous deploy script introduce this\n" +
     "# release without failing before it knows how to install the credential.\n";
+  const home = persistedHomeEnv();
+  if (home) {
+    unit = unit.replace(
+      /^Environment="PATH=.*"$/m,
+      (m) => `${m}\nEnvironment="OPENSESSION_HOME=${home}"`,
+    );
+  }
   if (scope === "system") {
     return unit
       .replace(/^User=.*$/m, `User=${await resolveUsername()}`)
@@ -510,6 +534,10 @@ export function renderLauncher(): string {
 
 export function renderPlist(): string {
   const exec = serverExec();
+  const home = persistedHomeEnv();
+  const homeVar = home
+    ? `\n    <key>OPENSESSION_HOME</key><string>${xml(home)}</string>`
+    : "";
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -523,7 +551,7 @@ export function renderPlist(): string {
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key><string>${xml(servicePath(exec.binDir))}</string>
-    <key>NODE_ENV</key><string>production</string>
+    <key>NODE_ENV</key><string>production</string>${homeVar}
   </dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>


### PR DESCRIPTION
Keep a long-running simple-mode install from silently filling its disk.

Most of the degradation surface is already handled (the worktree reaper, disk-gc for build caches, audit retention, the session-index sweeper). The gap was the service logs: launchd's `StandardOutPath`/`StandardErrorPath` and the systemd unit redirect the server's stdout and stderr into `~/.opensession/logs/` and rotate nothing, so a box left running for weeks fills its disk and the failures read as a mystery outage.

- A boot-armed maintenance sweep (every 6 hours, idempotent) rotates each service log in place once it passes a cap (25 MB: copy to `.1`, truncate the live file, which is safe under append redirection), and warns when free disk is 90% or higher. It only touches its own logs, never user data.
- `opensession doctor` gains a Disk section (free space and service-log sizes), so "why did my laptop fill up" has an answer.

Larger cleanup (pruning old sessions, dead engine scopes, cache caps) is left for a follow-up rather than risk deleting user work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
