### PR TITLE
Add typed session reducer and effect protocol

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -139,10 +139,13 @@ firing enters the same command mailbox with a deterministic request id. A
 restart or duplicate wake therefore runs the decision once.
 
 External effects can be added to the kernel outbox in the same transaction
-that completes a command. Delivery is destination-idempotent at-least-once: a
+that completes a command. Effect payloads and fenced results are discriminated
+unions in `lifecycle-protocol.ts`. Executors register once by typed effect kind,
+validate a persisted payload before physical work, and cannot replace another
+executor for the same kind. Delivery is destination-idempotent at-least-once: a
 crash after a destination accepts an effect but before acknowledgement retries
 the stable effect id. It is exact-once only where the destination honors that
-id. Each effect has a stable destination id and unique command-local key. Registered handlers retry with exponential backoff; poison
+id. Each effect has a stable destination id and unique command-local key. Registered executors retry with exponential backoff; poison
 effects dead-letter after a bounded attempt count. Unknown kinds remain queued but
 are excluded from registered-kind work batches, so version skew cannot make them head-of-line block compatible work. Timers and
 outbox effects both dead-letter after bounded attempts; authenticated operators
@@ -176,10 +179,13 @@ A command admission is short: the actor fingerprints and persists the intent,
 allocates a fenced `executionId`, and immediately returns an execution descriptor.
 It does not retain a per-session gateway lease and does not stop reducing run,
 delivery or ask messages while physical work is active. Different command intents
-can be admitted concurrently. The gateway effect adapter preserves physical effect
-order for compatibility operations, but that queue is not authoritative: every
-item in it is already durable in the actor. A restart re-admits replay-safe intent
-and marks ambiguous non-replay-safe execution indeterminate.
+can be admitted concurrently. The temporary `LegacyGatewayEffect` adapter preserves physical effect
+order for eight compatibility call sites, but that queue is not authoritative:
+every item in it is already durable in the actor. Its operation union and exact
+production call-site baseline are structural migration fences. New lifecycle
+work must use typed reducer messages and executors rather than add a callback.
+A restart re-admits replay-safe intent and marks ambiguous non-replay-safe
+execution indeterminate.
 
 Retries of an executing request attach as bounded waiters to the same execution;
 they never allocate a second physical effect. Active executions and waiters have

--- a/packages/core/opensession-server/src/server/human-asks.ts
+++ b/packages/core/opensession-server/src/server/human-asks.ts
@@ -45,7 +45,7 @@ import {
   updateSlackBlocks,
 } from "../agents/slack/slack-api";
 import { configuredServer, personaName, productName } from "./config";
-import { registerSessionEffectHandler, sessionKernel } from "./session-kernel";
+import { registerSessionEffectExecutor, sessionKernel } from "./session-kernel";
 import { workspaceName } from "./workspaces";
 
 const HOME = homeDir();
@@ -625,10 +625,8 @@ export async function deliverAsk(id: string, opts?: { skipUi?: boolean },): Prom
   return true;
 }
 
