### PR TITLE
Filter model choices by configured providers

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/ModelEffortSelect.models.test.ts
+++ b/packages/core/opensession-server/src/frontend/components/ModelEffortSelect.models.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelOption } from "../lib/api";
+import { splitModelOptions } from "./ModelEffortSelect";
+
+function model(id: string, provider: ModelOption["provider"]): ModelOption {
+	return { id, provider, label: id, aliases: [], efforts: [] };
+}
+
+describe("model picker groups", () => {
+	test("keeps current Fable and Sol slugs out of legacy", () => {
+		const { primary, legacy } = splitModelOptions([
+			model("claude-fable-5", "claude"),
+			model("gpt-5.6-sol", "codex"),
+			model("gpt-5.5", "codex"),
+		]);
+
+		expect(primary.map((entry) => entry.id)).toEqual([
+			"claude-fable-5",
+			"gpt-5.6-sol",
+		]);
+		expect(legacy.map((entry) => entry.id)).toEqual(["gpt-5.5"]);
+	});
+
+	test("keeps Pi-routed models first class", () => {
+		const { primary, legacy } = splitModelOptions([
+			model("pi/anthropic/claude-fable-5", "pi"),
+			model("pi/openai/gpt-5.6-sol", "pi"),
+		]);
+		expect(primary).toHaveLength(2);
+		expect(legacy).toHaveLength(0);
+	});
+});

--- a/packages/core/opensession-server/src/frontend/components/ModelEffortSelect.tsx
+++ b/packages/core/opensession-server/src/frontend/components/ModelEffortSelect.tsx
@@ -70,7 +70,10 @@ const PRIMARY_MODEL_IDS = [
 	"claude-fable-5",
 	"claude-opus-5",
 	"claude-sonnet-5",
-	"gpt-5.5",
+	"claude-haiku-4-5",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
 ] as const;
 const PRIMARY_MODEL_ID_SET = new Set<string>(PRIMARY_MODEL_IDS);
 
