### PR TITLE
Keep remote sandbox path independent of release checkout

### DIFF
--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-install.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-install.test.ts
@@ -2,7 +2,7 @@ import {afterEach, describe, expect, test} from "bun:test";
 import {mkdtempSync, rmSync, writeFileSync} from "fs";
 import {tmpdir} from "os";
 import {join} from "path";
-import {bootstrapRemoteSandbox, bootstrapSignature, remoteRunnerHostCommand, REMOTE_RUNNER_BINARY, type RemoteDriver} from "./bootstrap";
+import {bootstrapRemoteSandbox, bootstrapSignature, remoteRunnerHostCommand, REMOTE_REPO, REMOTE_RUNNER_BINARY, type RemoteDriver} from "./bootstrap";
 
 const originalConfig = process.env.OPENSESSION_SANDBOX_CONFIG;
 const scratch: string[] = [];
@@ -14,6 +14,10 @@ afterEach(() => {
 });
 
 describe("remote runner bootstrap", () => {
+  test("keeps the guest checkout independent from the host release path", () => {
+    expect(REMOTE_REPO).toBe("/home/ubuntu/projects/opensession");
+  });
+
   test("repairs the workload identity client after a provider resume", async () => {
     const commands: string[] = [];
     const driver: RemoteDriver = {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -148,7 +148,9 @@ const REMOTE_NODE_MAJOR = Number(REMOTE_NODE_VERSION.split(".")[0]);
 const REMOTE_JUST_VERSION = "1.43.1";
 const REMOTE_GH_VERSION = "2.83.1";
 const REMOTE_RUNTIME_REVISION = "workspace-runtime-v8";
-const REMOTE_REPO = REPO_ROOT; // /home/ubuntu/projects/opensession
+// This path exists inside every remote sandbox. It must not inherit the host
+// service's checkout path (for example a dedicated production release tree).
+export const REMOTE_REPO = `${REMOTE_HOME}/projects/opensession`;
 export const REMOTE_RUNNER_BINARY = `${REMOTE_HOME}/.local/bin/opensession-runner`;
 const BOOTSTRAP_MARKER = `${REMOTE_HOME}/.bks-bootstrapped`;
 /** Where per-launch openai seed material lands in-sandbox — threaded to the


### PR DESCRIPTION
## Summary
- keep the checkout path inside remote sandboxes fixed at `/home/ubuntu/projects/opensession`
- prevent the host service's dedicated release-checkout path from leaking into remote bootstrap commands
- add a regression assertion for the guest path contract

## Production impact
After moving the service to `/home/ubuntu/releases/opensession`, a durable Daytona preparation effect repeatedly attempted to chmod that host-only path inside the guest. The guest checkout remains at `/home/ubuntu/projects/opensession`.

## Verification
- `bun test packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-install.test.ts` (4 tests)
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts` (407 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
