### PR TITLE
Add native image region comments

### DIFF
--- a/packages/clients/ios/OS1/Models/ImageRegionComment.swift
+++ b/packages/clients/ios/OS1/Models/ImageRegionComment.swift
@@ -1,0 +1,190 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+/// A rectangle expressed against an image's displayed bounds. Normalized
+/// coordinates keep the same pixels selected when the keyboard or window
+/// changes the available space.
+struct ImageRegion: Equatable, Sendable {
+    var x: CGFloat
+    var y: CGFloat
+    var width: CGFloat
+    var height: CGFloat
+
+    static func between(_ start: CGPoint, _ end: CGPoint) -> ImageRegion {
+        let a = CGPoint(x: clamp(start.x), y: clamp(start.y))
+        let b = CGPoint(x: clamp(end.x), y: clamp(end.y))
+        return ImageRegion(
+            x: min(a.x, b.x),
+            y: min(a.y, b.y),
+            width: abs(b.x - a.x),
+            height: abs(b.y - a.y)
+        )
+    }
+
+    func moved(dx: CGFloat, dy: CGFloat) -> ImageRegion {
+        let boundedWidth = min(1, max(0, width))
+        let boundedHeight = min(1, max(0, height))
+        return ImageRegion(
+            x: min(1 - boundedWidth, max(0, x + dx)),
+            y: min(1 - boundedHeight, max(0, y + dy)),
+            width: boundedWidth,
+            height: boundedHeight
+        )
+    }
+
+    func resized(
+        from handle: ImageRegionHandle,
+        dx: CGFloat,
+        dy: CGFloat,
+        minimum: CGSize = .zero
+    ) -> ImageRegion {
+        let left = x
+        let right = x + width
+        let top = y
+        let bottom = y + height
+        let horizontal: (CGFloat, CGFloat)
+        if handle.movesWest {
+            horizontal = Self.span(anchor: right, moving: left + dx, minimum: minimum.width)
+        } else if handle.movesEast {
+            horizontal = Self.span(anchor: left, moving: right + dx, minimum: minimum.width)
+        } else {
+            horizontal = (Self.clamp(left), Self.clamp(right))
+        }
+        let vertical: (CGFloat, CGFloat)
+        if handle.movesNorth {
+            vertical = Self.span(anchor: bottom, moving: top + dy, minimum: minimum.height)
+        } else if handle.movesSouth {
+            vertical = Self.span(anchor: top, moving: bottom + dy, minimum: minimum.height)
+        } else {
+            vertical = (Self.clamp(top), Self.clamp(bottom))
+        }
+        return ImageRegion(
+            x: horizontal.0,
+            y: vertical.0,
+            width: horizontal.1 - horizontal.0,
+            height: vertical.1 - vertical.0
+        )
+    }
+
+    func pixelRect(imageSize: CGSize) -> CGRect {
+        let sourceWidth = max(1, imageSize.width.rounded())
+        let sourceHeight = max(1, imageSize.height.rounded())
+        let originX = min(sourceWidth - 1, max(0, floor(Self.clamp(x) * sourceWidth)))
+        let originY = min(sourceHeight - 1, max(0, floor(Self.clamp(y) * sourceHeight)))
+        let right = min(
+            sourceWidth,
+            max(originX + 1, ceil(Self.clamp(x + width) * sourceWidth))
+        )
+        let bottom = min(
+            sourceHeight,
+            max(originY + 1, ceil(Self.clamp(y + height) * sourceHeight))
+        )
+        return CGRect(x: originX, y: originY, width: right - originX, height: bottom - originY)
+    }
+
+    private static func span(
+        anchor: CGFloat,
+        moving: CGFloat,
+        minimum: CGFloat
+    ) -> (CGFloat, CGFloat) {
+        let fixed = clamp(anchor)
+        let minimum = min(1, max(0, minimum))
+        var edge = clamp(moving)
+        if abs(edge - fixed) < minimum {
+            edge = edge >= fixed ? fixed + minimum : fixed - minimum
+        }
+        return (max(0, min(fixed, edge)), min(1, max(fixed, edge)))
+    }
+
+    private static func clamp(_ value: CGFloat) -> CGFloat {
+        guard value.isFinite else { return 0 }
+        return min(1, max(0, value))
+    }
+}
+
+enum ImageRegionHandle: CaseIterable, Sendable {
+    case northWest, north, northEast, east, southEast, south, southWest, west
+
+    var movesNorth: Bool { self == .northWest || self == .north || self == .northEast }
+    var movesEast: Bool { self == .northEast || self == .east || self == .southEast }
+    var movesSouth: Bool { self == .southEast || self == .south || self == .southWest }
+    var movesWest: Bool { self == .southWest || self == .west || self == .northWest }
+
+}
+
+enum ImageRegionCrop {
+    static let maximumEdge = 2_000
+
+    static func outputSize(for size: CGSize) -> CGSize {
+        let width = max(1, size.width.rounded())
+        let height = max(1, size.height.rounded())
+        let scale = min(1, CGFloat(maximumEdge) / max(width, height))
+        return CGSize(
+            width: max(1, (width * scale).rounded()),
+            height: max(1, (height * scale).rounded())
+        )
+    }
+
+    #if canImport(UIKit)
+    static func attachment(from image: UIImage, region: ImageRegion) -> AttachedImage? {
+        guard let source = normalizedCGImage(image) else { return nil }
+        return attachment(from: source, region: region)
+    }
+
+    private static func normalizedCGImage(_ image: UIImage) -> CGImage? {
+        if image.imageOrientation == .up, let cgImage = image.cgImage { return cgImage }
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale
+        let rendered = UIGraphicsImageRenderer(size: image.size, format: format).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+        return rendered.cgImage
+    }
+    #else
+    static func attachment(from image: NSImage, region: ImageRegion) -> AttachedImage? {
+        var rect = CGRect(origin: .zero, size: image.size)
+        guard let source = image.cgImage(forProposedRect: &rect, context: nil, hints: nil)
+        else { return nil }
+        return attachment(from: source, region: region)
+    }
+    #endif
+
+    private static func attachment(from source: CGImage, region: ImageRegion) -> AttachedImage? {
+        let cropRect = region.pixelRect(
+            imageSize: CGSize(width: source.width, height: source.height)
+        )
+        guard let cropped = source.cropping(to: cropRect) else { return nil }
+        let target = outputSize(for: cropRect.size)
+        guard let context = CGContext(
+            data: nil,
+            width: Int(target.width),
+            height: Int(target.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.interpolationQuality = .high
+        context.draw(cropped, in: CGRect(origin: .zero, size: target))
+        guard let output = context.makeImage() else { return nil }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data, UTType.png.identifier as CFString, 1, nil
+        ) else { return nil }
+        CGImageDestinationAddImage(destination, output, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return AttachedImage(
+            id: UUID().uuidString,
+            jpegData: data as Data,
+            mediaType: "image/png"
+        )
+    }
+}

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -942,6 +942,31 @@ final class SessionViewModel {
         sendSeq += 1
     }
 
+    /// Sends a crop and its comment as one complete message without reading or
+    /// clearing anything waiting in the ordinary composer.
+    @discardableResult
+    func sendImageRegionComment(_ text: String, image: AttachedImage) -> Bool {
+        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return false }
+        let busyMode = UserDefaults.standard.string(forKey: "os1.composer.busySend") ?? "queue"
+        guard outbox.enqueue(
+            sessionId: session.id,
+            content: text,
+            images: [image.dataURL],
+            effort: effort.isEmpty ? nil : effort,
+            fastMode: fastMode ? true : nil,
+            busyMode: busyMode,
+            user: ServerConfig.shared.userName
+        ) != nil else {
+            notice = "Too many unsent messages. Send or delete some first."
+            return false
+        }
+        HideStore.shared.unhide(for: session)
+        replySuggestions = []
+        sendSeq += 1
+        return true
+    }
+
     /// The server took a message: put it where the server says it went. This
     /// replaces the old guess from local `isRunning` — a client that has been
     /// offline has no idea whether a run started meanwhile, and a bubble in

--- a/packages/clients/ios/OS1/Views/ImageAttachments.swift
+++ b/packages/clients/ios/OS1/Views/ImageAttachments.swift
@@ -4,7 +4,24 @@ import CoreTransferable
 import UniformTypeIdentifiers
 #if canImport(UIKit)
 import UIKit
+#else
+import AppKit
 #endif
+
+struct ImageRegionCommentAction {
+    let send: (_ text: String, _ image: AttachedImage) -> Bool
+}
+
+private struct ImageRegionCommentActionKey: EnvironmentKey {
+    static let defaultValue: ImageRegionCommentAction? = nil
+}
+
+extension EnvironmentValues {
+    var imageRegionCommentAction: ImageRegionCommentAction? {
+        get { self[ImageRegionCommentActionKey.self] }
+        set { self[ImageRegionCommentActionKey.self] = newValue }
+    }
+}
 
 /// Paperclip button that appends picked images to a binding. iOS picks from
 /// the photo library (PhotosPicker); macOS opens the file panel — the natural
@@ -287,6 +304,12 @@ struct ExpandableDataImage: View {
 
     @State private var previewPresented = false
 
+    private var allowsRegionComment: Bool {
+        guard gallery.indices.contains(galleryIndex) else { return false }
+        if case .conversation = gallery[galleryIndex].source { return true }
+        return false
+    }
+
     #if os(iOS)
     private var items: [PreviewImage] {
         gallery.isEmpty
@@ -336,7 +359,11 @@ struct ExpandableDataImage: View {
         .accessibilityHint("Shows the image larger")
         .help("Open image")
         .sheet(isPresented: $previewPresented) {
-            MacImagePreview(images: [data], index: 0)
+            MacImagePreview(
+                images: [data],
+                index: 0,
+                allowsRegionComment: allowsRegionComment
+            )
         }
         #endif
     }
@@ -484,6 +511,270 @@ struct ConversationImageStrip: View {
     }
 }
 
+#if canImport(UIKit)
+private typealias RegionPlatformImage = UIImage
+#else
+private typealias RegionPlatformImage = NSImage
+#endif
+
+/// Selects and comments on a crop without touching the ordinary composer.
+/// The crop is sent as an ordinary image attachment only after Send succeeds.
+private struct ImageRegionCommentEditor: View {
+    let image: RegionPlatformImage
+    let onSend: (_ text: String, _ image: AttachedImage) -> Bool
+    let onCancel: () -> Void
+
+    @State private var selection: ImageRegion?
+    @State private var comment = ""
+    @State private var error: String?
+    @FocusState private var commentFocused: Bool
+
+    private var imageSize: CGSize {
+        #if canImport(UIKit)
+        image.size
+        #else
+        image.size
+        #endif
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            GeometryReader { proxy in
+                let frame = aspectFit(imageSize, in: proxy.size)
+                imageView
+                    .frame(width: frame.width, height: frame.height)
+                    .overlay {
+                        ImageRegionSelectionCanvas(selection: $selection) {
+                            commentFocused = true
+                        }
+                    }
+                    .position(x: frame.midX, y: frame.midY)
+            }
+            .background(.black)
+            commentPanel
+        }
+        .background(.black)
+        #if os(macOS)
+        .frame(minWidth: 620, idealWidth: 760, minHeight: 560, idealHeight: 720)
+        #endif
+    }
+
+    private var header: some View {
+        HStack {
+            Button("Cancel", action: onCancel)
+                .buttonStyle(.plain)
+            Spacer()
+            Text("Comment on region")
+                .font(.headline)
+            Spacer()
+            Color.clear.frame(width: 48, height: 1)
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 18)
+        .frame(height: 52)
+        .background(.black)
+    }
+
+    @ViewBuilder private var imageView: some View {
+        #if canImport(UIKit)
+        Image(uiImage: image).resizable().scaledToFit()
+        #else
+        Image(nsImage: image).resizable().scaledToFit()
+        #endif
+    }
+
+    private var commentPanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField("Comment", text: $comment, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .focused($commentFocused)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(.background, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .onSubmit(send)
+            if let error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+            HStack {
+                Text(selection == nil ? "Drag on the image to select a region." : "Drag the box or its handles to adjust it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Send", action: send)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSend)
+            }
+        }
+        .padding(14)
+        .background(.regularMaterial)
+    }
+
+    private var canSend: Bool {
+        selection != nil && !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func send() {
+        let text = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let selection, !text.isEmpty,
+              let attachment = ImageRegionCrop.attachment(from: image, region: selection)
+        else { return }
+        if !onSend(text, attachment) {
+            error = "Could not send this comment."
+        }
+    }
+
+    private func aspectFit(_ image: CGSize, in available: CGSize) -> CGRect {
+        guard image.width > 0, image.height > 0 else {
+            return CGRect(origin: .zero, size: available)
+        }
+        let scale = min(available.width / image.width, available.height / image.height)
+        let size = CGSize(width: image.width * scale, height: image.height * scale)
+        return CGRect(
+            x: (available.width - size.width) / 2,
+            y: (available.height - size.height) / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+private struct ImageRegionSelectionCanvas: View {
+    @Binding var selection: ImageRegion?
+    let onSelection: () -> Void
+    @State private var gestureStart: ImageRegion?
+    @State private var selectionStart: CGPoint?
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .gesture(createGesture(size: proxy.size))
+                if let selection {
+                    selectionOverlay(selection, size: proxy.size)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Image region selection")
+    }
+
+    private func selectionOverlay(_ region: ImageRegion, size: CGSize) -> some View {
+        let rect = screenRect(region, size: size)
+        return ZStack {
+            dimmedOutside(rect, size: size)
+                .allowsHitTesting(false)
+            Rectangle()
+                .fill(.clear)
+                .contentShape(Rectangle())
+                .frame(width: rect.width, height: rect.height)
+                .overlay { Rectangle().stroke(.white, lineWidth: 2) }
+                .position(x: rect.midX, y: rect.midY)
+                .gesture(moveGesture(size: size))
+            ForEach(ImageRegionHandle.allCases, id: \.self) { handle in
+                Circle()
+                    .fill(.white)
+                    .overlay { Circle().stroke(.black.opacity(0.45), lineWidth: 1) }
+                    .frame(width: 16, height: 16)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+                    .position(handlePoint(handle, in: rect))
+                    .gesture(resizeGesture(handle, size: size))
+                    .accessibilityLabel("Resize selected region")
+            }
+        }
+    }
+
+    private func dimmedOutside(_ rect: CGRect, size: CGSize) -> some View {
+        ZStack {
+            Rectangle().fill(.black.opacity(0.52))
+            Rectangle()
+                .fill(.black)
+                .frame(width: rect.width, height: rect.height)
+                .position(x: rect.midX, y: rect.midY)
+                .blendMode(.destinationOut)
+        }
+        .compositingGroup()
+        .frame(width: size.width, height: size.height)
+    }
+
+    private func createGesture(size: CGSize) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                if selectionStart == nil { selectionStart = normalized(value.startLocation, size: size) }
+                guard let selectionStart else { return }
+                selection = ImageRegion.between(selectionStart, normalized(value.location, size: size))
+            }
+            .onEnded { _ in
+                selectionStart = nil
+                if let selection,
+                   (selection.width * size.width < 12 || selection.height * size.height < 12) {
+                    self.selection = nil
+                } else {
+                    onSelection()
+                }
+            }
+    }
+
+    private func moveGesture(size: CGSize) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                if gestureStart == nil { gestureStart = selection }
+                guard let gestureStart else { return }
+                selection = gestureStart.moved(
+                    dx: value.translation.width / size.width,
+                    dy: value.translation.height / size.height
+                )
+            }
+            .onEnded { _ in gestureStart = nil }
+    }
+
+    private func resizeGesture(_ handle: ImageRegionHandle, size: CGSize) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                if gestureStart == nil { gestureStart = selection }
+                guard let gestureStart else { return }
+                selection = gestureStart.resized(
+                    from: handle,
+                    dx: value.translation.width / size.width,
+                    dy: value.translation.height / size.height,
+                    minimum: CGSize(width: 12 / size.width, height: 12 / size.height)
+                )
+            }
+            .onEnded { _ in gestureStart = nil }
+    }
+
+    private func screenRect(_ region: ImageRegion, size: CGSize) -> CGRect {
+        CGRect(
+            x: region.x * size.width,
+            y: region.y * size.height,
+            width: region.width * size.width,
+            height: region.height * size.height
+        )
+    }
+
+    private func normalized(_ point: CGPoint, size: CGSize) -> CGPoint {
+        CGPoint(x: point.x / max(1, size.width), y: point.y / max(1, size.height))
+    }
+
+    private func handlePoint(_ handle: ImageRegionHandle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .northWest: CGPoint(x: rect.minX, y: rect.minY)
+        case .north: CGPoint(x: rect.midX, y: rect.minY)
+        case .northEast: CGPoint(x: rect.maxX, y: rect.minY)
+        case .east: CGPoint(x: rect.maxX, y: rect.midY)
+        case .southEast: CGPoint(x: rect.maxX, y: rect.maxY)
+        case .south: CGPoint(x: rect.midX, y: rect.maxY)
+        case .southWest: CGPoint(x: rect.minX, y: rect.maxY)
+        case .west: CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+}
+
 #if os(macOS)
 /// A staged picture, large enough to check before it goes out.
 ///