-registerSessionEffectHandler("human_ask_deliver", async (item) => {
-  const payload = item.payload as
-    { askId?: unknown; skipUi?: unknown } | undefined;
-  if (typeof payload?.askId !== "string") return;
+registerSessionEffectExecutor("human_ask_deliver", async (item) => {
+  const payload = item.payload;
   const ask = asks.get(payload.askId);
   if (!ask || ask.state !== "scheduled") return;
   const delivered = await deliverAsk(payload.askId, {

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -57,7 +57,12 @@ import { asDataUrlList, countImageRefs, parseImageDataUrls } from "../uploads";
 import { notifyMentions } from "../mentions";
 import { reviewTeamFor } from "../people";
 import { sendPushToUser } from "../push";
-import { sessionKernel, sessionKernelStore, tombstoneSessionKernel, } from "../session-kernel";
+import {
+	legacyGatewayEffect,
+	sessionKernel,
+	sessionKernelStore,
+	tombstoneSessionKernel,
+} from "../session-kernel";
 import {
 	canonicalCommandPayload,
 	sessionIdForRequest,
@@ -722,10 +727,9 @@ export async function handleSessionsRoutes(
 			const requestId = suppliedRequestId || crypto.randomUUID();
 			const actorScope = ctx.authUser?.login || actor || "anonymous";
 			const targetId = sessionIdForRequest(actorScope, requestId);
-			const accepted = await sessionKernel(targetId).dispatch(
-				{
+			const accepted = await sessionKernel(targetId).dispatchLegacy(
+				legacyGatewayEffect("create_session", {
 					requestId,
-					type: "create_session",
 					payload: {
 						targetId,
 						hash: new Bun.CryptoHasher("sha256")
@@ -734,7 +738,7 @@ export async function handleSessionsRoutes(
 					},
 					source: "rest",
 					replaySafe: true,
-				},
+				}),
 				async () => {
 					return getSessionControl().createSession({
 						id: targetId,

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -46,7 +46,11 @@ import { ownedWorktree } from "./session-workspace";
 import { createWorktree, ensureAskCheckout, ensureScratchDir, getRepo, isRegisteredWorktree, listWorktrees, repoForPath, repoForPathOrNull, resolveUniqueBranch, worktreePathFor } from "./worktree";
 import { broadcastToSession } from "./ws-hub";
 import { randomUUIDv7 } from "bun";
-import { sessionKernel, sessionKernelOwnsCurrentCommand } from "./session-kernel";
+import {
+	legacyGatewayEffect,
+	sessionKernel,
+	sessionKernelOwnsCurrentCommand,
+} from "./session-kernel";
 import {
 	canonicalCommandPayload,
 	sessionIdForRequest,
@@ -141,14 +145,13 @@ registerSessionControl({
 	answerQuestion: async (id, answers, opts) => {
 		const requestId = opts?.requestId || randomUUIDv7();
 		const questionId = pendingAskAwaitingAnswer(id)?.questionId || null;
-		const accepted = await sessionKernel(id).dispatch(
-			{
+		const accepted = await sessionKernel(id).dispatchLegacy(
+			legacyGatewayEffect("answer_question", {
 				requestId,
-				type: "answer_question",
 				payload: { questionId, answers },
 				source: "session_control",
 				replaySafe: true,
-			},
+			}),
 			() => {
 				const pending = pendingAskAwaitingAnswer(id);
 				if (!pending || pending.questionId !== questionId) return false;
@@ -345,14 +348,13 @@ registerSessionControl({
 		};
 		if (sessionKernelOwnsCurrentCommand(id)) return deliverOwned();
 		try {
-			const accepted = await sessionKernel(id).dispatch(
-				{
+			const accepted = await sessionKernel(id).dispatchLegacy(
+				legacyGatewayEffect("submit_prompt", {
 					requestId: deliveryId,
-					type: "submit_prompt",
 					payload: identity,
 					source: "session_control",
-				replaySafe: true,
-				},
+					replaySafe: true,
+				}),
 				deliverOwned,
 			);
 			return {
@@ -368,14 +370,13 @@ registerSessionControl({
 	cancelSession: async (id, opts) => {
 		const requestId = opts?.requestId || randomUUIDv7();
 		const targetRunId = sessionKernel(id).runState().currentRunId || null;
-		const accepted = await sessionKernel(id).dispatch(
-			{
+		const accepted = await sessionKernel(id).dispatchLegacy(
+			legacyGatewayEffect("cancel_session", {
 				requestId,
-				type: "cancel_session",
 				payload: { targetRunId },
 				source: "session_control",
 				replaySafe: true,
-			},
+			}),
 			() => {
 				if ((sessionKernel(id).runState().currentRunId || null) !== targetRunId)
 					throw new Error("The run targeted by this command has already changed");
@@ -408,14 +409,13 @@ registerSessionControl({
 			const identity = new Bun.CryptoHasher("sha256")
 				.update(canonicalCommandPayload(ownedInput))
 				.digest("hex");
-			const accepted = await sessionKernel(commandOwner).dispatch(
-				{
+			const accepted = await sessionKernel(commandOwner).dispatchLegacy(
+				legacyGatewayEffect("create_session", {
 					requestId,
-					type: "create_session",
 					payload: { targetId: requestedId, identity },
 					source: "session_control",
-				replaySafe: true,
-				},
+					replaySafe: true,
+				}),
 				() => getSessionControl().createSession(ownedInput),
 			);
 			return accepted.result;

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -6,6 +6,18 @@ import {
   sessionKernel,
 } from "./kernel";
 import { SESSION_KERNEL_MAX_WAITERS_PER_COMMAND } from "./actor-protocol";
+import {
+  legacyGatewayEffect,
+  type LegacyGatewayEffect,
+  type LegacyGatewayEffectInput,
+} from "./lifecycle-protocol";
+
+function testEffect(
+  input: LegacyGatewayEffectInput & { type?: string },
+): LegacyGatewayEffect {
+  const { type: _legacyTestLabel, ...effect } = input;
+  return legacyGatewayEffect("submit_prompt", effect);
+}
 
 let client: SessionKernelActorClient | undefined;
 afterEach(() => {
@@ -28,11 +40,11 @@ async function actor(): Promise<SessionKernelActorClient> {
 describe("session kernel actor boundary", () => {
   test("admits independent commands while physical work is active", async () => {
     const host = await actor();
-    const first = await host.begin("s1", { requestId: "first", type: "test" });
-    const second = await host.begin("s1", {
+    const first = await host.begin("s1", testEffect({ requestId: "first", type: "test" }));
+    const second = await host.begin("s1", testEffect({
       requestId: "second",
       type: "test",
-    });
+    }));
     expect(first.executionId).toBeString();
     expect(second.executionId).toBeString();
     expect(second.executionId).not.toBe(first.executionId);
@@ -46,27 +58,27 @@ describe("session kernel actor boundary", () => {
 
   test("coalesces and bounds waiters for the same execution", async () => {
     const host = await actor();
-    const active = await host.begin("bounded", {
+    const active = await host.begin("bounded", testEffect({
       requestId: "same",
       type: "test",
       payload: { stable: true },
-    });
+    }));
     const waiting = Array.from(
       { length: SESSION_KERNEL_MAX_WAITERS_PER_COMMAND },
       () =>
-        host.begin("bounded", {
+        host.begin("bounded", testEffect({
           requestId: "same",
           type: "test",
           payload: { stable: true },
-        }),
+        })),
     );
     await Bun.sleep(25);
     await expect(
-      host.begin("bounded", {
+      host.begin("bounded", testEffect({
         requestId: "same",
         type: "test",
         payload: { stable: true },
-      }),
+      })),
     ).rejects.toMatchObject({ retryable: true });
     await host.complete(active.executionId!, "done", []);
     expect(
@@ -88,13 +100,13 @@ describe("session kernel actor boundary", () => {
       host.fail("missing-execution", "disk failed", true),
     ).rejects.toThrow();
     await expect(
-      host.begin("s1", { requestId: "after-fatal", type: "test" }),
+      host.begin("s1", testEffect({ requestId: "after-fatal", type: "test" })),
     ).rejects.toThrow();
   });
 
   test("starts compatibility work independently during an async execution", async () => {
     const host = await actor();
-    const first = await host.begin("s1", { requestId: "first", type: "test" });
+    const first = await host.begin("s1", testEffect({ requestId: "first", type: "test" }));
     const syncDuring = host.beginSync("s1", {
       requestId: "sync",
       type: "sync:transcript_append",
@@ -123,10 +135,10 @@ describe("session kernel actor boundary", () => {
 
   test("a tombstone rejects compatibility writes during an active execution", async () => {
     const host = await actor();
-    const active = await host.begin("deleted", {
+    const active = await host.begin("deleted", testEffect({
       requestId: "active",
       type: "test",
-    });
+    }));
     host.store.tombstoneSession("deleted");
     expect(() =>
       host.beginSync("deleted", {
@@ -139,17 +151,23 @@ describe("session kernel actor boundary", () => {
 
   test("persists detached writes while a command effect is active", async () => {
     const host = await actor();
-    const active = await host.begin("detached", {
+    const active = await host.begin("detached", testEffect({
       requestId: "active",
       type: "submit_prompt",
-    });
+    }));
     installSessionKernelActor(host);
     const kernel = sessionKernel("detached");
 
     kernel.setRunState({ state: "running", event: "stream_started" });
-    kernel.enqueueEffect("notify", { ok: true }, "detached-effect");
+    kernel.enqueueEffect(
+      "human_ask_deliver",
+      { askId: "detached", skipUi: false },
+      "detached-effect",
+    );
     expect(kernel.runState().state).toBe("running");
-    expect(host.store.pendingOutbox(Date.now(), 10, ["notify"])).toHaveLength(
+    expect(
+      host.store.pendingOutbox(Date.now(), 10, ["human_ask_deliver"]),
+    ).toHaveLength(
       1,
     );
 
@@ -158,10 +176,10 @@ describe("session kernel actor boundary", () => {
 
   test("reduces run events atomically while gateway work is still active", async () => {
     const host = await actor();
-    const active = await host.begin("autonomous", {
+    const active = await host.begin("autonomous", testEffect({
       requestId: "physical-work",
       type: "submit_prompt",
-    });
+    }));
     expect(
       host.decideRunEvent({ sessionId: "autonomous", event: "prompt" }),
     ).toMatchObject({ accepted: true, from: "idle", to: "starting" });
@@ -220,16 +238,16 @@ describe("session kernel actor boundary", () => {
     host.terminate();
     client = undefined;
     await expect(
-      host.begin("s1", { requestId: "after-stop", type: "test" }),
+      host.begin("s1", testEffect({ requestId: "after-stop", type: "test" })),
     ).rejects.toThrow("actor stopped");
   });
 
   test("returns a terminal failure instead of re-executing it", async () => {
     const host = await actor();
-    const first = await host.begin("sticky", {
+    const first = await host.begin("sticky", testEffect({
       requestId: "same",
       type: "test",
-    });
+    }));
     await host.complete(
       first.executionId!,
       { __sessionKernelFailure: true, message: "not allowed" },
@@ -237,7 +255,7 @@ describe("session kernel actor boundary", () => {
     );
     let failure: unknown;
     try {
-      await host.begin("sticky", { requestId: "same", type: "test" });
+      await host.begin("sticky", testEffect({ requestId: "same", type: "test" }));
     } catch (error) {
       failure = error;
     }
@@ -247,10 +265,10 @@ describe("session kernel actor boundary", () => {
 
   test("acknowledges replay results through async IPC", async () => {
     const host = await actor();
-    const admission = await host.begin("ack", {
+    const admission = await host.begin("ack", testEffect({
       requestId: "one",
       type: "take",
-    });
+    }));
     await host.complete(admission.executionId!, { item: "kept" }, []);
     await host.acknowledgeCommand("ack", "one");
     expect(host.store.command("ack", "one")?.acknowledgedAt).toBeNumber();
@@ -290,18 +308,18 @@ describe("session kernel actor boundary", () => {
 
   test("returns a committed result after an uncertain reply", async () => {
     const host = await actor();
-    const first = await host.begin("s1", {
+    const first = await host.begin("s1", testEffect({
       requestId: "same",
       type: "test",
       payload: { n: 1 },
-    });
+    }));
     await host.complete(first.executionId!, { accepted: true }, []);
     expect(
-      await host.begin("s1", {
+      await host.begin("s1", testEffect({
         requestId: "same",
         type: "test",
         payload: { n: 1 },
-      }),
+      })),
     ).toMatchObject({ duplicate: true, result: { accepted: true } });
   });
   test("resizes read-only delivery snapshots beyond the initial buffer", async () => {
@@ -331,8 +349,8 @@ describe("session kernel actor boundary", () => {
       releaseFirst = resolve;
     });
     const order: string[] = [];
-    const first = kernel.dispatch(
-      { requestId: "first-effect", type: "test", replaySafe: true },
+    const first = kernel.dispatchLegacy(
+      testEffect({ requestId: "first-effect", type: "test", replaySafe: true }),
       async () => {
         order.push("first-start");
         await firstBlocked;
@@ -340,8 +358,8 @@ describe("session kernel actor boundary", () => {
         return "first";
       },
     );
-    const second = kernel.dispatch(
-      { requestId: "second-effect", type: "test", replaySafe: true },
+    const second = kernel.dispatchLegacy(
+      testEffect({ requestId: "second-effect", type: "test", replaySafe: true }),
       () => {
         order.push("second");
         return "second";

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -1,4 +1,7 @@
-import type { SessionCommand } from "./kernel";
+import type {
+  LegacyGatewayEffect,
+  SessionActorReducerCommand,
+} from "./lifecycle-protocol";
 import type {
   DurableCommandRecord,
   DurableDeliveryState,
@@ -151,7 +154,7 @@ export class SessionKernelActorClient {
 
   async begin(
     sessionId: string,
-    command: SessionCommand,
+    command: LegacyGatewayEffect,
   ): Promise<{ duplicate: boolean; executionId?: string; result?: unknown }> {
     const response = await this.request({
       t: "begin",
@@ -202,7 +205,13 @@ export class SessionKernelActorClient {
 
   beginSync(
     sessionId: string,
-    command: SessionCommand,
+    command: {
+      requestId: string;
+      type: string;
+      payload?: unknown;
+      source?: string;
+      replaySafe?: boolean;
+    },
   ): { duplicate: boolean; executionId?: string; result?: unknown } {
     const admission = this.callStore<{
       duplicate: boolean;
@@ -275,7 +284,10 @@ export class SessionKernelActorClient {
 
   decideAsk<T extends AskActorRequest>(request: T): AskActorResult<T> {
     return this.callSync<AskActorResult<T>>(
-      { t: "ask", request },
+      {
+        t: "reduce",
+        command: { kind: "ask", commandId: crypto.randomUUID(), request },
+      },
       `ask ${request.op}`,
       request.op === "snapshot" || request.op === "entries",
     );
@@ -285,7 +297,14 @@ export class SessionKernelActorClient {
     request: T,
   ): DeliveryActorResult<T> {
     return this.callSync<DeliveryActorResult<T>>(
-      { t: "delivery", request },
+      {
+        t: "reduce",
+        command: {
+          kind: "delivery",
+          commandId: crypto.randomUUID(),
+          request,
+        },
+      },
       `delivery ${request.op}`,
       request.op === "snapshot" || request.op === "entries",
     );
@@ -293,7 +312,14 @@ export class SessionKernelActorClient {
 
   decideRunEvent(decision: RunEventDecision): RunEventDecisionResult {
     const result = this.callSync<RunEventDecisionResult>(
-      { t: "decide_run_event", decision },
+      {
+        t: "reduce",
+        command: {
+          kind: "run_event",
+          commandId: crypto.randomUUID(),
+          decision,
+        },
+      },
       "run event decision",
     );
     if (result.accepted)
@@ -315,9 +341,7 @@ export class SessionKernelActorClient {
   private callSync<TResult>(
     request:
       | { t: "store"; method: string; args: unknown[] }
-      | { t: "decide_run_event"; decision: RunEventDecision }
-      | { t: "delivery"; request: DeliveryActorRequest }
-      | { t: "ask"; request: AskActorRequest },
+      | { t: "reduce"; command: SessionActorReducerCommand },
     label: string,
     large = false,
     outputBytes = large ? LARGE_OUTPUT_BYTES : SMALL_OUTPUT_BYTES,

--- a/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
@@ -1,14 +1,14 @@
-import type { SessionCommand } from "./kernel";
-import type { DeliveryActorRequest } from "./delivery-protocol";
-import type { AskActorRequest } from "./ask-protocol";
+import type {
+  LegacyGatewayEffect,
+  SessionActorReducerCommand,
+} from "./lifecycle-protocol";
 import type {
   DurableOutboxItem,
   DurableTimer,
-  RunEventDecision,
   RunEventDecisionResult,
 } from "./store";
 
-export const SESSION_KERNEL_ACTOR_VERSION = 5;
+export const SESSION_KERNEL_ACTOR_VERSION = 6;
 export const SESSION_KERNEL_MAX_WAITERS_PER_COMMAND = 64;
 export const SESSION_KERNEL_MAX_WAITERS_TOTAL = 4096;
 export const SESSION_KERNEL_MAX_EXECUTIONS_PER_SESSION = 128;
@@ -16,7 +16,12 @@ export const SESSION_KERNEL_MAX_EXECUTIONS_TOTAL = 4096;
 
 export type KernelActorAsyncRequest =
   | { t: "hello"; rpcId: string; version: number }
-  | { t: "begin"; rpcId: string; command: SessionCommand; sessionId: string }
+  | {
+      t: "begin";
+      rpcId: string;
+      command: LegacyGatewayEffect;
+      sessionId: string;
+    }
   | { t: "acknowledge"; rpcId: string; sessionId: string; requestId: string }
   | { t: "stats"; rpcId: string }
   | { t: "maintain"; rpcId: string }
@@ -80,8 +85,6 @@ type SyncBuffers = {
 
 export type KernelActorSyncRequest =
   | ({ t: "store"; method: string; args: unknown[] } & SyncBuffers)
-  | ({ t: "decide_run_event"; decision: RunEventDecision } & SyncBuffers)
-  | ({ t: "delivery"; request: DeliveryActorRequest } & SyncBuffers)
-  | ({ t: "ask"; request: AskActorRequest } & SyncBuffers);
+  | ({ t: "reduce"; command: SessionActorReducerCommand } & SyncBuffers);
 
 export type KernelActorRunEventResult = RunEventDecisionResult;

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -49,11 +49,11 @@ export function startSessionKernelActorWorker(): void {
     try {
       if (store.isTombstoned(request.sessionId))
         throw new Error(`Session ${request.sessionId} was deleted`);
-      const key = requestKey(request.sessionId, request.command.requestId);
+      const key = requestKey(request.sessionId, request.command.commandId);
       const currentExecutionId = executingRequests.get(key);
       const existing = store.command(
         request.sessionId,
-        request.command.requestId,
+        request.command.commandId,
       );
       const terminal =
         existing?.status === "completed" ||
@@ -72,8 +72,8 @@ export function startSessionKernelActorWorker(): void {
         });
       const persisted = store.acceptCommand({
         sessionId: request.sessionId,
-        requestId: request.command.requestId,
-        type: request.command.type,
+        requestId: request.command.commandId,
+        type: request.command.operation,
         payload: request.command.payload,
         replaySafe: request.command.replaySafe,
       });
@@ -115,8 +115,8 @@ export function startSessionKernelActorWorker(): void {
       const execution: Execution = {
         executionId: crypto.randomUUID(),
         sessionId: request.sessionId,
-        requestId: request.command.requestId,
-        type: request.command.type,
+        requestId: request.command.commandId,
+        type: request.command.operation,
         waiters: [],
       };
       executions.set(execution.executionId, execution);
@@ -125,7 +125,7 @@ export function startSessionKernelActorWorker(): void {
         request.sessionId,
         (executionsPerSession.get(request.sessionId) ?? 0) + 1,
       );
-      store.markProcessing(request.sessionId, request.command.requestId);
+      store.markProcessing(request.sessionId, request.command.commandId);
       post({
         t: "begin_result",
         rpcId: request.rpcId,
@@ -295,68 +295,71 @@ export function startSessionKernelActorWorker(): void {
     const output = new Uint8Array(request.output);
     try {
       let result: unknown;
-      if (request.t === "decide_run_event")
-        result = store.applyRunEvent(request.decision);
-      else if (request.t === "delivery") {
-        const delivery = request.request;
-        if (delivery.op === "snapshot")
-          result = store.deliverySnapshot(delivery.sessionId);
-        else if (delivery.op === "entries")
-          result = store.deliveryEntries(delivery.slot);
-        else if (delivery.op === "set")
-          result = store.setDeliverySlot(
-            delivery.sessionId,
-            delivery.slot,
-            delivery.value,
-          );
-        else if (delivery.op === "delete")
-          result = store.deleteDeliverySlot(delivery.sessionId, delivery.slot);
-        else if (delivery.op === "clear_slot")
-          result = store.clearDeliverySlot(delivery.slot);
-        else if (delivery.op === "prepare_steer")
-          result = store.prepareSteerDelivery(
-            delivery.sessionId,
-            delivery.itemId,
-            delivery.item,
-          );
-        else if (delivery.op === "accept_steer")
-          result = store.acceptSteerDelivery(
-            delivery.sessionId,
-            delivery.itemId,
-          );
-        else if (delivery.op === "reject_steer")
-          result = store.rejectSteerDelivery(
-            delivery.sessionId,
-            delivery.itemId,
-          );
-        else if (delivery.op === "settle_pending_steers")
-          result = store.settlePendingSteers();
-        else if (delivery.op === "requeue_steers")
-          result = store.requeueSteerDeliveries(
-            delivery.sessionId,
-            delivery.items,
-          );
-        else if (delivery.op === "claim_dispatch")
-          result = store.claimDeliveryDispatch(delivery);
-        else if (delivery.op === "ack_dispatch")
-          result = store.ackDeliveryDispatch(
-            delivery.sessionId,
-            delivery.promptEntryId,
-          );
-        else
-          result = store.failDeliveryDispatch(
-            delivery.sessionId,
-            delivery.promptEntryId,
-          );
-      } else if (request.t === "ask") {
-        const ask = request.request;
-        if (ask.op === "snapshot") result = store.askSnapshot(ask.sessionId);
-        else if (ask.op === "entries") result = store.askEntries();
-        else if (ask.op === "set")
-          result = store.setAskRecord(ask.sessionId, ask.value);
-        else if (ask.op === "delete")
-          result = store.deleteAskRecord(ask.sessionId);
-        else result = store.clearAskRecords();
+      if (request.t === "reduce") {
+        const command = request.command;
+        if (command.kind === "run_event")
+          result = store.applyRunEvent(command.decision);
+        else if (command.kind === "delivery") {
+          const delivery = command.request;
+          if (delivery.op === "snapshot")
+            result = store.deliverySnapshot(delivery.sessionId);
+          else if (delivery.op === "entries")
+            result = store.deliveryEntries(delivery.slot);
+          else if (delivery.op === "set")
+            result = store.setDeliverySlot(
+              delivery.sessionId,
+              delivery.slot,
+              delivery.value,
+            );
+          else if (delivery.op === "delete")
+            result = store.deleteDeliverySlot(delivery.sessionId, delivery.slot);
+          else if (delivery.op === "clear_slot")
+            result = store.clearDeliverySlot(delivery.slot);
+          else if (delivery.op === "prepare_steer")
+            result = store.prepareSteerDelivery(
+              delivery.sessionId,
+              delivery.itemId,
+              delivery.item,
+            );
+          else if (delivery.op === "accept_steer")
+            result = store.acceptSteerDelivery(
+              delivery.sessionId,
+              delivery.itemId,
+            );
+          else if (delivery.op === "reject_steer")
+            result = store.rejectSteerDelivery(
+              delivery.sessionId,
+              delivery.itemId,
+            );
+          else if (delivery.op === "settle_pending_steers")
+            result = store.settlePendingSteers();
+          else if (delivery.op === "requeue_steers")
+            result = store.requeueSteerDeliveries(
+              delivery.sessionId,
+              delivery.items,
+            );
+          else if (delivery.op === "claim_dispatch")
+            result = store.claimDeliveryDispatch(delivery);
+          else if (delivery.op === "ack_dispatch")
+            result = store.ackDeliveryDispatch(
+              delivery.sessionId,
+              delivery.promptEntryId,
+            );
+          else
+            result = store.failDeliveryDispatch(
+              delivery.sessionId,
+              delivery.promptEntryId,
+            );
+        } else {
+          const ask = command.request;
+          if (ask.op === "snapshot") result = store.askSnapshot(ask.sessionId);
+          else if (ask.op === "entries") result = store.askEntries();
+          else if (ask.op === "set")
+            result = store.setAskRecord(ask.sessionId, ask.value);
+          else if (ask.op === "delete")
+            result = store.deleteAskRecord(ask.sessionId);
+          else result = store.clearAskRecords();
+        }
       } else if (request.method === "$beginSync")
         result = beginSync(request.args[0] as string, request.args[1] as any);
       else if (request.method === "$completeSync")
@@ -407,12 +410,7 @@ export function startSessionKernelActorWorker(): void {
     event: MessageEvent<KernelActorAsyncRequest | KernelActorSyncRequest>,
   ) => {
     const request = event.data;
-    if (
-      request.t === "store" ||
-      request.t === "decide_run_event" ||
-      request.t === "delivery" ||
-      request.t === "ask"
-    ) {
+    if (request.t === "store" || request.t === "reduce") {
       syncStore(request);
       return;
     }

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SessionEffectExecutorRegistry,
+} from "./effect-executors";
+import type { DurableOutboxItem } from "./store";
+
+function outbox(payload: unknown, kind = "human_ask_deliver"): DurableOutboxItem {
+  return {
+    id: 1,
+    effectId: "session:human_ask_deliver:ask",
+    effectKey: "ask",
+    sessionId: "session",
+    kind,
+    payload,
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: 1,
+  };
+}
+
+describe("session effect executor registry", () => {
+  test("decodes typed payloads before execution", async () => {
+    const registry = new SessionEffectExecutorRegistry();
+    let delivered: { askId: string; skipUi: boolean } | undefined;
+    registry.register("human_ask_deliver", (item) => {
+      delivered = item.payload;
+    });
+
+    expect(
+      await registry.execute(outbox({ askId: "ask-one", skipUi: false })),
+    ).toBe(true);
+    expect(delivered).toEqual({ askId: "ask-one", skipUi: false });
+  });
+
+  test("rejects malformed known effects and ignores unknown versions", async () => {
+    const registry = new SessionEffectExecutorRegistry();
+    registry.register("human_ask_deliver", () => {});
+
+    await expect(
+      registry.execute(outbox({ askId: "ask-one" })),
+    ).rejects.toThrow("Invalid human_ask_deliver effect payload");
+    expect(await registry.execute(outbox(null, "future_effect"))).toBe(false);
+  });
+
+  test("allows exactly one executor per effect kind", () => {
+    const registry = new SessionEffectExecutorRegistry();
+    const unregister = registry.register("human_ask_deliver", () => {});
+    expect(() =>
+      registry.register("human_ask_deliver", () => {}),
+    ).toThrow("already registered");
+    unregister();
+    expect(registry.kinds()).toEqual([]);
+  });
+});

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
@@ -1,0 +1,115 @@
+import type { DurableOutboxItem } from "./store";
+import type {
+  SessionActorEffectFor,
+  SessionActorEffectKind,
+} from "./lifecycle-protocol";
+
+type EffectItem<K extends SessionActorEffectKind> = Omit<
+  DurableOutboxItem,
+  "kind" | "payload"
+> &
+  SessionActorEffectFor<K>;
+
+type EffectExecutor<K extends SessionActorEffectKind> = (
+  item: EffectItem<K>,
+) => void | Promise<void>;
+
+type EffectExecutors = {
+  [K in SessionActorEffectKind]?: EffectExecutor<K>;
+};
+
+function humanAskDeliverPayload(
+  payload: unknown,
+): SessionActorEffectFor<"human_ask_deliver">["payload"] {
+  const value = payload as { askId?: unknown; skipUi?: unknown } | undefined;
+  if (typeof value?.askId !== "string" || typeof value.skipUi !== "boolean")
+    throw new Error("Invalid human_ask_deliver effect payload");
+  return { askId: value.askId, skipUi: value.skipUi };
+}
+
+const payloadDecoders: {
+  [K in SessionActorEffectKind]: (
+    payload: unknown,
+  ) => SessionActorEffectFor<K>["payload"];
+} = {
+  human_ask_deliver: humanAskDeliverPayload,
+};
+
+export class SessionEffectExecutorRegistry {
+  private readonly executors: EffectExecutors = {};
+
+  register<K extends SessionActorEffectKind>(
+    kind: K,
+    executor: EffectExecutor<K>,
+  ): () => void {
+    if (this.executors[kind])
+      throw new Error(`Session effect executor ${kind} is already registered`);
+    this.executors[kind] = executor as EffectExecutors[K];
+    return () => {
+      if (this.executors[kind] === executor) delete this.executors[kind];
+    };
+  }
+
+  kinds(): SessionActorEffectKind[] {
+    return Object.keys(this.executors) as SessionActorEffectKind[];
+  }
+
+  replaceForTest<K extends SessionActorEffectKind>(
+    kind: K,
+    executor: EffectExecutor<K>,
+  ): () => void {
+    if (process.env.NODE_ENV !== "test")
+      throw new Error("Session effect executors can only be replaced in tests");
+    const previous = this.executors[kind];
+    this.executors[kind] = executor as EffectExecutors[K];
+    return () => {
+      if (this.executors[kind] !== executor) return;
+      if (previous) this.executors[kind] = previous;
+      else delete this.executors[kind];
+    };
+  }
+
+  async execute(item: DurableOutboxItem): Promise<boolean> {
+    const kind = item.kind as SessionActorEffectKind;
+    const executor = this.executors[kind] as
+      | EffectExecutor<typeof kind>
+      | undefined;
+    const decode = payloadDecoders[kind];
+    if (!executor || !decode) return false;
+    const effectItem = {
+      ...item,
+      kind,
+      payload: decode(item.payload),
+    } as EffectItem<typeof kind>;
+    await executor(effectItem);
+    return true;
+  }
+}
+
+const globalRegistry = globalThis as typeof globalThis & {
+  __opensessionSessionEffectExecutors?: SessionEffectExecutorRegistry;
+};
+const registry = (globalRegistry.__opensessionSessionEffectExecutors ??=
+  new SessionEffectExecutorRegistry());
+
+export function registerSessionEffectExecutor<
+  K extends SessionActorEffectKind,
+>(kind: K, executor: EffectExecutor<K>): () => void {
+  return registry.register(kind, executor);
+}
+
+export function registeredSessionEffectKinds(): SessionActorEffectKind[] {
+  return registry.kinds();
+}
+
+export function replaceSessionEffectExecutorForTest<
+  K extends SessionActorEffectKind,
+>(kind: K, executor: EffectExecutor<K>): () => void {
+  return registry.replaceForTest(kind, executor);
+}
+
+export function executeSessionEffect(
+  item: DurableOutboxItem,
+): Promise<boolean> {
+  return registry.execute(item);
+}

--- a/packages/core/opensession-server/src/server/session-kernel/index.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/index.ts
@@ -7,3 +7,5 @@ export * from "./delivery-map";
 export * from "./delivery-protocol";
 export * from "./ask-map";
 export * from "./ask-protocol";
+export * from "./lifecycle-protocol";
+export * from "./effect-executors";

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -14,7 +14,17 @@ import {
 	DeliveryOwnedMap,
 	sessionKernel,
 	tombstoneSessionKernel,
+	legacyGatewayEffect,
+	type LegacyGatewayEffect,
+	type LegacyGatewayEffectInput,
 } from ".";
+
+function testEffect(
+	input: LegacyGatewayEffectInput & { type?: string },
+): LegacyGatewayEffect {
+	const { type: _legacyTestLabel, ...effect } = input;
+	return legacyGatewayEffect("submit_prompt", effect);
+}
 
 let store: SessionKernelStore;
 let previous: SessionKernelStore | undefined;
@@ -67,8 +77,8 @@ describe("SessionKernel", () => {
 	test("serializes commands for one session", async () => {
 		const order: string[] = [];
 		const kernel = sessionKernel("s1");
-		const first = kernel.dispatch(
-			{ requestId: "a", type: "test" },
+		const first = kernel.dispatchLegacy(
+			testEffect({ requestId: "a", type: "test" }),
 			async () => {
 				order.push("a:start");
 				await Bun.sleep(5);
@@ -76,8 +86,8 @@ describe("SessionKernel", () => {
 				return "a";
 			},
 		);
-		const second = kernel.dispatch(
-			{ requestId: "b", type: "test" },
+		const second = kernel.dispatchLegacy(
+			testEffect({ requestId: "b", type: "test" }),
 			() => {
 				order.push("b");
 				return "b";
@@ -91,8 +101,8 @@ describe("SessionKernel", () => {
 	test("rejects a nested same-session dispatch instead of deadlocking", async () => {
 		const kernel = sessionKernel("nested");
 		await expect(
-			kernel.dispatch({ requestId: "outer", type: "outer" }, async () =>
-				kernel.dispatch({ requestId: "inner", type: "inner" }, () => "inner"),
+			kernel.dispatchLegacy(testEffect({ requestId: "outer", type: "outer" }), async () =>
+				kernel.dispatchLegacy(testEffect({ requestId: "inner", type: "inner" }), () => "inner"),
 			),
 		).rejects.toThrow("Nested SessionKernel dispatch");
 	});
@@ -100,29 +110,29 @@ describe("SessionKernel", () => {
 	test("session-file style mutations share the durable command mailbox", async () => {
 		const kernel = sessionKernel("lanes");
 		const order: string[] = [];
-		const command = kernel.dispatch(
-			{ requestId: "command", type: "command" },
+		const command = kernel.dispatchLegacy(
+			testEffect({ requestId: "command", type: "command" }),
 			async () => {
 				order.push("command:start");
 				await Bun.sleep(5);
 				order.push("command:end");
 			},
 		);
-		const write = kernel.runExclusive("file", () => order.push("file"));
+		const write = kernel.runExclusive("session_file_updated", () => order.push("file"));
 		await Promise.all([command, write]);
 		expect(order).toEqual(["command:start", "command:end", "file"]);
 	});
 
 	test("deduplicates a completed command durably", async () => {
 		let calls = 0;
-		const command = { requestId: "stable", type: "deliver", payload: { text: "hi" }, };
-		const first = await sessionKernel("s1").dispatch(command, () => {
+		const command = testEffect({ requestId: "stable", type: "deliver", payload: { text: "hi" }, });
+		const first = await sessionKernel("s1").dispatchLegacy(command, () => {
 			calls += 1;
 			return { status: "queued" };
 		});
 		expect(first.duplicate).toBe(false);
 		clearSessionKernel("unrelated");
-		const second = await sessionKernel("s1").dispatch(command, () => {
+		const second = await sessionKernel("s1").dispatchLegacy(command, () => {
 			calls += 1;
 			return { status: "started" };
 		});
@@ -133,13 +143,13 @@ describe("SessionKernel", () => {
 
 	test("keeps completed receipts for clients that reconnect after compaction", async () => {
 		let calls = 0;
-		const command = { requestId: "forever", type: "deliver", payload: { n: 1 } };
-		await sessionKernel("retained").dispatch(command, () => {
+		const command = testEffect({ requestId: "forever", type: "deliver", payload: { n: 1 } });
+		await sessionKernel("retained").dispatchLegacy(command, () => {
 			calls += 1;
 			return "done";
 		});
 		store.compact(Date.now() + 365 * 24 * 60 * 60_000);
-		const replay = await sessionKernel("retained").dispatch(command, () => {
+		const replay = await sessionKernel("retained").dispatchLegacy(command, () => {
 			calls += 1;
 			return "duplicate";
 		});
@@ -149,8 +159,8 @@ describe("SessionKernel", () => {
 
 	test("compacts large permanent results without forgetting the receipt", async () => {
 		let calls = 0;
-		const command = { requestId: "large", type: "take" };
-		await sessionKernel("large-result").dispatch(command, () => {
+		const command = testEffect({ requestId: "large", type: "take" });
+		await sessionKernel("large-result").dispatchLegacy(command, () => {
 			calls += 1;
 			return { item: "x".repeat(128 * 1024) };
 		});
@@ -165,7 +175,7 @@ describe("SessionKernel", () => {
 			__sessionKernelResultReleased: true,
 			sha256: receipt?.resultHash,
 		});
-		const replay = await sessionKernel("large-result").dispatch(command, () => {
+		const replay = await sessionKernel("large-result").dispatchLegacy(command, () => {
 			calls += 1;
 		});
 		expect(replay.duplicate).toBe(true);
@@ -174,15 +184,15 @@ describe("SessionKernel", () => {
 
 	test("keeps terminal failures sticky", async () => {
 		let calls = 0;
-		const command = { requestId: "terminal", type: "delete" };
+		const command = testEffect({ requestId: "terminal", type: "delete" });
 		await expect(
-			sessionKernel("failed").dispatch(command, () => {
+			sessionKernel("failed").dispatchLegacy(command, () => {
 				calls += 1;
 				throw new Error("not allowed");
 			}),
 		).rejects.toThrow("not allowed");
 		await expect(
-			sessionKernel("failed").dispatch(command, () => {
+			sessionKernel("failed").dispatchLegacy(command, () => {
 				calls += 1;
 			}),
 		).rejects.toThrow("not allowed");
@@ -190,13 +200,13 @@ describe("SessionKernel", () => {
 	});
 
 	test("rejects request id reuse with another payload", async () => {
-		await sessionKernel("s1").dispatch(
-			{ requestId: "same", type: "deliver", payload: { text: "one" } },
+		await sessionKernel("s1").dispatchLegacy(
+			testEffect({ requestId: "same", type: "deliver", payload: { text: "one" } }),
 			() => "ok",
 		);
 		await expect(
-			sessionKernel("s1").dispatch(
-				{ requestId: "same", type: "deliver", payload: { text: "two" } },
+			sessionKernel("s1").dispatchLegacy(
+				testEffect({ requestId: "same", type: "deliver", payload: { text: "two" } }),
 				() => "bad",
 			),
 		).rejects.toThrow("reused with another payload");
@@ -208,8 +218,8 @@ describe("SessionKernel", () => {
 		const firstStore = new SessionKernelStore(path);
 		__setSessionKernelStoreForTest(firstStore);
 		try {
-			await sessionKernel("restart").dispatch(
-				{ requestId: "request-1", type: "submit", payload: { text: "once" } },
+			await sessionKernel("restart").dispatchLegacy(
+				testEffect({ requestId: "request-1", type: "submit", payload: { text: "once" } }),
 				() => ({ status: "queued" }),
 			);
 			sessionKernel("restart").registerRun(
@@ -222,8 +232,8 @@ describe("SessionKernel", () => {
 			const secondStore = new SessionKernelStore(path);
 			__setSessionKernelStoreForTest(secondStore);
 			let calls = 0;
-			const replay = await sessionKernel("restart").dispatch(
-				{ requestId: "request-1", type: "submit", payload: { text: "once" } },
+			const replay = await sessionKernel("restart").dispatchLegacy(
+				testEffect({ requestId: "request-1", type: "submit", payload: { text: "once" } }),
 				() => {
 					calls += 1;
 					return { status: "started" };
@@ -253,7 +263,7 @@ describe("SessionKernel", () => {
 		firstStore.acceptCommand({
 			sessionId: "restart",
 			requestId: "accepted",
-			type: "submit",
+			type: "submit_prompt",
 			payload: { text: "once" },
 			replaySafe: true,
 		});
@@ -266,13 +276,13 @@ describe("SessionKernel", () => {
 				"pending",
 			);
 			let calls = 0;
-			const accepted = await sessionKernel("restart").dispatch(
-				{
+			const accepted = await sessionKernel("restart").dispatchLegacy(
+				testEffect({
 					requestId: "accepted",
 					type: "submit",
 					payload: { text: "once" },
 					replaySafe: true,
-				},
+				}),
 				() => {
 					calls += 1;
 					return { queued: true };
@@ -336,10 +346,10 @@ describe("SessionKernel", () => {
 
 	test("never retries a non-replay-safe timeout", async () => {
 		let calls = 0;
-		const command = { requestId: "unsafe-timeout", type: "physical" };
+		const command = testEffect({ requestId: "unsafe-timeout", type: "physical" });
 		for (let attempt = 0; attempt < 2; attempt++)
 			await expect(
-				sessionKernel("unsafe-timeout").dispatch(command, () => {
+				sessionKernel("unsafe-timeout").dispatchLegacy(command, () => {
 					calls += 1;
 					throw new Error("operation timed out");
 				}),
@@ -397,7 +407,7 @@ describe("SessionKernel", () => {
 			"was deleted",
 		);
 		await expect(
-			sessionKernel(id).dispatch({ requestId: "late", type: "prompt" }, () => {},),
+			sessionKernel(id).dispatchLegacy(testEffect({ requestId: "late", type: "prompt" }), () => {},),
 		).rejects.toThrow("was deleted");
 	});
 
@@ -514,10 +524,14 @@ describe("SessionKernel", () => {
 	});
 
 	test("commits command completion and its effects in one decision transaction", async () => {
-		await sessionKernel("decision").dispatch(
-			{ requestId: "request", type: "notify" },
+		await sessionKernel("decision").dispatchLegacy(
+			testEffect({ requestId: "request", type: "notify" }),
 			(kernel) => {
-				kernel.enqueueEffect("slack", { text: "hello" }, "message-1");
+				kernel.enqueueEffect(
+					"human_ask_deliver",
+					{ askId: "ask-one", skipUi: false },
+					"message-1",
+				);
 				return { accepted: true };
 			},
 		);
@@ -527,9 +541,9 @@ describe("SessionKernel", () => {
 		});
 		expect(store.pendingOutbox()).toEqual([
 			expect.objectContaining({
-				effectId: "decision:slack:message-1",
+				effectId: "decision:human_ask_deliver:message-1",
 				effectKey: "message-1",
-				payload: { text: "hello" },
+				payload: { askId: "ask-one", skipUi: false },
 			}),
 		]);
 	});
@@ -544,10 +558,14 @@ describe("SessionKernel", () => {
 
 	test("does not publish staged effects when a command fails", async () => {
 		await expect(
-			sessionKernel("decision-failed").dispatch(
-				{ requestId: "request", type: "notify" },
+			sessionKernel("decision-failed").dispatchLegacy(
+				testEffect({ requestId: "request", type: "notify" }),
 				(kernel) => {
-					kernel.enqueueEffect("slack", { text: "no" }, "message-1");
+					kernel.enqueueEffect(
+						"human_ask_deliver",
+						{ askId: "ask-one", skipUi: false },
+						"message-1",
+					);
 					throw new Error("decision rejected");
 				},
 			),
@@ -680,16 +698,25 @@ describe("SessionKernel durable runtime", () => {
 	});
 
 	test("unknown durable kinds cannot starve registered work", async () => {
-		const { drainSessionKernelRuntime, registerSessionEffectHandler, registerSessionTimerHandler, waitForSessionKernelRuntimeIdle, } = await import("./runtime");
+		const { drainSessionKernelRuntime, registerSessionTimerHandler, waitForSessionKernelRuntimeIdle, } = await import("./runtime");
+		const { replaceSessionEffectExecutorForTest } = await import("./effect-executors");
 		for (let i = 0; i < 120; i++) {
 			store.enqueueOutbox(`unknown-${i}`, "future_effect", null, String(i));
 			store.scheduleTimer({ sessionId: `unknown-${i}`, timerId: "future", kind: "future_timer", dueAt: Date.now() - 1, payload: null, });
 		}
-		store.enqueueOutbox("known", "known_effect", null, "known");
+		store.enqueueOutbox(
+			"known",
+			"human_ask_deliver",
+			{ askId: "known", skipUi: false },
+			"known",
+		);
 		store.scheduleTimer({ sessionId: "known", timerId: "known", kind: "known_timer", dueAt: Date.now() - 1, payload: null, });
 		let effects = 0;
 		let timers = 0;
-		const unregisterEffect = registerSessionEffectHandler("known_effect", () => { effects += 1; });
+		const unregisterEffect = replaceSessionEffectExecutorForTest(
+			"human_ask_deliver",
+			() => { effects += 1; },
+		);
 		const unregisterTimer = registerSessionTimerHandler("known_timer", () => { timers += 1; });
 		try {
 			await drainSessionKernelRuntime();
@@ -714,14 +741,18 @@ describe("SessionKernel durable runtime", () => {
 	});
 
 	test("retries an outbox effect until it succeeds", async () => {
-		const { drainSessionKernelRuntime, registerSessionEffectHandler, waitForSessionKernelRuntimeIdle, } = await import("./runtime");
+		const { drainSessionKernelRuntime, waitForSessionKernelRuntimeIdle, } = await import("./runtime");
+		const { replaceSessionEffectExecutorForTest } = await import("./effect-executors");
 		let calls = 0;
-		const unregister = registerSessionEffectHandler("notify", () => {
+		const unregister = replaceSessionEffectExecutorForTest("human_ask_deliver", () => {
 			calls += 1;
 			if (calls === 1) throw new Error("temporary");
 		});
 		try {
-			sessionKernel("outbox-session").enqueueEffect("notify", { message: "hi", });
+			sessionKernel("outbox-session").enqueueEffect(
+				"human_ask_deliver",
+				{ askId: "retry", skipUi: false },
+			);
 			await drainSessionKernelRuntime();
 			await waitForSessionKernelRuntimeIdle();
 			expect(store.pendingOutbox(Date.now() + 2_000)).toHaveLength(1);

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -7,6 +7,14 @@
  */
 import { audit } from "../audit";
 import type { AskActorRequest, AskActorResult } from "./ask-protocol";
+import {
+	legacyGatewayEffect,
+	type LegacyGatewayEffect,
+	type LegacyGatewayEffectOperation,
+	type SessionActorEffectFor,
+	type SessionActorEffectKind,
+	type StagedSessionActorEffect,
+} from "./lifecycle-protocol";
 import type {
   DeliveryActorRequest,
   DeliveryActorResult,
@@ -26,17 +34,6 @@ import {
 	type RunEventDecision,
 	type RunEventDecisionResult,
 } from "./store";
-
-export interface SessionCommand<TPayload = unknown> {
-	requestId: string;
-	type: string;
-	payload?: TPayload;
-	source?: string;
-	/** Physical work may be safely re-entered after actor loss because it adopts stable effects. */
-	replaySafe?: boolean;
-	/** Retry handler failures regardless of message classification (timers/outbox-style policy). */
-	retryFailures?: boolean;
-}
 
 export interface SessionCommandResult<TResult = unknown> {
 	result: TResult;
@@ -66,11 +63,10 @@ const globalState = globalThis as typeof globalThis & {
 	__opensessionSessionKernel?: GlobalKernelState;
 };
 const state = (globalState.__opensessionSessionKernel ??= {});
-type StagedEffect = { kind: string; payload: unknown; effectKey: string };
 type CommandContext = {
 	sessionId: string;
 	requestId: string;
-	effects: StagedEffect[];
+	effects: StagedSessionActorEffect[];
 };
 const commandContext = new AsyncLocalStorage<CommandContext>();
 
@@ -348,24 +344,24 @@ export class SessionKernel {
 		);
 	}
 
-	async dispatch<TResult>(
-		command: SessionCommand,
+	async dispatchLegacy<TResult>(
+		command: LegacyGatewayEffect,
 		handler: CommandHandler<TResult>,
 	): Promise<SessionCommandResult<TResult>> {
 		this.assertWritable();
-		if (!command.requestId)
+		if (!command.commandId)
 			throw new Error("Session commands require requestId");
 		if (this.ownsCurrentCommand())
 			throw new Error(`Nested SessionKernel dispatch for ${this.sessionId}`);
-		const existingPromise = this.inFlight.get(command.requestId);
+		const existingPromise = this.inFlight.get(command.commandId);
 		if (existingPromise)
 			return existingPromise as Promise<SessionCommandResult<TResult>>;
 
 		if (!state.actor) {
 			const persisted = sessionKernelStore().acceptCommand({
 				sessionId: this.sessionId,
-				requestId: command.requestId,
-				type: command.type,
+				requestId: command.commandId,
+				type: command.operation,
 				payload: command.payload,
 				replaySafe: command.replaySafe,
 			});
@@ -401,16 +397,16 @@ export class SessionKernel {
 			},
 		);
 		this.inFlight.set(
-			command.requestId,
+			command.commandId,
 			resultPromise as Promise<SessionCommandResult<unknown>>,
 		);
     let settled = false;
     const cleanup = () => {
       if (settled) return;
       settled = true;
-      this.activeCommandIds.delete(command.requestId);
+      this.activeCommandIds.delete(command.commandId);
       this.queued -= 1;
-      this.inFlight.delete(command.requestId);
+      this.inFlight.delete(command.commandId);
       this.touch();
     };
 
@@ -419,12 +415,12 @@ export class SessionKernel {
         if (!state.actor)
 					sessionKernelStore().markProcessing(
 						this.sessionId,
-						command.requestId,
+						command.commandId,
 					);
-				this.activeCommandIds.add(command.requestId);
+				this.activeCommandIds.add(command.commandId);
 				const context: CommandContext = {
 					sessionId: this.sessionId,
-					requestId: command.requestId,
+					requestId: command.commandId,
 					effects: [],
 				};
 				const result = await commandContext.run(context, () => handler(this));
@@ -433,16 +429,16 @@ export class SessionKernel {
 				else
 					sessionKernelStore().completeCommandDecision({
 						sessionId: this.sessionId,
-						requestId: command.requestId,
-						type: command.type,
+						requestId: command.commandId,
+						type: command.operation,
 						result,
 						effects: context.effects,
 					});
 				audit({
 					msg: "session_command_completed",
 					session_id: this.sessionId,
-					request_id: command.requestId,
-					command: command.type,
+					request_id: command.commandId,
+					command: command.operation,
 					source: command.source,
 				});
 				resolve({ result, duplicate: false });
@@ -457,22 +453,22 @@ export class SessionKernel {
             await state.actor.fail(executionId, message, retryable);
 					} catch (settleError) {
             console.error(
-              `[session-kernel] Failed to settle ${this.sessionId}/${command.requestId}:`,
+              `[session-kernel] Failed to settle ${this.sessionId}/${command.commandId}:`,
               settleError,
             );
 					}
 				} else if (retryable)
 					sessionKernelStore().failCommand(
 						this.sessionId,
-						command.requestId,
+						command.commandId,
 						message,
 						true,
 					);
 				else
 					sessionKernelStore().completeCommandDecision({
 						sessionId: this.sessionId,
-						requestId: command.requestId,
-						type: command.type,
+						requestId: command.commandId,
+						type: command.operation,
             result: {
               __sessionKernelFailure: true,
               message: message.slice(0, 2_000),
@@ -482,8 +478,8 @@ export class SessionKernel {
 				audit({
 					msg: "session_command_failed",
 					session_id: this.sessionId,
-					request_id: command.requestId,
-					command: command.type,
+					request_id: command.commandId,
+					command: command.operation,
 					error: message,
 				});
 				reject(error);
@@ -550,7 +546,10 @@ export class SessionKernel {
 
   /** Admit compatibility work, then serialize its physical gateway effect. */
 	runExclusive<TResult>(
-		name: string,
+		name: Extract<
+			LegacyGatewayEffectOperation,
+			"session_file_updated" | "delete_session"
+		>,
 		operation: () => TResult | Promise<TResult>,
 	): Promise<TResult> {
 		this.assertWritable();
@@ -562,12 +561,11 @@ export class SessionKernel {
 		};
 		if (this.ownsCurrentCommand()) return ownedOperation();
 		if (state.actor) {
-			return this.dispatch(
-				{
+			return this.dispatchLegacy(
+				legacyGatewayEffect(name, {
 					requestId: crypto.randomUUID(),
-					type: `exclusive:${name}`,
 					source: "compatibility",
-				},
+				}),
 				operation,
 			).then((accepted) => accepted.result);
 		}
@@ -642,9 +640,9 @@ export class SessionKernel {
 		);
 	}
 
-	enqueueEffect(
-		kind: string,
-		payload: unknown,
+	enqueueEffect<K extends SessionActorEffectKind>(
+		kind: K,
+		payload: SessionActorEffectFor<K>["payload"],
 		effectKey: string = crypto.randomUUID(),
 	): number | undefined {
 		this.touch();
@@ -653,7 +651,7 @@ export class SessionKernel {
 			current?.sessionId === this.sessionId &&
 			this.activeCommandIds.has(current.requestId)
 		) {
-			current.effects.push({ kind, payload, effectKey });
+			current.effects.push({ kind, payload, effectKey } as StagedSessionActorEffect);
 			return undefined;
 		}
 		if (state.actor) {
@@ -663,7 +661,7 @@ export class SessionKernel {
 					const staged = commandContext.getStore();
           if (!staged)
             throw new Error("Session effect has no actor decision context");
-					staged.effects.push({ kind, payload, effectKey });
+					staged.effects.push({ kind, payload, effectKey } as StagedSessionActorEffect);
 				},
 				false,
 			);

--- a/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
@@ -1,0 +1,145 @@
+import type { AskActorRequest } from "./ask-protocol";
+import type { DeliveryActorRequest } from "./delivery-protocol";
+import type { RunEventDecision } from "./store";
+
+/**
+ * Temporary physical work that still executes as a gateway callback.
+ *
+ * Adding an operation is intentionally a protocol change. The ownership test
+ * also fixes the production call-site budget, so migration can only shrink
+ * this adapter unless a reviewer deliberately changes both fences.
+ */
+export const LEGACY_GATEWAY_EFFECT_OPERATIONS = Object.freeze([
+  "answer_question",
+  "cancel_session",
+  "create_session",
+  "delete_session",
+  "session_file_updated",
+  "submit_prompt",
+  "timer_fired",
+  "websocket_command",
+] as const);
+
+export const LEGACY_GATEWAY_EFFECT_SITE_BASELINE = 8;
+
+export type LegacyGatewayEffectOperation =
+  (typeof LEGACY_GATEWAY_EFFECT_OPERATIONS)[number];
+
+export type LegacyGatewayEffect<TPayload = unknown> = {
+  kind: "legacy_gateway_effect";
+  operation: LegacyGatewayEffectOperation;
+  commandId: string;
+  payload?: TPayload;
+  source?: string;
+  replaySafe?: boolean;
+  retryFailures?: boolean;
+};
+
+export type LegacyGatewayEffectInput<TPayload = unknown> = Omit<
+  LegacyGatewayEffect<TPayload>,
+  "kind" | "operation" | "commandId"
+> & { requestId: string };
+
+export function legacyGatewayEffect<TPayload = unknown>(
+  operation: LegacyGatewayEffectOperation,
+  input: LegacyGatewayEffectInput<TPayload>,
+): LegacyGatewayEffect<TPayload> {
+  const { requestId: commandId, ...effect } = input;
+  return { kind: "legacy_gateway_effect", operation, commandId, ...effect };
+}
+
+export type RunFence = {
+  runId: string;
+  generation: number;
+};
+
+export type SessionActorReducerCommand =
+  | {
+      kind: "run_event";
+      commandId: string;
+      decision: RunEventDecision;
+    }
+  | {
+      kind: "delivery";
+      commandId: string;
+      request: DeliveryActorRequest;
+    }
+  | {
+      kind: "ask";
+      commandId: string;
+      request: AskActorRequest;
+    };
+
+export type SessionActorCommand =
+  | SessionActorReducerCommand
+  | {
+      kind: "effect_result";
+      commandId: string;
+      result: SessionActorEffectResult;
+    }
+  | LegacyGatewayEffect;
+
+export type SessionActorEvent =
+  | { kind: "command_accepted"; commandId: string }
+  | { kind: "command_completed"; commandId: string }
+  | { kind: "command_failed"; commandId: string; error: string }
+  | { kind: "effect_emitted"; commandId: string; effectId: string }
+  | { kind: "effect_resulted"; commandId: string; effectId: string }
+  | {
+      kind: "stale_result_rejected";
+      commandId: string;
+      effectId: string;
+      actorEpoch: string;
+    };
+
+export type HumanAskDeliverEffect = {
+  kind: "human_ask_deliver";
+  payload: {
+    askId: string;
+    skipUi: boolean;
+  };
+};
+
+export type SessionActorEffect = HumanAskDeliverEffect;
+export type SessionActorEffectKind = SessionActorEffect["kind"];
+export type SessionActorEffectFor<K extends SessionActorEffectKind> = Extract<
+  SessionActorEffect,
+  { kind: K }
+>;
+export type StagedSessionActorEffect = {
+  [K in SessionActorEffectKind]: SessionActorEffectFor<K> & {
+    effectKey: string;
+  };
+}[SessionActorEffectKind];
+
+export type SessionActorEffectEnvelope<
+  TEffect extends SessionActorEffect = SessionActorEffect,
+> = TEffect & {
+  actorEpoch: string;
+  commandId: string;
+  effectId: string;
+  run?: RunFence;
+};
+
+export type SessionActorEffectResult = {
+  kind: "effect_result";
+  actorEpoch: string;
+  commandId: string;
+  effectId: string;
+  run?: RunFence;
+} & (
+  | { outcome: "succeeded" }
+  | { outcome: "failed"; error: string; retryable: boolean }
+  | { outcome: "indeterminate"; error: string }
+);
+
+export type SessionActorCommandResult<TResult = unknown> = {
+  kind: "command_result";
+  actorEpoch: string;
+  commandId: string;
+  run?: RunFence;
+} & (
+  | { outcome: "completed"; result: TResult }
+  | { outcome: "failed"; error: string; retryable: boolean }
+  | { outcome: "indeterminate"; error: string }
+);

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join, resolve } from "path";
+import {
+	LEGACY_GATEWAY_EFFECT_OPERATIONS,
+	LEGACY_GATEWAY_EFFECT_SITE_BASELINE,
+} from "./lifecycle-protocol";
 
 const serverDir = resolve(import.meta.dir, "..");
 const read = (relative: string) => readFileSync(join(serverDir, relative), "utf8");
@@ -16,6 +20,28 @@ function sourceFiles(dir: string): string[] {
 }
 
 describe("single session ownership", () => {
+	test("legacy gateway effects cannot grow without changing the migration fence", () => {
+		const production = sourceFiles(serverDir).filter(
+			(path) => !path.endsWith(".test.ts"),
+		);
+		const sites = production.reduce((count, path) => {
+			const source = readFileSync(path, "utf8");
+			return count + (source.match(/\.dispatchLegacy\(/g)?.length ?? 0);
+		}, 0);
+		expect(sites).toBe(LEGACY_GATEWAY_EFFECT_SITE_BASELINE);
+		expect(LEGACY_GATEWAY_EFFECT_OPERATIONS).toEqual([
+			"answer_question",
+			"cancel_session",
+			"create_session",
+			"delete_session",
+			"session_file_updated",
+			"submit_prompt",
+			"timer_fired",
+			"websocket_command",
+		]);
+		expect(read("session-kernel/kernel.ts")).not.toContain("async dispatch<");
+	});
+
 	test("run, queue, ask and session-file state delegate to SessionKernel", () => {
 		expect(read("run-state.ts")).toContain("sessionKernel(sessionId)");
 		expect(read("queue-state.ts")).toContain("new DeliveryOwnedMap");
@@ -38,8 +64,9 @@ describe("single session ownership", () => {
 		const facade = read("run-state.ts");
 		const actor = read("session-kernel/actor-worker.ts");
 		expect(facade).toContain(".applyRunEvent({");
-		expect(actor).toContain('request.t === "decide_run_event"');
-		expect(actor).toContain("store.applyRunEvent(request.decision)");
+		expect(actor).toContain('request.t === "reduce"');
+		expect(actor).toContain('command.kind === "run_event"');
+		expect(actor).toContain("store.applyRunEvent(command.decision)");
 		expect(read("session-kernel/run-state-machine.ts")).toContain(
 			"export function nextRunState",
 		);
@@ -59,8 +86,8 @@ describe("single session ownership", () => {
 
 	test("all shared prompt delivery uses the durable command mailbox", () => {
 		const control = read("session-control-wiring.ts");
-		expect(control).toContain('type: "submit_prompt"');
-		expect(control).toContain("sessionKernel(id).dispatch");
+		expect(control).toContain('legacyGatewayEffect("submit_prompt"');
+		expect(control).toContain("sessionKernel(id).dispatchLegacy");
 		expect(read("routes/sessions.ts")).not.toContain("promptReceipt(");
 		expect(existsSync(join(serverDir, "prompt-receipts.ts"))).toBe(false);
 		const steerEligibility = control.indexOf('opts?.busy !== "queue"');
@@ -115,7 +142,7 @@ describe("single session ownership", () => {
 	test("Slack ask delivery is a durable production outbox effect", () => {
 		const source = read("human-asks.ts");
 		expect(source).toContain(
-			'registerSessionEffectHandler("human_ask_deliver"',
+			'registerSessionEffectExecutor("human_ask_deliver"',
 		);
 		expect(source).toContain('"human_ask_deliver",');
 		expect(source.match(/deliverAsk\(/g)?.length).toBe(2);
@@ -123,11 +150,11 @@ describe("single session ownership", () => {
 
 	test("create and cancel retries keep stable ownership targets", () => {
 		const ws = read("ws-handlers.ts");
-		expect(ws).toContain('"create_session",');
+		expect(ws).toContain('legacyGatewayEffect("websocket_command"');
 		expect(ws).toContain("sessionIdForRequest");
 		expect(ws).toContain('typeof msg.sessionId === "string"');
 		const routes = read("routes/sessions.ts");
-		expect(routes).toContain('type: "create_session"');
+		expect(routes).toContain('legacyGatewayEffect("create_session"');
 		expect(routes).toContain("id: targetId");
 		expect(read("../../../protocol/src/session.ts")).toContain(
 			'type: "cancel"; sessionId?: string; requestId?: string',
@@ -157,8 +184,8 @@ describe("single session ownership", () => {
 		const create = read("session-create.ts");
 		expect(create).toContain("createPlan.resolved");
 		expect(create).toContain("spec.openingPromptEntryId");
-		expect(wiring).toContain('type: "cancel_session"');
-		expect(wiring).toContain('type: "answer_question"');
+		expect(wiring).toContain('legacyGatewayEffect("cancel_session"');
+		expect(wiring).toContain('legacyGatewayEffect("answer_question"');
 		const tools = read("../agents/slack/sessions-tools.ts");
 		expect(tools).toContain("durableToolRequestId");
 		expect(tools).toContain('durableToolRequestId(ctx, "create_session", extra)');

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -6,16 +6,18 @@ import {
 	sessionKernelStore,
 	maintainSessionKernel,
 } from "./kernel";
-import type { DurableOutboxItem, DurableTimer } from "./store";
+import type { DurableTimer } from "./store";
+import {
+	executeSessionEffect,
+	registeredSessionEffectKinds,
+} from "./effect-executors";
+import { legacyGatewayEffect } from "./lifecycle-protocol";
 import { pruneCreatePlans } from "../session-create-plan";
 import { audit } from "../audit";
 
 type TimerHandler = (timer: DurableTimer) => void | Promise<void>;
-type EffectHandler = (item: DurableOutboxItem) => void | Promise<void>;
-
 type RuntimeState = {
 	timerHandlers: Map<string, TimerHandler>;
-	effectHandlers: Map<string, EffectHandler>;
 	handle?: ReturnType<typeof setInterval>;
 	draining?: boolean;
 	lastCompactAt?: number;
@@ -28,7 +30,6 @@ const globalRuntime = globalThis as typeof globalThis & {
 };
 const runtime: RuntimeState = (globalRuntime.__opensessionSessionKernelRuntime ??= {
 	timerHandlers: new Map(),
-	effectHandlers: new Map(),
 });
 
 export function registerSessionTimerHandler(
@@ -42,24 +43,12 @@ export function registerSessionTimerHandler(
 	};
 }
 
-export function registerSessionEffectHandler(
-	kind: string,
-	handler: EffectHandler,
-): () => void {
-	runtime.effectHandlers.set(kind, handler);
-	return () => {
-		if (runtime.effectHandlers.get(kind) === handler)
-			runtime.effectHandlers.delete(kind);
-	};
-}
-
 export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 	const handler = runtime.timerHandlers.get(timer.kind);
 	if (!handler) return false;
-	await sessionKernel(timer.sessionId).dispatch(
-		{
+	await sessionKernel(timer.sessionId).dispatchLegacy(
+		legacyGatewayEffect("timer_fired", {
 			requestId: `timer:${timer.timerId}:${timer.token}`,
-			type: "timer_fired",
 			payload: {
 				timerId: timer.timerId,
 				kind: timer.kind,
@@ -67,9 +56,9 @@ export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 				payload: timer.payload,
 			},
 			source: "timer",
-				replaySafe: true,
-				retryFailures: true,
-		},
+			replaySafe: true,
+			retryFailures: true,
+		}),
 		() => handler(timer),
 	);
 	sessionKernelStore().settleTimerSuccess(timer.sessionId, timer.timerId, timer.token);
@@ -89,7 +78,7 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 	runtime.draining = true;
 	try {
 		const timerKinds = [...runtime.timerHandlers.keys()];
-		const effectKinds = [...runtime.effectHandlers.keys()];
+		const effectKinds = registeredSessionEffectKinds();
 		const work = await sessionKernelRuntimeWork(timerKinds, effectKinds);
 		const activeTimers = (runtime.activeTimers ??= new Set());
 		for (const timer of work.timers) {
@@ -122,13 +111,11 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 		for (const item of work.outbox) {
 			if (activeOutbox.size >= 8) break;
 			if (activeOutbox.has(item.id)) continue;
-			const handler = runtime.effectHandlers.get(item.kind);
-			if (!handler) continue;
 			activeOutbox.add(item.id);
-			void Promise.resolve()
-				.then(() => handler(item))
-				.then(() =>
-			sessionKernelStore().ackOutbox(item.id))
+			void executeSessionEffect(item)
+				.then((executed) => {
+					if (executed) sessionKernelStore().ackOutbox(item.id);
+				})
 				.catch((error) => {
 					const message =
 						error instanceof Error ? error.message : String(error);

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -58,6 +58,7 @@ import { join } from "node:path";
 import {
 	acknowledgeSessionCommand,
 	isRetryableSessionCommandError,
+	legacyGatewayEffect,
 	sessionKernel,
 } from "./session-kernel";
 
@@ -579,17 +580,17 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 			kernelDispatchTokens.add(kernelToken);
 				try {
 					const accepted =
-			await sessionKernel(commandSessionId).dispatch(
-				{
+			await sessionKernel(commandSessionId).dispatchLegacy(
+				legacyGatewayEffect("websocket_command", {
 					requestId,
-					type: msg.type,
 					payload: {
+						command: msg.type,
 						messageHash,
 						...(targetRunId !== undefined ? { targetRunId } : {}),
 					},
 					source: "websocket",
 					replaySafe: true,
-				},
+				}),
 				async () => {
 					if (
 						targetRunId !== undefined &&


### PR DESCRIPTION
## Summary
- route run, delivery, and ask reductions through one typed actor command union
- add typed command, event, effect, and fenced result contracts plus a typed executor registry
- replace the generic callback API with an explicit `LegacyGatewayEffect` bridge
- fence the bridge at eight production call sites and eight fixed operations so it can only shrink without an explicit architectural change
- migrate human ask delivery to validated typed effect execution

## Verification
- `bun run typecheck`
- 89 focused actor, kernel, ask, effect executor, and ownership tests
- `bun scripts/check-module-side-effects.ts` (386 modules)
- `git diff --check`

A local all-repository test run reached 3,749 passing tests but also hit 57 existing environment and baseline failures, including unavailable Lima simple-mode infrastructure, stateful config/report fixtures, prewarm timeouts, and the existing UI audit budget. The focused SessionKernel matrix passes cleanly.

Started by Complete durable session actor migration (goal) in [this OS session](https://os.tella.dev/session/os-01a02492-de18-749f-844a-68cbe5734c57)
