### PR TITLE
Allow actor-owned compatibility writes

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { SessionKernelActorClient } from "./actor-client";
+import {
+  __setSessionKernelStoreForTest,
+  installSessionKernelActor,
+  sessionKernel,
+} from "./kernel";
 import { SESSION_KERNEL_MAX_QUEUED_PER_SESSION } from "./actor-protocol";
 
 let client: SessionKernelActorClient | undefined;
 afterEach(() => {
+  installSessionKernelActor(undefined);
+  __setSessionKernelStoreForTest(undefined);
   client?.terminate();
   client = undefined;
 });
@@ -61,16 +68,43 @@ describe("session kernel actor boundary", () => {
     await expect(host.begin("s1", { requestId: "after-fatal", type: "test" })).rejects.toThrow();
   });
 
-  test("rejects a synchronous compatibility write while an async lease is active", async () => {
+  test("borrows the actor writer for compatibility work during an async lease", async () => {
     const host = await actor();
     const first = await host.begin("s1", { requestId: "first", type: "test" });
-    expect(() =>
-      host.beginSync("s1", { requestId: "sync", type: "sync:test" }),
-    ).toThrow("raced the s1 mailbox");
+    const borrowed = host.beginSync("s1", {
+      requestId: "sync",
+      type: "sync:transcript_append",
+    });
+    expect(borrowed).toEqual({ duplicate: false, borrowed: true });
+    host.store.setRunState({
+      sessionId: "s1",
+      state: "running",
+      event: "stream_started",
+    });
+    expect(host.store.runState("s1").state).toBe("running");
+    expect(host.store.command("s1", "sync")).toBeUndefined();
     await host.complete(first.leaseId!, null, []);
-    const sync = host.beginSync("s1", { requestId: "sync", type: "sync:test" });
+
+    const sync = host.beginSync("s1", { requestId: "after", type: "sync:test" });
     expect(sync.leaseId).toBeString();
     host.completeSync(sync.leaseId!, "done", []);
+  });
+
+  test("persists detached writes while a command owns the mailbox", async () => {
+    const host = await actor();
+    const active = await host.begin("detached", {
+      requestId: "active",
+      type: "submit_prompt",
+    });
+    installSessionKernelActor(host);
+    const kernel = sessionKernel("detached");
+
+    kernel.setRunState({ state: "running", event: "stream_started" });
+    kernel.enqueueEffect("notify", { ok: true }, "detached-effect");
+    expect(kernel.runState().state).toBe("running");
+    expect(host.store.pendingOutbox(Date.now(), 10, ["notify"])).toHaveLength(1);
+
+    await host.complete(active.leaseId!, "done", []);
   });
 
   test("hydrates persisted run state into the gateway projection", async () => {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -174,9 +174,10 @@ export class SessionKernelActorClient {
   beginSync(
     sessionId: string,
     command: SessionCommand,
-  ): { duplicate: boolean; leaseId?: string; result?: unknown } {
+  ): { duplicate: boolean; borrowed?: boolean; leaseId?: string; result?: unknown } {
     const admission = this.callStore<{
       duplicate: boolean;
+      borrowed?: boolean;
       leaseId?: string;
       result?: unknown;
     }>("$beginSync", [sessionId, command]);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -185,8 +185,12 @@ export function startSessionKernelActorWorker(): void {
     sessionId: string,
     command: { requestId: string; type: string; payload?: unknown; replaySafe?: boolean },
   ) {
-    if (active.has(sessionId))
-      throw new Error(`Session mutation raced the ${sessionId} mailbox`);
+    // Compatibility writes can arrive from detached run callbacks while a
+    // durable command owns the session. They still execute in this Worker, so
+    // borrow its physical writer instead of trying to open a second lease (the
+    // synchronous caller cannot wait for the active gateway command without
+    // deadlocking that command's settlement).
+    if (active.has(sessionId)) return { duplicate: false, borrowed: true };
     if (store.isTombstoned(sessionId))
       throw new Error(`Session ${sessionId} was deleted`);
     const persisted = store.acceptCommand({

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -129,6 +129,31 @@ export class SessionKernel {
 				source: "compatibility",
 			});
 			if (admission.duplicate) return admission.result as TResult;
+			if (admission.borrowed) {
+				// Detached callbacks can write while their long-lived command owns
+				// the mailbox. The Worker remains the sole physical writer; effects
+				// are persisted directly because there is no second decision to settle.
+				const borrowed: CommandContext = {
+					sessionId: this.sessionId,
+					requestId,
+					effects: [],
+				};
+				const result = commandContext.run(borrowed, mutate);
+				if (
+					record &&
+					operation !== "session_delete" &&
+					operation !== "transcript_delete"
+				)
+					this.recordChange(operation);
+				for (const effect of borrowed.effects)
+					sessionKernelStore().enqueueOutbox(
+						this.sessionId,
+						effect.kind,
+						effect.payload,
+						effect.effectKey,
+					);
+				return result;
+			}
 			if (!admission.leaseId)
 			throw new Error("Session kernel actor did not grant a sync lease");
 		const context: CommandContext = {


### PR DESCRIPTION
## Summary
- let synchronous compatibility writes borrow the SessionKernel actor's existing physical writer while a durable command owns the mailbox
- persist borrowed effects directly instead of opening a second command lease that cannot synchronously wait
- cover detached run-state, transcript-style, and outbox writes during an active command

## Incident
After opensession#101 deployed, detached callbacks and queue drains hit `Session mutation raced the … mailbox` while long-lived prompt and recovery commands held the actor lease. This failed session creation, transcript persistence, queue drains, and recovery settlement across multiple sessions.

## Verification
- `bun run typecheck`
- 112 focused kernel, create, host, route, and side-effect tests
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
