### PR TITLE
Stage creation attachments through the durable actor

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -176,10 +176,13 @@ If a backend naturally ends without a terminal event, its wrapper replaces the
 live journal with a durable abnormal-completion receipt instead of clearing it;
 boot recovery or the opening executor settles that receipt without relaunching.
 A crash after actor settlement adopts the completed receipt without launching
-another turn. Direct `opening_dispatched` transitions without a typed effect are rejected. Attachment
-staging and removal of the remaining create-plan compatibility authority are the
-next creation cutovers; the presence or absence of a plan file is not actor
-lifecycle evidence.
+another turn. Direct `opening_dispatched` transitions without a typed effect are rejected.
+Non-image create attachments are durably spooled to bounded source references,
+then copied or adopted at deterministic session-owned paths by
+`creation_attachment_stage`; digest crossover fails closed and inline bodies
+never enter actor payloads. Removing the remaining create-plan compatibility
+authority is the next creation cutover; the presence or absence of a plan file
+is not actor lifecycle evidence.
 
 ## Run ownership
 

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -25,7 +25,7 @@ import { SESSION_EFFORTS, type SessionEffort, providerFor, resolveModel } from "
 import { configuredInteractiveDefaultModel } from "./model-catalog";
 import { deliveryQueueState, durableQueueItem, liftUserStop, promptQueues, acceptQueuedSteer, prepareQueuedSteer, rejectQueuedSteer, requeueSteerReceipts, stoppedSessions } from "./queue-state";
 import { drainQueue, enqueuePrompt, runSessionPrompt, sessionMentionsNote, watchExternalRunAndDrain } from "./run-session";
-import { parseImageDataUrls, stageFileAttachments, withUploadsNote } from "./uploads";
+import { creationAttachmentPath, parseImageDataUrls, prepareCreationAttachmentSources, withUploadsNote } from "./uploads";
 import { type Sandbox } from "./sandbox";
 import { isRemoteSandboxProvider, resolveRequestedSandbox } from "./sandbox/config";
 import { resolveInteractiveSandbox } from "./sandbox/defaults";
