### PR TITLE
Adopt existing checkouts when re-registering repos

### DIFF
--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import {
   adoptExistingCheckout,
   githubCredentialHelperCommand,
+  matchesCodeStorageCheckout,
   validGithubFullName,
 } from "./setup-repos";
 
@@ -96,6 +97,24 @@ describe("adoptExistingCheckout", () => {
     );
     expect(adopted?.ghRepo).toBe("acme/widget");
     expect(adopted?.defaultBranch).toBe("main");
+  });
+
+  test("only adopts a code.storage checkout from the configured organization", async () => {
+    const dest = await makeCheckout(
+      join(tmpRoot(), "widget"),
+      "https://old-org.code.storage/acme/widget.git",
+    );
+    const inspected = await adoptExistingCheckout(
+      dest,
+      (i) => matchesCodeStorageCheckout(i, "old-org", "acme/widget"),
+    );
+    expect(inspected?.cs).toEqual({ org: "old-org", repoId: "acme/widget" });
+    expect(
+      adoptExistingCheckout(
+        dest,
+        (i) => matchesCodeStorageCheckout(i, "new-org", "acme/widget"),
+      ),
+    ).rejects.toThrow(/Clone destination already exists/);
   });
 
   test("refuses a checkout of a different repo", async () => {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, test } from "bun:test";
-import { githubCredentialHelperCommand, validGithubFullName } from "./setup-repos";
+import { $ } from "bun";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  adoptExistingCheckout,
+  githubCredentialHelperCommand,
+  validGithubFullName,
+} from "./setup-repos";
 
 describe("validGithubFullName", () => {
   test("accepts ordinary owner/name pairs", () => {
@@ -52,4 +60,60 @@ describe("githubCredentialHelperCommand", () => {
     expect(command).toEndWith("scripts/gh-credential.ts");
   });
 
+});
+
+describe("adoptExistingCheckout", () => {
+  const roots: string[] = [];
+  const tmpRoot = () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-adopt-"));
+    roots.push(dir);
+    return dir;
+  };
+  afterAll(() => {
+    for (const dir of roots) rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function makeCheckout(dir: string, origin: string): Promise<string> {
+    mkdirSync(dir, { recursive: true });
+    await $`git -C ${dir} init -q -b main`.quiet();
+    await $`git -C ${dir} remote add origin ${origin}`.quiet();
+    await $`git -C ${dir} -c user.email=t@e -c user.name=t commit -q --allow-empty -m init`.quiet();
+    return dir;
+  }
+
+  test("returns null when nothing is at the destination", async () => {
+    expect(await adoptExistingCheckout(join(tmpRoot(), "absent"), () => true)).toBe(null);
+  });
+
+  test("adopts a checkout of the same repo (no token needed)", async () => {
+    const dest = await makeCheckout(
+      join(tmpRoot(), "widget"),
+      "https://github.com/acme/widget.git",
+    );
+    const adopted = await adoptExistingCheckout(
+      dest,
+      (i) => (i.ghRepo || "").toLowerCase() === "acme/widget",
+    );
+    expect(adopted?.ghRepo).toBe("acme/widget");
+    expect(adopted?.defaultBranch).toBe("main");
+  });
+
+  test("refuses a checkout of a different repo", async () => {
+    const dest = await makeCheckout(
+      join(tmpRoot(), "widget"),
+      "https://github.com/acme/other.git",
+    );
+    expect(
+      adoptExistingCheckout(dest, (i) => (i.ghRepo || "").toLowerCase() === "acme/widget"),
+    ).rejects.toThrow(/Clone destination already exists/);
+  });
+
+  test("refuses a non-git directory at the destination", async () => {
+    const dest = join(tmpRoot(), "widget");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "notes.txt"), "hi");
+    expect(adoptExistingCheckout(dest, () => true)).rejects.toThrow(
+      /Clone destination already exists/,
+    );
+  });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -326,10 +326,12 @@ async function configureGithubCredentialHelper(checkoutPath: string): Promise<vo
  * non-git directory, or a checkout of a DIFFERENT repo — still throws, since
  * adopting it would silently register the wrong code.
  */
+type InspectedRepo = Awaited<ReturnType<typeof inspectRepo>>;
+
 export async function adoptExistingCheckout(
   dest: string,
-  matches: (inspected: Awaited<ReturnType<typeof inspectRepo>>) => boolean,
-): Promise<Awaited<ReturnType<typeof inspectRepo>> | null> {
+  matches: (inspected: InspectedRepo) => boolean,
+): Promise<InspectedRepo | null> {
   if (!existsSync(dest)) return null;
   const inspected = await inspectRepo(dest).catch(() => null);
   if (!inspected || !matches(inspected)) {
@@ -407,6 +409,17 @@ export function validCsRepoId(value: unknown): value is string {
   return typeof value === "string" && CS_REPO_ID_RE.test(value);
 }
 
+export function matchesCodeStorageCheckout(
+  inspected: InspectedRepo,
+  org: string,
+  repoId: string,
+): boolean {
+  return (
+    inspected.cs?.org.toLowerCase() === org.toLowerCase() &&
+    inspected.cs.repoId.toLowerCase() === repoId.toLowerCase()
+  );
+}
+
 async function registerCodestorageRepo(input: {
   repoId: string;
   id?: string;
@@ -428,7 +441,7 @@ async function registerCodestorageRepo(input: {
   const dest = `${root}/${id}`;
   const adopted = await adoptExistingCheckout(
     dest,
-    (i) => (i.cs?.repoId || "").toLowerCase() === csRepo.toLowerCase(),
+    (i) => matchesCodeStorageCheckout(i, cfg.org, csRepo),
   );
   mkdirSync(root, { recursive: true });
   try {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -310,6 +310,34 @@ async function configureGithubCredentialHelper(checkoutPath: string): Promise<vo
   await $`git -C ${checkoutPath} config --add ${helperKey} ${githubCredentialHelperCommand()}`.quiet();
 }
 
+/**
+ * Adopt a checkout already sitting at the clone destination, or refuse.
+ *
+ * Uninstall deliberately preserves ~/checkouts — it is the user's code, not
+ * app state — so a reinstall (or any re-registration after the repo was
+ * removed from config) starts with an empty config and a full checkouts dir.
+ * Registering the same repo again should take what is on disk instead of
+ * failing, which also works before GitHub auth is set up: adoption needs no
+ * token, only the existing origin.
+ *
+ * Returns the inspected repo when the path holds a checkout of the very repo
+ * being registered (so the caller can skip the clone and keep the checkout on
+ * a later failure), null when nothing is there. Anything else at the path — a
+ * non-git directory, or a checkout of a DIFFERENT repo — still throws, since
+ * adopting it would silently register the wrong code.
+ */
+export async function adoptExistingCheckout(
+  dest: string,
+  matches: (inspected: Awaited<ReturnType<typeof inspectRepo>>) => boolean,
+): Promise<Awaited<ReturnType<typeof inspectRepo>> | null> {
+  if (!existsSync(dest)) return null;
+  const inspected = await inspectRepo(dest).catch(() => null);
+  if (!inspected || !matches(inspected)) {
+    throw new Error(`Clone destination already exists: ${dest}`);
+  }
+  return inspected;
+}
+
 async function registerGithubRepo(input: {
   fullName: string;
   id?: string;
@@ -325,18 +353,20 @@ async function registerGithubRepo(input: {
   }
   const root = checkoutsRoot();
   const dest = `${root}/${id}`;
-  if (existsSync(dest)) {
-    throw new Error(`Clone destination already exists: ${dest}`);
-  }
+  const adopted = await adoptExistingCheckout(
+    dest,
+    (i) => (i.ghRepo || "").toLowerCase() === input.fullName.toLowerCase(),
+  );
   mkdirSync(root, { recursive: true });
   try {
-    await cloneGithubRepo(input.fullName, dest, input.credential?.env.GH_TOKEN);
+    if (!adopted) await cloneGithubRepo(input.fullName, dest, input.credential?.env.GH_TOKEN);
     // A private clone authenticated through a one-shot GIT_ASKPASS; the remote
     // it leaves is tokenless, so wire the credential helper for future
     // fetch/push. No-op for a public (tokenless) clone — the helper simply has
-    // nothing to answer with.
+    // nothing to answer with. An adopted checkout gets it too, so a checkout
+    // left by a previous install authenticates with the current credential.
     if (input.credential) await configureGithubCredentialHelper(dest);
-    const inspected = await inspectRepo(dest);
+    const inspected = adopted ?? (await inspectRepo(dest));
     const config = rawConfig();
     const repos = {
       ...((config.repos && typeof config.repos === "object" && !Array.isArray(config.repos)
@@ -354,10 +384,17 @@ async function registerGithubRepo(input: {
     repos[id] = entry;
     config.repos = repos;
     persistRawConfig(config);
-    audit({ kind: "setup_repo_register", repo: input.fullName, id, path: inspected.path });
+    audit({
+      kind: "setup_repo_register",
+      repo: input.fullName,
+      id,
+      path: inspected.path,
+      ...(adopted ? { adopted: true } : {}),
+    });
     return { id, ...entry };
   } catch (error) {
-    rmSync(dest, { recursive: true, force: true });
+    // Only clean up a checkout this call created. An adopted one predates us.
+    if (!adopted) rmSync(dest, { recursive: true, force: true });
     throw error;
   }
 }
@@ -389,15 +426,18 @@ async function registerCodestorageRepo(input: {
   }
   const root = checkoutsRoot();
   const dest = `${root}/${id}`;
-  if (existsSync(dest)) {
-    throw new Error(`Clone destination already exists: ${dest}`);
-  }
+  const adopted = await adoptExistingCheckout(
+    dest,
+    (i) => (i.cs?.repoId || "").toLowerCase() === csRepo.toLowerCase(),
+  );
   mkdirSync(root, { recursive: true });
   try {
     // Clones with a short-lived JWT, persists the credential-free remote, and
-    // wires the URL-scoped credential helper for ambient git fetch/push.
-    await cloneCsCheckout(csRepo, dest);
-    const inspected = await inspectRepo(dest);
+    // wires the URL-scoped credential helper for ambient git fetch/push. An
+    // adopted checkout already carries both (boot re-wires the helper for
+    // every configured code.storage repo).
+    if (!adopted) await cloneCsCheckout(csRepo, dest);
+    const inspected = adopted ?? (await inspectRepo(dest));
     const config = rawConfig();
     const repos = {
       ...((config.repos && typeof config.repos === "object" && !Array.isArray(config.repos)
@@ -416,10 +456,16 @@ async function registerCodestorageRepo(input: {
     repos[id] = entry;
     config.repos = repos;
     persistRawConfig(config);
-    audit({ kind: "setup_repo_register", repo: csRepo, id, path: inspected.path });
+    audit({
+      kind: "setup_repo_register",
+      repo: csRepo,
+      id,
+      path: inspected.path,
+      ...(adopted ? { adopted: true } : {}),
+    });
     return { id, ...entry };
   } catch (error) {
-    rmSync(dest, { recursive: true, force: true });
+    if (!adopted) rmSync(dest, { recursive: true, force: true });
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

- adopt an existing checkout when its remote matches the repo being registered
- let reinstalls re-register preserved checkouts without requiring GitHub authentication first
- keep rejecting unrelated or non-git destinations and never delete an adopted checkout during failure cleanup
- apply the same behavior to GitHub and code.storage repositories

## Tests

- `bun test packages/core/opensession-server/src/server/routes/setup-repos.test.ts`
- `bunx tsc --noEmit -p tsconfig.json`

Started by John Soutar in [this OS session](https://os.tella.dev/session/os-01a0330a-4f2d-7e34-89a8-c8f154504d85)
