### PR TITLE
Ship every Worker as an on-disk sidecar for compiled builds

### DIFF
--- a/packages/core/opensession-server/src/runner-host/exe.ts
+++ b/packages/core/opensession-server/src/runner-host/exe.ts
@@ -60,3 +60,16 @@ export function transcriptSearchWorkerArgv(bun: string, entry: string): string[]
 		? [process.execPath, "transcript-search-worker"]
 		: [bun, entry];
 }
+
+/**
+ * Resolve a Web Worker entry that survives `bun build --compile`, which does not
+ * embed Worker entry points: at runtime `new Worker(new URL("./w.ts",
+ * import.meta.url))` resolves to a bunfs path that was never bundled and fails
+ * with ModuleNotFound. A compiled binary loads the worker from a sibling
+ * `<name>.js` staged beside the executable (scripts/build-compile.ts, next to
+ * the sharp sidecar); a source checkout runs the TypeScript entry at `sourceUrl`.
+ * Keep the sidecar names in sync with build-compile's WORKER_SIDECARS list.
+ */
+export function workerEntry(sidecarName: string, sourceUrl: string | URL): string | URL {
+	return isCompiledBinary() ? join(dirname(process.execPath), sidecarName) : sourceUrl;
+}

--- a/packages/core/opensession-server/src/server/code-flow.ts
+++ b/packages/core/opensession-server/src/server/code-flow.ts
@@ -5,10 +5,10 @@
  * host worktrees, remote sandboxes, GitHub and code.storage stay consistent.
  */
 import { createHash, randomUUID } from "node:crypto";
-import { constants, existsSync } from "node:fs";
+import { workerEntry } from "../runner-host/exe";
+import { constants } from "node:fs";
 import { open, readlink, realpath, stat as fileStat } from "node:fs/promises";
 import { resolve, sep } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { UnifiedSession } from "./types";
 import type { Repo } from "./config";
 import { getSessionDiff, parsePatchFiles, type DiffFile } from "./git-diff";
@@ -98,11 +98,8 @@ function resetAnalysisWorker() {
 	analysisWorker = null;
 }
 
