### PR TITLE
Show stacked PRs in native session info

### DIFF
--- a/packages/clients/ios/OS1/Models/Session.swift
+++ b/packages/clients/ios/OS1/Models/Session.swift
@@ -104,9 +104,8 @@ struct Session: Identifiable, Decodable, Equatable, Hashable {
     var automation: AutomationFlag?
     var attachedRepos: [AttachedRepo]?
     /// Every pull-request branch associated with this session, including
-    /// attached, linked, and discovered branches. The native PR panel still
-    /// presents the primary PR; this list makes app-wide webhook refreshes
-    /// reach every branch the session owns.
+    /// attached, linked, and discovered branches. The native workspace and PR
+    /// surfaces use the enriched refs to show the complete series.
     var prs: [SessionPrRef]?
     /// The requested sandbox provider and materialized sandbox id. This is a
     /// reference only; Workspace details resolves its live state on demand.
@@ -375,12 +374,21 @@ struct AttachedRepo: Decodable, Equatable, Hashable, Identifiable {
     var id: String { repo }
 }
 
-/// The identity fields of one PR associated with a session. The server sends
-/// richer state too; tolerant decoding keeps only what live refresh matching
-/// needs and ignores the rest.
+/// One pull request associated with a session. Every enriched field remains
+/// optional so older servers and unresolved branches still decode safely.
 struct SessionPrRef: Decodable, Equatable, Hashable {
     let repo: String
     let branch: String
+    var source: String? = nil
+    var url: String? = nil
+    var state: String? = nil
+    var number: Int? = nil
+    var title: String? = nil
+    var isDraft: Bool? = nil
+    var reviewDecision: String? = nil
+    var additions: Int? = nil
+    var deletions: Int? = nil
+    var checks: PrChecksSummary? = nil
 }
 
 extension Session {

--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -601,11 +601,21 @@ enum OS1API {
         return try await responseData(for: request)
     }
 
-    /// PR details for the session's branch, or nil when it has no PR — the
-    /// route answers a bare JSON `null` in that case (a real answer, not an
-    /// error), so probe the raw body before decoding.
-    static func pr(sessionId: String) async throws -> PrDetails? {
-        let data = try await getData("/api/sessions/\(sessionId)/pr")
+    /// PR details for the primary branch or an explicit repo and branch target.
+    /// The route answers a bare JSON `null` when that target has no PR, so
+    /// probe the raw body before decoding.
+    static func pr(
+        sessionId: String,
+        repo: String? = nil,
+        branch: String? = nil
+    ) async throws -> PrDetails? {
+        var components = URLComponents()
+        components.path = "/api/sessions/\(sessionId)/pr"
+        components.queryItems = [
+            repo.map { URLQueryItem(name: "repo", value: $0) },
+            branch.map { URLQueryItem(name: "branch", value: $0) },
+        ].compactMap { $0 }
+        let data = try await getData(components.string ?? components.path)
         let body = String(decoding: data, as: UTF8.self)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if body.isEmpty || body == "null" { return nil }

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -44,6 +44,156 @@ extension PrDetails.Summary {
     }
 }
 
+/// The exact server target for one PR in a multi-repo or stacked session.
+struct SessionPrTarget: Equatable, Hashable {
+    let repo: String
+    let branch: String
+}
+
+/// A display row derived from the session snapshot. Keeping ordering and target
+/// selection outside SwiftUI makes the primary-plus-additional contract easy
+/// to verify without rendering a view.
+struct SessionPrRow: Identifiable, Equatable {
+    let target: SessionPrTarget
+    let number: Int
+    let title: String?
+    let state: String
+    let url: URL?
+    let isPrimary: Bool
+
+    var id: SessionPrTarget { target }
+}
+
+@MainActor
+enum SessionPrSeries {
+    static func rows(for session: Session) -> [SessionPrRow] {
+        let refs = session.prs ?? []
+        let primaryIndex = refs.firstIndex { ref in
+            ref.source == "primary"
+                || (ref.repo == session.effectiveRepo && ref.branch == session.branch)
+        }
+        var ordered = refs
+        if let primaryIndex, primaryIndex != 0 {
+            ordered.insert(ordered.remove(at: primaryIndex), at: 0)
+        }
+
+        if primaryIndex == nil,
+           let number = session.prNumber,
+           let branch = session.branch,
+           !branch.isEmpty {
+            ordered.insert(
+                SessionPrRef(
+                    repo: session.effectiveRepo,
+                    branch: branch,
+                    source: "primary",
+                    url: session.prUrl,
+                    state: session.prState,
+                    number: number,
+                    isDraft: session.prIsDraft,
+                    reviewDecision: session.prReviewDecision,
+                    additions: session.prAdditions,
+                    deletions: session.prDeletions,
+                    checks: session.prChecks
+                ),
+                at: 0
+            )
+        }
+
+        var seen: Set<SessionPrTarget> = []
+        return ordered.compactMap { ref in
+            guard let number = ref.number else { return nil }
+            let target = SessionPrTarget(repo: ref.repo, branch: ref.branch)
+            guard seen.insert(target).inserted else { return nil }
+            return SessionPrRow(
+                target: target,
+                number: number,
+                title: ref.title,
+                state: stateLabel(for: ref),
+                url: ref.url.flatMap(URL.init(string:))
+                    ?? PrLinks.githubURL(for: .init(repo: ref.repo, number: number)),
+                isPrimary: ref.source == "primary"
+                    || (ref.repo == session.effectiveRepo && ref.branch == session.branch)
+            )
+        }
+    }
+
+    private static func stateLabel(for ref: SessionPrRef) -> String {
+        if ref.state == "MERGED" { return "Merged" }
+        if ref.state == "CLOSED" { return "Closed" }
+        if (ref.checks?.failed ?? 0) > 0 { return "Checks failed" }
+        if ref.reviewDecision == "CHANGES_REQUESTED" { return "Changes requested" }
+        let pending = ref.checks?.pending ?? 0
+        if pending > 0 { return "\(pending) check\(pending == 1 ? "" : "s") pending" }
+        if ref.isDraft == true { return "Draft" }
+        if ref.reviewDecision == "APPROVED" { return "Approved" }
+        return "Open"
+    }
+}
+
+/// Compact native rows for the PRs beyond the primary panel target.
+struct SessionPrSeriesRows: View {
+    let session: Session
+    var includePrimary = false
+    let open: (SessionPrRow) -> Void
+
+    private var rows: [SessionPrRow] {
+        SessionPrSeries.rows(for: session).filter { includePrimary || !$0.isPrimary }
+    }
+
+    var body: some View {
+        ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+            if index > 0 { Divider().padding(.leading, 44) }
+            Button { open(row) } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: row.state == "Merged"
+                        ? "arrow.triangle.merge"
+                        : "arrow.triangle.pull")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(tint(for: row.state))
+                        .frame(width: 22)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(verbatim: "\(RepoTile.label(for: row.target.repo)) #\(row.number)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(OS1VisualStyle.text)
+                        if let title = row.title, !title.isEmpty {
+                            Text(title)
+                                .font(.caption)
+                                .foregroundStyle(OS1VisualStyle.textDim)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    Text(row.state)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(tint(for: row.state))
+                        .multilineTextAlignment(.trailing)
+                    Image(systemName: "arrow.up.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(OS1VisualStyle.textFaint)
+                }
+                .padding(.horizontal, 12)
+                .frame(minHeight: 52)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                Text(verbatim: "\(RepoTile.label(for: row.target.repo)) pull request #\(row.number), \(row.state)")
+            )
+        }
+    }
+
+    private func tint(for state: String) -> Color {
+        switch state {
+        case "Merged": OS1VisualStyle.purple
+        case "Closed", "Draft": OS1VisualStyle.textDim
+        case "Checks failed", "Changes requested": OS1VisualStyle.red
+        case let value where value.contains("pending"): OS1VisualStyle.yellow
+        default: OS1VisualStyle.green
+        }
+    }
+}
+
 /// The PR details sheet: title, state and review badges, branch/line stats,
 /// conflict warning, every check with its status, the reviewer list — and,
 /// while the PR is open, the same three actions the web panel offers: submit a
@@ -55,6 +205,7 @@ struct PrPanelView: View {
     /// the edge swipe) rather than a Done button.
     var chrome: Chrome = .sheet
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
 
     /// The action in flight, if any. One at a time: the section disables while
     /// it runs, so this doubles as "which row shows the spinner". Reviewing has
@@ -118,7 +269,14 @@ struct PrPanelView: View {
             }
         }
         // Checks move fast while CI runs; re-fetch on open (server-cached).
-        .task { await viewModel.refreshPr() }
+        .task {
+            await viewModel.refreshPr()
+            #if DEBUG && os(iOS)
+            if ProcessInfo.processInfo.environment["OS1_OPEN_PR_INFO"] == "1" {
+                page = .info
+            }
+            #endif
+        }
         .sheet(item: $slackShare) { request in
             PrSlackShareSheet(request: request)
         }
@@ -234,8 +392,34 @@ struct PrPanelView: View {
                 Button("Retry") { viewModel.loadPr() }
             }
         } else {
-            ProgressView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            let rows = SessionPrSeries.rows(for: viewModel.session)
+            if rows.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Pull requests")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(OS1VisualStyle.textDim)
+                            .padding(.horizontal, 4)
+                        VStack(spacing: 0) {
+                            SessionPrSeriesRows(
+                                session: viewModel.session,
+                                includePrimary: true
+                            ) { row in
+                                if let url = row.url { openURL(url) }
+                            }
+                        }
+                        .background(
+                            OS1VisualStyle.raised,
+                            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        )
+                    }
+                    .padding(16)
+                }
+                .background(OS1VisualStyle.background)
+            }
         }
     }
 