@@ -503,13 +794,17 @@ struct ConversationImageStrip: View {
 /// without saying so. A composer's attachments are always bytes in hand.
 struct MacImagePreview: View {
     let images: [Data]
+    var allowsRegionComment = false
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.imageRegionCommentAction) private var commentAction
     @State private var index: Int
+    @State private var commenting = false
     private let idealHeight: CGFloat
 
-    init(images: [Data], index: Int) {
+    init(images: [Data], index: Int, allowsRegionComment: Bool = false) {
         self.images = images
+        self.allowsRegionComment = allowsRegionComment
         _index = State(initialValue: min(max(index, 0), max(images.count - 1, 0)))
         idealHeight = Self.idealHeight(for: images.first)
     }
@@ -521,6 +816,20 @@ struct MacImagePreview: View {
             controls
         }
         .frame(minWidth: 480, idealWidth: Self.idealWidth, minHeight: 380, idealHeight: idealHeight)
+        .sheet(isPresented: $commenting) {
+            if images.indices.contains(index), let image = NSImage(data: images[index]),
+               let commentAction {
+                ImageRegionCommentEditor(
+                    image: image,
+                    onSend: { text, attachment in
+                        let sent = commentAction.send(text, attachment)
+                        if sent { dismiss() }
+                        return sent
+                    },
+                    onCancel: { commenting = false }
+                )
+            }
+        }
     }
 
     private static let idealWidth: CGFloat = 760
@@ -574,6 +883,9 @@ struct MacImagePreview: View {
                     .accessibilityLabel("Next image")
             }
             Spacer()
+            if allowsRegionComment, commentAction != nil {
+                Button("Comment") { commenting = true }
+            }
             Button("Done") { dismiss() }
                 .keyboardShortcut(.cancelAction)
         }
