### PR TITLE
Offer native Undo after archiving sessions

### DIFF
--- a/packages/clients/ios/OS1/Models/ArchiveUndoOffer.swift
+++ b/packages/clients/ios/OS1/Models/ArchiveUndoOffer.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// One archive action and the exact sessions it can restore while visible.
+struct ArchiveUndoOffer: Identifiable, Equatable {
+    let id: UUID
+    let sessions: [Session]
+    let expiresAt: Date
+
+    var message: String {
+        sessions.count == 1 ? "Archived" : "Archived \(sessions.count) sessions"
+    }
+}

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -28,8 +28,33 @@ final class SessionsListViewModel {
     /// Kept separate from the live-list failure, whose banner describes a
     /// different request.
     private(set) var archivedLoadFailure: String?
+    /// Each visible Undo owns the snapshot archived by that action. Keeping
+    /// snapshots separate prevents a later archive from changing an older button.
+    private(set) var archiveUndoOffers: [ArchiveUndoOffer] = []
 
+    private let now: () -> Date
+    private let archiveUndoLifetime: TimeInterval
+    private let setArchived: (String, Bool) async throws -> Void
+    private let reconcilesArchiveMutations: Bool
+    @ObservationIgnored private var archiveUndoExpiryTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored private var archiveRequests: [
+        String: (id: UUID, task: Task<Void, Never>)
+    ] = [:]
     private var pollTask: Task<Void, Never>?
+
+    init(
+        now: @escaping () -> Date = Date.init,
+        archiveUndoLifetime: TimeInterval = 7,
+        setArchived: @escaping (String, Bool) async throws -> Void = { id, archived in
+            try await OS1API.setArchived(sessionId: id, archived: archived)
+        },
+        reconcilesArchiveMutations: Bool = true
+    ) {
+        self.now = now
+        self.archiveUndoLifetime = archiveUndoLifetime
+        self.setArchived = setArchived
+        self.reconcilesArchiveMutations = reconcilesArchiveMutations
+    }
 
     /// The server's archived index, kept apart from `archivedSessions` so the
     /// local overlay (a row archived on this device, one restored a moment
@@ -663,35 +688,126 @@ final class SessionsListViewModel {
     /// Swipe-to-archive: drop the row immediately, tell the server in the
     /// background, and roll back (surfacing the error) if that fails.
     func archive(_ session: Session) {
+        archive([session])
+    }
+
+    /// Archive one workspace as one action, with one exact Undo snapshot.
+    func archive(_ archivedSessions: [Session]) {
+        guard !archivedSessions.isEmpty else { return }
         archiveFailure = nil
+        offerArchiveUndo(for: archivedSessions)
+        for session in archivedSessions {
+            archiveSession(session)
+        }
+    }
+
+    private func archiveSession(_ session: Session) {
         setSessions(
             sessions.filter { $0.id != session.id },
             rows: sidebarRowsCache.flatMap { rowsRemoving(sessionId: session.id, from: $0) }
         )
         var archived = session
         archived.archived = true
-        locallyArchived[session.id] = (archived, Date())
+        locallyArchived[session.id] = (archived, now())
         publishArchived()
-        Task {
+        let requestId = UUID()
+        let request = Task { [weak self] in
+            guard let self else { return }
             do {
-                try await OS1API.setArchived(sessionId: session.id, archived: true)
+                try await setArchived(session.id, true)
                 // Archived rows travel on their own request now, so the one
                 // just archived reaches the Archived screen only when that
-                // request is made again — ask straight away instead of
-                // leaving the local placeholder to stand in for half a minute.
-                await refreshArchived(force: true)
+                // request is made again. Ask straight away instead of leaving
+                // the local placeholder to stand in for half a minute.
+                if reconcilesArchiveMutations {
+                    await refreshArchived(force: true)
+                }
             } catch {
                 locallyArchived.removeValue(forKey: session.id)
+                removeFromArchiveUndo(sessionId: session.id)
                 publishArchived()
                 if !sessions.contains(where: { $0.id == session.id }) {
                     setSessions(
                         [session] + sessions,
-                        rows: sidebarRowsCache.flatMap { rowsInserting(session, into: $0) }
+                        rows: sidebarRowsCache.flatMap { self.rowsInserting(session, into: $0) }
                     )
                 }
-                archiveFailure = session
-                self.error = "Couldn't archive: \(error.localizedDescription)"
+                if !isLocallyUnarchived(session.id) {
+                    archiveFailure = session
+                    self.error = "Couldn't archive: \(error.localizedDescription)"
+                }
             }
+        }
+        archiveRequests[session.id] = (requestId, request)
+        Task { [weak self] in
+            await request.value
+            self?.archiveRequestFinished(sessionId: session.id, requestId: requestId)
+        }
+    }
+
+    private func archiveRequestFinished(sessionId: String, requestId: UUID) {
+        guard archiveRequests[sessionId]?.id == requestId else { return }
+        archiveRequests.removeValue(forKey: sessionId)
+    }
+
+    private func offerArchiveUndo(for sessions: [Session]) {
+        let offer = ArchiveUndoOffer(
+            id: UUID(),
+            sessions: sessions,
+            expiresAt: now().addingTimeInterval(archiveUndoLifetime)
+        )
+        archiveUndoOffers.append(offer)
+        let lifetime = archiveUndoLifetime
+        archiveUndoExpiryTasks[offer.id] = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(lifetime))
+            guard !Task.isCancelled else { return }
+            self?.expireArchiveUndo(id: offer.id)
+        }
+    }
+
+    /// Spend one offer by id. The id resolves its own snapshot, never the most
+    /// recent archive, so repeated actions cannot repoint an older Undo.
+    @discardableResult
+    func undoArchive(_ offerId: UUID) -> Bool {
+        expireArchiveUndos(at: now())
+        guard let index = archiveUndoOffers.firstIndex(where: { $0.id == offerId }) else {
+            return false
+        }
+        let offer = archiveUndoOffers.remove(at: index)
+        archiveUndoExpiryTasks.removeValue(forKey: offerId)?.cancel()
+        for session in offer.sessions {
+            unarchive(session)
+        }
+        return true
+    }
+
+    func expireArchiveUndos(at date: Date) {
+        let expired = archiveUndoOffers.filter { $0.expiresAt <= date }.map(\.id)
+        guard !expired.isEmpty else { return }
+        let ids = Set(expired)
+        archiveUndoOffers.removeAll { ids.contains($0.id) }
+        for id in expired {
+            archiveUndoExpiryTasks.removeValue(forKey: id)?.cancel()
+        }
+    }
+
+    private func expireArchiveUndo(id: UUID) {
+        archiveUndoOffers.removeAll { $0.id == id }
+        archiveUndoExpiryTasks.removeValue(forKey: id)
+    }
+
+    private func removeFromArchiveUndo(sessionId: String) {
+        archiveUndoOffers = archiveUndoOffers.compactMap { offer in
+            let remaining = offer.sessions.filter { $0.id != sessionId }
+            guard !remaining.isEmpty else {
+                archiveUndoExpiryTasks.removeValue(forKey: offer.id)?.cancel()
+                return nil
+            }
+            return ArchiveUndoOffer(
+                id: offer.id,
+                sessions: remaining,
+                expiresAt: offer.expiresAt
+            )
         }
     }
 
@@ -704,7 +820,8 @@ final class SessionsListViewModel {
     /// server. The short-lived suppression avoids a cached archived row
     /// flashing back into the sheet before the PATCH reaches `/api/sessions`.
     func unarchive(_ session: Session) {
-        locallyUnarchived[session.id] = Date()
+        let pendingArchive = archiveRequests.removeValue(forKey: session.id)?.task
+        locallyUnarchived[session.id] = now()
         var restored = session
         restored.archived = false
         publishArchived()
@@ -713,20 +830,23 @@ final class SessionsListViewModel {
             rows: sidebarRowsCache.flatMap { rowsInserting(restored, into: $0) }
         )
         Task {
+            if let pendingArchive { await pendingArchive.value }
             do {
-                try await OS1API.setArchived(sessionId: session.id, archived: false)
+                try await setArchived(session.id, false)
                 // The restored row is a summary until the live list carries
                 // it (and the archived index stops), so ask both rather than
                 // leaving a half-populated row in the sidebar until the next
                 // poll comes round.
-                await refresh()
-                await refreshArchived(force: true)
+                if reconcilesArchiveMutations {
+                    await refresh()
+                    await refreshArchived(force: true)
+                }
             } catch {
                 locallyUnarchived.removeValue(forKey: session.id)
                 setSessions(sessions.filter { $0.id != session.id })
                 publishArchived()
                 self.error = "Couldn't restore: \(error.localizedDescription)"
-                await refresh()
+                if reconcilesArchiveMutations { await refresh() }
             }
         }
     }

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -94,6 +94,10 @@ struct SessionsListView: View {
     @State private var createError: String?
     @State private var createErrorTitle = "Couldn't start session"
     @State private var showArchived = false
+    #if DEBUG
+    /// One targeted archive used only by the simulator screenshot command.
+    @State private var didRunArchiveCaptureHook = false
+    #endif
     /// The view controls (`SessionsFilterPanel`): a sheet on the phone, a
     /// popover on the Mac.
     @State private var showFilterPanel = false
@@ -310,6 +314,14 @@ struct SessionsListView: View {
 
     var body: some View {
         navigationContainer
+            .overlay(alignment: .bottom) {
+                ArchiveUndoStack(
+                    offers: viewModel.archiveUndoOffers,
+                    onUndo: viewModel.undoArchive
+                )
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
+            }
             // Session-id links in agent output (SessionLinks) are ordinary
             // markdown links on a private scheme; catching them here — above
             // the navigation container — is what lets a transcript push the
@@ -420,6 +432,9 @@ struct SessionsListView: View {
             .onChange(of: viewModel.hasLoaded) {
                 autoOpenFromEnvironment()
                 openRequestedSession()
+                #if DEBUG
+                archiveCaptureFixture()
+                #endif
             }
             // "Start an Agent" (StartAgentIntent — Action Button, widget,
             // Siri). It can run before this view exists (cold launch) or while
@@ -2634,14 +2649,25 @@ struct SessionsListView: View {
             // Mac hover button / Delete key / context menu: collapse the row
             // instead of blinking it out.
             withAnimation(.snappy(duration: 0.28)) {
-                workspace.sessions.forEach(viewModel.archive)
+                viewModel.archive(workspace.sessions)
             }
         } else {
             // Swipe path: the List's destructive-role delete animation owns
             // the removal; wrapping the mutation would fight it.
-            workspace.sessions.forEach(viewModel.archive)
+            viewModel.archive(workspace.sessions)
         }
     }
+
+    #if DEBUG
+    private func archiveCaptureFixture() {
+        guard !didRunArchiveCaptureHook, viewModel.hasLoaded,
+              let id = ProcessInfo.processInfo.environment["OS1_ARCHIVE_UNDO_SESSION"],
+              let session = viewModel.sessions.first(where: { $0.id == id })
+        else { return }
+        didRunArchiveCaptureHook = true
+        viewModel.archive(session)
+    }
+    #endif
 
     private var sessionCacheScope: SessionViewModelCache.Scope {
         let config = ServerConfig.shared
@@ -3520,6 +3546,45 @@ struct SessionsListView: View {
             await viewModel.refresh()
             isRetrying = false
         }
+    }
+}
+
+private struct ArchiveUndoStack: View {
+    let offers: [ArchiveUndoOffer]
+    let onUndo: (UUID) -> Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ForEach(offers) { offer in
+                HStack(spacing: 12) {
+                    Image(systemName: "archivebox.fill")
+                        .foregroundStyle(.secondary)
+                    Text(offer.message)
+                        .font(.subheadline.weight(.medium))
+                    Spacer(minLength: 8)
+                    Button("Undo") {
+                        withAnimation(.snappy(duration: 0.22)) {
+                            _ = onUndo(offer.id)
+                        }
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .buttonStyle(.plain)
+                    .foregroundStyle(OS1VisualStyle.accent)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .frame(maxWidth: 380)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14)
+                        .strokeBorder(OS1VisualStyle.border.opacity(0.7), lineWidth: 0.5)
+                }
+                .shadow(color: .black.opacity(0.14), radius: 12, y: 4)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .accessibilityElement(children: .contain)
+            }
+        }
+        .animation(.snappy(duration: 0.22), value: offers.map(\.id))
     }
 }
 

--- a/packages/clients/ios/OS1Tests/ArchiveUndoTests.swift
+++ b/packages/clients/ios/OS1Tests/ArchiveUndoTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import OS1
+
+@MainActor
+final class ArchiveUndoTests: XCTestCase {
+    private func sessions(_ json: String) throws -> [Session] {
+        try JSONDecoder().decode([Session].self, from: Data(json.utf8))
+    }
+
+    private func model(now: @escaping () -> Date) -> SessionsListViewModel {
+        SessionsListViewModel(
+            now: now,
+            archiveUndoLifetime: 7,
+            setArchived: { _, _ in },
+            reconcilesArchiveMutations: false
+        )
+    }
+
+    func testUndoRestoresTheSnapshotOwnedByItsArchiveAction() throws {
+        let now = Date(timeIntervalSince1970: 100)
+        let model = model(now: { now })
+        let rows = try sessions(
+            #"[{"id":"workspace-a"},{"id":"workspace-b"},{"id":"later"}]"#
+        )
+
+        model.archive(Array(rows.prefix(2)))
+        let firstOffer = try XCTUnwrap(model.archiveUndoOffers.first)
+        model.archive(rows[2])
+        let laterOffer = try XCTUnwrap(model.archiveUndoOffers.last)
+
+        XCTAssertTrue(model.undoArchive(firstOffer.id))
+        XCTAssertEqual(Set(model.sessions.map(\.id)), ["workspace-a", "workspace-b"])
+        XCTAssertEqual(model.archiveUndoOffers.map(\.id), [laterOffer.id])
+        XCTAssertFalse(model.sessions.contains(where: { $0.id == "later" }))
+    }
+
+    func testExpiredAndRepeatedArchiveOffersStayIndependent() throws {
+        var now = Date(timeIntervalSince1970: 200)
+        let model = model(now: { now })
+        let rows = try sessions(#"[{"id":"first"},{"id":"second"}]"#)
+
+        model.archive(rows[0])
+        let firstOffer = try XCTUnwrap(model.archiveUndoOffers.first)
+        now = now.addingTimeInterval(4)
+        model.archive(rows[1])
+        let secondOffer = try XCTUnwrap(model.archiveUndoOffers.last)
+
+        XCTAssertNotEqual(firstOffer.id, secondOffer.id)
+        now = now.addingTimeInterval(4)
+        model.expireArchiveUndos(at: now)
+        XCTAssertEqual(model.archiveUndoOffers.map(\.id), [secondOffer.id])
+        XCTAssertFalse(model.undoArchive(firstOffer.id))
+        XCTAssertTrue(model.undoArchive(secondOffer.id))
+        XCTAssertEqual(model.sessions.map(\.id), ["second"])
+    }
+}


### PR DESCRIPTION
## Summary
- show a short-lived native Undo banner after every session or workspace archive
- bind each Undo to its own archived snapshot so repeated actions stay independent
- route menu, swipe, tab close, and in-session workspace archives through the existing optimistic archive and unarchive paths
- cover snapshot restoration and staggered expiry with native tests

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac tests: 919 passed, 0 failed
- iPhone 17 Pro simulator screenshot captured after a real archive action

<!-- opensession:walkthrough -->
## Walkthrough

Native archive actions now show a short-lived SwiftUI Undo banner. Each banner keeps the exact session or workspace snapshot archived by that action, so repeated archives remain independent and Undo restores only its own sessions.

Verified with OS1 and OS1Mac builds plus the full OS1Mac test suite, including snapshot ownership and staggered expiry coverage.

| Before | After |
| --- | --- |
| — | ![After — iOS archive feedback with the native Undo action](https://github.com/user-attachments/assets/38771c49-68be-441b-a3c4-f7d1fda5d62d) |

<sub>Published from the session's Review tab.</sub>
<!-- /opensession:walkthrough -->

Created by [this OS session](https://os.tella.dev/session/bks-d1e9dea2-0551-79e4-99f0-dec81b1ce6aa)