### PR TITLE
Route every remaining GitHub reader through the App (no PAT reader left)

### DIFF
--- a/deploy/sandbox/microvm/refresh-sandbox-golden.sh
+++ b/deploy/sandbox/microvm/refresh-sandbox-golden.sh
@@ -60,7 +60,7 @@ compute_pins() {
   (
   cd "$ROOT"
   # Server-env parity: the systemd unit loads ~/.opensession.env
-  # (EnvironmentFile=), and injectToken prefers a live GITHUB_API_TOKEN from
+  # (EnvironmentFile=), and injectCloneCredential resolves the selected live GitHub credential from
   # the environment over persisted config tokens. Load the same file here so
   # the pin computation resolves the clone URL exactly like the server would
   # (a real env var also outranks the repo-local .env bun auto-loads).
@@ -68,7 +68,7 @@ compute_pins() {
     set -a; . "$CFG_HOME/.opensession.env"; set +a
   fi
   HOME="$CFG_HOME" GOLDEN_WANT_CLONE_URL="${1:-}" "$BUN_BIN" -e '
-import { bootstrapSignature, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
+import { bootstrapSignature, injectCloneCredential, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
 import { sandboxConfig } from "./src/server/sandbox/config.ts";
 import { REPO_ROOT } from "./src/runner-host/protocol.ts";
 const cfg = sandboxConfig();
@@ -77,7 +77,7 @@ console.log(cfg.runnerSha || "");
 if (process.env.GOLDEN_WANT_CLONE_URL) {
   let url;
   if (cfg.runnerRepoUrl) {
-    // Mirror bootstrap.ts toHttpsUrl+injectToken for the explicit-URL case.
+    // Mirror bootstrap.ts toHttpsUrl+injectCloneCredential for the explicit-URL case.
     let https = cfg.runnerRepoUrl;
     const scp = https.match(/^git@([^:]+):(.+?)(\.git)?$/);
     const ssh = https.match(/^ssh:\/\/git@([^/]+)\/(.+?)(\.git)?$/);
@@ -86,13 +86,7 @@ if (process.env.GOLDEN_WANT_CLONE_URL) {
     if (!/^https:\/\//.test(https)) {
       throw new Error(`runnerRepoUrl is not https-reachable: ${cfg.runnerRepoUrl}`);
     }
-    const cred = cfg.cloneCredential;
-    if (cred?.type === "https-token") {
-      const live = /^https:\/\/github\.com\//i.test(https) ? process.env.GITHUB_API_TOKEN : undefined;
-      const token = live || cred.token;
-      if (token) https = https.replace(/^https:\/\//, `https://x-access-token:${token}@`);
-    }
-    url = https;
+    url = await injectCloneCredential(https);
   } else {
     url = await remoteCloneUrl({ id: "opensession", repo: REPO_ROOT });
   }

--- a/packages/core/opensession-server/src/agents/slack/github-reviews.ts
+++ b/packages/core/opensession-server/src/agents/slack/github-reviews.ts
@@ -17,7 +17,6 @@ import { GITHUB_REPO } from "./state";
 import { ghRateLimited, noteGhRateLimited } from "../../server/github-limit";
 import { configuredIntegration } from "../../server/config";
 
-const GITHUB_TOKEN = process.env.GITHUB_API_TOKEN;
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 
 // ---------------------------------------------------------------------------
@@ -25,11 +24,13 @@ const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 // ---------------------------------------------------------------------------
 
 export async function githubApi(path: string): Promise<any> {
-  if (!GITHUB_TOKEN) return null;
+  const { githubToken } = await import("../../server/github-app");
+  const token = await githubToken();
+  if (!token) return null;
   try {
     const resp = await fetchWithTimeout(`https://api.github.com${path}`, {
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
     });

--- a/packages/core/opensession-server/src/server/account-health.ts
+++ b/packages/core/opensession-server/src/server/account-health.ts
@@ -286,6 +286,33 @@ async function githubPatIssues(): Promise<Issue[]> {
   ];
 }
 
+/**
+ * The GitHub App is the credential the bot now rides on most installs. If it is
+ * configured (client id + key) but cannot mint an installation token — a revoked
+ * key, an uninstalled App, a wrong installation owner — every bot gh/PR flow is
+ * down, exactly like a dead PAT. Warn on that. Skipped when no App is set up, so
+ * a PAT-only install is unaffected.
+ */
+async function githubAppIssues(): Promise<Issue[]> {
+  const { githubAppConfigured, githubAppInstallationToken } = await import(
+    "./github-app"
+  );
+  if (!githubAppConfigured()) return [];
+  if (await githubAppInstallationToken()) return [];
+  const agent = personaName();
+  const owner = githubWriteOwners()[0] || "the configured owner";
+  return [
+    {
+      key: "github:app:dead",
+      message:
+        `${agent} here — the GitHub App is configured but cannot mint an ` +
+        `installation token: every bot gh/PR flow is down. Check the App is still ` +
+        `installed on ${owner}'s repositories and that its private key is valid.`,
+      notify: FALLBACK_TEAMMATE,
+    },
+  ];
+}
+
 /** One sweep: detect, dedupe against state, DM, persist. Exported for tests/manual runs. */
 export async function sweepAccountHealth(): Promise<Issue[]> {
   // Repair before detecting: refresh idle codex accounts' ChatGPT tokens so
@@ -293,7 +320,11 @@ export async function sweepAccountHealth(): Promise<Issue[]> {
   await refreshIdleCodexTokens().catch((e) =>
     console.warn("[account-health] codex token refresh failed:", e)
   );
-  const issues = [...detectAccountIssues(), ...(await githubPatIssues())];
+  const issues = [
+    ...detectAccountIssues(),
+    ...(await githubPatIssues()),
+    ...(await githubAppIssues()),
+  ];
   const state = readState();
   const now = Date.now();
   const live = new Set(issues.map((i) => i.key));

--- a/packages/core/opensession-server/src/server/github-limit.ts
+++ b/packages/core/opensession-server/src/server/github-limit.ts
@@ -131,11 +131,14 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
 
 /**
  * Token for direct api.github.com calls made on the bot's behalf (conditional
- * change probes and the like): the GITHUB_API_TOKEN PAT when configured, else
- * the gh CLI's own token, probed once and cached for the process lifetime.
+ * change probes and the like): the App installation token (or GITHUB_API_TOKEN)
+ * that the REST helpers use, else the gh CLI's own token, probed once and cached
+ * for the process lifetime.
  */
 export async function botGhToken(): Promise<string | null> {
-  if (process.env.GITHUB_API_TOKEN) return process.env.GITHUB_API_TOKEN;
+  const { githubToken } = await import("./github-app");
+  const primary = await githubToken();
+  if (primary) return primary;
   if (state.botToken !== undefined) return state.botToken;
   try {
     const proc = Bun.spawn(["gh", "auth", "token"], {

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -1604,7 +1604,7 @@ async function* runPiAttempt(
     const githubCodeRun =
       mode === "code" && baseJournalKind(journal?.kind).startsWith("github-");
     const githubEnv = githubCodeRun
-      ? opts.githubEnv || {}
+      ? opts.githubEnv || githubRunEnv()
       : interactiveGithub
         ? githubRunEnv(user || author?.name)
         : {};

--- a/packages/core/opensession-server/src/server/pr-images.ts
+++ b/packages/core/opensession-server/src/server/pr-images.ts
@@ -152,7 +152,8 @@ const repoVisibilityCache = new Map<string, boolean>();
 export async function repoIsPrivate(ghRepo: string): Promise<boolean | null> {
   const cached = repoVisibilityCache.get(ghRepo);
   if (cached !== undefined) return cached;
-  const token = process.env.GITHUB_API_TOKEN || process.env.GH_TOKEN;
+  const { githubToken } = await import("./github-app");
+  const token = (await githubToken()) || process.env.GH_TOKEN;
   if (!token) return null;
   try {
     const res = await fetch(`https://api.github.com/repos/${ghRepo}`, {

--- a/packages/core/opensession-server/src/server/routes/instance-settings.ts
+++ b/packages/core/opensession-server/src/server/routes/instance-settings.ts
@@ -106,11 +106,12 @@ async function githubOrganizationProfile(
 	ctx: RouteContext,
 	login: string,
 ): Promise<Response> {
+	const { githubToken } = await import("../github-app");
 	const tokens = [
 		ctx.authUser?.login
 			? githubCredentialForLogin(ctx.authUser.login)?.env.GH_TOKEN
 			: undefined,
-		process.env.GITHUB_API_TOKEN,
+		await githubToken(),
 	].filter((token): token is string => !!token);
 	const response = await fetchWithTimeout(
 		`https://api.github.com/orgs/${encodeURIComponent(login)}`,

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -8,6 +8,7 @@ import {
   githubCredentialHelperCommand,
   matchesCodeStorageCheckout,
   validGithubFullName,
+  listReposViaAppInstallation,
 } from "./setup-repos";
 
 describe("validGithubFullName", () => {
@@ -47,6 +48,35 @@ describe("validGithubFullName", () => {
   });
 });
 
+
+describe("App installation repository listing", () => {
+  test("uses the installation endpoint rather than a user endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return Response.json({
+        repositories: [
+          {
+            full_name: "tellahq/opensession",
+            private: true,
+            default_branch: "main",
+            pushed_at: "2026-08-24T00:00:00Z",
+          },
+        ],
+      });
+    }) as typeof fetch;
+    try {
+      const repos = await listReposViaAppInstallation("ghs_installation");
+      expect(repos.map((repo) => repo.fullName)).toEqual(["tellahq/opensession"]);
+      expect(urls).toEqual([
+        "https://api.github.com/installation/repositories?per_page=100&page=1",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 describe("githubCredentialHelperCommand", () => {
   test("uses the stable installed command for compiled releases", () => {

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -130,6 +130,26 @@ async function listReposViaUserRepos(token: string): Promise<PickerRepo[]> {
   return repos.slice(0, REPO_LIST_CAP);
 }
 
+/** GitHub App installation-token path. Installation tokens cannot call the
+ * user endpoints used by PATs and App user tokens. */
+export async function listReposViaAppInstallation(token: string): Promise<PickerRepo[]> {
+  const registered = registeredGhRepos();
+  const repos: PickerRepo[] = [];
+  for (let page = 1; repos.length < REPO_LIST_CAP && page <= 5; page++) {
+    const { ok, body } = await githubJson(
+      token,
+      `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+    );
+    if (!ok || !Array.isArray(body?.repositories)) break;
+    for (const raw of body.repositories) {
+      const repo = toPickerRepo(raw, registered);
+      if (repo) repos.push(repo);
+    }
+    if (body.repositories.length < 100) break;
+  }
+  return repos.slice(0, REPO_LIST_CAP);
+}
+
 /** GitHub App user-token path: union of the token's accessible installations.
  *  Returns null when the token isn't installation-scoped (classic OAuth/PAT)
  *  so the caller can fall back to /user/repos. */
@@ -496,7 +516,8 @@ export async function handleSetupRepoRoutes(
     // the bot PAT, else an empty (but well-formed) answer.
     const userCredential = actingGithubCredential(ctx);
     // Bot credential: the App installation token when configured, else the PAT.
-    const { githubToken } = await import("../github-app");
+    const { githubBotCredentialMode, githubToken } = await import("../github-app");
+    const botCredential = githubBotCredentialMode();
     const botToken = userCredential ? null : await githubToken();
     const token = userCredential?.env.GH_TOKEN || botToken;
     const source: "user" | "bot" | null = userCredential
@@ -507,7 +528,9 @@ export async function handleSetupRepoRoutes(
     if (!token || !source) {
       return Response.json({ source: null, repos: [] });
     }
-    const cacheKey = userCredential ? userCredential.principal : "bot";
+    const cacheKey = userCredential
+      ? userCredential.principal
+      : `bot:${botCredential}`;
     const cached = repoListCache.get(cacheKey);
     if (cached && Date.now() - cached.at < REPO_CACHE_TTL_MS) {
       return Response.json(cached.payload);
@@ -517,8 +540,10 @@ export async function handleSetupRepoRoutes(
       // OAuth) via /user/repos. The installations call itself tells us which
       // kind we have — a non-App token gets an error and we fall back.
       const repos =
-        (source === "user" ? await listReposViaInstallations(token) : null) ??
-        (await listReposViaUserRepos(token));
+        source === "bot" && botCredential === "app"
+          ? await listReposViaAppInstallation(token)
+          : (source === "user" ? await listReposViaInstallations(token) : null) ??
+            (await listReposViaUserRepos(token));
       repos.sort((a, b) => (b.pushedAt || "").localeCompare(a.pushedAt || ""));
       const payload = {
         source,

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -495,10 +495,13 @@ export async function handleSetupRepoRoutes(
     // user in operator mode, the sole connected account in simple mode), else
     // the bot PAT, else an empty (but well-formed) answer.
     const userCredential = actingGithubCredential(ctx);
-    const token = userCredential?.env.GH_TOKEN || process.env.GITHUB_API_TOKEN;
+    // Bot credential: the App installation token when configured, else the PAT.
+    const { githubToken } = await import("../github-app");
+    const botToken = userCredential ? null : await githubToken();
+    const token = userCredential?.env.GH_TOKEN || botToken;
     const source: "user" | "bot" | null = userCredential
       ? "user"
-      : process.env.GITHUB_API_TOKEN
+      : botToken
         ? "bot"
         : null;
     if (!token || !source) {

--- a/packages/core/opensession-server/src/server/routes/setup-team.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.ts
@@ -190,9 +190,10 @@ async function syncGithubOrganizationMembers(ctx: RouteContext): Promise<Respons
   const userCredential = ctx.authUser?.login
     ? githubCredentialForLogin(ctx.authUser.login)
     : null;
+  const { githubToken } = await import("../github-app");
   const credentials = [
     userCredential?.env.GH_TOKEN,
-    process.env.GITHUB_API_TOKEN,
+    await githubToken(),
   ].filter((token, index, all): token is string => !!token && all.indexOf(token) === index);
   if (credentials.length === 0) {
     return Response.json({

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
@@ -8,7 +8,17 @@ import {
   remoteModelProviderId,
   remoteRunNeedsAnthropic,
   remoteRunNeedsOpenai,
+  selectedCloneToken,
 } from "./bootstrap";
+
+describe("GitHub clone credential cutover", () => {
+  test("App mode never falls back to a persisted PAT", () => {
+    expect(selectedCloneToken(undefined, "retired-pat", true, "app")).toBeUndefined();
+    expect(selectedCloneToken("fresh-app", "retired-pat", true, "app")).toBe("fresh-app");
+    expect(selectedCloneToken(undefined, "active-pat", true, "pat")).toBe("active-pat");
+    expect(selectedCloneToken(undefined, "other-host", false, "app")).toBe("other-host");
+  });
+});
 
 describe("remote engine credential projection", () => {
   test("every remote provider delegates launch credential projection to bootstrap", () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
@@ -48,7 +48,7 @@ describe("remote repo lifecycle", () => {
 		expect(bootstrapSignature()).toContain("node@24.18.1");
 		expect(bootstrapSignature()).toContain("just@1.43.1");
 		expect(bootstrapSignature()).toContain("gh@2.83.1");
-		expect(bootstrapSignature()).toContain("workspace-runtime-v7");
+		expect(bootstrapSignature()).toContain("workspace-runtime-v8");
 	});
 
 	test("setup is skipped after its durable stamp", async () => {
@@ -190,6 +190,29 @@ describe("remote repo lifecycle", () => {
 		expect(d.commands[1]!.command).toContain("ln -s");
 		expect(d.commands[1]!.command).not.toContain("mount --bind");
 		expect(d.commands[2]!.command).toContain("git clone --filter=blob:none");
+	});
+
+	test("scrubs a short-lived GitHub token after the bounded clone", async () => {
+		const d = driver([
+			{ exitCode: 0, stdout: "none\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "feature/new-ui\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "absent\n" },
+		]);
+		await setupRemoteWorkspace(
+			d.value,
+			"/work/feature",
+			"https://x-access-token:short-lived@github.com/tellahq/opensession.git",
+			"feature/new-ui",
+			"main",
+		);
+
+		const scrub = d.commands.find(({ command }) =>
+			command.startsWith("git remote set-url origin"),
+		);
+		expect(scrub?.command).toContain("https://github.com/tellahq/opensession.git");
+		expect(scrub?.command).not.toContain("short-lived");
 	});
 
 	test("cleans up a failed warm attach before cold-cloning", async () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -592,18 +592,27 @@ function credentialFreeHttpsUrl(httpsUrl: string): string {
   return parsed.toString();
 }
 
-function injectToken(httpsUrl: string): string {
+async function injectToken(httpsUrl: string): Promise<string> {
   const cred = sandboxConfig().cloneCredential;
   if (cred?.type === "https-token") {
-    // A hosted instance keeps a long-lived, org-scoped bot credential in
-    // GITHUB_API_TOKEN. Prefer it for GitHub clones over the config's token:
-    // GitHub App user tokens expire in ~8h, so persisting one in sandbox.json
-    // makes every fresh Daytona/Modal bootstrap fail days later. Self-hosters
-    // without the env keep the explicit cloneCredential.token behavior, and
+    // GitHub clones get a freshly resolved credential — used only for the
+    // bounded clone/fetch, then stripped (the origin is left credential-free),
+    // so a short-lived token is fine here. Prefer the App installation token
+    // (repo-scoped write), then the org-scoped bot PAT. Both are resolved live
+    // per bootstrap, never the config's persisted token, which goes stale and
+    // fails days later. Self-hosters without either keep cloneCredential.token;
     // non-GitHub origins never receive our GitHub-specific credential.
-    const liveGithubToken = /^https:\/\/github\.com\//i.test(httpsUrl)
-      ? process.env.GITHUB_API_TOKEN
-      : undefined;
+    let liveGithubToken: string | undefined;
+    const ghMatch = httpsUrl.match(/^https:\/\/github\.com\/(.+?)(?:\.git)?$/i);
+    if (ghMatch) {
+      const { githubAppRepositoryToken, githubToken } = await import(
+        "../../github-app"
+      );
+      liveGithubToken =
+        (await githubAppRepositoryToken(ghMatch[1])) ||
+        (await githubToken()) ||
+        undefined;
+    }
     const token = liveGithubToken || cred.token;
     if (token) {
       return httpsUrl.replace(/^https:\/\//, `https://x-access-token:${token}@`);
@@ -647,7 +656,7 @@ export async function remoteCloneUrl(repo: {
       `repo ${repo.id} has no https-reachable origin (origin="${redactUrl(origin) || "none"}") — remote sandboxes clone over https; set an origin or ghRepo`,
     );
   }
-  return injectToken(https);
+  return await injectToken(https);
 }
 
 /**
@@ -928,7 +937,7 @@ export async function bootstrapRemoteSandbox(
   const runnerCloneUrl = cfg.runnerBundleUrl
     ? undefined
     : cfg.runnerRepoUrl && toHttpsUrl(cfg.runnerRepoUrl)
-      ? injectToken(toHttpsUrl(cfg.runnerRepoUrl)!)
+      ? await injectToken(toHttpsUrl(cfg.runnerRepoUrl)!)
       : await remoteCloneUrl(runnerRepo);
   const hasRepo = await driver.exec(`test -f ${REMOTE_REPO}/package.json`);
   if (hasRepo.exitCode !== 0) {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -601,7 +601,19 @@ function isGithubHttpsUrl(httpsUrl: string): boolean {
   }
 }
 
-async function injectToken(httpsUrl: string): Promise<string> {
+/** Pick clone authority without crossing the operator's credential cutover.
+ * In App mode a missing live GitHub token fails closed; the persisted token may
+ * be the retired PAT. Non-GitHub hosts retain their explicit clone credential. */
+export function selectedCloneToken(
+  liveToken: string | undefined,
+  persistedToken: string | undefined,
+  github: boolean,
+  mode: "pat" | "app",
+): string | undefined {
+  return liveToken || (github && mode === "app" ? undefined : persistedToken);
+}
+
+export async function injectCloneCredential(httpsUrl: string): Promise<string> {
   const cred = sandboxConfig().cloneCredential;
   if (cred?.type === "https-token") {
     // GitHub clones get a freshly resolved credential — used only for the
@@ -622,7 +634,13 @@ async function injectToken(httpsUrl: string): Promise<string> {
         (await githubToken()) ||
         undefined;
     }
-    const token = liveGithubToken || cred.token;
+    const { githubBotCredentialMode } = await import("../../github-app");
+    const token = selectedCloneToken(
+      liveGithubToken,
+      cred.token,
+      !!ghMatch,
+      githubBotCredentialMode(),
+    );
     if (token) {
       return httpsUrl.replace(/^https:\/\//, `https://x-access-token:${token}@`);
     }
@@ -665,7 +683,7 @@ export async function remoteCloneUrl(repo: {
       `repo ${repo.id} has no https-reachable origin (origin="${redactUrl(origin) || "none"}") — remote sandboxes clone over https; set an origin or ghRepo`,
     );
   }
-  return await injectToken(https);
+  return await injectCloneCredential(https);
 }
 
 /**
@@ -946,7 +964,7 @@ export async function bootstrapRemoteSandbox(
   const runnerCloneUrl = cfg.runnerBundleUrl
     ? undefined
     : cfg.runnerRepoUrl && toHttpsUrl(cfg.runnerRepoUrl)
-      ? await injectToken(toHttpsUrl(cfg.runnerRepoUrl)!)
+      ? await injectCloneCredential(toHttpsUrl(cfg.runnerRepoUrl)!)
       : await remoteCloneUrl(runnerRepo);
   const hasRepo = await driver.exec(`test -f ${REMOTE_REPO}/package.json`);
   if (hasRepo.exitCode !== 0) {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -592,6 +592,15 @@ function credentialFreeHttpsUrl(httpsUrl: string): string {
   return parsed.toString();
 }
 
+function isGithubHttpsUrl(httpsUrl: string): boolean {
+  try {
+    const parsed = new URL(httpsUrl);
+    return parsed.protocol === "https:" && parsed.hostname.toLowerCase() === "github.com";
+  } catch {
+    return false;
+  }
+}
+
 async function injectToken(httpsUrl: string): Promise<string> {
   const cred = sandboxConfig().cloneCredential;
   if (cred?.type === "https-token") {
@@ -1374,8 +1383,8 @@ export async function setupRemoteWorkspace(
   }
   if (!cloned) {
     console.log(`[sandbox-remote] cloning ${redactUrl(cloneUrl)} into ${cwd}`);
-    // Blobless partial clone: full history/refs but blobs fetched lazily via
-    // the persisted (tokenized) origin URL. A large repo's full .git can be
+    // Blobless partial clone: full history/refs, with later blobs fetched via
+    // a fresh run-scoped credential helper. A large repo's full .git can be
     // ~2.4GB vs ~450MB blobless — on a 10GiB sandbox disk that headroom is
     // the difference between working and ENOSPC (verified live 2026-07-09:
     // full clone died on the default 3GiB disk with an EMPTY git error,
@@ -1421,6 +1430,19 @@ export async function setupRemoteWorkspace(
     }
   }
   mark("branch ready");
+  // Installation tokens expire in about an hour. Keep them only for this
+  // bounded clone/fetch, then leave a credential-free GitHub origin. Every run
+  // projects a fresh token through the process-local credential helper below,
+  // so lazy blob fetches and pushes never depend on a token at rest.
+  if (isGithubHttpsUrl(cloneUrl)) {
+    const safeOrigin = credentialFreeHttpsUrl(cloneUrl);
+    const scrubbed = await driver.exec(
+      `git remote set-url origin ${shellQuoteWord(safeOrigin)}`,
+      { cwd },
+    );
+    if (scrubbed.exitCode !== 0)
+      throw new Error(`could not scrub GitHub clone credential: ${scrubbed.stderr.trim().slice(0, 300)}`);
+  }
   // Per-session only: warm/template preparation never calls this path, so
   // private files are injected after restore and can never land in a shared
   // provider snapshot.
@@ -1645,13 +1667,28 @@ function makeRemoteLauncher(
       ]);
       secureFiles.push(claudeAccountsPath, REMOTE_MCP_CONFIG);
 
-      // Interactive parity for GitHub uses a run-scoped access-token file.
-      // Do not put it in spec.json or the launch command, and never project it
-      // into the fail-closed automation profile. githubRunEnv reads this file
-      // inside the guest and installs a process-local HTTPS credential helper.
-      const githubAuth = automationProfile
+      // GitHub credentials are projected through a private, run-scoped file,
+      // never spec.json, argv, or the persisted origin. Interactive runs prefer
+      // their user's token. GitHub code automations and user-less interactive
+      // runs receive a freshly resolved service credential for this one repo;
+      // every other automation stays credential-free.
+      let githubAuth = automationProfile
         ? {}
         : githubAuthEnv(spec.user || spec.author?.name);
+      const githubCodeAutomation =
+        automationProfile &&
+        spec.mode === "code" &&
+        (spec.journalKind || "").startsWith("github-");
+      if (!githubAuth.GH_TOKEN && (!automationProfile || githubCodeAutomation)) {
+        const origin = await driver.exec("git remote get-url origin", { cwd: spec.cwd });
+        const match = origin.exitCode === 0
+          ? origin.stdout.trim().match(/^https:\/\/github\.com\/(?:x-access-token:[^@]+@)?([^/]+\/[^/]+)$/i)
+          : null;
+        if (match) {
+          const { githubServiceCredentialEnv } = await import("../../github-app");
+          githubAuth = await githubServiceCredentialEnv(match[1].replace(/\.git$/i, ""));
+        }
+      }
       const githubAuthPath = `${dir}/github-auth.json`;
       if (githubAuth.GH_TOKEN) {
         await driver.writeFile(githubAuthPath, JSON.stringify(githubAuth));

--- a/packages/core/opensession-server/src/server/sandbox/config.ts
+++ b/packages/core/opensession-server/src/server/sandbox/config.ts
@@ -252,9 +252,9 @@ export interface SandboxConfig {
   firecrackerMicrovm?: SandboxFirecrackerMicrovmConfig;
   /** Credential-minimal unattended-run profile. */
   automation?: SandboxAutomationConfig;
-  /** Clone auth for remote-provider workspaces + runner bootstrap. On hosted
-   *  GitHub clones, the live GITHUB_API_TOKEN takes precedence so an expiring
-   *  GitHub App user token is never treated as durable sandbox config. */
+  /** Clone auth for remote-provider workspaces + runner bootstrap. The selected
+   *  live GitHub service credential takes precedence; App mode never falls back
+   *  to a persisted token because it may be the retired PAT. */
   cloneCredential?: SandboxCloneCredential;
   /** Warm-on-typing prewarm pool. Absent = defaults, with `enabled` true
    *  whenever a provider with a prewarm adapter is configured. */

--- a/packages/core/opensession-server/src/server/worktree.ts
+++ b/packages/core/opensession-server/src/server/worktree.ts
@@ -609,15 +609,38 @@ export async function reviveWorktree(branch: string, repoId?: string): Promise<s
  * Explicit refspecs bypass the remote config. Found on a repo cloned
  * single-branch during node provisioning; `--unshallow` fixes depth, not this.
  */
+/**
+ * Git env that authenticates a server-side fetch/push against `ghRepo` with the
+ * App installation token (contents scope), so the code-mode PR worktrees below
+ * resolve on PRIVATE repos with no bot PAT. Empty when the App can't mint — a
+ * public repo fetches anonymously, and the injected env just re-passes the
+ * process env. The token is cached in github-app.ts, so this does not re-mint
+ * per call.
+ */
+async function gitAppCredentialEnv(
+  ghRepo: string | undefined,
+): Promise<Record<string, string>> {
+  if (!ghRepo) return {};
+  const { githubAppRepositoryToken } = await import("./github-app");
+  const { githubGitCredentialEnv } = await import("./github-git-credential");
+  const token = await githubAppRepositoryToken(ghRepo);
+  return token ? githubGitCredentialEnv(token) : {};
+}
+
 async function fetchBranchesWithTracking(
   gitDir: string,
+  ghRepo: string | undefined,
   ...branches: (string | undefined)[]
 ): Promise<void> {
   const specs = [...new Set(branches.filter((b): b is string => !!b))].map(
     (b) => `+refs/heads/${b}:refs/remotes/origin/${b}`,
   );
   if (specs.length === 0) return;
-  await $`git -C ${gitDir} fetch origin ${specs} --quiet`;
+  const env = await gitAppCredentialEnv(ghRepo);
+  await $`git -C ${gitDir} fetch origin ${specs} --quiet`.env({
+    ...process.env,
+    ...env,
+  });
 }
 
 /**
@@ -633,9 +656,11 @@ export async function createWorktreeForPrBranch(headRef: string, repoId?: string
   const wtPath = `${worktreesDir()}/${repo.wtPrefix}-${headRef}-os`;
 
   const reused = await withGitLock(async () => {
-    await fetchBranchesWithTracking(repo.repo, headRef);
+    await fetchBranchesWithTracking(repo.repo, repo.ghRepo, headRef);
     if (existsSync(wtPath)) {
-      await $`git -C ${wtPath} fetch origin ${headRef} --quiet`.nothrow();
+      await $`git -C ${wtPath} fetch origin ${headRef} --quiet`
+        .env({ ...process.env, ...(await gitAppCredentialEnv(repo.ghRepo)) })
+        .nothrow();
       await $`git -C ${wtPath} reset --hard origin/${headRef}`.quiet().nothrow();
       return true;
     }
@@ -669,7 +694,7 @@ export async function createReviewWorktreeForPrHead(
   const repo = getRepo(repoId);
   const wtPath = `${worktreesDir()}/${repo.wtPrefix}-${headRef}-os-review`;
   return withGitLock(async () => {
-    await fetchBranchesWithTracking(repo.repo, headRef, baseRef || repo.defaultBranch);
+    await fetchBranchesWithTracking(repo.repo, repo.ghRepo, headRef, baseRef || repo.defaultBranch);
     if (existsSync(wtPath)) {
       // A code session recovering from a deleted worktree may have borrowed this
       // path and switched it onto the source branch. Restore review ownership.

--- a/packages/core/opensession-server/src/server/worktree.ts
+++ b/packages/core/opensession-server/src/server/worktree.ts
@@ -613,7 +613,6 @@ async function githubServiceGitEnv(ghRepo: string | undefined) {
   const { githubServiceCredentialEnv } = await import("./github-app");
   return { ...process.env, ...(await githubServiceCredentialEnv(ghRepo)) };
 }
-}
 
 async function fetchBranchesWithTracking(
   gitDir: string,


### PR DESCRIPTION
Stage (c) — the last of the App-single-credential migration. **Stacked on #157 → #153.**

#153 moved the PR agent's REST/GraphQL onto the App token. The review agent then flagged that code-mode git and several other readers still used the PAT. This routes **every** remaining reader through the App.

## Readers routed
| Reader | Now |
|---|---|
| `github-limit` rate probe, `pr-images`, Slack `githubApi` | `githubToken()` (App→PAT) |
| setup: repo list, team sync, org lookup | acting user's token, then App→PAT |
| **code-mode git** (`createWorktreeForPrBranch`, review worktree) | inject the App repo token via `githubGitCredentialEnv` |
| sandbox clone | fresh App repo token (used for the bounded clone, then stripped), then PAT |
| `account-health` | also alerts when a configured App can't mint (App-world "dead PAT") |

## Result: zero PAT readers
Every remaining `GITHUB_API_TOKEN` reference is now the single fallback inside `githubToken()`, the health monitor, or a presence/status boolean. No operational path reads the PAT as its primary credential.

## Verification
- **Git auth proven locally** (the key risk): minted the App repo token exactly as `githubAppRepositoryToken` does and confirmed `git ls-remote` (read) and `git push --dry-run` (write) both authenticate against `tellahq/opensession` with `GITHUB_API_TOKEN` and `GH_TOKEN` unset.
- `tsc --noEmit` (no new errors) + module side-effects guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Safe rollout

This stage honors the explicit PAT/App setting throughout. In App mode, repository tokens are short-lived and repo-scoped, remote origins are scrubbed after clone, and later runs receive freshly resolved credentials without persisting secrets in Git config or host specs.

Created by [this OS session](https://os.tella.dev/session/os-01a033fd-020d-76bc-be85-60b19b241fbc)