### PR TITLE
Reconcile pre-execution creation dead letters

### DIFF
--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -93,6 +93,7 @@ import { beginShutdown } from "./src/server/shutdown-state";
 import { setServiceReadiness } from "./src/server/service-readiness";
 import {
 	reconcileSessionKernelOwnership,
+	reconcileCompatibleCreationBranchEffects,
 	startSessionKernelActor,
 	startSessionKernelRuntime,
 	stopSessionKernelRuntime,
@@ -881,6 +882,15 @@ if (!g.__opensessionBooted) {
 		} catch (error) {
 			throw error;
 		}
+		// Re-admit only historical branch effects rejected before execution by
+		// retired compatibility checks. Do this behind the recovery gate so the
+		// runtime cannot race the dead-letter transition.
+		const reconciledBranchEffects =
+			await reconcileCompatibleCreationBranchEffects();
+		if (reconciledBranchEffects.length)
+			console.warn(
+				`[session-kernel] Reconciled ${reconciledBranchEffects.length} compatible branch effect(s)`,
+			);
 		// Only now may durable timers and effects wake actors: every recovery
 		// stage above completed and ownership is established.
 		startSessionKernelRuntime();

--- a/packages/core/opensession-server/src/server/codex-device-login.ts
+++ b/packages/core/opensession-server/src/server/codex-device-login.ts
@@ -164,7 +164,12 @@ export function startDeviceLogin(
   let proc: ChildProcess;
   try {
     proc = spawn("codex", ["login", "--device-auth"], {
-      env: { HOME, PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin", CODEX_HOME: dir },
+      env: {
+        HOME,
+        PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
+        CODEX_HOME: dir,
+        NODE_ENV: process.env.NODE_ENV || "production",
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
   } catch (e: any) {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -39,6 +39,42 @@ async function actor(): Promise<SessionKernelActorClient> {
 }
 
 describe("session kernel actor boundary", () => {
+  test("reconciles compatible branch dead letters inside the actor store", async () => {
+    const host = await actor();
+    const id = host.store.enqueueOutbox(
+      "shared-session",
+      "creation_branch_prepare",
+      {
+        creationIdentity: "creation-one",
+        creationGeneration: 1,
+        project: "opensession",
+        branch: "feature",
+        worktreePath: "/srv/opensession",
+        isolated: false,
+        mode: "adopt_or_create",
+      },
+      "shared-branch",
+    );
+    host.store.noteOutboxFailure(
+      id,
+      "Worktree destination /srv/opensession exists without a registered branch",
+      1,
+    );
+
+    expect(
+      host.store.retryCompatibleCreationBranchDeadLetters([
+        { project: "opensession", worktreePath: "/srv/opensession" },
+      ]),
+    ).toEqual([
+      {
+        id,
+        sessionId: "shared-session",
+        reason: "shared_checkout_destination_adoptable",
+      },
+    ]);
+    expect(host.store.pendingOutbox(Date.now() + 1_000)).toHaveLength(1);
+  });
+
   test("admits independent commands while physical work is active", async () => {
     const host = await actor();
     const first = await host.begin("s1", testEffect({ requestId: "first", type: "test" }));

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -773,6 +773,24 @@ class RemoteStore implements SessionKernelStoreApi {
   retryDeadOutbox(id: number) {
     return this.call<boolean>("retryDeadOutbox", id);
   }
+  retryCompatibleCreationBranchDeadLetters(
+    destinations: ReadonlyArray<{ project: string; worktreePath: string }>,
+    now?: number,
+  ) {
+    return this.call<
+      Array<{
+        id: number;
+        sessionId: string;
+        reason:
+          | "shared_checkout_destination_adoptable"
+          | "legacy_empty_base_branch";
+      }>
+    >(
+      "retryCompatibleCreationBranchDeadLetters",
+      destinations,
+      now,
+    );
+  }
   ackOutbox(id: number) {
     this.call("ackOutbox", id);
   }

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
@@ -8,7 +8,7 @@ import type {
 import { createWorkspace, getWorkspace, type Workspace } from "../workspaces";
 import type { WorktreeInfo } from "../worktree";
 import { registerSessionEffectExecutor } from "./effect-executors";
-import { sessionKernel } from "./kernel";
+import { sessionKernel, sessionKernelStore } from "./kernel";
 import type { SessionActorEffectFor } from "./lifecycle-protocol";
 import type {
   CreationEventDecisionResult,
@@ -391,6 +391,44 @@ export async function executeCreationCredentialResolve(
   throw new CreationEffectIndeterminateError(
     `Credential effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
   );
+}
+
+/**
+ * Re-admit branch effects rejected before execution by retired compatibility
+ * checks. The store matches exact historical errors and validates configured
+ * shared destinations before clearing any dead-letter marker.
+ */
+export async function reconcileCompatibleCreationBranchEffects(): Promise<
+  Array<{
+    id: number;
+    sessionId: string;
+    reason: "shared_checkout_destination_adoptable" | "legacy_empty_base_branch";
+  }>
+> {
+  const [{ configuredRepos }, { sharedCheckoutForNewSessions }, { audit }] =
+    await Promise.all([
+      import("../config"),
+      import("../worktree"),
+      import("../audit"),
+    ]);
+  const destinations = Object.values(configuredRepos())
+    .filter((repo) => sharedCheckoutForNewSessions(repo))
+    .map((repo) => ({
+      project: repo.id,
+      worktreePath: resolve(repo.repo),
+    }));
+  const retried = sessionKernelStore().retryCompatibleCreationBranchDeadLetters(
+    destinations,
+  );
+  for (const item of retried)
+    audit({
+      msg: "session_kernel_dead_letter_reconciled",
+      kind: "outbox",
+      session_id: item.sessionId,
+      outbox_id: item.id,
+      reason: item.reason,
+    });
+  return retried;
 }
 
 const registrationGlobal = globalThis as typeof globalThis & {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1142,6 +1142,85 @@ describe("SessionKernel durable runtime", () => {
 		expect(store.stats().deadLetteredOutbox).toBe(0);
 	});
 
+	test("re-admits only pre-execution branch compatibility false positives", () => {
+		const sharedPayload = {
+			creationIdentity: "creation-one",
+			creationGeneration: 1,
+			project: "opensession",
+			branch: "feature",
+			worktreePath: "/srv/opensession",
+			isolated: false,
+			mode: "adopt_or_create",
+		};
+		const matching = store.enqueueOutbox(
+			"shared-session",
+			"creation_branch_prepare",
+			sharedPayload,
+			"shared-branch",
+		);
+		const ordinary = store.enqueueOutbox(
+			"ordinary-session",
+			"creation_branch_prepare",
+			{ ...sharedPayload, worktreePath: "/srv/ordinary" },
+			"ordinary-branch",
+		);
+		const legacyEmptyBase = store.enqueueOutbox(
+			"legacy-session",
+			"creation_branch_prepare",
+			{
+				...sharedPayload,
+				project: "tella-fusion",
+				worktreePath: "/srv/tella-fusion-feature",
+				baseBranch: "",
+			},
+			"legacy-empty-base",
+		);
+		const differentFailure = store.enqueueOutbox(
+			"different-session",
+			"creation_branch_prepare",
+			sharedPayload,
+			"different-failure",
+		);
+		store.noteOutboxFailure(
+			matching,
+			"Worktree destination /srv/opensession exists without a registered branch",
+			1,
+		);
+		store.noteOutboxFailure(
+			ordinary,
+			"Worktree destination /srv/ordinary exists without a registered branch",
+			1,
+		);
+		store.noteOutboxFailure(
+			legacyEmptyBase,
+			"Invalid creation_branch_prepare effect payload: baseBranch",
+			1,
+		);
+		store.noteOutboxFailure(differentFailure, "credential unavailable", 1);
+
+		expect(
+			store.retryCompatibleCreationBranchDeadLetters([
+				{ project: "opensession", worktreePath: "/srv/opensession" },
+			]),
+		).toEqual([
+			{
+				id: matching,
+				sessionId: "shared-session",
+				reason: "shared_checkout_destination_adoptable",
+			},
+			{
+				id: legacyEmptyBase,
+				sessionId: "legacy-session",
+				reason: "legacy_empty_base_branch",
+			},
+		]);
+		expect(store.pendingOutbox(Date.now() + 1_000).map((item) => item.id)).toEqual([
+			matching,
+			legacyEmptyBase,
+		]);
+		expect(store.stats().deadLetteredOutbox).toBe(2);
+	});
+
 	test("retries an outbox effect until it succeeds", async () => {
 		const { drainSessionKernelRuntime, waitForSessionKernelRuntimeIdle, } = await import("./runtime");
 		const { replaceSessionEffectExecutorForTest } = await import("./effect-executors");

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2376,6 +2376,104 @@ export class SessionKernelStore {
 		return result.changes > 0;
 	}
 
+	/**
+	 * Re-admit branch effects rejected before physical work by compatibility bugs:
+	 * the former shared-checkout classifier and the old empty-base decoder. The
+	 * caller supplies trusted shared destinations; every other failure stays dead.
+	 */
+	retryCompatibleCreationBranchDeadLetters(
+		destinations: ReadonlyArray<{ project: string; worktreePath: string }>,
+		now = Date.now(),
+	): Array<{
+		id: number;
+		sessionId: string;
+		reason: "shared_checkout_destination_adoptable" | "legacy_empty_base_branch";
+	}> {
+		const allowed = new Set(
+			destinations.map(({ project, worktreePath }) =>
+				JSON.stringify([project, worktreePath]),
+			),
+		);
+		const rows = this.db
+			.query(
+				`SELECT id, session_id, payload, last_error
+				 FROM session_kernel_outbox
+				 WHERE kind = 'creation_branch_prepare'
+				   AND dead_lettered_at IS NOT NULL
+				 ORDER BY id
+				 LIMIT 1000`,
+			)
+			.all() as Array<{
+				id: number;
+				session_id: string;
+				payload: string;
+				last_error: string | null;
+			}>;
+		const retried: Array<{
+			id: number;
+			sessionId: string;
+			reason: "shared_checkout_destination_adoptable" | "legacy_empty_base_branch";
+		}> = [];
+		const tx = this.db.transaction(() => {
+			for (const row of rows) {
+				let payload: Record<string, unknown>;
+				try {
+					const parsed = JSON.parse(row.payload);
+					if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+						continue;
+					payload = parsed as Record<string, unknown>;
+				} catch {
+					continue;
+				}
+				if (
+					typeof payload.creationIdentity !== "string" ||
+					payload.creationIdentity.length === 0 ||
+					!Number.isSafeInteger(payload.creationGeneration) ||
+					Number(payload.creationGeneration) < 1 ||
+					typeof payload.project !== "string" ||
+					typeof payload.worktreePath !== "string" ||
+					typeof payload.branch !== "string" ||
+					payload.branch.length === 0 ||
+					payload.mode !== "adopt_or_create" ||
+					typeof payload.isolated !== "boolean"
+				)
+					continue;
+				const sharedCheckoutFalsePositive =
+					payload.isolated === false &&
+					allowed.has(
+						JSON.stringify([payload.project, payload.worktreePath]),
+					) &&
+					row.last_error ===
+						`Worktree destination ${payload.worktreePath} exists without a registered branch`;
+				// This decoder rejection happened before any executor or physical Git
+				// action. Current additive decoding treats the old empty sentinel as
+				// an omitted optional base, so replay cannot duplicate prior work.
+				const legacyEmptyBaseBranch =
+					payload.baseBranch === "" &&
+					row.last_error ===
+						"Invalid creation_branch_prepare effect payload: baseBranch";
+				if (!sharedCheckoutFalsePositive && !legacyEmptyBaseBranch) continue;
+				const result = this.db.run(
+					`UPDATE session_kernel_outbox
+					 SET attempts = 0, next_attempt_at = ?, last_error = NULL,
+					     dead_lettered_at = NULL
+					 WHERE id = ? AND dead_lettered_at IS NOT NULL`,
+					[now, row.id],
+				);
+				if (result.changes > 0)
+					retried.push({
+						id: Number(row.id),
+						sessionId: row.session_id,
+						reason: sharedCheckoutFalsePositive
+							? "shared_checkout_destination_adoptable"
+							: "legacy_empty_base_branch",
+					});
+			}
+		});
+		tx.immediate();
+		return retried;
+	}
+
 	ackOutbox(id: number): void {
 		this.db.run("DELETE FROM session_kernel_outbox WHERE id = ?", [id]);
 	}


### PR DESCRIPTION
## Summary
- reconcile only creation branch dead letters produced before physical execution by the retired shared-checkout classifier or empty-base decoder
- run reconciliation through the actor-owned store behind the boot recovery gate
- audit every re-admitted effect and leave unrelated or malformed dead letters untouched
- fix the minimal Codex login environment typing regression exposed by current `main`

## Verification
- `bun run typecheck`
- 77 focused SessionKernel, actor-boundary, and creation-executor tests
- `bun scripts/check-module-side-effects.ts` (409 modules)
- `git diff --check origin/main...HEAD`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
