### PR TITLE
Fence background intake during graceful shutdown

### DIFF
--- a/packages/core/opensession-server/src/agents/github/review.ts
+++ b/packages/core/opensession-server/src/agents/github/review.ts
@@ -6,6 +6,7 @@
  * Deduped on head SHA so the same commit isn't reviewed twice.
  */
 import { personaName } from "../../server/config";
+import { isShuttingDown } from "../../server/shutdown-state";
 import {
   getPrDetails,
   getPrDetailsFresh,
@@ -148,6 +149,10 @@ export async function runReview(
   force = false,
   steer?: string,
 ): Promise<ReviewResult | null> {
+  if (isShuttingDown()) {
+    console.log(`[github] PR #${pr.number} review parked during shutdown`);
+    return null;
+  }
   if (!claimLock("review", pr.number, pr.ghRepo)) {
     console.log(`[github] review already running for PR #${pr.number}, skipping`);
     return null;
@@ -400,7 +405,8 @@ export async function runReview(
       );
     };
 
-    if (cancellationRequested()) return finishCancelled(placeholderId || undefined);
+    if (cancellationRequested() || isShuttingDown())
+      return finishCancelled(placeholderId || undefined);
     console.log(`[github] Reviewing PR #${pr.number} @ ${pr.headSha.slice(0, 7)} (${isUpdate ? "update" : "initial"})`);
     let finalResult: GithubRunResult;
     if (recoveredReviewResult) {

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -23,6 +23,7 @@ import {
   transitionRunState,
 } from "./run-state";
 import type { StreamEvent, ImageInput } from "./run-events";
+import { isShuttingDown } from "./shutdown-state";
 // Type-only, so the direct engines stay lazily loaded (see the dispatch table
 // below): this pulls in the contract's signatures, never the SDKs.
 // Static import is deliberate: the pi-runner module itself is cheap (the
@@ -1211,7 +1212,7 @@ export function resumeInterruptedRuns(
     let started = false;
     let queuedTooLong: ReturnType<typeof setTimeout> | undefined;
     const start = async () => {
-      if (started) return;
+      if (started || isShuttingDown()) return;
       started = true;
       clearTimeout(queuedTooLong);
       if (settledRunKeys.has(run.runKey)) {

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -13,6 +13,7 @@ import {
   webhookBodyTooLargeResponse,
 } from "./shared/bounded-body";
 import { labelIdentity } from "./shared/user-mappings";
+import { isShuttingDown } from "./shutdown-state";
 import { parseCron, cronMatches, nextRun } from "./cron";
 import {
   STRIPE_CONFIRM_TOOLS,
@@ -1122,6 +1123,10 @@ export async function runAutomation(
     modelOverride?: string;
   }
 ): Promise<void> {
+  if (isShuttingDown()) {
+    console.log(`[automations] "${automation.name}" parked during shutdown`);
+    return;
+  }
   const trigger = options?.trigger || "manual";
   // Cron/manual runs don't stack; event/webhook runs are per-event, so they may overlap
   const concurrent = trigger === "event" || trigger === "webhook";
@@ -1676,6 +1681,7 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
   if (schedulerInterval) return;
 
   schedulerInterval = setInterval(() => {
+    if (isShuttingDown()) return;
     const now = new Date();
     const minuteKey = now.toISOString().slice(0, 16);
     if (minuteKey === lastFiredMinute) return;
@@ -1720,6 +1726,8 @@ export function getWebhookRoutes(
   const routes = new Map<string, (req: Request, url: URL) => Promise<Response>>();
 
   routes.set("POST /automations/*", async (req, url) => {
+    if (isShuttingDown())
+      return Response.json({ error: "Server restarting" }, { status: 503 });
     const m = url.pathname.match(/^\/automations\/([^/]+)\/([^/]+)$/);
     if (!m) return Response.json({ error: "Bad path" }, { status: 400 });
 

--- a/packages/core/opensession-server/src/server/queue-state-restart.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-restart.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
+	beginNextPromptDispatch,
 	hydratePersistedQueueState,
 	persistQueues,
 	promptDispatches,
@@ -153,7 +154,7 @@ describe("steer receipt restart persistence", () => {
 		expect(steeredReceipts.has(SESSION)).toBe(false);
 	});
 
-	test("an ordinary unjournaled dispatch is still requeued", () => {
+	test("an ordinary multi-item dispatch keeps its identity after a crash", () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-ordinary-dispatch-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -162,7 +163,10 @@ describe("steer receipt restart persistence", () => {
 				dispatching: {
 					[SESSION]: {
 						promptEntryId: "ordinary-entry",
-						items: [{ id: "ordinary", content: "retry me" }],
+						items: [
+							{ id: "ordinary-one", content: "retry me" },
+							{ id: "ordinary-two", content: "and me" },
+						],
 					},
 				},
 			}),
@@ -175,9 +179,17 @@ describe("steer receipt restart persistence", () => {
 			deliveredUserTexts: () => [],
 			effects: false,
 		});
-		expect(restored.queuedCount).toBe(1);
+		expect(restored.queuedCount).toBe(2);
 		expect(promptQueues.get(SESSION)?.[0]?.promptEntryId).toBe("ordinary-entry");
 		expect(promptDispatches.has(SESSION)).toBe(false);
+		expect(beginNextPromptDispatch(SESSION, {}, false)).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "ordinary-entry",
+			batch: [
+				{ id: "ordinary-one", promptEntryId: "ordinary-entry" },
+				{ id: "ordinary-two" },
+			],
+		});
 	});
 
 	test("a cold restart preserves an actor-owned create dispatch even after journaling", () => {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1121,6 +1121,38 @@ describe("SessionKernel", () => {
 		});
 	});
 
+	test("reuses a failed multi-item dispatch identity", () => {
+		store.setDeliverySlot("failed-multi-dispatch", "queued", [
+			{ id: "one", content: "first" },
+			{ id: "two", content: "second" },
+		]);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "failed-multi-dispatch",
+			promptEntryId: "stable-batch-entry",
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-batch-entry",
+			items: [{ id: "one" }, { id: "two" }],
+		});
+		expect(
+			store.failDeliveryDispatch(
+				"failed-multi-dispatch",
+				"stable-batch-entry",
+			),
+		).toBe(true);
+		expect(store.claimNextDeliveryDispatch({
+			sessionId: "failed-multi-dispatch",
+			promptEntryId: "replacement-must-not-win",
+		})).toMatchObject({
+			kind: "deliver",
+			promptEntryId: "stable-batch-entry",
+			items: [
+				{ id: "one", promptEntryId: "stable-batch-entry" },
+				{ id: "two" },
+			],
+		});
+	});
+
 	test("recovers an ambiguous prepared steer without duplicate queue delivery", () => {
 		store.setDeliverySlot("steer-recovery", "queued", [
 			{ id: "steer-one", content: "fold me in" },

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1915,9 +1915,7 @@ export class SessionKernelStore {
         });
         if (plan.kind === "hold") return plan;
         const promptEntryId =
-          plan.batch.length === 1 && plan.batch[0]?.promptEntryId
-            ? plan.batch[0].promptEntryId
-            : input.promptEntryId;
+          plan.batch[0]?.promptEntryId || input.promptEntryId;
         if (!promptEntryId || promptEntryId.length > 256)
           throw new Error("Invalid claimed prompt dispatch identity");
         state.queued = plan.rest;
@@ -2036,7 +2034,11 @@ export class SessionKernelStore {
         { promptEntryId?: string; items?: unknown[] } | undefined;
       if (dispatch?.promptEntryId !== promptEntryId)
         throw new Error("Prompt dispatch changed before failure settlement");
-      const restored = dispatch.items ?? [];
+      const restored = (dispatch.items ?? []).map((item, index) =>
+        index === 0 && item && typeof item === "object" && !Array.isArray(item)
+          ? { ...(item as Record<string, unknown>), promptEntryId }
+          : item,
+      );
       const restoredIds = new Set(
         (restored as Array<{ id?: string }>)
           .map((item) => item.id)

--- a/packages/core/opensession-server/src/server/shutdown-intake.test.ts
+++ b/packages/core/opensession-server/src/server/shutdown-intake.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+const read = (relative: string) =>
+  Bun.file(new URL(relative, import.meta.url)).text();
+
+describe("shutdown intake fence", () => {
+  test("parks automation scheduler, webhook, and direct runs", async () => {
+    const source = await read("./automations.ts");
+    const run = source.indexOf("export async function runAutomation(");
+    const count = source.indexOf("runningCounts.set", run);
+    expect(source.indexOf("if (isShuttingDown())", run)).toBeLessThan(count);
+    expect(source).toContain(
+      "schedulerInterval = setInterval(() => {\n    if (isShuttingDown()) return;",
+    );
+    expect(source).toContain(
+      'return Response.json({ error: "Server restarting" }, { status: 503 })',
+    );
+  });
+
+  test("parks new GitHub reviews before claiming their lock", async () => {
+    const source = await read("../agents/github/review.ts");
+    const review = source.indexOf("export async function runReview(");
+    expect(source.indexOf("if (isShuttingDown())", review)).toBeLessThan(
+      source.indexOf('claimLock("review"', review),
+    );
+    expect(source).toContain(
+      "if (cancellationRequested() || isShuttingDown())",
+    );
+  });
+
+  test("does not start a queued boot recovery after shutdown begins", async () => {
+    const source = await read("./agent-runner.ts");
+    const recovery = source.indexOf("const recoveryTask = (");
+    const start = source.indexOf("const start = async () =>", recovery);
+    expect(source.indexOf("if (started || isShuttingDown()) return", start)).toBeGreaterThan(start);
+    expect(source.indexOf("if (started || isShuttingDown()) return", start)).toBeLessThan(
+      source.indexOf("started = true", start),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- park direct, scheduled, event, and webhook automations once graceful shutdown begins
- reject new automation webhooks with 503 during restart
- stop new GitHub reviews before lock/session creation and cancel a pre-model review that crosses the shutdown boundary
- prevent queued boot-recovery tasks from launching after the shutdown snapshot

This addresses a live restart where the draining process grew from two to four in-flight runs by launching a cron automation, two recovered creates, and a PR review after SIGTERM, forcing a manual cgroup kill.

## Dependency
- Stacked on #168.

## Verification
- shutdown and restart suite: 39 tests, 131 assertions
- `bun run typecheck`
- module side-effect scan (413 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
