### PR TITLE
Fix compiled binary boot: load the session-kernel worker from an on-disk sidecar

### DIFF
--- a/docs/compiled-binary.md
+++ b/docs/compiled-binary.md
@@ -12,7 +12,8 @@ compiled in and run in-process. The `--source` install (a git checkout +
 
 ```bash
 # Release artefact (the default install downloads this): the target binary +
-# a sharp sidecar + the service templates + release.json, tarred.
+# a sharp sidecar + the session-kernel worker sidecar + the service templates
+# + release.json, tarred.
 bun scripts/build-compile.ts --os linux --arch arm64 --out ~/.cache/opensession-release
 
 # Just the host binary, for local testing (no sidecar).
@@ -70,6 +71,16 @@ returns `501` (the Open Graph meta tags still emit). To enable social cards,
 place a minimal `node_modules` with `sharp` + the platform `@img/sharp-*`
 beside the binary — e.g. copy `node_modules/sharp` and
 `node_modules/@img/sharp-<platform>` (+ its `sharp-libvips-<platform>`).
+
+**External: the session-kernel worker.** The kernel actor runs in a real Worker
+thread. The gateway blocks on `Atomics.wait` against a `SharedArrayBuffer` the
+worker fills, so it cannot run in-process or as a subprocess, and `bun build
+--compile` does not embed Worker entry points. The worker therefore ships as a
+`session-kernel-worker.js` sidecar beside the binary;
+`src/server/session-kernel/actor-runtime.ts` loads it from `process.execPath`'s
+directory in compiled mode, and from the TypeScript entry in a source checkout.
+Unlike sharp it is not lazy: the kernel is authoritative and starts before the
+gateway hydrates session state, so a missing sidecar fails boot, not one feature.
 
 **External: the `claude` CLI.** The Anthropic bridge is the Claude Agent SDK
 running in-process (`src/server/anthropic-bridge.ts`), and the SDK shells out

--- a/packages/core/opensession-server/src/server/session-kernel/actor-runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-runtime.ts
@@ -1,6 +1,8 @@
 import { SessionKernelActorClient } from "./actor-client";
 import { installSessionKernelActor } from "./kernel";
 import { setServiceReadiness } from "../service-readiness";
+import { dirname, join } from "node:path";
+import { isCompiledBinary } from "../../runner-host/exe";
 
 type ActorRuntimeState = {
   client?: SessionKernelActorClient;
@@ -11,17 +13,27 @@ const globalActor = globalThis as typeof globalThis & {
 };
 const runtime = (globalActor.__opensessionSessionKernelActor ??= {});
 
+/**
+ * The kernel runs in a real Worker thread: the client blocks on Atomics.wait
+ * against a SharedArrayBuffer the worker fills, so neither an in-process port
+ * nor a subprocess can stand in for it. `bun build --compile` does not embed
+ * Worker entry points, so a compiled binary loads the worker from a sibling
+ * `session-kernel-worker.js` shipped beside the executable (scripts/build-
+ * compile.ts stages it next to the sharp sidecar). A source checkout runs the
+ * TypeScript entry directly.
+ */
+function sessionKernelWorkerUrl(): string {
+  return isCompiledBinary()
+    ? join(dirname(process.execPath), "session-kernel-worker.js")
+    : new URL("../../session-kernel-worker.ts", import.meta.url).href;
+}
+
 /** Start the authoritative actor before the gateway hydrates mutable session state. */
 export function startSessionKernelActor(): Promise<void> {
   if (runtime.client) return Promise.resolve();
   if (runtime.starting) return runtime.starting;
   runtime.starting = (async () => {
-    const worker = new Worker(
-      new URL("../../session-kernel-worker.ts", import.meta.url).href,
-      {
-        type: "module",
-      },
-    );
+    const worker = new Worker(sessionKernelWorkerUrl(), { type: "module" });
     const client = new SessionKernelActorClient(worker, (error) => {
       setServiceReadiness("failed", error);
       console.error("[session-kernel] authoritative actor failed; stopping gateway:", error);

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -213,6 +213,26 @@ async function buildSharpSidecar(stage: string, sharpVersion: string): Promise<v
 }
 
 
+/**
+ * Ship the session-kernel Worker as an on-disk `.js` sidecar. `bun build
+ * --compile` does not embed Worker entry points, so a compiled binary loads
+ * this file from beside the executable (actor-runtime.ts resolves it via
+ * process.execPath). Plain bundled JS the embedded Bun runs, so it is platform-
+ * neutral and needs no cross-target flag.
+ */
+async function buildWorkerSidecar(destDir: string): Promise<void> {
+	const entry = join(REPO_ROOT, "packages", "core", "opensession-server", "src", "session-kernel-worker.ts");
+	const out = join(destDir, "session-kernel-worker.js");
+	mkdirSync(destDir, { recursive: true });
+	const proc = Bun.spawn(["bun", "build", "--target=bun", entry, "--outfile", out], {
+		cwd: REPO_ROOT,
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	if ((await proc.exited) !== 0) throw new Error("session-kernel worker sidecar build failed");
+	console.log(`[compile] session-kernel worker sidecar: ${(statSync(out).size / 1e3).toFixed(0)} KB`);
+}
+
 async function main(): Promise<void> {
 	const { version: fver, distDir, metaPath, shellPath } = await buildFrontendDist();
 
@@ -221,6 +241,7 @@ async function main(): Promise<void> {
 	if (bareOut && !has("out") && !has("os") && !has("arch")) {
 		const outfile = resolve(bareOut);
 		await compileBinary(outfile, fver, distDir, metaPath, shellPath);
+		await buildWorkerSidecar(dirname(outfile));
 		const mb = (statSync(outfile).size / 1e6).toFixed(1);
 		console.log(`\n[compile] built ${outfile} (${mb} MB, v=${fver})`);
 		return;
@@ -257,6 +278,8 @@ async function main(): Promise<void> {
 		cpSync(source, destination);
 		chmodSync(destination, statSync(source).mode & 0o777);
 	}
+	console.log("\n== session-kernel worker sidecar");
+	await buildWorkerSidecar(stage);
 	console.log("\n== sharp sidecar");
 	await buildSharpSidecar(stage, sharpVersion);
 


### PR DESCRIPTION
## Problem

Every compiled single-executable release is dead on arrival. The server fails to boot with:

    Session kernel actor failed: BuildMessage: ModuleNotFound resolving "/session-kernel-worker.ts" (entry point)

The session kernel is the authoritative owner of session state and starts before the gateway hydrates, so when it can't load the whole server refuses to boot. This affects the v0.4.3/v0.4.4/v0.4.5 artefacts.

## Root cause

The kernel runs in a Worker thread, and the gateway reads its store synchronously by blocking on `Atomics.wait` against a `SharedArrayBuffer` the worker fills. That transport requires a real second thread: it cannot run in-process (Atomics.wait deadlocks a single thread) or as a subprocess (SharedArrayBuffer is not shared across processes).

`bun build --compile` (Bun 1.3.13) does not embed Worker entry points, so `new Worker(new URL("session-kernel-worker.ts", import.meta.url))` resolved at runtime to a bunfs path that was never bundled. Confirmed in isolation: the canonical `new Worker(new URL(...))` pattern works under `bun run` but fails identically under `--compile`, and `new Worker(process.execPath)` tries to parse the binary as source.

## Fix

Ship the worker as a `session-kernel-worker.js` sidecar beside the binary (the same shape as the sharp sidecar) and load it from `process.execPath`'s directory in compiled mode. A source checkout still runs the TypeScript entry, so the Worker stays a real thread and the SharedArrayBuffer transport is unchanged.

- `build-compile.ts` bundles `session-kernel-worker.ts` (`bun build --target=bun`, 72 KB) into the release next to the sharp sidecar, and beside the outfile in `--outfile` mode.
- `actor-runtime.ts` resolves the worker URL: `join(dirname(process.execPath), "session-kernel-worker.js")` when compiled, the `.ts` URL from source.

## Verification

Built the full darwin-arm64 artefact from this branch and installed it through the health-gated update: boots healthy, no rollback. Booting past the health gate means the kernel `hello()` handshake over the Worker + SharedArrayBuffer succeeded, so the actor is genuinely alive. Typecheck clean.

## Known follow-up (not in this PR)

`workflow-worker.ts` and `code-flow-worker.ts` use the same non-embeddable `new Worker(new URL(...))` pattern, so they will fail the same way in a compiled binary when their features run. They are lazy rather than boot-critical, so they do not block the release, but they need the same sidecar treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)