@@ -52,6 +52,7 @@ import { randomUUIDv7 } from "bun";
 import {
 	ensureCreationPlanned,
 	legacyGatewayEffect,
+	requestCreationAttachment,
 	requestCreationBranch,
 	requestCreationCredential,
 	requestCreationWorkspace,
@@ -817,9 +818,28 @@ registerSessionControl({
 		// prompts on existing sessions — this create path bypasses
 		// runSessionPromptInner.
 		const createMentionsNote = sessionMentionsNote(prompt);
+		const attachmentSources =
+			createPlan.attachments ?? prepareCreationAttachmentSources(bksId, rawFiles);
+		if (!createPlan.attachments && attachmentSources.length)
+			createPlan = updateCreatePlan(bksId, createIdentity, {
+				attachments: attachmentSources,
+			});
+		for (const attachment of attachmentSources)
+			await requestCreationAttachment({
+				sessionId: bksId,
+				identity: createIdentity,
+				...attachment,
+			});
 		let openingPrompt = withUploadsNote(
 			prompt,
-			stageFileAttachments(bksId, rawFiles),
+			attachmentSources.map((attachment) => ({
+				name: attachment.name,
+				path: creationAttachmentPath(
+					bksId,
+					attachment.attachmentId,
+					attachment.name,
+				),
+			})),
 		);
 		if (createMentionsNote) openingPrompt += `
 

--- a/packages/core/opensession-server/src/server/session-create-plan.test.ts
+++ b/packages/core/opensession-server/src/server/session-create-plan.test.ts
@@ -101,6 +101,12 @@ describe("durable create plan", () => {
       const first = updateCreatePlan("os-create", "same", {
         branch: "feature/stable",
         workspaceId: createPlanWorkspaceId("os-create"),
+        attachments: [{
+          attachmentId: "attachment-one",
+          name: "brief.pdf",
+          sourceRef: "uploads:staged%2Fbrief.pdf",
+          digest: "sha256:brief",
+        }],
         resolved: {
           model: "pi/openai/gpt-5.5",
           sandboxProvider: "docker",

--- a/packages/core/opensession-server/src/server/session-create-plan.ts
+++ b/packages/core/opensession-server/src/server/session-create-plan.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { OPENSESSION_SESSIONS_DIR } from "./paths";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import type { SessionKernelStoreApi } from "./session-kernel/store";
+import type { CreationAttachmentSource } from "./uploads";
 
 export interface DurableCreatePlan {
   version: 1;
@@ -11,7 +12,9 @@ export interface DurableCreatePlan {
   createdAt: string;
   branch?: string;
   workspaceId?: string;
-  /** Serializable ResolvedCreate decisions; attachments and functions stay external. */
+  /** Durable source identities only. Attachment bodies remain in the upload spool. */
+  attachments?: CreationAttachmentSource[];
+  /** Serializable ResolvedCreate decisions; attachment bodies and functions stay external. */
   resolved?: Record<string, unknown>;
 }
 
@@ -50,7 +53,10 @@ export function updateCreatePlan(
   sessionId: string,
   identity: string,
   patch: Partial<
-    Pick<DurableCreatePlan, "branch" | "workspaceId" | "resolved">
+    Pick<
+      DurableCreatePlan,
+      "branch" | "workspaceId" | "attachments" | "resolved"
+    >
   > = {},
 ): DurableCreatePlan {
   const prior = readCreatePlan(sessionId, identity);

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -81,13 +81,14 @@ import { commitAuthorFor, userMatchesAny } from "./shared/user-mappings";
 import { sanitizeBranchSlug } from "./suggest-branch";
 import { type NativeSessionFile, type SessionUsage, type UnifiedSession, } from "./types";
 import { storeAppendUserLineEarly, transcriptLineUser } from "./transcript-persistence";
-import { parseImageDataUrls, stageFileAttachments, withUploadsNote, } from "./uploads";
+import { creationAttachmentPath, parseImageDataUrls, prepareCreationAttachmentSources, withUploadsNote, } from "./uploads";
 import { resolvePlainWorkspace } from "./workspace-resolve";
 import { resolveWorkspaceModelPreset } from "./workspace-model-presets";
 import { type Workspace, getWorkspace, updateWorkspace, } from "./workspaces";
 import {
 	type CreationOpeningEffectItem,
 	ensureCreationPlanned,
+	requestCreationAttachment,
 	requestCreationBranch,
 	requestCreationCredential,
 	requestCreationOpening,
@@ -1940,10 +1941,30 @@ export async function handleCreateSessionMessage(
 				!!msg.createWorkspace &&
 				!msg.createWorkspace.name) ||
 			(!mintedForSession && !!workspace?.draft && workspace.draft.autoName !== false);
-		// Non-image attachments: stage to disk, hand the agent the paths.
+		// Non-image attachment bodies are reduced to durable source refs at
+		// intake; only the actor can materialize their session-owned paths.
+		const attachmentSources =
+			createPlan.attachments ?? prepareCreationAttachmentSources(bksId, msg.files);
+		if (!createPlan.attachments && attachmentSources.length)
+			createPlan = updateCreatePlan(bksId, createIdentity, {
+				attachments: attachmentSources,
+			});
+		for (const attachment of attachmentSources)
+			await requestCreationAttachment({
+				sessionId: bksId,
+				identity: createIdentity,
+				...attachment,
+			});
 		let openingPrompt = withUploadsNote(
 			prompt,
-			stageFileAttachments(bksId, msg.files),
+			attachmentSources.map((attachment) => ({
+				name: attachment.name,
+				path: creationAttachmentPath(
+					bksId,
+					attachment.attachmentId,
+					attachment.name,
+				),
+			})),
 		);
 		if (deferredAutoRepo) {
 			openingPrompt += `\n\n${wrapContext(

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts
@@ -6,11 +6,13 @@ import { createWorkspace, getWorkspace } from "../workspaces";
 import { createWorktree, listWorktrees } from "../worktree";
 import {
   CreationEffectIndeterminateError,
+  executeCreationAttachmentStage,
   executeCreationBranchPrepare,
   executeCreationCredentialResolve,
   executeCreationOpeningTurn,
   executeCreationSandboxPrepare,
   executeCreationWorkspacePrepare,
+  type CreationAttachmentEffectItem,
   type CreationBranchEffectItem,
   type CreationCredentialEffectItem,
   type CreationOpeningEffectItem,
@@ -116,6 +118,28 @@ function sandboxItem(): CreationSandboxEffectItem {
       trustProfile: "interactive",
       egressAllowlist: ["github.com"],
       mode: "adopt_or_create",
+    },
+    attempts: 0,
+    nextAttemptAt: 0,
+    createdAt: 1,
+  };
+}
+
+function attachmentItem(): CreationAttachmentEffectItem {
+  return {
+    id: 5,
+    effectId: "session:creation_attachment_stage:attachment-effect",
+    effectKey: "attachment:attachment-one",
+    sessionId: "session-one",
+    kind: "creation_attachment_stage",
+    payload: {
+      creationIdentity: "create-one",
+      creationGeneration: 1,
+      attachmentId: "attachment-one",
+      name: "brief.pdf",
+      sourceRef: "uploads:staged%2Fbrief.pdf",
+      digest: "sha256:brief",
+      mode: "reconcile_or_stage",
     },
     attempts: 0,
     nextAttemptAt: 0,
@@ -442,6 +466,36 @@ describe("creation sandbox effect executor", () => {
         throw new Error("must not result");
       },
     })).rejects.toBeInstanceOf(CreationEffectIndeterminateError);
+  });
+});
+
+describe("creation attachment effect executor", () => {
+  test("adopts a staged destination after a crash before actor settlement", async () => {
+    let stages = 0;
+    let results = 0;
+    const dependencies = {
+      stage: (_sessionId: string, source: any) => {
+        stages += 1;
+        expect(source).toMatchObject({
+          attachmentId: "attachment-one",
+          name: "brief.pdf",
+          digest: "sha256:brief",
+        });
+        return { name: "brief.pdf", path: "/uploads/session-one/attachment-one-brief.pdf" };
+      },
+      result: () => {
+        results += 1;
+        return results === 1
+          ? { accepted: false as const, reason: "invalid_transition" as const }
+          : { accepted: true as const };
+      },
+    };
+    await expect(
+      executeCreationAttachmentStage(attachmentItem(), dependencies),
+    ).rejects.toBeInstanceOf(CreationEffectIndeterminateError);
+    await executeCreationAttachmentStage(attachmentItem(), dependencies);
+    expect(stages).toBe(2);
+    expect(results).toBe(2);
   });
 });
 

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
@@ -6,6 +6,7 @@ import type {
   SandboxSessionSpec,
 } from "../sandbox/provider";
 import { createWorkspace, getWorkspace, type Workspace } from "../workspaces";