-function analysisWorkerUrl(): string {
-	const bundled = new URL("./code-flow-worker.js", import.meta.url);
-	return existsSync(fileURLToPath(bundled))
-		? bundled.href
-		: new URL("./code-flow-worker.ts", import.meta.url).href;
+function analysisWorkerUrl(): string | URL {
+	return workerEntry("code-flow-worker.js", new URL("./code-flow-worker.ts", import.meta.url).href);
 }
 
 function analyzeInWorker(input: CodeFlowAnalysisInput): Promise<CodeFlowResult> {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-runtime.ts
@@ -1,8 +1,7 @@
 import { SessionKernelActorClient } from "./actor-client";
 import { installSessionKernelActor } from "./kernel";
 import { setServiceReadiness } from "../service-readiness";
-import { dirname, join } from "node:path";
-import { isCompiledBinary } from "../../runner-host/exe";
+import { workerEntry } from "../../runner-host/exe";
 
 type ActorRuntimeState = {
   client?: SessionKernelActorClient;
@@ -22,10 +21,8 @@ const runtime = (globalActor.__opensessionSessionKernelActor ??= {});
  * compile.ts stages it next to the sharp sidecar). A source checkout runs the
  * TypeScript entry directly.
  */
-function sessionKernelWorkerUrl(): string {
-  return isCompiledBinary()
-    ? join(dirname(process.execPath), "session-kernel-worker.js")
-    : new URL("../../session-kernel-worker.ts", import.meta.url).href;
+function sessionKernelWorkerUrl(): string | URL {
+  return workerEntry("session-kernel-worker.js", new URL("../../session-kernel-worker.ts", import.meta.url).href);
 }
 
 /** Start the authoritative actor before the gateway hydrates mutable session state. */

--- a/packages/core/opensession-server/src/server/workflow-runner.ts
+++ b/packages/core/opensession-server/src/server/workflow-runner.ts
@@ -25,6 +25,7 @@
  */
 
 import { randomUUIDv7 } from "bun";
+import { workerEntry } from "../runner-host/exe";
 import {
 	appendWorkflowJournal,
 	cancelLiveWorkflow,
@@ -1217,7 +1218,7 @@ function runWorkflow(
 		// Minimal env (belt) on top of the worker-side scrub (braces) — a Bun
 		// Worker is a same-process thread and would otherwise inherit the
 		// server's full secret-bearing process.env.
-		worker = new Worker(new URL("./workflow-worker.ts", import.meta.url).href, {
+		worker = new Worker(workerEntry("workflow-worker.js", new URL("./workflow-worker.ts", import.meta.url).href), {
 			env: { WORKFLOW_WORKER: "1" },
 		} as WorkerOptions);
 		worker.addEventListener("message", (event) => {

--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -220,17 +220,30 @@ async function buildSharpSidecar(stage: string, sharpVersion: string): Promise<v
  * process.execPath). Plain bundled JS the embedded Bun runs, so it is platform-
  * neutral and needs no cross-target flag.
  */
-async function buildWorkerSidecar(destDir: string): Promise<void> {
-	const entry = join(REPO_ROOT, "packages", "core", "opensession-server", "src", "session-kernel-worker.ts");
-	const out = join(destDir, "session-kernel-worker.js");
+/**
+ * Web Workers do not embed into `bun build --compile` binaries, so each worker
+ * ships as an on-disk `.js` sidecar beside the executable and is resolved from
+ * process.execPath's dir at runtime (workerEntry in runner-host/exe.ts). Keep
+ * this list in sync with those workerEntry sidecar names.
+ */
+const WORKER_SIDECARS: Array<{ entry: string; name: string }> = [
+	{ entry: "packages/core/opensession-server/src/session-kernel-worker.ts", name: "session-kernel-worker.js" },
+	{ entry: "packages/core/opensession-server/src/server/workflow-worker.ts", name: "workflow-worker.js" },
+	{ entry: "packages/core/opensession-server/src/server/code-flow-worker.ts", name: "code-flow-worker.js" },
+];
+
+async function buildWorkerSidecars(destDir: string): Promise<void> {
 	mkdirSync(destDir, { recursive: true });
-	const proc = Bun.spawn(["bun", "build", "--target=bun", entry, "--outfile", out], {
-		cwd: REPO_ROOT,
-		stdout: "inherit",
-		stderr: "inherit",
-	});
-	if ((await proc.exited) !== 0) throw new Error("session-kernel worker sidecar build failed");
-	console.log(`[compile] session-kernel worker sidecar: ${(statSync(out).size / 1e3).toFixed(0)} KB`);
+	for (const { entry, name } of WORKER_SIDECARS) {
+		const out = join(destDir, name);
+		const proc = Bun.spawn(["bun", "build", "--target=bun", join(REPO_ROOT, entry), "--outfile", out], {
+			cwd: REPO_ROOT,
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+		if ((await proc.exited) !== 0) throw new Error(`${name} sidecar build failed`);
+		console.log(`[compile] ${name} sidecar: ${(statSync(out).size / 1e3).toFixed(0)} KB`);
+	}
 }
 
 async function main(): Promise<void> {
@@ -241,7 +254,7 @@ async function main(): Promise<void> {
 	if (bareOut && !has("out") && !has("os") && !has("arch")) {
 		const outfile = resolve(bareOut);
 		await compileBinary(outfile, fver, distDir, metaPath, shellPath);
-		await buildWorkerSidecar(dirname(outfile));
+		await buildWorkerSidecars(dirname(outfile));
 		const mb = (statSync(outfile).size / 1e6).toFixed(1);
 		console.log(`\n[compile] built ${outfile} (${mb} MB, v=${fver})`);
 		return;
@@ -278,8 +291,8 @@ async function main(): Promise<void> {
 		cpSync(source, destination);
 		chmodSync(destination, statSync(source).mode & 0o777);
 	}
-	console.log("\n== session-kernel worker sidecar");
-	await buildWorkerSidecar(stage);
+	console.log("\n== worker sidecars");
+	await buildWorkerSidecars(stage);
 	console.log("\n== sharp sidecar");
 	await buildSharpSidecar(stage, sharpVersion);
 


### PR DESCRIPTION
Follow-up to #125 (session-kernel sidecar). That fix covered one of three Workers; this covers the other two.

## Problem

`workflow-worker.ts` and `code-flow-worker.ts` use the same `new Worker(new URL("./x.ts", import.meta.url))` pattern that `bun build --compile` cannot embed. In a compiled binary they resolve to an unbundled bunfs path and throw `ModuleNotFound` the moment their feature runs — a Workflow tool call, or a code-flow diff analysis. They are lazy (not boot-critical like the kernel), so a compiled release boots fine and then dies on first use of either feature.

Verified empirically by spawning each worker's exact expression in a compiled binary:

```
workflow-worker:  FAIL -> ModuleNotFound resolving "/$bunfs/root/workflow-worker.ts"
code-flow-worker: FAIL -> ModuleNotFound resolving "/$bunfs/root/code-flow-worker.ts"
```

`code-flow.ts`'s `analysisWorkerUrl()` already *tried* a `.js` fallback, but checked `new URL("./code-flow-worker.js", import.meta.url)` — a bunfs path that is always empty — so it fell through to the `.ts` and failed anyway.

## Fix

Factor the compiled/source resolution into a shared `workerEntry(sidecarName, sourceUrl)` helper in `runner-host/exe.ts` and route all three Worker spawns through it (session-kernel included, replacing its inline version from #125). `build-compile.ts` stages all three `.js` sidecars beside the binary from one `WORKER_SIDECARS` list. Compiled mode resolves each from `process.execPath`'s dir; a source checkout runs the TypeScript entry.

Neither lazy worker uses `SharedArrayBuffer`/`Atomics` (unlike the kernel), so a separate thread is not strictly required, but the sidecar keeps all three consistent.

## Verification

- Built with all three sidecars staged; a probe spawning `workflow-worker.js` and `code-flow-worker.js` from beside a compiled binary now loads both with no ModuleNotFound (was the failure above).
- Full darwin-arm64 artefact built and installed through the health-gated update: boots healthy, no rollback (confirms routing session-kernel through the shared helper did not regress boot).
- Typecheck clean; `check-module-side-effects` passes (390 modules, no import-time effects from the new imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)