### PR TITLE
Defer create replay to durable opening ownership

### DIFF
--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -38,7 +38,7 @@ import {
 	type SessionSummary,
 	registerSessionControl,
 } from "./session-control";
-import { type ResolvedCreate, actorCreationSetupPlan, forkHandoffContext, runOpeningCreateOnce, resolveForkContext, resolvePinnedAccountId } from "./session-create";
+import { type ResolvedCreate, actorCreationSetupPlan, forkHandoffContext, runOpeningCreateOnce, resolveForkContext, resolvePinnedAccountId, waitForCreatedSessionProjection } from "./session-create";
 import { resolveSessionRepoContext, workspaceOwningWorktree } from "./session-repos";
 import { engineUserTexts, getAllSessions, mergedSessionTranscript } from "./sessions";
 import { rebuildIndex } from "./slack-links";
@@ -455,8 +455,33 @@ registerSessionControl({
 		const createIdentity = new Bun.CryptoHasher("sha256")
 			.update(canonicalCommandPayload(ownedInput))
 			.digest("hex");
+		const durableCreation = sessionKernel(bksId).creationState();
+		if (durableCreation && durableCreation.identity !== createIdentity)
+			throw new Error("Create request identity crossed durable session ownership");
+		let completedCreate = findSession(requestedId);
+		if (
+			durableCreation?.state === "opening_dispatched" ||
+			durableCreation?.state === "ready" ||
+			durableCreation?.state === "failed"
+		) {
+			completedCreate = await waitForCreatedSessionProjection(
+				bksId,
+				createIdentity,
+			);
+			if (durableCreation.state === "ready") clearCreatePlan(bksId);
+			return {
+				id: bksId,
+				createdBy:
+					completedCreate.createdBy ||
+					completedCreate.startedBy ||
+					user ||
+					"Anonymous",
+				createdAt:
+					completedCreate.createdAt ||
+					new Date(durableCreation.updatedAt).toISOString(),
+			};
+		}
 		let createPlan = actorCreationSetupPlan(bksId, createIdentity);
-		const completedCreate = findSession(requestedId);
 		if (
 			completedCreate?.claudeSessionId ||
 			completedCreate?.codexThreadId

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -407,6 +407,26 @@ const activeOpeningCreates = new Map<
 	}
 >();
 
+export async function waitForCreatedSessionProjection(
+	sessionId: string,
+	identity: string,
+	timeoutMs = 24 * 60 * 60_000,
+): Promise<UnifiedSession> {
+	const deadline = Date.now() + timeoutMs;
+	while (true) {
+		const state = sessionKernel(sessionId).creationState();
+		if (!state || state.identity !== identity)
+			throw new Error("Create request identity crossed durable session ownership");
+		const projected = findSession(sessionId);
+		if (projected) return projected;
+		if (state.state === "failed")
+			throw new Error("Session creation failed before it was persisted");
+		if (Date.now() >= deadline)
+			throw new Error("Session creation remains durably pending");
+		await Bun.sleep(25);
+	}
+}
+
 export function actorCreationSetupPlan(
 	sessionId: string,
 	identity: string,
@@ -1484,8 +1504,39 @@ export async function handleCreateSessionMessage(
 			? sessionIdForRequest(ws.data?.authLogin || user || "anonymous", requestId)
 			: newSessionId());
 	const createIdentity = requestId || clientSessionId || bksId;
+	const durableCreation = sessionKernel(bksId).creationState();
+	if (durableCreation && durableCreation.identity !== createIdentity) {
+		failCreate("Create request identity crossed durable session ownership");
+		return;
+	}
+	let recoveringSession = findSession(bksId);
+	if (
+		durableCreation?.state === "opening_dispatched" ||
+		durableCreation?.state === "ready" ||
+		durableCreation?.state === "failed"
+	) {
+		try {
+			recoveringSession = await waitForCreatedSessionProjection(
+				bksId,
+				createIdentity,
+			);
+		} catch (error) {
+			failCreate(error instanceof Error ? error.message : String(error));
+			throw error;
+		}
+		if (durableCreation.state === "ready") clearCreatePlan(bksId);
+		const response = {
+			type: "session_created",
+			id: bksId,
+			...(recoveringSession.workspaceId
+				? { workspaceId: recoveringSession.workspaceId }
+				: {}),
+		};
+		sendCreateFrame(attempt, response);
+		finishCreate();
+		return response;
+	}
 	let createPlan = actorCreationSetupPlan(bksId, createIdentity);
-	const recoveringSession = findSession(bksId);
 	if (
 		recoveringSession?.claudeSessionId ||
 		recoveringSession?.codexThreadId

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -261,7 +261,7 @@ describe("single session ownership", () => {
 
 	test("interrupted creates resume their environment setup, not only their prompt", () => {
 		const create = read("session-create.ts");
-		expect(create).toContain("const recoveringSession = findSession(bksId)");
+		expect(create).toContain("let recoveringSession = findSession(bksId)");
 		expect(create).toContain('existingBranch: restored.worktreeKind === "existing"');
 		expect(create).toContain("const actorPlan =");
 		expect(create).toContain("creation?.setupPlan?.resolved");
@@ -276,6 +276,25 @@ describe("single session ownership", () => {
 		expect(create).not.toContain("if (requeuePromptDispatch(bksId))");
 		const routes = read("routes/sessions.ts");
 		expect(routes).not.toContain("requeuePromptDispatch(targetId)");
+	});
+
+	test("create replay waits for a resolvable projection before success", () => {
+		const create = read("session-create.ts");
+		const wiring = read("session-control-wiring.ts");
+		for (const source of [create, wiring]) {
+			expect(source).toContain("waitForCreatedSessionProjection(");
+			expect(source.indexOf("sessionKernel(bksId).creationState()"))
+				.toBeLessThan(source.indexOf("actorCreationSetupPlan(bksId, createIdentity)"));
+		}
+		expect(create).toContain("failCreate(error instanceof Error");
+		expect(create).toContain("if (projected) return projected");
+		expect(create.indexOf("if (projected) return projected")).toBeLessThan(
+			create.indexOf('if (state.state === "failed")'),
+		);
+		const ws = read("ws-handlers.ts");
+		expect(ws).toContain("const kernelDispatchErrors = new Map<string, Error>()");
+		expect(ws).toContain("if (dispatchError) throw dispatchError");
+		expect(ws).toContain("kernelDispatchErrors.set(");
 	});
 
 	test("actor setup plans and MCP controls retain stable request identity", () => {
@@ -501,7 +520,8 @@ describe("single session ownership", () => {
 	test("WebSocket session mutations enter the mailbox before dispatch", () => {
 		const source = read("ws-handlers.ts");
 		expect(source).toContain("kernelCommands.has(msg.type)");
-		expect(source).toContain("kernelDispatchTokens.delete");
+		expect(source).toContain("isInternalKernelDispatch(");
+		expect(source).toContain("kernelDispatchTokens.delete(kernelToken)");
 		expect(source).toContain("__sessionKernelToken");
 		expect(source).not.toContain("__sessionKernelOwned");
 		expect(source).toContain('source: "websocket"');

--- a/packages/core/opensession-server/src/server/session-kernel/ws-command-bridge.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ws-command-bridge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { isInternalKernelDispatch } from "./ws-command-bridge";
+
+describe("recursive WebSocket command token", () => {
+  test("membership checks do not retire the token before failure is consumed", () => {
+    const active = new Set(["command-one"]);
+    expect(isInternalKernelDispatch(active, "command-one")).toBe(true);
+    expect(isInternalKernelDispatch(active, "command-one")).toBe(true);
+    expect(active.has("command-one")).toBe(true);
+    active.delete("command-one");
+    expect(isInternalKernelDispatch(active, "command-one")).toBe(false);
+  });
+
+  test("rejects unrelated and malformed tokens", () => {
+    const active = new Set(["owned"]);
+    expect(isInternalKernelDispatch(active, "foreign")).toBe(false);
+    expect(isInternalKernelDispatch(active, null)).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/session-kernel/ws-command-bridge.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ws-command-bridge.ts
@@ -1,0 +1,7 @@
+/** True only for a recursive command owned by the active outer dispatch. */
+export function isInternalKernelDispatch(
+  activeTokens: ReadonlySet<string>,
+  token: unknown,
+): token is string {
+  return typeof token === "string" && activeTokens.has(token);
+}

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -54,6 +54,7 @@ import { BOOT_ID, allClients, broadcastToAll, broadcastToSession, globalPresence
 import { existsSync, readFileSync, statSync, watch } from "fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isInternalKernelDispatch } from "./session-kernel/ws-command-bridge";
 import {
 	acknowledgeSessionCommand,
 	isRetryableSessionCommandError,
@@ -430,6 +431,7 @@ function serveTranscriptV2(
 
 const kernelDispatchTokens = new Set<string>();
 const kernelDispatchResults = new Map<string, unknown>();
+const kernelDispatchErrors = new Map<string, Error>();
 
 export const websocketHandlers: WebSocketHandler<WSClientData> = {
 	// Default is 16 MB — too small for a base64'd attachment near MAX_UPLOAD_BYTES,
@@ -556,9 +558,10 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				: typeof ws.data?.watchingSessionId === "string"
 					? ws.data.watchingSessionId
 					: undefined;
-		const internalKernelToken =
-			typeof msg.__sessionKernelToken === "string" &&
-			kernelDispatchTokens.delete(msg.__sessionKernelToken);
+		const internalKernelToken = isInternalKernelDispatch(
+			kernelDispatchTokens,
+			msg.__sessionKernelToken,
+		);
 		if (
 			!internalKernelToken &&
 			commandSessionId &&
@@ -605,6 +608,8 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 							__sessionKernelToken: kernelToken,
 						}),
 					);
+					const dispatchError = kernelDispatchErrors.get(kernelToken);
+					if (dispatchError) throw dispatchError;
 					return kernelDispatchResults.get(kernelToken);
 				},
 					);
@@ -649,6 +654,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				} finally {
 			kernelDispatchTokens.delete(kernelToken);
 					kernelDispatchResults.delete(kernelToken);
+					kernelDispatchErrors.delete(kernelToken);
 				}
 			return;
 		}
@@ -1530,14 +1536,27 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 		}
 		} catch (e) {
 			console.error(`[ws] ${msg?.type || "unknown"} handler failed:`, e);
-			try {
-				ws.send(
-					JSON.stringify({
-						type: "error",
-						message: `Internal error handling "${msg?.type || "message"}" — see server log`,
-					}),
+			const kernelToken = isInternalKernelDispatch(
+				kernelDispatchTokens,
+				msg?.__sessionKernelToken,
+			)
+				? msg.__sessionKernelToken
+				: undefined;
+			if (kernelToken) {
+				kernelDispatchErrors.set(
+					kernelToken,
+					e instanceof Error ? e : new Error(String(e)),
 				);
-			} catch {}
+			} else {
+				try {
+					ws.send(
+						JSON.stringify({
+							type: "error",
+							message: `Internal error handling "${msg?.type || "message"}" — see server log`,
+						}),
+					);
+				} catch {}
+			}
 		}
 	},
 


### PR DESCRIPTION
## Summary
- stop WebSocket and MCP create-command replay from re-entering setup after the actor has committed a terminal or opening-owned state
- wait for the session projection, or terminal failure, before returning protocol success
- read and identity-fence actor state before invoking setup-plan helpers
- route Web failure through `failCreate` so the pending socket cohort is always retired
- propagate token-scoped recursive handler errors into a failed durable `command_result`

This fixes the live `Creation setup plan was rejected: invalid_transition` recovery path without acknowledging an unresolvable session.

## Verification
- focused ownership and creation suite: 38 tests, 286 assertions
- `bun run typecheck`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