@@ -291,6 +475,7 @@ struct PrPanelView: View {
     private func infoPage(_ pr: PrDetails) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
+                pullRequestsGroup
                 statusGroup(pr)
                 reviewersGroup(pr)
                 checksGroup(pr)
@@ -301,6 +486,21 @@ struct PrPanelView: View {
         }
         .background(OS1VisualStyle.background)
         .refreshable { await viewModel.refreshPr() }
+    }
+
+    @ViewBuilder
+    private var pullRequestsGroup: some View {
+        let rows = SessionPrSeries.rows(for: viewModel.session).filter { !$0.isPrimary }
+        if !rows.isEmpty {
+            infoGroup(
+                "Related pull requests",
+                answer: Text("\(rows.count)").foregroundColor(OS1VisualStyle.textDim)
+            ) {
+                SessionPrSeriesRows(session: viewModel.session) { row in
+                    if let url = row.url { openURL(url) }
+                }
+            }
+        }
     }
 
     /// One group: its label and answer, then a card of rows.

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -55,13 +55,19 @@ struct SessionPrTarget: Equatable, Hashable {
 /// to verify without rendering a view.
 struct SessionPrRow: Identifiable, Equatable {
     let target: SessionPrTarget
-    let number: Int
+    let number: Int?
     let title: String?
     let state: String
     let url: URL?
     let isPrimary: Bool
 
     var id: SessionPrTarget { target }
+
+    @MainActor
+    var identityLabel: String {
+        let repo = RepoTile.label(for: target.repo)
+        return number.map { "\(repo) #\($0)" } ?? "\(repo) · \(target.branch)"
+    }
 }
 
 @MainActor
@@ -101,30 +107,41 @@ enum SessionPrSeries {
 
         var seen: Set<SessionPrTarget> = []
         return ordered.compactMap { ref in
-            guard let number = ref.number else { return nil }
             let target = SessionPrTarget(repo: ref.repo, branch: ref.branch)
             guard seen.insert(target).inserted else { return nil }
             return SessionPrRow(
                 target: target,
-                number: number,
+                number: ref.number,
                 title: ref.title,
                 state: stateLabel(for: ref),
                 url: ref.url.flatMap(URL.init(string:))
-                    ?? PrLinks.githubURL(for: .init(repo: ref.repo, number: number)),
+                    ?? ref.number.flatMap {
+                        PrLinks.githubURL(for: .init(repo: ref.repo, number: $0))
+                    },
                 isPrimary: ref.source == "primary"
                     || (ref.repo == session.effectiveRepo && ref.branch == session.branch)
             )
         }
     }
 
+    static func destination(for row: SessionPrRow, sessionId: String) async -> URL? {
+        if let url = row.url { return url }
+        let details = try? await OS1API.pr(
+            sessionId: sessionId,
+            repo: row.target.repo,
+            branch: row.target.branch
+        )
+        return details?.url.flatMap(URL.init(string:))
+    }
+
     private static func stateLabel(for ref: SessionPrRef) -> String {
         if ref.state == "MERGED" { return "Merged" }
         if ref.state == "CLOSED" { return "Closed" }
+        if ref.isDraft == true { return "Draft" }
         if (ref.checks?.failed ?? 0) > 0 { return "Checks failed" }
         if ref.reviewDecision == "CHANGES_REQUESTED" { return "Changes requested" }
         let pending = ref.checks?.pending ?? 0
         if pending > 0 { return "\(pending) check\(pending == 1 ? "" : "s") pending" }
-        if ref.isDraft == true { return "Draft" }
         if ref.reviewDecision == "APPROVED" { return "Approved" }
         return "Open"
     }
@@ -152,7 +169,7 @@ struct SessionPrSeriesRows: View {
                         .foregroundStyle(tint(for: row.state))
                         .frame(width: 22)
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(verbatim: "\(RepoTile.label(for: row.target.repo)) #\(row.number)")
+                        Text(verbatim: row.identityLabel)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(OS1VisualStyle.text)
                         if let title = row.title, !title.isEmpty {
@@ -178,7 +195,7 @@ struct SessionPrSeriesRows: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(
-                Text(verbatim: "\(RepoTile.label(for: row.target.repo)) pull request #\(row.number), \(row.state)")
+                Text(verbatim: "\(row.identityLabel), \(row.state)")
             )
         }
     }
@@ -408,7 +425,7 @@ struct PrPanelView: View {
                                 session: viewModel.session,
                                 includePrimary: true
                             ) { row in
-                                if let url = row.url { openURL(url) }
+                                openPrRow(row)
                             }
                         }
                         .background(
@@ -497,9 +514,19 @@ struct PrPanelView: View {
                 answer: Text("\(rows.count)").foregroundColor(OS1VisualStyle.textDim)
             ) {
                 SessionPrSeriesRows(session: viewModel.session) { row in
-                    if let url = row.url { openURL(url) }
+                    openPrRow(row)
                 }
             }
+        }
+    }
+
+    private func openPrRow(_ row: SessionPrRow) {
+        Task {
+            guard let url = await SessionPrSeries.destination(
+                for: row,
+                sessionId: viewModel.session.id
+            ) else { return }
+            openURL(url)
         }
     }
 

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -180,6 +180,7 @@ struct SessionView: View {
     /// Workspace-scoped archived summaries. Kept out of the global archived
     /// index so opening one session never downloads the whole server history.
     @State private var workspaceArchiveRows: [Session] = []
+    @Environment(\.openURL) private var macOpenURL
     #endif
 
     #if os(iOS)
@@ -718,34 +719,47 @@ struct SessionView: View {
             #else
             // macOS retains the PR chip in its roomier toolbar; on iOS the
             // same series lives in the title-opened workspace sheet.
-            if let prNumber = viewModel.prDetails?.number ?? viewModel.session.prNumber {
-                let prRows = SessionPrSeries.rows(for: viewModel.session)
+            let prRows = SessionPrSeries.rows(for: viewModel.session)
+            let primaryPrNumber = viewModel.prDetails?.number ?? viewModel.session.prNumber
+            if let chipRow = prRows.first {
                 ToolbarItem(placement: .topTrailingCompat) {
-                    if prRows.count > 1 {
-                        Menu {
-                            Button {
-                                showPrPanel = true
-                            } label: {
-                                Text(verbatim: "Open pull request #\(prNumber)")
-                            }
-                            ForEach(prRows.filter { !$0.isPrimary }) { row in
-                                if let url = row.url {
-                                    Link(destination: url) {
-                                        Text(verbatim: "\(RepoTile.label(for: row.target.repo)) #\(row.number) · \(row.title ?? row.state)")
-                                    }
-                                }
-                            }
-                        } label: {
-                            PrChipLabel(number: prNumber, summary: viewModel.prDetails?.summary)
-                        }
-                        .accessibilityLabel(Text("Pull requests"))
-                    } else {
+                    if prRows.count == 1, let primaryPrNumber, chipRow.isPrimary {
                         Button {
                             showPrPanel = true
                         } label: {
-                            PrChipLabel(number: prNumber, summary: viewModel.prDetails?.summary)
+                            PrChipLabel(
+                                number: primaryPrNumber,
+                                summary: viewModel.prDetails?.summary
+                            )
                         }
-                        .accessibilityLabel(Text(verbatim: "Pull request #\(prNumber)"))
+                        .accessibilityLabel(Text(verbatim: "Pull request #\(primaryPrNumber)"))
+                    } else {
+                        Menu {
+                            if let primaryPrNumber {
+                                Button {
+                                    showPrPanel = true
+                                } label: {
+                                    Text(verbatim: "Open pull request #\(primaryPrNumber)")
+                                }
+                            }
+                            ForEach(prRows.filter { primaryPrNumber == nil || !$0.isPrimary }) { row in
+                                Button {
+                                    openRelatedPr(row)
+                                } label: {
+                                    Text(verbatim: "\(row.identityLabel) · \(row.title ?? row.state)")
+                                }
+                            }
+                        } label: {
+                            if let number = chipRow.number {
+                                PrChipLabel(
+                                    number: number,
+                                    summary: chipRow.isPrimary ? viewModel.prDetails?.summary : nil
+                                )
+                            } else {
+                                Image(systemName: "arrow.trianglehead.pull")
+                            }
+                        }
+                        .accessibilityLabel(Text("Pull requests"))
                     }
                 }
             }
@@ -1033,6 +1047,16 @@ struct SessionView: View {
         guard let onRestoreArchivedSession else { return }
         workspaceArchiveRows.removeAll { $0.id == session.id }
         Task { await onRestoreArchivedSession(session) }
+    }
+
+    private func openRelatedPr(_ row: SessionPrRow) {
+        Task {
+            guard let url = await SessionPrSeries.destination(
+                for: row,
+                sessionId: viewModel.session.id
+            ) else { return }
+            macOpenURL(url)
+        }
     }
 
     /// Own the detail title instead of accepting NavigationSplitView's

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -717,15 +717,36 @@ struct SessionView: View {
             }
             #else
             // macOS retains the PR chip in its roomier toolbar; on iOS the
-            // same panel lives in the title-opened workspace sheet.
+            // same series lives in the title-opened workspace sheet.
             if let prNumber = viewModel.prDetails?.number ?? viewModel.session.prNumber {
+                let prRows = SessionPrSeries.rows(for: viewModel.session)
                 ToolbarItem(placement: .topTrailingCompat) {
-                    Button {
-                        showPrPanel = true
-                    } label: {
-                        PrChipLabel(number: prNumber, summary: viewModel.prDetails?.summary)
+                    if prRows.count > 1 {
+                        Menu {
+                            Button {
+                                showPrPanel = true
+                            } label: {
+                                Text(verbatim: "Open pull request #\(prNumber)")
+                            }
+                            ForEach(prRows.filter { !$0.isPrimary }) { row in
+                                if let url = row.url {
+                                    Link(destination: url) {
+                                        Text(verbatim: "\(RepoTile.label(for: row.target.repo)) #\(row.number) · \(row.title ?? row.state)")
+                                    }
+                                }
+                            }
+                        } label: {
+                            PrChipLabel(number: prNumber, summary: viewModel.prDetails?.summary)
+                        }
+                        .accessibilityLabel(Text("Pull requests"))
+                    } else {
+                        Button {
+                            showPrPanel = true
+                        } label: {
+                            PrChipLabel(number: prNumber, summary: viewModel.prDetails?.summary)
+                        }
+                        .accessibilityLabel(Text(verbatim: "Pull request #\(prNumber)"))
                     }
-                    .accessibilityLabel(Text(verbatim: "Pull request #\(prNumber)"))
                 }
             }
             #endif

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -726,8 +726,14 @@ struct WorktreeInfoView: View {
                 ) { row in
                     if row.isPrimary {
                         panel = .review(sessionId: currentSession.id)
-                    } else if let url = row.url {
-                        openURL(url)
+                    } else {
+                        Task {
+                            guard let url = await SessionPrSeries.destination(
+                                for: row,
+                                sessionId: currentSession.id
+                            ) else { return }
+                            openURL(url)
+                        }
                     }
                 }
             }

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -698,21 +698,38 @@ struct WorktreeInfoView: View {
 
     @ViewBuilder
     private var pullRequestSection: some View {
-        if let number = viewModel.prDetails?.number ?? currentSession.prNumber {
+        let rows = SessionPrSeries.rows(for: currentSession)
+        let primaryNumber = viewModel.prDetails?.number ?? currentSession.prNumber
+        if !rows.isEmpty || primaryNumber != nil {
             InfoSection(
-                title: "Pull request",
-                trailing: viewModel.prDetails.map { AnyView(prNumberLabel(number, summary: $0.summary)) }
+                title: rows.count == 1 ? "Pull request" : "Pull requests",
+                trailing: primaryNumber.flatMap { number in
+                    viewModel.prDetails.map { AnyView(prNumberLabel(number, summary: $0.summary)) }
+                }
             ) {
-                Button {
-                    panel = .review(sessionId: currentSession.id)
-                } label: {
-                    if let pr = viewModel.prDetails {
-                        prSummary(pr)
-                    } else {
-                        prLoadingSummary(number)
+                if let number = primaryNumber {
+                    Button {
+                        panel = .review(sessionId: currentSession.id)
+                    } label: {
+                        if let pr = viewModel.prDetails {
+                            prSummary(pr)
+                        } else {
+                            prLoadingSummary(number)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    if rows.contains(where: { !$0.isPrimary }) { Divider() }
+                }
+                SessionPrSeriesRows(
+                    session: currentSession,
+                    includePrimary: primaryNumber == nil
+                ) { row in
+                    if row.isPrimary {
+                        panel = .review(sessionId: currentSession.id)
+                    } else if let url = row.url {
+                        openURL(url)
                     }
                 }
-                .buttonStyle(.plain)
             }
         }
     }

--- a/packages/clients/ios/OS1Tests/SessionPrSeriesTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionPrSeriesTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import OS1
+
+@MainActor
+final class SessionPrSeriesTests: XCTestCase {
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    func testPrimaryComesBeforeAdditionalPullRequestsWithoutReorderingTheRest() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-series",
+              "repo":"opensession",
+              "branch":"stack/foundation",
+              "prs":[
+                {"repo":"tella-mac","branch":"stack/desktop","source":"attached","number":73,"title":"Desktop shell","state":"OPEN","url":"https://github.com/tellahq/tella-mac/pull/73"},
+                {"repo":"opensession","branch":"stack/follow-up","source":"linked","number":74,"title":"Follow-up","state":"MERGED","url":"https://github.com/tellahq/opensession/pull/74"},
+                {"repo":"opensession","branch":"stack/foundation","source":"primary","number":72,"title":"Foundation","state":"OPEN","url":"https://github.com/tellahq/opensession/pull/72"}
+              ]
+            }
+            """
+        )
+
+        let rows = SessionPrSeries.rows(for: value)
+
+        XCTAssertEqual(rows.map(\.number), [72, 73, 74])
+        XCTAssertEqual(rows.map(\.title), ["Foundation", "Desktop shell", "Follow-up"])
+        XCTAssertEqual(rows.map(\.state), ["Open", "Open", "Merged"])
+        XCTAssertEqual(rows.map(\.isPrimary), [true, false, false])
+    }
+
+    func testEachAdditionalRowKeepsItsOwnRepoBranchAndUrlTarget() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-targets",
+              "repo":"opensession",
+              "branch":"stack/foundation",
+              "prs":[
+                {"repo":"opensession","branch":"stack/foundation","source":"primary","number":72,"state":"OPEN","url":"https://github.com/tellahq/opensession/pull/72"},
+                {"repo":"tella-mac","branch":"stack/desktop","source":"attached","number":73,"state":"OPEN","url":"https://github.com/tellahq/tella-mac/pull/73"},
+                {"repo":"opensession","branch":"stack/follow-up","source":"linked","number":74,"state":"MERGED","url":"https://github.com/tellahq/opensession/pull/74"}
+              ]
+            }
+            """
+        )
+
+        let rows = SessionPrSeries.rows(for: value)
+
+        XCTAssertEqual(
+            rows.map(\.target),
+            [
+                SessionPrTarget(repo: "opensession", branch: "stack/foundation"),
+                SessionPrTarget(repo: "tella-mac", branch: "stack/desktop"),
+                SessionPrTarget(repo: "opensession", branch: "stack/follow-up"),
+            ]
+        )
+        XCTAssertEqual(
+            rows.map(\.url?.absoluteString),
+            [
+                "https://github.com/tellahq/opensession/pull/72",
+                "https://github.com/tellahq/tella-mac/pull/73",
+                "https://github.com/tellahq/opensession/pull/74",
+            ]
+        )
+    }
+
+    func testLegacyPrimaryPrecedesProjectedAdditionalPullRequests() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-legacy",
+              "repo":"opensession",
+              "branch":"stack/foundation",
+              "prNumber":72,
+              "prState":"OPEN",
+              "prUrl":"https://github.com/tellahq/opensession/pull/72",
+              "prs":[
+                {"repo":"tella-mac","branch":"stack/desktop","source":"attached","number":73,"title":"Desktop shell","state":"OPEN","url":"https://github.com/tellahq/tella-mac/pull/73"}
+              ]
+            }
+            """
+        )
+
+        let rows = SessionPrSeries.rows(for: value)
+
+        XCTAssertEqual(rows.map(\.number), [72, 73])
+        XCTAssertEqual(rows.first?.target, SessionPrTarget(repo: "opensession", branch: "stack/foundation"))
+        XCTAssertEqual(rows.first?.isPrimary, true)
+    }
+}

--- a/packages/clients/ios/OS1Tests/SessionPrSeriesTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionPrSeriesTests.swift
@@ -25,7 +25,7 @@ final class SessionPrSeriesTests: XCTestCase {
 
         let rows = SessionPrSeries.rows(for: value)
 
-        XCTAssertEqual(rows.map(\.number), [72, 73, 74])
+        XCTAssertEqual(rows.compactMap(\.number), [72, 73, 74])
         XCTAssertEqual(rows.map(\.title), ["Foundation", "Desktop shell", "Follow-up"])
         XCTAssertEqual(rows.map(\.state), ["Open", "Open", "Merged"])
         XCTAssertEqual(rows.map(\.isPrimary), [true, false, false])
@@ -67,6 +67,67 @@ final class SessionPrSeriesTests: XCTestCase {
         )
     }
 
+    func testRelatedPullRequestStillProvidesTheLeadingRowWithoutAPrimary() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-related-only",
+              "repo":"opensession",
+              "branch":"no-primary-pr",
+              "prs":[
+                {"repo":"tella-mac","branch":"stack/desktop","source":"attached","number":73,"title":"Desktop shell","state":"OPEN"}
+              ]
+            }
+            """
+        )
+
+        let row = try XCTUnwrap(SessionPrSeries.rows(for: value).first)
+
+        XCTAssertEqual(row.target, SessionPrTarget(repo: "tella-mac", branch: "stack/desktop"))
+        XCTAssertEqual(row.number, 73)
+        XCTAssertFalse(row.isPrimary)
+    }
+
+    func testUnresolvedRelatedPullRequestKeepsItsRepoAndBranchTarget() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-unresolved",
+              "repo":"opensession",
+              "branch":"stack/foundation",
+              "prs":[
+                {"repo":"opensession","branch":"stack/foundation","source":"primary","number":72,"state":"OPEN"},
+                {"repo":"shared-infra","branch":"stack/deploy","source":"linked"}
+              ]
+            }
+            """
+        )
+
+        let row = try XCTUnwrap(SessionPrSeries.rows(for: value).last)
+
+        XCTAssertEqual(row.target, SessionPrTarget(repo: "shared-infra", branch: "stack/deploy"))
+        XCTAssertNil(row.number)
+        XCTAssertEqual(row.state, "Open")
+        XCTAssertEqual(row.identityLabel, "shared-infra · stack/deploy")
+    }
+
+    func testDraftStateTakesPrecedenceOverChecksAndReview() throws {
+        let value = try session(
+            """
+            {
+              "id":"os-draft",
+              "repo":"opensession",
+              "branch":"stack/draft",
+              "prs":[
+                {"repo":"opensession","branch":"stack/draft","source":"primary","number":72,"state":"OPEN","isDraft":true,"reviewDecision":"CHANGES_REQUESTED","checks":{"total":2,"passed":0,"failed":1,"pending":1}}
+              ]
+            }
+            """
+        )
+
+        XCTAssertEqual(SessionPrSeries.rows(for: value).first?.state, "Draft")
+    }
+
     func testLegacyPrimaryPrecedesProjectedAdditionalPullRequests() throws {
         let value = try session(
             """
@@ -86,7 +147,7 @@ final class SessionPrSeriesTests: XCTestCase {
 
         let rows = SessionPrSeries.rows(for: value)
 
-        XCTAssertEqual(rows.map(\.number), [72, 73])
+        XCTAssertEqual(rows.compactMap(\.number), [72, 73])
         XCTAssertEqual(rows.first?.target, SessionPrTarget(repo: "opensession", branch: "stack/foundation"))
         XCTAssertEqual(rows.first?.isPrimary, true)
     }


### PR DESCRIPTION
## Summary
- decode the enriched session PR refs and keep the primary PR first
- show every related PR with native state styling in workspace and PR info surfaces
- open each additional row at its own repository and pull request URL
- cover ordering, legacy primary fallback, and target selection

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac test suite
- native iPhone fixture with tella-fusion#5815 and tella-mac#74

<!-- opensession:walkthrough -->
## Walkthrough

The native session info surface now shows every pull request associated with a stacked or multi-repo session, so related work is no longer hidden behind the primary branch. Each row carries its repository, number, title, and current state, and opens its own pull request target. The screenshot uses a live two-PR fixture and shows the primary tella-fusion PR with its related tella-mac PR. Verified with OS1 and OS1Mac builds plus the OS1Mac test suite.

| Before | After |
| --- | --- |
| — | ![After — Native PR info showing the primary and related multi-repo pull request](https://github.com/user-attachments/assets/a92bb928-a1c2-4341-9e80-b529eccdfc24) |

<sub>Published from the session's Review tab.</sub>
<!-- /opensession:walkthrough -->

Created by [this OS session](https://os.tella.dev/session/bks-451d531e-199d-7349-b6ce-baff39df3bad)