@@ -612,6 +924,8 @@ struct FullScreenImagePreview: View {
     /// on the picture in front of you without fetching it again.
     @State private var loaded: [String: UIImage] = [:]
     @State private var copied = false
+    @State private var commenting = false
+    @Environment(\.imageRegionCommentAction) private var commentAction
 
     /// The close-button row, above the safe area.
     private static let topBarHeight: CGFloat = 52
@@ -670,6 +984,22 @@ struct FullScreenImagePreview: View {
         .ignoresSafeArea()
         .statusBarHidden()
         .persistentSystemOverlays(chromeVisible ? .automatic : .hidden)
+        .fullScreenCover(isPresented: $commenting) {
+            if let image = currentImage, let commentAction {
+                ImageRegionCommentEditor(
+                    image: image,
+                    onSend: { text, attachment in
+                        let sent = commentAction.send(text, attachment)
+                        if sent {
+                            commenting = false
+                            dismiss()
+                        }
+                        return sent
+                    },
+                    onCancel: { commenting = false }
+                )
+            }
+        }
     }
 
     private func pager(chromeInsets: UIEdgeInsets) -> some View {
@@ -833,9 +1163,31 @@ struct FullScreenImagePreview: View {
         HStack(spacing: 0) {
             shareButton
             Spacer()
+            if canCommentOnCurrentImage {
+                commentButton
+                Spacer()
+            }
             copyButton
         }
         .padding(.horizontal, 20)
+    }
+
+    private var canCommentOnCurrentImage: Bool {
+        guard currentImage != nil, commentAction != nil, items.indices.contains(index) else {
+            return false
+        }
+        if case .conversation = items[index].source { return true }
+        return false
+    }
+
+    private var commentButton: some View {
+        Button {
+            commenting = true
+        } label: {
+            actionIcon("text.bubble")
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Comment on image region")
     }
 
     @ViewBuilder private var shareButton: some View {

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -1295,6 +1295,12 @@ struct SessionView: View {
             },
             failureContinuation: continuation
         )
+        .environment(
+            \.imageRegionCommentAction,
+            ImageRegionCommentAction { text, image in
+                viewModel.sendImageRegionComment(text, image: image)
+            }
+        )
         .id(block.id)
         .transcriptTail(block.id == tailId)
     }

--- a/packages/clients/ios/OS1Tests/ImageRegionCommentTests.swift
+++ b/packages/clients/ios/OS1Tests/ImageRegionCommentTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OS1
+
+final class ImageRegionGeometryTests: XCTestCase {
+    func testSelectionClampsAndSupportsReverseDrag() {
+        let region = ImageRegion.between(
+            CGPoint(x: 0.8, y: 1.2),
+            CGPoint(x: -0.1, y: 0.25)
+        )
+
+        XCTAssertEqual(region, ImageRegion(x: 0, y: 0.25, width: 0.8, height: 0.75))
+    }
+
+    func testMoveStopsAtImageEdgeWithoutShrinking() {
+        let region = ImageRegion(x: 0.6, y: 0.3, width: 0.3, height: 0.4)
+
+        XCTAssertEqual(
+            region.moved(dx: 0.5, dy: -0.8),
+            ImageRegion(x: 0.7, y: 0, width: 0.3, height: 0.4)
+        )
+    }
+
+    func testCornerResizeKeepsOppositeCornerAndMinimumSize() {
+        let region = ImageRegion(x: 0.2, y: 0.2, width: 0.5, height: 0.5)
+        let resized = region.resized(
+            from: .southEast,
+            dx: -0.48,
+            dy: -0.48,
+            minimum: CGSize(width: 0.1, height: 0.1)
+        )
+
+        XCTAssertEqual(resized.x, 0.2, accuracy: 0.0001)
+        XCTAssertEqual(resized.y, 0.2, accuracy: 0.0001)
+        XCTAssertEqual(resized.width, 0.1, accuracy: 0.0001)
+        XCTAssertEqual(resized.height, 0.1, accuracy: 0.0001)
+    }
+
+    func testPixelCropRoundsOutwardAndStaysInBounds() {
+        let region = ImageRegion(x: 0.1, y: 0.2, width: 0.35, height: 0.4)
+
+        XCTAssertEqual(
+            region.pixelRect(imageSize: CGSize(width: 101, height: 79)),
+            CGRect(x: 10, y: 15, width: 36, height: 33)
+        )
+    }
+
+    func testLargeCropOutputIsBoundedWithoutChangingAspectRatio() {
+        let size = ImageRegionCrop.outputSize(for: CGSize(width: 4_000, height: 1_000))
+
+        XCTAssertEqual(size, CGSize(width: 2_000, height: 500))
+    }
+}
+
+@MainActor
+final class ImageRegionCommentHandoffTests: XCTestCase {
+    func testRegionCommentQueuesIsolatedMessageAndPreservesComposer() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("os1-region-comment-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let outbox = Outbox(directory: directory, monitorNetwork: false)
+        outbox.transport = { _, _ in .unavailable("offline") }
+        let viewModel = SessionViewModel(session: Session(id: "bks-1"), outbox: outbox)
+        let original = AttachedImage(id: "draft", jpegData: Data([1, 2, 3]))
+        let crop = AttachedImage(
+            id: "crop",
+            jpegData: Data([4, 5, 6]),
+            mediaType: "image/png"
+        )
+        viewModel.draft = "Existing draft"
+        viewModel.attachedImages = [original]
+
+        XCTAssertTrue(viewModel.sendImageRegionComment("  Direct comment  ", image: crop))
+
+        XCTAssertEqual(viewModel.draft, "Existing draft")
+        XCTAssertEqual(viewModel.attachedImages, [original])
+        let item = try XCTUnwrap(outbox.items(for: "bks-1").first)
+        XCTAssertEqual(item.content, "Direct comment")
+        XCTAssertEqual(outbox.images(for: item), [crop.dataURL])
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -90,8 +90,11 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering, iOS 26+
   Routine calls fold into one `N steps` run, and consecutive edits to the same
   file into one row — the path once, the summed ±lines, and a `×3` count —
   both opening to the individual calls.
-  Transcript videos stream inline on both platforms. Tool-result screenshots
-  and recordings marked as featured stay visible when their work fold closes,
+  Transcript videos stream inline on both platforms. An already-sent image can
+  be opened, cropped with a movable and resizable selection, and sent back with
+  a direct comment without changing the original or the current composer draft.
+  Tool-result screenshots and recordings marked as featured stay visible when
+  their work fold closes,
   while incidental media remains inside the producing tool row.
   A `Task` row opens the sub-agent's own transcript in a sheet (polled while
   the worker runs, via `GET /api/sessions/:id/subagent/:agentId`), and a
@@ -406,6 +409,7 @@ OS1/
     TranscriptEntry.swift    Transcript entry (REST + WS frames)
     AskQuestion.swift        Pending AskUserQuestion
     AttachedImage.swift      Composer image attachments
+    ImageRegionComment.swift Normalized crop geometry and image derivation
     AttachedFile.swift       Open-in and staged file attachments
     ModelCatalog.swift       Workspace model catalog + engine routing
     ToolPresentation.swift   Canonical tool names, families, summaries, ±lines


### PR DESCRIPTION
## Summary
- add native iOS selection, move, and eight-handle resize controls for regions of sent transcript images
- crop the selected pixels into a bounded PNG and send it with a direct comment through an isolated outbox handoff
- preserve the source image and any text or images already staged in the composer
- provide the same comment flow from the macOS image sheet
- cover normalized crop geometry and composer-preserving handoff semantics

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac tests: 923 passed
- iOS simulator capture at device-native 1206×2622

<!-- opensession:walkthrough -->
## Walkthrough

The native transcript image viewer now supports direct region comments. A person can drag a crop, move it, resize it from any edge or corner, enter a comment, and send the derived PNG as a normal prompt while the original image and composer draft remain unchanged. The same flow is available from the macOS image sheet, and normalized crop geometry plus isolated outbox handoff are covered by focused tests.

| Before | After |
| --- | --- |
| — | ![After — iOS region selection with resize handles and direct comment field](https://github.com/user-attachments/assets/8ba04c0f-9b8a-4684-9621-8cba0501b7b9) |

<sub>Published from the session's Review tab.</sub>
<!-- /opensession:walkthrough -->

Created by [this OS session](https://os.tella.dev/session/bks-37acaf60-5223-7baa-99eb-1d9e2834ff42)