### PR TITLE
Launch opening turns from the durable actor outbox

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -148,10 +148,38 @@ durable effect carries the complete non-secret provider/session specification;
 the provider's idempotent `ensure` adopts resources by canonical session key.
 Session-key or returned-provider crossover is indeterminate, and a crash after
 provider acceptance re-enters the same ensure before returning the fenced actor
-receipt. Create entry points do not emit this effect yet. Attachment and
-opening-turn executors plus removal of the remaining create-plan authority are
-the next cutovers; the presence or absence of a plan file is not
-actor lifecycle evidence.
+receipt. Create entry points emit this effect before opening a sandboxed run.
+
+Opening turns also enter the durable outbox. Create intake first records the
+stable prompt dispatch, then atomically moves the creation aggregate to
+`opening_dispatched` with one `creation_opening_turn` effect. The executor uses
+the active create registration or reconstructs the same specification from the
+durable plan after restart. It settles `ready` or `failed` through the effect
+fence before acknowledging the prompt dispatch. Run-journal admission and cold
+queue restoration preserve actor-owned create dispatches until that settlement.
+Boot leaves local openings with the generic run adopter and settles the actor
+from that adopter's fenced terminal callback; remote sandbox and Runner journals
+are deferred to executors that can physically adopt them. Runner openings derive
+one stable host identity from the opening run fence, persist the prompt and host
+identities in the run journal, and advance a durable
+`prepared → launching → started` launch phase in a session-keyed launch-state
+file as well as the run journal. A prepared retry may launch; a definite server
+preflight rejection records a permanent `rejected` fence, while ambiguous
+launching/started failures are quarantined out of boot recovery. Ambiguous
+adoption requires positive Runner liveness evidence and otherwise fails closed
+instead of duplicating or later reviving a creation already reported failed. Long-running opening effects use a
+separate bounded runtime pool so they cannot consume all general outbox capacity.
+The terminal event consumer persists final session/outcome projections and settles
+the actor before requesting another generator item, so local, sandbox, and Runner
+generator `finally` blocks cannot retire the only physical-owner journal first.
+If a backend naturally ends without a terminal event, its wrapper replaces the
+live journal with a durable abnormal-completion receipt instead of clearing it;
+boot recovery or the opening executor settles that receipt without relaunching.
+A crash after actor settlement adopts the completed receipt without launching
+another turn. Direct `opening_dispatched` transitions without a typed effect are rejected. Attachment
+staging and removal of the remaining create-plan compatibility authority are the
+next creation cutovers; the presence or absence of a plan file is not actor
+lifecycle evidence.
 
 ## Run ownership
 

--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -32,7 +32,7 @@ import { startPlainArchiveSweep } from "./src/server/plain-archive";
 import { devInstanceBootError, isDevInstance } from "./src/server/dev-mode";
 import { startPrReviewNotificationTicker } from "./src/server/pr-review-notifications";
 import { startPublicIngress } from "./src/server/public-ingress";
