### PR TITLE
Prepare creation sandboxes through the actor

### DIFF
--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -1018,7 +1018,7 @@ ${createMentionsNote}`;
 					},
 					emit: (m) => broadcastToSession(bksId, { ...m, sessionId: bksId }),
 					fail: (message) => reject(new Error(message)),
-				});
+				}, createIdentity);
 				if (!opening.owner) {
 					const existing = findSession(bksId);
 					resolve({

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -83,6 +83,7 @@ import {
 	ensureCreationPlanned,
 	requestCreationBranch,
 	requestCreationCredential,
+	requestCreationSandbox,
 	requestCreationWorkspace,
 } from "./session-kernel";
 import { AUTO_REPO, ensureAskCheckout, ensureScratchDir, getRepo, isRegisteredWorktree, listWorktrees, NO_REPO, repoForPath, repoForPathOrNull, resolveUniqueBranch, sharedCheckoutForNewSessions, worktreeHeadBranch, worktreePathFor, } from "./worktree";
@@ -374,19 +375,27 @@ async function attachCreateRepos(
 	return attached;
 }
 
-const activeOpeningCreates = new Map<string, Promise<void>>();
+const activeOpeningCreates = new Map<
+	string,
+	{ identity: string; done: Promise<void> }
+>();
 
 export function runOpeningCreateOnce(
 	spec: ResolvedCreate,
 	io: CreateSessionIO,
+	creationIdentity: string,
 ): { owner: boolean; done: Promise<void> } {
 	const existing = activeOpeningCreates.get(spec.id);
-	if (existing) return { owner: false, done: existing };
-	const done = openCreatedSession(spec, io).finally(() => {
-		if (activeOpeningCreates.get(spec.id) === done)
+	if (existing) {
+		if (existing.identity !== creationIdentity)
+			throw new Error("Create request identity crossed active opening ownership");
+		return { owner: false, done: existing.done };
+	}
+	const done = openCreatedSession(spec, io, creationIdentity).finally(() => {
+		if (activeOpeningCreates.get(spec.id)?.done === done)
 			activeOpeningCreates.delete(spec.id);
 	});
-	activeOpeningCreates.set(spec.id, done);
+	activeOpeningCreates.set(spec.id, { identity: creationIdentity, done });
 	return { owner: true, done };
 }
 
@@ -472,7 +481,7 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 				sessionId,
 				message,
 			}),
-	});
+	}, plan.identity);
 	if (opening.owner) {
 		await opening.done;
 		clearCreatePlan(sessionId);
@@ -483,6 +492,7 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 export async function openCreatedSession(
 	spec: ResolvedCreate,
 	io: CreateSessionIO,
+	creationIdentity: string,
 ): Promise<void> {
 	const bksId = spec.id;
 	// Replace the raw first-line title with a short summary in the background;
@@ -749,7 +759,22 @@ export async function openCreatedSession(
 			let sandboxOpeningRun: AsyncGenerator<StreamEvent> | null = null;
 			let runnerOpeningRun: AsyncGenerator<StreamEvent> | null = null;
 			if (spec.sandboxProvider) {
+				// Creation owns the first physical sandbox preparation. The opening
+				// launcher still calls provider.ensure as an idempotent adoption step
+				// until launch itself becomes a later actor-issued effect.
 				const created = findSession(bksId);
+				await requestCreationSandbox({
+					sessionId: bksId,
+					identity: creationIdentity,
+					provider: spec.sandboxProvider,
+					repo: spec.repoId,
+					branch: spec.branch || undefined,
+					sessionMode: spec.mode,
+					cwd: spec.wtPath,
+					attachedDirs: created?.attachedRepos
+						?.map((repo) => repo.dir)
+						.filter(Boolean),
+				}, { timeoutMs: 15 * 60_000 });
 				sandboxOpeningRun = created
 					? await maybeLaunchSandboxedRun(created, {
 							prompt: openingPromptForRun,
@@ -1946,7 +1971,7 @@ export async function handleCreateSessionMessage(
 			failCreate(message);
 			releaseAdmission();
 		},
-	});
+	}, createIdentity);
 	if (!opening.owner) {
 		createResponse = {
 			type: "session_created",

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -55,6 +55,30 @@ describe("session kernel actor boundary", () => {
       },
       "shared-branch",
     );
+    host.store.applyCreationEvent({
+      sessionId: "shared-session",
+      identity: "creation-one",
+      event: "plan",
+    });
+    host.store.applyCreationEvent({
+      sessionId: "shared-session",
+      identity: "creation-one",
+      event: "preparation_started",
+      nextEffectId: "shared-branch",
+      effect: {
+        kind: "creation_branch_prepare",
+        effectKey: "shared-branch",
+        payload: {
+          creationIdentity: "creation-one",
+          creationGeneration: 1,
+          project: "opensession",
+          branch: "feature",
+          worktreePath: "/srv/opensession",
+          isolated: false,
+          mode: "adopt_or_create",
+        },
+      },
+    });
     host.store.noteOutboxFailure(
       id,
       "Worktree destination /srv/opensession exists without a registered branch",

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1234,6 +1234,40 @@ describe("SessionKernel durable runtime", () => {
 			sharedPayload,
 			"different-failure",
 		);
+		const ownEffect = (
+			sessionId: string,
+			effectKey: string,
+			payload: Record<string, unknown>,
+		) => {
+			store.applyCreationEvent({
+				sessionId,
+				identity: String(payload.creationIdentity),
+				event: "plan",
+			});
+			store.applyCreationEvent({
+				sessionId,
+				identity: String(payload.creationIdentity),
+				event: "preparation_started",
+				nextEffectId: effectKey,
+				effect: {
+					kind: "creation_branch_prepare",
+					effectKey,
+					payload: payload as any,
+				},
+			});
+		};
+		ownEffect("shared-session", "shared-branch", sharedPayload);
+		ownEffect("ordinary-session", "ordinary-branch", {
+			...sharedPayload,
+			worktreePath: "/srv/ordinary",
+		});
+		ownEffect("legacy-session", "legacy-empty-base", {
+			...sharedPayload,
+			project: "tella-fusion",
+			worktreePath: "/srv/tella-fusion-feature",
+			baseBranch: "",
+		});
+		ownEffect("different-session", "different-failure", sharedPayload);
 		store.noteOutboxFailure(
 			matching,
 			"Worktree destination /srv/opensession exists without a registered branch",

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1142,6 +1142,59 @@ describe("SessionKernel durable runtime", () => {
 		expect(store.stats().deadLetteredOutbox).toBe(0);
 	});
 
+	test("dead-lettered creation effects fail their actor lifecycle", async () => {
+		const {
+			CreationEffectIndeterminateError,
+			ensureCreationEffectExecutors,
+		} = await import("./creation-effect-executors");
+		const {
+			drainSessionKernelRuntime,
+			waitForSessionKernelRuntimeIdle,
+		} = await import("./runtime");
+		const { replaceSessionEffectExecutorForTest } = await import("./effect-executors");
+		ensureCreationEffectExecutors();
+		store.applyCreationEvent({
+			sessionId: "creation-dead",
+			identity: "identity-dead",
+			event: "plan",
+		});
+		store.applyCreationEvent({
+			sessionId: "creation-dead",
+			identity: "identity-dead",
+			event: "preparation_started",
+			nextEffectId: "sandbox:dead",
+			effect: {
+				kind: "creation_sandbox_prepare",
+				effectKey: "sandbox:dead",
+				payload: {
+					creationIdentity: "identity-dead",
+					creationGeneration: 1,
+					provider: "modal",
+					sandboxKey: "creation-dead",
+					mode: "adopt_or_create",
+				},
+			},
+		});
+		const unregister = replaceSessionEffectExecutorForTest(
+			"creation_sandbox_prepare",
+			() => {
+				throw new CreationEffectIndeterminateError("ambiguous sandbox");
+			},
+		);
+		try {
+			await drainSessionKernelRuntime();
+			await waitForSessionKernelRuntimeIdle();
+			expect(store.creationState("creation-dead")).toMatchObject({
+				state: "failed",
+				currentEffectId: undefined,
+				completedEffectIds: ["sandbox:dead"],
+			});
+			expect(store.stats().deadLetteredOutbox).toBe(1);
+		} finally {
+			unregister();
+		}
+	});
+
 	test("re-admits only pre-execution branch compatibility false positives", () => {
 		const sharedPayload = {
 			creationIdentity: "creation-one",

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -280,6 +280,10 @@ describe("single session ownership", () => {
 		expect(create).toContain("actorWorktreeMaterializer({");
 		expect(create).toContain("await requestCreationCredential({");
 		expect(create).toContain("await requestCreationBranch({");
+		expect(create).toContain("await requestCreationSandbox({");
+		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
+			create.indexOf("await maybeLaunchSandboxedRun("),
+		);
 		expect(create).toContain(
 			"baseBranch: input.baseBranch || getRepo(input.project).defaultBranch",
 		);
@@ -291,7 +295,7 @@ describe("single session ownership", () => {
 		expect(wiring).toContain('legacyGatewayEffect("answer_question"');
 		const tools = read("../agents/slack/sessions-tools.ts");
 		expect(tools).toContain("durableToolRequestId");
-		expect(tools).toContain('durableToolRequestId(ctx, "create_session", extra)');
+		expect(tools).toContain('durableToolRequestId(ctx, "create_session", extra');
 		const native = readFileSync(
 			resolve(serverDir, "../../../../clients/ios/OS1/Networking/SessionCreateIntent.swift"),
 			"utf8",

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -6,7 +6,7 @@ import {
 	sessionKernelStore,
 	maintainSessionKernel,
 } from "./kernel";
-import type { DurableTimer } from "./store";
+import type { DurableOutboxItem, DurableTimer } from "./store";
 import {
 	executeSessionEffect,
 	registeredSessionEffectKinds,
@@ -20,6 +20,32 @@ import {
 import { audit } from "../audit";
 
 type TimerHandler = (timer: DurableTimer) => void | Promise<void>;
+
+function failDeadCreationEffect(
+	item: DurableOutboxItem,
+	error: string,
+): void {
+	if (!item.kind.startsWith("creation_")) return;
+	const payload = item.payload as
+		| { creationIdentity?: unknown; creationGeneration?: unknown }
+		| undefined;
+	if (
+		typeof payload?.creationIdentity !== "string" ||
+		payload.creationIdentity.length === 0 ||
+		!Number.isSafeInteger(payload.creationGeneration)
+	)
+		return;
+	const result = sessionKernel(item.sessionId).applyCreationEvent({
+		identity: payload.creationIdentity,
+		event: "failed",
+		effectId: item.effectKey,
+		detail: { effectKind: item.kind, error },
+	});
+	if (!result.accepted && result.reason !== "stale_effect")
+		throw new Error(
+			`Creation effect ${item.effectId} failure was rejected: ${result.reason || "unknown"}`,
+		);
+}
 type RuntimeState = {
 	timerHandlers: Map<string, TimerHandler>;
 	handle?: ReturnType<typeof setInterval>;
@@ -128,8 +154,10 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 						message,
 						error instanceof CreationEffectIndeterminateError ? 1 : 20,
 					);
-					if (settled.deadLetteredNow)
+					if (settled.deadLetteredNow) {
+						failDeadCreationEffect(item, message);
 						audit({ msg: "session_kernel_dead_lettered", kind: "outbox", session_id: item.sessionId, outbox_id: item.id, error: message });
+					}
 					console.error(
 						`[session-kernel] outbox ${item.kind}/${item.id} failed:`,error,
 					);

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2396,11 +2396,15 @@ export class SessionKernelStore {
 		);
 		const rows = this.db
 			.query(
-				`SELECT id, session_id, payload, last_error
-				 FROM session_kernel_outbox
-				 WHERE kind = 'creation_branch_prepare'
-				   AND dead_lettered_at IS NOT NULL
-				 ORDER BY id
+				`SELECT outbox.id, outbox.session_id, outbox.payload, outbox.last_error
+				 FROM session_kernel_outbox AS outbox
+				 JOIN session_kernel_creation AS creation
+				   ON creation.session_id = outbox.session_id
+				  AND creation.state = 'preparing'
+				  AND creation.current_effect_id = outbox.effect_key
+				 WHERE outbox.kind = 'creation_branch_prepare'
+				   AND outbox.dead_lettered_at IS NOT NULL
+				 ORDER BY outbox.id
 				 LIMIT 1000`,
 			)
 			.all() as Array<{


### PR DESCRIPTION
## Summary
- route initial sandbox preparation through the durable creation actor before opening-turn launch
- carry the stable creation identity through web, MCP, and restart recovery paths
- keep the existing run-time ensure only as an idempotent adoption bridge
- fail the actor-owned creation lifecycle when a typed creation effect reaches a permanent dead letter
- fence concurrent opening-create coalescing by creation identity

## Verification
- `bun run typecheck`
- 109 focused SessionKernel, creation-intent, ownership, and effect-executor tests
- `bun scripts/check-module-side-effects.ts` (409 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
