### PR TITLE
Repos: show durable setup progress and add local checkouts

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
@@ -3,9 +3,11 @@ import { Button } from "../ui/button";
 import { Field, Input } from "../ui/input";
 import { Modal } from "../ui/modal";
 import { Popover } from "../ui/popover";
+import { Segmented, SegmentedOption } from "../ui/segmented";
 import { Switch } from "../ui/switch";
 import { cn } from "../ui/cn";
 import { EmptyState, InlineAlert, LoadingState } from "../ui/state";
+import { Spinner } from "../ui/spinner";
 import {
 	SettingCard,
 	SettingRow,
@@ -46,9 +48,9 @@ import { Badge } from "../ui/badge";
 // token) the add flow browses the reachable repos; without one it falls back
 // to a manual owner/name entry. When the code.storage integration is
 // configured, its org's repos are offered in their own section alongside
-// GitHub. Registering clones the repo server-side, so an add can take tens of
-// seconds — the row keeps a working state the whole way and nothing here
-// times out early.
+// GitHub. Remote registration clones server-side, so an add can take tens of
+// seconds. Pending state stays owned by the settings panel so it remains
+// visible if the dialog closes. Existing local checkouts register in place.
 
 export function ReposSection({
 	repos,
@@ -65,6 +67,8 @@ export function ReposSection({
 	compact?: boolean;
 }) {
 	const [pickerOpen, setPickerOpen] = useState(false);
+	const [pendingRepo, setPendingRepo] = useState<PendingRepo | null>(null);
+	const [pickerError, setPickerError] = useState<string | null>(null);
 	// Focused when the picker opens, so a long list is one keystroke from
 	// being filtered. Only one of the picker's two inputs renders at a time.
 	const pickerInput = useRef<HTMLInputElement>(null);
@@ -96,10 +100,15 @@ export function ReposSection({
 				actions={
 					<Button
 						size="sm"
-						icon={<IconPlus size={16} />}
+						icon={pendingRepo ? <Spinner /> : <IconPlus size={16} />}
+						disabled={pendingRepo !== null}
 						onClick={() => setPickerOpen(true)}
 					>
-						Add repository
+						{pendingRepo
+							? pendingRepo.action === "clone"
+								? "Cloning…"
+								: "Registering…"
+							: "Add repository"}
 					</Button>
 				}
 			>
@@ -112,13 +121,23 @@ export function ReposSection({
 			{/* On top rather than inline: the picker is a list of its own, and
 			    pushing the registered repos down the page to browse a second
 			    list made the two read as one. Adding stays a detour. */}
+			{pickerError && !pickerOpen && (
+				<InlineAlert className="mb-3">{pickerError}</InlineAlert>
+			)}
 			<Modal.Root open={pickerOpen} onOpenChange={setPickerOpen}>
 				<Modal.Content widthClassName="max-w-[34rem]" initialFocus={pickerInput}>
 					<Modal.Header
 						title="Add repository"
-						description="Clone a repository onto the server so sessions can work in it."
+						description="Clone a remote repository or register a Git checkout already on the server."
 					/>
-					<AddRepoPicker inputRef={pickerInput} onAdded={onChanged} />
+					<AddRepoPicker
+						inputRef={pickerInput}
+						onAdded={onChanged}
+						pendingRepo={pendingRepo}
+						onPendingChange={setPendingRepo}
+						error={pickerError}
+						setError={setPickerError}
+					/>
 				</Modal.Content>
 			</Modal.Root>
 			<SettingCard>
@@ -159,9 +178,10 @@ export function ReposSection({
 				)}
 			</SettingCard>
 			<SettingsHint>
-				Registering clones the repo onto the server. Code sessions use isolated
-				worktrees by default. Commit <code>.agents/</code> scripts to provision those
-				worktrees and boot previews. See docs/repo-lifecycle.md.
+				Remote repositories are cloned onto the server. Local folders stay where
+				they are. Code sessions use isolated worktrees by default. New repos are
+				usable right away with no restart. Commit <code>.agents/</code> scripts to
+				provision those worktrees and boot previews. See docs/repo-lifecycle.md.
 			</SettingsHint>
 		</>
 	);
@@ -568,6 +588,19 @@ interface CsBrowseResult {
 }
 
 type RepoSource = "github" | "codestorage";
+type AddRepoMode = "remote" | "local";
+
+interface PendingRepo {
+	label: string;
+	action: "clone" | "register";
+}
+
+interface RepoRegistration {
+	pending: PendingRepo;
+	json: Record<string, string>;
+	successMessage: string;
+	onRegistered?: () => void;
+}
 
 function filterRepos(repos: BrowseRepo[], filter: string): BrowseRepo[] {
 	const q = filter.trim().toLowerCase();
@@ -582,14 +615,10 @@ function filterRepos(repos: BrowseRepo[], filter: string): BrowseRepo[] {
 function RepoPickRow({
 	repo,
 	registered,
-	working,
-	disabled,
 	onAdd,
 }: {
 	repo: BrowseRepo;
 	registered: boolean;
-	working: boolean;
-	disabled: boolean;
 	onAdd: () => void;
 }) {
 	return (
@@ -614,10 +643,10 @@ function RepoPickRow({
 			<Button
 				size="sm"
 				variant={registered ? "ghost" : "default"}
-				disabled={registered || disabled}
+				disabled={registered}
 				onClick={onAdd}
 			>
-				{registered ? "Added" : working ? "Cloning…" : "Add"}
+				{registered ? "Added" : "Add"}
 			</Button>
 		</div>
 	);
@@ -626,11 +655,145 @@ function RepoPickRow({
 function AddRepoPicker({
 	inputRef,
 	onAdded,
+	pendingRepo,
+	onPendingChange,
+	error,
+	setError,
 }: {
 	/** Focused once the list resolves. Which input exists depends on whether
 	 *  there's a credential to browse with, so both branches take it. */
 	inputRef?: React.RefObject<HTMLInputElement | null>;
 	onAdded: () => void | Promise<void>;
+	pendingRepo: PendingRepo | null;
+	onPendingChange: (pending: PendingRepo | null) => void;
+	error: string | null;
+	setError: (error: string | null) => void;
+}) {
+	const [mode, setMode] = useState<AddRepoMode>("remote");
+	const [localPath, setLocalPath] = useState("");
+
+	useEffect(() => {
+		if (!pendingRepo && mode === "local") inputRef?.current?.focus();
+	}, [mode, pendingRepo, inputRef]);
+
+	async function registerRepo(input: RepoRegistration): Promise<void> {
+		if (pendingRepo) return;
+		onPendingChange(input.pending);
+		setError(null);
+		try {
+			// Remote clones can take tens of seconds. Keep the request unbounded and
+			// the panel-level pending state visible until registration and refresh end.
+			await setupRequest("/api/setup/repos", {
+				method: "POST",
+				json: input.json,
+			});
+			input.onRegistered?.();
+			toast(input.successMessage);
+			notifyReposChanged();
+			await onAdded();
+		} catch (cause) {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		} finally {
+			onPendingChange(null);
+		}
+	}
+
+	async function addLocalRepo() {
+		const path = localPath.trim();
+		if (!path) return;
+		await registerRepo({
+			pending: { label: path, action: "register" },
+			json: { source: "local", path },
+			successMessage: "Repository registered",
+			onRegistered: () => setLocalPath(""),
+		});
+	}
+
+	return (
+		// No surface of its own: the dialog is already the card this sits on.
+		<div>
+			{pendingRepo && (
+				<div className="flex min-h-[240px] flex-col items-center justify-center text-center">
+					<LoadingState className="max-w-full [&>div]:max-w-full">
+						<span className="max-w-full break-all">
+							{pendingRepo.action === "clone" ? "Cloning " : "Registering "}
+							{pendingRepo.label}…
+						</span>
+					</LoadingState>
+					<p className="m-0 mt-2 max-w-[38ch] text-supporting leading-relaxed text-dim">
+						You can close this window. The repository will appear here when it is
+						ready.
+					</p>
+				</div>
+			)}
+			<div className={pendingRepo ? "hidden" : undefined}>
+				<Segmented
+					className="mb-3 w-full"
+					label="Repository source"
+					value={mode}
+					onValueChange={(value) => {
+						setMode(value as AddRepoMode);
+						setError(null);
+					}}
+				>
+					<SegmentedOption value="remote" className="flex-1 justify-center">
+						Remote
+					</SegmentedOption>
+					<SegmentedOption value="local" className="flex-1 justify-center">
+						Local folder
+					</SegmentedOption>
+				</Segmented>
+				{mode === "local" && (
+					<>
+						<div className="text-supporting leading-relaxed text-dim">
+							Use a Git checkout on the server with a working origin remote.
+						</div>
+						<div className="mt-2.5 flex items-center gap-2 phone:flex-col phone:items-stretch">
+							<input
+								ref={inputRef}
+								className={cn(settingsInputClass, "min-w-0 flex-1 font-mono")}
+								value={localPath}
+								onChange={(e) => setLocalPath(e.target.value)}
+								placeholder="/srv/repos/repository"
+								aria-label="Absolute repository path"
+								autoCapitalize="none"
+								autoCorrect="off"
+								spellCheck={false}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" && localPath.trim()) addLocalRepo();
+								}}
+							/>
+							<Button
+								variant="primary"
+								disabled={!localPath.trim()}
+								onClick={addLocalRepo}
+							>
+								Add
+							</Button>
+						</div>
+					</>
+				)}
+				<div className={mode === "remote" ? undefined : "hidden"}>
+					<RemoteRepoPicker
+						active={mode === "remote" && !pendingRepo}
+						inputRef={inputRef}
+						registerRepo={registerRepo}
+					/>
+				</div>
+			</div>
+			{error && <InlineAlert className="mt-2.5">{error}</InlineAlert>}
+		</div>
+	);
+}
+
+function RemoteRepoPicker({
+	active,
+	inputRef,
+	registerRepo,
+}: {
+	active: boolean;
+	inputRef?: React.RefObject<HTMLInputElement | null>;
+	registerRepo: (input: RepoRegistration) => Promise<void>;
 }) {
 	const [browse, setBrowse] = useState<BrowseResult | null>(null);
 	const [browseFailed, setBrowseFailed] = useState(false);
@@ -638,79 +801,62 @@ function AddRepoPicker({
 	// answers; an unconfigured integration answers `source: null` (no section).
 	const [csBrowse, setCsBrowse] = useState<CsBrowseResult | null>(null);
 	// Configured-but-failing (bad key path, API outage): the route answers 502
-	// with the server's error — distinct from "not configured", which hides the
-	// section entirely.
+	// with the server's error, unlike the unconfigured 200 response.
 	const [csError, setCsError] = useState<string | null>(null);
 	const [filter, setFilter] = useState("");
-	const [addingRepo, setAddingRepo] = useState<string | null>(null);
 	const [added, setAdded] = useState<ReadonlySet<string>>(new Set());
-	const [error, setError] = useState<string | null>(null);
 	const [manual, setManual] = useState("");
 
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
 			await (async () => {
-const body = await setupRequest<BrowseResult>("/api/setup/github/repos");
+				const body = await setupRequest<BrowseResult>("/api/setup/github/repos");
 				if (!cancelled) setBrowse(body);
-})().catch(async () => {
-if (!cancelled) setBrowseFailed(true);
-});
+			})().catch(async () => {
+				if (!cancelled) setBrowseFailed(true);
+			});
 		})();
 		(async () => {
 			await (async () => {
-const body = await setupRequest<CsBrowseResult>(
+				const body = await setupRequest<CsBrowseResult>(
 					"/api/setup/codestorage/repos",
 				);
 				if (!cancelled) setCsBrowse(body);
-})().catch(async (e: any) => {
-// A throw means configured-but-failing (the route answers 200 with
+			})().catch(async (e: any) => {
+				// A throw means configured-but-failing (the route answers 200 with
 				// source: null when unconfigured) — surface the server's error
 				// instead of silently hiding the section. GitHub is unaffected.
 				if (!cancelled)
 					setCsError(e?.message || "Couldn’t reach code.storage right now.");
-});
+			});
 		})();
 		return () => {
 			cancelled = true;
 		};
 	}, []);
 
-	// The list arrives after the dialog has opened, so the dialog's initial
-	// focus finds no field to land on. Focus it the moment it exists.
+	// The list arrives after the dialog opens, so initialFocus has no field yet.
 	useEffect(() => {
-		if (browse || browseFailed) inputRef?.current?.focus();
-	}, [browse, browseFailed, inputRef]);
+		if (active && (browse || browseFailed)) inputRef?.current?.focus();
+	}, [active, browse, browseFailed, inputRef]);
+
+	async function addRepo(fullName: string, source: RepoSource = "github") {
+		const key = `${source}:${fullName}`;
+		await registerRepo({
+			pending: { label: fullName, action: "clone" },
+			json: source === "codestorage" ? { source, fullName } : { fullName },
+			successMessage: `${fullName} registered`,
+			onRegistered: () => {
+				setAdded((previous) => new Set(previous).add(key));
+				setManual("");
+			},
+		});
+	}
 
 	const filtered = (filterRepos(browse?.repos ?? [], filter));
 	const csFiltered = (filterRepos(csBrowse?.repos ?? [], filter));
 	const csConfigured = csBrowse?.source === "org";
-
-	async function addRepo(fullName: string, source: RepoSource = "github") {
-		if (addingRepo) return;
-		const key = `${source}:${fullName}`;
-		setAddingRepo(key);
-		setError(null);
-		await (async () => {
-// Registering clones server-side — can take tens of seconds. No client
-			// timeout; the button holds its working state until the server answers.
-			// code.storage repos reuse the same submit shape with a source marker.
-			await setupRequest("/api/setup/repos", {
-				method: "POST",
-				json:
-					source === "codestorage" ? { source, fullName } : { fullName },
-			});
-			setAdded((prev) => new Set(prev).add(key));
-			setManual("");
-			toast(`${fullName} registered`);
-			notifyReposChanged();
-			await onAdded();
-})().catch(async (e: any) => {
-setError(e.message);
-}).finally(async () => {
-setAddingRepo(null);
-});
-	}
 
 	const manualValid = /^[^/\s]+\/[^/\s]+$/.test(manual.trim());
 	const totalListed =
@@ -718,8 +864,7 @@ setAddingRepo(null);
 		(csConfigured ? (csBrowse?.repos.length ?? 0) : 0);
 
 	return (
-		// No surface of its own: the dialog is already the card this sits on.
-		<div>
+		<>
 			{!browse && !browseFailed ? (
 				<LoadingState placement="row">Looking up your GitHub repositories…</LoadingState>
 			) : browse && browse.source !== null ? (
@@ -748,9 +893,9 @@ setAddingRepo(null);
 								<RepoPickRow
 									key={r.fullName}
 									repo={r}
-									registered={r.registered || added.has(`github:${r.fullName}`)}
-									working={addingRepo === `github:${r.fullName}`}
-									disabled={addingRepo !== null}
+									registered={
+										r.registered || added.has(`github:${r.fullName}`)
+									}
 									onAdd={() => addRepo(r.fullName)}
 								/>
 							))
@@ -787,16 +932,16 @@ setAddingRepo(null);
 							autoCapitalize="none"
 							spellCheck={false}
 							onKeyDown={(e) => {
-								if (e.key === "Enter" && manualValid && !addingRepo)
+								if (e.key === "Enter" && manualValid)
 									addRepo(manual.trim());
 							}}
 						/>
 						<Button
 							variant="primary"
-							disabled={!manualValid || addingRepo !== null}
+							disabled={!manualValid}
 							onClick={() => addRepo(manual.trim())}
 						>
-							{addingRepo ? "Cloning…" : "Add"}
+							Add
 						</Button>
 					</div>
 				</>
@@ -826,8 +971,6 @@ setAddingRepo(null);
 										registered={
 											r.registered || added.has(`codestorage:${r.fullName}`)
 										}
-										working={addingRepo === `codestorage:${r.fullName}`}
-										disabled={addingRepo !== null}
 										onAdd={() => addRepo(r.fullName, "codestorage")}
 									/>
 								))
@@ -836,7 +979,6 @@ setAddingRepo(null);
 					)}
 				</>
 			)}
-			{error && <InlineAlert className="mt-2.5">{error}</InlineAlert>}
-		</div>
+		</>
 	);
 }

