### PR TITLE
Unify file drag ownership

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/Composer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Composer.tsx
@@ -54,7 +54,6 @@ import {
   IconStopSquare,
   IconPencil,
   IconTrash,
-  IconArrowUpToLine,
 } from "./icons";
 import {
   composerBox,
@@ -113,9 +112,8 @@ import {
 import { getVimModePref, onVimModeChanged } from "../lib/vim-pref";
 import { useVimMode } from "../hooks/useVimMode";
 import { useIsPhone } from "../hooks/useIsPhone";
-import { hasDraggedFiles } from "../lib/file-drag";
 import { motion, AnimatePresence } from "motion/react";
-import { composerMorph, composerChipMotion, duration, ease } from "../ui/motion";
+import { composerMorph, composerChipMotion } from "../ui/motion";
 import { ModelEffortSelect, shortModelLabel } from "./ModelEffortSelect";
 import type { SessionUsage } from "../lib/types";
 
@@ -511,8 +509,6 @@ export function Composer({
   );
   const [localStaging, setLocalStaging] = useState<StagingCount>(NOTHING_STAGING);
   const activeStaging = staging ?? localStaging;
-  const [fileDragActive, setFileDragActive] = useState(false);
-  const fileDragWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPhone = useIsPhone();
   const noteChord = useShortcutLabel("composer-note");
   const attachChord = useShortcutLabel("composer-attach");
@@ -698,8 +694,7 @@ export function Composer({
     isStaging(activeStaging) ||
     pastedTexts.length > 0 ||
     !!quote ||
-    hasAttached ||
-    fileDragActive;
+    hasAttached;
   const minimized = isPhone && !focused && !hasContent && !modelMenuOpen;
   const composerIconButtonClass = cn(
     paletteIconBtn,
@@ -940,64 +935,6 @@ export function Composer({
       e.preventDefault();
       void addFiles(pasted);
     }
-  }
-
-  function resetFileDrag() {
-    if (fileDragWatchdogRef.current) clearTimeout(fileDragWatchdogRef.current);
-    fileDragWatchdogRef.current = null;
-    setFileDragActive(false);
-  }
-
-  function armFileDragWatchdog() {
-    if (fileDragWatchdogRef.current) clearTimeout(fileDragWatchdogRef.current);
-    // Native OS drags do not always finish with dragleave or dragend (Escape is
-    // the common case). Dragover keeps this alive while the pointer is here.
-    fileDragWatchdogRef.current = setTimeout(resetFileDrag, 500);
-  }
-
-  useEffect(() => {
-    if (!fileDragActive) return;
-    function finishFileDrag(event: KeyboardEvent | DragEvent) {
-      if (event instanceof KeyboardEvent && event.key !== "Escape") return;
-      resetFileDrag();
-    }
-    window.addEventListener("keydown", finishFileDrag, true);
-    window.addEventListener("dragend", finishFileDrag, true);
-    return () => {
-      if (fileDragWatchdogRef.current) clearTimeout(fileDragWatchdogRef.current);
-      window.removeEventListener("keydown", finishFileDrag, true);
-      window.removeEventListener("dragend", finishFileDrag, true);
-    };
-  }, [fileDragActive]);
-
-  function handleDragEnter(e: React.DragEvent) {
-    if (!canAttach || disabled || !hasDraggedFiles(e.dataTransfer)) return;
-    e.preventDefault();
-    armFileDragWatchdog();
-    setFileDragActive(true);
-  }
-
-  function handleDragLeave(e: React.DragEvent) {
-    if (!hasDraggedFiles(e.dataTransfer)) return;
-    const next = e.relatedTarget;
-    if (next instanceof Node && e.currentTarget.contains(next)) return;
-    resetFileDrag();
-  }
-
-  function handleDragOver(e: React.DragEvent) {
-    if (!canAttach || disabled || !hasDraggedFiles(e.dataTransfer)) return;
-    e.preventDefault();
-    armFileDragWatchdog();
-    setFileDragActive(true);
-    e.dataTransfer.dropEffect = "copy";
-  }
-
-  function handleDrop(e: React.DragEvent) {
-    if (!hasDraggedFiles(e.dataTransfer)) return;
-    e.preventDefault();
-    resetFileDrag();
-    if (!canAttach || disabled || !e.dataTransfer.files.length) return;
-    void addFiles(e.dataTransfer.files);
   }
 
   function removeImage(i: number) {
@@ -1540,38 +1477,7 @@ export function Composer({
           disabled && "opacity-60",
         )}
         style={surfaceStyle}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
       >
-        <AnimatePresence initial={false}>
-          {fileDragActive && (
-            <motion.div
-              key="file-drop-overlay"
-              className="pointer-events-none !absolute inset-0 !z-[7] flex items-center justify-center gap-3 rounded-[inherit] bg-[color-mix(in_srgb,var(--composer-surface)_90%,transparent)] px-5 text-left [backdrop-filter:blur(8px)]"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ type: "tween", duration: duration.micro, ease }}
-              aria-hidden="true"
-              data-composer-file-drop-overlay
-            >
-              <IconArrowUpToLine size={26} className="shrink-0 text-fg" />
-              <div className="min-w-0">
-                <div className="text-control-label font-semibold text-fg">Add files</div>
-                <div className="text-label leading-snug text-dim">
-                  Drop here to attach them to your message.
-                </div>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
-        {fileDragActive && (
-          <span className="sr-only" role="status">
-            Drop files to attach
-          </span>
-        )}
         {/* The mic lives in the toolbar, but recording replaces this entire
             surface. VoiceInput portals the active bar here so a positioned
             toolbar cannot trap it at one-row height. */}

--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -10,7 +10,7 @@ import {
 	fetchModels,
 	type ModelOption,
 } from "../lib/api";
-import type { FileAttachment } from "../lib/images";
+import { splitAttachments, type FileAttachment } from "../lib/images";
 import { TranscriptBlocks } from "./TranscriptBlocks";
 import { Composer } from "./Composer";
 import { mergeTranscriptEntries } from "../lib/transcript-state";
@@ -26,6 +26,14 @@ import {
 } from "../lib/msg-classes";
 import { TypingIndicator } from "./TypingIndicator";
 import { duration, ease } from "../ui/motion";
+import {
+	addStaging,
+	countStaging,
+	NOTHING_STAGING,
+	subtractStaging,
+} from "../lib/attachments";
+import { hasDraggedFiles } from "../lib/file-drag";
+import { IconArrowUpToLine } from "./icons";
 
 interface DeskConversationProps {
 	sessionId: string;
@@ -80,6 +88,9 @@ export function DeskConversation({
 	// does; both ride along on the prompt.
 	const [images, setImages] = useState<string[]>([]);
 	const [files, setFiles] = useState<FileAttachment[]>([]);
+	const [dropStaging, setDropStaging] = useState(NOTHING_STAGING);
+	const [fileDragActive, setFileDragActive] = useState(false);
+	const fileDragWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	// The model pill's catalog. Empty until it loads — the pill falls back to
 	// naming the id it was given, so nothing waits on this.
 	const [models, setModels] = useState<ModelOption[]>([]);
@@ -112,6 +123,76 @@ export function DeskConversation({
 		// start makes the two pieces read as one compacting surface.
 		setDictationHidesSuggestions(active);
 	}
+	async function addDeskAttachments(picked: FileList | File[]) {
+		const selected = Array.from(picked);
+		const batch = countStaging(selected);
+		setDropStaging((current) => addStaging(current, batch));
+		try {
+			const { images: addedImages, files: addedFiles, rejected } =
+				await splitAttachments(selected);
+			if (addedImages.length)
+				setImages((current) => [...current, ...addedImages]);
+			if (addedFiles.length)
+				setFiles((current) => [...current, ...addedFiles]);
+			if (rejected.length) alert(`Couldn't attach:\n${rejected.join("\n")}`);
+		} finally {
+			setDropStaging((current) => subtractStaging(current, batch));
+		}
+	}
+
+	function resetFileDrag() {
+		if (fileDragWatchdogRef.current) clearTimeout(fileDragWatchdogRef.current);
+		fileDragWatchdogRef.current = null;
+		setFileDragActive(false);
+	}
+
+	function armFileDragWatchdog() {
+		if (fileDragWatchdogRef.current) clearTimeout(fileDragWatchdogRef.current);
+		fileDragWatchdogRef.current = setTimeout(resetFileDrag, 500);
+	}
+
+	useEffect(() => {
+		if (!presenceActive || !connected) return;
+		function handleDragEnter(event: DragEvent) {
+			if (!hasDraggedFiles(event.dataTransfer)) return;
+			event.preventDefault();
+			armFileDragWatchdog();
+			setFileDragActive(true);
+		}
+		function handleDragLeave(event: DragEvent) {
+			if (!hasDraggedFiles(event.dataTransfer)) return;
+			const next = event.relatedTarget;
+			if (next instanceof Node && document.documentElement.contains(next)) return;
+			resetFileDrag();
+		}
+		function handleDragOver(event: DragEvent) {
+			if (!hasDraggedFiles(event.dataTransfer)) return;
+			event.preventDefault();
+			armFileDragWatchdog();
+			setFileDragActive(true);
+			if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+		}
+		function handleDrop(event: DragEvent) {
+			if (!hasDraggedFiles(event.dataTransfer)) return;
+			event.preventDefault();
+			event.stopPropagation();
+			const dropped = event.dataTransfer?.files;
+			resetFileDrag();
+			if (dropped?.length) void addDeskAttachments(dropped);
+		}
+		window.addEventListener("dragenter", handleDragEnter, true);
+		window.addEventListener("dragleave", handleDragLeave, true);
+		window.addEventListener("dragover", handleDragOver, true);
+		window.addEventListener("drop", handleDrop, true);
+		return () => {
+			window.removeEventListener("dragenter", handleDragEnter, true);
+			window.removeEventListener("dragleave", handleDragLeave, true);
+			window.removeEventListener("dragover", handleDragOver, true);
+			window.removeEventListener("drop", handleDrop, true);
+			resetFileDrag();
+		};
+	}, [presenceActive, connected, sessionId]);
+
 	// Stick to the live edge only while the reader is already there, so a
 	// streaming reply doesn't yank them up from scrollback.
 	const followRef = useRef(true);
@@ -461,42 +542,75 @@ export function DeskConversation({
 				</div>
 
 				<TypingIndicator users={typingUsers} className="mb-1 px-5" />
-				{/* The session composer itself, so the Desk gets what a session gets:
-				    attachments, dictation, @-mentions, the model and effort pill, and
-				    the same send/queue/steer gestures. */}
-				<Composer
-					draftKey={`desk:${sessionId}`}
-					onSend={handleSend}
-					onTyping={(active) => setTyping(sessionId, active)}
-					onDictationActive={handleDictationActive}
-					attachmentShortcutActive={presenceActive}
-					placeholder={
-						connected ? placeholder || "Ask your Desk…" : "Not connected"
-					}
-					disabled={!connected}
-					sendDisabled={(text) =>
-						!text.trim() && images.length === 0 && files.length === 0
-					}
-					busy={isRunning}
-					images={images}
-					onImagesChange={setImages}
-					files={files}
-					onFilesChange={setFiles}
-					prefill={prefill}
-					models={models}
-					defaultModel={defaultModel}
-					model={model}
-					onModelChange={handleModelChange}
-					modelTitle="Model and reasoning effort for your Desk"
-					effort={effort}
-					onEffortChange={setEffort}
-					mentionFetch={(q) => fetchFileMentions(q, sessionId)}
-					paletteFetch={(q) =>
-						fetchMentionSuggestions(q, sessionId, getCurrentUser())
-					}
-					autoFocus={autoFocus}
-					textareaRef={textareaRef}
-				/>
+				{/* The open Desk owns the app-wide drop over the session underneath. */}
+				<div
+					className="relative"
+					data-global-file-composer={presenceActive && connected ? "" : undefined}
+				>
+					<Composer
+						draftKey={`desk:${sessionId}`}
+						onSend={handleSend}
+						onTyping={(active) => setTyping(sessionId, active)}
+						onDictationActive={handleDictationActive}
+						attachmentShortcutActive={presenceActive}
+						placeholder={
+							connected ? placeholder || "Ask your Desk…" : "Not connected"
+						}
+						disabled={!connected}
+						sendDisabled={(text) =>
+							!text.trim() && images.length === 0 && files.length === 0
+						}
+						busy={isRunning}
+						images={images}
+						onImagesChange={setImages}
+						files={files}
+						onFilesChange={setFiles}
+						staging={dropStaging}
+						onAddAttachments={addDeskAttachments}
+						prefill={prefill}
+						models={models}
+						defaultModel={defaultModel}
+						model={model}
+						onModelChange={handleModelChange}
+						modelTitle="Model and reasoning effort for your Desk"
+						effort={effort}
+						onEffortChange={setEffort}
+						mentionFetch={(q) => fetchFileMentions(q, sessionId)}
+						paletteFetch={(q) =>
+							fetchMentionSuggestions(q, sessionId, getCurrentUser())
+						}
+						autoFocus={autoFocus}
+						textareaRef={textareaRef}
+					/>
+					<AnimatePresence initial={false}>
+						{fileDragActive && (
+							<motion.div
+								className="pointer-events-none absolute inset-0 z-[20] flex items-center justify-center gap-3 rounded-[var(--composer-radius)] bg-[color-mix(in_srgb,var(--composer-surface)_90%,transparent)] px-5 text-left [backdrop-filter:blur(8px)]"
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								exit={{ opacity: 0 }}
+								transition={{ type: "tween", duration: duration.micro, ease }}
+								aria-hidden="true"
+								data-composer-file-drop-overlay
+							>
+								<IconArrowUpToLine size={26} className="shrink-0 text-fg" />
+								<div className="min-w-0">
+									<div className="text-control-label font-semibold text-fg">
+										Add files
+									</div>
+									<div className="text-label leading-snug text-dim">
+										Drop here to attach them to your message.
+									</div>
+								</div>
+							</motion.div>
+						)}
+					</AnimatePresence>
+					{fileDragActive && (
+						<span className="sr-only" role="status">
+							Drop files to attach
+						</span>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -169,7 +169,10 @@ import {
 	sameImages,
 	subtractStaging,
 } from "../lib/attachments";
-import { hasDraggedFiles } from "../lib/file-drag";
+import {
+	foregroundFileComposerOpen,
+	hasDraggedFiles,
+} from "../lib/file-drag";
 import {
 	isHiddenForSession,
 	onHidesChanged,
@@ -1790,6 +1793,10 @@ export function SessionViewer({
 		}
 		function handleFileDragEnter(event: DragEvent) {
 			if (!hasDraggedFiles(event.dataTransfer)) return;
+			if (foregroundFileComposerOpen()) {
+				finishFileDrag();
+				return;
+			}
 			event.preventDefault();
 			armFileDragWatchdog();
 			if (cancelledFileDragRef.current) return;
@@ -1802,6 +1809,10 @@ export function SessionViewer({
 		}
 		function handleFileDragLeave(event: DragEvent) {
 			if (!hasDraggedFiles(event.dataTransfer)) return;
+			if (foregroundFileComposerOpen()) {
+				finishFileDrag();
+				return;
+			}
 			const next = event.relatedTarget;
 			const leftApp =
 				!(next instanceof Node) || !document.documentElement.contains(next);
@@ -1825,6 +1836,10 @@ export function SessionViewer({
 		}
 		function handleFileDragOver(event: DragEvent) {
 			if (!hasDraggedFiles(event.dataTransfer)) return;
+			if (foregroundFileComposerOpen()) {
+				finishFileDrag();
+				return;
+			}
 			event.preventDefault();
 			armFileDragWatchdog();
 			if (cancelledFileDragRef.current) {
@@ -1840,6 +1855,10 @@ export function SessionViewer({
 		}
 		function handleFileDrop(event: DragEvent) {
 			if (!hasDraggedFiles(event.dataTransfer)) return;
+			if (foregroundFileComposerOpen()) {
+				finishFileDrag();
+				return;
+			}
 			event.preventDefault();
 			event.stopPropagation();
 			const cancelled = cancelledFileDragRef.current;

--- a/packages/core/opensession-server/src/frontend/lib/file-drag.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/file-drag.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import { hasDraggedFiles } from "./file-drag";
+import {
+  foregroundFileComposerOpen,
+  hasDraggedFiles,
+} from "./file-drag";
 
 test("recognizes file drags before the files are available", () => {
   expect(hasDraggedFiles({ types: ["Files"] })).toBe(true);
@@ -11,4 +14,13 @@ test("ignores links, text, and internal app drags", () => {
   expect(hasDraggedFiles({ types: ["text/plain"] })).toBe(false);
   expect(hasDraggedFiles({ types: [] })).toBe(false);
   expect(hasDraggedFiles(null)).toBe(false);
+});
+
+test("only a visible foreground composer claims the app-wide drop", () => {
+  const hidden = { getClientRects: () => ({ length: 0 }) };
+  const visible = { getClientRects: () => ({ length: 1 }) };
+
+  expect(foregroundFileComposerOpen([])).toBe(false);
+  expect(foregroundFileComposerOpen([hidden])).toBe(false);
+  expect(foregroundFileComposerOpen([hidden, visible])).toBe(true);
 });

--- a/packages/core/opensession-server/src/frontend/lib/file-drag.ts
+++ b/packages/core/opensession-server/src/frontend/lib/file-drag.ts
@@ -5,3 +5,20 @@ export function hasDraggedFiles(
 ): boolean {
   return Array.from(dataTransfer?.types ?? []).includes("Files");
 }
+
+export const GLOBAL_FILE_COMPOSER_ATTR = "data-global-file-composer";
+
+/** Whether a visible foreground composer owns the app-wide file drop. Hidden,
+ * kept-mounted surfaces have no client rects and cannot steal the active drop. */
+export function foregroundFileComposerOpen(
+  candidates?: Iterable<{ getClientRects(): { length: number } }>,
+): boolean {
+  const nodes =
+    candidates ??
+    (typeof document === "undefined"
+      ? []
+      : document.querySelectorAll<HTMLElement>(
+          `[${GLOBAL_FILE_COMPOSER_ATTR}]`,
+        ));
+  return Array.from(nodes).some((node) => node.getClientRects().length > 0);
+}


### PR DESCRIPTION
## Summary
- remove file drag state and drop handlers from the shared session composer
- keep one app-wide drop target for regular sessions
- let the foreground Desk composer own drops without activating the session underneath

## Verification
- `bun test packages/core/opensession-server/src/frontend/lib/file-drag.test.ts`
- `bun run typecheck`
- verified the app-wide drop overlay at desktop and phone widths

Created by [this OS session](https://os.tella.dev/session/os-01a02495-4afb-7431-9a61-c42db90a73a8)