### PR TITLE
Match self-deploy to run-host helper v2

### DIFF
--- a/deploy/executor-service.test.ts
+++ b/deploy/executor-service.test.ts
@@ -46,6 +46,8 @@ describe("executor deployment", () => {
     expect(deploy).toContain("target executor failed readiness; attempting rollback to pin");
     expect(deploy).toContain("opensession-executor.service");
     expect(deploy).toContain("EXECUTOR_READY_FILE");
+    expect(deploy).toContain("RUN_HOST_HELPER_VERSION=2");
+    expect(deploy).toContain('check-version "$RUN_HOST_HELPER_VERSION"');
     expect(deploy).not.toContain("sudo -n cp");
     expect(deploy).not.toContain("sudo -n rm");
     expect(deploy).toContain("rollback_schema_compatible");

--- a/deploy/self-deploy.sh
+++ b/deploy/self-deploy.sh
@@ -43,6 +43,7 @@ ALLOW_RESET="${OPENSESSION_DEPLOY_ALLOW_RESET:-0}"
 SERVICE_NAME="${OPENSESSION_SERVICE_NAME:-opensession.service}"
 EXECUTOR_SERVICE_NAME="opensession-executor.service"
 EXECUTOR_READY_FILE="/run/opensession-executor/ready"
+RUN_HOST_HELPER_VERSION=2
 
 # Health gate: 30 x 2s = 60s budget, matching deploy.sh's post-restart gate.
 HEALTH_TRIES=30
@@ -140,9 +141,9 @@ refresh_executor() {
     return 1
   fi
   if [ "$(id -u)" = "0" ]; then
-    /usr/local/libexec/opensession-run-host check-version 1
+    /usr/local/libexec/opensession-run-host check-version "$RUN_HOST_HELPER_VERSION"
   else
-    sudo -n /usr/local/libexec/opensession-run-host check-version 1
+    sudo -n /usr/local/libexec/opensession-run-host check-version "$RUN_HOST_HELPER_VERSION"
   fi
   run_systemctl restart "$EXECUTOR_SERVICE_NAME"
   local i


### PR DESCRIPTION
## Summary
- make self-deploy validate the installed run-host helper at protocol version 2
- cover the privileged helper version contract in deployment tests

## Verification
- `bun test deploy/executor-service.test.ts packages/core/opensession-server/src/server/self-deploy.test.ts` (17 tests)
- `bun run typecheck`
- `bash -n deploy/self-deploy.sh`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
