### PR TITLE
Settle durable creation opening lifecycle

### DIFF
--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -81,10 +81,13 @@ import { resolveWorkspaceModelPreset } from "./workspace-model-presets";
 import { type Workspace, getWorkspace, updateWorkspace, } from "./workspaces";
 import {
 	ensureCreationPlanned,
+	markCreationOpeningDispatched,
 	requestCreationBranch,
 	requestCreationCredential,
 	requestCreationSandbox,
 	requestCreationWorkspace,
+	settleCreationFailed,
+	settleCreationSucceeded,
 } from "./session-kernel";
 import { AUTO_REPO, ensureAskCheckout, ensureScratchDir, getRepo, isRegisteredWorktree, listWorktrees, NO_REPO, repoForPath, repoForPathOrNull, resolveUniqueBranch, sharedCheckoutForNewSessions, worktreeHeadBranch, worktreePathFor, } from "./worktree";
 import { type WSClientData, broadcastToSession, preparingWorkspaces, } from "./ws-hub";
@@ -391,10 +394,15 @@ export function runOpeningCreateOnce(
 			throw new Error("Create request identity crossed active opening ownership");
 		return { owner: false, done: existing.done };
 	}
-	const done = openCreatedSession(spec, io, creationIdentity).finally(() => {
-		if (activeOpeningCreates.get(spec.id)?.done === done)
-			activeOpeningCreates.delete(spec.id);
-	});
+	const done = openCreatedSession(spec, io, creationIdentity)
+		.catch((error) => {
+			settleCreationFailed(spec.id, creationIdentity, error);
+			throw error;
+		})
+		.finally(() => {
+			if (activeOpeningCreates.get(spec.id)?.done === done)
+				activeOpeningCreates.delete(spec.id);
+		});
 	activeOpeningCreates.set(spec.id, { identity: creationIdentity, done });
 	return { owner: true, done };
 }
@@ -775,6 +783,7 @@ export async function openCreatedSession(
 						?.map((repo) => repo.dir)
 						.filter(Boolean),
 				}, { timeoutMs: 15 * 60_000 });
