### PR TITLE
Bring native session creation and Slack receipts up to date

### DIFF
--- a/packages/clients/ios/OS1/Models/ComposerSessionProjection.swift
+++ b/packages/clients/ios/OS1/Models/ComposerSessionProjection.swift
@@ -57,6 +57,10 @@ struct ComposerSessionProjection {
         self.references = references
     }
 
+    /// The text currently shown in the composer. This is suitable for naming
+    /// a new session while `canonicalText` remains the model's prompt.
+    var titlePrompt: String { displayText }
+
     /// Apply one field edit without ever replacing the canonical draft with
     /// its projected titles. Editing any part of a title consumes that whole
     /// reference, matching its atomic presentation.

--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -1598,6 +1598,7 @@ enum OS1API {
     /// server-suggested branch; the opening run starts immediately.
     static func createSession(
         prompt: String,
+        titlePrompt: String? = nil,
         repo: String,
         mode: String,
         model: String? = nil,
@@ -1612,6 +1613,7 @@ enum OS1API {
         struct CreateResponse: Decodable { let id: String }
         var body = createSessionBody(
             prompt: prompt,
+            titlePrompt: titlePrompt,
             repo: repo,
             mode: mode,
             model: model,
@@ -1641,6 +1643,7 @@ enum OS1API {
     /// omitting `repo` means inherit-or-default and is not repo-less.
     static func createSessionBody(
         prompt: String,
+        titlePrompt: String? = nil,
         repo: String,
         mode: String,
         model: String? = nil,
@@ -1654,6 +1657,7 @@ enum OS1API {
         requestId: String? = nil
     ) -> [String: Any] {
         var body: [String: Any] = ["prompt": prompt, "mode": mode]
+        if let titlePrompt, !titlePrompt.isEmpty { body["titlePrompt"] = titlePrompt }
         if let requestId, !requestId.isEmpty { body["requestId"] = requestId }
         // Sent only when the composer actually offered the choice. Omitting it
         // lets the instance's own sandbox default decide, which is the right
@@ -1673,6 +1677,21 @@ enum OS1API {
         if !stagedFiles.isEmpty { body["files"] = stagedFiles }
         if !user.isEmpty { body["user"] = user }
         return body
+    }
+
+    static func undoSlackComposer(sessionId: String, channelId: String, ts: String) async throws {
+        struct UndoResponse: Decodable, Sendable { let status: String }
+        let encoded = sessionId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? sessionId
+        let _: UndoResponse = try await post(
+            "/api/sessions/\(encoded)/slack-composer/undo",
+            body: slackComposerUndoBody(channelId: channelId, ts: ts)
+        )
+    }
+
+    static func slackComposerUndoBody(channelId: String, ts: String) -> [String: Any] {
+        ["channel": channelId, "ts": ts]
     }
 
     /// Upload one composer file before it rides a prompt or session create.

--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -195,7 +195,8 @@ enum ServerEvent: Sendable {
                     requestId: requestId,
                     status: status,
                     channel: channel,
-                    permalink: frame.permalink
+                    permalink: frame.permalink,
+                    ts: frame.ts
                 )
             )
         case "workflow_update":
@@ -261,8 +262,34 @@ struct SlackComposeReceipt: Equatable, Sendable, Identifiable {
     let status: Status
     let channel: Channel?
     let permalink: String?
+    /// The Slack message timestamp. Present when the message can still be
+    /// taken back out of Slack.
+    let ts: String?
+
+    /// The defaults keep the older call sites that never knew a timestamp,
+    /// such as the cancel path, building a receipt in one line.
+    init(
+        requestId: String,
+        status: Status,
+        channel: Channel? = nil,
+        permalink: String? = nil,
+        ts: String? = nil
+    ) {
+        self.requestId = requestId
+        self.status = status
+        self.channel = channel
+        self.permalink = permalink
+        self.ts = ts
+    }
 
     var id: String { requestId }
+
+    /// Slack accepts a delete only from the account that posted, which is the
+    /// person's own grant, so offering this can never touch someone else's
+    /// message. It needs both the channel and the timestamp to name one.
+    var canUndo: Bool {
+        status == .sent && channel != nil && !(ts ?? "").isEmpty
+    }
 }
 
 /// One server-generated quick reply. The short label is the chip; the full
@@ -457,6 +484,7 @@ private struct RawFrame: Decodable {
     let status: String?
     let channel: WireSlackChannel?
     let permalink: String?
+    let ts: String?
     let run: WorkflowRun?
     let repo: String?
     let branch: String?

--- a/packages/clients/ios/OS1/Networking/SlackAPI.swift
+++ b/packages/clients/ios/OS1/Networking/SlackAPI.swift
@@ -21,6 +21,8 @@ enum SlackAPI {
         let status: String
         let channel: Channel?
         let permalink: String?
+        /// The posted message's timestamp, which is what an undo names.
+        let ts: String?
     }
 
     private struct UploadResponse: Decodable, Sendable {

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -90,6 +90,7 @@ final class SessionViewModel {
     private(set) var replySuggestions: [ReplySuggestion] = []
     private(set) var pendingSlackComposer: SlackComposeRequest?
     private(set) var slackComposeReceipt: SlackComposeReceipt?
+    private(set) var isUndoingSlackComposeReceipt = false
     private(set) var connectionState: ConnectionState = .connecting
     private(set) var isLoadingConversation = true
     /// A watch that never receives transcript_init is not a loading state
@@ -128,6 +129,28 @@ final class SessionViewModel {
         slackComposeReceipt = receipt
     }
 
+    func undoSlackComposeReceipt() async {
+        guard !isUndoingSlackComposeReceipt,
+              let receipt = slackComposeReceipt,
+              let channelId = receipt.channel?.id,
+              let ts = receipt.ts,
+              receipt.canUndo
+        else { return }
+
+        isUndoingSlackComposeReceipt = true
+        defer { isUndoingSlackComposeReceipt = false }
+        do {
+            try await slackComposerUndoer(session.id, channelId, ts)
+            guard slackComposeReceipt?.requestId == receipt.requestId else { return }
+            slackComposeReceipt = nil
+            notice = "Removed from Slack"
+        } catch {
+            notice = error.localizedDescription.isEmpty
+                ? "Couldn't undo the Slack message"
+                : error.localizedDescription
+        }
+    }
+
     // ── Pull request ──
     /// PR details for the session's branch (toolbar chip + PR panel).
     /// nil until the first fetch lands — the chip falls back to the sessions
@@ -150,6 +173,7 @@ final class SessionViewModel {
     private(set) var workflowLoadFailed = false
     private var workflowEventRevision = 0
     private let workflowLoader: @MainActor (String) async throws -> [WorkflowRun]
+    private let slackComposerUndoer: @MainActor (String, String, String) async throws -> Void
 
     // ── Session goal ──
     /// Goal set from this app (`/goal`), used to label the composer menu's
@@ -406,6 +430,11 @@ final class SessionViewModel {
         },
         workflowLoader: @escaping @MainActor (String) async throws -> [WorkflowRun] = {
             try await OS1API.workflowRuns(sessionId: $0)
+        },
+        slackComposerUndoer: @escaping @MainActor (
+            String, String, String
+        ) async throws -> Void = {
+            try await OS1API.undoSlackComposer(sessionId: $0, channelId: $1, ts: $2)
         }
     ) {
         self.session = session
@@ -414,6 +443,7 @@ final class SessionViewModel {
         self.conversationLoadTimeout = conversationLoadTimeout
         self.prLoader = prLoader
         self.workflowLoader = workflowLoader
+        self.slackComposerUndoer = slackComposerUndoer
         self.isRunning = session.isRunning ?? false
         self.usage = session.usage
         self.model = session.model ?? ""

--- a/packages/clients/ios/OS1/Views/ComposerSessionBinding.swift
+++ b/packages/clients/ios/OS1/Views/ComposerSessionBinding.swift
@@ -90,6 +90,18 @@ final class ComposerSessionProjectionState {
         )
     }
 
+    func titlePrompt(
+        for canonical: String,
+        titleGeneration: Int,
+        refreshTitles: Bool
+    ) -> String {
+        projection(
+            for: canonical,
+            titleGeneration: titleGeneration,
+            refreshTitles: refreshTitles
+        ).titlePrompt
+    }
+
     private func projection(
         for canonical: String,
         titleGeneration: Int,

--- a/packages/clients/ios/OS1/Views/NewSessionView.swift
+++ b/packages/clients/ios/OS1/Views/NewSessionView.swift
@@ -1064,6 +1064,11 @@ struct NewSessionView: View {
         Haptics.play(.send)
         dictation.stop()
         let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let titlePrompt = sessionProjection.titlePrompt(
+            for: prompt,
+            titleGeneration: TranscriptLinks.shared.generation,
+            refreshTitles: !promptFocused
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
         let imageURLs = images.map(\.dataURL)
         if repo != Session.noRepoID { lastRepo = repo }
         let provisionalTitle = text.isEmpty
@@ -1091,6 +1096,7 @@ struct NewSessionView: View {
             do {
                 let id = try await OS1API.createSession(
                     prompt: text,
+                    titlePrompt: titlePrompt,
                     repo: repo,
                     mode: mode,
                     model: model.isEmpty ? nil : model,

--- a/packages/clients/ios/OS1/Views/PrSlackShareSheet.swift
+++ b/packages/clients/ios/OS1/Views/PrSlackShareSheet.swift
@@ -371,7 +371,8 @@ struct PrSlackShareSheet: View {
                         channel: response.channel.map {
                             .init(id: $0.id, name: $0.name)
                         },
-                        permalink: response.permalink
+                        permalink: response.permalink,
+                        ts: response.ts
                     ))
                 } else if request.merged {
                     var screenshots: [String] = []

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -1205,7 +1205,12 @@ struct SessionView: View {
             .transcriptTail(true)
         }
         if let receipt = viewModel.slackComposeReceipt {
-            SlackComposeReceiptRow(receipt: receipt)
+            SlackComposeReceiptRow(
+                receipt: receipt,
+                isUndoing: viewModel.isUndoingSlackComposeReceipt
+            ) {
+                Task { await viewModel.undoSlackComposeReceipt() }
+            }
                 .id("slack-receipt-\(receipt.id)")
                 .transcriptTail(true)
         }
@@ -1386,6 +1391,8 @@ private extension View {
 
 private struct SlackComposeReceiptRow: View {
     let receipt: SlackComposeReceipt
+    let isUndoing: Bool
+    let onUndo: () -> Void
 
     var body: some View {
         HStack(spacing: 6) {
@@ -1405,6 +1412,14 @@ private struct SlackComposeReceiptRow: View {
                     Link("Open in Slack", destination: url)
                         .underline()
                 }
+                if receipt.canUndo {
+                    Text("·").foregroundStyle(OS1VisualStyle.textFaint)
+                    Button(isUndoing ? "Undoing…" : "Undo", action: onUndo)
+                        .buttonStyle(.plain)
+                        .underline()
+                        .disabled(isUndoing)
+                        .accessibilityHint("Removes this message from Slack")
+                }
             } else {
                 Text("Slack message cancelled")
             }
@@ -1412,7 +1427,7 @@ private struct SlackComposeReceiptRow: View {
         .font(.footnote)
         .foregroundStyle(OS1VisualStyle.textDim)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/packages/clients/ios/OS1Tests/ComposerSessionProjectionTests.swift
+++ b/packages/clients/ios/OS1Tests/ComposerSessionProjectionTests.swift
@@ -20,6 +20,14 @@ final class ComposerSessionProjectionTests: XCTestCase {
         XCTAssertEqual(projection.canonicalText, canonical)
     }
 
+    func testTitlePromptUsesTheVisibleSessionName() {
+        let canonical = "Compare @session:\(id) now"
+        let projection = ComposerSessionProjection(canonical)
+
+        XCTAssertEqual(projection.titlePrompt, "Compare @session:\(title) now")
+        XCTAssertEqual(projection.canonicalText, canonical)
+    }
+
     func testPastedSessionURLProjectsTitleButRetainsCanonicalURL() {
         let url = "\(serverOrigin)/workspace/ws-example/session/\(id)"
         let canonical = "Use \(url) for context"

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -194,8 +194,8 @@ final class ServerEventTests: XCTestCase {
         }
     }
 
-    func testSlackComposerSentReceiptDecodesDestinationAndPermalink() {
-        let json = #"{"type":"slack_composer_resolved","sessionId":"bks-1","requestId":"slack-1","status":"sent","channel":{"id":"C123","name":"shipping"},"permalink":"https://tella.slack.com/archives/C123/p1700000000000000"}"#
+    func testSlackComposerSentReceiptDecodesUndoTimestamp() {
+        let json = #"{"type":"slack_composer_resolved","sessionId":"bks-1","requestId":"slack-1","status":"sent","channel":{"id":"C123","name":"shipping"},"permalink":"https://tella.slack.com/archives/C123/p1700000000000000","ts":"1700000000.000000"}"#
         guard case .slackComposerResolved(let sessionId, let receipt) = parse(json) else {
             return XCTFail("expected .slackComposerResolved")
         }
@@ -207,6 +207,8 @@ final class ServerEventTests: XCTestCase {
             receipt.permalink,
             "https://tella.slack.com/archives/C123/p1700000000000000"
         )
+        XCTAssertEqual(receipt.ts, "1700000000.000000")
+        XCTAssertTrue(receipt.canUndo)
     }
 
     func testSlackComposerCancelledReceiptDecodesWithoutDestination() {
@@ -218,6 +220,8 @@ final class ServerEventTests: XCTestCase {
         XCTAssertEqual(receipt.status, .cancelled)
         XCTAssertNil(receipt.channel)
         XCTAssertNil(receipt.permalink)
+        XCTAssertNil(receipt.ts)
+        XCTAssertFalse(receipt.canUndo)
     }
 
     func testSessionNotesDecodeAndADeletedNoteCarriesItsId() {

--- a/packages/clients/ios/OS1Tests/SessionTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionTests.swift
@@ -74,6 +74,33 @@ final class SessionTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionCreationCarriesVisibleTitlePromptWithoutChangingPrompt() {
+        let canonical = "Compare @session:os-01901901-2345-7123-8123-123456789abc"
+        let visible = "Compare @session:Checkout reliability"
+        let body = OS1API.createSessionBody(
+            prompt: canonical,
+            titlePrompt: visible,
+            repo: "opensession",
+            mode: "ask",
+            user: "Alice"
+        )
+
+        XCTAssertEqual(body["prompt"] as? String, canonical)
+        XCTAssertEqual(body["titlePrompt"] as? String, visible)
+    }
+
+    @MainActor
+    func testSlackComposerUndoBodyNamesThePostedMessage() {
+        let body = OS1API.slackComposerUndoBody(
+            channelId: "C123",
+            ts: "1700000000.000000"
+        )
+
+        XCTAssertEqual(body["channel"] as? String, "C123")
+        XCTAssertEqual(body["ts"] as? String, "1700000000.000000")
+    }
+
+    @MainActor
     func testSessionCreationCarriesOnlyStagedFiles() {
         let staged = AttachedFile(
             name: "incident.pdf",

--- a/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
@@ -258,6 +258,53 @@ final class SessionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.slackComposeReceipt, current)
     }
 
+    func testSlackReceiptIsRemovedOnlyAfterUndoSucceeds() async {
+        var request: (String, String, String)?
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            slackComposerUndoer: { request = ($0, $1, $2) }
+        )
+        let receipt = SlackComposeReceipt(
+            requestId: "slack-1",
+            status: .sent,
+            channel: .init(id: "C123", name: "shipping"),
+            permalink: nil,
+            ts: "1700000000.000000"
+        )
+        viewModel.resolveSlackComposer(receipt)
+
+        await viewModel.undoSlackComposeReceipt()
+
+        XCTAssertEqual(request?.0, "bks-1")
+        XCTAssertEqual(request?.1, "C123")
+        XCTAssertEqual(request?.2, "1700000000.000000")
+        XCTAssertNil(viewModel.slackComposeReceipt)
+        XCTAssertEqual(viewModel.notice, "Removed from Slack")
+    }
+
+    func testFailedSlackUndoKeepsReceiptAndReportsTheFailure() async {
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            slackComposerUndoer: { _, _, _ in
+                throw OS1API.APIError.server("Slack could not delete that message")
+            }
+        )
+        let receipt = SlackComposeReceipt(
+            requestId: "slack-1",
+            status: .sent,
+            channel: .init(id: "C123", name: "shipping"),
+            permalink: nil,
+            ts: "1700000000.000000"
+        )
+        viewModel.resolveSlackComposer(receipt)
+
+        await viewModel.undoSlackComposeReceipt()
+
+        XCTAssertEqual(viewModel.slackComposeReceipt, receipt)
+        XCTAssertEqual(viewModel.notice, "Slack could not delete that message")
+        XCTAssertFalse(viewModel.isUndoingSlackComposeReceipt)
+    }
+
     func testResyncDropsCachedPartialPrefixOfOffscreenCompletion() {
         let viewModel = makeViewModel()
         viewModel.handle(.sessionStatus(sessionId: "bks-1", isRunning: true))


### PR DESCRIPTION
## Summary
- decode Slack message timestamps and offer an accessible Undo action on sent receipts
- keep failed Undo attempts visible and clear receipts only after Slack confirms deletion
- send the composer's visible session-name projection as `titlePrompt` while preserving the canonical model prompt
- add focused protocol, request-body, projection, and state tests

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac test suite
- live title exercise: `@session:bks-b1d485d5-d684-74e3-9461-29fc449082a2` remained canonical while the generated title used “Add Slack undo and title prompts”

<!-- opensession:walkthrough -->
## Walkthrough

Native Slack receipts now expose an accessible Undo action, so a sent message can be removed without losing the receipt when Slack reports an error. Native session creation also names referenced sessions from the text the person sees while preserving the canonical prompt delivered to the model.

The screenshot shows the sent receipt with Open in Slack and Undo actions in the macOS app. Both native schemes built successfully, the OS1Mac test suite passed, and a live creation exercise generated a title from the referenced session’s visible name.

| Before | After |
| --- | --- |
| — | ![After — Sent Slack receipt with an accessible Undo action](https://github.com/user-attachments/assets/6a5a37fa-cda2-47f8-a227-e13a8e092418) |

<sub>Published from the session's Review tab.</sub>
<!-- /opensession:walkthrough -->

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-b1d485d5-d684-74e3-9461-29fc449082a2)