### PR TITLE
Keep Slack posts attributed to their requester

### DIFF
--- a/packages/core/opensession-server/src/server/connections.ts
+++ b/packages/core/opensession-server/src/server/connections.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync, copyFileSync, watchFile } from "fs";
 import { writeFileAtomic } from "./shared/atomic-write";
 import { configuredPaths } from "./config";
 import { mcpOauthStatus, mcpSharedGrantHeader, mcpUserGrantHeader, mcpUserGrantToken, oauthPresetFor } from "./mcp-oauth";
+import { resolveTeammate } from "./shared/user-mappings";
 
 const HOME = homeDir();
 // mcp-config.json location. OPENSESSION_MCP_CONFIG env → config
@@ -95,15 +96,37 @@ export function withDynamicCredentials(
           const candidates = (Array.isArray(user) ? user : [user]).filter(
             (u): u is string => !!u,
           );
+          const personal = candidates
+            .map((identity) => ({
+              identity,
+              token: mcpUserGrantToken(name, identity),
+            }))
+            .find(({ token }) => !!token);
           const token =
-            candidates
-              .map((u) => mcpUserGrantToken(name, u))
-              .find((t) => !!t) ??
+            personal?.token ??
             mcpSharedGrantHeader(name)?.replace(/^Bearer\s+/i, "");
-          if (token)
+          const actorIdentity = personal?.identity ?? candidates[0];
+          const actor = actorIdentity
+            ? resolveTeammate(actorIdentity)?.name ?? actorIdentity
+            : undefined;
+          const attributionEnv =
+            name === "slack" && actor
+              ? {
+                  OPENSESSION_SLACK_ACTOR: actor,
+                  OPENSESSION_SLACK_PERSONAL: personal ? "1" : "0",
+                }
+              : {};
+          if (token || Object.keys(attributionEnv).length)
             out = {
               ...out,
-              [name]: { ...c, env: { ...c.env, [preset.envVar]: token } },
+              [name]: {
+                ...c,
+                env: {
+                  ...c.env,
+                  ...(token ? { [preset.envVar]: token } : {}),
+                  ...attributionEnv,
+                },
+              },
             };
         }
         continue;

--- a/packages/core/opensession-server/src/server/run-instructions-slack.test.ts
+++ b/packages/core/opensession-server/src/server/run-instructions-slack.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { buildRunInstructions } from "./run-instructions";
+
+describe("Slack run instructions", () => {
+  test("keeps interactive posts on the attributed MCP path", () => {
+    const instructions = buildRunInstructions({ isAsk: false });
+
+    expect(instructions).toContain("## Slack identity and attribution");
+    expect(instructions).toContain("use the configured `slack` MCP tools");
+    expect(instructions).toContain("Never call Slack with `curl`");
+  });
+});

--- a/packages/core/opensession-server/src/server/run-instructions.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.ts
@@ -104,6 +104,15 @@ export function buildRunInstructions(input: {
       "in a private repo. If every controlled channel fails, stop and report the failure " +
       "instead of escalating to a third-party host."
   );
+  parts.push(
+    "## Slack identity and attribution\nWhen an Open Session user asks you to post a Slack " +
+      "message or file, use the configured `slack` MCP tools. They use the session owner's " +
+      "personal Slack connection when available, and bot fallbacks add the requester's name. " +
+      "Never call Slack with `curl`, import the internal Slack API helpers from shell code, or " +
+      "reuse a bot token from the host. Those paths bypass personal attribution. If the Slack " +
+      "MCP cannot complete the post, report the failure instead of switching to an unattributed " +
+      "route. Use the editable Slack composer when the human has not explicitly told you to send."
+  );
   // Open Session vends bounded instance-role credentials to eligible runs.
   // Interactive SSO was both unnecessary and noisy: models started `aws sso
   // login`, then blocked the UI and pinged teammates with expiring device

--- a/scripts/mcp-slack.test.ts
+++ b/scripts/mcp-slack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildSlackMessageBody } from "./mcp-slack";
+import { attributedSlackText, buildSlackMessageBody, tools } from "./mcp-slack";
 
 describe("buildSlackMessageBody", () => {
   test("uses Slack defaults when unfurl options are omitted", () => {
@@ -22,5 +22,26 @@ describe("buildSlackMessageBody", () => {
       unfurl_links: false,
       unfurl_media: false,
     });
+  });
+});
+
+
+describe("attributedSlackText", () => {
+  test("keeps personal Slack posts under the connected person's account", () => {
+    expect(attributedSlackText("Shipped it", "Michiel Westerbeek", true)).toBe(
+      "Shipped it",
+    );
+  });
+
+  test("names the requester when Slack falls back to the bot", () => {
+    expect(attributedSlackText("Shipped it", "Michiel Westerbeek", false)).toBe(
+      "Shipped it\n\nSent by Michiel Westerbeek via Open Session",
+    );
+  });
+});
+
+describe("Slack MCP tools", () => {
+  test("supports attributed local file uploads", () => {
+    expect(tools.map((tool) => tool.name)).toContain("slack_post_files");
   });
 });