+import type { CreationAttachmentSource } from "../uploads";
 import type { WorktreeInfo } from "../worktree";
 import { registerSessionEffectExecutor } from "./effect-executors";
 import { sessionKernel, sessionKernelStore } from "./kernel";
@@ -19,6 +20,7 @@ type WorkspaceEffect = SessionActorEffectFor<"creation_workspace_prepare">;
 type BranchEffect = SessionActorEffectFor<"creation_branch_prepare">;
 type CredentialEffect = SessionActorEffectFor<"creation_credential_resolve">;
 type SandboxEffect = SessionActorEffectFor<"creation_sandbox_prepare">;
+type AttachmentEffect = SessionActorEffectFor<"creation_attachment_stage">;
 type OpeningEffect = SessionActorEffectFor<"creation_opening_turn">;
 export type CreationWorkspaceEffectItem = Omit<
   DurableOutboxItem,
@@ -36,6 +38,10 @@ export type CreationSandboxEffectItem = Omit<
   DurableOutboxItem,
   "kind" | "payload"
 > & SandboxEffect;
+export type CreationAttachmentEffectItem = Omit<
+  DurableOutboxItem,
+  "kind" | "payload"
+> & AttachmentEffect;
 export type CreationOpeningEffectItem = Omit<
   DurableOutboxItem,
   "kind" | "payload"
@@ -398,6 +404,48 @@ export async function executeCreationCredentialResolve(
   );
 }
 
