### PR TITLE
docs: bring simple-mode install docs up to date and give the README a try-it-out guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,40 @@ first.
 curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh | bash
 ```
 
-Installs Bun, the `claude` and `codex` CLIs, and the
-Tailscale client if you do not have them, clones the source to
-`~/.opensession/src`, puts an `opensession` command on your `PATH`, and walks
-you through configuration. Budget 5-15 minutes on a fresh box — mostly
-unattended download and dependency install.
+On a fresh box this downloads the compiled release for your OS and
+architecture, unpacks it under `~/.opensession`, installs the `claude` CLI,
+puts an `opensession` command on your `PATH`, writes a default configuration,
+and installs and starts a per-user service (a LaunchAgent on macOS, a `systemd
+--user` unit on Linux). No questions. The last line it prints is a local URL,
+by default <http://127.0.0.1:3850>. Budget 5 to 15 minutes, mostly unattended
+download.
+
+Give it a model account, then run something:
 
 ```sh
-opensession start      # run it
-opensession doctor     # check the install
-opensession update     # pull, reinstall, restart
+claude setup-token     # on a Claude Max login; copy the sk-ant-… it prints
+```
+
+Open the URL, paste that token into Workspace → Usage, pick a repo, write a
+prompt, and create the session. A turn that actually runs is the proof the
+install works, not a health check.
+
+Check on it any time:
+
+```sh
+opensession doctor     # verify the install and report engine readiness
+opensession status     # is the service up?
+opensession update     # upgrade in place, health-gated
 opensession --help     # everything else
 ```
 
-Or run it straight from a checkout:
+Connect GitHub and the other integrations later from **Settings →
+Connections** in the UI; [docs/setup/github.md](docs/setup/github.md) covers
+the GitHub setup.
+
+Or install from a source checkout instead. This is the path for
+self-development (sessions that modify Open Session itself) and for
+contributing:
 
 ```sh
 git clone https://github.com/tellahq/opensession.git
@@ -83,8 +103,8 @@ for me. Go step by step and ask me one question at a time before acting.
    integrations to enable (Slack, GitHub, Linear, Plain, Stripe — all
    optional, all can wait).
 4. Model accounts: help me add a Claude subscription token (`claude
-   setup-token` on a Max login) and/or a ChatGPT-plan Codex login. The
-   installer put both CLIs on this box already.
+   setup-token` on a Max login). The installer put the `claude` CLI on this
+   box already; add the `codex` CLI with `--codex` for a ChatGPT-plan login.
 5. Networking: keep it on 127.0.0.1 unless I pick Tailscale or an SSH
    tunnel. GitHub sign-in is available, but keep the server private even when
    I enable it.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Give it a model account, then run something:
 claude setup-token     # on a Claude Max login; copy the sk-ant-… it prints
 ```
 
-Open the URL, paste that token into Workspace → Usage, pick a repo, write a
+Open the URL, paste that token into Workspace → Providers, pick a repo, write a
 prompt, and create the session. A turn that actually runs is the proof the
 install works, not a health check.
 

--- a/adrs/simple-mode.md
+++ b/adrs/simple-mode.md
@@ -70,8 +70,8 @@ On a fresh macOS or Ubuntu box with only `curl` and `git`:
   cannot hit the five-minute bar.
   - Artefact: a `bun build --compile` single executable, tarred as
     `opensession-<ver>-<os>-<arch>.tar.gz` beside a small `node_modules`
