### PR TITLE
Preserve multi-message dispatch identity on retry

### DIFF
--- a/packages/core/opensession-server/src/server/queue-state-restart.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-restart.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
+	beginNextPromptDispatch,
+	deleteQueuedPrompt,
 	hydratePersistedQueueState,
 	persistQueues,
 	promptDispatches,
@@ -153,7 +155,7 @@ describe("steer receipt restart persistence", () => {
 		expect(steeredReceipts.has(SESSION)).toBe(false);
 	});
 
-	test("an ordinary unjournaled dispatch is still requeued", () => {
+	test("an ordinary multi-item dispatch keeps its identity after a crash", () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-ordinary-dispatch-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -162,7 +164,10 @@ describe("steer receipt restart persistence", () => {
 				dispatching: {
 					[SESSION]: {
 						promptEntryId: "ordinary-entry",
-						items: [{ id: "ordinary", content: "retry me" }],
+						items: [
+							{ id: "ordinary-one", content: "retry me" },
+							{ id: "ordinary-two", content: "and me" },
+						],
 					},
 				},
 			}),
@@ -175,9 +180,25 @@ describe("steer receipt restart persistence", () => {
 			deliveredUserTexts: () => [],
 			effects: false,
 		});
-		expect(restored.queuedCount).toBe(1);
+		expect(restored.queuedCount).toBe(2);
 		expect(promptQueues.get(SESSION)?.[0]?.promptEntryId).toBe("ordinary-entry");
 		expect(promptDispatches.has(SESSION)).toBe(false);
+		expect(deleteQueuedPrompt(SESSION, "ordinary-one", undefined, false)).toBe(
+			true,
+		);
+		expect(
+			beginNextPromptDispatch(
+				SESSION,
+				{ soloId: "ordinary-two", interruptMark: true },
+				false,
+			),
+		).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "ordinary-entry",
+			batch: [
+				{ id: "ordinary-two", retryDispatchId: "ordinary-entry" },
+			],
+		});
 	});
 
 	test("a cold restart preserves an actor-owned create dispatch even after journaling", () => {

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -36,6 +36,9 @@ export type QueueItem = {
    * Reusing it lets a recovery upsert the existing visible user line instead
    * of rendering the message twice. */
 	promptEntryId?: string;
+	/** Actor-internal identity for a previously accepted multi-item dispatch.
+	 * The restored group drains atomically before later queue policy can split it. */
+	retryDispatchId?: string;
 	content: string;
 	user?: string;
 	images?: string[];
@@ -453,9 +456,11 @@ export function restorePersistedQueueState(options: {
 		) {
 			continue;
 		}
-		const items = dispatch.items.map((item, index) =>
-			index === 0 ? { ...item, promptEntryId: dispatch.promptEntryId } : item,
-		);
+		const items = dispatch.items.map((item, index) => ({
+			...item,
+			retryDispatchId: dispatch.promptEntryId,
+			...(index === 0 ? { promptEntryId: dispatch.promptEntryId } : {}),
+		}));
 		queued.set(sessionId, [...items, ...(queued.get(sessionId) || [])]);
 	}
 

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1121,6 +1121,76 @@ describe("SessionKernel", () => {
 		});
 	});
 
+	test("reuses a failed multi-item dispatch identity", () => {
+		store.setDeliverySlot("failed-multi-dispatch", "queued", [
+			{ id: "one", content: "first" },
+			{ id: "two", content: "second" },
+		]);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "failed-multi-dispatch",
+			promptEntryId: "stable-batch-entry",
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-batch-entry",
+			items: [{ id: "one" }, { id: "two" }],
+		});
+		expect(
+			store.failDeliveryDispatch(
+				"failed-multi-dispatch",
+				"stable-batch-entry",
+			),
+		).toBe(true);
+		const restored = store.deliverySnapshot("failed-multi-dispatch").queued;
+		store.setDeliverySlot("failed-multi-dispatch", "queued", [
+			...restored,
+			{ id: "later", content: "must stay later" },
+		]);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "failed-multi-dispatch",
+			promptEntryId: "replacement-must-not-win",
+			soloId: "two",
+			interruptMark: true,
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-batch-entry",
+			items: [
+				{
+					id: "one",
+					promptEntryId: "stable-batch-entry",
+					retryDispatchId: "stable-batch-entry",
+				},
+				{ id: "two", retryDispatchId: "stable-batch-entry" },
+			],
+		});
+		expect(store.deliverySnapshot("failed-multi-dispatch").queued).toEqual([
+			{ id: "later", content: "must stay later" },
+		]);
+
+		expect(
+			store.failDeliveryDispatch(
+				"failed-multi-dispatch",
+				"stable-batch-entry",
+			),
+		).toBe(true);
+		store.setDeliverySlot(
+			"failed-multi-dispatch",
+			"queued",
+			store
+				.deliverySnapshot("failed-multi-dispatch")
+				.queued.filter((item) => (item as { id?: string }).id !== "one"),
+		);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "failed-multi-dispatch",
+			promptEntryId: "replacement-still-must-not-win",
+			soloId: "two",
+			interruptMark: true,
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-batch-entry",
+			items: [{ id: "two", retryDispatchId: "stable-batch-entry" }],
+		});
+	});
+
 	test("recovers an ambiguous prepared steer without duplicate queue delivery", () => {
 		store.setDeliverySlot("steer-recovery", "queued", [
 			{ id: "steer-one", content: "fold me in" },

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1908,16 +1908,27 @@ export class SessionKernelStore {
         if (state.dispatch) throw new Error("A prompt dispatch is already active");
         const queued = state.queued as QueueItem[];
         if (!queued.length) return { kind: "empty" as const };
-        const plan = selectQueueBatch(queued, {
-          soloId: input.soloId,
-          interruptMark: input.interruptMark,
-          stillWorking: input.stillWorking,
-        });
+        const retryDispatchId = queued.find(
+          (item) => item.retryDispatchId,
+        )?.retryDispatchId;
+        const plan = retryDispatchId
+          ? {
+              kind: "deliver" as const,
+              batch: queued.filter(
+                (item) => item.retryDispatchId === retryDispatchId,
+              ),
+              rest: queued.filter(
+                (item) => item.retryDispatchId !== retryDispatchId,
+              ),
+            }
+          : selectQueueBatch(queued, {
+              soloId: input.soloId,
+              interruptMark: input.interruptMark,
+              stillWorking: input.stillWorking,
+            });
         if (plan.kind === "hold") return plan;
         const promptEntryId =
-          plan.batch.length === 1 && plan.batch[0]?.promptEntryId
-            ? plan.batch[0].promptEntryId
-            : input.promptEntryId;
+          retryDispatchId || plan.batch[0]?.promptEntryId || input.promptEntryId;
         if (!promptEntryId || promptEntryId.length > 256)
           throw new Error("Invalid claimed prompt dispatch identity");
         state.queued = plan.rest;
@@ -2036,7 +2047,15 @@ export class SessionKernelStore {
         { promptEntryId?: string; items?: unknown[] } | undefined;
       if (dispatch?.promptEntryId !== promptEntryId)
         throw new Error("Prompt dispatch changed before failure settlement");
-      const restored = dispatch.items ?? [];
+      const restored = (dispatch.items ?? []).map((item, index) =>
+        item && typeof item === "object" && !Array.isArray(item)
+          ? {
+              ...(item as Record<string, unknown>),
+              retryDispatchId: promptEntryId,
+              ...(index === 0 ? { promptEntryId } : {}),
+            }
+          : item,
+      );
       const restoredIds = new Set(
         (restored as Array<{ id?: string }>)
           .map((item) => item.id)


### PR DESCRIPTION
## Summary
- preserve one accepted dispatch ID across every item when a pre-journal batch is restored
- drain restored groups atomically before solo/hold/later queue policy can split or reorder them
- reuse that restored identity for multi-message batches, not only single-message turns
- cover both explicit failure settlement and cold crash restoration through the gateway helper

This prevents early transcript user rows from being duplicated when a multi-message batch retries before a run journal adopts it.

## Verification
- focused queue, actor and restart suite: 86 tests, 757 assertions
- `bun run typecheck`
- module side-effect scan (413 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
