### PR TITLE
Move run-state decisions into the session actor

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -16,6 +16,11 @@ executor event belongs to the current run.
 The implementation lives in
 `packages/core/opensession-server/src/server/session-kernel/`.
 
+The target is an Erlang/Durable Objects style state machine: each typed message
+is reduced and committed in one short actor turn, external work is emitted as a
+durable effect, and results return as fenced messages. The actor never waits for
+a model run or gateway callback before processing the next state fact.
+
 ## Durable state
 
 `~/.opensession-sessions/session-kernel.sqlite` contains:
@@ -84,9 +89,13 @@ again from durable state.
 
 ## Run ownership
 
-Run state is durable and explicit. Registering a new run id increments the
-session generation. Registering the same logical run again, such as a detached
-host reconnect, keeps its generation.
+Run state is durable and explicit. Run events are typed actor messages. The
+Worker validates the transition, current run id and generation, then commits the
+new state and change event in one SQLite transaction. This reducer remains
+responsive even while a gateway command is waiting on external work.
+
+Registering a new run id increments the session generation. Registering the
+same logical run again, such as a detached host reconnect, keeps its generation.
 
 Detached host events and direct side-effect frames (transcript, asks and failed
 steers) are accepted only while their stable logical run id is current. An
@@ -157,17 +166,20 @@ and replay committed changes without becoming another session owner.
 The writable `SessionKernelStore` and per-session lease coordinator run in
 `session-kernel-worker.ts`, a separate JavaScript actor isolate. The gateway
 starts and handshakes that actor before hydrating queue or ask projections.
-Asynchronous commands acquire an actor lease. Runtime timer/outbox work is loaded
-through asynchronous typed IPC, so the one-second wake does not block the gateway
-or allocate fixed multi-megabyte SharedArrayBuffers. Remaining synchronous
-compatibility writes use a bounded SharedArrayBuffer RPC and fail closed rather
-than entering an active mailbox; they are a migration bridge, not the target
-API. The actor is therefore the only code that opens the writable kernel
-database in a production server.
+Run-state facts use exhaustive typed IPC and are reduced autonomously in the
+Worker. Runtime timer/outbox work is loaded through asynchronous typed IPC, so
+the one-second wake does not block the gateway or allocate fixed multi-megabyte
+SharedArrayBuffers. Remaining gateway command closures still use the older lease
+adapter while their queue, ask, create and turn behavior moves into typed
+reducers. Synchronous compatibility writes use a bounded SharedArrayBuffer RPC;
+when they must run during an older lease, the Worker remains the sole physical
+writer and batches any resulting outbox effects in one transaction. This bridge
+is not the target API and must shrink with each migrated domain.
 
-Decision closures still execute in the gateway as effect adapters, but every
-such execution is fenced by the actor lease and its command result is committed
-by the actor. Terminal failures are durable receipts and do not execute again.
+Unmigrated decision closures still execute in the gateway as effect adapters,
+but every such execution is fenced by the compatibility lease and its command
+result is committed by the actor. Run-state transitions no longer use that
+path. Terminal failures are durable receipts and do not execute again.
 If the actor is lost after physical execution begins, commands fail closed as
 `indeterminate` unless the call site explicitly declares a stable adoption path
 with `replaySafe`. Handler failures can retry only for replay-safe commands;

--- a/packages/core/opensession-server/src/server/run-state.ts
+++ b/packages/core/opensession-server/src/server/run-state.ts
@@ -11,150 +11,17 @@
 import { audit } from "./audit";
 import { clearSessionKernel, sessionKernel, sessionKernelStore } from "./session-kernel";
 