-    sharp sidecar (its platform native cannot be embedded), the engine seed,
-    and `release.json`. `src/main.ts` is the front controller (server / CLI /
+    sharp sidecar (its platform native cannot be embedded), the service
+    templates, and `release.json`. `src/main.ts` is the front controller (server / CLI /
     runner-host / mcp-proxy behind one argv), so the binary re-execs itself
     for its side entrypoints via `process.execPath`; the prebuilt frontend is
     baked in with `Bun.embeddedFiles`. `bun build --compile --target=bun-<os>-

--- a/docs/compiled-binary.md
+++ b/docs/compiled-binary.md
@@ -3,18 +3,19 @@
 The default simple-mode artefact is one self-contained executable built with
 [`bun build --compile`](https://bun.com/docs/bundler/executables): the server,
 CLI, run host and MCP proxy behind one argv, with the prebuilt frontend baked
-in. It boots and serves the UI with nothing on `PATH` except the external
-engine CLIs (`opencode` / `claude`). The `--source` install (a git checkout +
+in. It boots and serves the UI with nothing on `PATH` except the `claude` CLI
+(and `codex` for the ChatGPT path); the Pi engine and its Anthropic bridge are
+compiled in and run in-process. The `--source` install (a git checkout +
 `bun install`) stays as the self-development and contributor path.
 
 ## Build
 
 ```bash
 # Release artefact (the default install downloads this): the target binary +
-# a sharp sidecar + the engine seed + release.json, tarred.
+# a sharp sidecar + the service templates + release.json, tarred.
 bun scripts/build-compile.ts --os linux --arch arm64 --out ~/.cache/opensession-release
 
-# Just the host binary, for local testing (no sidecar, no seed).
+# Just the host binary, for local testing (no sidecar).
 bun scripts/build-compile.ts --outfile dist/opensession
 ```
 
@@ -70,20 +71,13 @@ place a minimal `node_modules` with `sharp` + the platform `@img/sharp-*`
 beside the binary — e.g. copy `node_modules/sharp` and
 `node_modules/@img/sharp-<platform>` (+ its `sharp-libvips-<platform>`).
 
-**External — opencode plugins.** The external `opencode serve` / meridian
-processes load their plugins from FILE PATHS on disk, which a compiled binary
-cannot provide from its `/$bunfs` (and `Bun.resolveSync` inside a compiled
-binary resolves against the embedded graph, not a disk `node_modules`). So the
-artefact ships an `opencode-plugins/` sidecar beside the binary: the Meridian
-bridge stack (`opencode-with-claude`, `@rynfar/meridian`,
-`@rynfar/meridian-plugin-opencode-scrub`, exact-pinned and patched as the
-checkout installs them, with the never-run Claude Code / Agent SDK per-platform
-binaries pruned) plus the `opencode-plugin-*.js` files. `pluginsRoot()`
-(`src/runner-host/exe.ts`) points at this sidecar when compiled, and the
-meridian packages resolve by reading the sidecar package's `package.json` entry
-by hand. Without it a Claude turn fails with "the meridian bridge packages are
-not installed". Source mode resolves from `import.meta.dir` / the checkout
-`node_modules` unchanged.
+**External: the `claude` CLI.** The Anthropic bridge is the Claude Agent SDK
+running in-process (`src/server/anthropic-bridge.ts`), and the SDK shells out
+to the installed `claude` binary (`OPENSESSION_CLAUDE_BIN`, default `claude` on
+`PATH`) for every `pi/anthropic/*` turn. The binary is not embedded: the
+installer puts it on the box (`--no-engine` skips it) and `doctor` reports it
+when missing. The Pi engine and its provider adapters compile into the binary
+and resolve from the embedded graph, so no plugins sidecar ships beside it.
 
 Other native addons in the dependency tree (`@libsql/*`, `@cbor-extract/*`,
 `@anthropic-ai/claude-agent-sdk` audio-capture, `@mariozechner/clipboard`,
@@ -95,8 +89,8 @@ feature runs. The build-only natives (`@tailwindcss/oxide`, `lightningcss`,
 ## What doesn't work in this mode
 
 Features absent or degraded in the compiled binary versus a source/tarball
-install. Everything the shipped artefact covers (the sharp sidecar, the engine
-seed, install/service/update, non-sandbox turns) works and is not listed here.
+install. Everything the shipped artefact covers (the sharp sidecar,
+install/service/update, non-sandbox turns) works and is not listed here.
 
 - **On-box self-development.** No source tree ships in the binary, so code
   sessions cannot run against the Open Session checkout itself (the

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -59,11 +59,12 @@ UI and API at the root of your instance URL.
 - [Bun](https://bun.sh) — runtime, package manager, and bundler. No Node/Vite.
   The installer brings its own; you only need it up front for a manual install.
 - `git`, and the [`gh` CLI](https://cli.github.com) for PR operations.
-- The `pi` binary — the engine that runs every agent turn. The installer
-  installs it by default (`--no-engine` opts out).
-- The `claude` CLI (Claude Code) — the bundled Meridian bridge shells out to
-  it for Anthropic models (`OPENSESSION_CLAUDE_BIN`, default: `claude` found
-  on `PATH`).
+- The Pi engine runs every agent turn. It is compiled into the release binary
+  and runs in-process; a source install gets it through `bun install`. Nothing
+  installs a separate `pi` binary on the box.
+- The `claude` CLI (Claude Code) is what the bundled Meridian bridge shells out
+  to for Anthropic models (`OPENSESSION_CLAUDE_BIN`, default: `claude` found on
+  `PATH`). The installer adds it by default (`--no-engine` opts out).
 - **Tailscale** — the recommended way to expose the UI at all. The installer
   installs it with `--tailscale` (the default install binds loopback only);
   joining a network is a separate step that needs your account.

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -39,10 +39,11 @@ networking, TLS, GitHub and systemd are all optional for session #1. Come back
 to them when the first session has run.
 
 Prerequisites: Linux, macOS, or Windows 10/11 with WSL2, plus `git` and
-`curl`. The installer brings its own [Bun](https://bun.sh) and
-[Pi](https://pi.ai). `gh` (authenticated) is needed for
-pull-request operations. See [README.md](README.md#minimum-requirements) for
-the optional extras.
+`curl`. The default release install needs nothing else on the box: the
+compiled binary embeds the Bun runtime and the Pi engine. A source install
+uses [Bun](https://bun.sh), which the installer adds when it is missing. `gh`
+(authenticated) is needed for pull-request operations. See
+[README.md](README.md#minimum-requirements) for the optional extras.
 
 Provisioning a fresh cloud box first? [ec2.md](ec2.md). There is one
 cloud-init trap worth knowing about.
@@ -112,15 +113,17 @@ place of `Ubuntu`.
 curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh | bash
 ```
 
-This installs missing prerequisites, clones the source to
-`~/.opensession/src` (or unpacks a release with `--artifact`), installs
-dependencies and the engine, puts an `opensession` command on your `PATH`,
-writes a default configuration (127.0.0.1:3850, a scratch repo, no
-integrations), installs and starts the service, and ends with the URL. No
-questions. `--advanced` runs the full onboarding wizard instead; a defaults
-install upgrades to a full one at any time with `opensession onboard --force`.
-It is safe to re-run: an existing install is fast-forwarded, and existing
-config is backed up rather than overwritten.
+This downloads the compiled release for your OS and architecture and unpacks
+it under `~/.opensession/releases` (with `src` linked at it), installs the
+`claude` CLI, puts an `opensession` command on your `PATH`, writes a default
+configuration (127.0.0.1:3850, a scratch repo, no integrations), installs and
+starts the service, and ends with the URL. No questions. If no release is
+published for your platform yet it falls back to a source clone; `--source`
+forces the git checkout, and `--artifact <path|url>` installs a specific
+release tarball. `--advanced` runs the full onboarding wizard instead; a
+defaults install upgrades to a full one at any time with `opensession onboard
+--force`. It is safe to re-run: an existing install is fast-forwarded, and
+existing config is backed up rather than overwritten.
 
 Useful flags — `--dir <path>` to install elsewhere, `--channel <ref>` to track
 a branch or tag, `--advanced` for the wizard, `--org <name>` to set up an org
@@ -128,13 +131,12 @@ install, `--tailscale` to install Tailscale, `--codex` for the ChatGPT sign-in
 CLI, `--no-engine` to skip the model CLI, `--yes` to never prompt, `--uninstall`
 to remove it. `--help` lists them all.
 
-The engine is pinned to the OpenCode version this checkout was built against
-(`opensession.opencodeVersion` in package.json); `OPENCODE_VERSION=latest`
-(or a specific version) overrides. A release artefact also ships OpenCode's
-own first-run install prebuilt (`engine-seed/`, the `@opencode-ai/plugin`
-tree it would otherwise npm-install into `~/.config/opencode` on the first
-session) and the installer prefetches its model catalogue, so the first turn
-does not pay that minute.
+The Pi engine is compiled into the release binary and runs in-process, so
+there is no separate engine to seed or version. A release tarball carries the
+`opensession` executable, a small `sharp` sidecar for social-card rendering,
+the systemd service templates, and `release.json`; nothing else has to be
+fetched before the first turn. The one external tool a turn needs is the
+`claude` CLI, which the installer puts on the box (`--no-engine` skips it).
 
 ### Tailscale: `--tailscale`
 

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -17,21 +17,19 @@ Then, end to end:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh | bash
-# onboarding: accept the defaults — bind 127.0.0.1, press enter through the
-# public base URL, point it at one repo, say no to every integration
+# installs the compiled release, onboards with defaults, starts the service,
+# and prints your local URL
 claude setup-token     # on your Max login; copy the sk-ant-… it prints
-opensession start
 ```
 
-Now **open <http://127.0.0.1:3850>**. Add your account under Workspace → Usage
+Now **open the URL the installer prints** (`http://127.0.0.1:3850` by default). Add your account under Workspace → Usage
 (paste the `sk-ant-…`, or use the ChatGPT device-code sign-in for the OpenAI
 path), then pick your repo on the home screen, write a prompt, and create the
 session. A turn that actually runs is the only proof the install works, not a
 health check.
 
-Budget 5-15 minutes on a fresh box, most of it unattended: the installer
-downloads the compiled release binary and the model CLIs (the Pi engine is bundled in the binary), and installs a
-multi-gigabyte dependency tree.
+Budget a few minutes on a fresh box, most of it unattended: the installer
+downloads the compiled release binary and the model CLIs (the Pi engine is bundled in the binary).
 
 Sections 3-7 below — automations, the env-var inventory, the `config.json`
 reference, MCP — are reference material you can skip on a first install, and

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -22,7 +22,7 @@ curl -fsSL https://raw.githubusercontent.com/tellahq/opensession/main/install.sh
 claude setup-token     # on your Max login; copy the sk-ant-… it prints
 ```
 
-Now **open the URL the installer prints** (`http://127.0.0.1:3850` by default). Add your account under Workspace → Usage
+Now **open the URL the installer prints** (`http://127.0.0.1:3850` by default). Add your account under Workspace → Providers
 (paste the `sk-ant-…`, or use the ChatGPT device-code sign-in for the OpenAI
 path), then pick your repo on the home screen, write a prompt, and create the
 session. A turn that actually runs is the only proof the install works, not a
@@ -365,7 +365,7 @@ on:
 claude setup-token   # on a Claude Max login; prints sk-ant-…
 ```
 
-Accounts are added in the web UI under **Workspace → Usage** — which means
+Accounts are added in the web UI under **Workspace → Providers**, which means
 this step happens *after* [section 8](#8-first-run): the server has to be
 running before you can paste anything into it. Mint the token whenever you
 like, start the server, then paste it. (The same page signs in ChatGPT-plan


### PR DESCRIPTION
## What

Reconciles the simple-mode install docs with what actually ships on `main` (and in the released v0.4.3), and turns the README Quickstart into a clear try-it-out path.

The default install downloads a compiled single-executable release for the box's OS and architecture, unpacks it under `~/.opensession`, installs the `claude` CLI, and starts a per-user service (a LaunchAgent on macOS, a `systemd --user` unit on Linux) that ends with a local URL. The Pi engine is compiled into the binary and runs in-process, so there is no engine seed, no OpenCode version pin, and no opencode-plugins sidecar. The docs still described a source-clone-first install and an external OpenCode engine.

## Changes

- **README.md**: the install one-liner is the obvious try-it-out path. First run is described as a local URL plus a running service; verify with `opensession doctor`; add a model account with `claude setup-token`; connect integrations from Settings -> Connections. The source checkout is framed as the self-development path. The "paste into an agent" block no longer claims `codex` is installed by default (it needs `--codex`).
- **docs/setup/install.md**: the default path is the compiled release, not a source clone (source is `--source`); the OpenCode/engine-seed paragraph is replaced with the in-process Pi engine and the actual release-tarball contents.
- **docs/compiled-binary.md**: the Anthropic bridge is the in-process Claude Agent SDK shelling out to the `claude` CLI. Removes the stale opencode-plugins sidecar and engine-seed references.
- **docs/setup/README.md**: Pi is bundled in the release binary, not a separately installed `pi` binary; `--no-engine` opts out of the `claude` CLI.
- **adrs/simple-mode.md**: the release artefact carries the service templates and `release.json`, not an engine seed.

## Scope notes

- `docs/setup/github.md` was left as-is. On this branch and in v0.4.3 the GitHub PR agent still uses a `GITHUB_API_TOKEN` PAT and `gh auth login` for the machine user (`github-rest.ts`, `IntegrationSetupDialog.tsx`). The App-only GitHub story lives on the unmerged `stack/3-github-app` branch, so documenting it here would describe a feature not on `main`. The per-user auth section already correctly describes the OAuth App device flow the Connections UI implements.
- `docs/setup/networking.md` and `slack.md` were left as-is: the no-exposed-ports story (Slack Socket Mode, `gh webhook forward`) is not on this branch (`slack.md` still states "Not Socket Mode"; the webhook server needs a reverse proxy). It lives on `stack/4-no-exposed-ports`.
- All `docs/setup/README.md` index links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)