### PR TITLE
Fix install PATH hint order and honor appOrg for App tokens

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -899,10 +899,14 @@ if [ "$ADVANCED" != "1" ] && [ "$server_ready" != "1" ]; then
 else
   step "Done"
 fi
+# The PATH hint has to precede the command list: on a fresh install the shell
+# that launched the installer has not picked up the new PATH entry, so a reader
+# who runs `opensession status` from the top of this list before sourcing their
+# profile hits "command not found".
+show_path_refresh_hint
 info "opensession status    ${D}is the server up?${N}"
 info "opensession doctor    ${D}check the install${N}"
 info "opensession --help    ${D}everything else${N}"
-show_path_refresh_hint
 if [ "$server_ready" = "1" ]; then
   printf '\n  %sOpen %s%s\n' "$B" "$url" "$N"
 fi

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -72,10 +72,16 @@ export async function githubAppInstallationToken(): Promise<string | null> {
       const res = await fetch("https://api.github.com/app/installations", { headers });
       const installs = (await res.json()) as Array<{ id: number; account?: { login?: string } }>;
       if (!Array.isArray(installs) || !installs.length) throw new Error("no installations");
-      const owner =
-        typeof githubConfig.installationOwner === "string"
-          ? githubConfig.installationOwner.toLowerCase()
-          : "";
+      // Prefer an explicit installation owner, then the org captured at setup
+      // (appOrg) — the same precedence setup-team.ts uses. Without the appOrg
+      // fallback, an org App installed on more than one account has no way to
+      // disambiguate and falls back to the bot PAT even though appOrg already
+      // names the intended owner.
+      const owner = (
+        [githubConfig.installationOwner, githubConfig.appOrg].find(
+          (value): value is string => typeof value === "string" && !!value.trim(),
+        ) ?? ""
+      ).toLowerCase();
       const selected = owner
         ? installs.find((installation) => installation.account?.login?.toLowerCase() === owner)
         : installs.length === 1


### PR DESCRIPTION
Two independent first-run fixes, from reviewing a fresh simple-mode install.

## install.sh — PATH hint before the command list

On a fresh install the shell that launched the installer has not picked up the new PATH entry, so `opensession` is not yet resolvable there. The summary printed the `opensession status/doctor/--help` list *above* the `source ~/.zshrc` hint, so a reader who runs the first command hits "command not found" and only then sees the fix. The hint now precedes the command list.

## github-app.ts — honor `appOrg` in installation-owner selection

Installation-token owner selection read only `installationOwner`, which nothing in the setup flow writes. An org App installed on more than one account (e.g. the org plus the owner's personal account) then has no way to disambiguate and throws, dropping to the bot PAT — even though the setup-captured `appOrg` already names the intended owner. Owner selection now falls back `installationOwner → appOrg`, the same precedence `setup-team.ts` already uses.

## Verification
- `bun test` github-auth + runner-bootstrap suites: 33 pass, 0 fail
- `tsc --noEmit`: no new errors (one pre-existing unrelated `pi-ai/bun-oauth` module-resolution error remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)