### PR TITLE
Claim queued turn batches inside the session actor

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -90,8 +90,12 @@ actor is unavailable. The direct store adapter exists only for isolated tests.
 Delivery mutation and dispatch claim, acknowledgement or failure are short typed
 Worker reductions. Mutation replies contain only the operation result and new
 revision. They invalidate the gateway projection instead of returning or eagerly
-refetching the full attachment-bearing aggregate. Claiming a batch removes it from the queue and installs its
-dispatch in one SQLite transaction. Failure atomically restores that exact batch
+refetching the full attachment-bearing aggregate. Queue batching policy (solo
+interrupts, auto-continue, review handoffs, delegated reports and worker holds)
+now runs inside the same actor reduction as the claim. The gateway supplies
+only live policy facts such as whether child workers remain. Claiming removes
+the selected batch from the queue and installs its dispatch in one SQLite
+transaction. Failure atomically restores that exact batch
 ahead of later work. Steering first moves an item to a pending-steer checkpoint,
 then reports runner acceptance or rejection as a second typed fact. Restart treats
 an unresolved checkpoint as ambiguous acceptance and reconciles it through the

--- a/packages/core/opensession-server/src/server/queue-state-update.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-update.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { classifyEntry } from "@tellahq/opensession-protocol/notices";
 import {
 	acknowledgePromptDispatch,
+	beginNextPromptDispatch,
 	beginPromptDispatch,
 	clientVisibleQueuedCount,
 	isDelegatedQueueItem,
@@ -30,6 +31,27 @@ describe("takeQueuedPrompt", () => {
 				files: [{ name: "brief.pdf", path: "/tmp/brief.pdf" }],
 			},
 			{ id: "q2", content: "second", user: "Michiel" },
+		]);
+	});
+
+	test("selects and claims through the compatibility actor store", () => {
+		const claim = beginNextPromptDispatch(
+			SESSION,
+			{ soloId: "q2", interruptMark: true, stillWorking: true },
+			false,
+		);
+		expect(claim).toMatchObject({
+			kind: "deliver",
+			batch: [{ id: "q2", content: "second", user: "Michiel" }],
+		});
+		expect(promptQueues.get(SESSION)).toEqual([
+			{
+				id: "q1",
+				content: "first",
+				user: "Kent",
+				images: [PNG],
+				files: [{ name: "brief.pdf", path: "/tmp/brief.pdf" }],
+			},
 		]);
 	});
 

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -500,6 +500,34 @@ export function restorePersistedQueueState(options: {
 	};
 }
 
+/** Let the actor select and claim the next queue batch in one transaction. */
+export function beginNextPromptDispatch(
+	sessionId: string,
+	opts: {
+		soloId?: string;
+		interruptMark?: boolean;
+		stillWorking?: boolean;
+	},
+	effects = true,
+):
+	| { kind: "empty" }
+	| { kind: "hold"; heldCount: number }
+	| { kind: "deliver"; promptEntryId: string; batch: QueueItem[] } {
+	const claimed = sessionDelivery({
+		op: "claim_next_dispatch",
+		sessionId,
+		promptEntryId: crypto.randomUUID(),
+		...opts,
+	});
+	if (claimed.kind !== "deliver") return claimed;
+	if (effects) persistQueues();
+	return {
+		kind: "deliver",
+		promptEntryId: claimed.promptEntryId,
+		batch: claimed.items as QueueItem[],
+	};
+}
+
 /** Move a selected queue batch into durable dispatching state before starting
  * runner work. The caller has already removed the batch from promptQueues, so
  * this single persistence point records either the old queued copy (if we die

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -123,6 +123,7 @@ import { broadcastToSession, sessionWatchers } from "./ws-hub";
 import { getWorkspace } from "./workspaces";
 import {
 	broadcastQueue,
+	beginNextPromptDispatch,
 	beginPromptDispatch,
 	durableQueueItem,
 	acknowledgePromptDispatch,
@@ -231,7 +232,6 @@ import {
 	WEDGE_RETRY_PROMPT,
 } from "./auto-continue";
 import { SYSTEM_RESTART_USER } from "./session-actors";
-import { selectQueueBatch } from "./queue-hold";
 
 const g = globalThis as any;
 
@@ -240,7 +240,7 @@ const g = globalThis as any;
 // in a row parks for the human instead of looping. Cleared when a human prompt
 // arrives or a turn does real (tool-calling) work — which also means that while
 // the agent keeps genuinely working through announced steps, queued messages
-// stay held behind fresh auto-continues (the queue-hold in the run-end handler)
+// stay held behind fresh auto-continues (the actor queue hold at run end)
 // until a turn ends without announcing more work.
 const autoContinueNudged: Set<string> = (g.__autoContinueNudged ??= new Set());
 
@@ -310,7 +310,7 @@ export function runningChildCount(sessionId: string): number {
 
 /** Append a message to a session's drainable queue and persist + broadcast.
  *  `front` puts it ahead of everything already queued — used by the run-end
- *  queue-hold so its auto-continue delivers before the user's queued messages. */
+ *  actor queue hold so its auto-continue delivers before queued user messages. */
 export function enqueuePrompt(
 	sessionId: string,
 	item: QueueItem,
@@ -1023,7 +1023,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
 			watchExternalRunAndDrain(sessionId);
 			return;
 		}
