### PR TITLE
Add native code fence copy controls

### DIFF
--- a/packages/clients/ios/OS1/Models/MarkdownCodeFence.swift
+++ b/packages/clients/ios/OS1/Models/MarkdownCodeFence.swift
@@ -33,10 +33,19 @@ enum MarkdownCodeFenceParser {
         var index = 0
 
         while index < lines.count {
-            guard let opening = opening(in: lines[index]),
-                  let closingIndex = closingIndex(in: lines, after: index, opening: opening) else {
+            guard let opening = opening(in: lines[index]) else {
                 index += 1
                 continue
+            }
+            // Once an opening fence is seen, every later line belongs to it
+            // until a matching close. A shorter nested-looking fence is code,
+            // not a new block that can be extracted independently.
+            guard let closingIndex = closingIndex(
+                in: lines,
+                after: index,
+                opening: opening
+            ) else {
+                break
             }
 
             appendMarkdown(lines[markdownStart..<index], to: &segments)

--- a/packages/clients/ios/OS1/Models/MarkdownCodeFence.swift
+++ b/packages/clients/ios/OS1/Models/MarkdownCodeFence.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+protocol CodeFenceClipboard {
+    func write(_ text: String)
+}
+
+struct MarkdownCodeFence: Equatable {
+    let language: String
+    let contents: String
+
+    func copy(to clipboard: some CodeFenceClipboard) {
+        clipboard.write(contents)
+    }
+}
+
+enum MarkdownCodeFenceSegment: Equatable {
+    case markdown(String)
+    case fence(MarkdownCodeFence)
+}
+
+enum MarkdownCodeFenceParser {
+    private struct Opening {
+        let marker: Character
+        let length: Int
+        let indentation: Int
+        let language: String
+    }
+
+    static func split(_ markdown: String) -> [MarkdownCodeFenceSegment] {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var segments: [MarkdownCodeFenceSegment] = []
+        var markdownStart = 0
+        var index = 0
+
+        while index < lines.count {
+            guard let opening = opening(in: lines[index]),
+                  let closingIndex = closingIndex(in: lines, after: index, opening: opening) else {
+                index += 1
+                continue
+            }
+
+            appendMarkdown(lines[markdownStart..<index], to: &segments)
+            let code = lines[(index + 1)..<closingIndex]
+                .map { removeIndentation(from: $0, count: opening.indentation) }
+                .joined(separator: "\n")
+            segments.append(.fence(.init(language: opening.language, contents: code)))
+            index = closingIndex + 1
+            markdownStart = index
+        }
+
+        appendMarkdown(lines[markdownStart..<lines.count], to: &segments)
+        return segments.isEmpty ? [.markdown(markdown)] : segments
+    }
+
+    private static func opening(in line: String) -> Opening? {
+        let indentation = line.prefix(while: { $0 == " " }).count
+        guard indentation <= 3 else { return nil }
+
+        let body = line.dropFirst(indentation)
+        guard let marker = body.first, marker == "`" || marker == "~" else { return nil }
+        let length = body.prefix(while: { $0 == marker }).count
+        guard length >= 3 else { return nil }
+
+        let info = String(body.dropFirst(length)).trimmingCharacters(in: .whitespaces)
+        guard marker != "`" || !info.contains("`") else { return nil }
+        let language = info.split(whereSeparator: { $0.isWhitespace }).first.map(String.init) ?? ""
+        return Opening(marker: marker, length: length, indentation: indentation, language: language)
+    }
+
+    private static func closingIndex(
+        in lines: [String],
+        after openingIndex: Int,
+        opening: Opening
+    ) -> Int? {
+        lines.indices.dropFirst(openingIndex + 1).first { index in
+            isClosing(lines[index], opening: opening)
+        }
+    }
+
+    private static func isClosing(_ line: String, opening: Opening) -> Bool {
+        let indentation = line.prefix(while: { $0 == " " }).count
+        guard indentation <= 3 else { return false }
+
+        let body = line.dropFirst(indentation)
+        let markerLength = body.prefix(while: { $0 == opening.marker }).count
+        guard markerLength >= opening.length else { return false }
+        return body.dropFirst(markerLength).allSatisfy { $0.isWhitespace }
+    }
+
+    private static func removeIndentation(from line: String, count: Int) -> String {
+        let removable = line.prefix(count).prefix(while: { $0 == " " }).count
+        return String(line.dropFirst(removable))
+    }
+
+    private static func appendMarkdown(
+        _ lines: ArraySlice<String>,
+        to segments: inout [MarkdownCodeFenceSegment]
+    ) {
+        guard !lines.isEmpty else { return }
+        let markdown = lines.joined(separator: "\n")
+        guard !markdown.isEmpty else { return }
+        segments.append(.markdown(markdown))
+    }
+}
+
+#if os(iOS)
+import UIKit
+
+struct SystemCodeFenceClipboard: CodeFenceClipboard {
+    func write(_ text: String) {
+        UIPasteboard.general.string = text
+    }
+}
+#elseif os(macOS)
+import AppKit
+
+struct SystemCodeFenceClipboard: CodeFenceClipboard {
+    func write(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+}
+#endif

--- a/packages/clients/ios/OS1/Views/MarkdownBody.swift
+++ b/packages/clients/ios/OS1/Views/MarkdownBody.swift
@@ -42,10 +42,11 @@ struct MarkdownBody: View {
         self.dimmed = dimmed
     }
 
-    /// One rendered piece of a message: prose for the library, a diagram, or a
-    /// table this app lays out itself.
+    /// One rendered piece of a message: prose for the library, a code fence,
+    /// a diagram, or a table this app lays out itself.
     private enum Block {
         case markdown(String)
+        case codeFence(MarkdownCodeFence)
         case mermaid(String)
         case table(MarkdownTable)
     }
@@ -66,6 +67,8 @@ struct MarkdownBody: View {
                     switch block {
                     case .markdown(let value):
                         markdown(value)
+                    case .codeFence(let fence):
+                        MarkdownCodeFenceView(fence: fence)
                     case .mermaid(let source):
                         MermaidDiagramView(source: source)
                     case .table(let table):
@@ -83,10 +86,17 @@ struct MarkdownBody: View {
             case .mermaid(let source):
                 return [.mermaid(source)]
             case .markdown(let value):
-                return MarkdownTableSegmenter.split(value).map { piece in
+                return MarkdownTableSegmenter.split(value).flatMap { piece -> [Block] in
                     switch piece {
-                    case .markdown(let prose): .markdown(prose)
-                    case .table(let table): .table(table)
+                    case .markdown(let prose):
+                        return MarkdownCodeFenceParser.split(prose).map { segment in
+                            switch segment {
+                            case .markdown(let value): .markdown(value)
+                            case .fence(let fence): .codeFence(fence)
+                            }
+                        }
+                    case .table(let table):
+                        return [.table(table)]
                     }
                 }
             }

--- a/packages/clients/ios/OS1/Views/MarkdownCodeFenceView.swift
+++ b/packages/clients/ios/OS1/Views/MarkdownCodeFenceView.swift
@@ -64,10 +64,18 @@ struct MarkdownCodeFenceView: View {
             in: RoundedRectangle(cornerRadius: 12, style: .continuous)
         )
         .task(id: HighlightRequest(code: fence.contents, colorScheme: colorScheme)) {
-            attributedText = await MarkdownCodeHighlighter.shared.attributedText(
+            let result = await MarkdownCodeHighlighter.shared.attributedText(
                 for: fence.contents,
                 colorScheme: colorScheme
             )
+            guard !Task.isCancelled else { return }
+            attributedText = result.map {
+                SyntaxHighlighting.restoringEdgeWhitespace(
+                    $0,
+                    in: fence.contents,
+                    fallbackColor: OS1VisualStyle.textDim
+                )
+            }
         }
         .onDisappear {
             feedbackTask?.cancel()

--- a/packages/clients/ios/OS1/Views/MarkdownCodeFenceView.swift
+++ b/packages/clients/ios/OS1/Views/MarkdownCodeFenceView.swift
@@ -1,0 +1,100 @@
+import HighlightSwift
+import SwiftUI
+
+private actor MarkdownCodeHighlighter {
+    static let shared = MarkdownCodeHighlighter()
+
+    private let highlighter = Highlight()
+
+    func attributedText(for code: String, colorScheme: ColorScheme) async -> AttributedString? {
+        let colors: HighlightColors = colorScheme == .dark ? .dark(.github) : .light(.github)
+        return try? await highlighter.attributedText(code, colors: colors)
+    }
+}
+
+struct MarkdownCodeFenceView: View {
+    let fence: MarkdownCodeFence
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var attributedText: AttributedString?
+    @State private var isCopied = false
+    @State private var feedbackTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                if !fence.language.isEmpty {
+                    Text(fence.language)
+                        .foregroundStyle(OS1VisualStyle.textDim)
+                }
+                Spacer(minLength: 8)
+                Button(action: didTapCopy) {
+                    Label(
+                        isCopied ? "Copied" : "Copy code",
+                        systemImage: isCopied ? "checkmark" : "document.on.document"
+                    )
+                    .contentTransition(.symbolEffect(.replace))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(OS1VisualStyle.textDim)
+                .contentShape(Rectangle())
+                .accessibilityLabel(isCopied ? "Copied" : "Copy code")
+                .accessibilityHint("Copies only this code block")
+                #if os(iOS)
+                .frame(minHeight: 44)
+                #else
+                .frame(minHeight: 28)
+                #endif
+            }
+            .font(.caption)
+            .padding(.horizontal, 14)
+
+            ScrollView(.horizontal) {
+                Text(attributedText ?? AttributedString(fence.contents))
+                    .font(codeFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 14)
+            }
+            .scrollIndicators(.automatic)
+        }
+        .background(
+            OS1VisualStyle.markdownCodeWell,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
+        .task(id: HighlightRequest(code: fence.contents, colorScheme: colorScheme)) {
+            attributedText = await MarkdownCodeHighlighter.shared.attributedText(
+                for: fence.contents,
+                colorScheme: colorScheme
+            )
+        }
+        .onDisappear {
+            feedbackTask?.cancel()
+        }
+    }
+
+    private var codeFont: Font {
+        #if os(iOS)
+        .system(size: 15, design: .monospaced)
+        #else
+        .system(size: 12, design: .monospaced)
+        #endif
+    }
+
+    private func didTapCopy() {
+        fence.copy(to: SystemCodeFenceClipboard())
+        isCopied = true
+        feedbackTask?.cancel()
+        feedbackTask = Task {
+            try? await Task.sleep(for: .milliseconds(1600))
+            guard !Task.isCancelled else { return }
+            isCopied = false
+        }
+    }
+
+    private struct HighlightRequest: Equatable {
+        let code: String
+        let colorScheme: ColorScheme
+    }
+}

--- a/packages/clients/ios/OS1/Views/SyntaxHighlightedCodeText.swift
+++ b/packages/clients/ios/OS1/Views/SyntaxHighlightedCodeText.swift
@@ -144,6 +144,28 @@ enum SyntaxHighlighting {
         )
     }
 
+    /// HighlightSwift trims the input before converting its HTML. Put those
+    /// exact edge characters back so rendering never changes source layout.
+    static func restoringEdgeWhitespace(
+        _ value: AttributedString,
+        in text: String,
+        fallbackColor: Color
+    ) -> AttributedString {
+        var fallback = AttributedString(text)
+        fallback.foregroundColor = fallbackColor
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let range = text.range(of: trimmed) else {
+            return fallback
+        }
+        var output = AttributedString(String(text[..<range.lowerBound]))
+        output.foregroundColor = fallbackColor
+        output.append(value)
+        var suffix = AttributedString(String(text[range.upperBound...]))
+        suffix.foregroundColor = fallbackColor
+        output.append(suffix)
+        return output
+    }
+
     private static let store = Store()
 
     private actor Store {
@@ -232,7 +254,13 @@ struct SyntaxHighlightedCodeText: View {
                 colorScheme: colorScheme
             )
             guard !Task.isCancelled else { return }
-            highlighted = result.map(restoringWhitespace)
+            highlighted = result.map {
+                SyntaxHighlighting.restoringEdgeWhitespace(
+                    $0,
+                    in: renderedText,
+                    fallbackColor: fallbackColor
+                )
+            }
         }
     }
 
@@ -280,22 +308,6 @@ struct SyntaxHighlightedCodeText: View {
             index = characters.index(after: index)
         }
         appendLine(lineStart..<characters.endIndex)
-        return output
-    }
-
-    /// HighlightSwift trims the input before converting its HTML. Put those
-    /// exact characters back so selecting a code asset still copies its source.
-    private func restoringWhitespace(_ value: AttributedString) -> AttributedString {
-        let trimmed = renderedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let range = renderedText.range(of: trimmed) else {
-            return fallback
-        }
-        var output = AttributedString(String(renderedText[..<range.lowerBound]))
-        output.foregroundColor = fallbackColor
-        output.append(value)
-        var suffix = AttributedString(String(renderedText[range.upperBound...]))
-        suffix.foregroundColor = fallbackColor
-        output.append(suffix)
         return output
     }
 }

--- a/packages/clients/ios/OS1Tests/MarkdownCodeFenceTests.swift
+++ b/packages/clients/ios/OS1Tests/MarkdownCodeFenceTests.swift
@@ -22,6 +22,18 @@ final class MarkdownCodeFenceTests: XCTestCase {
 
         XCTAssertEqual(clipboard.text, "printf 'one\\n'\nprintf 'two\\n'")
     }
+
+    func testCompleteExampleInsideUnclosedLongerFenceIsNotExtracted() {
+        let markdown = """
+        ````text
+        An example:
+        ```swift
+        print(1)
+        ```
+        """
+
+        XCTAssertEqual(MarkdownCodeFenceParser.split(markdown), [.markdown(markdown)])
+    }
 }
 
 private final class RecordingCodeFenceClipboard: CodeFenceClipboard {

--- a/packages/clients/ios/OS1Tests/MarkdownCodeFenceTests.swift
+++ b/packages/clients/ios/OS1Tests/MarkdownCodeFenceTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OS1
+
+final class MarkdownCodeFenceTests: XCTestCase {
+    func testOneLineFenceCopiesOnlyItsContents() throws {
+        let segments = MarkdownCodeFenceParser.split("Before\n\n```swift\nprint(1)\n```\n\nAfter")
+        let fence = try XCTUnwrap(segments.compactMap(\.fence).first)
+        let clipboard = RecordingCodeFenceClipboard()
+
+        fence.copy(to: clipboard)
+
+        XCTAssertEqual(fence.language, "swift")
+        XCTAssertEqual(clipboard.text, "print(1)")
+    }
+
+    func testMultilineFencePreservesLineBreaksWhenCopied() throws {
+        let segments = MarkdownCodeFenceParser.split("~~~bash\nprintf 'one\\n'\nprintf 'two\\n'\n~~~")
+        let fence = try XCTUnwrap(segments.compactMap(\.fence).first)
+        let clipboard = RecordingCodeFenceClipboard()
+
+        fence.copy(to: clipboard)
+
+        XCTAssertEqual(clipboard.text, "printf 'one\\n'\nprintf 'two\\n'")
+    }
+}
+
+private final class RecordingCodeFenceClipboard: CodeFenceClipboard {
+    var text: String?
+
+    func write(_ text: String) {
+        self.text = text
+    }
+}
+
+private extension MarkdownCodeFenceSegment {
+    var fence: MarkdownCodeFence? {
+        if case .fence(let fence) = self {
+            return fence
+        }
+        return nil
+    }
+}

--- a/packages/clients/ios/OS1Tests/SyntaxHighlightingTests.swift
+++ b/packages/clients/ios/OS1Tests/SyntaxHighlightingTests.swift
@@ -39,4 +39,17 @@ final class SyntaxHighlightingTests: XCTestCase {
         )
         XCTAssertNil(SyntaxHighlighting.splitGutter("result.swift\n2:first"))
     }
+
+    func testHighlightingRestoresSignificantEdgeWhitespace() {
+        let source = "  return value\n"
+        let highlighted = AttributedString("return value")
+
+        let restored = SyntaxHighlighting.restoringEdgeWhitespace(
+            highlighted,
+            in: source,
+            fallbackColor: OS1VisualStyle.textDim
+        )
+
+        XCTAssertEqual(String(restored.characters), source)
+    }
 }


### PR DESCRIPTION
## Summary
- render durable fenced code blocks with an always-visible native copy action on iOS and macOS
- copy only parsed fence contents and show brief inline copied feedback
- preserve the persistent SwiftStreamingMarkdown path for in-flight streaming
- cover one-line and multiline parsing and copy actions

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac test suite
- iPhone 17 Pro simulator screenshot

<!-- opensession:walkthrough -->
## Walkthrough

Fenced code blocks in durable native transcripts now have an always-visible Copy code action, which matters most on iPhone where selecting inside a horizontally scrolling code well is awkward. The action copies only the parsed fence contents, uses a full native button target with a VoiceOver hint, and briefly switches to Copied without changing transcript text. Streaming remains on the persistent SwiftStreamingMarkdown renderer, while focused tests cover one-line and multiline copy payloads.

| Before | After |
| --- | --- |
| — | ![After — iPhone transcript code fence with its native Copy code action visible](https://github.com/user-attachments/assets/fc59456d-3b6d-44a3-a326-a943a6e7fcc5) |

<sub>Published from the session's Review tab.</sub>
<!-- /opensession:walkthrough -->

Created by [this OS session](https://os.tella.dev/session/bks-b0c9f6cb-407d-7665-8cd4-92e3aef9147d)