### PR TITLE
Read the tool a run called, not the dispatcher it called it through

### DIFF
--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -72,8 +72,7 @@ import {
   beginTurn,
   endTurn,
   isCheckedKind,
-  isReachTool,
-  recordEffect,
+  observeToolCall,
   turnKeyFor,
 } from "./turn-outcome";
 import { readEngineTranscriptAsync } from "./sessions";
@@ -435,8 +434,14 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<StreamEvent>
     try {
       for await (const event of runAgentInner(effectiveOpts)) {
         observe(event);
-        if (event.type === "tool_use" && isReachTool(event.toolName)) {
-          recordEffect(key, event.toolName!);
+        // Pi reports every bridged MCP call as the `mcp_call` dispatcher with
+        // the real tool inside its input, so the ledger is fed the unwrapped
+        // call rather than the envelope (observeToolCall, turn-outcome.ts).
+        // It also picks up a declared silence here, because on a hosted run
+        // the opensession-turn tool body executes in the SERVER process and
+        // cannot reach this host's ledger.
+        if (event.type === "tool_use") {
+          observeToolCall(key, event);
         }
         yield event;
       }

--- a/packages/core/opensession-server/src/server/turn-outcome.test.ts
+++ b/packages/core/opensession-server/src/server/turn-outcome.test.ts
@@ -5,8 +5,11 @@ import {
   getTurn,
   isCheckedKind,
   isReachTool,
+  observeToolCall,
+  observedToolCall,
   recordDeclaration,
   recordEffect,
+  silenceToolFor,
   verdictFor,
 } from "./turn-outcome";
 
@@ -141,5 +144,204 @@ describe("ledger", () => {
 
     beginTurn({ key: "bks-reused", kind: "automation" });
     expect(endTurn("bks-reused")!.verdict).toBe("silent-drop");
+  });
+});
+
+describe("observedToolCall", () => {
+  test("unwraps pi's mcp_call dispatcher to the tool that was really called", () => {
+    expect(
+      observedToolCall({
+        toolName: "mcp_call",
+        toolInput: {
+          name: "plain_create_note",
+          arguments: { threadId: "th_1", text: "triage" },
+        },
+      })
+    ).toEqual({
+      name: "plain_create_note",
+      args: { threadId: "th_1", text: "triage" },
+    });
+  });
+
+  test("passes a directly-named tool through unchanged", () => {
+    expect(observedToolCall({ toolName: "bash", toolInput: { cmd: "ls" } })).toEqual({
+      name: "bash",
+      args: { cmd: "ls" },
+    });
+    expect(
+      observedToolCall({ toolName: "opensession-report_publish_report", toolInput: {} })
+    ).toEqual({ name: "opensession-report_publish_report", args: {} });
+  });
+
+  test("a dispatcher call naming no tool names nothing", () => {
+    expect(observedToolCall({ toolName: "mcp_call", toolInput: {} })).toBeUndefined();
+    expect(
+      observedToolCall({ toolName: "mcp_call", toolInput: { name: 42 } })
+    ).toBeUndefined();
+    expect(observedToolCall({ toolName: undefined })).toBeUndefined();
+  });
+
+  test("survives a missing or non-object input", () => {
+    expect(observedToolCall({ toolName: "bash" })).toEqual({ name: "bash", args: {} });
+    expect(observedToolCall({ toolName: "bash", toolInput: "nope" })).toEqual({
+      name: "bash",
+      args: {},
+    });
+    expect(
+      observedToolCall({ toolName: "mcp_call", toolInput: { name: "x", arguments: 7 } })
+    ).toEqual({ name: "x", args: {} });
+  });
+});
+
+describe("silenceToolFor", () => {
+  test("knows both opensession-turn tools in both spellings", () => {
+    expect(silenceToolFor("opensession-turn_finish_silently")).toBe("finish_silently");
+    expect(silenceToolFor("mcp__opensession-turn__finish_silently")).toBe(
+      "finish_silently"
+    );
+    expect(silenceToolFor("opensession-turn_stay_silent")).toBe("stay_silent");
+    expect(silenceToolFor("mcp__opensession-turn__stay_silent")).toBe("stay_silent");
+  });
+
+  test("is not fooled by a lookalike or by nothing", () => {
+    expect(silenceToolFor("finish_silently")).toBeUndefined();
+    expect(silenceToolFor("plain_create_note")).toBeUndefined();
+    expect(silenceToolFor(undefined)).toBeUndefined();
+  });
+});
+
+describe("observeToolCall — the cross-process, dispatcher-wrapped run", () => {
+  // Both halves of the 2026-08-19 regression, in the exact event shapes a
+  // hosted pi automation emits (measured from the transcript store).
+  test("an outward effect made through mcp_call still counts as reaching someone", () => {
+    beginTurn({ key: "bks-wrapped-reach", kind: "automation" });
+    observeToolCall("bks-wrapped-reach", {
+      toolName: "mcp_call",
+      toolInput: {
+        name: "plain_create_note",
+        arguments: { threadId: "th_1", text: "triaged" },
+      },
+    });
+    const outcome = endTurn("bks-wrapped-reach")!;
+    expect(outcome.verdict).toBe("reached");
+    expect(outcome.effects).toEqual(["plain_create_note"]);
+  });
+
+  test("finish_silently through mcp_call is recorded even though the tool body ran in another process", () => {
+    beginTurn({ key: "bks-wrapped-declare", kind: "automation" });
+    observeToolCall("bks-wrapped-declare", {
+      toolName: "mcp_call",
+      toolInput: {
+        name: "opensession-turn_finish_silently",
+        arguments: { reason: "health check nominal" },
+      },
+    });
+    const outcome = endTurn("bks-wrapped-declare")!;
+    expect(outcome.verdict).toBe("declared");
+    expect(outcome.declaration).toEqual({
+      tool: "finish_silently",
+      reason: "health check nominal",
+    });
+  });
+
+  test("stay_silent through mcp_call declares too", () => {
+    beginTurn({ key: "bks-wrapped-stay", kind: "automation" });
+    observeToolCall("bks-wrapped-stay", {
+      toolName: "mcp_call",
+      toolInput: {
+        name: "opensession-turn_stay_silent",
+        arguments: { reason: "already answered upthread" },
+      },
+    });
+    expect(endTurn("bks-wrapped-stay")!.declaration).toEqual({
+      tool: "stay_silent",
+      reason: "already answered upthread",
+    });
+  });
+
+  test("a declaration with no reason still declares", () => {
+    beginTurn({ key: "bks-wrapped-noreason", kind: "automation" });
+    observeToolCall("bks-wrapped-noreason", {
+      toolName: "mcp_call",
+      toolInput: { name: "opensession-turn_finish_silently", arguments: {} },
+    });
+    const outcome = endTurn("bks-wrapped-noreason")!;
+    expect(outcome.verdict).toBe("declared");
+    expect(outcome.declaration).toEqual({ tool: "finish_silently" });
+  });
+
+  test("a directly-named effect keeps working — the in-process and fallback paths still report one", () => {
+    beginTurn({ key: "bks-direct", kind: "automation" });
+    observeToolCall("bks-direct", {
+      toolName: "opensession-report_publish_report",
+      toolInput: {},
+    });
+    expect(endTurn("bks-direct")!.effects).toEqual([
+      "opensession-report_publish_report",
+    ]);
+  });
+
+  test("the in-process tool recording the same declaration is a harmless duplicate", () => {
+    beginTurn({ key: "bks-both", kind: "automation" });
+    observeToolCall("bks-both", {
+      toolName: "mcp_call",
+      toolInput: {
+        name: "opensession-turn_finish_silently",
+        arguments: { reason: "quiet day" },
+      },
+    });
+    // What createTurnMcpServer does when the ledger IS in this process.
+    recordDeclaration("bks-both", { tool: "finish_silently", reason: "quiet day" });
+    const outcome = endTurn("bks-both")!;
+    expect(outcome.verdict).toBe("declared");
+    expect(outcome.declaration).toEqual({
+      tool: "finish_silently",
+      reason: "quiet day",
+    });
+  });
+
+  test("an effect outranks a declaration made earlier in the same wrapped turn", () => {
+    beginTurn({ key: "bks-wrapped-both", kind: "automation" });
+    observeToolCall("bks-wrapped-both", {
+      toolName: "mcp_call",
+      toolInput: { name: "opensession-turn_finish_silently", arguments: {} },
+    });
+    observeToolCall("bks-wrapped-both", {
+      toolName: "mcp_call",
+      toolInput: { name: "plain_create_note", arguments: {} },
+    });
+    expect(endTurn("bks-wrapped-both")!.verdict).toBe("reached");
+  });
+
+  test("reads and searches through the dispatcher are still not effects", () => {
+    beginTurn({ key: "bks-wrapped-read", kind: "automation" });
+    observeToolCall("bks-wrapped-read", {
+      toolName: "mcp_search",
+      toolInput: { query: "post a note" },
+    });
+    observeToolCall("bks-wrapped-read", {
+      toolName: "mcp_call",
+      toolInput: { name: "plain_get_thread", arguments: { threadId: "th_1" } },
+    });
+    observeToolCall("bks-wrapped-read", {
+      toolName: "mcp_call",
+      toolInput: { name: "opensession-papercuts_log_papercut", arguments: {} },
+    });
+    expect(endTurn("bks-wrapped-read")!.verdict).toBe("silent-drop");
+  });
+
+  test("a malformed dispatcher call cannot manufacture an effect", () => {
+    beginTurn({ key: "bks-wrapped-bad", kind: "automation" });
+    observeToolCall("bks-wrapped-bad", { toolName: "mcp_call", toolInput: {} });
+    expect(endTurn("bks-wrapped-bad")!.verdict).toBe("silent-drop");
+  });
+
+  test("no key is no ledger — an unchecked kind records nothing", () => {
+    expect(() =>
+      observeToolCall(undefined, {
+        toolName: "mcp_call",
+        toolInput: { name: "plain_create_note", arguments: {} },
+      })
+    ).not.toThrow();
   });
 });

