### PR TITLE
Generate Slack app manifests in the setup wizard

### DIFF
--- a/docs/setup/slack.md
+++ b/docs/setup/slack.md
@@ -115,6 +115,7 @@ Bot token scopes to grant:
 - `reactions:write`
 - `app_mentions:read`
 - `links:read`, `links:write` (session-link unfurls)
+- `emoji:read` (custom workspace emoji)
 - `channels:history`, `groups:history`, `im:history`, `mpim:history`
 - `channels:read`, `groups:read`, `im:read`
 - `channels:manage`, `groups:write` (create/archive/topic/invite worktree

--- a/docs/setup/slack.md
+++ b/docs/setup/slack.md
@@ -4,6 +4,24 @@ The Slack agent (`packages/core/opensession-server/src/agents/slack/`) is the ma
 @-mentions become agent runs, worktree channels drive coding sessions, and
 watched channels fire automations.
 
+## Creating the app (manifest)
+
+Don't tick seventeen scopes by hand. **Settings → Setup → Slack** generates an
+app manifest from this instance's own configuration and opens Slack's
+"Create new app → From a manifest" flow with it pre-loaded
+(`src/frontend/lib/slack-manifest.ts`). The manifest carries the bot scopes,
+the bot event subscriptions, interactivity, and — for the HTTP transport — the
+two request URLs derived from the instance's webhook base.
+
+Pick the transport in that dialog before creating the app: **Socket Mode**
+emits `socket_mode_enabled: true` and no request URLs, **HTTP** emits
+both `/slack/events` and `/slack/actions`. The JSON is also copyable, for
+pasting into an existing app under **App Manifest**.
+
+A manifest cannot carry credentials. After creating and installing the app you
+still paste the bot token (and either the app-level token or the signing
+secret) into the setup dialog by hand.
+
 ## Tokens and env vars
 
 Outbound Web API calls always use the **bot token** (`xoxb-…`). Event intake

--- a/docs/setup/slack.md
+++ b/docs/setup/slack.md
@@ -6,12 +6,13 @@ watched channels fire automations.
 
 ## Creating the app (manifest)
 
-Don't tick seventeen scopes by hand. **Settings → Setup → Slack** generates an
+Don't tick scopes by hand. **Settings → Setup → Slack** generates an
 app manifest from this instance's own configuration and opens Slack's
 "Create new app → From a manifest" flow with it pre-loaded
 (`src/frontend/lib/slack-manifest.ts`). The manifest carries the bot scopes,
-the bot event subscriptions, interactivity, and — for the HTTP transport — the
-two request URLs derived from the instance's webhook base.
+the bot event subscriptions, interactivity, the public UI domain for session-link
+unfurls, and — for the HTTP transport — the two request URLs derived from the
+instance's webhook base.
 
 Pick the transport in that dialog before creating the app: **Socket Mode**
 emits `socket_mode_enabled: true` and no request URLs, **HTTP** emits
@@ -51,8 +52,9 @@ The agent picks its transport from configuration. Both feed the same shared
 dispatch (`dispatchSlackEvent` / `dispatchSlackInteractive` in
 `agents/slack/index.ts`), so the two paths behave identically once a payload
 arrives. The event subscriptions the code consumes are the same either way:
-`message.im` (DMs), `app_mention`, and plain `message` events in channels (for
-session-linked mirroring and watched-channel automations).
+`message.im` (DMs), `app_mention`, `link_shared` (session-link unfurls), and
+plain `message` events in channels (for session-linked mirroring and
+watched-channel automations).
 
 ### Socket Mode (recommended for simple installs)
 
@@ -111,6 +113,8 @@ Bot token scopes to grant:
 - `chat:write`, `chat:write.customize`
 - `files:write` (merged visual-change screenshots)
 - `reactions:write`
+- `app_mentions:read`
+- `links:read`, `links:write` (session-link unfurls)
 - `channels:history`, `groups:history`, `im:history`, `mpim:history`
 - `channels:read`, `groups:read`, `im:read`
 - `channels:manage`, `groups:write` (create/archive/topic/invite worktree

--- a/packages/core/opensession-server/src/frontend/components/IntegrationSetupDialog.tsx
+++ b/packages/core/opensession-server/src/frontend/components/IntegrationSetupDialog.tsx
@@ -8,6 +8,7 @@ import { Segmented, SegmentedOption } from "../ui/segmented";
 import { Switch } from "../ui/switch";
 import { toast } from "../ui/toast";
 import { WEBHOOK_BASE_URL } from "../lib/brand";
+import { SLACK_SCOPE_GROUPS } from "../lib/slack-manifest";
 import {
 	publicWebhookAvailable,
 	savedSlackTransport,
@@ -15,6 +16,7 @@ import {
 	type SlackTransport,
 } from "../lib/slack-setup";
 import { IconTile } from "./BrandTile";
+import { SlackManifestGuide } from "./SlackManifestGuide";
 import {
 	Code,
 	CopyableCode,
@@ -45,6 +47,9 @@ function Value({ value }: { value: string }) {
 
 type Guide = {
 	description: string;
+	/** Rendered above the numbered steps, for a provider that can be set up
+	 *  from generated config rather than transcription — Slack's manifest. */
+	intro?: ReactNode;
 	steps: ReactNode[];
 	/** Permission tokens you transcribe into the provider's own form. Data,
 	 *  rather than bold runs inside a sentence — see ScopeGroups. */
@@ -110,56 +115,32 @@ function guideFor(
 
 		case "slack": {
 			const socket = transport === "socket";
-			const transportSteps: ReactNode[] = socket
-				? [
-						<>Turn on Socket Mode in your Slack app.</>,
-						<>Create an app-level token with the <strong>connections:write</strong> scope under Basic Information. It starts with <code>xapp-</code>.</>,
-						<>Under Event Subscriptions, subscribe to <strong>message.im</strong>, <strong>app_mention</strong>, and <strong>message</strong>. Enable Interactivity too. Socket Mode needs no request URLs.</>,
-						<>Paste the bot token and app-level token into the fields above.</>,
-					]
-				: [
-						<>
-							Under Event Subscriptions, subscribe to <strong>message.im</strong>, <strong>app_mention</strong>, and <strong>message</strong>. Set the request URL to:
-							<Value value={url("/slack/events")} />
-						</>,
-						<>
-							Enable Interactivity and set its request URL to:
-							<Value value={url("/slack/actions")} />
-						</>,
-						<>Paste the bot token and signing secret into the fields above.</>,
-					];
 			return {
 				description: "Create a Slack bot for DMs, mentions, session channels, and interactive controls.",
+				intro: <SlackManifestGuide transport={transport} />,
 				steps: [
-					<>Create a Slack app, add the bot scopes below, and install it to your workspace.</>,
-					...transportSteps,
-					<>Set an allowed Slack user id so admin tools are not open to every workspace member.</>,
+					<>Create the app from the manifest above, then install it to your workspace.</>,
+					socket ? (
+						<>
+							Open <strong>Basic Information → App-Level Tokens</strong>, generate a token with the <strong>connections:write</strong> scope, and paste the <Code>xapp-</Code> value into <Code>SLACK_APP_TOKEN</Code> above.
+						</>
+					) : (
+						<>
+							Copy the signing secret from <strong>Basic Information</strong> into <Code>SLACK_SIGNING_SECRET</Code> above. The manifest already includes the event and interactivity request URLs.
+						</>
+					),
+					<>Copy the bot token from <strong>OAuth &amp; Permissions</strong> after installing, and set an allowed Slack user id so admin tools are not open to every workspace member.</>,
 					<>Enable Slack, save, restart Open Session, and invite the bot to every existing channel it should read.</>,
 				],
-				scopes: [
-					{
-						label: "Writing",
-						items: ["chat:write", "chat:write.customize", "files:write", "reactions:write", "assistant:write"],
-					},
-					{
-						label: "History",
-						items: ["channels:history", "groups:history", "im:history", "mpim:history"],
-					},
-					{
-						label: "Channels and people",
-						items: [
-							"channels:read",
-							"groups:read",
-							"im:read",
-							"channels:manage",
-							"groups:write",
-							"channels:join",
-							"im:write",
-							"users:read",
-						],
-					},
-				],
-				scopesNote: socket ? <>The app-level token only needs <strong>connections:write</strong>.</> : undefined,
+				// Same list the manifest carries, so the chips and the generated app
+				// can never drift apart. Keep it visible for someone reviewing an
+				// existing app rather than creating a new one.
+				scopes: SLACK_SCOPE_GROUPS,
+				scopesNote: socket ? (
+					<>The manifest grants all of these. The app-level token only needs <strong>connections:write</strong>.</>
+				) : (
+					<>The manifest grants all of these and enables interactivity.</>
+				),
 			};
 		}
 
@@ -464,6 +445,7 @@ export function IntegrationSetupDialog({
 					actions={<LinkChips links={integration.links} className="mt-0" />}
 				>
 					<div className="flex flex-col gap-4">
+						{guide.intro}
 						<SetupSteps steps={guide.steps} />
 						{guide.scopes && (
 							<GuideBlock title="Bot scopes">

--- a/packages/core/opensession-server/src/frontend/components/SlackManifestGuide.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SlackManifestGuide.tsx
@@ -1,0 +1,64 @@
+import { Button } from "../ui/button";
+import { CopyCheck, useCopy } from "../ui/copy";
+import { Disclosure } from "../ui/disclosure";
+import { PRODUCT_NAME, WEBHOOK_BASE_URL } from "../lib/brand";
+import {
+	slackCreateAppUrl,
+	slackManifestJson,
+} from "../lib/slack-manifest";
+import type { SlackTransport } from "../lib/slack-setup";
+import { IconCopy } from "./icons";
+
+/**
+ * Creates the Slack app from generated configuration instead of asking the
+ * person to transcribe scopes, subscriptions, and request URLs. The transport
+ * comes from the dialog's credential choice so the manifest and form agree.
+ */
+export function SlackManifestGuide({ transport }: { transport: SlackTransport }) {
+	const options = {
+		webhookBaseUrl: WEBHOOK_BASE_URL,
+		transport,
+		appName: PRODUCT_NAME,
+	};
+	const json = slackManifestJson(options);
+	const { copied, copy } = useCopy();
+
+	return (
+		<div className="flex flex-col gap-3 rounded-lg bg-surface p-3">
+			<div className="flex flex-wrap items-center gap-2">
+				<Button
+					variant="primary"
+					size="sm"
+					render={
+						<a
+							href={slackCreateAppUrl(options)}
+							target="_blank"
+							rel="noreferrer"
+						/>
+					}
+				>
+					Create Slack app
+				</Button>
+				<Button
+					size="sm"
+					onClick={() => copy(json, { toast: "Manifest copied" })}
+				>
+					<CopyCheck copied={copied} size={14} idle={<IconCopy size={14} />} />
+					{copied ? "Copied" : "Copy manifest"}
+				</Button>
+			</div>
+
+			<p className="m-0 text-supporting leading-relaxed text-dim">
+				The manifest fills in the scopes, event subscriptions
+				{transport === "http" ? ", request URLs" : " and Socket Mode"}, and
+				interactivity. Credentials are still yours to paste above.
+			</p>
+
+			<Disclosure title="Manifest JSON" panelClassName="pt-2">
+				<pre className="m-0 max-h-72 overflow-auto rounded-control bg-panel p-2.5 font-mono text-meta leading-relaxed text-dim">
+					{json}
+				</pre>
+			</Disclosure>
+		</div>
+	);
+}

--- a/packages/core/opensession-server/src/frontend/components/SlackManifestGuide.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SlackManifestGuide.tsx
@@ -1,7 +1,7 @@
 import { Button } from "../ui/button";
 import { CopyCheck, useCopy } from "../ui/copy";
 import { Disclosure } from "../ui/disclosure";
-import { PRODUCT_NAME, WEBHOOK_BASE_URL } from "../lib/brand";
+import { PRODUCT_NAME, PUBLIC_BASE_URL, WEBHOOK_BASE_URL } from "../lib/brand";
 import {
 	slackCreateAppUrl,
 	slackManifestJson,
@@ -16,6 +16,7 @@ import { IconCopy } from "./icons";
  */
 export function SlackManifestGuide({ transport }: { transport: SlackTransport }) {
 	const options = {
+		publicBaseUrl: PUBLIC_BASE_URL,
 		webhookBaseUrl: WEBHOOK_BASE_URL,
 		transport,
 		appName: PRODUCT_NAME,

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
@@ -7,16 +7,20 @@ import {
 	slackManifestJson,
 } from "./slack-manifest";
 
-const base = { webhookBaseUrl: "https://os.example.ts.net", appName: "Open Session" };
+const base = {
+	publicBaseUrl: "https://os.example.ts.net",
+	webhookBaseUrl: "https://hooks.example.ts.net",
+	appName: "Open Session",
+};
 
 describe("buildSlackManifest", () => {
 	test("HTTP transport carries both request URLs", () => {
 		const manifest = buildSlackManifest({ ...base, transport: "http" }) as any;
 		expect(manifest.settings.event_subscriptions.request_url).toBe(
-			"https://os.example.ts.net/slack/events",
+			"https://hooks.example.ts.net/slack/events",
 		);
 		expect(manifest.settings.interactivity.request_url).toBe(
-			"https://os.example.ts.net/slack/actions",
+			"https://hooks.example.ts.net/slack/actions",
 		);
 		expect(manifest.settings.socket_mode_enabled).toBe(false);
 	});
@@ -34,11 +38,11 @@ describe("buildSlackManifest", () => {
 	test("a trailing slash on the base URL does not double up", () => {
 		const manifest = buildSlackManifest({
 			...base,
-			webhookBaseUrl: "https://os.example.ts.net/",
+			webhookBaseUrl: "https://hooks.example.ts.net/",
 			transport: "http",
 		}) as any;
 		expect(manifest.settings.event_subscriptions.request_url).toBe(
-			"https://os.example.ts.net/slack/events",
+			"https://hooks.example.ts.net/slack/events",
 		);
 	});
 
@@ -51,6 +55,23 @@ describe("buildSlackManifest", () => {
 		expect(SLACK_BOT_SCOPES).toContain("files:write");
 		expect(SLACK_BOT_SCOPES).toContain("assistant:write");
 		expect(new Set(SLACK_BOT_SCOPES).size).toBe(SLACK_BOT_SCOPES.length);
+	});
+
+	test("subscribing to app mentions also grants their required scope", () => {
+		expect(SLACK_BOT_EVENTS).toContain("app_mention");
+		expect(SLACK_BOT_SCOPES).toContain("app_mentions:read");
+	});
+
+	test("session-link unfurls include their event, scopes, and public UI domain", () => {
+		const manifest = buildSlackManifest({
+			...base,
+			publicBaseUrl: "https://app.example.com:8443/sessions",
+			transport: "socket",
+		}) as any;
+		expect(SLACK_BOT_EVENTS).toContain("link_shared");
+		expect(SLACK_BOT_SCOPES).toContain("links:read");
+		expect(SLACK_BOT_SCOPES).toContain("links:write");
+		expect(manifest.features.unfurl_domains).toEqual(["app.example.com"]);
 	});
 
 	test("names are clamped to Slack's 35-character app-name limit", () => {
@@ -79,7 +100,7 @@ describe("slackCreateAppUrl", () => {
 		expect(url.searchParams.get("new_app")).toBe("1");
 		const parsed = JSON.parse(url.searchParams.get("manifest_json") || "{}");
 		expect(parsed.settings.event_subscriptions.request_url).toBe(
-			"https://os.example.ts.net/slack/events",
+			"https://hooks.example.ts.net/slack/events",
 		);
 	});
 });

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
@@ -62,6 +62,10 @@ describe("buildSlackManifest", () => {
 		expect(SLACK_BOT_SCOPES).toContain("app_mentions:read");
 	});
 
+	test("custom workspace emoji grant their required scope", () => {
+		expect(SLACK_BOT_SCOPES).toContain("emoji:read");
+	});
+
 	test("session-link unfurls include their event, scopes, and public UI domain", () => {
 		const manifest = buildSlackManifest({
 			...base,

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+	SLACK_BOT_EVENTS,
+	SLACK_BOT_SCOPES,
+	buildSlackManifest,
+	slackCreateAppUrl,
+	slackManifestJson,
+} from "./slack-manifest";
+
+const base = { webhookBaseUrl: "https://os.example.ts.net", appName: "Open Session" };
+
+describe("buildSlackManifest", () => {
+	test("HTTP transport carries both request URLs", () => {
+		const manifest = buildSlackManifest({ ...base, transport: "http" }) as any;
+		expect(manifest.settings.event_subscriptions.request_url).toBe(
+			"https://os.example.ts.net/slack/events",
+		);
+		expect(manifest.settings.interactivity.request_url).toBe(
+			"https://os.example.ts.net/slack/actions",
+		);
+		expect(manifest.settings.socket_mode_enabled).toBe(false);
+	});
+
+	test("Socket Mode omits request URLs entirely", () => {
+		// A Socket Mode instance may have no reachable address at all, so a URL
+		// here would be a promise the deployment cannot keep.
+		const manifest = buildSlackManifest({ ...base, transport: "socket" }) as any;
+		expect(manifest.settings.socket_mode_enabled).toBe(true);
+		expect(manifest.settings.event_subscriptions.request_url).toBeUndefined();
+		expect(manifest.settings.interactivity.request_url).toBeUndefined();
+		expect(manifest.settings.interactivity.is_enabled).toBe(true);
+	});
+
+	test("a trailing slash on the base URL does not double up", () => {
+		const manifest = buildSlackManifest({
+			...base,
+			webhookBaseUrl: "https://os.example.ts.net/",
+			transport: "http",
+		}) as any;
+		expect(manifest.settings.event_subscriptions.request_url).toBe(
+			"https://os.example.ts.net/slack/events",
+		);
+	});
+
+	test("scopes and events match the documented sets", () => {
+		const manifest = buildSlackManifest({ ...base, transport: "http" }) as any;
+		expect(manifest.oauth_config.scopes.bot).toEqual(SLACK_BOT_SCOPES);
+		expect(manifest.settings.event_subscriptions.bot_events).toEqual(SLACK_BOT_EVENTS);
+		// The agent uploads merged visual-change screenshots, so file writing is
+		// load-bearing — the dialog used to claim no file scope was needed.
+		expect(SLACK_BOT_SCOPES).toContain("files:write");
+		expect(SLACK_BOT_SCOPES).toContain("assistant:write");
+		expect(new Set(SLACK_BOT_SCOPES).size).toBe(SLACK_BOT_SCOPES.length);
+	});
+
+	test("names are clamped to Slack's 35-character app-name limit", () => {
+		const manifest = buildSlackManifest({
+			...base,
+			appName: "An Extremely Long Instance Product Name That Slack Will Reject",
+			transport: "socket",
+		}) as any;
+		expect(manifest.display_information.name.length).toBeLessThanOrEqual(35);
+	});
+
+	test("a blank instance name falls back rather than producing an invalid app", () => {
+		const manifest = buildSlackManifest({
+			...base,
+			appName: "   ",
+			transport: "socket",
+		}) as any;
+		expect(manifest.display_information.name).toBe("Open Session");
+	});
+});
+
+describe("slackCreateAppUrl", () => {
+	test("round-trips the manifest through the query parameter", () => {
+		const url = new URL(slackCreateAppUrl({ ...base, transport: "http" }));
+		expect(url.origin + url.pathname).toBe("https://api.slack.com/apps");
+		expect(url.searchParams.get("new_app")).toBe("1");
+		const parsed = JSON.parse(url.searchParams.get("manifest_json") || "{}");
+		expect(parsed.settings.event_subscriptions.request_url).toBe(
+			"https://os.example.ts.net/slack/events",
+		);
+	});
+});
+
+describe("slackManifestJson", () => {
+	test("is pretty-printed, since people read and paste it by hand", () => {
+		const json = slackManifestJson({ ...base, transport: "socket" });
+		expect(json).toContain("\n  ");
+		expect(JSON.parse(json)).toEqual(buildSlackManifest({ ...base, transport: "socket" }));
+	});
+});

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
@@ -40,8 +40,8 @@ export const SLACK_SCOPE_GROUPS: { label: string; items: string[] }[] = [
 		items: ["channels:history", "groups:history", "im:history", "mpim:history"],
 	},
 	{
-		label: "Events and links",
-		items: ["app_mentions:read", "links:read", "links:write"],
+		label: "Events, links, and emoji",
+		items: ["app_mentions:read", "links:read", "links:write", "emoji:read"],
 	},
 	{
 		label: "Channels and people",

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
@@ -2,8 +2,8 @@
  * The Slack app manifest this instance needs, generated from its own config.
  *
  * Setting Slack up by hand is the longest walk in the whole Setup page: create
- * an app, tick seventeen bot scopes one at a time, subscribe to four event
- * types, paste two request URLs, enable interactivity. Every one of those is
+ * an app, tick every bot scope one at a time, subscribe to each event type,
+ * paste two request URLs, enable interactivity. Every one of those is
  * something we already know — the scopes come from the Web API methods the
  * agent calls, the URLs from the instance's own webhook base — so the person
  * should not be transcribing them.
@@ -40,6 +40,10 @@ export const SLACK_SCOPE_GROUPS: { label: string; items: string[] }[] = [
 		items: ["channels:history", "groups:history", "im:history", "mpim:history"],
 	},
 	{
+		label: "Events and links",
+		items: ["app_mentions:read", "links:read", "links:write"],
+	},
+	{
 		label: "Channels and people",
 		items: [
 			"channels:read",
@@ -64,6 +68,7 @@ export const SLACK_BOT_SCOPES: string[] = SLACK_SCOPE_GROUPS.flatMap(
 export const SLACK_BOT_EVENTS: string[] = [
 	"app_mention",
 	"assistant_thread_started",
+	"link_shared",
 	"message.channels",
 	"message.groups",
 	"message.im",
@@ -71,8 +76,10 @@ export const SLACK_BOT_EVENTS: string[] = [
 ];
 
 export interface SlackManifestOptions {
-	/** Instance webhook base, e.g. https://os.example.ts.net. Only used by the
-	 *  HTTP transport; Socket Mode never needs a reachable address. */
+	/** Public UI base whose hostname Slack watches for session-link unfurls. */
+	publicBaseUrl: string;
+	/** Instance webhook base, e.g. https://hooks.example.com. Only used by the
+	 *  HTTP transport; Socket Mode never needs a reachable webhook address. */
 	webhookBaseUrl: string;
 	transport: SlackTransport;
 	/** App and bot display name. Slack caps the app name at 35 characters and
@@ -95,6 +102,10 @@ function actionsUrl(webhookBaseUrl: string): string {
 	return `${webhookBaseUrl.replace(/\/$/, "")}/slack/actions`;
 }
 
+function publicHostname(publicBaseUrl: string): string {
+	return new URL(publicBaseUrl).hostname;
+}
+
 /**
  * The manifest object. Shape follows Slack's app-manifest schema; anything we
  * do not use is left out rather than written as a default, so the generated
@@ -103,7 +114,7 @@ function actionsUrl(webhookBaseUrl: string): string {
 export function buildSlackManifest(
 	options: SlackManifestOptions,
 ): Record<string, unknown> {
-	const { webhookBaseUrl, transport } = options;
+	const { publicBaseUrl, webhookBaseUrl, transport } = options;
 	const appName = clampName(options.appName, 35);
 	const socket = transport === "socket";
 	return {
@@ -113,6 +124,7 @@ export function buildSlackManifest(
 			background_color: "#4a154b",
 		},
 		features: {
+			unfurl_domains: [publicHostname(publicBaseUrl)],
 			bot_user: {
 				display_name: clampName(appName, 80),
 				always_online: true,

--- a/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slack-manifest.ts
@@ -1,0 +1,160 @@
+/**
+ * The Slack app manifest this instance needs, generated from its own config.
+ *
+ * Setting Slack up by hand is the longest walk in the whole Setup page: create
+ * an app, tick seventeen bot scopes one at a time, subscribe to four event
+ * types, paste two request URLs, enable interactivity. Every one of those is
+ * something we already know — the scopes come from the Web API methods the
+ * agent calls, the URLs from the instance's own webhook base — so the person
+ * should not be transcribing them.
+ *
+ * Slack reads all of it from a manifest. `api.slack.com/apps?new_app=1` takes
+ * a `manifest_json` query parameter and opens its create-app form with the
+ * manifest already filled in, which turns the walk into: click, review, create.
+ *
+ * The one thing a manifest CANNOT carry is a credential. Tokens and the
+ * signing secret are minted after the app exists, so the guide still asks for
+ * those two paste steps and nothing else.
+ *
+ * Keep the scope list here in sync with docs/setup/slack.md — that doc derives
+ * it from the actual `slackApiCall` sites, and this is the same list as data.
+ */
+
+import type { SlackTransport } from "./slack-setup";
+
+/** Bot token scopes, grouped by what they buy — the same grouping the setup
+ *  dialog renders as copyable chips, so there is one source for both. */
+export const SLACK_SCOPE_GROUPS: { label: string; items: string[] }[] = [
+	{
+		label: "Writing",
+		items: [
+			"chat:write",
+			"chat:write.customize",
+			"files:write",
+			"reactions:write",
+			"assistant:write",
+		],
+	},
+	{
+		label: "History",
+		items: ["channels:history", "groups:history", "im:history", "mpim:history"],
+	},
+	{
+		label: "Channels and people",
+		items: [
+			"channels:read",
+			"groups:read",
+			"im:read",
+			"channels:manage",
+			"groups:write",
+			"channels:join",
+			"im:write",
+			"users:read",
+		],
+	},
+];
+
+export const SLACK_BOT_SCOPES: string[] = SLACK_SCOPE_GROUPS.flatMap(
+	(group) => group.items,
+);
+
+/** The events dispatchSlackEvent actually handles (agents/slack/index.ts).
+ *  `message.*` is one subscription per conversation kind — the docs say
+ *  "plain message events in channels", which is what these four spell. */
+export const SLACK_BOT_EVENTS: string[] = [
+	"app_mention",
+	"assistant_thread_started",
+	"message.channels",
+	"message.groups",
+	"message.im",
+	"message.mpim",
+];
+
+export interface SlackManifestOptions {
+	/** Instance webhook base, e.g. https://os.example.ts.net. Only used by the
+	 *  HTTP transport; Socket Mode never needs a reachable address. */
+	webhookBaseUrl: string;
+	transport: SlackTransport;
+	/** App and bot display name. Slack caps the app name at 35 characters and
+	 *  the bot display name at 80. */
+	appName: string;
+}
+
+/** Slack rejects a manifest whose name is over 35 characters rather than
+ *  truncating it, and an instance is free to call itself anything. */
+function clampName(name: string, max: number): string {
+	const trimmed = name.trim() || "Open Session";
+	return trimmed.length > max ? trimmed.slice(0, max).trim() : trimmed;
+}
+
+function eventsUrl(webhookBaseUrl: string): string {
+	return `${webhookBaseUrl.replace(/\/$/, "")}/slack/events`;
+}
+
+function actionsUrl(webhookBaseUrl: string): string {
+	return `${webhookBaseUrl.replace(/\/$/, "")}/slack/actions`;
+}
+
+/**
+ * The manifest object. Shape follows Slack's app-manifest schema; anything we
+ * do not use is left out rather than written as a default, so the generated
+ * JSON reads as "what this app needs" instead of a filled-in template.
+ */
+export function buildSlackManifest(
+	options: SlackManifestOptions,
+): Record<string, unknown> {
+	const { webhookBaseUrl, transport } = options;
+	const appName = clampName(options.appName, 35);
+	const socket = transport === "socket";
+	return {
+		display_information: {
+			name: appName,
+			description: `${appName} coding agent: DMs, mentions, session channels and interactive controls.`,
+			background_color: "#4a154b",
+		},
+		features: {
+			bot_user: {
+				display_name: clampName(appName, 80),
+				always_online: true,
+			},
+			// The agent calls assistant.threads.setStatus / setSuggestedPrompts,
+			// which Slack only accepts from an app with the assistant surface on.
+			assistant_view: {
+				assistant_description: "Ask for a change, a review, or a question about the code.",
+				suggested_prompts: [],
+			},
+		},
+		oauth_config: {
+			scopes: { bot: SLACK_BOT_SCOPES },
+		},
+		settings: {
+			event_subscriptions: {
+				...(socket ? {} : { request_url: eventsUrl(webhookBaseUrl) }),
+				bot_events: SLACK_BOT_EVENTS,
+			},
+			interactivity: {
+				is_enabled: true,
+				...(socket ? {} : { request_url: actionsUrl(webhookBaseUrl) }),
+			},
+			socket_mode_enabled: socket,
+			org_deploy_enabled: false,
+			token_rotation_enabled: false,
+		},
+	};
+}
+
+/** Pretty JSON, because the person may well read it before creating the app
+ *  and may paste it into Slack's own manifest box by hand. */
+export function slackManifestJson(options: SlackManifestOptions): string {
+	return JSON.stringify(buildSlackManifest(options), null, 2);
+}
+
+/**
+ * Slack's create-app form, pre-filled. `new_app=1` opens the "Create new app"
+ * dialog and `manifest_json` selects "From a manifest" with the config already
+ * loaded, so the person reviews and confirms rather than transcribing.
+ */
+export function slackCreateAppUrl(options: SlackManifestOptions): string {
+	const manifest = JSON.stringify(buildSlackManifest(options));
+	return `https://api.slack.com/apps?new_app=1&manifest_json=${encodeURIComponent(manifest)}`;
+}


### PR DESCRIPTION
## Summary

- generate a Slack app manifest from the instance name, webhook base URL, transport, bot scopes, event subscriptions, and interactivity settings
- open Slack's create-app flow with the manifest preloaded, with a copyable JSON fallback for existing apps
- keep the generated manifest synchronized with the setup dialog's Socket Mode or HTTP selection
- use the manifest scope list for the setup chips, including the required `files:write` scope
- document the manifest-based setup flow

## Testing

- `bun test packages/core/opensession-server/src/frontend/lib/slack-manifest.test.ts packages/core/opensession-server/src/frontend/lib/slack-setup.test.ts` (14 passed)
- `bun run typecheck`
- verified the setup dialog at desktop and phone widths

Started by John Soutar in [this OS session](https://os.tella.dev/session/os-01a032fd-809e-7445-a954-9542fd3e0a40)