-export type RunState =
-	| "idle"
-	| "preparing"
-	| "starting"
-	| "running"
-	| "ask_blocked"
-	| "stopped"
-	| "failed"
-	| "interrupted"
-	| "reattaching";
-
-export type RunEvent =
-	| "prompt"
-	| "workspace_prepare"
-	| "workspace_ready"
-	| "workspace_failed"
-	| "run_registered"
-	| "start_failed"
-	| "start_aborted"
-	| "ask_posed"
-	| "ask_resolved"
-	| "steer"
-	| "turn_end"
-	| "run_failed"
-	| "cancel"
-	| "engine_died"
-	| "shutdown_orphaned"
-	| "boot_journal_found"
-	| "reattach_start"
-	| "reattach_ok"
-	| "reattach_fail"
-	| "resume_reprompt";
-
-/**
- * The full transition table. Absence of an edge is load-bearing: an event
- * arriving in a state with no edge for it is exactly the illegal combination
- * this module exists to surface (e.g. `turn_end` while `idle` = a double
- * teardown; `ask_resolved` while `running` = an answer for an ask nobody's
- * waiting on).
- *
- * Deliberate leniency edges, so half-wired paths degrade to logging instead of
- * false alarms: `run_registered` straight from idle/stopped/failed/interrupted/
- * reattaching (a run path whose reserve/recovery marker isn't instrumented —
- * e.g. the Slack/Linear loops, or a domain-specific boot recovery); self-edges
- * for queue-while-busy (`prompt`), mid-run `steer`, rotation re-registration
- * (`run_registered` while running), and ask-overwrite (`ask_posed` while
- * ask_blocked); and `stopped` absorbing the cancelled run's own teardown
- * (`turn_end`/`run_failed` land after the Stop that caused them).
- */
-export const RUN_STATE_TRANSITIONS: Record<
-	RunState,
-	Partial<Record<RunEvent, RunState>>
-> = {
-	idle: {
-		prompt: "starting",
-		workspace_prepare: "preparing",
-		boot_journal_found: "interrupted",
-		run_registered: "running",
-	},
-	preparing: {
-		boot_journal_found: "interrupted",
-		workspace_ready: "idle",
-		workspace_failed: "failed",
-		cancel: "idle",
-	},
-	starting: {
-		boot_journal_found: "interrupted",
-		run_registered: "running",
-		start_failed: "failed",
-		start_aborted: "idle",
-		run_failed: "failed",
-		cancel: "stopped",
-		prompt: "starting",
-	},
-	running: {
-		boot_journal_found: "interrupted",
-		ask_posed: "ask_blocked",
-		turn_end: "idle",
-		run_failed: "failed",
-		cancel: "stopped",
-		engine_died: "interrupted",
-		shutdown_orphaned: "interrupted",
-		prompt: "running",
-		steer: "running",
-		run_registered: "running",
-	},
-	ask_blocked: {
-		boot_journal_found: "interrupted",
-		ask_resolved: "running",
-		turn_end: "idle",
-		run_failed: "failed",
-		cancel: "stopped",
-		engine_died: "interrupted",
-		shutdown_orphaned: "interrupted",
-		prompt: "ask_blocked",
-		steer: "ask_blocked",
-		ask_posed: "ask_blocked",
-	},
-	stopped: {
-		boot_journal_found: "interrupted",
-		prompt: "starting",
-		run_registered: "running",
-		turn_end: "stopped",
-		run_failed: "stopped",
-		cancel: "stopped",
-	},
-	failed: {
-		boot_journal_found: "interrupted",
-		prompt: "starting",
-		run_registered: "running",
-	},
-	interrupted: {
-		reattach_start: "reattaching",
-		resume_reprompt: "starting",
-		cancel: "stopped",
-		engine_died: "interrupted",
-		boot_journal_found: "interrupted",
-		run_registered: "running",
-		// An engine death mid-run fires engine_died → interrupted at the
-		// watcher, then the run's own terminal outcome (recordRunOutcome)
-		// lands moments later. A dead-server turn is lost, not resumable —
-		// the follow-up outcome settles it as failed/idle rather than
-		// rejecting.
-		run_failed: "failed",
-		turn_end: "idle",
-	},
-	reattaching: {
-		boot_journal_found: "interrupted",
-		reattach_ok: "running",
-		reattach_fail: "interrupted",
-		run_failed: "failed",
-		cancel: "stopped",
-		engine_died: "interrupted",
-		run_registered: "running",
-	},
-};
-
-/** Pure lookup: the next state, or undefined when no edge exists. */
-export function nextRunState(
-	state: RunState,
-	event: RunEvent,
-): RunState | undefined {
-	return RUN_STATE_TRANSITIONS[state]?.[event];
-}
+export {
+	RUN_STATE_TRANSITIONS,
+	nextRunState,
+	type RunEvent,
+	type RunState,
+} from "./session-kernel/run-state-machine";
+import {
+	nextRunState,
+	type RunEvent,
+	type RunState,
+} from "./session-kernel/run-state-machine";
 
 export type RunStateEntry = {
 	state: RunState;
@@ -208,63 +75,61 @@ export function transitionRunState(
 	detail?: Record<string, unknown>,
 	emit: AuditEmit = audit,
 ): RunState {
-	const from = getRunState(sessionId);
-	const to = nextRunState(from, event);
-	if (to === undefined) {
-		console.warn(
-			`[run-state] rejected: ${event} while ${from} (session ${sessionId})`,
-		);
-		emit({
-			msg: "run_state_rejected",
-			session_id: sessionId,
-			state: from,
-			event,
-			...detail,
-		});
-		return from;
-	}
-	const runKey = typeof detail?.run_key === "string" ? detail.run_key : undefined;
-	if (!detachedRunHost() && event === "run_registered" && runKey) {
-		const owner = sessionKernel(sessionId).runState();
-		if (
-			owner.currentRunId &&
-			owner.currentRunId !== runKey &&
-			(from === "running" ||
-				from === "ask_blocked" ||
-				from === "interrupted" ||
-				from === "reattaching")
-		) {
-			emit({
-				msg: "stale_run_registration_rejected",
-				session_id: sessionId,
-				current_run_id: owner.currentRunId,
-				rejected_run_id: runKey,
-				state: from,
-			});
+	if (detachedRunHost()) {
+		const from = getRunState(sessionId);
+		const to = nextRunState(from, event);
+		if (!to) {
+			console.warn(`[run-state] rejected: ${event} while ${from} (session ${sessionId})`);
+			emit({ msg: "run_state_rejected", session_id: sessionId, state: from, event, ...detail });
 			return from;
 		}
-	}
-	if (detachedRunHost()) {
 		detachedHostStates.set(sessionId, {
 			state: to,
 			since: new Date().toISOString(),
 			lastEvent: event,
 		});
-	} else {
-	const kernel = sessionKernel(sessionId);
-	if (runKey && (event === "run_registered" || event === "boot_journal_found"))
-		kernel.registerRun(runKey, to, event, detail);
-	else kernel.setRunState({ state: to, event, detail });
+		emit({ msg: "run_state_transition", session_id: sessionId, from, to, event, ...detail });
+		return to;
+	}
+
+	const runKey = typeof detail?.run_key === "string" ? detail.run_key : undefined;
+	const decision = sessionKernel(sessionId).applyRunEvent({
+		event,
+		detail,
+		runKey,
+	});
+	if (!decision.accepted) {
+		if (decision.reason === "stale_run") {
+			emit({
+				msg: "stale_run_registration_rejected",
+				session_id: sessionId,
+				current_run_id: decision.currentRunId,
+				rejected_run_id: decision.rejectedRunId,
+				state: decision.from,
+			});
+		} else {
+			console.warn(
+				`[run-state] rejected: ${event} while ${decision.from} (session ${sessionId})`,
+			);
+			emit({
+				msg: "run_state_rejected",
+				session_id: sessionId,
+				state: decision.from,
+				event,
+				...detail,
+			});
+		}
+		return decision.from;
 	}
 	emit({
 		msg: "run_state_transition",
 		session_id: sessionId,
-		from,
-		to,
+		from: decision.from,
+		to: decision.to,
 		event,
 		...detail,
 	});
-	return to;
+	return decision.to;
 }
 
 /** Drop tracking for a deleted session. */

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -90,6 +90,17 @@ describe("session kernel actor boundary", () => {
     host.completeSync(sync.leaseId!, "done", []);
   });
 
+  test("a tombstone rejects compatibility writes even during an active lease", async () => {
+    const host = await actor();
+    const active = await host.begin("deleted", { requestId: "active", type: "test" });
+    host.store.tombstoneSession("deleted");
+    expect(() => host.beginSync("deleted", {
+      requestId: "late",
+      type: "sync:transcript_append",
+    })).toThrow("Session deleted was deleted");
+    await host.complete(active.leaseId!, null, []);
+  });
+
   test("persists detached writes while a command owns the mailbox", async () => {
     const host = await actor();
     const active = await host.begin("detached", {
@@ -104,6 +115,41 @@ describe("session kernel actor boundary", () => {
     expect(kernel.runState().state).toBe("running");
     expect(host.store.pendingOutbox(Date.now(), 10, ["notify"])).toHaveLength(1);
 
+    await host.complete(active.leaseId!, "done", []);
+  });
+
+  test("reduces run events atomically while gateway work is still active", async () => {
+    const host = await actor();
+    const active = await host.begin("autonomous", {
+      requestId: "physical-work",
+      type: "submit_prompt",
+    });
+    expect(host.decideRunEvent({ sessionId: "autonomous", event: "prompt" }))
+      .toMatchObject({ accepted: true, from: "idle", to: "starting" });
+    expect(host.decideRunEvent({
+      sessionId: "autonomous",
+      event: "run_registered",
+      runKey: "run-1",
+    })).toMatchObject({
+      accepted: true,
+      from: "starting",
+      to: "running",
+      state: { currentRunId: "run-1", generation: 1 },
+    });
+    expect(host.decideRunEvent({
+      sessionId: "autonomous",
+      event: "run_registered",
+      runKey: "stale-run",
+    })).toMatchObject({
+      accepted: false,
+      reason: "stale_run",
+      state: { currentRunId: "run-1", generation: 1 },
+    });
+    expect(host.store.runState("autonomous")).toMatchObject({
+      state: "running",
+      currentRunId: "run-1",
+      generation: 1,
+    });
     await host.complete(active.leaseId!, "done", []);
   });
 

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -4,6 +4,8 @@ import type {
   DurableOutboxItem,
   DurableRunState,
   DurableTimer,
+  RunEventDecision,
+  RunEventDecisionResult,
   SessionKernelStoreApi,
 } from "./store";
 import {
@@ -240,41 +242,49 @@ export class SessionKernelActorClient {
     }
   }
 
-  callStore<TResult>(method: string, args: unknown[]): TResult {
-    if (this.deadError) throw this.deadError;
-    const controlBuffer = new SharedArrayBuffer(
-      Int32Array.BYTES_PER_ELEMENT * 2,
+  decideRunEvent(decision: RunEventDecision): RunEventDecisionResult {
+    const result = this.callSync<RunEventDecisionResult>(
+      { t: "decide_run_event", decision },
+      "run event decision",
     );
+    if (result.accepted)
+      (this.store as RemoteStore).noteRunState(decision.sessionId, result.state);
+    return result;
+  }
+
+  callStore<TResult>(method: string, args: unknown[]): TResult {
+    return this.callSync<TResult>(
+      { t: "store", method, args },
+      method,
+      LARGE_STORE_RESPONSES.has(method),
+    );
+  }
+
+  private callSync<TResult>(
+    request:
+      | { t: "store"; method: string; args: unknown[] }
+      | { t: "decide_run_event"; decision: RunEventDecision },
+    label: string,
+    large = false,
+  ): TResult {
+    if (this.deadError) throw this.deadError;
+    const controlBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
     const outputBuffer = new SharedArrayBuffer(
-      LARGE_STORE_RESPONSES.has(method)
-        ? LARGE_OUTPUT_BYTES
-        : SMALL_OUTPUT_BYTES,
+      large ? LARGE_OUTPUT_BYTES : SMALL_OUTPUT_BYTES,
     );
     const control = new Int32Array(controlBuffer);
-    this.worker.postMessage({
-      t: "store",
-      method,
-      args,
-      control: controlBuffer,
-      output: outputBuffer,
-    });
+    this.worker.postMessage({ ...request, control: controlBuffer, output: outputBuffer });
     const waited = Atomics.wait(control, 0, 0, 10_000);
     if (waited === "timed-out") {
-      const error = new Error(`Session kernel actor timed out in ${method}`);
+      const error = new Error(`Session kernel actor timed out in ${label}`);
       this.markDead(error);
       throw error;
     }
     const length = Atomics.load(control, 1);
-    const text = new TextDecoder().decode(
-      new Uint8Array(outputBuffer, 0, length),
-    );
-    const response = JSON.parse(text) as {
-      ok: boolean;
-      result?: TResult;
-      error?: string;
-    };
+    const text = new TextDecoder().decode(new Uint8Array(outputBuffer, 0, length));
+    const response = JSON.parse(text) as { ok: boolean; result?: TResult; error?: string };
     if (!response.ok)
-      throw new Error(response.error || `Session kernel ${method} failed`);
+      throw new Error(response.error || `Session kernel ${label} failed`);
     return response.result as TResult;
   }
 
@@ -341,6 +351,9 @@ class RemoteStore implements SessionKernelStoreApi {
     this.runStateCache.clear();
     for (const state of this.call<Array<DurableRunState & { sessionId: string }>>("runStates"))
       this.runStateCache.set(state.sessionId, state);
+  }
+  noteRunState(sessionId: string, state: DurableRunState): void {
+    this.runStateCache.set(sessionId, state);
   }
   noteChange(sessionId: string): void {
     const current = this.runStateCache.get(sessionId) ?? {
@@ -418,6 +431,9 @@ class RemoteStore implements SessionKernelStoreApi {
       limit,
     );
   }
+  applyRunEvent(input: RunEventDecision) {
+    return this.actor.decideRunEvent(input);
+  }
   setRunState(input: Parameters<SessionKernelStoreApi["setRunState"]>[0]) {
     const next = this.call<DurableRunState>("setRunState", input);
     this.runStateCache.set(input.sessionId, next);
@@ -462,6 +478,12 @@ class RemoteStore implements SessionKernelStoreApi {
       payload,
       effectKey,
     );
+  }
+  enqueueOutboxMany(
+    sessionId: string,
+    effects: Array<{ kind: string; payload: unknown; effectKey: string }>,
+  ) {
+    return this.call<number[]>("enqueueOutboxMany", sessionId, effects);
   }
   pendingOutbox(now?: number, limit?: number, kinds?: readonly string[]) {
     return this.call<DurableOutboxItem[]>("pendingOutbox", now, limit, kinds);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
@@ -1,7 +1,7 @@
 import type { SessionCommand } from "./kernel";
-import type { DurableOutboxItem, DurableTimer } from "./store";
+import type { DurableOutboxItem, DurableTimer, RunEventDecision, RunEventDecisionResult } from "./store";
 
-export const SESSION_KERNEL_ACTOR_VERSION = 2;
+export const SESSION_KERNEL_ACTOR_VERSION = 3;
 export const SESSION_KERNEL_MAX_QUEUED_PER_SESSION = 128;
 export const SESSION_KERNEL_MAX_QUEUED_TOTAL = 4096;
 
@@ -47,10 +47,13 @@ export type KernelActorAsyncResponse =
     }
   | { t: "error"; rpcId: string; error: string; retryable?: boolean };
 
-export type KernelActorSyncRequest = {
-  t: "store";
-  method: string;
-  args: unknown[];
+type SyncBuffers = {
   control: SharedArrayBuffer;
   output: SharedArrayBuffer;
 };
+
+export type KernelActorSyncRequest =
+  | ({ t: "store"; method: string; args: unknown[] } & SyncBuffers)
+  | ({ t: "decide_run_event"; decision: RunEventDecision } & SyncBuffers);
+
+export type KernelActorRunEventResult = RunEventDecisionResult;

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -190,9 +190,9 @@ export function startSessionKernelActorWorker(): void {
     // borrow its physical writer instead of trying to open a second lease (the
     // synchronous caller cannot wait for the active gateway command without
     // deadlocking that command's settlement).
-    if (active.has(sessionId)) return { duplicate: false, borrowed: true };
     if (store.isTombstoned(sessionId))
       throw new Error(`Session ${sessionId} was deleted`);
+    if (active.has(sessionId)) return { duplicate: false, borrowed: true };
     const persisted = store.acceptCommand({
       sessionId,
       requestId: command.requestId,
@@ -247,7 +247,9 @@ export function startSessionKernelActorWorker(): void {
     const output = new Uint8Array(request.output);
     try {
       let result: unknown;
-      if (request.method === "$beginSync")
+      if (request.t === "decide_run_event")
+        result = store.applyRunEvent(request.decision);
+      else if (request.method === "$beginSync")
         result = beginSync(request.args[0] as string, request.args[1] as any);
       else if (request.method === "$completeSync")
         result = completeSync(
@@ -291,7 +293,7 @@ export function startSessionKernelActorWorker(): void {
     event: MessageEvent<KernelActorAsyncRequest | KernelActorSyncRequest>,
   ) => {
     const request = event.data;
-    if (request.t === "store") {
+    if (request.t === "store" || request.t === "decide_run_event") {
       syncStore(request);
       return;
     }

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -403,6 +403,32 @@ describe("SessionKernel", () => {
 		});
 	});
 
+	test("reduces and fences run events in one actor-store transaction", () => {
+		expect(store.applyRunEvent({ sessionId: "fsm", event: "prompt" })).toMatchObject({
+			accepted: true,
+			from: "idle",
+			to: "starting",
+		});
+		expect(store.applyRunEvent({
+			sessionId: "fsm",
+			event: "run_registered",
+			runKey: "run-1",
+		})).toMatchObject({
+			accepted: true,
+			state: { state: "running", currentRunId: "run-1", generation: 1 },
+		});
+		expect(store.applyRunEvent({
+			sessionId: "fsm",
+			event: "run_registered",
+			runKey: "stale",
+		})).toMatchObject({
+			accepted: false,
+			reason: "stale_run",
+			state: { currentRunId: "run-1", generation: 1, changeSeq: 2 },
+		});
+		expect(store.changesSince("fsm", 0)).toHaveLength(2);
+	});
+
 	test("commits command completion and its effects in one decision transaction", async () => {
 		await sessionKernel("decision").dispatch(
 			{ requestId: "request", type: "notify" },
@@ -422,6 +448,14 @@ describe("SessionKernel", () => {
 				payload: { text: "hello" },
 			}),
 		]);
+	});
+
+	test("batches compatibility effects in one store transaction", () => {
+		expect(store.enqueueOutboxMany("borrowed", [
+			{ kind: "one", payload: { n: 1 }, effectKey: "a" },
+			{ kind: "two", payload: { n: 2 }, effectKey: "b" },
+		])).toHaveLength(2);
+		expect(store.pendingOutbox().map((effect) => effect.effectKey)).toEqual(["a", "b"]);
 	});
 
 	test("does not publish staged effects when a command fails", async () => {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -17,6 +17,8 @@ import {
 	type DurableCommandRecord,
 	type DurableRunState,
 	type DurableTimer,
+	type RunEventDecision,
+	type RunEventDecisionResult,
 } from "./store";
 
 export interface SessionCommand<TPayload = unknown> {
@@ -145,13 +147,7 @@ export class SessionKernel {
 					operation !== "transcript_delete"
 				)
 					this.recordChange(operation);
-				for (const effect of borrowed.effects)
-					sessionKernelStore().enqueueOutbox(
-						this.sessionId,
-						effect.kind,
-						effect.payload,
-						effect.effectKey,
-					);
+				sessionKernelStore().enqueueOutboxMany(this.sessionId, borrowed.effects);
 				return result;
 			}
 			if (!admission.leaseId)
@@ -201,6 +197,13 @@ export class SessionKernel {
 			operation !== "transcript_delete"
 		)
 			throw new Error(`Session ${this.sessionId} was deleted`);
+	}
+
+	applyRunEvent(input: Omit<RunEventDecision, "sessionId">): RunEventDecisionResult {
+		this.assertWritable(`run_state:${input.event}`);
+		this.touch();
+		const decision = { sessionId: this.sessionId, ...input };
+		return sessionKernelStore().applyRunEvent(decision);
 	}
 
 	runState(): DurableRunState {

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -26,6 +26,17 @@ describe("single session ownership", () => {
 		);
 	});
 
+	test("run-state decisions execute atomically inside the actor", () => {
+		const facade = read("run-state.ts");
+		const actor = read("session-kernel/actor-worker.ts");
+		expect(facade).toContain(".applyRunEvent({");
+		expect(actor).toContain('request.t === "decide_run_event"');
+		expect(actor).toContain("store.applyRunEvent(request.decision)");
+		expect(read("session-kernel/run-state-machine.ts")).toContain(
+			"export function nextRunState",
+		);
+	});
+
 	test("every transcript mutation enters the session owner", () => {
 		const source = read("transcript-store.ts");
 		for (const operation of [

--- a/packages/core/opensession-server/src/server/session-kernel/run-state-machine.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/run-state-machine.ts
@@ -1,0 +1,153 @@
+/** Pure run-state reducer shared by the autonomous actor and projections. */
+
+export type RunState =
+	| "idle"
+	| "preparing"
+	| "starting"
+	| "running"
+	| "ask_blocked"
+	| "stopped"
+	| "failed"
+	| "interrupted"
+	| "reattaching";
+
+export type RunEvent =
+	| "prompt"
+	| "workspace_prepare"
+	| "workspace_ready"
+	| "workspace_failed"
+	| "run_registered"
+	| "start_failed"
+	| "start_aborted"
+	| "ask_posed"
+	| "ask_resolved"
+	| "steer"
+	| "turn_end"
+	| "run_failed"
+	| "cancel"
+	| "engine_died"
+	| "shutdown_orphaned"
+	| "boot_journal_found"
+	| "boot_owner_missing"
+	| "reattach_start"
+	| "reattach_ok"
+	| "reattach_fail"
+	| "resume_reprompt";
+
+/**
+ * The full transition table. Absence of an edge is load-bearing: an event
+ * arriving in a state with no edge for it is exactly the illegal combination
+ * this module exists to surface (e.g. `turn_end` while `idle` = a double
+ * teardown; `ask_resolved` while `running` = an answer for an ask nobody's
+ * waiting on).
+ *
+ * Deliberate leniency edges, so half-wired paths degrade to logging instead of
+ * false alarms: `run_registered` straight from idle/stopped/failed/interrupted/
+ * reattaching (a run path whose reserve/recovery marker isn't instrumented —
+ * e.g. the Slack/Linear loops, or a domain-specific boot recovery); self-edges
+ * for queue-while-busy (`prompt`), mid-run `steer`, rotation re-registration
+ * (`run_registered` while running), and ask-overwrite (`ask_posed` while
+ * ask_blocked); and `stopped` absorbing the cancelled run's own teardown
+ * (`turn_end`/`run_failed` land after the Stop that caused them).
+ */
+export const RUN_STATE_TRANSITIONS: Record<
+	RunState,
+	Partial<Record<RunEvent, RunState>>
+> = {
+	idle: {
+		prompt: "starting",
+		workspace_prepare: "preparing",
+		boot_journal_found: "interrupted",
+		run_registered: "running",
+	},
+	preparing: {
+		boot_owner_missing: "failed",
+		boot_journal_found: "interrupted",
+		workspace_ready: "idle",
+		workspace_failed: "failed",
+		cancel: "idle",
+	},
+	starting: {
+		boot_owner_missing: "failed",
+		boot_journal_found: "interrupted",
+		run_registered: "running",
+		start_failed: "failed",
+		start_aborted: "idle",
+		run_failed: "failed",
+		cancel: "stopped",
+		prompt: "starting",
+	},
+	running: {
+		boot_owner_missing: "failed",
+		boot_journal_found: "interrupted",
+		ask_posed: "ask_blocked",
+		turn_end: "idle",
+		run_failed: "failed",
+		cancel: "stopped",
+		engine_died: "interrupted",
+		shutdown_orphaned: "interrupted",
+		prompt: "running",
+		steer: "running",
+		run_registered: "running",
+	},
+	ask_blocked: {
+		boot_owner_missing: "failed",
+		boot_journal_found: "interrupted",
+		ask_resolved: "running",
+		turn_end: "idle",
+		run_failed: "failed",
+		cancel: "stopped",
+		engine_died: "interrupted",
+		shutdown_orphaned: "interrupted",
+		prompt: "ask_blocked",
+		steer: "ask_blocked",
+		ask_posed: "ask_blocked",
+	},
+	stopped: {
+		boot_journal_found: "interrupted",
+		prompt: "starting",
+		run_registered: "running",
+		turn_end: "stopped",
+		run_failed: "stopped",
+		cancel: "stopped",
+	},
+	failed: {
+		boot_journal_found: "interrupted",
+		prompt: "starting",
+		run_registered: "running",
+	},
+	interrupted: {
+		boot_owner_missing: "failed",
+		reattach_start: "reattaching",
+		resume_reprompt: "starting",
+		cancel: "stopped",
+		engine_died: "interrupted",
+		boot_journal_found: "interrupted",
+		run_registered: "running",
+		// An engine death mid-run fires engine_died → interrupted at the
+		// watcher, then the run's own terminal outcome (recordRunOutcome)
+		// lands moments later. A dead-server turn is lost, not resumable —
+		// the follow-up outcome settles it as failed/idle rather than
+		// rejecting.
+		run_failed: "failed",
+		turn_end: "idle",
+	},
+	reattaching: {
+		boot_owner_missing: "failed",
+		boot_journal_found: "interrupted",
+		reattach_ok: "running",
+		reattach_fail: "interrupted",
+		run_failed: "failed",
+		cancel: "stopped",
+		engine_died: "interrupted",
+		run_registered: "running",
+	},
+};
+
+/** Pure lookup: the next state, or undefined when no edge exists. */
+export function nextRunState(
+	state: RunState,
+	event: RunEvent,
+): RunState | undefined {
+	return RUN_STATE_TRANSITIONS[state]?.[event];
+}

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -183,8 +183,7 @@ export function reconcileSessionKernelOwnership(
 	for (const state of sessionKernelStore().runStates()) {
 		if (!unsettled.has(state.state) || ownedSessionIds.has(state.sessionId))
 			continue;
-		sessionKernel(state.sessionId).setRunState({
-			state: "failed",
+		sessionKernel(state.sessionId).applyRunEvent({
 			event: "boot_owner_missing",
 			detail: { previousState: state.state },
 		});

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -6,6 +6,7 @@
  * but they never participate in admission or recovery decisions.
  */
 import { Database } from "bun:sqlite";
+import { nextRunState, type RunEvent, type RunState } from "./run-state-machine";
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "fs";
 import { dirname } from "path";
 import { sessionsDir } from "../paths";
@@ -137,6 +138,23 @@ export function sessionKernelDbPath(): string {
 	if (process.env.NODE_ENV === "test") return ":memory:";
 	return `${sessionsDir()}/session-kernel.sqlite`;
 }
+
+export type RunEventDecision = {
+	sessionId: string;
+	event: RunEvent;
+	detail?: Record<string, unknown>;
+	runKey?: string;
+};
+
+export type RunEventDecisionResult = {
+	accepted: boolean;
+	from: RunState;
+	to: RunState;
+	reason?: "invalid_transition" | "stale_run";
+	currentRunId?: string;
+	rejectedRunId?: string;
+	state: DurableRunState;
+};
 
 export class SessionKernelStore {
 	private readonly db: Database;
@@ -663,6 +681,85 @@ export class SessionKernelStore {
 		}));
 	}
 
+	applyRunEvent(input: RunEventDecision): RunEventDecisionResult {
+		const now = Date.now();
+		const since = new Date(now).toISOString();
+		let result!: RunEventDecisionResult;
+		const tx = this.db.transaction(() => {
+			const prior = this.runState(input.sessionId);
+			const from = prior.state as RunState;
+			const to = nextRunState(from, input.event);
+			if (!to) {
+				result = { accepted: false, from, to: from, reason: "invalid_transition", state: prior };
+				return;
+			}
+			if (
+				input.event === "run_registered" &&
+				input.runKey &&
+				prior.currentRunId &&
+				prior.currentRunId !== input.runKey &&
+				["running", "ask_blocked", "interrupted", "reattaching"].includes(from)
+			) {
+				result = {
+					accepted: false,
+					from,
+					to: from,
+					reason: "stale_run",
+					currentRunId: prior.currentRunId,
+					rejectedRunId: input.runKey,
+					state: prior,
+				};
+				return;
+			}
+			const registers =
+				!!input.runKey &&
+				(input.event === "run_registered" || input.event === "boot_journal_found");
+			const generation = registers && prior.currentRunId !== input.runKey
+				? prior.generation + 1
+				: prior.generation;
+			const currentRunId = ["idle", "stopped", "failed"].includes(to)
+				? undefined
+				: (registers ? input.runKey : prior.currentRunId);
+			const changeSeq = prior.changeSeq + 1;
+			this.db.run(
+				`INSERT INTO session_kernel_state
+					(session_id, run_state, run_since, last_event, generation,
+					 current_run_id, change_seq, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(session_id) DO UPDATE SET
+					run_state = excluded.run_state,
+					run_since = excluded.run_since,
+					last_event = excluded.last_event,
+					generation = excluded.generation,
+					current_run_id = excluded.current_run_id,
+					change_seq = excluded.change_seq,
+					updated_at = excluded.updated_at`,
+				[input.sessionId, to, since, input.event, generation, currentRunId ?? null, changeSeq, now],
+			);
+			this.db.run(
+				`INSERT INTO session_kernel_changes
+					(session_id, change_seq, kind, payload, created_at)
+				 VALUES (?, ?, 'run_state', ?, ?)`,
+				[input.sessionId, changeSeq, json({ state: to, event: input.event, detail: input.detail }), now],
+			);
+			const state: DurableRunState = {
+				state: to,
+				since,
+				lastEvent: input.event,
+				generation,
+				currentRunId,
+				changeSeq,
+			};
+			result = { accepted: true, from, to, state };
+		});
+		tx.immediate();
+		if (result.accepted) {
+			this.runStateCache.set(input.sessionId, result.state);
+			this.dirtyChangeSessions.add(input.sessionId);
+		}
+		return result;
+	}
+
 	setRunState(input: {
 		sessionId: string;
 		state: string;
@@ -910,6 +1007,20 @@ export class SessionKernelStore {
 				"SELECT id FROM session_kernel_outbox WHERE session_id = ? AND kind = ? AND effect_key = ?",).get(sessionId, kind, effectKey) as { id: number } | null;
 		if (!row) throw new Error("Outbox effect was not persisted");
 		return Number(row.id);
+	}
+
+	enqueueOutboxMany(
+		sessionId: string,
+		effects: Array<{ kind: string; payload: unknown; effectKey: string }>,
+	): number[] {
+		if (effects.length === 0) return [];
+		const ids: number[] = [];
+		const tx = this.db.transaction(() => {
+			for (const effect of effects)
+				ids.push(this.enqueueOutbox(sessionId, effect.kind, effect.payload, effect.effectKey));
+		});
+		tx.immediate();
+		return ids;
 	}
 
 	completeCommandDecision(input: {


### PR DESCRIPTION
## Summary
- move run-state reduction, stale-run checks, generation allocation, state persistence and change emission into one typed Worker message and SQLite transaction
- keep the actor responsive to run facts while an older gateway command lease waits on physical work
- extract the pure reducer for use by both the actor and detached run-host projections
- close the PR 117 tombstone ordering gap and batch borrowed outbox effects transactionally

## Architecture
This is the first production slice of the Erlang/Durable Objects direction. The actor now autonomously decides run-state facts instead of lending that decision to gateway code. Queue, ask, create and turn closures remain behind the compatibility lease and are called out explicitly in the architecture document as the next domains to migrate.

## Verification
- `bun run typecheck`
- 118 focused actor, kernel, run-state, host, create and side-effect tests
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