-		// Batch selection lives in queue-hold.ts (pure, unit-tested): a solo
+		// Batch selection lives in the actor's pure queue reducer: a solo
 		// interrupt (queue chip ▲) delivers one item, a head auto-continue
 		// delivers alone, and while child worker runs are still going, human
 		// composer sends (item.hold) stay parked until the agent FULLY
@@ -1034,38 +1034,28 @@ async function drainQueueInner(sessionId: string): Promise<void> {
 		// both whether this batch skips the hold and whether it gets the steer
 		// note below, so an expired one can never do one without the other.
 		const interrupt = consumeInterruptMark(sessionId);
-		const plan = selectQueueBatch(queue, {
+		// Selection and claim are one actor reduction. Queue contents cannot
+		// change between the gateway choosing a batch and durable dispatch ownership.
+		const claim = beginNextPromptDispatch(sessionId, {
 			soloId: interrupt?.soloId,
 			interruptMark: interrupt !== undefined,
 			stillWorking: runningChildCount(sessionId) > 0,
 		});
-		if (plan.kind === "hold") {
+		if (claim.kind === "empty") continue;
+		if (claim.kind === "hold") {
 			if (!queueHoldNotified.has(sessionId)) {
 				queueHoldNotified.add(sessionId);
 				broadcastToSession(sessionId, {
 					type: "notice",
 					sessionId,
-					message: `Holding ${plan.heldCount} queued message${plan.heldCount === 1 ? "" : "s"} until the agent fully completes (worker sessions still running). Steer sends one in sooner.`,
+					message: `Holding ${claim.heldCount} queued message${claim.heldCount === 1 ? "" : "s"} until the agent fully completes (worker sessions still running). Steer sends one in sooner.`,
 				});
 			}
 			watchExternalRunAndDrain(sessionId);
 			return;
 		}
 		queueHoldNotified.delete(sessionId);
-		const batch = plan.batch;
-		// Claiming removes this exact batch and installs its dispatch in one actor
-		// transaction. A crash cannot leave the items in neither location.
-		// Persist the delivery intent before starting work. If the process dies
-		// after this point but before the runner journals its run, boot restores
-		// this batch to the front of the queue.
-		const promptEntryId = beginPromptDispatch(
-			sessionId,
-			batch,
-			undefined,
-			true,
-			undefined,
-			true,
-		);
+		const { batch, promptEntryId } = claim;
 		broadcastQueue(sessionId);
 		let combined = batch
 			.map((m) =>

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -513,6 +513,38 @@ describe("session kernel actor boundary", () => {
     expect(snapshotCalls).toBe(1);
   });
 
+  test("selects and claims a queue batch through the actor protocol", async () => {
+    const host = await actor();
+    host.decideDelivery({
+      op: "set",
+      sessionId: "actor-next-dispatch",
+      slot: "queued",
+      value: [
+        { id: "held", content: "later", hold: true },
+        { id: "solo", promptEntryId: "stable-entry", content: "now", hold: true },
+      ],
+    });
+    expect(host.decideDelivery({
+      op: "claim_next_dispatch",
+      sessionId: "actor-next-dispatch",
+      promptEntryId: "candidate-entry",
+      soloId: "solo",
+      interruptMark: true,
+      stillWorking: true,
+    })).toMatchObject({
+      kind: "deliver",
+      promptEntryId: "stable-entry",
+      items: [{ id: "solo", promptEntryId: "stable-entry" }],
+    });
+    expect(host.decideDelivery({
+      op: "snapshot",
+      sessionId: "actor-next-dispatch",
+    })).toMatchObject({
+      queued: [{ id: "held" }],
+      dispatch: { promptEntryId: "stable-entry" },
+    });
+  });
+
   test("keeps actor reducers responsive while gateway effects stay ordered", async () => {
     const host = await actor();
     installSessionKernelActor(host);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -682,6 +682,14 @@ class RemoteStore implements SessionKernelStoreApi {
       items,
     });
   }
+  claimNextDeliveryDispatch(
+    input: Parameters<SessionKernelStoreApi["claimNextDeliveryDispatch"]>[0],
+  ): ReturnType<SessionKernelStoreApi["claimNextDeliveryDispatch"]> {
+    return this.actor.decideDelivery({
+      op: "claim_next_dispatch",
+      ...input,
+    }) as ReturnType<SessionKernelStoreApi["claimNextDeliveryDispatch"]>;
+  }
   claimDeliveryDispatch(
     input: Parameters<SessionKernelStoreApi["claimDeliveryDispatch"]>[0],
   ) {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-protocol.ts
@@ -8,7 +8,7 @@ import type {
   RunEventDecisionResult,
 } from "./store";
 
-export const SESSION_KERNEL_ACTOR_VERSION = 9;
+export const SESSION_KERNEL_ACTOR_VERSION = 10;
 export const SESSION_KERNEL_MAX_WAITERS_PER_COMMAND = 64;
 export const SESSION_KERNEL_MAX_WAITERS_TOTAL = 4096;
 export const SESSION_KERNEL_MAX_EXECUTIONS_PER_SESSION = 128;

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -341,6 +341,8 @@ export function startSessionKernelActorWorker(): void {
               delivery.sessionId,
               delivery.items,
             );
+          else if (delivery.op === "claim_next_dispatch")
+            result = store.claimNextDeliveryDispatch(delivery);
           else if (delivery.op === "claim_dispatch")
             result = store.claimDeliveryDispatch(delivery);
           else if (delivery.op === "ack_dispatch")

--- a/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
@@ -17,6 +17,14 @@ export type DeliveryActorRequest =
   | { op: "settle_pending_steers" }
   | { op: "requeue_steers"; sessionId: string; items: unknown[] }
   | {
+      op: "claim_next_dispatch";
+      sessionId: string;
+      promptEntryId: string;
+      soloId?: string;
+      interruptMark?: boolean;
+      stillWorking?: boolean;
+    }
+  | {
       op: "claim_dispatch";
       sessionId: string;
       items: DeliveryItem[];
@@ -45,6 +53,16 @@ export type DeliveryActorResult<T extends DeliveryActorRequest> =
       ? Array<[string, unknown]>
       : T extends { op: "claim_dispatch" }
         ? { promptEntryId: string; items: unknown[]; revision: number }
+        : T extends { op: "claim_next_dispatch" }
+          ?
+              | { kind: "empty"; revision: number }
+              | { kind: "hold"; heldCount: number; revision: number }
+              | {
+                  kind: "deliver";
+                  promptEntryId: string;
+                  items: unknown[];
+                  revision: number;
+                }
         : T extends { op: "prepare_steer" }
           ? unknown | undefined
           : T extends {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1071,6 +1071,56 @@ describe("SessionKernel", () => {
 		expect(store.deliverySnapshot("delivery").dispatch).toBeUndefined();
 	});
 
+	test("selects and claims the next queue batch in one actor transaction", () => {
+		store.setDeliverySlot("next-delivery", "queued", [
+			{ id: "held", content: "wait", hold: true },
+			{
+				id: "solo",
+				promptEntryId: "stable-solo-entry",
+				content: "send now",
+				hold: true,
+			},
+		]);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "next-delivery",
+			promptEntryId: "unused-entry",
+			stillWorking: true,
+		})).toMatchObject({ kind: "hold", heldCount: 2 });
+		expect(store.deliverySnapshot("next-delivery").queued).toHaveLength(2);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "next-delivery",
+			promptEntryId: "solo-entry",
+			soloId: "solo",
+			interruptMark: true,
+			stillWorking: true,
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-solo-entry",
+			items: [
+				{
+					id: "solo",
+					promptEntryId: "stable-solo-entry",
+					content: "send now",
+					hold: true,
+				},
+			],
+		});
+		expect(store.deliverySnapshot("next-delivery")).toMatchObject({
+			queued: [{ id: "held", content: "wait", hold: true }],
+			dispatch: {
+				promptEntryId: "stable-solo-entry",
+				items: [
+					{
+						id: "solo",
+						promptEntryId: "stable-solo-entry",
+						content: "send now",
+						hold: true,
+					},
+				],
+			},
+		});
+	});
+
 	test("recovers an ambiguous prepared steer without duplicate queue delivery", () => {
 		store.setDeliverySlot("steer-recovery", "queued", [
 			{ id: "steer-one", content: "fold me in" },

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -138,6 +138,8 @@ export function sessionDelivery<T extends DeliveryActorRequest>(
     result = store.settlePendingSteers();
   else if (request.op === "requeue_steers")
     result = store.requeueSteerDeliveries(request.sessionId, request.items);
+  else if (request.op === "claim_next_dispatch")
+    result = store.claimNextDeliveryDispatch(request);
   else if (request.op === "claim_dispatch")
     result = store.claimDeliveryDispatch(request);
   else if (request.op === "ack_dispatch")

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -158,6 +158,15 @@ describe("single session ownership", () => {
 		);
 	});
 
+	test("queue selection and dispatch claim execute atomically inside the actor", () => {
+		const run = read("run-session.ts");
+		const actor = read("session-kernel/actor-worker.ts");
+		expect(run).toContain("beginNextPromptDispatch(sessionId");
+		expect(run).not.toContain("selectQueueBatch(queue");
+		expect(actor).toContain('delivery.op === "claim_next_dispatch"');
+		expect(actor).toContain("store.claimNextDeliveryDispatch(delivery)");
+	});
+
 	test("run-state decisions execute atomically inside the actor", () => {
 		const facade = read("run-state.ts");
 		const actor = read("session-kernel/actor-worker.ts");

--- a/packages/core/opensession-server/src/server/session-kernel/queue-batch-reducer.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/queue-batch-reducer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { AUTO_CONTINUE_USER } from "./auto-continue";
-import { selectQueueBatch } from "./queue-hold";
-import type { QueueItem } from "./queue-state";
-import { agentActor, workerActor } from "./session-actors";
+import { AUTO_CONTINUE_USER } from "../auto-continue";
+import { selectQueueBatch } from "./queue-batch-reducer";
+import type { QueueItem } from "../queue-state";
+import { agentActor, workerActor } from "../session-actors";
 
 const SOURCE = "os-019fe194-5fbe-7000-a81e-d0a656ad77f4";
 const human = (id: string): QueueItem => ({ id, content: id, user: "Jaap", hold: true });

--- a/packages/core/opensession-server/src/server/session-kernel/queue-batch-reducer.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/queue-batch-reducer.ts
@@ -1,12 +1,12 @@
 /**
- * Pure queue-batch selection for run-session's drain loop, split out so the
- * "queued messages deliver only when the agent FULLY completes" promise is
- * unit-testable. The drain calls this once per pass with the live queue and
- * the session's continuation state; it never mutates the input.
+ * Pure queue-batch selection for the actor's atomic delivery claim. The
+ * "queued messages deliver only when the agent FULLY completes" promise stays
+ * unit-testable while the gateway supplies only live policy facts. The reducer
+ * never mutates its input.
  */
-import { AUTO_CONTINUE_USER } from "./auto-continue";
-import type { QueueItem } from "./queue-state";
-import { delegatedActorParent } from "./session-actors";
+import { AUTO_CONTINUE_USER } from "../auto-continue";
+import type { QueueItem } from "../queue-state";
+import { delegatedActorParent } from "../session-actors";
 
 export type QueueBatchPlan =
 	| { kind: "deliver"; batch: QueueItem[]; rest: QueueItem[] }

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -20,6 +20,8 @@ import type { StagedCreationActorEffect } from "./creation-effect-protocol";
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync } from "fs";
 import { dirname } from "path";
 import { sessionsDir } from "../paths";
+import { selectQueueBatch } from "./queue-batch-reducer";
+import type { QueueItem } from "../queue-state";
 
 export type DurableCommandStatus =
   "pending" | "processing" | "completed" | "failed" | "indeterminate";
@@ -1876,6 +1878,71 @@ export class SessionKernelStore {
       });
     }
     return count;
+  }
+
+  claimNextDeliveryDispatch(input: {
+    sessionId: string;
+    promptEntryId: string;
+    soloId?: string;
+    interruptMark?: boolean;
+    stillWorking?: boolean;
+  }):
+    | { kind: "empty"; revision: number }
+    | { kind: "hold"; heldCount: number; revision: number }
+    | {
+        kind: "deliver";
+        promptEntryId: string;
+        items: QueueItem[];
+        revision: number;
+      } {
+    if (
+      !input.promptEntryId ||
+      input.promptEntryId.length > 256 ||
+      (input.soloId !== undefined &&
+        (!input.soloId || input.soloId.length > 256))
+    ) throw new Error("Invalid next prompt dispatch identity");
+    const mutation = this.mutateDelivery(
+      input.sessionId,
+      "delivery_next_dispatch_claimed",
+      (state) => {
+        if (state.dispatch) throw new Error("A prompt dispatch is already active");
+        const queued = state.queued as QueueItem[];
+        if (!queued.length) return { kind: "empty" as const };
+        const plan = selectQueueBatch(queued, {
+          soloId: input.soloId,
+          interruptMark: input.interruptMark,
+          stillWorking: input.stillWorking,
+        });
+        if (plan.kind === "hold") return plan;
+        const promptEntryId =
+          plan.batch.length === 1 && plan.batch[0]?.promptEntryId
+            ? plan.batch[0].promptEntryId
+            : input.promptEntryId;
+        if (!promptEntryId || promptEntryId.length > 256)
+          throw new Error("Invalid claimed prompt dispatch identity");
+        state.queued = plan.rest;
+        state.dispatch = {
+          promptEntryId,
+          items: plan.batch,
+        };
+        return {
+          kind: "deliver" as const,
+          promptEntryId,
+          items: plan.batch,
+        };
+      },
+    );
+    return {
+      ...(mutation.result as
+        | { kind: "empty" }
+        | { kind: "hold"; heldCount: number }
+        | {
+            kind: "deliver";
+            promptEntryId: string;
+            items: QueueItem[];
+          }),
+      revision: mutation.state.revision,
+    };
   }
 
   claimDeliveryDispatch(input: {


### PR DESCRIPTION
## Summary
- move solo, hold, auto-continue, review-handoff, and delegated-report batch selection into a pure actor reducer
- select the batch and install its pre-journal dispatch in one SQLite transaction
- preserve stable single-message prompt identities and validate externally supplied claim fences
- return only the claimed batch/revision while actor projection invalidation refreshes the gateway cache

## Verification
- focused queue, restart, actor, and ownership suite: 116 tests, 1005 assertions
- `bun run typecheck`
- module side-effect scan (413 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
