### PR TITLE
Route a refused WebSocket upgrade to the sign-in card

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/UserPicker.tsx
+++ b/packages/core/opensession-server/src/frontend/components/UserPicker.tsx
@@ -11,7 +11,7 @@ import { cn } from "../ui/cn";
 import { DeviceCode } from "../ui/device-code";
 import { InlineAlert } from "../ui/state";
 import { PulseDot } from "../ui/status";
-import { AUTH_STATUS_EVENT } from "../lib/auth-ready";
+import { AUTH_STATUS_EVENT, authGatesOut } from "../lib/auth-ready";
 
 /**
  * Mutable compatibility view for older consumers. `usePeople()` owns the
@@ -85,6 +85,14 @@ let authStatusCache: AuthStatus | null = null;
 function setAuthStatusCache(status: AuthStatus) {
   authStatusCache = status;
   window.dispatchEvent(new Event(AUTH_STATUS_EVENT));
+}
+
+/** Publish an auth status discovered outside UserGate — the WebSocket layer
+ *  learns the gate turned on (or that a fresh load landed on a gated instance)
+ *  from a refused upgrade, and drives UserGate to the sign-in card through
+ *  this, without a reload that would loop on the card's own refused socket. */
+export function publishAuthStatus(status: AuthStatus): void {
+  setAuthStatusCache(status);
 }
 
 /** Reactive sign-in state; null until /api/auth/status answers (or when the
@@ -261,6 +269,25 @@ export function UserGate({ children }: { children: React.ReactNode }) {
   useEffect(() => {
 		loadAuth();
   }, []);
+
+	// A refused WebSocket upgrade can reveal the gate is up before this
+	// component's own status resolves (the optimistic paint below) or after it
+	// resolved to no-gate (the gate was enabled under an open tab). Honor that
+	// signal so the sign-in card, not a "reconnecting" overlay, stands in for a
+	// browser the server will no longer accept.
+	const liveAuth = useAuthStatus();
+	if (authGatesOut(liveAuth) && !(auth?.required && auth.authenticated)) {
+		return (
+			<GithubSignIn
+				reconnect={liveAuth!.reconnectRequired === true}
+				login={liveAuth!.login}
+				onSignedIn={(status) => {
+					setAuth(status);
+					setAuthStatusCache(status);
+				}}
+			/>
+		);
+	}
 
 	// Returning visitors already have a local identity. Let the app paint while
 	// the server verifies its HttpOnly session, as it did before this check grew

--- a/packages/core/opensession-server/src/frontend/hooks/useWebSocket.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useWebSocket.ts
@@ -5,7 +5,8 @@ import { countSessionPerf } from "../lib/session-performance";
 import { withMutationRequestId } from "../lib/ws-request-id";
 import { BASE_PATH } from "../lib/base";
 import { toast } from "../ui/toast";
-import { whenCurrentUserReady } from "../lib/auth-ready";
+import { authGatesOut, whenCurrentUserReady } from "../lib/auth-ready";
+import { publishAuthStatus } from "../components/UserPicker";
 import {
   localCommandScope,
   shouldRetireCommandResult,
@@ -313,13 +314,22 @@ export function useWebSocket(presenceActive = true) {
           const response = await fetch(`${API_BASE}/auth/status`);
           const status = response.ok ? await response.json() : null;
           if (status?.local && !status.authenticated) return;
-          // The session stopped being accepted while this tab stayed open:
-          // it expired, or the GitHub grant behind it died. Retrying every 2s
-          // for ever leaves a live-looking app that can reach nothing, so
-          // reload into the gate, which asks for the sign-in that repairs it.
-          if (everOpenRef.current && status?.required && !status.authenticated) {
-            window.location.reload();
-            return;
+          if (authGatesOut(status)) {
+            if (everOpenRef.current) {
+              // The session stopped being accepted while this tab stayed open:
+              // it expired, or the GitHub grant behind it died. Retrying every
+              // 2s for ever leaves a live-looking app that can reach nothing, so
+              // reload into the gate, which asks for the sign-in that repairs it.
+              window.location.reload();
+              return;
+            }
+            // A socket that never opened means a fresh load into a gated
+            // instance (the upgrade 401s immediately). Reloading here would loop
+            // on the sign-in card, whose own socket also 401s, so publish the
+            // gated status instead: UserGate renders the sign-in card over the
+            // optimistically-painted app. Fall through to keep retrying, so a
+            // completed sign-in reconnects without a manual refresh.
+            publishAuthStatus(status);
           }
         } catch {}
       }

--- a/packages/core/opensession-server/src/frontend/lib/auth-ready.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/auth-ready.test.ts
@@ -1,0 +1,29 @@
+// authGatesOut is the single predicate UserGate and useWebSocket share to
+// decide "the instance now requires sign-in and this browser has no accepted
+// session" — the state where every authenticated route and the UI WebSocket
+// upgrade 401. UserGate renders the sign-in card on it; useWebSocket stops
+// presenting the refused upgrade as a reconnect overlay. If the two ever
+// disagreed, a gated browser would sit forever on "Connection lost. retrying"
+// with no way to sign in — the lockout this pins shut.
+
+import { describe, expect, test } from "bun:test";
+import { authGatesOut } from "./auth-ready";
+
+describe("authGatesOut", () => {
+	test("gated: sign-in required and this browser is not authenticated", () => {
+		expect(authGatesOut({ required: true, authenticated: false })).toBe(true);
+	});
+
+	test("not gated: signed in", () => {
+		expect(authGatesOut({ required: true, authenticated: true })).toBe(false);
+	});
+
+	test("not gated: instance does not require sign-in", () => {
+		expect(authGatesOut({ required: false, authenticated: false })).toBe(false);
+	});
+
+	test("unknown status (null/undefined) is never a lockout", () => {
+		expect(authGatesOut(null)).toBe(false);
+		expect(authGatesOut(undefined)).toBe(false);
+	});
+});

--- a/packages/core/opensession-server/src/frontend/lib/auth-ready.ts
+++ b/packages/core/opensession-server/src/frontend/lib/auth-ready.ts
@@ -3,6 +3,18 @@ const USER_KEY = "opensession-user";
 const LEGACY_USER_KEY = "backstage-user";
 export const AUTH_STATUS_EVENT = "opensession-auth-status-changed";
 
+/** True when the instance requires sign-in and this browser holds no accepted
+ *  session — the state in which every authenticated route and the UI WebSocket
+ *  upgrade 401, so the only correct UI is the sign-in card, never a reconnect
+ *  overlay. Shared by UserGate (renders the card) and useWebSocket (stops
+ *  presenting a refused upgrade as a transient disconnect) so the two never
+ *  disagree about what a 401 means. */
+export function authGatesOut(
+	status: { required?: boolean; authenticated?: boolean } | null | undefined,
+): boolean {
+	return !!status?.required && !status.authenticated;
+}
+
 function storedCurrentUser(): string {
 	if (typeof localStorage === "undefined") return "Anonymous";
 	return localStorage.getItem(USER_KEY) || localStorage.getItem(LEGACY_USER_KEY) || "Anonymous";


### PR DESCRIPTION
## The lockout

After enabling org GitHub sign-in on a fresh local install, the browser got stuck on **"Connection lost. retrying"** with no way to sign in.

Root cause, traced end to end (server proven by direct probes, client by code):

- When `integrations.github.userPrAuth` is on and the browser holds no accepted session, the server returns **401 on every authenticated route and on the UI WebSocket upgrade** (verified: gate on + no cookie → `/api/auth/status` returns `{required:true, authenticated:false}`, `/ws` → 401, all `/api/*` → 401; `GET /` still 200).
- `useWebSocket` mounts **above** `UserGate`, so the socket 401s and `RestartOverlay` renders "Connection lost. retrying" — a *network* message for what is really an *auth* state.
- The existing recovery (reload into the sign-in gate) fired only when the socket had **previously opened** (`everOpenRef`). A fresh load into a gated instance — the upgrade 401s immediately, never opening — fell through to retry forever, and `UserGate`'s optimistic paint (for a returning browser whose `localStorage` identity survived the reinstall) left the connection overlay standing in for the sign-in card.

This was **not** a server bug: the gate flip and admin roster are correct and atomic, the session cookie is non-`Secure`/`HttpOnly`/`SameSite=Lax` (stores fine on localhost). The defect is that the client surfaces an auth-required 401 as a connection failure.

## The fix

One shared predicate, `authGatesOut(status)` (in `lib/auth-ready.ts`), used by both deciders so they never disagree about what a 401 means:

- **`useWebSocket`**: on a socket that closes without ever opening, publish the gated status instead of reloading. A reload would loop on the sign-in card, whose own socket also 401s. Falls through to keep retrying, so a completed sign-in reconnects without a manual refresh. The previously-open path keeps its reload.
- **`UserGate`**: render the GitHub sign-in card the moment a gated status is published, overriding the optimistic paint.

Net: a gated browser with no session always lands on the sign-in card, never on an infinite reconnect overlay.

## Why this is the fix, not "don't enable sign-in for localhost"

Per-user sign-in is a legitimate mode for a single-machine install: run it on a VPS, `opensession bind` it onto a tailnet, and share the URL with colleagues, and the gate is exactly what protects it. So the right behavior is a gate that recovers cleanly — the admin who enables it and every colleague who opens the URL land on the sign-in card — which is what this PR does.

## Verification
- Reproduced the server side deterministically on a real install (flipped `userPrAuth` on, probed un-cookied endpoints, restored) — the 401s above are measured, not assumed.
- `bun test lib/auth-ready.test.ts` — 4 pass (the shared predicate's contract).
- `tsc --noEmit` — no new errors.
- **No screenshot**: the change swaps a connection overlay for the existing sign-in card; exercising it live needs a real GitHub device flow. I can build a patched binary and walk it on the affected Mac if you want visual proof before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)