### PR TITLE
Recover branch creation without a stack base

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -175,6 +175,26 @@ describe("creation branch intents", () => {
     }
   });
 
+  test("normalizes an empty optional base branch before persistence", async () => {
+    const input = {
+      ...branchInput,
+      sessionId: "create-branch-without-base",
+      identity: "request-branch-without-base",
+      baseBranch: "",
+    };
+    const { store, kernel } = harness(input.sessionId);
+    try {
+      await expect(requestCreationBranch(input, {
+        kernel,
+        timeoutMs: 5,
+        pollMs: 1,
+      })).rejects.toThrow("remains durably pending");
+      expect(store.pendingOutbox()[0]?.payload).not.toHaveProperty("baseBranch");
+    } finally {
+      store.close();
+    }
+  });
+
   test("leaves timed-out branch work durable and does not re-emit it", async () => {
     const { store, kernel } = harness(branchInput.sessionId);
     try {

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -153,7 +153,7 @@ export async function requestCreationBranch(
           project: input.project,
           branch: input.branch,
           worktreePath: input.worktreePath,
-          baseBranch: input.baseBranch,
+          baseBranch: input.baseBranch || undefined,
           isolated: input.isolated,
           existingBranch: input.existingBranch,
           credentialPrincipal: input.credentialPrincipal,

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
@@ -65,6 +65,7 @@ describe("session effect executor registry", () => {
       project: "opensession",
       branch: "feature/create-one",
       worktreePath: "/worktrees/create-one",
+      baseBranch: "",
       isolated: true,
       existingBranch: true,
       credentialPrincipal: "user:alice",

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
@@ -95,7 +95,7 @@ function creationPayload<K extends Exclude<
         branch: requiredString(kind, value.branch, "branch"),
         worktreePath: requiredString(kind, value.worktreePath, "worktreePath"),
         baseBranch:
-          value.baseBranch === undefined
+          value.baseBranch === undefined || value.baseBranch === ""
             ? undefined
             : requiredString(kind, value.baseBranch, "baseBranch"),
         isolated: value.isolated === true,


### PR DESCRIPTION
## Summary

- normalize an empty optional branch base before writing the durable creation effect
- decode already-persisted empty branch bases as absent so pending effects recover after update
- cover both producer normalization and legacy outbox decoding

## Why

Normal, non-stacked session creation represents the missing stack base as an empty string. The durable branch effect decoder treated only `undefined` as absent, rejected the empty value, and retried until the caller reported that branch creation remained durably pending.

## Tests

- `bun test packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts packages/core/opensession-server/src/server/session-kernel/kernel.test.ts`
- 67 passed, 0 failed

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a0292f-26bb-7248-b7eb-54bd1aa43452)