+type AttachmentExecutorDependencies = {
+  stage: (
+    sessionId: string,
+    source: CreationAttachmentSource,
+  ) =>
+    | { name: string; path: string }
+    | Promise<{ name: string; path: string }>;
+  result: (item: CreationAttachmentEffectItem) => CreationEventDecisionResult;
+  afterDestinationAccepted?: (path: string) => void;
+};
+
+const defaultAttachmentDependencies: AttachmentExecutorDependencies = {
+  stage: async (sessionId, source) =>
+    (await import("../uploads")).stageCreationAttachment(sessionId, source),
+  result: (item) =>
+    sessionKernel(item.sessionId).applyCreationEvent({
+      identity: item.payload.creationIdentity,
+      event: "preparation_started",
+      effectId: item.effectKey,
+      detail: { attachmentId: item.payload.attachmentId },
+    }),
+};
+
+/** Stage or adopt one digest-fenced session attachment, then settle its receipt. */
+export async function executeCreationAttachmentStage(
+  item: CreationAttachmentEffectItem,
+  dependencies: AttachmentExecutorDependencies = defaultAttachmentDependencies,
+): Promise<void> {
+  const staged = await dependencies.stage(item.sessionId, {
+    attachmentId: item.payload.attachmentId,
+    name: item.payload.name,
+    sourceRef: item.payload.sourceRef,
+    digest: item.payload.digest,
+  });
+  dependencies.afterDestinationAccepted?.(staged.path);
+  const result = dependencies.result(item);
+  if (result.accepted || result.reason === "stale_effect") return;
+  throw new CreationEffectIndeterminateError(
+    `Attachment effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
+  );
+}
+
 type OpeningExecutorDependencies = {
   launch: (item: CreationOpeningEffectItem) => Promise<void>;
 };
@@ -463,6 +511,7 @@ const registrationGlobal = globalThis as typeof globalThis & {
   __opensessionCreationBranchExecutorRegistered?: boolean;
   __opensessionCreationCredentialExecutorRegistered?: boolean;
   __opensessionCreationSandboxExecutorRegistered?: boolean;
+  __opensessionCreationAttachmentExecutorRegistered?: boolean;
   __opensessionCreationOpeningExecutorRegistered?: boolean;
 };
 
@@ -494,6 +543,13 @@ export function ensureCreationEffectExecutors(): void {
       executeCreationCredentialResolve,
     );
     registrationGlobal.__opensessionCreationCredentialExecutorRegistered = true;
+  }
+  if (!registrationGlobal.__opensessionCreationAttachmentExecutorRegistered) {
+    registerSessionEffectExecutor(
+      "creation_attachment_stage",
+      executeCreationAttachmentStage,
+    );
+    registrationGlobal.__opensessionCreationAttachmentExecutorRegistered = true;
   }
   if (!registrationGlobal.__opensessionCreationOpeningExecutorRegistered) {
     registerSessionEffectExecutor(

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-protocol.ts
@@ -61,6 +61,7 @@ export type CreationAttachmentStageEffect = {
   kind: "creation_attachment_stage";
   payload: CreationEffectBase & {
     attachmentId: string;
+    name: string;
     sourceRef: string;
     digest: string;
     mode: "reconcile_or_stage";

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  requestCreationAttachment,
   requestCreationBranch,
   requestCreationCredential,
   requestCreationOpening,
@@ -67,6 +68,56 @@ describe("creation lifecycle intents", () => {
           kernel,
         ).state,
       ).toBe("failed");
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("creation attachment intents", () => {
+  test("emits one source-ref effect and waits for its durable receipt", async () => {
+    const attachment = {
+      sessionId: "create-attachment-intent",
+      identity: "request-attachment-intent",
+      attachmentId: "attachment-one",
+      name: "brief.pdf",
+      sourceRef: "uploads:staged%2Fbrief.pdf",
+      digest: "sha256:brief",
+    };
+    const { store, kernel } = harness(attachment.sessionId);
+    try {
+      const pending = requestCreationAttachment(attachment, {
+        kernel,
+        timeoutMs: 1_000,
+        pollMs: 5,
+      });
+      await Bun.sleep(5);
+      expect(store.pendingOutbox()).toMatchObject([{
+        kind: "creation_attachment_stage",
+        effectKey: "attachment:attachment-one",
+        payload: {
+          creationIdentity: attachment.identity,
+          creationGeneration: 1,
+          attachmentId: "attachment-one",
+          name: "brief.pdf",
+          sourceRef: "uploads:staged%2Fbrief.pdf",
+          digest: "sha256:brief",
+          mode: "reconcile_or_stage",
+        },
+      }]);
+      expect(store.applyCreationEvent({
+        sessionId: attachment.sessionId,
+        identity: attachment.identity,
+        event: "preparation_started",
+        effectId: "attachment:attachment-one",
+      }).accepted).toBe(true);
+      expect((await pending).completedEffectIds).toContain(
+        "attachment:attachment-one",
+      );
+      expect(
+        await requestCreationAttachment(attachment, { kernel }),
+      ).toMatchObject({ state: "preparing" });
+      expect(store.pendingOutbox()).toHaveLength(1);
     } finally {
       store.close();
     }

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -46,6 +46,15 @@ export type CreationSandboxIntent = {
   egressAllowlist?: string[];
 };
 
+export type CreationAttachmentIntent = {
+  sessionId: string;
+  identity: string;
+  attachmentId: string;
+  name: string;
+  sourceRef: string;
+  digest: string;
+};
+
 export type CreationOpeningIntent = {
   sessionId: string;
   identity: string;
@@ -135,6 +144,60 @@ export function settleCreationFailed(
       `Creation failure was rejected: ${settled.reason || "unknown"}`,
     );
   return settled.state;
+}
+
+/** Stage one source-ref attachment through the actor and wait for its receipt. */
+export async function requestCreationAttachment(
+  input: CreationAttachmentIntent,
+  options: CreationIntentOptions = {},
+): Promise<DurableCreationState> {
+  const kernel = options.kernel ?? sessionKernel(input.sessionId);
+  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  const effectId = `attachment:${input.attachmentId}`;
+  if (state.completedEffectIds.includes(effectId)) return state;
+  if (state.currentEffectId && state.currentEffectId !== effectId)
+    throw new Error(
+      `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
+    );
+  if (!state.currentEffectId) {
+    const emitted = kernel.applyCreationEvent({
+      identity: input.identity,
+      event: "preparation_started",
+      nextEffectId: effectId,
+      effect: {
+        kind: "creation_attachment_stage",
+        effectKey: effectId,
+        payload: {
+          creationIdentity: input.identity,
+          creationGeneration: state.generation,
+          attachmentId: input.attachmentId,
+          name: input.name,
+          sourceRef: input.sourceRef,
+          digest: input.digest,
+          mode: "reconcile_or_stage",
+        },
+      },
+    });
+    if (!emitted.accepted || !emitted.state)
+      throw new Error(
+        `Creation attachment intent was rejected: ${emitted.reason || "unknown"}`,
+      );
+    state = emitted.state;
+  }
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000);
+  while (!state.completedEffectIds.includes(effectId)) {
+    if (Date.now() >= deadline)
+      throw new Error(
+        `Creation attachment effect ${effectId} remains durably pending`,
+      );
+    await Bun.sleep(options.pollMs ?? 25);
+    const current = kernel.creationState();
+    if (!current)
+      throw new Error("Creation state disappeared while attachment was pending");
+    assertIdentity(current, input.identity);
+    state = current;
+  }
+  return state;
 }
 
 /** Emit one stable opening launch and wait for the executor's actor settlement. */

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts
@@ -118,6 +118,7 @@ describe("session effect executor registry", () => {
     expect(await registry.execute(outbox({
       ...fence,
       attachmentId: "attachment-one",
+      name: "brief.pdf",
       sourceRef: "staged:attachment-one",
       digest: "sha256:digest",
       mode: "reconcile_or_stage",
@@ -126,6 +127,7 @@ describe("session effect executor registry", () => {
     expect(attachment).toEqual({
       ...fence,
       attachmentId: "attachment-one",
+      name: "brief.pdf",
       sourceRef: "staged:attachment-one",
       digest: "sha256:digest",
       mode: "reconcile_or_stage",

--- a/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/effect-executors.ts
@@ -187,6 +187,7 @@ function creationPayload<K extends Exclude<
       return {
         ...base,
         attachmentId: requiredString(kind, value.attachmentId, "attachmentId"),
+        name: requiredString(kind, value.name, "name"),
         sourceRef: requiredString(kind, value.sourceRef, "sourceRef"),
         digest: requiredString(kind, value.digest, "digest"),
         mode: value.mode,

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -137,13 +137,21 @@ describe("single session ownership", () => {
 			'"creation_credential_resolve",\n      executeCreationCredentialResolve',
 		);
 		expect(creationExecutors).toContain(
+			'"creation_attachment_stage",\n      executeCreationAttachmentStage',
+		);
+		expect(creationExecutors).toContain(
 			'"creation_opening_turn",\n      executeCreationOpeningTurn',
 		);
 		expect(creationExecutors).toContain(
 			"payload.sandboxKey !== item.sessionId",
 		);
 		expect(creationExecutors).toContain("resolveCurrentCredential");
+		expect(creationExecutors).toContain("stageCreationAttachment");
 		expect(creationExecutors).not.toContain("payload.gitEnv");
+		expect(read("session-create.ts")).not.toContain("stageFileAttachments(");
+		expect(read("session-control-wiring.ts")).not.toContain(
+			"stageFileAttachments(",
+		);
 		expect(creationExecutors).toContain("assertAdoptableWorkspace(workspace, item)");
 		expect(creationExecutors.indexOf("dependencies.result(item)")).toBeGreaterThan(
 			creationExecutors.indexOf("dependencies.createWorkspace({"),

--- a/packages/core/opensession-server/src/server/uploads.test.ts
+++ b/packages/core/opensession-server/src/server/uploads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,8 +9,14 @@ import { join } from "node:path";
 const SCRATCH = mkdtempSync(join(tmpdir(), "uploads-"));
 const saved = process.env.OPENSESSION_STATE_DIR;
 process.env.OPENSESSION_STATE_DIR = SCRATCH;
-const { UPLOADS_DIR, countImageRefs, parseImageDataUrls, stageInlineImages } =
-	await import("./uploads");
+const {
+	UPLOADS_DIR,
+	countImageRefs,
+	parseImageDataUrls,
+	prepareCreationAttachmentSources,
+	stageCreationAttachment,
+	stageInlineImages,
+} = await import("./uploads");
 if (saved === undefined) delete process.env.OPENSESSION_STATE_DIR;
 else process.env.OPENSESSION_STATE_DIR = saved;
 
@@ -28,6 +34,48 @@ function stage(name: string, bytes: Buffer = PNG): string {
 	writeFileSync(path, bytes);
 	return `/media?path=${encodeURIComponent(path)}`;
 }
+
+describe("actor-owned creation attachments", () => {
+	test("spools inline input once and adopts one digest-fenced destination", () => {
+		const raw = [{
+			name: "brief.txt",
+			dataUrl: `data:text/plain;base64,${Buffer.from("hello").toString("base64")}`,
+		}];
+		const [source] = prepareCreationAttachmentSources("create-session", raw);
+		expect(source.name).toBe("brief.txt");
+		expect(source.sourceRef).toStartWith("uploads:");
+		expect(source.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+		expect(prepareCreationAttachmentSources("create-session", raw)).toEqual([
+			source,
+		]);
+		const staged = stageCreationAttachment("create-session", source);
+		expect(readFileSync(staged.path, "utf8")).toBe("hello");
+		unlinkSync(
+			`${UPLOADS_DIR}/${decodeURIComponent(source.sourceRef.slice("uploads:".length))}`,
+		);
+		expect(stageCreationAttachment("create-session", source)).toEqual(staged);
+	});
+
+	test("rejects malformed input instead of silently dropping an intent", () => {
+		expect(() =>
+			prepareCreationAttachmentSources("invalid-session", [
+				{ name: "missing-body.txt" },
+			]),
+		).toThrow("invalid file attachment");
+	});
+
+	test("rejects destination crossover instead of overwriting", () => {
+		const [source] = prepareCreationAttachmentSources("cross-session", [{
+			name: "brief.txt",
+			dataUrl: `data:text/plain;base64,${Buffer.from("first").toString("base64")}`,
+		}]);
+		const staged = stageCreationAttachment("cross-session", source);
+		writeFileSync(staged.path, "changed");
+		expect(() => stageCreationAttachment("cross-session", source)).toThrow(
+			"destination changed",
+		);
+	});
+});
 
 describe("composer image references", () => {
 	test("reads a staged ref back into vision bytes", () => {

--- a/packages/core/opensession-server/src/server/uploads.ts
+++ b/packages/core/opensession-server/src/server/uploads.ts
@@ -9,11 +9,13 @@
  * accepted for small files and older clients.
  */
 
+import { createHash } from "crypto";
 import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
 	realpathSync,
+	renameSync,
 	statSync,
 	unlinkSync,
 	writeFileSync,
@@ -116,6 +118,7 @@ const STAGED_UPLOADS_DIR = `${UPLOADS_DIR}/staged`;
 // Cap so a single upload can't OOM the process. The HTTP path streams, but the
 // inline base64/WS path buffers, so keep it modest.
 export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+const MAX_CREATION_ATTACHMENTS = 32;
 const MAX_INLINE_IMAGES = 6;
 const INLINE_IMAGE_EXTENSIONS: Record<string, string> = {
 	"image/png": ".png",
@@ -145,6 +148,13 @@ export const WS_MAX_PAYLOAD_BYTES =
 type ParsedUpload =
 	| { kind: "staged"; name: string; path: string }
 	| { kind: "inline"; name: string; data: string };
+
+export type CreationAttachmentSource = {
+	attachmentId: string;
+	name: string;
+	sourceRef: string;
+	digest: string;
+};
 
 /** Normalize composer `files` entries into staged-path refs or inline base64. */
 export function parseFileUploads(raw?: unknown): ParsedUpload[] | undefined {
@@ -298,6 +308,128 @@ export async function stageHttpUpload(
 		);
 	writeFileSync(p, buf);
 	return { name: name || wanted, path: p };
+}
+
+function uploadDigest(bytes: Buffer): string {
+	return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function sourceRefForPath(path: string): string {
+	if (!isWithinUploads(path)) throw new Error("Attachment source is outside uploads");
+	const base = realpathSync(UPLOADS_DIR);
+	const real = realpathSync(path);
+	return `uploads:${encodeURIComponent(real.slice(base.length + 1))}`;
+}
+
+function pathForSourceRef(sourceRef: string): string {
+	if (!sourceRef.startsWith("uploads:"))
+		throw new Error("Unsupported creation attachment source");
+	const relative = decodeURIComponent(sourceRef.slice("uploads:".length));
+	if (!relative || relative.includes("\0") || relative.split("/").includes(".."))
+		throw new Error("Invalid creation attachment source");
+	const path = `${UPLOADS_DIR}/${relative}`;
+	if (!isWithinUploads(path)) throw new Error("Attachment source crossed uploads");
+	return path;
+}
+
+export function creationAttachmentPath(
+	sessionId: string,
+	attachmentId: string,
+	name: string,
+): string {
+	if (!/^[A-Za-z0-9_-]{8,128}$/.test(attachmentId))
+		throw new Error("Invalid creation attachment id");
+	return `${UPLOADS_DIR}/${sanitizeFilename(sessionId)}/${attachmentId}-${sanitizeFilename(name)}`;
+}
+
+/** Durably spool inline bodies and reduce all create inputs to bounded source refs. */
+export function prepareCreationAttachmentSources(
+	sessionId: string,
+	raw?: unknown,
+): CreationAttachmentSource[] {
+	if (raw === undefined) return [];
+	if (!Array.isArray(raw)) throw new Error("files must be an array");
+	const uploads = parseFileUploads(raw) ?? [];
+	if (uploads.length !== raw.length)
+		throw new Error("Creation contains an invalid file attachment");
+	if (uploads.length > MAX_CREATION_ATTACHMENTS)
+		throw new Error(
+			`too many creation attachments (max ${MAX_CREATION_ATTACHMENTS})`,
+		);
+	mkdirSync(STAGED_UPLOADS_DIR, { recursive: true });
+	let totalBytes = 0;
+	return uploads.map((upload, index) => {
+		let bytes: Buffer;
+		let sourcePath: string;
+		if (upload.kind === "staged") {
+			if (!isWithinUploads(upload.path) || !existsSync(upload.path))
+				throw new Error(`Creation attachment source is unavailable: ${upload.name}`);
+			bytes = readFileSync(upload.path);
+			sourcePath = upload.path;
+		} else {
+			bytes = Buffer.from(upload.data, "base64");
+			sourcePath = "";
+		}
+		if (!bytes.length || bytes.length > MAX_UPLOAD_BYTES)
+			throw new Error(`Creation attachment has invalid size: ${upload.name}`);
+		totalBytes += bytes.length;
+		if (totalBytes > MAX_UPLOAD_BYTES)
+			throw new Error(
+				`creation attachments too large (max ${MAX_UPLOAD_BYTES} bytes total)`,
+			);
+		const digest = uploadDigest(bytes);
+		const attachmentId = createHash("sha256")
+			.update(`${sessionId}\0${index}\0${upload.name}\0${digest}`)
+			.digest("hex")
+			.slice(0, 32);
+		if (!sourcePath) {
+			sourcePath = `${STAGED_UPLOADS_DIR}/creation-${attachmentId}`;
+			if (existsSync(sourcePath)) {
+				if (uploadDigest(readFileSync(sourcePath)) !== digest)
+					throw new Error(`Creation attachment source ${attachmentId} changed`);
+			} else {
+				writeFileSync(sourcePath, bytes, { mode: 0o600 });
+			}
+		}
+		return {
+			attachmentId,
+			name: upload.name || "file",
+			sourceRef: sourceRefForPath(sourcePath),
+			digest,
+		};
+	});
+}
+
+/** Copy or adopt one exact actor-owned destination after validating its source. */
+export function stageCreationAttachment(
+	sessionId: string,
+	source: CreationAttachmentSource,
+): { name: string; path: string } {
+	const path = creationAttachmentPath(
+		sessionId,
+		source.attachmentId,
+		source.name,
+	);
+	mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+	if (existsSync(path)) {
+		if (uploadDigest(readFileSync(path)) !== source.digest)
+			throw new Error(`Creation attachment ${source.attachmentId} destination changed`);
+		return { name: source.name, path };
+	}
+	const sourcePath = pathForSourceRef(source.sourceRef);
+	const bytes = readFileSync(sourcePath);
+	if (!bytes.length || bytes.length > MAX_UPLOAD_BYTES)
+		throw new Error(`Creation attachment ${source.attachmentId} has invalid size`);
+	if (uploadDigest(bytes) !== source.digest)
+		throw new Error(`Creation attachment ${source.attachmentId} digest changed`);
+	const temp = `${path}.tmp-${process.pid}-${crypto.randomUUID()}`;
+	try {
+		writeFileSync(temp, bytes, { mode: 0o600 });
+		renameSync(temp, path);
+	} finally {
+		try { unlinkSync(temp); } catch {}
+	}
+	return { name: source.name, path };
 }
 
 /**


### PR DESCRIPTION
## Summary
- spool inline create attachments into bounded durable source references and persist their identities in the create plan
- emit and execute `creation_attachment_stage` effects with stable IDs, digests, and deterministic session-owned destinations
- adopt completed destinations after crashes, reject source/destination crossover, and remove direct create-time `stageFileAttachments` authority from web and MCP creation

## Verification
- `bun test packages/core/opensession-server/src/server/session-create-plan.test.ts packages/core/opensession-server/src/server/uploads.test.ts packages/core/opensession-server/src/server/session-kernel/effect-executors.test.ts packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.test.ts packages/core/opensession-server/src/server/session-kernel/kernel.test.ts packages/core/opensession-server/src/server/session-kernel/ownership.test.ts` (120 tests, 1002 assertions)
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts` (412 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
