### PR TITLE
Skip running native Next chat fallbacks

### DIFF
--- a/packages/clients/ios/OS1/SidebarNext.swift
+++ b/packages/clients/ios/OS1/SidebarNext.swift
@@ -33,6 +33,6 @@ enum SidebarNext {
         }
 
         return candidates.first { isUnread($0) && !$0.isRunning }
-            ?? candidates.first
+            ?? candidates.first { !$0.isRunning }
     }
 }

--- a/packages/clients/ios/OS1Tests/SidebarNextTests.swift
+++ b/packages/clients/ios/OS1Tests/SidebarNextTests.swift
@@ -56,6 +56,21 @@ final class SidebarNextTests: XCTestCase {
         )
     }
 
+    func testFallbackSkipsRunningWork() {
+        let rows = [row("current"), row("running", running: true), row("ready")]
+
+        XCTAssertEqual(
+            SidebarNext.workspace(after: "current", in: rows) { _ in false }?.id,
+            "ready"
+        )
+    }
+
+    func testFallbackReturnsNilWhenEveryOtherChatIsRunning() {
+        let rows = [row("current"), row("running", running: true)]
+
+        XCTAssertNil(SidebarNext.workspace(after: "current", in: rows) { _ in false })
+    }
+
     func testPinnedCopiesAndDraftRowsDoNotBecomeExtraChats() {
         let current = row("current")
         let next = row("next")


### PR DESCRIPTION
## Summary
- skip running work in the native Next chat fallback
- return no destination when every remaining chat is running
- cover mixed and all-running fallback cases

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac test suite

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-2469526d-299a-7baa-94f5-5c16a6c4973f)