--- a/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
@@ -693,9 +693,8 @@ function AddRepoPicker({
 			await onAdded();
 		} catch (cause) {
 			setError(cause instanceof Error ? cause.message : String(cause));
-		} finally {
-			onPendingChange(null);
 		}
+		onPendingChange(null);
 	}
 
 	async function addLocalRepo() {

--- a/packages/core/opensession-server/src/server/routes/repo-inspection.test.ts
+++ b/packages/core/opensession-server/src/server/routes/repo-inspection.test.ts
@@ -2,11 +2,34 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { inspectRepo, repoHasBranch } from "./repo-inspection";
+import {
+  inspectRepo,
+  normalizeRepoOrigin,
+  repoHasBranch,
+  repoOriginIdentity,
+} from "./repo-inspection";
 
 function git(...args: string[]): void {
   expect(Bun.spawnSync(["git", ...args]).exitCode).toBe(0);
 }
+
+describe("normalizeRepoOrigin", () => {
+  test("treats HTTPS and scp-style remotes as the same repository", () => {
+    expect(normalizeRepoOrigin("https://gitlab.com/acme/widget.git")).toBe(
+      "gitlab.com/acme/widget",
+    );
+    expect(normalizeRepoOrigin("git@gitlab.com:acme/widget.git")).toBe(
+      "gitlab.com/acme/widget",
+    );
+    expect(normalizeRepoOrigin("https://token@gitlab.com/acme/widget.git")).toBe(
+      "gitlab.com/acme/widget",
+    );
+  });
+
+  test("ignores registered checkouts that are unavailable", async () => {
+    await expect(repoOriginIdentity("/missing/repository")).resolves.toBeNull();
+  });
+});
 
 describe("inspectRepo", () => {
   test("uses the remote HEAD when the local origin/HEAD is stale", async () => {

--- a/packages/core/opensession-server/src/server/routes/repo-inspection.test.ts
+++ b/packages/core/opensession-server/src/server/routes/repo-inspection.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import {
   inspectRepo,
   normalizeRepoOrigin,
@@ -24,6 +31,22 @@ describe("normalizeRepoOrigin", () => {
     expect(normalizeRepoOrigin("https://token@gitlab.com/acme/widget.git")).toBe(
       "gitlab.com/acme/widget",
     );
+  });
+
+  test("normalizes local paths, file URLs, and resolvable symlinks", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-origin-identity-"));
+    try {
+      const remote = join(dir, "widget.git");
+      const symlink = join(dir, "widget-link.git");
+      mkdirSync(remote);
+      symlinkSync(remote, symlink);
+      const expected = normalizeRepoOrigin(remote);
+
+      expect(normalizeRepoOrigin(pathToFileURL(remote).href)).toBe(expected);
+      expect(normalizeRepoOrigin(symlink)).toBe(expected);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("ignores registered checkouts that are unavailable", async () => {

--- a/packages/core/opensession-server/src/server/routes/repo-inspection.ts
+++ b/packages/core/opensession-server/src/server/routes/repo-inspection.ts
@@ -22,6 +22,32 @@ export function repoIdFromName(input: string): string {
   return id || "repo";
 }
 
+function remotePathIdentity(path: string): string {
+  return path.replace(/^\/+/, "").replace(/[\\/]+$/, "").replace(/\.git$/i, "");
+}
+
+/** Protocol- and credential-free origin identity used only for duplicate checks. */
+export function normalizeRepoOrigin(remote: string): string {
+  const value = remote.trim();
+  if (!value) return "";
+
+  if (value.includes("://")) {
+    try {
+      const url = new URL(value);
+      if (url.hostname) {
+        const host = `${url.hostname.toLowerCase()}${url.port ? `:${url.port}` : ""}`;
+        return `${host}/${remotePathIdentity(url.pathname)}`;
+      }
+    } catch {
+      // Fall through to Git's scp-like and local-path forms.
+    }
+  }
+
+  const scp = value.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
+  if (scp) return `${scp[1].toLowerCase()}/${remotePathIdentity(scp[2])}`;
+  return remotePathIdentity(value);
+}
+
 function githubRepoFromRemote(remote: string): string | undefined {
   const normalized = remote.trim().replace(/\.git$/i, "");
   const match = normalized.match(/^(?:https?:\/\/github\.com\/|ssh:\/\/git@github\.com\/|git@github\.com:)([^/]+\/[^/]+)$/i);
@@ -38,9 +64,20 @@ async function hasCommit(path: string, ref: string): Promise<boolean> {
   ).exitCode === 0;
 }
 
+export async function repoOriginIdentity(repoPath: string): Promise<string | null> {
+  try {
+    const origin = await git(["remote", "get-url", "origin"], repoPath);
+    if (origin.exitCode !== 0 || !origin.stdout) return null;
+    return normalizeRepoOrigin(origin.stdout) || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function inspectRepo(repoPath: string): Promise<{
   path: string;
   defaultBranch: string;
+  originIdentity: string;
   ghRepo?: string;
   cs?: { org: string; repoId: string };
 }> {
@@ -88,6 +125,7 @@ export async function inspectRepo(repoPath: string): Promise<{
   return {
     path,
     defaultBranch,
+    originIdentity: normalizeRepoOrigin(origin.stdout),
     ghRepo: githubRepoFromRemote(origin.stdout),
     ...(cs ? { cs } : {}),
   };

--- a/packages/core/opensession-server/src/server/routes/repo-inspection.ts
+++ b/packages/core/opensession-server/src/server/routes/repo-inspection.ts
@@ -28,6 +28,16 @@ function githubRepoFromRemote(remote: string): string | undefined {
   return match?.[1];
 }
 
+function defaultBranchFromLsRemote(output: string): string | undefined {
+  return output.match(/^ref:\s+refs\/heads\/(.+)\s+HEAD$/m)?.[1];
+}
+
+async function hasCommit(path: string, ref: string): Promise<boolean> {
+  return (
+    await git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], path)
+  ).exitCode === 0;
+}
+
 export async function inspectRepo(repoPath: string): Promise<{
   path: string;
   defaultBranch: string;
@@ -37,18 +47,48 @@ export async function inspectRepo(repoPath: string): Promise<{
   const root = await git(["rev-parse", "--show-toplevel"], repoPath);
   if (root.exitCode !== 0 || !root.stdout) throw new Error("Path is not a Git repository");
   const path = realpathSync(root.stdout);
-  const remoteSymref = await git(["ls-remote", "--symref", "origin", "HEAD"], path);
-  const remoteDefault = remoteSymref.stdout.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m)?.[1];
-  const remoteHead = await git(["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], path);
-  const current = await git(["branch", "--show-current"], path);
-  const defaultBranch = remoteDefault || remoteHead.stdout.replace(/^origin\//, "") || current.stdout;
-  if (!defaultBranch) throw new Error("Repository must have a checked-out branch");
-  const origin = await git(["remote", "get-url", "origin"], path);
-  const cs = origin.exitCode === 0 ? parseCsRemote(origin.stdout) : null;
+  const [origin, remoteSymref, remoteHead] = await Promise.all([
+    git(["remote", "get-url", "origin"], path),
+    git(["ls-remote", "--symref", "origin", "HEAD"], path),
+    git(
+      ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+      path,
+    ),
+  ]);
+  if (origin.exitCode !== 0 || !origin.stdout) {
+    throw new Error("Repository must have an origin remote");
+  }
+
+  const defaultBranch =
+    defaultBranchFromLsRemote(remoteSymref.stdout) ||
+    remoteHead.stdout.replace(/^origin\//, "");
+  if (!defaultBranch) {
+    throw new Error(
+      "Could not determine origin's default branch. Fetch the repository and set origin/HEAD, then try again",
+    );
+  }
+
+  const remoteRef = `refs/remotes/origin/${defaultBranch}`;
+  if (!(await hasCommit(path, remoteRef))) {
+    await git(
+      [
+        "fetch",
+        "--quiet",
+        "origin",
+        `+refs/heads/${defaultBranch}:${remoteRef}`,
+      ],
+      path,
+    );
+  }
+  if (!(await hasCommit(path, remoteRef))) {
+    throw new Error(`Repository must have a commit on origin/${defaultBranch}`);
+  }
+
+  const cs = parseCsRemote(origin.stdout);
   return {
     path,
     defaultBranch,
-    ...(origin.exitCode === 0 ? { ghRepo: githubRepoFromRemote(origin.stdout) } : {}),
+    ghRepo: githubRepoFromRemote(origin.stdout),
     ...(cs ? { cs } : {}),
   };
 }

--- a/packages/core/opensession-server/src/server/routes/repo-inspection.ts
+++ b/packages/core/opensession-server/src/server/routes/repo-inspection.ts
@@ -1,5 +1,6 @@
-import { basename } from "path";
 import { realpathSync } from "fs";
+import { basename, isAbsolute, resolve } from "path";
+import { fileURLToPath } from "url";
 import { parseCsRemote } from "../codestorage/remote";
 
 async function git(args: string[], cwd?: string): Promise<{ exitCode: number; stdout: string }> {
@@ -26,14 +27,28 @@ function remotePathIdentity(path: string): string {
   return path.replace(/^\/+/, "").replace(/[\\/]+$/, "").replace(/\.git$/i, "");
 }
 
+function localOriginIdentity(path: string, cwd?: string): string {
+  const resolved = isAbsolute(path) ? path : resolve(cwd || process.cwd(), path);
+  let canonical = resolved;
+  try {
+    canonical = realpathSync(resolved);
+  } catch {
+    // Missing remotes still get a stable absolute identity.
+  }
+  return `file:${canonical.replace(/[\\/]+$/, "").replace(/\.git$/i, "")}`;
+}
+
 /** Protocol- and credential-free origin identity used only for duplicate checks. */
-export function normalizeRepoOrigin(remote: string): string {
+export function normalizeRepoOrigin(remote: string, cwd?: string): string {
   const value = remote.trim();
   if (!value) return "";
 
   if (value.includes("://")) {
     try {
       const url = new URL(value);
+      if (url.protocol === "file:") {
+        return localOriginIdentity(fileURLToPath(url), cwd);
+      }
       if (url.hostname) {
         const host = `${url.hostname.toLowerCase()}${url.port ? `:${url.port}` : ""}`;
         return `${host}/${remotePathIdentity(url.pathname)}`;
@@ -45,7 +60,7 @@ export function normalizeRepoOrigin(remote: string): string {
 
   const scp = value.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
   if (scp) return `${scp[1].toLowerCase()}/${remotePathIdentity(scp[2])}`;
-  return remotePathIdentity(value);
+  return localOriginIdentity(value, cwd);
 }
 
 function githubRepoFromRemote(remote: string): string | undefined {
@@ -68,7 +83,7 @@ export async function repoOriginIdentity(repoPath: string): Promise<string | nul
   try {
     const origin = await git(["remote", "get-url", "origin"], repoPath);
     if (origin.exitCode !== 0 || !origin.stdout) return null;
-    return normalizeRepoOrigin(origin.stdout) || null;
+    return normalizeRepoOrigin(origin.stdout, repoPath) || null;
   } catch {
     return null;
   }
@@ -125,7 +140,7 @@ export async function inspectRepo(repoPath: string): Promise<{
   return {
     path,
     defaultBranch,
-    originIdentity: normalizeRepoOrigin(origin.stdout),
+    originIdentity: normalizeRepoOrigin(origin.stdout, path),
     ghRepo: githubRepoFromRemote(origin.stdout),
     ...(cs ? { cs } : {}),
   };

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -474,6 +474,7 @@ describe("adoptExistingCheckout", () => {
 
 const savedConfig = process.env.OPENSESSION_CONFIG;
 const savedWorktreesDir = process.env.OPENSESSION_WORKTREES_DIR;
+const savedHome = process.env.HOME;
 const localRoots: string[] = [];
 
 afterEach(() => {
@@ -481,6 +482,8 @@ afterEach(() => {
   else process.env.OPENSESSION_CONFIG = savedConfig;
   if (savedWorktreesDir === undefined) delete process.env.OPENSESSION_WORKTREES_DIR;
   else process.env.OPENSESSION_WORKTREES_DIR = savedWorktreesDir;
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
   for (const dir of localRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -677,6 +680,61 @@ describe("local repository registration", () => {
     expect(response?.status).toBe(409);
     expect(await response?.json()).toEqual({
       error: "Worktree prefix already registered: prefix-target",
+    });
+  });
+
+  test.serial("rejects another checkout with the same generic origin", async () => {
+    const root = localRoot();
+    const registeredCheckout = createRemoteCheckout(root, "registered", "main");
+    const duplicateCheckout = join(root, "duplicate");
+    git(["clone", join(root, "registered.git"), duplicateCheckout]);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      repos: {
+        existing: {
+          repo: registeredCheckout,
+          wtPrefix: "existing",
+          defaultBranch: "main",
+        },
+      },
+    }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: duplicateCheckout }),
+    );
+
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: "Repository origin is already registered: existing",
+    });
+  });
+
+  test.serial("rejects a remote registration whose checkout path is already owned", async () => {
+    const root = localRoot();
+    const checkouts = join(root, "checkouts");
+    mkdirSync(checkouts, { recursive: true });
+    const checkout = createRemoteCheckout(checkouts, "widget", "main");
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      repos: {
+        legacy: {
+          repo: checkout,
+          wtPrefix: "legacy",
+          defaultBranch: "main",
+        },
+      },
+    }));
+    process.env.HOME = root;
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ fullName: "acme/widget" }),
+    );
+
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: `Repository is already registered: ${realpathSync(checkout)}`,
     });
   });
 

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -12,6 +12,7 @@ import {
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import { createWorktree } from "../worktree";
 import {
   adoptExistingCheckout,
@@ -683,11 +684,13 @@ describe("local repository registration", () => {
     });
   });
 
-  test.serial("rejects another checkout with the same generic origin", async () => {
+  test.serial("rejects the same local origin through a file URL", async () => {
     const root = localRoot();
     const registeredCheckout = createRemoteCheckout(root, "registered", "main");
+    const remote = join(root, "registered.git");
     const duplicateCheckout = join(root, "duplicate");
-    git(["clone", join(root, "registered.git"), duplicateCheckout]);
+    git(["clone", remote, duplicateCheckout]);
+    git(["remote", "set-url", "origin", pathToFileURL(remote).href], duplicateCheckout);
     const configPath = join(root, "config.json");
     writeFileSync(configPath, JSON.stringify({
       repos: {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -1,8 +1,18 @@
 import { $ } from "bun";
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { createWorktree } from "../worktree";
 import {
   adoptExistingCheckout,
   githubCredentialHelperCommand,
@@ -12,6 +22,7 @@ import {
   validGithubFullName,
   listReposViaAppInstallation,
 } from "./setup-repos";
+import type { RouteContext } from "./context";
 
 const originalConfig = process.env.OPENSESSION_CONFIG;
 const tempDirs: string[] = [];
@@ -401,6 +412,8 @@ describe("adoptExistingCheckout", () => {
     await $`git -C ${dir} init -q -b main`.quiet();
     await $`git -C ${dir} remote add origin ${origin}`.quiet();
     await $`git -C ${dir} -c user.email=t@e -c user.name=t commit -q --allow-empty -m init`.quiet();
+    await $`git -C ${dir} update-ref refs/remotes/origin/main HEAD`.quiet();
+    await $`git -C ${dir} symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main`.quiet();
     return dir;
   }
 
@@ -456,5 +469,274 @@ describe("adoptExistingCheckout", () => {
     expect(adoptExistingCheckout(dest, () => true)).rejects.toThrow(
       /Clone destination already exists/,
     );
+  });
+});
+
+const savedConfig = process.env.OPENSESSION_CONFIG;
+const savedWorktreesDir = process.env.OPENSESSION_WORKTREES_DIR;
+const localRoots: string[] = [];
+
+afterEach(() => {
+  if (savedConfig === undefined) delete process.env.OPENSESSION_CONFIG;
+  else process.env.OPENSESSION_CONFIG = savedConfig;
+  if (savedWorktreesDir === undefined) delete process.env.OPENSESSION_WORKTREES_DIR;
+  else process.env.OPENSESSION_WORKTREES_DIR = savedWorktreesDir;
+  for (const dir of localRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function localRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "opensession-local-repo-"));
+  localRoots.push(root);
+  return root;
+}
+
+function gitRaw(args: string[], cwd?: string): string {
+  const result = Bun.spawnSync(["git", ...args], {
+    ...(cwd ? { cwd } : {}),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString() || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.toString();
+}
+
+function git(args: string[], cwd?: string): string {
+  return gitRaw(args, cwd).trim();
+}
+
+function createRemoteCheckout(
+  root: string,
+  name = "existing-checkout",
+  defaultBranch = "trunk",
+): string {
+  const remote = join(root, `${name}.git`);
+  const checkout = join(root, name);
+  git(["init", "--bare", "-b", defaultBranch, remote]);
+  git(["init", "-b", defaultBranch, checkout]);
+  git(["config", "user.name", "Open Session test"], checkout);
+  git(["config", "user.email", "test@opensession.dev"], checkout);
+  writeFileSync(join(checkout, "README.md"), `${name}\n`);
+  git(["add", "README.md"], checkout);
+  git(["commit", "-m", "Initial commit"], checkout);
+  git(["remote", "add", "origin", remote], checkout);
+  git(["push", "-u", "origin", defaultBranch], checkout);
+  git(["remote", "set-head", "origin", defaultBranch], checkout);
+  return checkout;
+}
+
+function postRepo(body: unknown): RouteContext {
+  const url = new URL("http://localhost/api/setup/repos");
+  return {
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    url,
+    path: url.pathname,
+    publicPrefix: "",
+  };
+}
+
+describe("local repository registration", () => {
+  test.serial("registers a usable checkout without cloning it", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({ repos: {} }));
+    process.env.OPENSESSION_CONFIG = configPath;
+    process.env.OPENSESSION_WORKTREES_DIR = join(root, "worktrees");
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(201);
+    expect(await response?.json()).toMatchObject({
+      id: "existing-checkout",
+      repo: realpathSync(checkout),
+      defaultBranch: "trunk",
+      default: true,
+    });
+    const worktree = await createWorktree("registered-worktree", "existing-checkout");
+    expect(existsSync(worktree)).toBe(true);
+    expect(git(["branch", "--show-current"], worktree)).toBe("registered-worktree");
+  });
+
+  test.serial("preserves the implicit built-in repository", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "local-project");
+    const configPath = join(root, "missing-config.json");
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(201);
+    const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(saved.repos.opensession).toMatchObject({
+      label: "Open Session",
+      sharedCheckout: true,
+      default: true,
+    });
+    expect(saved.repos["local-project"]).toMatchObject({
+      repo: realpathSync(checkout),
+      defaultBranch: "trunk",
+    });
+  });
+
+  test.serial("uses the remote default instead of the checked-out topic branch", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "topic-checkout", "main");
+    git(["switch", "-c", "topic"], checkout);
+    writeFileSync(join(checkout, "topic.txt"), "topic\n");
+    git(["add", "topic.txt"], checkout);
+    git(["commit", "-m", "Topic commit"], checkout);
+    git(["push", "-u", "origin", "topic"], checkout);
+    git(["remote", "set-head", "origin", "-d"], checkout);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({ repos: {} }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(201);
+    expect(await response?.json()).toMatchObject({ defaultBranch: "main" });
+  });
+
+  test.serial("rejects a repository without a usable origin", async () => {
+    const root = localRoot();
+    const checkout = join(root, "originless");
+    git(["init", "-b", "main", checkout]);
+    git(["config", "user.name", "Open Session test"], checkout);
+    git(["config", "user.email", "test@opensession.dev"], checkout);
+    writeFileSync(join(checkout, "README.md"), "originless\n");
+    git(["add", "README.md"], checkout);
+    git(["commit", "-m", "Initial commit"], checkout);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({ repos: {} }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error: "Repository must have an origin remote",
+    });
+  });
+
+  test.serial("rejects the same checkout through a symlink", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "duplicate-target");
+    const symlink = join(root, "checkout-link");
+    symlinkSync(checkout, symlink);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      repos: {
+        existing: { repo: symlink, wtPrefix: "existing", defaultBranch: "trunk" },
+      },
+    }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: `Repository is already registered: ${realpathSync(checkout)}`,
+    });
+  });
+
+  test.serial("rejects a duplicate worktree prefix", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "prefix-target");
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      repos: {
+        existing: {
+          repo: join(root, "different-checkout"),
+          wtPrefix: "prefix-target",
+          defaultBranch: "main",
+        },
+      },
+    }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(409);
+    expect(await response?.json()).toEqual({
+      error: "Worktree prefix already registered: prefix-target",
+    });
+  });
+
+  test.serial("configures a detected code.storage checkout", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "cs-checkout");
+    git(["remote", "set-url", "origin", "https://acme.code.storage/team/widget.git"], checkout);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      repos: {},
+      integrations: {
+        codeStorage: { org: "acme", privateKeyPath: join(root, "key.pem") },
+      },
+    }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(201);
+    expect(await response?.json()).toMatchObject({
+      host: "codestorage",
+      csRepo: "team/widget",
+    });
+    expect(
+      gitRaw([
+        "config",
+        "--get-all",
+        "credential.https://acme.code.storage.helper",
+      ], checkout).replace(/\n$/, "").split("\n"),
+    ).toEqual(["", expect.stringContaining("scripts/cs-credential.ts")]);
+  });
+
+  test.serial("does not overwrite a malformed repos config", async () => {
+    const root = localRoot();
+    const checkout = createRemoteCheckout(root, "malformed-config");
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, JSON.stringify({ repos: [] }));
+    process.env.OPENSESSION_CONFIG = configPath;
+
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: checkout }),
+    );
+
+    expect(response?.status).toBe(500);
+    expect(await response?.json()).toEqual({
+      error: "Config repos must contain a JSON object",
+    });
+    expect(JSON.parse(readFileSync(configPath, "utf-8"))).toEqual({ repos: [] });
+  });
+
+  test.serial("requires an absolute path", async () => {
+    const response = await handleSetupRepoRoutes(
+      postRepo({ source: "local", path: "relative/repo" }),
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error: "path must be an absolute path to a Git repository",
+    });
   });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -34,6 +34,7 @@ import { cloneCsCheckout, ensureCsCredentialHelper } from "../codestorage/remote
 import {
   persistRawConfig,
   rawConfig,
+  reposForMutation,
   repoSectionForMutation,
   withConfigMutationLock,
 } from "../config-mutation";

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -4,14 +4,22 @@
  *
  *   GET  /api/setup/github/repos: repos the instance's GitHub credential can
  *                                  see, for the registration picker.
- *   POST /api/setup/repos: clone `owner/name` and register it in config.repos.
+ *   POST /api/setup/repos: clone a remote or register an existing local checkout.
  *   PATCH /api/setup/repos/:id: change its default branch or worktree policy.
  */
 
 import { $ } from "bun";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { basename, isAbsolute, join } from "path";
 import { audit } from "../audit";
 import {
   codeStorageConfig,
@@ -21,11 +29,10 @@ import {
   type RepoSection,
 } from "../config";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
-import { cloneCsCheckout } from "../codestorage/remote";
+import { cloneCsCheckout, ensureCsCredentialHelper } from "../codestorage/remote";
 import {
   persistRawConfig,
   rawConfig,
-  reposForMutation,
   repoSectionForMutation,
   withConfigMutationLock,
 } from "../config-mutation";
@@ -354,6 +361,90 @@ function checkoutsRoot(): string {
   return `${homeDir()}/checkouts`;
 }
 
+function setupRepoError(message: string, status: number): Error {
+  const error = new Error(message);
+  (error as Error & { status: number }).status = status;
+  return error;
+}
+
+function statusForError(error: unknown, fallback = 500): number {
+  const status = (error as { status?: unknown } | null)?.status;
+  return typeof status === "number" ? status : fallback;
+}
+
+function canonicalRepoPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function sectionFromRepo(repo: Repo): RepoSection {
+  const { id: _id, ...section } = repo;
+  return section;
+}
+
+function assertRepoSlotAvailable(
+  id: string,
+  registered: Record<string, Repo>,
+): void {
+  if (registered[id]) {
+    throw setupRepoError(`Repository id already registered: ${id}`, 409);
+  }
+  if (Object.values(registered).some((repo) => repo.wtPrefix === id)) {
+    throw setupRepoError(`Worktree prefix already registered: ${id}`, 409);
+  }
+}
+
+/** Once config has an explicit `repos` object it becomes authoritative. Seed
+ *  it from the effective registry when the first repo is added so turning an
+ *  implicit built-in registry into an explicit one cannot remove that repo. */
+function repoSectionsForMutation(
+  config: Record<string, unknown>,
+  registered: Record<string, Repo>,
+): Record<string, RepoSection> {
+  if (config.repos === undefined) {
+    return Object.fromEntries(
+      Object.entries(registered).map(([id, repo]) => [id, sectionFromRepo(repo)]),
+    );
+  }
+  if (!config.repos || typeof config.repos !== "object" || Array.isArray(config.repos)) {
+    throw new Error("Config repos must contain a JSON object");
+  }
+  return { ...(config.repos as Record<string, RepoSection>) };
+}
+
+function persistRepoRegistration(input: {
+  id: string;
+  entry: RepoSection;
+  registered: Record<string, Repo>;
+  auditRepo: string;
+  adopted?: boolean;
+}): RepoSection & { id: string } {
+  const config = rawConfig();
+  const repos = repoSectionsForMutation(config, input.registered);
+  const entry: RepoSection = {
+    ...input.entry,
+    ...(Object.keys(input.registered).length === 0 ? { default: true } : {}),
+  };
+  repos[input.id] = entry;
+  config.repos = repos;
+  persistRawConfig(config);
+  // Registration changes the `registered` bit in both browse payloads. Do not
+  // serve a stale Add button when the picker reopens after a background clone.
+  repoListCache.clear();
+  csRepoListCache = null;
+  audit({
+    kind: "setup_repo_register",
+    repo: input.auditRepo,
+    id: input.id,
+    path: entry.repo,
+    ...(input.adopted ? { adopted: true } : {}),
+  });
+  return { id: input.id, ...entry };
+}
+
 async function configureGithubCredentialHelper(checkoutPath: string): Promise<void> {
   const helperKey = "credential.https://github.com.helper";
   await $`git -C ${checkoutPath} config --replace-all ${helperKey} ${""}`.quiet();
@@ -398,10 +489,14 @@ async function registerGithubRepo(input: {
 }): Promise<RepoSection & { id: string }> {
   const name = input.fullName.split("/")[1];
   const id = repoIdFromName(input.id?.trim() || name);
-  if (configuredRepos()[id]) {
-    const err = new Error(`Repository id already registered: ${id}`);
-    (err as any).status = 409;
-    throw err;
+  const registered = configuredRepos();
+  assertRepoSlotAvailable(id, registered);
+  if (
+    Object.values(registered).some(
+      (repo) => repo.ghRepo.toLowerCase() === input.fullName.toLowerCase(),
+    )
+  ) {
+    throw setupRepoError(`GitHub repository is already registered: ${input.fullName}`, 409);
   }
   const root = checkoutsRoot();
   const dest = `${root}/${id}`;
@@ -411,41 +506,124 @@ async function registerGithubRepo(input: {
   );
   mkdirSync(root, { recursive: true });
   try {
-    if (!adopted) await cloneGithubRepo(input.fullName, dest, input.credential?.env.GH_TOKEN);
-    // A private clone authenticated through a one-shot GIT_ASKPASS; the remote
-    // it leaves is tokenless, so wire the credential helper for future
-    // fetch/push. No-op for a public (tokenless) clone — the helper simply has
-    // nothing to answer with. An adopted checkout gets it too, so a checkout
-    // left by a previous install authenticates with the current credential.
+    if (!adopted) {
+      await cloneGithubRepo(input.fullName, dest, input.credential?.env.GH_TOKEN);
+    }
+    // A private clone authenticated through a one-shot GIT_ASKPASS leaves a
+    // tokenless remote. Wire the helper for future fetches and pushes, and
+    // refresh it on a checkout preserved from an earlier install.
     if (input.credential) await configureGithubCredentialHelper(dest);
     const inspected = adopted ?? (await inspectRepo(dest));
     const defaultBranch = await normalizeInspectedDefaultBranch(inspected.defaultBranch);
-    const config = rawConfig();
-    const repos = reposForMutation(config) as Record<string, RepoSection>;
-    const entry: RepoSection = {
-      label: name,
-      repo: inspected.path,
-      wtPrefix: id,
-      defaultBranch,
-      ghRepo: inspected.ghRepo || input.fullName,
-      ...(Object.keys(configuredRepos()).length === 0 ? { default: true } : {}),
-    };
-    repos[id] = entry;
-    config.repos = repos;
-    persistRawConfig(config);
-    audit({
-      kind: "setup_repo_register",
-      repo: input.fullName,
+    return persistRepoRegistration({
       id,
-      path: inspected.path,
-      ...(adopted ? { adopted: true } : {}),
+      registered,
+      auditRepo: input.fullName,
+      adopted: Boolean(adopted),
+      entry: {
+        label: name,
+        repo: inspected.path,
+        wtPrefix: id,
+        defaultBranch,
+        ghRepo: inspected.ghRepo || input.fullName,
+      },
     });
-    return { id, ...entry };
   } catch (error) {
     // Only clean up a checkout this call created. An adopted one predates us.
     if (!adopted) rmSync(dest, { recursive: true, force: true });
     throw error;
   }
+}
+
+async function inspectLocalRepo(input: {
+  path: string;
+  id?: string;
+}): Promise<{ inspected: InspectedRepo; name: string; id: string }> {
+  try {
+    const inspected = await inspectRepo(input.path);
+    const name = basename(inspected.path);
+    return {
+      inspected,
+      name,
+      id: repoIdFromName(input.id?.trim() || name),
+    };
+  } catch (error) {
+    throw setupRepoError(
+      error instanceof Error ? error.message : String(error),
+      400,
+    );
+  }
+}
+
+async function registerLocalRepo(input: {
+  inspected: InspectedRepo;
+  name: string;
+  id: string;
+}): Promise<RepoSection & { id: string }> {
+  const { inspected, name, id } = input;
+  const registered = configuredRepos();
+  assertRepoSlotAvailable(id, registered);
+  if (
+    Object.values(registered).some(
+      (repo) => canonicalRepoPath(repo.repo) === inspected.path,
+    )
+  ) {
+    throw setupRepoError(`Repository is already registered: ${inspected.path}`, 409);
+  }
+  if (
+    inspected.ghRepo &&
+    Object.values(registered).some(
+      (repo) => repo.ghRepo.toLowerCase() === inspected.ghRepo!.toLowerCase(),
+    )
+  ) {
+    throw setupRepoError(`GitHub repository is already registered: ${inspected.ghRepo}`, 409);
+  }
+  if (
+    inspected.cs &&
+    Object.values(registered).some(
+      (repo) =>
+        repo.host === "codestorage" &&
+        repo.csRepo?.toLowerCase() === inspected.cs!.repoId.toLowerCase(),
+    )
+  ) {
+    throw setupRepoError(
+      `code.storage repository is already registered: ${inspected.cs.repoId}`,
+      409,
+    );
+  }
+  if (inspected.cs) {
+    const csConfig = codeStorageConfig();
+    if (!csConfig) {
+      throw setupRepoError(
+        "code.storage is not configured (integrations.codeStorage)",
+        400,
+      );
+    }
+    if (csConfig.org !== inspected.cs.org) {
+      throw setupRepoError(
+        `code.storage is configured for ${csConfig.org}, not ${inspected.cs.org}`,
+        400,
+      );
+    }
+    await ensureCsCredentialHelper(inspected.path, inspected.cs.org);
+  }
+
+  const defaultBranch = await normalizeInspectedDefaultBranch(inspected.defaultBranch);
+  return persistRepoRegistration({
+    id,
+    registered,
+    auditRepo: inspected.path,
+    entry: {
+      label: name,
+      repo: inspected.path,
+      wtPrefix: id,
+      defaultBranch,
+      ...(inspected.ghRepo ? { ghRepo: inspected.ghRepo } : {}),
+      ...(inspected.cs
+        ? { host: "codestorage" as const, csRepo: inspected.cs.repoId }
+        : {}),
+    },
+  });
 }
 
 /** code.storage repo path, e.g. "acme/widget" — only ever reaches an https
@@ -479,10 +657,16 @@ async function registerCodestorageRepo(input: {
   const csRepo = resolved.url || input.repoId;
   const name = csRepo.split("/").pop() || csRepo;
   const id = repoIdFromName(input.id?.trim() || name);
-  if (configuredRepos()[id]) {
-    const err = new Error(`Repository id already registered: ${id}`);
-    (err as any).status = 409;
-    throw err;
+  const registered = configuredRepos();
+  assertRepoSlotAvailable(id, registered);
+  if (
+    Object.values(registered).some(
+      (repo) =>
+        repo.host === "codestorage" &&
+        repo.csRepo?.toLowerCase() === csRepo.toLowerCase(),
+    )
+  ) {
+    throw setupRepoError(`code.storage repository is already registered: ${csRepo}`, 409);
   }
   if (
     Object.values(configuredRepos()).some(
@@ -502,36 +686,25 @@ async function registerCodestorageRepo(input: {
   mkdirSync(root, { recursive: true });
   try {
     // Clones with a short-lived JWT, persists the credential-free remote, and
-    // wires the URL-scoped credential helper for ambient git fetch/push. An
-    // adopted checkout already carries both (boot re-wires the helper for
-    // every configured code.storage repo).
+    // wires the URL-scoped credential helper for ambient git fetch/push. Boot
+    // rewires the helper on a checkout preserved from an earlier install.
     if (!adopted) await cloneCsCheckout(csRepo, dest);
     const inspected = adopted ?? (await inspectRepo(dest));
-    const defaultBranch = await normalizeInspectedDefaultBranch(
-      inspected.defaultBranch || resolved.default_branch || "main",
-    );
-    const config = rawConfig();
-    const repos = reposForMutation(config) as Record<string, RepoSection>;
-    const entry: RepoSection = {
-      label: name,
-      repo: inspected.path,
-      wtPrefix: id,
-      defaultBranch,
-      host: "codestorage",
-      csRepo,
-      ...(Object.keys(configuredRepos()).length === 0 ? { default: true } : {}),
-    };
-    repos[id] = entry;
-    config.repos = repos;
-    persistRawConfig(config);
-    audit({
-      kind: "setup_repo_register",
-      repo: csRepo,
+    const defaultBranch = await normalizeInspectedDefaultBranch(inspected.defaultBranch);
+    return persistRepoRegistration({
       id,
-      path: inspected.path,
-      ...(adopted ? { adopted: true } : {}),
+      registered,
+      auditRepo: csRepo,
+      adopted: Boolean(adopted),
+      entry: {
+        label: name,
+        repo: inspected.path,
+        wtPrefix: id,
+        defaultBranch,
+        host: "codestorage",
+        csRepo,
+      },
     });
-    return { id, ...entry };
   } catch (error) {
     if (!adopted) rmSync(dest, { recursive: true, force: true });
     throw error;
@@ -563,6 +736,24 @@ function migrateLegacySelfDev(
 }
 
 // ── Routes ───────────────────────────────────────────────────────────────────
+
+function registrationErrorResponse(error: unknown): Response {
+  return Response.json(
+    { error: error instanceof Error ? error.message : String(error) },
+    { status: statusForError(error) },
+  );
+}
+
+async function registrationResponse(
+  register: () => Promise<RepoSection & { id: string }>,
+): Promise<Response> {
+  try {
+    const repo = await withConfigMutationLock(register);
+    return Response.json(repo, { status: 201 });
+  } catch (error) {
+    return registrationErrorResponse(error);
+  }
+}
 
 export async function handleSetupRepoRoutes(
   ctx: RouteContext,
@@ -643,8 +834,31 @@ export async function handleSetupRepoRoutes(
       source?: unknown;
       fullName?: unknown;
       repoId?: unknown;
+      path?: unknown;
       id?: unknown;
     } | null;
+    if (body?.source === "local") {
+      if (typeof body.path !== "string" || !isAbsolute(body.path.trim())) {
+        return Response.json(
+          { error: "path must be an absolute path to a Git repository" },
+          { status: 400 },
+        );
+      }
+      const localPath = body.path.trim();
+      if (body?.id !== undefined && (typeof body.id !== "string" || !body.id.trim())) {
+        return Response.json({ error: "id must be a non-empty string" }, { status: 400 });
+      }
+      let inspected: Awaited<ReturnType<typeof inspectLocalRepo>>;
+      try {
+        inspected = await inspectLocalRepo({
+          path: localPath,
+          ...(typeof body.id === "string" ? { id: body.id } : {}),
+        });
+      } catch (error) {
+        return registrationErrorResponse(error);
+      }
+      return registrationResponse(() => registerLocalRepo(inspected));
+    }
     if (body?.source === "codestorage") {
       // Accepts the id under either key so the wizard can reuse its GitHub
       // submit shape ({fullName}) unchanged.
@@ -664,21 +878,12 @@ export async function handleSetupRepoRoutes(
           { status: 400 },
         );
       }
-      try {
-        const repo = await withConfigMutationLock(() =>
-          registerCodestorageRepo({
-            repoId,
-            ...(typeof body!.id === "string" ? { id: body!.id } : {}),
-          }),
-        );
-        return Response.json(repo, { status: 201 });
-      } catch (e) {
-        const status = (e as any)?.status === 409 ? 409 : 400;
-        return Response.json(
-          { error: e instanceof Error ? e.message : String(e) },
-          { status },
-        );
-      }
+      return registrationResponse(() =>
+        registerCodestorageRepo({
+          repoId,
+          ...(typeof body!.id === "string" ? { id: body!.id } : {}),
+        }),
+      );
     }
     if (!validGithubFullName(body?.fullName)) {
       return Response.json(
@@ -692,22 +897,13 @@ export async function handleSetupRepoRoutes(
     // The acting token lets a private clone succeed without ambient gh /
     // credential-helper auth; absent, the clone stays anonymous (public repos).
     const credential = actingGithubCredential(ctx);
-    try {
-      const repo = await withConfigMutationLock(() =>
-        registerGithubRepo({
-          fullName: body!.fullName as string,
-          ...(typeof body!.id === "string" ? { id: body!.id } : {}),
-          ...(credential ? { credential } : {}),
-        }),
-      );
-      return Response.json(repo, { status: 201 });
-    } catch (e) {
-      const status = (e as any)?.status === 409 ? 409 : 400;
-      return Response.json(
-        { error: e instanceof Error ? e.message : String(e) },
-        { status },
-      );
-    }
+    return registrationResponse(() =>
+      registerGithubRepo({
+        fullName: body!.fullName as string,
+        ...(typeof body!.id === "string" ? { id: body!.id } : {}),
+        ...(credential ? { credential } : {}),
+      }),
+    );
   }
 
   const updateMatch = path.match(/^\/api\/setup\/repos\/([^/]+)$/);

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -28,6 +28,7 @@ import {
   type Repo,
   type RepoSection,
 } from "../config";
+import { remoteUrl as csRemoteUrl } from "../codestorage/auth";
 import { getRepo as getCsRepo, listRepos as listCsRepos } from "../codestorage/client";
 import { cloneCsCheckout, ensureCsCredentialHelper } from "../codestorage/remote";
 import {
@@ -44,9 +45,11 @@ import { shellSafeDefaultBranch } from "../repo-branch";
 import type { RouteContext } from "./context";
 import {
   inspectRepo,
+  normalizeRepoOrigin,
   repoCurrentBranch,
   repoHasBranch,
   repoIdFromName,
+  repoOriginIdentity,
 } from "./repo-inspection";
 
 /** Strict: this value reaches a spawn argv (always array-spawned, never a
@@ -397,6 +400,37 @@ function assertRepoSlotAvailable(
   }
 }
 
+function assertRepoPathAvailable(path: string, registered: Record<string, Repo>): void {
+  const canonical = canonicalRepoPath(path);
+  if (
+    Object.values(registered).some(
+      (repo) => canonicalRepoPath(repo.repo) === canonical,
+    )
+  ) {
+    throw setupRepoError(`Repository is already registered: ${canonical}`, 409);
+  }
+}
+
+async function assertRepoOriginAvailable(
+  originIdentity: string,
+  registered: Record<string, Repo>,
+): Promise<void> {
+  if (!originIdentity) return;
+  const matches = await Promise.all(
+    Object.values(registered).map(async (repo) => ({
+      repo,
+      originIdentity: await repoOriginIdentity(repo.repo),
+    })),
+  );
+  const duplicate = matches.find((match) => match.originIdentity === originIdentity);
+  if (duplicate) {
+    throw setupRepoError(
+      `Repository origin is already registered: ${duplicate.repo.id}`,
+      409,
+    );
+  }
+}
+
 /** Once config has an explicit `repos` object it becomes authoritative. Seed
  *  it from the effective registry when the first repo is added so turning an
  *  implicit built-in registry into an explicit one cannot remove that repo. */
@@ -500,6 +534,11 @@ async function registerGithubRepo(input: {
   }
   const root = checkoutsRoot();
   const dest = `${root}/${id}`;
+  assertRepoPathAvailable(dest, registered);
+  await assertRepoOriginAvailable(
+    normalizeRepoOrigin(`https://github.com/${input.fullName}.git`),
+    registered,
+  );
   const adopted = await adoptExistingCheckout(
     dest,
     (i) => (i.ghRepo || "").toLowerCase() === input.fullName.toLowerCase(),
@@ -563,13 +602,7 @@ async function registerLocalRepo(input: {
   const { inspected, name, id } = input;
   const registered = configuredRepos();
   assertRepoSlotAvailable(id, registered);
-  if (
-    Object.values(registered).some(
-      (repo) => canonicalRepoPath(repo.repo) === inspected.path,
-    )
-  ) {
-    throw setupRepoError(`Repository is already registered: ${inspected.path}`, 409);
-  }
+  assertRepoPathAvailable(inspected.path, registered);
   if (
     inspected.ghRepo &&
     Object.values(registered).some(
@@ -591,6 +624,7 @@ async function registerLocalRepo(input: {
       409,
     );
   }
+  await assertRepoOriginAvailable(inspected.originIdentity, registered);
   if (inspected.cs) {
     const csConfig = codeStorageConfig();
     if (!csConfig) {
@@ -668,17 +702,13 @@ async function registerCodestorageRepo(input: {
   ) {
     throw setupRepoError(`code.storage repository is already registered: ${csRepo}`, 409);
   }
-  if (
-    Object.values(configuredRepos()).some(
-      (repo) => repo.host === "codestorage" && repo.csRepo === csRepo,
-    )
-  ) {
-    const err = new Error(`code.storage repository already registered: ${csRepo}`);
-    (err as any).status = 409;
-    throw err;
-  }
   const root = checkoutsRoot();
   const dest = `${root}/${id}`;
+  assertRepoPathAvailable(dest, registered);
+  await assertRepoOriginAvailable(
+    normalizeRepoOrigin(csRemoteUrl(cfg.org, csRepo)),
+    registered,
+  );
   const adopted = await adoptExistingCheckout(
     dest,
     (i) => matchesCodeStorageCheckout(i, cfg.org, csRepo),


### PR DESCRIPTION
## Summary

- keep repository clone and registration progress visible in Settings, including after the add dialog is dismissed and reopened
- add a Local folder source that registers an existing server-side Git checkout by absolute path without cloning it
- validate the checkout's origin and remote default branch so it works with existing worktree creation
- preserve built-in repositories and reject duplicate IDs, paths, remote identities, and worktree prefixes
- retain the existing GitHub and code.storage flows, including credential helper setup and repository-change notifications

## Verification

- `bun test packages/core/opensession-server/src/server/config.test.ts packages/core/opensession-server/src/server/routes/repo-inspection.test.ts packages/core/opensession-server/src/server/routes/setup-repos.test.ts` (56 passed)
- `bun run typecheck`
- `bun run lint`
- `bun scripts/check-module-side-effects.ts`
- frontend build through `buildFrontend()`
- `git diff --check origin/main...HEAD`

The full test suite was also run: 4,096 passed, 8 skipped, and 75 failed in existing environment/baseline-sensitive coverage outside this change, including Lima/systemd-dependent install, Portal, prewarm, generated-catalog, SWR DOM setup, and bootstrap-signature checks. All focused repository setup coverage passes.

## Visual verification

Browser capture was not available in this Darwin environment because the Portal tooling requires `setsid` and bounded CDP requires `systemd-run`. Desktop and phone layouts were reviewed at the code and build level, but no screenshot artifact is attached.

Started by Jaap Frolich in [this Assistant session](http://100.81.254.102:3850/session/os-01a0111a-0f2f-7000-aec2-2b295c12f0e3)