--- a/scripts/mcp-slack.ts
+++ b/scripts/mcp-slack.ts
@@ -6,6 +6,10 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import {
+  postSlackFiles,
+  slackUploadPermalink,
+} from "../packages/core/opensession-server/src/agents/slack/slack-api";
 
 type ToolArguments = Record<string, unknown>;
 
@@ -25,7 +29,7 @@ const booleanUnfurlProperties = {
   },
 } as const;
 
-const tools = [
+export const tools = [
   {
     name: "slack_list_channels",
     description: "List public or pre-defined channels in the workspace with pagination",
@@ -52,6 +56,26 @@ const tools = [
         ...booleanUnfurlProperties,
       },
       required: ["channel_id", "text"],
+    },
+  },
+  {
+    name: "slack_post_files",
+    description: "Upload local files and post them to a Slack channel using the session owner's Slack identity",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string", description: "The ID of the channel to post to" },
+        file_paths: {
+          type: "array",
+          items: { type: "string" },
+          description: "Absolute paths of local files to upload (maximum 10)",
+        },
+        initial_comment: { type: "string", description: "Message shown with the files" },
+        title: { type: "string", description: "Optional title for the uploaded file or file set" },
+        alt_text: { type: "string", description: "Optional accessible description of the files" },
+        thread_ts: { type: "string", description: "Optional thread timestamp to reply under" },
+      },
+      required: ["channel_id", "file_paths", "initial_comment"],
     },
   },
   {
@@ -139,6 +163,35 @@ function requiredString(args: ToolArguments, name: string): string {
   return value;
 }
 
+function requiredStringArray(args: ToolArguments, name: string): string[] {
+  const value = args[name];
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > 10 ||
+    value.some((item) => typeof item !== "string" || !item)
+  ) {
+    throw new Error(`${name} must contain between 1 and 10 paths`);
+  }
+  return value;
+}
+
+export function attributedSlackText(
+  text: string,
+  actor = process.env.OPENSESSION_SLACK_ACTOR,
+  personal = process.env.OPENSESSION_SLACK_PERSONAL === "1",
+): string {
+  if (personal || !actor) return text;
+  return `${text}\n\nSent by ${actor} via Open Session`;
+}
+
+function optionalString(args: ToolArguments, name: string): string | undefined {
+  const value = args[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error(`${name} must be a string`);
+  return value;
+}
+
 function optionalBoolean(args: ToolArguments, name: string): boolean | undefined {
   const value = args[name];
   if (value === undefined) return undefined;
@@ -207,11 +260,17 @@ class SlackClient {
   }
 
   postMessage(channel: string, text: string, options: UnfurlOptions): Promise<unknown> {
-    return this.post("chat.postMessage", buildSlackMessageBody(channel, text, options));
+    return this.post(
+      "chat.postMessage",
+      buildSlackMessageBody(channel, attributedSlackText(text), options),
+    );
   }
 
   postReply(channel: string, threadTs: string, text: string, options: UnfurlOptions): Promise<unknown> {
-    return this.post("chat.postMessage", buildSlackMessageBody(channel, text, options, threadTs));
+    return this.post(
+      "chat.postMessage",
+      buildSlackMessageBody(channel, attributedSlackText(text), options, threadTs),
+    );
   }
 
   addReaction(channel: string, timestamp: string, reaction: string): Promise<unknown> {
@@ -268,6 +327,25 @@ async function main(): Promise<void> {
         case "slack_post_message":
           result = await client.postMessage(requiredString(args, "channel_id"), requiredString(args, "text"), options);
           break;
+        case "slack_post_files": {
+          const channel = requiredString(args, "channel_id");
+          const completed = await postSlackFiles(
+            channel,
+            requiredStringArray(args, "file_paths"),
+            attributedSlackText(requiredString(args, "initial_comment")),
+            {
+              title: optionalString(args, "title"),
+              altText: optionalString(args, "alt_text"),
+              threadTs: optionalString(args, "thread_ts"),
+            },
+            botToken,
+          );
+          result = {
+            ok: true,
+            permalink: await slackUploadPermalink(completed, channel, botToken),
+          };
+          break;
+        }
         case "slack_reply_to_thread":
           result = await client.postReply(
             requiredString(args, "channel_id"),


### PR DESCRIPTION
## Summary
- add an attributed `slack_post_files` MCP tool so agents no longer need to bypass the per-user Slack connection for media uploads
- run Slack text, replies, and file comments through the session owner's personal token when connected
- identify the requester in bot fallback posts
- instruct sessions never to use shell imports, curl, or host bot tokens for Slack delivery

## Root cause
The session needed to upload a video, but the Slack MCP only supported text. After the editable composer timed out, the agent imported the internal Slack helper from a shell command. That helper used the service bot token, so Slack showed Michael instead of Michiel.

## Validation
- `bun test scripts/mcp-slack.test.ts packages/core/opensession-server/src/server/run-instructions-slack.test.ts`
- `bun run typecheck`
- full suite: 3,745 passed; unrelated environment-dependent failures remain in the existing broad suite

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/slack-C0BE8KVFBEX-1787392083.169729)