-import { readActiveShutdownSnapshot, recoverableLocalHostSnapshotRecords, recordRecoveredRunEvent, restorePromptQueues, resumeDrainedSessions, snapshotActiveSessions, startLoopTicker } from "./src/server/run-session";
+import { creationOwnsPrompt, readActiveShutdownSnapshot, recoverableLocalHostSnapshotRecords, recordRecoveredRunEvent, restorePromptQueues, resumeDrainedSessions, settleRecoveredCreationOpening, snapshotActiveSessions, startLoopTicker } from "./src/server/run-session";
 import { startMcpHttpServer, startRunRpcServer } from "./src/server/run-rpc";
 import { handleSandboxWsUpgrade, startTimerPoisonHeartbeat, timerPoisonRequestCheck } from "./src/server/run-ws";
 import {
@@ -770,11 +770,22 @@ if (!g.__opensessionBooted) {
 		try {
 		const shutdownRecords = readActiveShutdownSnapshot();
 		const resumedIds = resumeInterruptedRuns(
-			(bksSessionId, terminalEvent) => {
+			(bksSessionId, terminalEvent, recoveredRun) => {
 				if (bksSessionId && terminalEvent) {
 					const failed =
 						terminalEvent.type === "error" ||
 						!!terminalEvent.usageLimitExhausted;
+					if (recoveredRun?.promptEntryId) {
+						settleRecoveredCreationOpening(
+							bksSessionId,
+							recoveredRun.promptEntryId,
+							failed
+								? terminalEvent.content ||
+									terminalEvent.result ||
+									"Recovered opening run failed"
+								: undefined,
+						);
+					}
 					recordRunOutcome(
 						bksSessionId,
 						failed
@@ -853,6 +864,11 @@ if (!g.__opensessionBooted) {
 			},
 			recordRecoveredRunEvent,
 			recoverableLocalHostSnapshotRecords(shutdownRecords),
+			(run) =>
+				!!run.osSessionId &&
+				!!run.promptEntryId &&
+				!!(run.runnerId || run.sandboxId) &&
+				creationOwnsPrompt(run.osSessionId, run.promptEntryId),
 		);
 		if (resumedIds.length > 0) {
 			console.log(

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -1125,12 +1125,14 @@ export function resumeInterruptedRuns(
   onResumed?: (
     osSessionId?: string,
     terminalEvent?: StreamEvent,
+    run?: ActiveRunRecord,
   ) => void,
   askHandlerFor?: (osSessionId: string) => AskHandler | undefined,
   inProcessMcpFor?: (osSessionId: string, user?: string) => Record<string, unknown> | undefined,
   reposNoteFor?: (osSessionId: string) => string | undefined,
   onEvent?: (osSessionId: string, event: StreamEvent) => void,
   snapshotLocalHostRuns: ActiveRunRecord[] = [],
+  deferRecovery?: (run: ActiveRunRecord) => boolean,
 ): string[] {
   const resumed: string[] = [];
   const settledRunKeys = new Set<string>();
@@ -1153,7 +1155,7 @@ export function resumeInterruptedRuns(
     try {
       emitRecoveryEvent(run, event);
       try {
-        onResumed?.(run.osSessionId, event);
+        onResumed?.(run.osSessionId, event, run);
       } catch (e) {
         console.error(`[runner] Recovery settlement callback failed for ${run.runKey}:`, e);
       }
@@ -1278,7 +1280,9 @@ export function resumeInterruptedRuns(
   const snapshotSeeds = snapshotLocalHostRuns.filter(
     (run) => !!run.hostId && !run.sandboxId && !run.runnerId,
   );
-  const taken = takeInterruptedRuns(snapshotSeeds);
+  const taken = takeInterruptedRuns(snapshotSeeds).filter(
+    (run) => !deferRecovery?.(run),
+  );
   // A graceful shutdown snapshot is intentionally broader than the shared
   // run journal: it also covers turns that finish during the drain. A local
   // detached host can still be alive even when its shared record disappeared
@@ -1294,6 +1298,10 @@ export function resumeInterruptedRuns(
   const recoveryTasks: Array<() => Promise<void>> = [];
 
   for (const run of interrupted) {
+    if (run.terminalFailure) {
+      reportRecoveryFailure(run, run.terminalFailure.content);
+      continue;
+    }
     // Detached review turns are consumed by the GitHub agent's persisted
     // activeRun workflow. Leave their journal record intact so runReview can
     // reattach the same host and continue through parsing and GitHub posting.

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -39,6 +39,7 @@ import {
 } from "./agent-runner";
 import {
   journalClear,
+  journalRecordAbnormalCompletion,
   journalSet,
   registerActiveRunProbe,
   type ActiveRunRecord,
@@ -270,6 +271,8 @@ async function* hostedEventsWithJournal(
     journalSet(record);
   });
   journalSet(record);
+  let sourceCompleted = false;
+  let sawTerminal = false;
   try {
     for await (const ev of handle.events()) {
       if (!sessionKernel(spec.osSessionId).isCurrentRun(record.runKey)) {
@@ -292,10 +295,14 @@ async function* hostedEventsWithJournal(
         if (shouldPersistModelSwitch(ev)) record.selectedModel = ev.toModel;
         journalSet(record);
       }
+      if (ev.type === "done" || ev.type === "error") sawTerminal = true;
       yield ev;
     }
+    sourceCompleted = true;
   } finally {
-    if (handle.ended) journalClear(record.runKey);
+    if (handle.ended && sourceCompleted && sawTerminal) journalClear(record.runKey);
+    else if (handle.ended && sourceCompleted)
+      journalRecordAbnormalCompletion(record);
   }
 }
 

--- a/packages/core/opensession-server/src/server/queue-state-restart.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-restart.test.ts
@@ -180,7 +180,7 @@ describe("steer receipt restart persistence", () => {
 		expect(promptDispatches.has(SESSION)).toBe(false);
 	});
 
-	test("a cold restart preserves a create dispatch for plan recovery", () => {
+	test("a cold restart preserves an actor-owned create dispatch even after journaling", () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-create-dispatch-adopt-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -198,7 +198,9 @@ describe("steer receipt restart persistence", () => {
 		const restored = restorePersistedQueueState({
 			storePath,
 			sessionExists: () => true,
-			journalOwnsPrompt: () => false,
+			journalOwnsPrompt: () => true,
+			creationOwnsPrompt: (_sessionId, promptEntryId) =>
+				promptEntryId === "create-request-1",
 			runOwnsSteers: () => false,
 			deliveredUserTexts: () => [],
 			effects: false,

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -389,6 +389,7 @@ export function restorePersistedQueueState(options: {
 	storePath?: string;
 	sessionExists: (sessionId: string) => boolean;
 	journalOwnsPrompt: (sessionId: string, promptEntryId: string) => boolean;
+	creationOwnsPrompt?: (sessionId: string, promptEntryId: string) => boolean;
 	runOwnsSteers: (sessionId: string) => boolean;
 	deliveredUserTexts: (sessionId: string) => string[];
 	effects?: boolean;
@@ -423,7 +424,8 @@ export function restorePersistedQueueState(options: {
 		if (
 			dispatch?.kind === "create" &&
 			dispatch.promptEntryId &&
-			!options.journalOwnsPrompt(sessionId, dispatch.promptEntryId)
+			(options.creationOwnsPrompt?.(sessionId, dispatch.promptEntryId) ||
+				!options.journalOwnsPrompt(sessionId, dispatch.promptEntryId))
 		) {
 			const createDispatch: PromptDispatch =
 				live?.kind === "create" && live.promptEntryId === dispatch.promptEntryId

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -114,6 +114,9 @@ export interface ActiveRunRecord {
   resumeAttempts?: number;
   /** Time the most recent boot recovery attempt started. */
   lastResumeAt?: string;
+  /** Durable abnormal completion observed before a backend produced a terminal
+   * stream event. Opening recovery adopts this receipt instead of relaunching. */
+  terminalFailure?: { type: "error"; content: string; at: string };
   startedAt: string;
   /** Stamped when a boot sweep hands the record to resumeInterruptedRuns. The
    *  record stays journaled until its resume outcome re-registers (journalSet)
@@ -247,7 +250,8 @@ export type RunQuarantineReason =
   | "duplicate_session"
   | "recursive_recovery_kind"
   | "resume_attempts_exhausted"
-  | "recovery_expired";
+  | "recovery_expired"
+  | "ambiguous_runner_launch";
 
 export interface QuarantinedRun {
   run: ActiveRunRecord;
@@ -337,6 +341,22 @@ export function journalMarkRecoveryAttached(record: ActiveRunRecord): ActiveRunR
   writeRunJournal(journal);
   const { claimedAt: _claimed, ...returned } = attached;
   return returned;
+}
+
+export function journalRecordAbnormalCompletion(
+  record: ActiveRunRecord,
+  content = "Physical run ended without a terminal event",
+): ActiveRunRecord {
+  const failed: ActiveRunRecord = {
+    ...record,
+    terminalFailure: {
+      type: "error",
+      content,
+      at: new Date().toISOString(),
+    },
+  };
+  journalSet(failed);
+  return failed;
 }
 
 export function journalClear(runKey: string): void {

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -158,13 +158,66 @@ import {
 } from "./session-repos";
 import { automationSessionMcp, interactiveMcpServers } from "./interactive-mcp";
 import { makeAskHandler, settleRestoredAskAfterRecovery } from "./asks";
+import {
+	settleCreationFailed,
+	settleCreationSucceeded,
+	sessionKernel,
+} from "./session-kernel";
+
+export function creationOwnsPrompt(sessionId: string, promptEntryId: string): boolean {
+	const creation = sessionKernel(sessionId).creationState();
+	return (
+		creation?.state === "opening_dispatched" &&
+		creation.currentEffectId === `opening:${promptEntryId}`
+	);
+}
+
+/** Settle an actor-owned opening recovered by the generic local-run adopter. */
+export function settleRecoveredCreationOpening(
+	sessionId: string,
+	promptEntryId: string,
+	failure?: string,
+): boolean {
+	const creation = sessionKernel(sessionId).creationState();
+	const effectId = `opening:${promptEntryId}`;
+	if (
+		!creation ||
+		creation.currentEffectId !== effectId ||
+		creation.state !== "opening_dispatched"
+	)
+		return false;
+	if (failure) {
+		settleCreationFailed(
+			sessionId,
+			creation.identity,
+			new Error(failure),
+			sessionKernel(sessionId),
+			effectId,
+		);
+	} else {
+		settleCreationSucceeded(
+			sessionId,
+			creation.identity,
+			sessionKernel(sessionId),
+			effectId,
+		);
+	}
+	acknowledgePromptDispatch(sessionId, promptEntryId);
+	return true;
+}
 
 // The runner writes its active-run journal before it can call an engine. Once
 // that journal names this prompt entry, normal boot recovery owns it and the
 // queue's pre-dispatch record is no longer needed.
-setJournalSetListener((record) =>
-	acknowledgePromptDispatch(record.osSessionId, record.promptEntryId),
-);
+setJournalSetListener((record) => {
+	if (
+		record.osSessionId &&
+		record.promptEntryId &&
+		creationOwnsPrompt(record.osSessionId, record.promptEntryId)
+	)
+		return;
+	acknowledgePromptDispatch(record.osSessionId, record.promptEntryId);
+});
 import { audit } from "./audit";
 import { githubCredentialForLogin, githubCredentialForRun } from "./github-auth";
 import {
@@ -503,6 +556,7 @@ export function restorePromptQueues(resumedSessionIds: Set<string>): void {
 				(run) =>
 					run.osSessionId === sessionId && run.promptEntryId === promptEntryId,
 			),
+		creationOwnsPrompt,
 		runOwnsSteers: (sessionId) =>
 			resumedSessionIds.has(sessionId) &&
 			active.some((run) => run.osSessionId === sessionId),

--- a/packages/core/opensession-server/src/server/runner-session.ts
+++ b/packages/core/opensession-server/src/server/runner-session.ts
@@ -13,7 +13,12 @@ import { HostHandle, type HandleCallbacks, type HostLauncher } from "./host-clie
 import { HOST_SPEC_NAME, runHostsDir, type RunHostSpec } from "../runner-host/protocol";
 import { OPENSESSION_SESSIONS_DIR } from "./paths";
 import { registerRunToken, unregisterRunToken } from "./run-rpc";
-import { launchRunnerHost, runnerHostAlive, runnerHostStatus } from "./runner-ws";
+import {
+	launchRunnerHost,
+	RunnerHostLaunchRejectedError,
+	runnerHostAlive,
+	runnerHostStatus,
+} from "./runner-ws";
 import { claimRunnerWorkload, getRunner, setRunnerWorkload } from "./runners";
 import { registerRunWsHost, runWsConnector } from "./run-ws";
 import type { UnifiedSession } from "./types";
@@ -25,11 +30,20 @@ import { makeAskHandler } from "./asks";
 import type { McpScope } from "./runner-shared";
 import type { StreamEvent } from "./agent-runner";
 import type { ImageInput } from "./run-events";
-import { journalClear, journalSet, type ActiveRunRecord } from "./run-journal";
+import {
+	activeRunRecords,
+	journalClear,
+	journalQuarantine,
+	journalRecordAbnormalCompletion,
+	journalSet,
+	type ActiveRunRecord,
+} from "./run-journal";
 import { writeJsonAtomic } from "./shared/atomic-write";
 
 type RunnerLaunchOpts = {
 	prompt: string;
+	promptEntryId?: string;
+	hostId?: string;
 	engineSessionId?: string;
 	images?: ImageInput[];
 	mcpServers?: McpScope;
@@ -38,6 +52,16 @@ type RunnerLaunchOpts = {
 };
 
 type RunnerEvents = AsyncGenerator<StreamEvent> & { runnerId: string };
+
+type RunnerOpeningLaunchState = {
+	version: 1;
+	hostId: string;
+	sessionId: string;
+	promptEntryId?: string;
+	phase: "prepared" | "launching" | "started" | "rejected";
+};
+
+const RUNNER_OPENING_LAUNCH_STATE = "opening-launch.json";
 
 function serverWsBase(): string {
 	return configuredServer().publicBaseUrl.replace(/\/$/, "");
@@ -57,15 +81,44 @@ export async function maybeLaunchRunnerRun(
 	const runner = claimRunnerWorkload(registeredRunner.id, { user: opts.user, repo: session.repo, sessionId: session.id, operation: "full session" });
 	if (!runner) throw new Error("This Runner is no longer available for this session");
 
-	const hostId = `rh-${Bun.randomUUIDv7()}`;
-	const rpcToken = crypto.randomUUID();
-	const wsToken = crypto.randomUUID();
+	const hostId = opts.hostId || `rh-${Bun.randomUUIDv7()}`;
 	const hostDir = `${runHostsDir(OPENSESSION_SESSIONS_DIR)}/${hostId}`;
-	mkdirSync(hostDir, { recursive: true });
-	const spec: RunHostSpec = {
+	const specPath = `${hostDir}/${HOST_SPEC_NAME}`;
+	const launchStatePath = `${hostDir}/${RUNNER_OPENING_LAUNCH_STATE}`;
+	const priorSpec = existsSync(specPath) ? readRunnerHostSpec(specPath) : null;
+	if (existsSync(specPath) && !priorSpec)
+		throw new Error(`Runner host ${hostId} has an unreadable durable specification`);
+	if (
+		priorSpec &&
+		(priorSpec.hostId !== hostId ||
+			priorSpec.osSessionId !== session.id ||
+			priorSpec.cwd !== session.worktreeDir ||
+			priorSpec.promptEntryId !== opts.promptEntryId)
+	)
+		throw new Error(`Runner host ${hostId} crossed opening ownership`);
+	const priorRun = activeRunRecords().find(
+		(run) =>
+			run.osSessionId === session.id &&
+			run.hostId === hostId &&
+			run.promptEntryId === opts.promptEntryId,
+	);
+	const priorLaunchState = existsSync(launchStatePath)
+		? readRunnerOpeningLaunchState(launchStatePath)
+		: null;
+	if (existsSync(launchStatePath) && !priorLaunchState)
+		throw new Error(`Runner host ${hostId} has unreadable durable launch state`);
+	if (
+		priorLaunchState &&
+		(priorLaunchState.hostId !== hostId ||
+			priorLaunchState.sessionId !== session.id ||
+			priorLaunchState.promptEntryId !== opts.promptEntryId)
+	)
+		throw new Error(`Runner host ${hostId} crossed durable launch ownership`);
+	const spec: RunHostSpec = priorSpec ?? {
 		hostId,
 		osSessionId: session.id,
 		prompt: opts.prompt,
+		promptEntryId: opts.promptEntryId,
 		engineSessionId: opts.engineSessionId,
 		cwd: session.worktreeDir,
 		mode: session.mode,
@@ -76,8 +129,8 @@ export async function maybeLaunchRunnerRun(
 		images: opts.images,
 		mcpServers: opts.mcpServers ?? "all",
 		proxyMcpServers: Object.keys(interactiveMcpServers(opts.user, session.id)),
-		rpcToken,
-		wsToken,
+		rpcToken: crypto.randomUUID(),
+		wsToken: crypto.randomUUID(),
 		reposNote: opts.reposNote,
 		confirmTools: STRIPE_CONFIRM_TOOLS,
 		author: commitAuthorFor(opts.user, session.startedBy),
@@ -86,11 +139,27 @@ export async function maybeLaunchRunnerRun(
 		fallbackModel: interactiveFallbackModel(session.model),
 		journalKind: "prompt",
 	};
-	writeJsonAtomic(`${hostDir}/${HOST_SPEC_NAME}`, spec);
-	journalSet({
+	if (!spec.rpcToken || !spec.wsToken)
+		throw new Error(`Runner host ${hostId} is missing its durable connection fence`);
+	if (!priorSpec) {
+		mkdirSync(hostDir, { recursive: true });
+		writeJsonAtomic(specPath, spec);
+	}
+	let launchState: RunnerOpeningLaunchState = priorLaunchState ?? {
+		version: 1,
+		hostId,
+		sessionId: session.id,
+		promptEntryId: opts.promptEntryId,
+		phase: priorRun?.launchPhase ?? "prepared",
+	};
+	if (!priorLaunchState) writeJsonAtomic(launchStatePath, launchState);
+	const rpcToken = spec.rpcToken;
+	const wsToken = spec.wsToken;
+	let run: ActiveRunRecord = {
+		...priorRun,
 		runKey: session.id,
 		osSessionId: session.id,
-		prompt: opts.prompt,
+		prompt: spec.prompt,
 		cwd: session.worktreeDir,
 		mode: session.mode,
 		mcpServers: opts.mcpServers ?? "all",
@@ -102,8 +171,13 @@ export async function maybeLaunchRunnerRun(
 		fallbackModel: interactiveFallbackModel(session.model),
 		kind: "prompt",
 		runnerId: runner.id,
-		startedAt: new Date().toISOString(),
-	});
+		hostId,
+		promptEntryId: opts.promptEntryId,
+		launchPhase:
+			launchState.phase === "rejected" ? "prepared" : launchState.phase,
+		startedAt: priorRun?.startedAt ?? new Date().toISOString(),
+	};
+	journalSet(run);
 	registerRunToken(rpcToken, { sessionId: session.id, user: opts.user });
 	registerRunWsHost(hostId, wsToken);
 	const hostSpecs = new Map<string, RunHostSpec>([[hostId, spec]]);
@@ -136,12 +210,58 @@ export async function maybeLaunchRunnerRun(
 	let handle: HostHandle | undefined;
 	try {
 		handle = new HostHandle(hostDir, spec, callbacks, launcher);
+		if (launchState.phase === "rejected")
+			throw new RunnerHostLaunchRejectedError(
+				`Runner opening ${hostId} was durably rejected before dispatch`,
+			);
+		if (run.launchPhase === "prepared") {
+			// `launching` is durable before the request can reach the Runner. A
+			// restart may adopt remote evidence, but may never infer non-execution
+			// from an absent connection and launch the same turn again.
+			launchState = { ...launchState, phase: "launching" };
+			writeJsonAtomic(launchStatePath, launchState);
+			run = { ...run, launchPhase: "launching" };
+			journalSet(run);
+			await launcher.launch(hostId, hostDir);
+			launchState = { ...launchState, phase: "started" };
+			writeJsonAtomic(launchStatePath, launchState);
+			run = { ...run, launchPhase: "started" };
+			journalSet(run);
+		} else {
+			const alive =
+				runnerHostAlive(hostId) &&
+				(await runnerHostStatus(runner.id, {
+					sessionId: session.id,
+					repo: session.repo,
+					workspacePath: session.worktreeDir,
+					hostId,
+					user: opts.user,
+				}));
+			if (!alive)
+				throw new Error(
+					`Runner opening ${hostId} was admitted but has no adoptable remote evidence`,
+				);
+			if (run.launchPhase !== "started") {
+				launchState = { ...launchState, phase: "started" };
+				writeJsonAtomic(launchStatePath, launchState);
+				run = { ...run, launchPhase: "started" };
+				journalSet(run);
+			}
+		}
 		await handle.connectWithWait(20_000);
 		const events = (async function* (): AsyncGenerator<StreamEvent> {
+			let sourceCompleted = false;
+			let sawTerminal = false;
 			try {
-				yield* handle!.events();
+				for await (const event of handle!.events()) {
+					if (event.type === "done" || event.type === "error")
+						sawTerminal = true;
+					yield event;
+				}
+				sourceCompleted = true;
 			} finally {
-				journalClear(session.id);
+				if (sourceCompleted && sawTerminal) journalClear(session.id);
+				else if (sourceCompleted) journalRecordAbnormalCompletion(run);
 				setRunnerWorkload(runner.id, undefined, session.id);
 			}
 		})() as RunnerEvents;
@@ -150,7 +270,23 @@ export async function maybeLaunchRunnerRun(
 	} catch (error) {
 		handle?.abandon();
 		unregisterRunToken(rpcToken);
-		journalClear(session.id);
+		if (
+			run.launchPhase === "prepared" ||
+			error instanceof RunnerHostLaunchRejectedError
+		) {
+			// Server-side preflight rejection proves the launch request was never
+			// sent. Fence retries durably before retiring the prepared journal.
+			launchState = { ...launchState, phase: "rejected" };
+			writeJsonAtomic(launchStatePath, launchState);
+			journalClear(session.id);
+		} else {
+			// Once launch admission may have crossed the Runner connection, absence
+			// is not proof of non-execution. Remove the record from boot recovery but
+			// retain it for operator inspection beside the actor's terminal failure.
+			journalQuarantine([
+				{ run, reason: "ambiguous_runner_launch", notify: false },
+			]);
+		}
 		setRunnerWorkload(runner.id, undefined, session.id);
 		throw error;
 	}
@@ -159,6 +295,28 @@ export async function maybeLaunchRunnerRun(
 function readRunnerHostSpec(path: string): RunHostSpec | null {
 	try {
 		return JSON.parse(readFileSync(path, "utf8")) as RunHostSpec;
+	} catch {
+		return null;
+	}
+}
+
+function readRunnerOpeningLaunchState(
+	path: string,
+): RunnerOpeningLaunchState | null {
+	try {
+		const value = JSON.parse(readFileSync(path, "utf8")) as Partial<RunnerOpeningLaunchState>;
+		if (
+			value.version !== 1 ||
+			typeof value.hostId !== "string" ||
+			typeof value.sessionId !== "string" ||
+			(value.promptEntryId !== undefined &&
+				typeof value.promptEntryId !== "string") ||
+			!["prepared", "launching", "started", "rejected"].includes(
+				String(value.phase),
+			)
+		)
+			return null;
+		return value as RunnerOpeningLaunchState;
 	} catch {
 		return null;
 	}
@@ -188,11 +346,19 @@ export async function resumeRunnerRun(
 				candidate &&
 				candidate.osSessionId === session.id &&
 				candidate.cwd === session.worktreeDir &&
+				(!run.hostId || candidate.hostId === run.hostId) &&
+				(!run.promptEntryId ||
+					candidate.promptEntryId === run.promptEntryId) &&
 				candidate.wsToken &&
 				candidate.rpcToken,
 			);
 		});
-	const candidate = candidates.at(-1);
+	const candidate =
+		run.hostId || run.promptEntryId
+			? candidates.length === 1
+				? candidates[0]
+				: undefined
+			: candidates.at(-1);
 	if (!candidate) return null;
 	const spec = candidate.spec;
 	registerRunToken(spec.rpcToken!, { sessionId: session.id, user: spec.user });

--- a/packages/core/opensession-server/src/server/runner-ws.ts
+++ b/packages/core/opensession-server/src/server/runner-ws.ts
@@ -478,6 +478,8 @@ export async function prepareRunnerWorkspace(
 	return { cwd: result.stdout };
 }
 
+export class RunnerHostLaunchRejectedError extends Error {}
+
 /** Start one run-host in a server-selected Runner workspace. */
 export async function launchRunnerHost(
 	runnerId: string,
@@ -485,12 +487,12 @@ export async function launchRunnerHost(
 ): Promise<void> {
 	const connection = connections.get(runnerId);
 	if (!connection || connection.protocolVersion !== PROTOCOL_VERSION)
-		throw new Error(`Runner ${runnerId} is not connected`);
+		throw new RunnerHostLaunchRejectedError(`Runner ${runnerId} is not connected`);
 	const runner = getRunner(runnerId);
 	if (!runner || !runnerAllowed(runner, { user: request.user, repo: request.repo, permission: "fullSessions" }))
-		throw new Error(`Runner ${runner?.name ?? runnerId} is not permitted for full sessions`);
+		throw new RunnerHostLaunchRejectedError(`Runner ${runner?.name ?? runnerId} is not permitted for full sessions`);
 	if (!runnerOwnsWorkspace(runner, request.spec.cwd, request.sessionId))
-		throw new Error("Runner host path is outside its managed workspace roots");
+		throw new RunnerHostLaunchRejectedError("Runner host path is outside its managed workspace roots");
 	const id = `rh${++executionCounter}-${Date.now().toString(36)}`;
 	const operationToken = randomBytes(18).toString("base64url");
 	exitedHosts.delete(request.spec.hostId);

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -61,7 +61,7 @@ import {
 } from "fs";
 import { dirname, isAbsolute, relative, resolve } from "path";
 import { OPENSESSION_SESSIONS_DIR, homeDir, stateDir } from "../../paths";
-import { journalSet, journalClear, journalClearIfLineage, type ActiveRunRecord } from "../../run-journal";
+import { journalSet, journalClear, journalClearIfLineage, journalRecordAbnormalCompletion, type ActiveRunRecord } from "../../run-journal";
 import { shouldPersistModelSwitch, type StreamEvent } from "../../run-events";
 import { recoveryKind, restartContinuationPrompt } from "../../agent-runner";
 import { accountsForRemoteUpload, type ClaudeAccount } from "../../claude-accounts";
@@ -1952,6 +1952,8 @@ async function* withRunJournal(
 ): AsyncGenerator<StreamEvent> {
   journalSet(record);
   touch();
+  let sourceCompleted = false;
+  let sawTerminal = false;
   try {
     for await (const ev of events) {
       if (ev.type === "init" && ev.sessionId && ev.sessionId !== record.claudeSessionId) {
@@ -1964,10 +1966,13 @@ async function* withRunJournal(
         if (shouldPersistModelSwitch(ev)) record.selectedModel = ev.toModel;
         journalSet(record);
       }
+      if (ev.type === "done" || ev.type === "error") sawTerminal = true;
       yield ev;
     }
+    sourceCompleted = true;
   } finally {
-    journalClear(record.runKey);
+    if (sourceCompleted && sawTerminal) journalClear(record.runKey);
+    else if (sourceCompleted) journalRecordAbnormalCompletion(record);
     touch();
   }
 }

--- a/packages/core/opensession-server/src/server/sandbox/docker.ts
+++ b/packages/core/opensession-server/src/server/sandbox/docker.ts
@@ -113,7 +113,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, unl
 import { dirname, resolve as resolvePath } from "path";
 import { homeDir, OPENSESSION_SESSIONS_DIR } from "../paths";
 import { stateDir, } from "../paths";
-import { journalSet, journalClear, journalClearIfLineage, type ActiveRunRecord } from "../run-journal";
+import { journalSet, journalClear, journalClearIfLineage, journalRecordAbnormalCompletion, type ActiveRunRecord } from "../run-journal";
 import { shouldPersistModelSwitch, type StreamEvent } from "../run-events";
 import { recoveryKind, restartContinuationPrompt } from "../agent-runner";
 import { modelSupportsSteer, providerFor } from "../models";
@@ -1083,6 +1083,8 @@ async function* withRunJournal(
   journalSet(record);
   touchStateActivity(record.sandboxId!);
   let sawDone = false;
+  let sawTerminal = false;
+  let sourceCompleted = false;
   try {
     for await (const ev of events) {
       if (ev.type === "init" && ev.sessionId && ev.sessionId !== record.claudeSessionId) {
@@ -1096,10 +1098,13 @@ async function* withRunJournal(
         journalSet(record);
       }
       if (ev.type === "done") sawDone = true;
+      if (ev.type === "done" || ev.type === "error") sawTerminal = true;
       yield ev;
     }
+    sourceCompleted = true;
   } finally {
-    journalClear(record.runKey);
+    if (sourceCompleted && sawTerminal) journalClear(record.runKey);
+    else if (sourceCompleted) journalRecordAbnormalCompletion(record);
     touchStateActivity(record.sandboxId!);
     if (sawDone) schedulePostRunSnapshot(record.sandboxId!);
   }

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -23,6 +23,11 @@ import type { ServerWebSocket } from "bun";
 import { randomUUIDv7 } from "bun";
 import { existsSync } from "node:fs";
 import { type StreamEvent, markSessionStarting, runAgent, unmarkSessionStarting, } from "./agent-runner";
+import {
+	activeRunRecords,
+	journalClearIfLineage,
+	journalRecordAbnormalCompletion,
+} from "./run-journal";
 import { makeAskHandler } from "./asks";
 import { getAccountById } from "./claude-accounts";
 import { getCodexAccountById } from "./codex-accounts";
@@ -81,14 +86,16 @@ import { resolvePlainWorkspace } from "./workspace-resolve";
 import { resolveWorkspaceModelPreset } from "./workspace-model-presets";
 import { type Workspace, getWorkspace, updateWorkspace, } from "./workspaces";
 import {
+	type CreationOpeningEffectItem,
 	ensureCreationPlanned,
-	markCreationOpeningDispatched,
 	requestCreationBranch,
 	requestCreationCredential,
+	requestCreationOpening,
 	requestCreationSandbox,
 	requestCreationWorkspace,
 	settleCreationFailed,
 	settleCreationSucceeded,
+	sessionKernel,
 } from "./session-kernel";
 import { AUTO_REPO, ensureAskCheckout, ensureScratchDir, getRepo, isRegisteredWorktree, listWorktrees, NO_REPO, repoForPath, repoForPathOrNull, resolveUniqueBranch, sharedCheckoutForNewSessions, worktreeHeadBranch, worktreePathFor, } from "./worktree";
 import { type WSClientData, broadcastToSession, preparingWorkspaces, } from "./ws-hub";
@@ -379,9 +386,21 @@ async function attachCreateRepos(
 	return attached;
 }
 
+function runnerOpeningHostId(runId: string, generation: number): string {
+	const digest = new Bun.CryptoHasher("sha256")
+		.update(`${runId}:${generation}`)
+		.digest("hex");
+	return `rh-opening-${digest.slice(0, 32)}`;
+}
+
 const activeOpeningCreates = new Map<
 	string,
-	{ identity: string; done: Promise<void> }
+	{
+		identity: string;
+		spec: ResolvedCreate;
+		io: CreateSessionIO;
+		done: Promise<void>;
+	}
 >();
 
 export function runOpeningCreateOnce(
@@ -395,16 +414,43 @@ export function runOpeningCreateOnce(
 			throw new Error("Create request identity crossed active opening ownership");
 		return { owner: false, done: existing.done };
 	}
-	const done = openCreatedSession(spec, io, creationIdentity)
-		.catch((error) => {
-			settleCreationFailed(spec.id, creationIdentity, error);
-			throw error;
-		})
-		.finally(() => {
-			if (activeOpeningCreates.get(spec.id)?.done === done)
-				activeOpeningCreates.delete(spec.id);
-		});
-	activeOpeningCreates.set(spec.id, { identity: creationIdentity, done });
+	const openingPromptEntryId = beginPromptDispatch(
+		spec.id,
+		[
+			{
+				content: spec.openingPrompt,
+				user: spec.user,
+				...(spec.images?.length
+					? {
+							images: spec.images.map(
+								(image) => `data:${image.mediaType};base64,${image.data}`,
+							),
+						}
+					: {}),
+			},
+		],
+		spec.openingPromptEntryId,
+		true,
+		"create",
+	);
+	if (openingPromptEntryId !== spec.openingPromptEntryId)
+		throw new Error("Opening prompt identity changed before actor dispatch");
+	const done = requestCreationOpening({
+		sessionId: spec.id,
+		identity: creationIdentity,
+		openingPromptEntryId,
+		runId: `opening:${spec.id}:${openingPromptEntryId}`,
+		runGeneration: 1,
+	}).then(() => undefined).finally(() => {
+		if (activeOpeningCreates.get(spec.id)?.done === done)
+			activeOpeningCreates.delete(spec.id);
+	});
+	activeOpeningCreates.set(spec.id, {
+		identity: creationIdentity,
+		spec,
+		io,
+		done,
+	});
 	return { owner: true, done };
 }
 
@@ -443,17 +489,21 @@ function actorWorktreeMaterializer(input: {
 	};
 }
 
-export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
+async function restorePlannedOpening(sessionId: string): Promise<{
+	spec: ResolvedCreate;
+	io: CreateSessionIO;
+	identity: string;
+} | null> {
 	const plan = readCreatePlanForRecovery(sessionId);
 	const dispatch = promptDispatches.get(sessionId);
-	if (!plan?.resolved || dispatch?.kind !== "create") return false;
+	if (!plan?.resolved || dispatch?.kind !== "create") return null;
 	const restored = restoreResolvedCreate<ResolvedCreate>(plan.resolved);
 	const restoredGitEnv = githubCredentialForPrincipal(restored.gitPrincipal)?.env;
 	if (
 		typeof restored.wtPath !== "string" ||
 		typeof restored.branch !== "string" ||
 		(restored.needsWorktree && typeof restored.repoId !== "string")
-	) return false;
+	) return null;
 	const ready = restored.needsWorktree
 		? await isRegisteredWorktree(restored.wtPath, restored.repoId!, restored.branch)
 		: true;
@@ -471,30 +521,148 @@ export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
 			})
 		: undefined;
 	const imageUrls = dispatch.items.flatMap((item) => item.images || []);
-	const spec: ResolvedCreate = {
-		...(restored as ResolvedCreate),
-		id: sessionId,
-		openingPromptEntryId: dispatch.promptEntryId,
-		images: parseImageDataUrls(imageUrls),
-		gitEnv: restoredGitEnv,
-		materializeWorktree,
-		needsWorktree: !!materializeWorktree,
+	return {
+		identity: plan.identity,
+		spec: {
+			...(restored as ResolvedCreate),
+			id: sessionId,
+			openingPromptEntryId: dispatch.promptEntryId,
+			images: parseImageDataUrls(imageUrls),
+			gitEnv: restoredGitEnv,
+			materializeWorktree,
+			needsWorktree: !!materializeWorktree,
+		},
+		io: {
+			announce: () => {},
+			emit: (message) =>
+				broadcastToSession(sessionId, { ...message, sessionId }),
+			fail: (message) =>
+				broadcastToSession(sessionId, {
+					type: "notice",
+					sessionId,
+					message,
+				}),
+		},
 	};
-	const opening = runOpeningCreateOnce(spec, {
-		announce: () => {},
-		emit: (message) =>
-			broadcastToSession(sessionId, { ...message, sessionId }),
-		fail: (message) =>
-			broadcastToSession(sessionId, {
-				type: "notice",
-				sessionId,
-				message,
-			}),
-	}, plan.identity);
-	if (opening.owner) {
-		await opening.done;
-		clearCreatePlan(sessionId);
+}
+
+export async function executeCreationOpeningEffect(
+	item: CreationOpeningEffectItem,
+): Promise<void> {
+	const state = sessionKernel(item.sessionId).creationState();
+	if (!state || state.identity !== item.payload.creationIdentity)
+		throw new Error("Opening effect crossed durable creation ownership");
+	if (state.generation !== item.payload.creationGeneration)
+		throw new Error("Opening effect used a stale creation generation");
+	if (
+		(state.state === "ready" || state.state === "failed") &&
+		state.completedEffectIds.includes(item.effectKey)
+	) {
+		acknowledgePromptDispatch(
+			item.sessionId,
+			item.payload.openingPromptEntryId,
+		);
+		if (state.state === "ready") clearCreatePlan(item.sessionId);
+		return;
 	}
+	if (
+		state.state !== "opening_dispatched" ||
+		state.currentEffectId !== item.effectKey
+	)
+		throw new Error("Opening effect no longer owns the creation lifecycle");
+	const openingJournal = activeRunRecords().find(
+		(run) =>
+			run.osSessionId === item.sessionId &&
+			run.promptEntryId === item.payload.openingPromptEntryId,
+	);
+	if (openingJournal?.terminalFailure) {
+		settleCreationFailed(
+			item.sessionId,
+			item.payload.creationIdentity,
+			new Error(openingJournal.terminalFailure.content),
+			sessionKernel(item.sessionId),
+			item.effectKey,
+		);
+		acknowledgePromptDispatch(
+			item.sessionId,
+			item.payload.openingPromptEntryId,
+		);
+		journalClearIfLineage(openingJournal);
+		return;
+	}
+	const localRecovery =
+		!!openingJournal && !openingJournal.runnerId && !openingJournal.sandboxId;
+	if (localRecovery) {
+		// Boot's generic local-run adopter owns the exact journal. It settles the
+		// actor from its terminal callback; waiting here keeps the durable effect
+		// pending without launching a second engine turn.
+		while (true) {
+			const recovered = sessionKernel(item.sessionId).creationState();
+			if (
+				(recovered?.state === "ready" || recovered?.state === "failed") &&
+				recovered.completedEffectIds.includes(item.effectKey)
+			) {
+				acknowledgePromptDispatch(
+					item.sessionId,
+					item.payload.openingPromptEntryId,
+				);
+				if (recovered.state === "ready") clearCreatePlan(item.sessionId);
+				return;
+			}
+			if (
+				!recovered ||
+				recovered.identity !== item.payload.creationIdentity ||
+				recovered.generation !== item.payload.creationGeneration ||
+				recovered.currentEffectId !== item.effectKey
+			)
+				throw new Error("Recovered local opening lost durable ownership");
+			await Bun.sleep(100);
+		}
+	}
+	const active = activeOpeningCreates.get(item.sessionId);
+	if (active && active.identity !== item.payload.creationIdentity)
+		throw new Error("Opening effect crossed active creation ownership");
+	const restored = active
+		? { spec: active.spec, io: active.io, identity: active.identity }
+		: await restorePlannedOpening(item.sessionId);
+	if (!restored)
+		throw new Error("Opening effect has no durable create plan to recover");
+	if (restored.identity !== item.payload.creationIdentity)
+		throw new Error("Opening effect create-plan identity changed during recovery");
+	if (restored.spec.openingPromptEntryId !== item.payload.openingPromptEntryId)
+		throw new Error("Opening effect prompt identity changed during recovery");
+	await openCreatedSession(
+		restored.spec,
+		restored.io,
+		restored.identity,
+		item.effectKey,
+		{
+			runId: item.payload.runId,
+			generation: item.payload.runGeneration,
+		},
+	);
+	const settled = sessionKernel(item.sessionId).creationState();
+	if (settled?.state === "ready") clearCreatePlan(item.sessionId);
+	else if (settled?.state !== "failed")
+		throw new Error("Opening effect returned without terminal actor settlement");
+}
+
+export async function resumePlannedCreate(sessionId: string): Promise<boolean> {
+	const state = sessionKernel(sessionId).creationState();
+	if (state?.state === "ready") {
+		clearCreatePlan(sessionId);
+		return true;
+	}
+	if (state?.state === "failed" || state?.currentEffectId?.startsWith("opening:"))
+		return true;
+	const restored = await restorePlannedOpening(sessionId);
+	if (!restored) return false;
+	const opening = runOpeningCreateOnce(
+		restored.spec,
+		restored.io,
+		restored.identity,
+	);
+	if (opening.owner) await opening.done;
 	return true;
 }
 
@@ -502,6 +670,8 @@ export async function openCreatedSession(
 	spec: ResolvedCreate,
 	io: CreateSessionIO,
 	creationIdentity: string,
+	creationEffectId?: string,
+	openingRun?: { runId: string; generation: number },
 ): Promise<void> {
 	const bksId = spec.id;
 	// Replace the raw first-line title with a short summary in the background;
@@ -525,6 +695,7 @@ export async function openCreatedSession(
 	// Set once the session has been announced — a later failure must then
 	// close out the stream instead of leaving the just-opened viewer spinning.
 	let announced = false;
+	let creationSettled = false;
 	let engineSessionId = "";
 	let effectiveModel = spec.model;
 	let selectedModel = spec.model;
@@ -784,7 +955,6 @@ export async function openCreatedSession(
 						?.map((repo) => repo.dir)
 						.filter(Boolean),
 				}, { timeoutMs: 15 * 60_000 });
-				markCreationOpeningDispatched(bksId, creationIdentity);
 				sandboxOpeningRun = created
 					? await maybeLaunchSandboxedRun(created, {
 							prompt: openingPromptForRun,
@@ -821,11 +991,19 @@ export async function openCreatedSession(
 				await touchNativeSession(bksId, {
 					runner: { id: spec.runnerTarget.id, name: spec.runnerTarget.name, workspacePath: spec.runnerTarget.workspacePath, lifecycle: "awake", },
 				});
-				markCreationOpeningDispatched(bksId, creationIdentity);
 				const created = findSession(bksId);
 				runnerOpeningRun = created
 					? await maybeLaunchRunnerRun(created, {
 						prompt: openingPromptForRun,
+						promptEntryId: openingPromptEntryId,
+						...(openingRun
+							? {
+								hostId: runnerOpeningHostId(
+									openingRun.runId,
+									openingRun.generation,
+								),
+							}
+							: {}),
 						images: spec.images,
 						mcpServers: spec.runMcpServers ?? [],
 						user: spec.user,
@@ -844,8 +1022,43 @@ export async function openCreatedSession(
 			// gets is read back rather than reassembled, so it can only name
 			// worktrees that were actually cut.
 			const spanning = attachedRepoIds.length ? findSession(bksId) : null;
-			if (!sandboxOpeningRun && !runnerOpeningRun)
-				markCreationOpeningDispatched(bksId, creationIdentity);
+			const settlePhysicalCompletion = async (): Promise<void> => {
+				if (creationSettled) return;
+				if (!persisted) await persist();
+				else
+					await touchNativeSession(
+						bksId,
+						{
+							...engineSessionPatch(
+								effectiveProvider,
+								engineSessionId
+							),
+							...(engineSessionId
+								? { lastEngineProvider: effectiveProvider }
+								: {}),
+							...(effectiveModel ? { lastEngineModel: effectiveModel } : {}),
+							...(modelHistory.length ? { modelHistory } : {}),
+							...headBranchPatch(),
+						}
+					);
+				if (latestUsage)
+					await touchNativeSession(bksId, { usage: latestUsage });
+				recordRunOutcome(bksId, runFailure, {
+					engineSessionId,
+					noticePersisted: failureNoticePersisted,
+				});
+				// This runs in the terminal event's consumer body, before requesting
+				// the generator's next item. Backend generator finally blocks may now
+				// retire their journal/host only after the actor has the receipt.
+				settleCreationSucceeded(
+					bksId,
+					creationIdentity,
+					undefined,
+					creationEffectId,
+				);
+				creationSettled = true;
+				acknowledgePromptDispatch(bksId, openingPromptEntryId);
+			};
 			for await (const event of sandboxOpeningRun ?? runnerOpeningRun ?? runAgent({
 				prompt: openingPromptForRun,
 				// A recovered create is the same logical turn. Reuse the durable
@@ -1047,41 +1260,24 @@ export async function openCreatedSession(
 					if (event.noticePersisted) failureNoticePersisted = true;
 					io.emit({ type: "error", message: event.content });
 				}
+				if (event.type === "done" || event.type === "error")
+					await settlePhysicalCompletion();
 			}
-
-			if (!persisted) await persist();
-			else
-				await touchNativeSession(
-					bksId,
-					{
-						...engineSessionPatch(
-							effectiveProvider,
-							engineSessionId
-						),
-						...(engineSessionId
-							? { lastEngineProvider: effectiveProvider }
-							: {}),
-						...(effectiveModel ? { lastEngineModel: effectiveModel } : {}),
-						...(modelHistory.length ? { modelHistory } : {}),
-						// The opening turn may have switched branches in the
-						// worktree (same sync as runSessionPromptInner's run-end
-						// patch) — keep the record on the actual HEAD.
-						...headBranchPatch(),
-					}
-				);
-			// Persist opening-run usage regardless of which branch ran
-			// above (persist() writes the base file without it).
-			if (latestUsage)
-				await touchNativeSession(bksId, { usage: latestUsage });
-			recordRunOutcome(bksId, runFailure, {
-				engineSessionId,
-				noticePersisted: failureNoticePersisted,
-			});
+			if (!creationSettled) {
+				for (const record of activeRunRecords()) {
+					if (
+						record.osSessionId === bksId &&
+						record.promptEntryId === openingPromptEntryId &&
+						!record.terminalFailure
+					)
+						journalRecordAbnormalCompletion(record);
+				}
+				throw new Error("Opening run ended without a terminal event");
+			}
 		} finally {
-			// Normal completion and handled launch failures no longer need the
-			// pre-launch record. If the process dies, this finally never runs and
-			// boot restores the opening prompt instead.
-			acknowledgePromptDispatch(bksId, openingPromptEntryId);
+			// Terminal-event handling settles the actor before backend generators may
+			// retire their physical-owner journal. This finally only releases the
+			// in-process admission marker.
 			unmarkSessionStarting(bksId, startToken);
 			// Safety net for throws before the worktree block's own finally
 			// (persist/announce failures) — must never leak a session stuck
@@ -1116,8 +1312,11 @@ export async function openCreatedSession(
 			else
 				onHumanAsksSessionIdle(bksId);
 		}
-		settleCreationSucceeded(bksId, creationIdentity);
 	} catch (e: any) {
+		if (creationSettled) {
+			console.error(`[create] Post-opening follow-up failed for ${bksId}:`, e);
+			return;
+		}
 		// Failure after the early announce: the client is already in the
 		// session — close out the stream and surface the failure there
 		// instead of leaving the viewer spinning. Before the announce there's
@@ -1153,7 +1352,22 @@ export async function openCreatedSession(
 		} else {
 			io.fail(e.message || String(e));
 		}
-		settleCreationFailed(bksId, creationIdentity, e);
+		settleCreationFailed(
+			bksId,
+			creationIdentity,
+			e,
+			undefined,
+			creationEffectId,
+		);
+		acknowledgePromptDispatch(bksId, openingPromptEntryId);
+		for (const record of activeRunRecords()) {
+			if (
+				record.osSessionId === bksId &&
+				record.promptEntryId === openingPromptEntryId &&
+				record.terminalFailure
+			)
+				journalClearIfLineage(record);
+		}
 	}
 }
 

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts
@@ -8,10 +8,12 @@ import {
   CreationEffectIndeterminateError,
   executeCreationBranchPrepare,
   executeCreationCredentialResolve,
+  executeCreationOpeningTurn,
   executeCreationSandboxPrepare,
   executeCreationWorkspacePrepare,
   type CreationBranchEffectItem,
   type CreationCredentialEffectItem,
+  type CreationOpeningEffectItem,
   type CreationSandboxEffectItem,
   type CreationWorkspaceEffectItem,
 } from "./creation-effect-executors";
@@ -114,6 +116,27 @@ function sandboxItem(): CreationSandboxEffectItem {
       trustProfile: "interactive",
       egressAllowlist: ["github.com"],
       mode: "adopt_or_create",
+    },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: 1,
+  };
+}
+
+function openingItem(): CreationOpeningEffectItem {
+  return {
+    id: 5,
+    effectId: "session:creation_opening_turn:opening-effect",
+    effectKey: "opening:opening-prompt-one",
+    sessionId: "session-one",
+    kind: "creation_opening_turn",
+    payload: {
+      creationIdentity: "create-one",
+      creationGeneration: 1,
+      openingPromptEntryId: "opening-prompt-one",
+      runId: "opening:session-one:opening-prompt-one",
+      runGeneration: 1,
+      mode: "adopt_or_launch",
     },
     attempts: 0,
     nextAttemptAt: 0,
@@ -419,6 +442,27 @@ describe("creation sandbox effect executor", () => {
         throw new Error("must not result");
       },
     })).rejects.toBeInstanceOf(CreationEffectIndeterminateError);
+  });
+});
+
+describe("creation opening effect executor", () => {
+  test("launches the exact session-keyed opening fence", async () => {
+    const launched: CreationOpeningEffectItem[] = [];
+    const input = openingItem();
+    await executeCreationOpeningTurn(input, {
+      launch: async (item) => {
+        launched.push(item);
+      },
+    });
+    expect(launched).toEqual([input]);
+  });
+
+  test("rejects an opening run id that crosses session ownership", async () => {
+    const input = openingItem();
+    input.payload.runId = "opening:another-session:opening-prompt-one";
+    await expect(
+      executeCreationOpeningTurn(input, { launch: async () => {} }),
+    ).rejects.toBeInstanceOf(CreationEffectIndeterminateError);
   });
 });
 

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
@@ -19,6 +19,7 @@ type WorkspaceEffect = SessionActorEffectFor<"creation_workspace_prepare">;
 type BranchEffect = SessionActorEffectFor<"creation_branch_prepare">;
 type CredentialEffect = SessionActorEffectFor<"creation_credential_resolve">;
 type SandboxEffect = SessionActorEffectFor<"creation_sandbox_prepare">;
+type OpeningEffect = SessionActorEffectFor<"creation_opening_turn">;
 export type CreationWorkspaceEffectItem = Omit<
   DurableOutboxItem,
   "kind" | "payload"
@@ -35,6 +36,10 @@ export type CreationSandboxEffectItem = Omit<
   DurableOutboxItem,
   "kind" | "payload"
 > & SandboxEffect;
+export type CreationOpeningEffectItem = Omit<
+  DurableOutboxItem,
+  "kind" | "payload"
+> & OpeningEffect;
 
 export class CreationEffectIndeterminateError extends Error {
   readonly indeterminate = true;
@@ -393,6 +398,28 @@ export async function executeCreationCredentialResolve(
   );
 }
 
+type OpeningExecutorDependencies = {
+  launch: (item: CreationOpeningEffectItem) => Promise<void>;
+};
+
+const defaultOpeningDependencies: OpeningExecutorDependencies = {
+  launch: async (item) =>
+    (await import("../session-create")).executeCreationOpeningEffect(item),
+};
+
+/** Launch or recover the one opening turn named by its durable actor fence. */
+export async function executeCreationOpeningTurn(
+  item: CreationOpeningEffectItem,
+  dependencies: OpeningExecutorDependencies = defaultOpeningDependencies,
+): Promise<void> {
+  const expectedRunId = `opening:${item.sessionId}:${item.payload.openingPromptEntryId}`;
+  if (item.payload.runId !== expectedRunId)
+    throw new CreationEffectIndeterminateError(
+      `Opening run ${item.payload.runId} crossed session ownership`,
+    );
+  await dependencies.launch(item);
+}
+
 /**
  * Re-admit branch effects rejected before execution by retired compatibility
  * checks. The store matches exact historical errors and validates configured
@@ -436,6 +463,7 @@ const registrationGlobal = globalThis as typeof globalThis & {
   __opensessionCreationBranchExecutorRegistered?: boolean;
   __opensessionCreationCredentialExecutorRegistered?: boolean;
   __opensessionCreationSandboxExecutorRegistered?: boolean;
+  __opensessionCreationOpeningExecutorRegistered?: boolean;
 };
 
 export function ensureCreationEffectExecutors(): void {
@@ -466,5 +494,12 @@ export function ensureCreationEffectExecutors(): void {
       executeCreationCredentialResolve,
     );
     registrationGlobal.__opensessionCreationCredentialExecutorRegistered = true;
+  }
+  if (!registrationGlobal.__opensessionCreationOpeningExecutorRegistered) {
+    registerSessionEffectExecutor(
+      "creation_opening_turn",
+      executeCreationOpeningTurn,
+    );
+    registrationGlobal.__opensessionCreationOpeningExecutorRegistered = true;
   }
 }

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
-  markCreationOpeningDispatched,
   requestCreationBranch,
   requestCreationCredential,
+  requestCreationOpening,
   requestCreationSandbox,
   requestCreationWorkspace,
   settleCreationFailed,
-  settleCreationSucceeded,
 } from "./creation-intents";
 import {
   SessionKernelStore,
@@ -50,76 +49,6 @@ const branchInput = {
 };
 
 describe("creation lifecycle intents", () => {
-  test("moves a preparation-free create through opening to ready idempotently", () => {
-    const { store, kernel } = harness("create-lifecycle");
-    try {
-      const opening = markCreationOpeningDispatched(
-        "create-lifecycle",
-        "request-lifecycle",
-        kernel,
-      );
-      expect(opening.state).toBe("opening_dispatched");
-      expect(opening.currentEffectId).toBeUndefined();
-      const ready = settleCreationSucceeded(
-        "create-lifecycle",
-        "request-lifecycle",
-        kernel,
-      );
-      expect(ready.state).toBe("ready");
-      expect(
-        settleCreationSucceeded(
-          "create-lifecycle",
-          "request-lifecycle",
-          kernel,
-        ).state,
-      ).toBe("ready");
-    } finally {
-      store.close();
-    }
-  });
-
-  test("refuses to dispatch an opening while preparation is pending", () => {
-    const { store, kernel } = harness("create-pending-opening");
-    try {
-      store.applyCreationEvent({
-        sessionId: "create-pending-opening",
-        identity: "request-pending",
-        event: "plan",
-      });
-      store.applyCreationEvent({
-        sessionId: "create-pending-opening",
-        identity: "request-pending",
-        event: "preparation_started",
-        nextEffectId: "prepare-pending",
-        effect: {
-          kind: "creation_workspace_prepare",
-          effectKey: "prepare-pending",
-          payload: {
-            creationIdentity: "request-pending",
-            creationGeneration: 1,
-            workspaceId: "ws-pending",
-            dedupeKey: "create:pending",
-            name: "Pending",
-            createdBy: "Alice",
-            mode: "adopt_or_create",
-          },
-        },
-      });
-      expect(() =>
-        markCreationOpeningDispatched(
-          "create-pending-opening",
-          "request-pending",
-          kernel,
-        ),
-      ).toThrow("must settle before opening");
-      expect(store.creationState("create-pending-opening")?.state).toBe(
-        "preparing",
-      );
-    } finally {
-      store.close();
-    }
-  });
-
   test("records terminal setup failure without launching an opening", () => {
     const { store, kernel } = harness("create-failed-lifecycle");
     try {
@@ -138,6 +67,138 @@ describe("creation lifecycle intents", () => {
           kernel,
         ).state,
       ).toBe("failed");
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("creation opening intents", () => {
+  const opening = {
+    sessionId: "create-opening-intent",
+    identity: "request-opening-intent",
+    openingPromptEntryId: "opening-prompt-one",
+    runId: "opening:create-opening-intent:opening-prompt-one",
+    runGeneration: 1,
+  };
+
+  test("waits for an accepted preparation effect before dispatching", async () => {
+    const pending = {
+      ...opening,
+      sessionId: "create-pending-opening",
+      identity: "request-pending-opening",
+    };
+    const { store, kernel } = harness(pending.sessionId);
+    try {
+      store.applyCreationEvent({
+        sessionId: pending.sessionId,
+        identity: pending.identity,
+        event: "plan",
+      });
+      store.applyCreationEvent({
+        sessionId: pending.sessionId,
+        identity: pending.identity,
+        event: "preparation_started",
+        nextEffectId: "prepare-pending",
+        effect: {
+          kind: "creation_workspace_prepare",
+          effectKey: "prepare-pending",
+          payload: {
+            creationIdentity: pending.identity,
+            creationGeneration: 1,
+            workspaceId: "ws-pending",
+            dedupeKey: "create:pending",
+            name: "Pending",
+            createdBy: "Alice",
+            mode: "adopt_or_create",
+          },
+        },
+      });
+      setTimeout(() => {
+        store.applyCreationEvent({
+          sessionId: pending.sessionId,
+          identity: pending.identity,
+          event: "preparation_started",
+          effectId: "prepare-pending",
+        });
+      }, 5);
+      setTimeout(() => {
+        store.applyCreationEvent({
+          sessionId: pending.sessionId,
+          identity: pending.identity,
+          event: "succeeded",
+          effectId: `opening:${pending.openingPromptEntryId}`,
+        });
+      }, 15);
+      const state = await requestCreationOpening(pending, {
+        kernel,
+        timeoutMs: 200,
+        pollMs: 1,
+      });
+      expect(state.state).toBe("ready");
+      expect(state.completedEffectIds).toEqual([
+        "prepare-pending",
+        `opening:${pending.openingPromptEntryId}`,
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  test("emits one durable opening launch and waits for terminal settlement", async () => {
+    const { store, kernel } = harness(opening.sessionId);
+    try {
+      setTimeout(() => {
+        store.applyCreationEvent({
+          sessionId: opening.sessionId,
+          identity: opening.identity,
+          event: "succeeded",
+          effectId: `opening:${opening.openingPromptEntryId}`,
+        });
+      }, 5);
+      const state = await requestCreationOpening(opening, {
+        kernel,
+        timeoutMs: 200,
+        pollMs: 1,
+      });
+      expect(state.state).toBe("ready");
+      expect(state.completedEffectIds).toContain(
+        `opening:${opening.openingPromptEntryId}`,
+      );
+      expect(store.pendingOutbox()).toMatchObject([
+        {
+          kind: "creation_opening_turn",
+          effectKey: `opening:${opening.openingPromptEntryId}`,
+          payload: {
+            openingPromptEntryId: opening.openingPromptEntryId,
+            runId: opening.runId,
+            runGeneration: 1,
+          },
+        },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  test("keeps a timed-out opening durable without emitting another launch", async () => {
+    const { store, kernel } = harness(opening.sessionId);
+    try {
+      await expect(
+        requestCreationOpening(opening, {
+          kernel,
+          timeoutMs: 5,
+          pollMs: 1,
+        }),
+      ).rejects.toThrow("remains durably pending");
+      await expect(
+        requestCreationOpening(opening, {
+          kernel,
+          timeoutMs: 5,
+          pollMs: 1,
+        }),
+      ).rejects.toThrow("remains durably pending");
+      expect(store.pendingOutbox()).toHaveLength(1);
     } finally {
       store.close();
     }

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -46,6 +46,14 @@ export type CreationSandboxIntent = {
   egressAllowlist?: string[];
 };
 
+export type CreationOpeningIntent = {
+  sessionId: string;
+  identity: string;
+  openingPromptEntryId: string;
+  runId: string;
+  runGeneration: number;
+};
+
 type CreationIntentKernel = Pick<
   ReturnType<typeof sessionKernel>,
   "creationState" | "applyCreationEvent"
@@ -83,50 +91,20 @@ export function ensureCreationPlanned(
   return planned.state;
 }
 
-/** Cross the durable preparation-to-opening boundary before launching a runner. */
-export function markCreationOpeningDispatched(
-  sessionId: string,
-  identity: string,
-  kernel: CreationIntentKernel = sessionKernel(sessionId),
-): DurableCreationState {
-  let state = ensureCreationPlanned(sessionId, identity, kernel);
-  if (state.state === "ready" || state.state === "opening_dispatched") return state;
-  assertIdentity(state, identity);
-  if (state.currentEffectId)
-    throw new Error(
-      `Creation effect ${state.currentEffectId} must settle before opening`,
-    );
-  if (state.state === "planned") {
-    const preparing = kernel.applyCreationEvent({
-      identity,
-      event: "preparation_started",
-    });
-    if (!preparing.accepted || !preparing.state)
-      throw new Error(
-        `Creation preparation was rejected: ${preparing.reason || "unknown"}`,
-      );
-    state = preparing.state;
-  }
-  const dispatched = kernel.applyCreationEvent({
-    identity,
-    event: "opening_dispatched",
-  });
-  if (!dispatched.accepted || !dispatched.state)
-    throw new Error(
-      `Creation opening dispatch was rejected: ${dispatched.reason || "unknown"}`,
-    );
-  return dispatched.state;
-}
-
 export function settleCreationSucceeded(
   sessionId: string,
   identity: string,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
+  effectId?: string,
 ): DurableCreationState {
   const state = ensureCreationPlanned(sessionId, identity, kernel);
   if (state.state === "ready") return state;
   assertIdentity(state, identity);
-  const settled = kernel.applyCreationEvent({ identity, event: "succeeded" });
+  const settled = kernel.applyCreationEvent({
+    identity,
+    event: "succeeded",
+    effectId,
+  });
   if (!settled.accepted || !settled.state)
     throw new Error(
       `Creation success was rejected: ${settled.reason || "unknown"}`,
@@ -139,6 +117,7 @@ export function settleCreationFailed(
   identity: string,
   error: unknown,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
+  effectId?: string,
 ): DurableCreationState {
   const existing = kernel.creationState();
   if (existing?.identity !== undefined && existing.identity !== identity)
@@ -148,6 +127,7 @@ export function settleCreationFailed(
   const settled = kernel.applyCreationEvent({
     identity,
     event: "failed",
+    effectId,
     detail: { error: error instanceof Error ? error.message : String(error) },
   });
   if (!settled.accepted || !settled.state)
@@ -155,6 +135,89 @@ export function settleCreationFailed(
       `Creation failure was rejected: ${settled.reason || "unknown"}`,
     );
   return settled.state;
+}
+
+/** Emit one stable opening launch and wait for the executor's actor settlement. */
+export async function requestCreationOpening(
+  input: CreationOpeningIntent,
+  options: CreationIntentOptions = {},
+): Promise<DurableCreationState> {
+  const kernel = options.kernel ?? sessionKernel(input.sessionId);
+  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  const effectId = `opening:${input.openingPromptEntryId}`;
+  const deadline = Date.now() + (options.timeoutMs ?? 24 * 60 * 60_000);
+  if (state.state === "ready") return state;
+  while (state.currentEffectId && state.currentEffectId !== effectId) {
+    if (state.state === "failed")
+      throw new Error("Session creation failed before opening dispatch");
+    if (Date.now() >= deadline)
+      throw new Error(
+        `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
+      );
+    await Bun.sleep(options.pollMs ?? 25);
+    const current = kernel.creationState();
+    if (!current)
+      throw new Error("Creation state disappeared before opening dispatch");
+    if (current.identity !== input.identity)
+      throw new Error("Create request identity crossed durable session ownership");
+    state = current;
+  }
+  if (state.state === "failed")
+    throw new Error("Session creation failed before opening dispatch");
+  if (state.state === "planned") {
+    const preparing = kernel.applyCreationEvent({
+      identity: input.identity,
+      event: "preparation_started",
+    });
+    if (!preparing.accepted || !preparing.state)
+      throw new Error(
+        `Creation preparation was rejected: ${preparing.reason || "unknown"}`,
+      );
+    state = preparing.state;
+  }
+  if (state.state === "preparing" && !state.currentEffectId) {
+    const emitted = kernel.applyCreationEvent({
+      identity: input.identity,
+      event: "opening_dispatched",
+      nextEffectId: effectId,
+      effect: {
+        kind: "creation_opening_turn",
+        effectKey: effectId,
+        payload: {
+          creationIdentity: input.identity,
+          creationGeneration: state.generation,
+          openingPromptEntryId: input.openingPromptEntryId,
+          runId: input.runId,
+          runGeneration: input.runGeneration,
+          mode: "adopt_or_launch",
+        },
+      },
+    });
+    if (!emitted.accepted || !emitted.state)
+      throw new Error(
+        `Creation opening intent was rejected: ${emitted.reason || "unknown"}`,
+      );
+    state = emitted.state;
+  }
+  if (
+    state.state !== "opening_dispatched" ||
+    state.currentEffectId !== effectId
+  )
+    throw new Error(`Creation opening ${effectId} has an invalid durable state`);
+  while (state.state !== "ready") {
+    if (state.state === "failed")
+      throw new Error("Session creation failed while opening was pending");
+    if (Date.now() >= deadline)
+      throw new Error(`Creation opening effect ${effectId} remains durably pending`);
+    await Bun.sleep(options.pollMs ?? 25);
+    const current = kernel.creationState();
+    if (!current)
+      throw new Error("Creation state disappeared while opening was pending");
+    if (current.identity !== input.identity)
+      throw new Error("Create request identity crossed durable session ownership");
+    state = current;
+  }
+  return state;
 }
 
 /** Emit one stable workspace intent and wait for its actor receipt, never its file. */

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -525,6 +525,22 @@ describe("SessionKernel", () => {
 	});
 
 	test("owns creation transitions and rejects stale effect results", () => {
+		store.applyCreationEvent({
+			sessionId: "create-opening-requires-effect",
+			identity: "request-direct",
+			event: "plan",
+		});
+		store.applyCreationEvent({
+			sessionId: "create-opening-requires-effect",
+			identity: "request-direct",
+			event: "preparation_started",
+		});
+		expect(store.applyCreationEvent({
+			sessionId: "create-opening-requires-effect",
+			identity: "request-direct",
+			event: "opening_dispatched",
+		})).toMatchObject({ accepted: false, reason: "invalid_effect" });
+
 		expect(store.applyCreationEvent({
 			sessionId: "create-fsm",
 			identity: "request-one",
@@ -648,6 +664,66 @@ describe("SessionKernel", () => {
 			{ kind: "creation_workspace_prepare", effectKey: "prepare-one" },
 			{ kind: "creation_opening_turn", effectKey: "opening-one" },
 		]);
+	});
+
+	test("settles an actor opening from an exactly journaled local recovery", async () => {
+		const sessionId = "local-opening-recovery";
+		const identity = "local-opening-request";
+		const promptEntryId = "local-opening-prompt";
+		const effectId = `opening:${promptEntryId}`;
+		expect(
+			store.applyCreationEvent({ sessionId, identity, event: "plan" }).accepted,
+		).toBe(true);
+		const preparationEffectId = "local-opening-preparation";
+		expect(
+			store.applyCreationEvent({
+				sessionId,
+				identity,
+				event: "preparation_started",
+				nextEffectId: preparationEffectId,
+				effect: {
+					kind: "creation_workspace_prepare",
+					effectKey: preparationEffectId,
+					payload: {
+						creationIdentity: identity,
+						creationGeneration: 1,
+						workspaceId: "local-opening-workspace",
+						dedupeKey: "local-opening-dedupe",
+						name: "Local opening",
+						createdBy: "Alice",
+						mode: "adopt_or_create",
+					},
+				},
+			}).accepted,
+		).toBe(true);
+		expect(
+			store.applyCreationEvent({
+				sessionId,
+				identity,
+				event: "opening_dispatched",
+				effectId: preparationEffectId,
+				nextEffectId: effectId,
+				effect: {
+					kind: "creation_opening_turn",
+					effectKey: effectId,
+					payload: {
+						creationIdentity: identity,
+						creationGeneration: 1,
+						openingPromptEntryId: promptEntryId,
+						runId: `opening:${sessionId}:${promptEntryId}`,
+						runGeneration: 1,
+						mode: "adopt_or_launch",
+					},
+				},
+			}).accepted,
+		).toBe(true);
+		const { settleRecoveredCreationOpening } = await import("../run-session");
+		expect(
+			settleRecoveredCreationOpening(sessionId, promptEntryId),
+		).toBe(true);
+		const settled = store.creationState(sessionId);
+		expect(settled?.state).toBe("ready");
+		expect(settled?.completedEffectIds).toContain(effectId);
 	});
 
 	test("clears an accepted creation effect so replay is a stale no-op", () => {

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -111,6 +111,9 @@ describe("single session ownership", () => {
 		);
 		expect(creationReduction).toContain("this.enqueueOutbox(");
 		expect(creationReduction).toContain("completedEffectIds.push(input.effectId!)");
+		expect(creationReduction).toContain(
+			'input.event === "opening_dispatched" && !effect',
+		);
 		expect(store).toContain("SESSION_KERNEL_MAX_CREATION_EFFECT_RECEIPTS");
 		expect(creationReduction.indexOf("this.enqueueOutbox(")).toBeLessThan(
 			creationReduction.indexOf("tx.immediate()"),
@@ -132,6 +135,9 @@ describe("single session ownership", () => {
 		);
 		expect(creationExecutors).toContain(
 			'"creation_credential_resolve",\n      executeCreationCredentialResolve',
+		);
+		expect(creationExecutors).toContain(
+			'"creation_opening_turn",\n      executeCreationOpeningTurn',
 		);
 		expect(creationExecutors).toContain(
 			"payload.sandboxKey !== item.sessionId",
@@ -281,18 +287,18 @@ describe("single session ownership", () => {
 		expect(create).toContain("await requestCreationCredential({");
 		expect(create).toContain("await requestCreationBranch({");
 		expect(create).toContain("await requestCreationSandbox({");
+		expect(create).toContain("requestCreationOpening({");
+		expect(create).toContain("executeCreationOpeningEffect(");
 		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
 			create.indexOf("await maybeLaunchSandboxedRun("),
 		);
-		expect(create.match(/markCreationOpeningDispatched\(/g)?.length).toBe(3);
+		expect(create).not.toContain("markCreationOpeningDispatched");
 		expect(create).toMatch(
-			/requestCreationSandbox\([\s\S]*?markCreationOpeningDispatched\([\s\S]*?maybeLaunchSandboxedRun\(/,
+			/executeCreationOpeningEffect\([\s\S]*?openCreatedSession\(/,
 		);
-		expect(create).toMatch(
-			/prepareRunnerWorkspace\([\s\S]*?markCreationOpeningDispatched\([\s\S]*?maybeLaunchRunnerRun\(/,
-		);
-		expect(create).toContain("settleCreationSucceeded(bksId, creationIdentity)");
-		expect(create).toContain("settleCreationFailed(bksId, creationIdentity, e)");
+		expect(create).toContain("settleCreationSucceeded(");
+		expect(create).toContain("settleCreationFailed(");
+		expect(create).toContain("creationEffectId,");
 		expect(create).toContain(
 			"baseBranch: input.baseBranch || getRepo(input.project).defaultBranch",
 		);
@@ -358,7 +364,44 @@ describe("single session ownership", () => {
 	test("create and sandbox recovery establish one execution owner", () => {
 		const queue = read("queue-state.ts");
 		expect(queue).toContain('kind?: "create"');
-		expect(read("run-session.ts")).toContain("resumePlannedCreate(sessionId)");
+		expect(queue).toContain("options.creationOwnsPrompt?.(");
+		const runSession = read("run-session.ts");
+		expect(runSession).toContain("resumePlannedCreate(sessionId)");
+		expect(runSession).toContain("creationOwnsPrompt(record.osSessionId");
+		const boot = read("../../opensession.ts");
+		expect(boot).toContain(
+			"creationOwnsPrompt(run.osSessionId, run.promptEntryId)",
+		);
+		expect(boot).toContain("!!(run.runnerId || run.sandboxId)");
+		expect(boot).toContain("settleRecoveredCreationOpening(");
+		const create = read("session-create.ts");
+		expect(create).toContain("const openingJournal = activeRunRecords().find(");
+		expect(create).toContain("Recovered local opening lost durable ownership");
+		const runner = read("runner-session.ts");
+		expect(runner).toContain("promptEntryId: opts.promptEntryId");
+		expect(runner).toContain("const hostId = opts.hostId ||");
+		expect(runner).toContain('run.launchPhase === "prepared"');
+		expect(runner).toContain('launchPhase: "launching"');
+		const durableLaunching = runner.indexOf(
+			'writeJsonAtomic(launchStatePath, launchState)',
+			runner.indexOf('phase: "launching"'),
+		);
+		const physicalLaunch = runner.indexOf(
+			"await launcher.launch(hostId, hostDir)",
+			durableLaunching,
+		);
+		expect(durableLaunching).toBeGreaterThan(0);
+		expect(physicalLaunch).toBeGreaterThan(durableLaunching);
+		expect(runner).toContain('launchPhase: "started"');
+		expect(runner).toContain('phase: "rejected"');
+		expect(runner).toContain('reason: "ambiguous_runner_launch"');
+		expect(runner).toContain("setRunnerWorkload(runner.id, undefined, session.id)");
+		expect(runner).toContain("has no adoptable remote evidence");
+		expect(read("runner-ws.ts")).toContain("RunnerHostLaunchRejectedError");
+		expect(runner).toContain("candidate.hostId === run.hostId");
+		const runtime = read("session-kernel/runtime.ts");
+		expect(runtime).toContain('item.kind === "creation_opening_turn"');
+		expect(runtime).toContain("activeOpeningOutbox");
 		for (const relative of [
 			"sandbox/docker.ts",
 			"sandbox/adapters/bootstrap.ts",
@@ -396,13 +439,41 @@ describe("single session ownership", () => {
 		}
 	});
 
-	test("opening runs settle session-file writes before continuing", () => {
+	test("opening runs settle actor receipts before owner retirement and follow-ups", () => {
 		const create = read("session-create.ts");
 		const writes = create
 			.split("\n")
 			.filter((line) => line.includes("touchNativeSession("));
 		expect(writes.length).toBeGreaterThan(0);
 		for (const line of writes) expect(line).toContain("await touchNativeSession(");
+		const creationSettlement = create.indexOf("settleCreationSucceeded(");
+		const dispatchAck = create.indexOf(
+			"acknowledgePromptDispatch(bksId, openingPromptEntryId)",
+			creationSettlement,
+		);
+		expect(creationSettlement).toBeGreaterThan(0);
+		expect(dispatchAck).toBeGreaterThan(creationSettlement);
+		expect(create).toContain(
+			'if (event.type === "done" || event.type === "error")',
+		);
+		expect(create).toContain("await settlePhysicalCompletion()");
+		expect(create).toContain(
+			"Terminal-event handling settles the actor before backend generators may",
+		);
+		expect(create).toContain(
+			'throw new Error("Opening run ended without a terminal event")',
+		);
+		expect(create).toContain("openingJournal?.terminalFailure");
+		for (const backend of [
+			"host-client.ts",
+			"runner-session.ts",
+			"sandbox/docker.ts",
+			"sandbox/adapters/bootstrap.ts",
+		]) {
+			const source = read(backend);
+			expect(source).toContain("journalRecordAbnormalCompletion(");
+			expect(source).toContain("sourceCompleted && sawTerminal");
+		}
 
 		const cache = read("session-cache.ts");
 		const outcome = cache.indexOf("if (errorMessage) {");

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -53,6 +53,7 @@ type RuntimeState = {
 	lastCompactAt?: number;
 	activeTimers?: Set<string>;
 	activeOutbox?: Set<number>;
+	activeOpeningOutbox?: Set<number>;
 };
 
 const globalRuntime = globalThis as typeof globalThis & {
@@ -109,7 +110,15 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 	try {
 		const timerKinds = [...runtime.timerHandlers.keys()];
 		const effectKinds = registeredSessionEffectKinds();
-		const work = await sessionKernelRuntimeWork(timerKinds, effectKinds);
+		const openingKind = "creation_opening_turn";
+		const work = await sessionKernelRuntimeWork(
+			timerKinds,
+			effectKinds.filter((kind) => kind !== openingKind),
+		);
+		if (effectKinds.includes(openingKind)) {
+			const openings = await sessionKernelRuntimeWork([], [openingKind], Date.now(), 8);
+			work.outbox.push(...openings.outbox);
+		}
 		const activeTimers = (runtime.activeTimers ??= new Set());
 		for (const timer of work.timers) {
 			if (activeTimers.size >= 8) break;
@@ -138,10 +147,17 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 				.finally(() => activeTimers.delete(key));
 		}
 		const activeOutbox = (runtime.activeOutbox ??= new Set());
+		const activeOpeningOutbox = (runtime.activeOpeningOutbox ??= new Set());
 		for (const item of work.outbox) {
-			if (activeOutbox.size >= 8) break;
-			if (activeOutbox.has(item.id)) continue;
-			activeOutbox.add(item.id);
+			// Opening turns can legitimately last for hours. Keep their bounded
+			// execution pool separate so eight accepted openings cannot starve
+			// delivery, preparation, or projection effects globally.
+			const active =
+				item.kind === "creation_opening_turn"
+					? activeOpeningOutbox
+					: activeOutbox;
+			if (active.size >= 8 || active.has(item.id)) continue;
+			active.add(item.id);
 			void executeSessionEffect(item)
 				.then((executed) => {
 					if (executed) sessionKernelStore().ackOutbox(item.id);
@@ -163,7 +179,7 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 					);
 				}
 				)
-				.finally(() => activeOutbox.delete(item.id));
+				.finally(() => active.delete(item.id));
 		}
 		passivateIdleSessionKernels();
 		if (!runtime.lastCompactAt || Date.now() - runtime.lastCompactAt > 60 * 60_000) {
@@ -222,7 +238,8 @@ export async function waitForSessionKernelRuntimeIdle(
 	const deadline = Date.now() + timeoutMs;
 	while (
 		(runtime.activeTimers?.size || 0) > 0 ||
-		(runtime.activeOutbox?.size || 0) > 0
+		(runtime.activeOutbox?.size || 0) > 0 ||
+		(runtime.activeOpeningOutbox?.size || 0) > 0
 	) {
 		if (Date.now() >= deadline) return false;
 		await Bun.sleep(5);

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -990,6 +990,7 @@ export class SessionKernelStore {
       }
       if (completesNewEffect) completedEffectIds.push(input.effectId!);
       const invalidEffect =
+        (input.event === "opening_dispatched" && !effect) ||
         (input.nextEffectId !== undefined && !effect) ||
         (!!effect && input.nextEffectId !== effect.effectKey) ||
         (!!effect && completedEffectIds.includes(effect.effectKey)) ||

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import * as mod from "./run-journal";
@@ -654,6 +654,61 @@ describe("run journal", () => {
 		expect(mod.takeInterruptedRuns()).toEqual([]);
 	});
 
+	it("defers actor-owned opening journals to the durable effect executor", () => {
+		mod.journalSet({
+			runKey: "opening-run",
+			osSessionId: "opening-session",
+			promptEntryId: "opening-prompt",
+			prompt: "start",
+			cwd: "/tmp",
+			mcpServers: [],
+			startedAt: new Date().toISOString(),
+		});
+		expect(
+			agent.resumeInterruptedRuns(
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				(run) => run.promptEntryId === "opening-prompt",
+			),
+		).toEqual([]);
+		expect(mod.activeRunRecords()).toMatchObject([
+			{ runKey: "opening-run", promptEntryId: "opening-prompt" },
+		]);
+	});
+
+	it("adopts a durable abnormal-completion receipt without relaunching", () => {
+		const runKey = "abnormal-opening";
+		const record: mod.ActiveRunRecord = {
+			runKey,
+			osSessionId: "abnormal-session",
+			promptEntryId: "abnormal-prompt",
+			prompt: "start",
+			cwd: "/tmp",
+			mcpServers: [],
+			startedAt: new Date().toISOString(),
+		};
+		mod.journalSet(record);
+		mod.journalRecordAbnormalCompletion(
+			record,
+			"Opening backend ended without a terminal event",
+		);
+		let terminal: StreamEvent | undefined;
+		expect(
+			agent.resumeInterruptedRuns((_sessionId, event) => {
+				terminal = event;
+			}),
+		).toEqual(["abnormal-session"]);
+		expect(terminal).toMatchObject({
+			type: "error",
+			content: "Opening backend ended without a terminal event",
+		});
+		expect(mod.activeRunRecords()).toEqual([]);
+	});
+
 	it("moves rejected recovery records into an inspectable quarantine", async () => {
 		for (let i = 0; i < 5; i++) {
 			mod.journalSet({ runKey: `batch-${i}`, cwd: "/tmp", mcpServers: [], startedAt: new Date().toISOString() });
@@ -669,6 +724,35 @@ describe("run journal", () => {
 		expect(Object.values(quarantine).map((run: any) => run.quarantineReason).sort()).toEqual([
 			"duplicate_session",
 			"recovery_expired",
+		]);
+	});
+
+	it("quarantines ambiguous Runner admission out of boot recovery", () => {
+		const run: mod.ActiveRunRecord = {
+			runKey: "ambiguous-runner-opening",
+			osSessionId: "ambiguous-runner-session",
+			runnerId: "runner-one",
+			hostId: "runner-host-one",
+			promptEntryId: "opening-prompt",
+			prompt: "start",
+			cwd: "/runner/workspace",
+			mcpServers: [],
+			launchPhase: "launching",
+			startedAt: new Date().toISOString(),
+		};
+		mod.journalSet(run);
+		mod.journalQuarantine([
+			{ run, reason: "ambiguous_runner_launch", notify: false },
+		]);
+		expect(mod.activeRunRecords()).toEqual([]);
+		const quarantine = JSON.parse(
+			readFileSync(join(dir, "active-runs.quarantine.json"), "utf8"),
+		);
+		expect(Object.values(quarantine)).toMatchObject([
+			{
+				runKey: "ambiguous-runner-opening",
+				quarantineReason: "ambiguous_runner_launch",
+			},
 		]);
 	});
 


### PR DESCRIPTION
## Summary
- persist the opening prompt dispatch before emitting one fenced `creation_opening_turn` effect
- launch normal and recovered opening turns only from the durable effect executor
- settle `ready` or `failed` through the effect receipt before acknowledging the prompt dispatch
- adopt terminal receipts after a crash without launching the opening again
- preserve actor-owned create dispatches across run journaling and defer their boot recovery to the opening executor
- fence Runner adoption with a deterministic generation-derived host ID, journaled host/prompt identity, and durable prepared/launching/started/rejected state
- quarantine ambiguous Runner admission out of boot recovery while clearing proven preflight rejection
- let generic local recovery settle actor-owned openings without relaunch, while remote opening recovery stays executor-owned
- isolate long opening effects in a bounded pool so general outbox work cannot starve
- settle actor completion from the terminal event consumer before any backend generator can retire its owner journal
- persist and adopt abnormal-completion receipts when a backend ends without a terminal event
- reject `opening_dispatched` reductions that do not atomically emit the typed effect

The create-plan file remains a compatibility projection used to reconstruct the executor input after restart. Attachment staging and removal of that remaining authority are separate follow-up slices.

## Verification
- `bun test packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts packages/core/opensession-server/src/server/session-kernel/kernel.test.ts packages/core/opensession-server/src/server/session-kernel/ownership.test.ts packages/core/opensession-server/src/server/session-create-plan.test.ts` (140 tests, 1084 assertions)
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts` (408 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