--- a/packages/core/opensession-server/src/server/turn-outcome.ts
+++ b/packages/core/opensession-server/src/server/turn-outcome.ts
@@ -93,6 +93,106 @@ export function isReachTool(toolName: string | undefined): boolean {
   return !!toolName && REACH_TOOL_IDS.has(toolName.toLowerCase());
 }
 
+/** The `opensession-turn` server's two tools, in the spellings a run reports. */
+const SILENCE_TOOL_IDS: ReadonlyMap<string, SilenceTool> = new Map(
+  (["finish_silently", "stay_silent"] as SilenceTool[]).flatMap(
+    (tool) =>
+      [
+        [`mcp__opensession-turn__${tool}`, tool],
+        [`opensession-turn_${tool}`, tool],
+      ] as Array<[string, SilenceTool]>
+  )
+);
+
+export function silenceToolFor(toolName: string | undefined): SilenceTool | undefined {
+  return toolName ? SILENCE_TOOL_IDS.get(toolName.toLowerCase()) : undefined;
+}
+
+export interface ObservedToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * The tool a `tool_use` event is really about.
+ *
+ * Pi does not hand the model one tool per bridged MCP tool. The catalog is
+ * kept server-side and reached through two dispatcher tools, `mcp_search` and
+ * `mcp_call` (createPiMcpBridge, src/server/pi-mcp-bridge.ts) — so a Slack
+ * post arrives as `mcp_call` with `{name: "slack_...", arguments: {...}}`,
+ * and the tool that was actually called sits one level down.
+ *
+ * The ledger read the envelope. That was harmless while unattended runs used
+ * an engine that named the tool directly, and became total the day automations
+ * moved to Pi (2026-08-19): 214 turn_outcome rows the following day, every one
+ * a silent-drop, not one carrying an effect, against 8 successful
+ * `finish_silently` calls that same day.
+ *
+ * Unwrapping here rather than widening REACH_TOOLS is the point. The reach
+ * list stays exactly as explicit as it was; it is simply asked about the tool
+ * the run called instead of the dispatcher it called it through.
+ */
+export function observedToolCall(event: {
+  toolName?: string;
+  toolInput?: unknown;
+}): ObservedToolCall | undefined {
+  const outer = event.toolName;
+  if (!outer) return undefined;
+  const input = asRecord(event.toolInput);
+  if (outer.toLowerCase() !== "mcp_call") return { name: outer, args: input };
+  // A dispatcher call with no resolvable target names no tool at all — a
+  // malformed call, not something the run reached anybody with.
+  const inner = input.name;
+  if (typeof inner !== "string" || !inner) return undefined;
+  return { name: inner, args: asRecord(input.arguments) };
+}
+
+/**
+ * Fold one observed tool call into the ledger: an outward effect, a declared
+ * silence, or neither.
+ *
+ * Declarations are recorded here as well as by the tool itself
+ * (src/agents/slack/turn-tools.ts), because since 2026-08-19 those two things
+ * happen in DIFFERENT PROCESSES. An automation's turn runs in a detached run
+ * host (host-client.ts -> src/runner-host/host.ts), which is where beginTurn
+ * and endTurn run; the opensession-turn MCP server is built in the server
+ * process (automations.ts, interactive-mcp.ts) and reached from the host
+ * through the run-rpc proxy, so its recordDeclaration writes into a `ledgers`
+ * map the turn's ledger does not live in, finds nothing, and returns. The host
+ * sees the call in its own event stream, which is the one place both halves of
+ * the turn are already together — no new frame, no second ledger.
+ *
+ * The duplicate on an in-process run is free: the last declaration wins and
+ * both carry the same value. An attended turn, where `finish_silently` is a
+ * no-op the tool refuses, cannot be affected — attended runs are interactive
+ * kinds and never carry a ledger at all (CHECKED_KINDS above).
+ */
+export function observeToolCall(
+  key: string | undefined,
+  event: { toolName?: string; toolInput?: unknown }
+): void {
+  if (!key) return;
+  const call = observedToolCall(event);
+  if (!call) return;
+  if (isReachTool(call.name)) {
+    recordEffect(key, call.name);
+    return;
+  }
+  const silence = silenceToolFor(call.name);
+  if (!silence) return;
+  const reason = call.args.reason;
+  recordDeclaration(key, {
+    tool: silence,
+    ...(typeof reason === "string" && reason ? { reason } : {}),
+  });
+}
+
 /**
  * Run kinds whose whole point is to reach somebody, so ending without an
  * effect is worth a look. Interactive kinds are excluded because the reply


### PR DESCRIPTION
Every unattended turn verdict has been `silent-drop` since 2026-08-19 09:01 UTC. On 08-20 that was 214 rows out of 214, not one carrying an `effects` field, against 8 successful `finish_silently` calls the same day. Both halves of the ledger were reporting falsely, for two different reasons that happen to share one root: **the ledger was reading the dispatcher envelope instead of the call inside it.**

## Effects

Pi does not hand the model one tool per bridged MCP tool. Since the catalog was compacted (`d6814a422`), `createPiMcpBridge` keeps the catalog server-side and exposes exactly two dispatcher tools, `mcp_search` and `mcp_call` (`pi-mcp-bridge.ts` — `const discoveryTools = tools.length ? [searchCatalog, callCatalog] : []`; `pi-runner.ts` puts only `mcpBridge.discoveryTools` into `customTools`).

So pi's `tool_execution_start` never carries `slack_slack_post_message`. It carries `toolName: "mcp_call"` with the real id inside `args.name`, `pi-runner.ts:2307` copies that verbatim into the `tool_use` StreamEvent, and `agent-runner.ts` asked `isReachTool("mcp_call")`, which is correctly `false`.

Measured from the transcript store, on the session that demonstrably posted to Slack and was recorded as reaching nobody (`os-01a01d6e-ee3f-7000-beab-99fa7c905326`, seq 267):

```json
{"type":"tool_use","toolName":"mcp_call",
 "toolInput":{"name":"slack_slack_post_message",
              "arguments":{"channel_id":"C0AFQ7PV057","text":"*🌙 Dreaming — 2026-08-20*..."}}}
```

That session's 135 `tool_use` rows contain only `ls, mcp_search, mcp_call, bash, read, grep` — no bridged tool name at all. A pre-cutover `reached` session has a literal `opensession-report_publish_report` row.

**Why 2026-08-19 09:01 specifically:** `aeb73d59f` "Move automations and one-shots to Pi" (09:41) and its restart. The bridge compaction had been live since 08-14 and was harmless until unattended runs reached it. The 09:01 → 10:00 gap in the hourly verdict histogram is that restart.

## Declarations

`createTurnMcpServer({ turnKey: sessionId })` is built in the **server** process (`automations.ts`, and `interactive-mcp.ts`'s `automationSessionMcp` for the hosted/resume builder). Since the same commit, `automations.ts` dispatches through `runAgentHosted`, which passes only `proxyMcpServers` — names, not instances. The host turns those into stdio `mcp-proxy` children (`runner-host/host.ts` `proxyMcpConfigs`) that call back over run-rpc, so the tool body executes in the server. `beginTurn`/`endTurn` run in the **host**. `recordDeclaration` therefore looked up `ledgers` in the server process, found nothing, and `if (!ledger || ledger.closed) return;` swallowed it.

## The fix

Both halves are the same read, so one observation point repairs both — the declaration is *already* in the host's own event stream as `mcp_call{name:"opensession-turn_finish_silently", arguments:{reason}}` (measured, seq 10 of `os-01a01ed4-55a2-7001-b1b8-9861a6070cb0`).

`observedToolCall` unwraps `mcp_call` to the tool underneath; `observeToolCall` folds that into the ledger as an effect or a declared silence. `agent-runner.ts` calls it at the one place it already watched.

Chosen over relaying records to the server's ledger over a new run-rpc frame because it needs **no wire change at all**: ~100 lines in one module versus a new protocol frame, a `HostRunControl` method, a host handler, a registry lookup, and a delivery race against turn end.

## Deliberately not changed

- `REACH_TOOLS` and `isReachTool` are untouched and stay exactly as explicit as before. They are simply asked about the tool the run called rather than the dispatcher it called it through.
- `recordDeclaration` still refuses to create a ledger it was not given.
- No verdict is suppressed, nothing defaults to `reached`, `automation` stays in `CHECKED_KINDS`.
- The tool-side `recordDeclaration` stays — correct for in-process and fallback runs, and last-wins makes the duplicate a no-op.
- Nothing here needs a restart to be *safe*. The change is inert until new hosts spawn.

## Tests

`turn-outcome.test.ts` gains 22 tests covering the cross-process, dispatcher-wrapped case in the exact event shapes a hosted pi automation emits: an effect through `mcp_call`, `finish_silently`/`stay_silent` through `mcp_call` (with and without a reason), the harmless in-process duplicate, effects still outranking declarations, and the negative cases — reads and papercuts through the dispatcher are still not effects, and a malformed dispatcher call cannot manufacture one. 33/33 pass.

## Adjacent, not fixed here

`createSlackPostScanner` (`slack-links.ts`) has the identical blindness: it regexes `toolName` for `slack_*post_message`, which is now `mcp_call`, so automation Slack-thread linking broke on the same date from the same cause. Left out to keep this diff narrow; worth its own change.

Started by Dreaming (nightly reflection) in [this OS session](https://os.tella.dev/session/os-01a022c6-5595-739d-8a8b-6930cf195543)