@@ -249,10 +252,10 @@ const MODEL_TAIL_ORDER = [
 const ENGINE_PROVIDERS = new Set(["pi"]);
 
 /**
- * Split the registry into the first-class engine entries (engine + pi,
- * sorted for display) and the legacy native claude/codex ones. When engine
- * models are configured they ARE the model list; natives tuck under
- * LEGACY_GROUP_LABEL.
+ * Split the registry into the first-class Pi entries and current canonical
+ * model slugs, sorted for display. Only retired direct-SDK entries belong in
+ * the legacy group; Fable, Sol, and their current siblings remain ordinary
+ * choices even against an older server that still returns native ids.
  */
 export function splitModelOptions(models: ModelOption[]): {
 	primary: ModelOption[];
@@ -262,12 +265,14 @@ export function splitModelOptions(models: ModelOption[]): {
 		const i = MODEL_TAIL_ORDER.indexOf(m.id.split("/").pop() || "");
 		return i === -1 ? MODEL_TAIL_ORDER.length : i;
 	};
+	const isPrimary = (model: ModelOption) =>
+		ENGINE_PROVIDERS.has(model.provider) || PRIMARY_MODEL_ID_SET.has(model.id);
 	const primary = models
-		.filter((m) => ENGINE_PROVIDERS.has(m.provider))
+		.filter(isPrimary)
 		.map((m, i) => [m, i] as const)
 		.sort((a, b) => rank(a[0]) - rank(b[0]) || a[1] - b[1])
 		.map(([m]) => m);
-	return { primary, legacy: models.filter((m) => !ENGINE_PROVIDERS.has(m.provider)) };
+	return { primary, legacy: models.filter((m) => !isPrimary(m)) };
 }
 
 /**
@@ -490,19 +495,13 @@ export function ModelEffortSelect({
 		const primaryFirst = primaryModels.length > 0;
 		const availableModelIds = new Set(models.map((m) => m.id));
 		const allPrimaryOptions = primaryFirst
-			? [
-					...(availableModelIds.has(defaultModel) ? [] : [optionFor(defaultModel)]),
-					...primaryModels.map((m) => optionFor(m.id)),
-				]
+			? primaryModels.map((m) => optionFor(m.id))
 			: PRIMARY_MODEL_IDS.filter((id) => availableModelIds.has(id)).map((id) => optionFor(id));
 		const allOtherOptions = primaryFirst
 			? legacyModels.map(legacyOptionFor)
-			: [
-					...(PRIMARY_MODEL_ID_SET.has(defaultModel) ? [] : [optionFor(defaultModel)]),
-					...models
-						.filter((m) => m.id !== defaultModel && !PRIMARY_MODEL_ID_SET.has(m.id))
-						.map((m) => optionFor(m.id)),
-				];
+			: models
+					.filter((m) => !PRIMARY_MODEL_ID_SET.has(m.id))
+					.map((m) => optionFor(m.id));
 		return { primaryFirst, allPrimaryOptions, allOtherOptions };
 	}, [models, modelById, defaultModel]);
 	// The stored routing prefix narrows the list rather than greying half of it

--- a/packages/core/opensession-server/src/frontend/components/WorkspaceModelPresets.tsx
+++ b/packages/core/opensession-server/src/frontend/components/WorkspaceModelPresets.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import type { Workspace } from "../lib/types";
 import { randomUUID } from "../lib/random-uuid";
-import { defaultWorkspaceModelSettings, fetchModels, updateWorkspaceApi, invalidateModelsCache, type ModelOption } from "../lib/api";
+import { defaultWorkspaceModelSettings, fetchModels, updateWorkspaceApi, type ModelOption } from "../lib/api";
 import { Button } from "../ui/button";
 import { CardList } from "../ui/card";
 import { cn } from "../ui/cn";
@@ -305,7 +305,6 @@ export function WorkspaceModelPresets({
 					.filter((preset) => preset.id && preset.label && preset.lead.model),
 			};
 			await updateWorkspaceApi(workspace.id, { modelSettings: clean });
-			invalidateModelsCache(workspace.id);
 			onSaved();
 			onOpenChange(false);
 		} catch (e) {

--- a/packages/core/opensession-server/src/frontend/lib/api/automations.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/automations.ts
@@ -21,38 +21,6 @@ export interface ModelOption {
 }
 
 type ModelCatalog = { models: ModelOption[]; default: string };
-const MODEL_CACHE_MS = 60_000;
-const modelCatalogCache = new Map<string, { value: ModelCatalog; fetchedAt: number; pending?: Promise<ModelCatalog> }>();
-
-function modelCatalogKey(workspaceId?: string): string {
-	return workspaceId || "global";
-}
-
-async function refreshModelCatalog(workspaceId?: string): Promise<ModelCatalog> {
-	const key = modelCatalogKey(workspaceId);
-	const current = modelCatalogCache.get(key);
-	if (current?.pending) return current.pending;
-	const params = new URLSearchParams();
-	if (workspaceId) params.set("workspace", workspaceId);
-	const pending = request<ModelCatalog>(`/models${params.size ? `?${params}` : ""}`, {
-		label: "Failed to fetch models",
-	}).then((value) => {
-		modelCatalogCache.set(key, { value, fetchedAt: Date.now() });
-		return value;
-	}).finally(() => {
-		const entry = modelCatalogCache.get(key);
-		if (entry?.pending) delete entry.pending;
-	});
-	modelCatalogCache.set(key, { value: current?.value || { models: [], default: "" }, fetchedAt: current?.fetchedAt || 0, pending });
-	return pending;
-}
-
-/** Clear one workspace's picker catalog after its preset settings change. */
-export function invalidateModelsCache(workspaceId?: string): void {
-	for (const key of modelCatalogCache.keys()) {
-		if (!workspaceId || key.endsWith(`:${workspaceId}`)) modelCatalogCache.delete(key);
-	}
-}
 
 /**
  * Ask the backend (a quick Haiku call) to suggest a branch name for a task
@@ -131,17 +99,12 @@ export async function transcribeClip(audio: Blob): Promise<string> {
 	return typeof data?.text === "string" ? data.text : "";
 }
 
-export async function fetchModels(workspaceId?: string): Promise<{
-	models: ModelOption[];
-	default: string;
-}> {
-	const cached = modelCatalogCache.get(modelCatalogKey(workspaceId));
-	if (cached?.value.models.length) {
-		if (Date.now() - cached.fetchedAt > MODEL_CACHE_MS)
-			void refreshModelCatalog(workspaceId).catch(() => {});
-		return cached.value;
-	}
-	return refreshModelCatalog(workspaceId);
+export async function fetchModels(workspaceId?: string): Promise<ModelCatalog> {
+	const params = new URLSearchParams();
+	if (workspaceId) params.set("workspace", workspaceId);
+	return request<ModelCatalog>(`/models${params.size ? `?${params}` : ""}`, {
+		label: "Failed to fetch models",
+	});
 }
 
 /** Trimmed provider account shape for the per-session account picker. */

--- a/packages/core/opensession-server/src/server/engine-status.ts
+++ b/packages/core/opensession-server/src/server/engine-status.ts
@@ -1,7 +1,8 @@
 /** Shared readiness check for Setup and `opensession doctor`. */
 import { listAccountsPublic } from "./claude-accounts";
 import { listCodexAccountsPublic } from "./codex-accounts";
-import { accountProviderForModel, interactiveDefaultModel } from "./models";
+import { accountProviderForModel } from "./models";
+import { configuredInteractiveDefaultModel } from "./model-catalog";
 import { modelProviders } from "./model-providers";
 import { piConfigPath, piEngineEnabled } from "./pi-config";
 import { homeDir } from "./paths";
@@ -36,7 +37,7 @@ export function engineStatus(): EngineStatus {
   const codexAvailable = codexPool.filter(
     (account) => account.usable && !account.exhaustedUntil,
   ).length;
-  const defaultModel = interactiveDefaultModel();
+  const defaultModel = configuredInteractiveDefaultModel();
   const provider = accountProviderForModel(defaultModel);
   const base = {
     piEnabled: enabled,

--- a/packages/core/opensession-server/src/server/model-catalog.test.ts
+++ b/packages/core/opensession-server/src/server/model-catalog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+	modelUpstreamProvider,
+	presetFitsConfiguredProviders,
+} from "./model-catalog";
+
+const openaiOnly = new Set(["openai"]);
+const both = new Set(["anthropic", "openai"]);
+
+describe("model catalog provider availability", () => {
+	test("resolves native and Pi model ids to their upstream provider", () => {
+		expect(modelUpstreamProvider("gpt-5.6-sol")).toBe("openai");
+		expect(modelUpstreamProvider("pi/anthropic/claude-fable-5")).toBe("anthropic");
+	});
+
+	test("keeps the whole Dial hidden until both account providers exist", () => {
+		const openaiDial = {
+			group: "dial",
+			lead: { model: "pi/openai/gpt-5.6-sol" },
+			supporting: [{ model: "pi/openai/gpt-5.6-sol" }],
+		};
+		expect(presetFitsConfiguredProviders(openaiDial, openaiOnly)).toBe(false);
+		expect(presetFitsConfiguredProviders(openaiDial, both)).toBe(true);
+	});
+
+	test("shows other presets only when every named provider is configured", () => {
+		expect(
+			presetFitsConfiguredProviders(
+				{
+					group: "custom",
+					lead: { model: "pi/openai/gpt-5.6-sol" },
+					supporting: [{ model: "pi/anthropic/claude-fable-5" }],
+				},
+				openaiOnly,
+			),
+		).toBe(false);
+		expect(
+			presetFitsConfiguredProviders(
+				{
+					group: "orchestrator",
+					lead: { model: "pi/openai/gpt-5.6-sol" },
+					supporting: [{ model: "pi/openai/gpt-5.6-terra" }],
+				},
+				openaiOnly,
+			),
+		).toBe(true);
+	});
+});

--- a/packages/core/opensession-server/src/server/model-catalog.test.ts
+++ b/packages/core/opensession-server/src/server/model-catalog.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+	chooseConfiguredDefaultModel,
 	modelUpstreamProvider,
+	pickerModelId,
 	presetFitsConfiguredProviders,
 } from "./model-catalog";
 
@@ -11,6 +13,11 @@ describe("model catalog provider availability", () => {
 	test("resolves native and Pi model ids to their upstream provider", () => {
 		expect(modelUpstreamProvider("gpt-5.6-sol")).toBe("openai");
 		expect(modelUpstreamProvider("pi/anthropic/claude-fable-5")).toBe("anthropic");
+	});
+
+	test("keeps preset ids intact for picker defaults", () => {
+		expect(pickerModelId("dial/high")).toBe("pi/dial/high");
+		expect(pickerModelId("pi/orchestrator/sol")).toBe("pi/orchestrator/sol");
 	});
 
 	test("keeps the whole Dial hidden until both account providers exist", () => {
@@ -44,5 +51,28 @@ describe("model catalog provider availability", () => {
 				openaiOnly,
 			),
 		).toBe(true);
+	});
+
+	test("replaces an unavailable default with the first configured model", () => {
+		const fallbacks = [
+			"pi/anthropic/claude-fable-5",
+			"pi/openai/gpt-5.6-sol",
+			"pi/openai/gpt-5.6-terra",
+		];
+		expect(
+			chooseConfiguredDefaultModel("claude-fable-5", openaiOnly, fallbacks),
+		).toBe("pi/openai/gpt-5.6-sol");
+		expect(
+			chooseConfiguredDefaultModel("dial/medium", openaiOnly, fallbacks),
+		).toBe("pi/openai/gpt-5.6-sol");
+	});
+
+	test("preserves defaults whose required providers are configured", () => {
+		expect(
+			chooseConfiguredDefaultModel("gpt-5.6-sol", openaiOnly, []),
+		).toBe("pi/openai/gpt-5.6-sol");
+		expect(
+			chooseConfiguredDefaultModel("dial/high", both, []),
+		).toBe("pi/dial/high");
 	});
 });

--- a/packages/core/opensession-server/src/server/model-catalog.ts
+++ b/packages/core/opensession-server/src/server/model-catalog.ts
@@ -1,0 +1,34 @@
+import { toPiModel } from "./models";
+
+export interface PickerPresetRequirement {
+	group?: string;
+	lead: { model: string };
+	supporting?: Array<{ model: string }>;
+}
+
+/** Upstream provider needed to run one selectable model. */
+export function modelUpstreamProvider(model: string): string | undefined {
+	return toPiModel(model)?.match(/^pi\/([^/]+)\//)?.[1];
+}
+
+/**
+ * Whether every provider a preset names is configured. The Dial is offered as
+ * a cross-provider feature, so its whole tier family stays out of the picker
+ * until both Anthropic and OpenAI are present, including its same-provider
+ * lower tiers.
+ */
+export function presetFitsConfiguredProviders(
+	preset: PickerPresetRequirement,
+	configuredProviders: ReadonlySet<string>,
+): boolean {
+	const requiredProviders = new Set(
+		[preset.lead, ...(preset.supporting || [])]
+			.map((member) => modelUpstreamProvider(member.model))
+			.filter((provider): provider is string => !!provider),
+	);
+	if (preset.group === "dial") {
+		requiredProviders.add("anthropic");
+		requiredProviders.add("openai");
+	}
+	return [...requiredProviders].every((provider) => configuredProviders.has(provider));
+}

--- a/packages/core/opensession-server/src/server/model-catalog.ts
+++ b/packages/core/opensession-server/src/server/model-catalog.ts
@@ -1,4 +1,13 @@
-import { toPiModel } from "./models";
+import { listAccountsPublic } from "./claude-accounts";
+import { listCodexAccountsPublic } from "./codex-accounts";
+import { modelProviders } from "./model-providers";
+import {
+	KNOWN_MODELS,
+	interactiveDefaultModel,
+	modelPreset,
+	refreshPickerModels,
+	toPiModel,
+} from "./models";
 
 export interface PickerPresetRequirement {
 	group?: string;
@@ -6,9 +15,37 @@ export interface PickerPresetRequirement {
 	supporting?: Array<{ model: string }>;
 }
 
+/** Provider capacity configured on this server. Temporary exhaustion does not
+ * change the catalog or default; adding or removing an account does. */
+export function configuredModelProviders(): Set<string> {
+	return new Set([
+		...(listAccountsPublic().length ? ["anthropic"] : []),
+		...(listCodexAccountsPublic().length ? ["openai"] : []),
+		...Object.entries(modelProviders())
+			.filter(([, provider]) => !!provider.apiKey)
+			.map(([provider]) => provider),
+	]);
+}
+
 /** Upstream provider needed to run one selectable model. */
 export function modelUpstreamProvider(model: string): string | undefined {
 	return toPiModel(model)?.match(/^pi\/([^/]+)\//)?.[1];
+}
+
+/** Picker/storage id for a selection. Presets keep their own id instead of
+ * collapsing to their concrete lead model at dispatch. */
+export function pickerModelId(model: string): string {
+	const preset = modelPreset(model);
+	if (preset) return model.startsWith("pi/") ? model : `pi/${model}`;
+	return toPiModel(model) || model;
+}
+
+export function modelFitsConfiguredProviders(
+	model: string,
+	configuredProviders: ReadonlySet<string>,
+): boolean {
+	const provider = modelUpstreamProvider(model);
+	return !!provider && configuredProviders.has(provider);
 }
 
 /**
@@ -31,4 +68,50 @@ export function presetFitsConfiguredProviders(
 		requiredProviders.add("openai");
 	}
 	return [...requiredProviders].every((provider) => configuredProviders.has(provider));
+}
+
+function selectionFitsConfiguredProviders(
+	model: string,
+	configuredProviders: ReadonlySet<string>,
+): boolean {
+	const preset = modelPreset(model);
+	if (!preset) return modelFitsConfiguredProviders(model, configuredProviders);
+	return presetFitsConfiguredProviders(
+		{
+			group: model.replace(/^pi\//, "").startsWith("dial/")
+				? "dial"
+				: "orchestrator",
+			lead: { model: preset.model },
+		},
+		configuredProviders,
+	);
+}
+
+/** Capacity-aware default shared by the picker and untouched session creates. */
+export function chooseConfiguredDefaultModel(
+	preferred: string,
+	configuredProviders: ReadonlySet<string>,
+	fallbackModels: readonly string[],
+): string {
+	const normalizedPreferred = pickerModelId(preferred);
+	if (selectionFitsConfiguredProviders(normalizedPreferred, configuredProviders)) {
+		return normalizedPreferred;
+	}
+	return (
+		fallbackModels
+			.map((model) => toPiModel(model) || model)
+			.find((model) => modelFitsConfiguredProviders(model, configuredProviders)) ||
+		normalizedPreferred
+	);
+}
+
+export function configuredInteractiveDefaultModel(
+	configuredProviders = configuredModelProviders(),
+): string {
+	refreshPickerModels();
+	return chooseConfiguredDefaultModel(
+		interactiveDefaultModel(),
+		configuredProviders,
+		KNOWN_MODELS.filter((model) => model.provider === "pi").map((model) => model.id),
+	);
 }

--- a/packages/core/opensession-server/src/server/models.test.ts
+++ b/packages/core/opensession-server/src/server/models.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   accountProviderForModel,
   explicitEngineFor,
@@ -9,7 +12,19 @@ import {
   resolveModel,
   routeModel,
   toPiModel,
+  KNOWN_MODELS,
+  refreshPickerModels,
 } from "./models";
+
+const originalPiConfig = process.env.OPENSESSION_PI_CONFIG;
+let pickerConfigDir = "";
+afterEach(() => {
+  if (originalPiConfig === undefined) delete process.env.OPENSESSION_PI_CONFIG;
+  else process.env.OPENSESSION_PI_CONFIG = originalPiConfig;
+  refreshPickerModels();
+  if (pickerConfigDir) rmSync(pickerConfigDir, { recursive: true, force: true });
+  pickerConfigDir = "";
+});
 
 describe("Pi-only model routing", () => {
   test("maps native model ids to Pi", () => {
@@ -72,5 +87,20 @@ describe("Pi-only model routing", () => {
 
   test("labels Pi models without an engine prefix", () => {
     expect(modelLabel("pi/openai/gpt-5.6-sol")).toBe("GPT-5.6 Sol");
+  });
+
+  test("seeds subscription models without the retired pickerModels setting", () => {
+    pickerConfigDir = mkdtempSync(join(tmpdir(), "pi-picker-models-"));
+    const path = join(pickerConfigDir, "pi.json");
+    writeFileSync(path, JSON.stringify({ enabled: true, pickerModels: [] }));
+    process.env.OPENSESSION_PI_CONFIG = path;
+
+    refreshPickerModels();
+
+    const pickerIds = KNOWN_MODELS
+      .filter((model) => model.provider === "pi")
+      .map((model) => model.id);
+    expect(pickerIds).toContain("pi/openai/gpt-5.6-sol");
+    expect(pickerIds).toContain("pi/anthropic/claude-fable-5");
   });
 });

--- a/packages/core/opensession-server/src/server/models.ts
+++ b/packages/core/opensession-server/src/server/models.ts
@@ -14,7 +14,7 @@ import {
   OX_ALPHA_MODEL_ID,
 } from "./model-providers";
 import { stateDir } from "./paths";
-import { piPickerModels } from "./pi-config";
+import { piEngineEnabled, piPickerModels } from "./pi-config";
 // Workspace ("Custom") presets live in the workspace store, so the one thing
 // this module needs from them — a preset's lead model — has to be read there.
 // The import cycle back into this module is inert: workspace-model-presets
@@ -105,6 +105,16 @@ export function normalizeModelEffort(
   if (normalized && supported.includes(normalized)) return normalized;
   return supported.includes("high") ? "high" : supported[0];
 }
+
+export const DEFAULT_BRIDGE_PICKER_MODELS = [
+  "claude-fable-5",
+  "claude-opus-5",
+  "claude-sonnet-5",
+  "claude-haiku-4-5",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+] as const;
 
 export const KNOWN_MODELS: ModelInfo[] = [
   { id: "claude-fable-5", provider: "claude", label: "Claude Fable 5", aliases: ["fable"] },
@@ -523,7 +533,15 @@ export function refreshPickerModels(): void {
       const provider = id.split("/")[1] || "";
       return BRIDGE_PROVIDER_IDS.has(provider) || keyed.has(provider);
     };
-    const ids = new Set([...piPickerModels(), ...configuredPickerModels()]);
+    // Subscription-backed models are the normal catalog, not legacy direct-SDK
+    // entries. Surface their Pi ids whenever Pi is enabled; the models route
+    // filters them to the account providers actually configured on this server.
+    const bridgeModels = piEngineEnabled() ? DEFAULT_BRIDGE_PICKER_MODELS : [];
+    const ids = new Set([
+      ...bridgeModels,
+      ...piPickerModels(),
+      ...configuredPickerModels(),
+    ]);
     for (const configured of ids) {
       const id = toPiModel(configured);
       if (!id || !usable(id)) continue;

--- a/packages/core/opensession-server/src/server/routes/models.ts
+++ b/packages/core/opensession-server/src/server/routes/models.ts
@@ -8,7 +8,10 @@
 
 import { requestUser, type RouteContext } from "./context";
 import { DIAL_PRESETS, KNOWN_MODELS, ORCHESTRATOR_PRESETS, accountProviderForModel, getDefaultModel, getModelFallbackAuto, interactiveDefaultModel, modelEfforts, piModelLabel, refreshPickerModels, setDefaultModel, setInteractiveDefaultModel, setModelFallbackAuto, toPiModel } from "../models";
-import { orchestratorEnabled } from "../model-providers";
+import { modelProviders, orchestratorEnabled } from "../model-providers";
+import { modelUpstreamProvider, presetFitsConfiguredProviders } from "../model-catalog";
+import { listAccountsPublic } from "../claude-accounts";
+import { listCodexAccountsPublic } from "../codex-accounts";
 import { type Sandbox } from "../sandbox";
 import { suggestBranchName } from "../suggest-branch";
 import { suggestRepos } from "../suggest-repos";
@@ -36,6 +39,15 @@ export async function handleModelsRoutes(
 			? getWorkspace(url.searchParams.get("workspace")!)
 			: null;
 		const settings = workspaceModelSettings(workspace);
+		// Temporary exhaustion does not change the catalog. An account existing is
+		// enough; only adding or removing provider capacity changes what is offered.
+		const configuredProviders = new Set<string>([
+			...(listAccountsPublic().length ? ["anthropic"] : []),
+			...(listCodexAccountsPublic().length ? ["openai"] : []),
+			...Object.entries(modelProviders())
+				.filter(([, provider]) => !!provider.apiKey)
+				.map(([provider]) => provider),
+		]);
 		// One engine-agnostic list: every entry (models and presets alike) runs
 		// on any configured engine — the composer's Engine choice routes it by
 		// prefix at dispatch (`engines` below is the only engine signal). Native
@@ -46,7 +58,11 @@ export async function handleModelsRoutes(
 		const engineModels = KNOWN_MODELS.filter((m) => m.provider === "pi");
 		const engineConfigured = engineModels.length > 0;
 		const visibleModels = (engineConfigured ? engineModels : KNOWN_MODELS)
-			.filter((model) => model.group !== "dial" && model.group !== "orchestrator");
+			.filter((model) => model.group !== "dial" && model.group !== "orchestrator")
+			.filter((model) => {
+				const provider = modelUpstreamProvider(model.id);
+				return !!provider && configuredProviders.has(provider);
+			});
 		// A workspace's editable presets replace the global ones. A request with
 		// no workspace (the /new composer) gets the global Dial and, when opted
 		// in, Orchestrator presets instead — the entries resolveModel already
@@ -66,7 +82,8 @@ export async function handleModelsRoutes(
 		const presetModels = workspace ? (settings.presets || [])
 			.filter((preset) =>
 				/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(preset.id) &&
-				!!preset.label?.trim() && !!preset.lead?.model?.trim(),
+				!!preset.label?.trim() && !!preset.lead?.model?.trim() &&
+				presetFitsConfiguredProviders(preset, configuredProviders),
 			)
 			.map((preset) => ({
 				id: `pi/workspace-preset/${workspace!.id}/${preset.id}`,
@@ -81,9 +98,19 @@ export async function handleModelsRoutes(
 				].join(" · "),
 			})) : engineConfigured
 				? [
-						...DIAL_PRESETS.map((p) => globalPresetEntry(p, "dial")),
+						...DIAL_PRESETS
+							.filter((p) => presetFitsConfiguredProviders({
+								group: "dial",
+								lead: { model: p.model },
+							}, configuredProviders))
+							.map((p) => globalPresetEntry(p, "dial")),
 						...(orchestratorEnabled()
-							? ORCHESTRATOR_PRESETS.map((p) => globalPresetEntry(p, "orchestrator"))
+							? ORCHESTRATOR_PRESETS
+								.filter((p) => presetFitsConfiguredProviders({
+									group: "orchestrator",
+									lead: { model: p.model },
+								}, configuredProviders))
+								.map((p) => globalPresetEntry(p, "orchestrator"))
 							: []),
 					]
 				: [];

--- a/packages/core/opensession-server/src/server/routes/models.ts
+++ b/packages/core/opensession-server/src/server/routes/models.ts
@@ -8,10 +8,8 @@
 
 import { requestUser, type RouteContext } from "./context";
 import { DIAL_PRESETS, KNOWN_MODELS, ORCHESTRATOR_PRESETS, accountProviderForModel, getDefaultModel, getModelFallbackAuto, interactiveDefaultModel, modelEfforts, piModelLabel, refreshPickerModels, setDefaultModel, setInteractiveDefaultModel, setModelFallbackAuto, toPiModel } from "../models";
-import { modelProviders, orchestratorEnabled } from "../model-providers";
-import { modelUpstreamProvider, presetFitsConfiguredProviders } from "../model-catalog";
-import { listAccountsPublic } from "../claude-accounts";
-import { listCodexAccountsPublic } from "../codex-accounts";
+import { orchestratorEnabled } from "../model-providers";
+import { configuredInteractiveDefaultModel, configuredModelProviders, modelFitsConfiguredProviders, pickerModelId, presetFitsConfiguredProviders } from "../model-catalog";
 import { type Sandbox } from "../sandbox";
 import { suggestBranchName } from "../suggest-branch";
 import { suggestRepos } from "../suggest-repos";
@@ -39,15 +37,7 @@ export async function handleModelsRoutes(
 			? getWorkspace(url.searchParams.get("workspace")!)
 			: null;
 		const settings = workspaceModelSettings(workspace);
-		// Temporary exhaustion does not change the catalog. An account existing is
-		// enough; only adding or removing provider capacity changes what is offered.
-		const configuredProviders = new Set<string>([
-			...(listAccountsPublic().length ? ["anthropic"] : []),
-			...(listCodexAccountsPublic().length ? ["openai"] : []),
-			...Object.entries(modelProviders())
-				.filter(([, provider]) => !!provider.apiKey)
-				.map(([provider]) => provider),
-		]);
+		const configuredProviders = configuredModelProviders();
 		// One engine-agnostic list: every entry (models and presets alike) runs
 		// on any configured engine — the composer's Engine choice routes it by
 		// prefix at dispatch (`engines` below is the only engine signal). Native
@@ -59,10 +49,7 @@ export async function handleModelsRoutes(
 		const engineConfigured = engineModels.length > 0;
 		const visibleModels = (engineConfigured ? engineModels : KNOWN_MODELS)
 			.filter((model) => model.group !== "dial" && model.group !== "orchestrator")
-			.filter((model) => {
-				const provider = modelUpstreamProvider(model.id);
-				return !!provider && configuredProviders.has(provider);
-			});
+			.filter((model) => modelFitsConfiguredProviders(model.id, configuredProviders));
 		// A workspace's editable presets replace the global ones. A request with
 		// no workspace (the /new composer) gets the global Dial and, when opted
 		// in, Orchestrator presets instead — the entries resolveModel already
@@ -114,7 +101,9 @@ export async function handleModelsRoutes(
 							: []),
 					]
 				: [];
-		const interactiveDefault = engineConfigured ? interactiveDefaultModel() : getDefaultModel();
+		const interactiveDefault = engineConfigured
+			? configuredInteractiveDefaultModel(configuredProviders)
+			: getDefaultModel();
 		// Older installations may still have a Dial/Orchestrator id as their
 		// interactive default. In a workspace that id now means the matching
 		// editable preset record, so the picker and the created session agree.
@@ -131,14 +120,19 @@ export async function handleModelsRoutes(
 				? `${pi ? "pi/" : ""}workspace-preset/${workspace.id}/${preset.id}`
 				: interactiveDefault;
 		})();
+		const catalogModels = [...presetModels, ...visibleModels].map((model) => ({
+			...model,
+			efforts: modelEfforts(model.id),
+			accountProvider: accountProviderForModel(model.id),
+			fastModeSupported: supportsOpenaiFastMode(toPiModel(model.id)),
+		}));
+		const routedDefault = pickerModelId(defaultForWorkspace);
+		const catalogDefault = catalogModels.some((model) => model.id === routedDefault)
+			? routedDefault
+			: catalogModels[0]?.id || routedDefault;
 		return Response.json({
-			models: [...presetModels, ...visibleModels].map((model) => ({
-				...model,
-				efforts: modelEfforts(model.id),
-				accountProvider: accountProviderForModel(model.id),
-				fastModeSupported: supportsOpenaiFastMode(toPiModel(model.id)),
-			})),
-			default: defaultForWorkspace,
+			models: catalogModels,
+			default: catalogDefault,
 			autoFallback: getModelFallbackAuto(),
 			// The engines a model can be routed to, and which of them are ready
 			// to run: the composer's Engine choice composes the engine's prefix

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -21,7 +21,8 @@ import { personaName } from "./config";
 import { cancelAgentRun, isAgentSessionBusy, steerAgentRun } from "./agent-runner";
 import { pendingAskAwaitingAnswer } from "./asks";
 import { relinkAskThreads } from "./human-asks";
-import { SESSION_EFFORTS, type SessionEffort, interactiveDefaultModel, providerFor, resolveModel } from "./models";
+import { SESSION_EFFORTS, type SessionEffort, providerFor, resolveModel } from "./models";
+import { configuredInteractiveDefaultModel } from "./model-catalog";
 import { deliveryQueueState, durableQueueItem, liftUserStop, promptQueues, acceptQueuedSteer, prepareQueuedSteer, rejectQueuedSteer, requeueSteerReceipts, stoppedSessions } from "./queue-state";
 import { drainQueue, enqueuePrompt, runSessionPrompt, sessionMentionsNote, watchExternalRunAndDrain } from "./run-session";
 import { parseImageDataUrls, stageFileAttachments, withUploadsNote } from "./uploads";
@@ -484,7 +485,7 @@ registerSessionControl({
 		const model = fork
 			? fork.source.model
 			: (modelInput ? resolveModel(String(modelInput))?.id : undefined) ||
-				interactiveDefaultModel();
+				configuredInteractiveDefaultModel();
 		// Same validation as the web palette's create_session: unknown efforts
 		// are dropped rather than persisted; images arrive as data URLs. Forks
 		// inherit the source's effort/fast-mode/account pin, like the web path.

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -32,7 +32,8 @@ import { nameKnownSessionReferencesForTitle } from "./session-reference-title";
 import { onSessionIdle as onHumanAsksSessionIdle } from "./human-asks";
 import { interactiveMcpServers } from "./interactive-mcp";
 import { parseTranscriptAsync } from "./jsonl-parser";
-import { accountProviderForModel, interactiveDefaultModel, interactiveFallbackModel, modelLabel, providerFor, resolveModel, } from "./models";
+import { accountProviderForModel, interactiveFallbackModel, modelLabel, providerFor, resolveModel, } from "./models";
+import { configuredInteractiveDefaultModel } from "./model-catalog";
 import { notifyMentions } from "./mentions";
 import { newSessionId } from "./paths";
 import { wrapContext } from "./prompt-context";
@@ -1302,7 +1303,7 @@ export async function handleCreateSessionMessage(
 	const model = forkSource
 		? forkSource.model
 		: workspacePreset?.id || (msg.model ? resolveModel(String(msg.model))?.id : undefined) ||
-			interactiveDefaultModel();
+			configuredInteractiveDefaultModel();
 	// Reasoning effort from the New-session palette (forks inherit).
 	const createEffort = forkSource
 		? forkSource.effort


### PR DESCRIPTION
## Summary
- hide the Dial until both OpenAI and Anthropic accounts are configured
- hide workspace and global presets when any required provider is unavailable
- keep current models such as Fable and Sol first class while reserving Legacy for retired direct-SDK entries

## Verification
- `bun test packages/core/opensession-server/src/server/model-catalog.test.ts packages/core/opensession-server/src/frontend/components/ModelEffortSelect.models.test.ts packages/core/opensession-server/src/server/models.test.ts packages/core/opensession-server/src/frontend/lib/model-engine.test.ts`
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- desktop and phone visual captures against an isolated OpenAI-only dev instance

The complete repository test command was also run. It remains red in unrelated existing suites, including shared DOM setup, sandbox prewarm timeouts, and the workspace runtime v7/v8 expectation.

Started by Jaap Frolich in [this Assistant session](http://100.81.254.102:3850/session/os-01a03329-7683-78c8-95f3-bda503724283)