+				markCreationOpeningDispatched(bksId, creationIdentity);
 				sandboxOpeningRun = created
 					? await maybeLaunchSandboxedRun(created, {
 							prompt: openingPromptForRun,
@@ -811,6 +820,7 @@ export async function openCreatedSession(
 				await touchNativeSession(bksId, {
 					runner: { id: spec.runnerTarget.id, name: spec.runnerTarget.name, workspacePath: spec.runnerTarget.workspacePath, lifecycle: "awake", },
 				});
+				markCreationOpeningDispatched(bksId, creationIdentity);
 				const created = findSession(bksId);
 				runnerOpeningRun = created
 					? await maybeLaunchRunnerRun(created, {
@@ -833,6 +843,8 @@ export async function openCreatedSession(
 			// gets is read back rather than reassembled, so it can only name
 			// worktrees that were actually cut.
 			const spanning = attachedRepoIds.length ? findSession(bksId) : null;
+			if (!sandboxOpeningRun && !runnerOpeningRun)
+				markCreationOpeningDispatched(bksId, creationIdentity);
 			for await (const event of sandboxOpeningRun ?? runnerOpeningRun ?? runAgent({
 				prompt: openingPromptForRun,
 				// A recovered create is the same logical turn. Reuse the durable
@@ -1103,6 +1115,7 @@ export async function openCreatedSession(
 			else
 				onHumanAsksSessionIdle(bksId);
 		}
+		settleCreationSucceeded(bksId, creationIdentity);
 	} catch (e: any) {
 		// Failure after the early announce: the client is already in the
 		// session — close out the stream and surface the failure there
@@ -1139,6 +1152,7 @@ export async function openCreatedSession(
 		} else {
 			io.fail(e.message || String(e));
 		}
+		settleCreationFailed(bksId, creationIdentity, e);
 	}
 }
 

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  markCreationOpeningDispatched,
   requestCreationBranch,
   requestCreationCredential,
   requestCreationSandbox,
   requestCreationWorkspace,
+  settleCreationFailed,
+  settleCreationSucceeded,
 } from "./creation-intents";
 import {
   SessionKernelStore,
@@ -45,6 +48,101 @@ const branchInput = {
   isolated: true,
   credentialPrincipal: "user:alice",
 };
+
+describe("creation lifecycle intents", () => {
+  test("moves a preparation-free create through opening to ready idempotently", () => {
+    const { store, kernel } = harness("create-lifecycle");
+    try {
+      const opening = markCreationOpeningDispatched(
+        "create-lifecycle",
+        "request-lifecycle",
+        kernel,
+      );
+      expect(opening.state).toBe("opening_dispatched");
+      expect(opening.currentEffectId).toBeUndefined();
+      const ready = settleCreationSucceeded(
+        "create-lifecycle",
+        "request-lifecycle",
+        kernel,
+      );
+      expect(ready.state).toBe("ready");
+      expect(
+        settleCreationSucceeded(
+          "create-lifecycle",
+          "request-lifecycle",
+          kernel,
+        ).state,
+      ).toBe("ready");
+    } finally {
+      store.close();
+    }
+  });
+
+  test("refuses to dispatch an opening while preparation is pending", () => {
+    const { store, kernel } = harness("create-pending-opening");
+    try {
+      store.applyCreationEvent({
+        sessionId: "create-pending-opening",
+        identity: "request-pending",
+        event: "plan",
+      });
+      store.applyCreationEvent({
+        sessionId: "create-pending-opening",
+        identity: "request-pending",
+        event: "preparation_started",
+        nextEffectId: "prepare-pending",
+        effect: {
+          kind: "creation_workspace_prepare",
+          effectKey: "prepare-pending",
+          payload: {
+            creationIdentity: "request-pending",
+            creationGeneration: 1,
+            workspaceId: "ws-pending",
+            dedupeKey: "create:pending",
+            name: "Pending",
+            createdBy: "Alice",
+            mode: "adopt_or_create",
+          },
+        },
+      });
+      expect(() =>
+        markCreationOpeningDispatched(
+          "create-pending-opening",
+          "request-pending",
+          kernel,
+        ),
+      ).toThrow("must settle before opening");
+      expect(store.creationState("create-pending-opening")?.state).toBe(
+        "preparing",
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test("records terminal setup failure without launching an opening", () => {
+    const { store, kernel } = harness("create-failed-lifecycle");
+    try {
+      const failed = settleCreationFailed(
+        "create-failed-lifecycle",
+        "request-failed",
+        new Error("workspace refused"),
+        kernel,
+      );
+      expect(failed.state).toBe("failed");
+      expect(
+        settleCreationFailed(
+          "create-failed-lifecycle",
+          "request-failed",
+          "duplicate",
+          kernel,
+        ).state,
+      ).toBe("failed");
+    } finally {
+      store.close();
+    }
+  });
+});
 
 describe("creation workspace intents", () => {
   test("waits for the actor receipt rather than destination evidence", async () => {

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -83,6 +83,80 @@ export function ensureCreationPlanned(
   return planned.state;
 }
 
+/** Cross the durable preparation-to-opening boundary before launching a runner. */
+export function markCreationOpeningDispatched(
+  sessionId: string,
+  identity: string,
+  kernel: CreationIntentKernel = sessionKernel(sessionId),
+): DurableCreationState {
+  let state = ensureCreationPlanned(sessionId, identity, kernel);
+  if (state.state === "ready" || state.state === "opening_dispatched") return state;
+  assertIdentity(state, identity);
+  if (state.currentEffectId)
+    throw new Error(
+      `Creation effect ${state.currentEffectId} must settle before opening`,
+    );
+  if (state.state === "planned") {
+    const preparing = kernel.applyCreationEvent({
+      identity,
+      event: "preparation_started",
+    });
+    if (!preparing.accepted || !preparing.state)
+      throw new Error(
+        `Creation preparation was rejected: ${preparing.reason || "unknown"}`,
+      );
+    state = preparing.state;
+  }
+  const dispatched = kernel.applyCreationEvent({
+    identity,
+    event: "opening_dispatched",
+  });
+  if (!dispatched.accepted || !dispatched.state)
+    throw new Error(
+      `Creation opening dispatch was rejected: ${dispatched.reason || "unknown"}`,
+    );
+  return dispatched.state;
+}
+
+export function settleCreationSucceeded(
+  sessionId: string,
+  identity: string,
+  kernel: CreationIntentKernel = sessionKernel(sessionId),
+): DurableCreationState {
+  const state = ensureCreationPlanned(sessionId, identity, kernel);
+  if (state.state === "ready") return state;
+  assertIdentity(state, identity);
+  const settled = kernel.applyCreationEvent({ identity, event: "succeeded" });
+  if (!settled.accepted || !settled.state)
+    throw new Error(
+      `Creation success was rejected: ${settled.reason || "unknown"}`,
+    );
+  return settled.state;
+}
+
+export function settleCreationFailed(
+  sessionId: string,
+  identity: string,
+  error: unknown,
+  kernel: CreationIntentKernel = sessionKernel(sessionId),
+): DurableCreationState {
+  const existing = kernel.creationState();
+  if (existing?.identity !== undefined && existing.identity !== identity)
+    throw new Error("Create request identity crossed durable session ownership");
+  if (existing?.state === "failed") return existing;
+  ensureCreationPlanned(sessionId, identity, kernel);
+  const settled = kernel.applyCreationEvent({
+    identity,
+    event: "failed",
+    detail: { error: error instanceof Error ? error.message : String(error) },
+  });
+  if (!settled.accepted || !settled.state)
+    throw new Error(
+      `Creation failure was rejected: ${settled.reason || "unknown"}`,
+    );
+  return settled.state;
+}
+
 /** Emit one stable workspace intent and wait for its actor receipt, never its file. */
 export async function requestCreationWorkspace(
   input: CreationWorkspaceIntent,

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -284,6 +284,15 @@ describe("single session ownership", () => {
 		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
 			create.indexOf("await maybeLaunchSandboxedRun("),
 		);
+		expect(create.match(/markCreationOpeningDispatched\(/g)?.length).toBe(3);
+		expect(create).toMatch(
+			/requestCreationSandbox\([\s\S]*?markCreationOpeningDispatched\([\s\S]*?maybeLaunchSandboxedRun\(/,
+		);
+		expect(create).toMatch(
+			/prepareRunnerWorkspace\([\s\S]*?markCreationOpeningDispatched\([\s\S]*?maybeLaunchRunnerRun\(/,
+		);
+		expect(create).toContain("settleCreationSucceeded(bksId, creationIdentity)");
+		expect(create).toContain("settleCreationFailed(bksId, creationIdentity, e)");
 		expect(create).toContain(
 			"baseBranch: input.baseBranch || getRepo(input.project).defaultBranch",
 		);


### PR DESCRIPTION
## Summary
- cross the actor-owned creation lifecycle into `opening_dispatched` immediately before each host, sandbox, or Runner opening launch
- settle successful openings as `ready` and setup failures as `failed`
- fail closed if an opening is attempted while a durable preparation effect is still pending
- make terminal lifecycle settlement idempotent for replay and restart paths

This is a bounded creation-cutover slice. Opening launch itself still uses the existing adapters and will move behind the durable `creation_opening_turn` effect in the next dependency-ordered slice.

## Verification
- `bun test packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts packages/core/opensession-server/src/server/session-kernel/kernel.test.ts packages/core/opensession-server/src/server/session-kernel/ownership.test.ts packages/core/opensession-server/src/server/session-create-plan.test.ts` (84 tests, 868 assertions)
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts` (407 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
