### PR TITLE
Configure Slack event delivery in setup

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/IntegrationSetupDialog.tsx
+++ b/packages/core/opensession-server/src/frontend/components/IntegrationSetupDialog.tsx
@@ -4,9 +4,16 @@ import { Disclosure } from "../ui/disclosure";
 import { Modal } from "../ui/modal";
 import { SettingsSection } from "../ui/settings";
 import { InlineAlert } from "../ui/state";
+import { Segmented, SegmentedOption } from "../ui/segmented";
 import { Switch } from "../ui/switch";
 import { toast } from "../ui/toast";
 import { WEBHOOK_BASE_URL } from "../lib/brand";
+import {
+	publicWebhookAvailable,
+	savedSlackTransport,
+	slackCredentialRequired,
+	type SlackTransport,
+} from "../lib/slack-setup";
 import { IconTile } from "./BrandTile";
 import {
 	Code,
@@ -53,7 +60,11 @@ function endpoint(publicBaseUrl: string, path: string): string {
 	return `${publicBaseUrl.replace(/\/$/, "")}${path}`;
 }
 
-function guideFor(integration: SetupIntegration, publicBaseUrl: string): Guide {
+function guideFor(
+	integration: SetupIntegration,
+	publicBaseUrl: string,
+	transport: SlackTransport,
+): Guide {
 	const url = (path: string) => endpoint(publicBaseUrl, path);
 
 	switch (integration.id) {
@@ -97,26 +108,38 @@ function guideFor(integration: SetupIntegration, publicBaseUrl: string): Guide {
 				],
 			};
 
-		case "slack":
+		case "slack": {
+			const socket = transport === "socket";
+			const transportSteps: ReactNode[] = socket
+				? [
+						<>Turn on Socket Mode in your Slack app.</>,
+						<>Create an app-level token with the <strong>connections:write</strong> scope under Basic Information. It starts with <code>xapp-</code>.</>,
+						<>Under Event Subscriptions, subscribe to <strong>message.im</strong>, <strong>app_mention</strong>, and <strong>message</strong>. Enable Interactivity too. Socket Mode needs no request URLs.</>,
+						<>Paste the bot token and app-level token into the fields above.</>,
+					]
+				: [
+						<>
+							Under Event Subscriptions, subscribe to <strong>message.im</strong>, <strong>app_mention</strong>, and <strong>message</strong>. Set the request URL to:
+							<Value value={url("/slack/events")} />
+						</>,
+						<>
+							Enable Interactivity and set its request URL to:
+							<Value value={url("/slack/actions")} />
+						</>,
+						<>Paste the bot token and signing secret into the fields above.</>,
+					];
 			return {
 				description: "Create a Slack bot for DMs, mentions, session channels, and interactive controls.",
 				steps: [
 					<>Create a Slack app, add the bot scopes below, and install it to your workspace.</>,
-					<>
-						Under Event Subscriptions, subscribe to <strong>message.im</strong>, <strong>app_mention</strong>, and <strong>message</strong>. Set the request URL to:
-						<Value value={url("/slack/events")} />
-					</>,
-					<>
-						Enable Interactivity and set its request URL to:
-						<Value value={url("/slack/actions")} />
-					</>,
-					<>Paste the bot token and signing secret into the fields above. Set an allowed Slack user id so admin tools are not open to every workspace member.</>,
+					...transportSteps,
+					<>Set an allowed Slack user id so admin tools are not open to every workspace member.</>,
 					<>Enable Slack, save, restart Open Session, and invite the bot to every existing channel it should read.</>,
 				],
 				scopes: [
 					{
 						label: "Writing",
-						items: ["chat:write", "chat:write.customize", "reactions:write", "assistant:write"],
+						items: ["chat:write", "chat:write.customize", "files:write", "reactions:write", "assistant:write"],
 					},
 					{
 						label: "History",
@@ -136,8 +159,9 @@ function guideFor(integration: SetupIntegration, publicBaseUrl: string): Guide {
 						],
 					},
 				],
-				scopesNote: <>No file scopes are needed.</>,
+				scopesNote: socket ? <>The app-level token only needs <strong>connections:write</strong>.</> : undefined,
 			};
+		}
 
 		case "stripe":
 			return {
@@ -232,16 +256,42 @@ export function IntegrationSetupDialog({
 	onOpenChange: (open: boolean) => void;
 	onSaved: (updated: SetupIntegration, restartRequired: boolean) => void;
 }) {
-	const guide = guideFor(integration, WEBHOOK_BASE_URL);
 	const [enabled, setEnabled] = useState(integration.enabled);
 	const [typed, setTyped] = useState<Record<string, string>>({});
 	const [cleared, setCleared] = useState<Record<string, boolean>>({});
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [transport, setTransport] = useState<SlackTransport>(() =>
+		savedSlackTransport(integration.env),
+	);
+	const guide = guideFor(integration, WEBHOOK_BASE_URL, transport);
+	const httpAvailable = publicWebhookAvailable(WEBHOOK_BASE_URL);
 
+	// Cancel discards a transport change just like it discards typed credentials.
 	useEffect(() => {
+		if (!open) return;
 		setEnabled(integration.enabled);
-	}, [integration.enabled]);
+		setTyped({});
+		setCleared({});
+		setError(null);
+		setTransport(savedSlackTransport(integration.env));
+	}, [open, integration]);
+
+	function pickTransport(next: SlackTransport) {
+		setTransport(next);
+		setTyped((current) => ({ ...current, SLACK_APP_TOKEN: "" }));
+		setCleared((current) => ({ ...current, SLACK_APP_TOKEN: next === "http" }));
+	}
+
+	const hiddenEnvKey =
+		integration.id === "slack"
+			? transport === "socket"
+				? "SLACK_SIGNING_SECRET"
+				: "SLACK_APP_TOKEN"
+			: null;
+	const visibleEnv = hiddenEnvKey
+		? integration.env.filter((envVar) => envVar.name !== hiddenEnvKey)
+		: integration.env;
 
 	const typedKeys = integration.env
 		.map((envVar) => envVar.name)
@@ -324,7 +374,39 @@ export function IntegrationSetupDialog({
 								/>
 							</div>
 						)}
-						{integration.env.length > 0 && (
+						{integration.id === "slack" && (
+							<div className={canToggle ? "mt-4 border-t border-line pt-4" : undefined}>
+								<div className="flex flex-wrap items-center gap-4">
+									<div className="min-w-[12rem] flex-1">
+										<div className="text-item-title font-medium text-fg">Event delivery</div>
+										<div className="mt-0.5 text-supporting text-dim">
+											{transport === "socket"
+												? "Uses an outbound connection and needs no public webhook URL."
+												: "Slack posts events to this instance's public webhook URL."}
+										</div>
+									</div>
+									<Segmented
+										label="Slack event delivery"
+										value={transport}
+										onValueChange={(next) => pickTransport(next as SlackTransport)}
+										className="ml-auto phone:ml-0 phone:w-full"
+									>
+										<SegmentedOption value="socket" disabled={saving} className="phone:min-h-11 phone:flex-1">
+											Socket Mode
+										</SegmentedOption>
+										<SegmentedOption value="http" disabled={saving || !httpAvailable} className="phone:min-h-11 phone:flex-1">
+											HTTP
+										</SegmentedOption>
+									</Segmented>
+								</div>
+								{transport === "http" && !httpAvailable && (
+									<InlineAlert variant="warn" className="mt-3">
+										This instance has no public webhook URL. Choose Socket Mode or configure a public URL first.
+									</InlineAlert>
+								)}
+							</div>
+						)}
+						{visibleEnv.length > 0 && (
 							<div
 								className={
 									canToggle
@@ -332,14 +414,18 @@ export function IntegrationSetupDialog({
 										: "flex flex-col gap-4"
 								}
 							>
-								{integration.env.map((envVar) => (
+								{visibleEnv.map((envVar) => (
 									<SecretField
 										key={envVar.name}
 										name={envVar.name}
 										label={<Code>{envVar.name}</Code>}
 										description={envVar.description}
 										present={envVar.present}
-										required={envVar.required}
+										required={
+											integration.id === "slack"
+												? slackCredentialRequired(envVar.name, envVar.required, transport)
+												: envVar.required
+										}
 										disabled={saving}
 										cleared={Boolean(
 											envVar.present &&

--- a/packages/core/opensession-server/src/frontend/lib/slack-setup.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-setup.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+	publicWebhookAvailable,
+	savedSlackTransport,
+	slackCredentialRequired,
+} from "./slack-setup";
+
+describe("savedSlackTransport", () => {
+	test("preserves configured Socket Mode and HTTP installs", () => {
+		expect(
+			savedSlackTransport([{ name: "SLACK_APP_TOKEN", present: true }]),
+		).toBe("socket");
+		expect(
+			savedSlackTransport([{ name: "SLACK_SIGNING_SECRET", present: true }]),
+		).toBe("http");
+	});
+
+	test("prefers Socket Mode for a new install", () => {
+		expect(savedSlackTransport([])).toBe("socket");
+	});
+});
+
+describe("publicWebhookAvailable", () => {
+	test("rejects simple-mode and loopback URLs", () => {
+		for (const url of [
+			"http://127.0.0.1:3850",
+			"http://localhost:3850",
+			"http://[::1]:3850",
+			"http://0.0.0.0:3848",
+			"not a url",
+		]) {
+			expect(publicWebhookAvailable(url)).toBe(false);
+		}
+	});
+
+	test("accepts an internet-facing webhook URL", () => {
+		expect(publicWebhookAvailable("https://hooks.example.com")).toBe(true);
+	});
+});
+
+describe("slackCredentialRequired", () => {
+	test("follows the transport currently selected in the UI", () => {
+		expect(slackCredentialRequired("SLACK_APP_TOKEN", false, "socket")).toBe(
+			true,
+		);
+		expect(
+			slackCredentialRequired("SLACK_SIGNING_SECRET", false, "socket"),
+		).toBe(false);
+		expect(slackCredentialRequired("SLACK_APP_TOKEN", false, "http")).toBe(
+			false,
+		);
+		expect(slackCredentialRequired("SLACK_SIGNING_SECRET", false, "http")).toBe(
+			true,
+		);
+	});
+
+	test("keeps unconditional requirements", () => {
+		expect(slackCredentialRequired("SLACK_BOT_TOKEN", true, "socket")).toBe(
+			true,
+		);
+		expect(slackCredentialRequired("SLACK_BOT_TOKEN", true, "http")).toBe(true);
+	});
+});

--- a/packages/core/opensession-server/src/frontend/lib/slack-setup.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-setup.ts
@@ -1,0 +1,46 @@
+/** Slack event delivery as presented in setup. The server selects Socket Mode
+ * when SLACK_APP_TOKEN is present and falls back to HTTP otherwise. */
+export type SlackTransport = "socket" | "http";
+
+type EnvPresence = { name: string; present: boolean };
+
+/** Preserve an existing transport. Prefer Socket Mode for a new setup because
+ * it works on an instance with no public ingress. */
+export function savedSlackTransport(
+	env: readonly EnvPresence[],
+): SlackTransport {
+	const present = (name: string) =>
+		env.some((item) => item.name === name && item.present);
+	if (present("SLACK_APP_TOKEN")) return "socket";
+	return present("SLACK_SIGNING_SECRET") ? "http" : "socket";
+}
+
+/** Whether Slack can POST to the configured webhook URL. Fresh and simple-mode
+ * installs resolve to loopback, which only Socket Mode can use. */
+export function publicWebhookAvailable(baseUrl: string): boolean {
+	try {
+		const host = new URL(baseUrl).hostname;
+		return ![
+			"127.0.0.1",
+			"localhost",
+			"::1",
+			"[::1]",
+			"0.0.0.0",
+			"[::]",
+		].includes(host);
+	} catch {
+		return false;
+	}
+}
+
+/** Resolve transport-specific requirements from the choice currently shown in
+ * the UI, rather than the saved transport represented by the API snapshot. */
+export function slackCredentialRequired(
+	name: string,
+	required: boolean,
+	transport: SlackTransport,
+): boolean {
+	if (name === "SLACK_APP_TOKEN") return transport === "socket";
+	if (name === "SLACK_SIGNING_SECRET") return transport === "http";
+	return required;
+}

--- a/packages/core/opensession-server/src/server/integrations/load.test.ts
+++ b/packages/core/opensession-server/src/server/integrations/load.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { activeIntegrations, isEnabled } from "./load";
-import { findIntegration, INTEGRATIONS } from "./registry";
+import { envRequired, findIntegration, INTEGRATIONS } from "./registry";
 
 const FLAGS = INTEGRATIONS.map((i) => i.enableFlag);
 const saved = new Map(FLAGS.map((f) => [f, process.env[f]]));
@@ -89,5 +89,24 @@ describe("activeIntegrations", () => {
     process.env.ENABLE_GITHUB_AGENT = "true";
     process.env.ENABLE_PLAIN_AGENT = "true";
     expect(activeIntegrations().map((i) => i.id)).toEqual(["plain", "github"]);
+  });
+});
+
+describe("envRequired", () => {
+  const slack = findIntegration("slack")!;
+  const signingSecret = slack.env.find((e) => e.name === "SLACK_SIGNING_SECRET")!;
+  const botToken = slack.env.find((e) => e.name === "SLACK_BOT_TOKEN")!;
+
+  test("Socket Mode does not require the HTTP signing secret", () => {
+    expect(envRequired(signingSecret, (name) => name === "SLACK_APP_TOKEN")).toBe(false);
+  });
+
+  test("the HTTP transport requires its signing secret", () => {
+    expect(envRequired(signingSecret, () => false)).toBe(true);
+  });
+
+  test("unconditional credentials stay required", () => {
+    expect(envRequired(botToken, () => true)).toBe(true);
+    expect(envRequired(botToken, () => false)).toBe(true);
   });
 });

--- a/packages/core/opensession-server/src/server/integrations/registry.ts
+++ b/packages/core/opensession-server/src/server/integrations/registry.ts
@@ -40,8 +40,18 @@ export type IntegrationEnv = {
   example?: string;
   /** Without this the integration cannot function at all. */
   required?: boolean;
+  /** Required only when another credential is absent. */
+  requiredWhen?: (present: (name: string) => boolean) => boolean;
   description: string;
 };
+
+/** Resolve conditional and unconditional credential requirements consistently. */
+export function envRequired(
+  env: IntegrationEnv,
+  present: (name: string) => boolean,
+): boolean {
+  return env.requiredWhen ? env.requiredWhen(present) : !!env.required;
+}
 
 export type IntegrationLink = {
   label: string;
@@ -121,13 +131,12 @@ export const INTEGRATIONS: IntegrationSpec[] = [
       {
         name: "SLACK_APP_TOKEN",
         example: "xapp-",
-        description:
-          "app-level token with connections:write. When set, the agent runs Socket Mode (outbound WebSocket, no public URL or signing secret) instead of the HTTP event routes",
+        description: "app-level token with connections:write for Socket Mode",
       },
       {
         name: "SLACK_SIGNING_SECRET",
-        description:
-          "verifies inbound event signatures for the HTTP transport; required unless SLACK_APP_TOKEN enables Socket Mode, where it is unused",
+        requiredWhen: (present) => !present("SLACK_APP_TOKEN"),
+        description: "signing secret for HTTP event requests",
       },
       { name: "ALLOWED_SLACK_USER_ID", description: "restricts admin tools to one user" },
       { name: "WORKTREE_HOOK_SECRET", description: "shared secret for worktree hooks" },

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -22,7 +22,7 @@
  */
 
 import { audit } from "../audit";
-import type { IntegrationSpec } from "../integrations/registry";
+import { envRequired, type IntegrationSpec } from "../integrations/registry";
 import { requireWorkspaceAdmin } from "../workspace-auth";
 import type { RouteContext } from "./context";
 import { handleSetupCodestorageRoutes } from "./setup-codestorage";
@@ -44,7 +44,7 @@ async function integrationSnapshot(
       : !!process.env[name];
   const env = spec.env.map((e) => ({
     name: e.name,
-    required: !!e.required,
+    required: envRequired(e, present),
     description: e.description,
     present: present(e.name),
   }));

--- a/scripts/lib/doctor.ts
+++ b/scripts/lib/doctor.ts
@@ -15,7 +15,10 @@ import { existsSync, statSync } from "fs";
 import { tailnetIp } from "./config-edit";
 import { CONFIG_PATH, ENV_PATH, REPO_ROOT } from "./paths";
 import { isCompiledBinary } from "../../packages/core/opensession-server/src/runner-host/exe";
-import { INTEGRATIONS } from "../../packages/core/opensession-server/src/server/integrations/registry";
+import {
+  envRequired,
+  INTEGRATIONS,
+} from "../../packages/core/opensession-server/src/server/integrations/registry";
 import * as service from "./service";
 import { dim, fail, heading, info, ok, run, warn } from "./ui";
 
@@ -170,7 +173,9 @@ async function checkIntegrations(t: Tally, config?: Record<string, unknown>): Pr
     if (!enabled(spec)) continue;
     anyEnabled = true;
 
-    const missing = spec.env.filter((e) => e.required && !value(e.name));
+    const missing = spec.env.filter(
+      (e) => envRequired(e, (name) => !!value(name)) && !value(e.name),
+    );
     if (missing.length) {
       fail(
         `${spec.label} is enabled but missing ${missing.map((m) => m.name).join(", ")}`,


### PR DESCRIPTION
## Summary

- add a Socket Mode or HTTP choice to Slack setup, with Socket Mode preferred for new installs
- disable HTTP when the instance has no public webhook URL and show only the credentials required by the selected transport
- keep setup status and `opensession doctor` aligned on transport-specific credential requirements
- update the Slack setup guide and bot scopes for the selected transport

## Verification

- `bun run typecheck`
- `bun test packages/core/opensession-server/src/frontend/lib/slack-setup.test.ts packages/core/opensession-server/src/server/integrations/load.test.ts packages/core/opensession-server/src/server/routes/setup-auth.test.ts packages/core/opensession-server/src/server/routes/setup-team.test.ts`
- `bun scripts/check-module-side-effects.ts`
- captured the Slack setup dialog at 1440×900 and 390×844

Created by [this OS session](https://os.tella.dev/session/os-01a024e2-6fed-723e-833a-cde60d02136a)
