### PR TITLE
Fence background intake during graceful shutdown

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -261,6 +261,16 @@ The runtime starts only after run-host recovery and queue restoration establish
 ownership. Any recovery-gate error fail-stops the gateway before timers or
 outbox effects can run. Shutdown stops the runtime before draining the server.
 
+Background intake observes the same process-wide shutdown fence. New cron,
+automation webhook, GitHub review and queued boot-recovery work cannot start
+after the fence. Automation triggers accepted before the fence write a bounded
+pre-launch intent with a stable session id and acceptance time before setup.
+The intent remains through physical execution: boot defers to an existing run
+journal, while completed projection effects record a terminal receipt that boot can
+settle without model replay. Ledger settlement precedes intent retirement.
+Accepted setup remains part of bounded drain accounting until physical handoff. Review shutdown preserves its active-run/result marker
+rather than treating restart as user cancellation.
+
 ## Read projections
 
 The existing session-list cache, list snapshots, search index, and workspace

--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -20,7 +20,7 @@ import { startLiveActivitySync } from "./src/server/live-activities";
 import { kickTranscriptBackfillOnce } from "./src/server/transcript-backfill";
 import { kickOrphanTranscriptSweep } from "./src/server/transcript-orphan-sweep";
 import { makeAskHandler, restorePendingAsks } from "./src/server/asks";
-import { automationResumeMcpForSession, ensureConfiguredAutomations, getWebhookRoutes, setEventSessionCallback, settleResumedAutomationRun, startScheduler } from "./src/server/automations";
+import { activeAutomationPreparationCount, automationResumeMcpForSession, ensureConfiguredAutomations, getWebhookRoutes, resumePendingAutomationRuns, setEventSessionCallback, settleResumedAutomationRun, startScheduler } from "./src/server/automations";
 import { startUsagePoller } from "./src/server/claude-accounts";
 import { startCodexUsagePoller } from "./src/server/codex-accounts";
 import { FRONTEND_SRC, IS_DEV, SPA_HEADERS, ensureFrontendBuilt, frontend, isPrebuiltFrontend, scheduleFrontendRebuild, sharedCheckoutEditors, spaEntry } from "./src/server/frontend-build";
@@ -658,12 +658,12 @@ if (!g.__opensessionBooted) {
 	}
 
 	// Cron-scheduled automations + internal event bus (agents → automations)
-	startScheduler(() => {
-		invalidateSessionsCache();
-	});
-	setEventSessionCallback(() => {
-		invalidateSessionsCache();
-	});
+	const onAutomationSession = () => invalidateSessionsCache();
+	setEventSessionCallback(onAutomationSession);
+	const resumedAutomationIntents = resumePendingAutomationRuns(onAutomationSession);
+	if (resumedAutomationIntents)
+		console.log(`[automations] Resumed ${resumedAutomationIntents} pre-launch intent(s)`);
+	startScheduler(onAutomationSession);
 	startPrReviewNotificationTicker();
 
 	// Scheduled prompts are durable SessionKernel timers. The runtime starts
@@ -1056,7 +1056,10 @@ if (!g.__opensessionBooted) {
 		// executing, and the next boot adopts the servers + reattaches the runs
 		// from the journal. Waiting on those would just delay the restart.
 		const undrainable = () =>
-			Math.max(0, activeAgentRunCount() - activeDetachedAgentRunCount());
+			Math.max(
+				activeAutomationPreparationCount(),
+				Math.max(0, activeAgentRunCount() - activeDetachedAgentRunCount()),
+			);
 		const deadline = timersDead ? 0 : Date.now() + DRAIN_TIMEOUT_MS;
 		let n = undrainable();
 		while (n > 0 && Date.now() < deadline) {

--- a/packages/core/opensession-server/src/agents/github/review.ts
+++ b/packages/core/opensession-server/src/agents/github/review.ts
@@ -6,6 +6,7 @@
  * Deduped on head SHA so the same commit isn't reviewed twice.
  */
 import { personaName } from "../../server/config";
+import { isShuttingDown } from "../../server/shutdown-state";
 import {
   getPrDetails,
   getPrDetailsFresh,
@@ -148,6 +149,10 @@ export async function runReview(
   force = false,
   steer?: string,
 ): Promise<ReviewResult | null> {
+  if (isShuttingDown()) {
+    console.log(`[github] PR #${pr.number} review parked during shutdown`);
+    return null;
+  }
   if (!claimLock("review", pr.number, pr.ghRepo)) {
     console.log(`[github] review already running for PR #${pr.number}, skipping`);
     return null;
@@ -401,6 +406,11 @@ export async function runReview(
     };
 
     if (cancellationRequested()) return finishCancelled(placeholderId || undefined);
+    if (isShuttingDown()) {
+      preserveRecovery = true;
+      console.log(`[github] PR #${pr.number} review parked for restart`);
+      return null;
+    }
     console.log(`[github] Reviewing PR #${pr.number} @ ${pr.headSha.slice(0, 7)} (${isUpdate ? "update" : "initial"})`);
     let finalResult: GithubRunResult;
     if (recoveredReviewResult) {
@@ -445,6 +455,11 @@ export async function runReview(
     // the review contract. Give the same engine session one bounded chance to
     // turn its completed inspection into a postable verdict.
     if (!finalResult.error && !isCompleteReviewOutput(parsed)) {
+      if (isShuttingDown()) {
+        preserveRecovery = true;
+        console.log(`[github] PR #${pr.number} review repair parked for restart`);
+        return null;
+      }
       console.warn(`[github] PR #${pr.number} review ended without structured output; repairing once`);
       finalResult = await runGithubAgent({
         prNumber: pr.number,

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -23,6 +23,7 @@ import {
   transitionRunState,
 } from "./run-state";
 import type { StreamEvent, ImageInput } from "./run-events";
+import { isShuttingDown } from "./shutdown-state";
 // Type-only, so the direct engines stay lazily loaded (see the dispatch table
 // below): this pulls in the contract's signatures, never the SDKs.
 // Static import is deliberate: the pi-runner module itself is cheap (the
@@ -1211,7 +1212,7 @@ export function resumeInterruptedRuns(
     let started = false;
     let queuedTooLong: ReturnType<typeof setTimeout> | undefined;
     const start = async () => {
-      if (started) return;
+      if (started || isShuttingDown()) return;
       started = true;
       clearTimeout(queuedTooLong);
       if (settledRunKeys.has(run.runKey)) {

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -6,6 +6,7 @@
 import { randomUUIDv7 } from "bun";
 import { OPENSESSION_SESSIONS_DIR , newSessionId} from "./paths";
 import { mkdirSync, readdirSync, readFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import {
   RequestBodyTooLargeError,
@@ -13,6 +14,7 @@ import {
   webhookBodyTooLargeResponse,
 } from "./shared/bounded-body";
 import { labelIdentity } from "./shared/user-mappings";
+import { isShuttingDown } from "./shutdown-state";
 import { parseCron, cronMatches, nextRun } from "./cron";
 import {
   STRIPE_CONFIRM_TOOLS,
@@ -22,6 +24,7 @@ import {
 import { getAccountById } from "./claude-accounts";
 import { getCodexAccountById } from "./codex-accounts";
 import { runAgent } from "./agent-runner";
+import { activeRunRecords } from "./run-journal";
 import { runAgentHosted } from "./host-client";
 import {
   providerFor,
@@ -1006,7 +1009,11 @@ function recordRunStart(id: string, run: AutomationRun): void {
     lastRunStatus: "running",
     lastRunError: undefined,
     lastTrigger: run.trigger,
-    runs: [run, ...(fresh.runs || [])].slice(0, RUNS_CAP),
+    runs: (fresh.runs || []).some((entry) => entry.sessionId === run.sessionId)
+      ? (fresh.runs || []).map((entry) =>
+          entry.sessionId === run.sessionId ? { ...entry, status: "running" as const } : entry,
+        )
+      : [run, ...(fresh.runs || [])].slice(0, RUNS_CAP),
   });
 }
 
@@ -1043,6 +1050,9 @@ export function settleResumedAutomationRun(sessionId: string, error: string | nu
       error: error || undefined,
       durationMs: Math.max(0, Date.now() - new Date(run.at).getTime()),
     });
+    const completedIntent = clearAutomationIntent(sessionId);
+    if (completedIntent?.deleteAutomationAfterRun)
+      deleteAutomation(automation.id);
     console.log(
       `[automations] Settled resumed run ${sessionId} for "${automation.name}" (${error ? "error" : "ok"})`
     );
@@ -1098,8 +1108,138 @@ function sandboxAutomationMcpEgress(mcpServers: string[]): string[] {
   return [...destinations];
 }
 
+const automationPreparations = new Set<string>();
+const activeAutomationIntentSessions = new Set<string>();
+
 export function isAutomationRunning(id: string): boolean {
   return (runningCounts.get(id) || 0) > 0;
+}
+
+export function activeAutomationPreparationCount(): number {
+  return automationPreparations.size;
+}
+
+type PendingAutomationIntent = {
+  version: 1;
+  automationId: string;
+  sessionId: string;
+  trigger: "cron" | "webhook" | "manual" | "event";
+  eventContext?: string;
+  modelOverride?: string;
+  acceptedAt: string;
+  deleteAutomationAfterRun?: boolean;
+  terminalAt?: string;
+  terminalError?: string;
+};
+
+const automationIntentDir = join(OPENSESSION_SESSIONS_DIR, "automation-intents");
+const automationIntentPath = (sessionId: string) =>
+  join(automationIntentDir, `${sessionId.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`);
+
+function persistAutomationIntent(intent: PendingAutomationIntent): void {
+  mkdirSync(automationIntentDir, { recursive: true, mode: 0o700 });
+  const path = automationIntentPath(intent.sessionId);
+  if (existsSync(path)) {
+    const existing = JSON.parse(readFileSync(path, "utf8")) as PendingAutomationIntent;
+    const identity = ({
+      acceptedAt: _acceptedAt,
+      terminalAt: _terminalAt,
+      terminalError: _terminalError,
+      ...value
+    }: PendingAutomationIntent) => JSON.stringify(value);
+    if (identity(existing) !== identity(intent))
+      throw new Error(`Automation intent ${intent.sessionId} changed identity`);
+    return;
+  }
+  writeJsonAtomic(path, intent, true, 0o600);
+}
+
+function recordAutomationIntentTerminal(
+  sessionId: string,
+  error?: string,
+): void {
+  const path = automationIntentPath(sessionId);
+  const intent = JSON.parse(readFileSync(path, "utf8")) as PendingAutomationIntent;
+  writeJsonAtomic(
+    path,
+    {
+      ...intent,
+      terminalAt: new Date().toISOString(),
+      terminalError: error,
+    },
+    true,
+    0o600,
+  );
+}
+
+function clearAutomationIntent(sessionId: string): PendingAutomationIntent | undefined {
+  const path = automationIntentPath(sessionId);
+  try {
+    const intent = JSON.parse(readFileSync(path, "utf8")) as PendingAutomationIntent;
+    unlinkSync(path);
+    return intent;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return undefined;
+  }
+}
+
+function hasAutomationIntent(sessionId: string): boolean {
+  return existsSync(automationIntentPath(sessionId));
+}
+
+export function resumePendingAutomationRuns(
+  onSessionCreated?: (sessionId: string) => void,
+): number {
+  if (isShuttingDown() || !existsSync(automationIntentDir)) return 0;
+  let resumed = 0;
+  for (const entry of readdirSync(automationIntentDir)) {
+    if (!entry.endsWith(".json")) continue;
+    try {
+      const intent = JSON.parse(
+        readFileSync(join(automationIntentDir, entry), "utf8"),
+      ) as PendingAutomationIntent;
+      if (
+        intent.version !== 1 ||
+        !intent.automationId ||
+        !intent.sessionId ||
+        !["cron", "webhook", "manual", "event"].includes(intent.trigger)
+      ) throw new Error("invalid automation intent");
+      const automation = getAutomation(intent.automationId);
+      if (!automation) throw new Error(`automation ${intent.automationId} is unavailable`);
+      if (intent.terminalAt) {
+        settleRun(automation.id, intent.sessionId, {
+          status: intent.terminalError ? "error" : "ok",
+          error: intent.terminalError,
+          durationMs: Math.max(0, Date.parse(intent.terminalAt) - Date.parse(intent.acceptedAt)),
+        });
+        const completedIntent = clearAutomationIntent(intent.sessionId);
+        if (completedIntent?.deleteAutomationAfterRun)
+          deleteAutomation(automation.id);
+        resumed++;
+        continue;
+      }
+      if (
+        automationPreparations.has(intent.sessionId) ||
+        activeAutomationIntentSessions.has(intent.sessionId) ||
+        activeRunRecords().some((run) => run.osSessionId === intent.sessionId)
+      ) continue;
+      void runAutomation(automation, onSessionCreated, {
+        trigger: intent.trigger,
+        eventContext: intent.eventContext,
+        modelOverride: intent.modelOverride,
+        osSessionId: intent.sessionId,
+        acceptedAt: intent.acceptedAt,
+        deleteAutomationAfterRun: intent.deleteAutomationAfterRun,
+      }).finally(() => {
+        if (!isShuttingDown()) resumePendingAutomationRuns(onSessionCreated);
+      });
+      resumed++;
+    } catch (error) {
+      console.error(`[automations] Pending intent ${entry} could not resume:`, error);
+    }
+  }
+  return resumed;
 }
 
 export async function runAutomation(
@@ -1114,6 +1254,10 @@ export async function runAutomation(
      * button) before the run starts, instead of waiting for onSessionCreated.
      */
     osSessionId?: string;
+    /** Durable acceptance time reused by pre-launch crash recovery. */
+    acceptedAt?: string;
+    /** Delete a consumed one-off only after intent/run settlement. */
+    deleteAutomationAfterRun?: boolean;
     /**
      * Model for THIS run only, beating the automation's configured model —
      * e.g. the Plain ticket router downgrading a basic ticket to a cheaper
@@ -1129,11 +1273,28 @@ export async function runAutomation(
     console.log(`[automations] "${automation.name}" still running, skipping`);
     return;
   }
-  runningCounts.set(automation.id, (runningCounts.get(automation.id) || 0) + 1);
-
-  const startedAt = new Date();
-  const stamp = startedAt.toISOString().slice(0, 16).replace("T", " ");
   const bksId = options?.osSessionId || newSessionId();
+  const acceptedAt = options?.acceptedAt || new Date().toISOString();
+  persistAutomationIntent({
+    version: 1,
+    automationId: automation.id,
+    sessionId: bksId,
+    trigger,
+    eventContext: options?.eventContext,
+    modelOverride: options?.modelOverride,
+    acceptedAt,
+    deleteAutomationAfterRun: options?.deleteAutomationAfterRun,
+  });
+  if (isShuttingDown()) {
+    console.log(`[automations] "${automation.name}" durably parked during shutdown`);
+    return;
+  }
+  runningCounts.set(automation.id, (runningCounts.get(automation.id) || 0) + 1);
+  activeAutomationIntentSessions.add(bksId);
+
+  const startedAt = new Date(acceptedAt);
+  const stamp = startedAt.toISOString().slice(0, 16).replace("T", " ");
+  automationPreparations.add(bksId);
   let sandboxRpcToken: string | undefined;
 
   try {
@@ -1421,6 +1582,10 @@ export async function runAutomation(
       const fb = automation.fallbackModel || DEFAULT_FALLBACK_MODEL;
       return fb ? automationModel(fb) : undefined;
     })();
+    // This run was admitted before shutdown. Keep it visible to the bounded
+    // drain until physical launch journals ownership; no later intake can join it.
+    if (isShuttingDown())
+      console.log(`[automations] "${automation.name}" completing accepted setup during shutdown`);
     let events: AsyncGenerator<StreamEvent>;
     if (sandbox) {
       sandboxRpcToken = crypto.randomUUID();
@@ -1493,6 +1658,8 @@ export async function runAutomation(
           });
     }
     for await (const event of events) {
+      // The engine stream is now physically adopted by agent-runner accounting.
+      automationPreparations.delete(bksId);
       if (event.type === "init") {
         engineSessionId = event.sessionId || "";
         if (event.provider) effectiveProvider = event.provider;
@@ -1548,11 +1715,15 @@ export async function runAutomation(
       preparedInputs.commit();
     }
 
+    recordAutomationIntentTerminal(bksId, errorMsg || undefined);
     settleRun(automation.id, bksId, {
       status: errorMsg ? "error" : "ok",
       error: errorMsg || undefined,
       durationMs: Date.now() - startedAt.getTime(),
     });
+    const completedIntent = clearAutomationIntent(bksId);
+    if (completedIntent?.deleteAutomationAfterRun)
+      deleteAutomation(automation.id);
     console.log(
       `[automations] "${automation.name}" finished ${errorMsg ? `with error: ${errorMsg}` : "ok"}`
     );
@@ -1563,7 +1734,11 @@ export async function runAutomation(
       error: e.message || String(e),
       durationMs: Date.now() - startedAt.getTime(),
     });
+    // A thrown consumer after physical adoption is ambiguous. Keep the intent;
+    // boot reconciles its active journal or terminal receipt before replay.
   } finally {
+    automationPreparations.delete(bksId);
+    activeAutomationIntentSessions.delete(bksId);
     unregisterRunToken(sandboxRpcToken);
     unregisterSessionMcpServers(bksId);
     const left = (runningCounts.get(automation.id) || 1) - 1;
@@ -1676,6 +1851,7 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
   if (schedulerInterval) return;
 
   schedulerInterval = setInterval(() => {
+    if (isShuttingDown()) return;
     const now = new Date();
     const minuteKey = now.toISOString().slice(0, 16);
     if (minuteKey === lastFiredMinute) return;
@@ -1691,9 +1867,19 @@ export function startScheduler(onSessionCreated?: (sessionId: string) => void): 
       if (automation.runOnceAt) {
         if (Date.parse(automation.runOnceAt) <= now.getTime()) {
           saveAutomation({ ...automation, runOnceAt: undefined, enabled: false });
-          void runAutomation({ ...automation, runOnceAt: undefined, enabled: false }, onSessionCreated, {
-            trigger: "cron",
-          }).finally(() => deleteAutomation(automation.id));
+          const osSessionId = newSessionId();
+          void runAutomation(
+            { ...automation, runOnceAt: undefined, enabled: false },
+            onSessionCreated,
+            {
+              trigger: "cron",
+              osSessionId,
+              deleteAutomationAfterRun: true,
+            },
+          ).finally(() => {
+            // Pre-launch failure stays durable and retains its disabled config.
+            if (!hasAutomationIntent(osSessionId)) deleteAutomation(automation.id);
+          });
         }
         continue;
       }
@@ -1720,6 +1906,8 @@ export function getWebhookRoutes(
   const routes = new Map<string, (req: Request, url: URL) => Promise<Response>>();
 
   routes.set("POST /automations/*", async (req, url) => {
+    if (isShuttingDown())
+      return Response.json({ error: "Server restarting" }, { status: 503 });
     const m = url.pathname.match(/^\/automations\/([^/]+)\/([^/]+)$/);
     if (!m) return Response.json({ error: "Bad path" }, { status: 400 });
 
@@ -1748,6 +1936,8 @@ export function getWebhookRoutes(
       throw error;
     }
 
+    if (isShuttingDown())
+      return Response.json({ error: "Server restarting" }, { status: 503 });
     console.log(`[automations] Webhook trigger: "${automation.name}"`);
     void runAutomation(automation, onSessionCreated, {
       trigger: "webhook",

--- a/packages/core/opensession-server/src/server/shutdown-intake.test.ts
+++ b/packages/core/opensession-server/src/server/shutdown-intake.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+const read = (relative: string) =>
+  Bun.file(new URL(relative, import.meta.url)).text();
+
+describe("shutdown intake fence", () => {
+  test("parks automation scheduler, webhook, and direct runs", async () => {
+    const source = await read("./automations.ts");
+    const run = source.indexOf("export async function runAutomation(");
+    const shutdown = source.indexOf("if (isShuttingDown())", run);
+    expect(source.indexOf("persistAutomationIntent({", run)).toBeLessThan(shutdown);
+    expect(shutdown).toBeLessThan(source.indexOf("runningCounts.set", run));
+    expect(source).toContain(
+      "schedulerInterval = setInterval(() => {\n    if (isShuttingDown()) return;",
+    );
+    expect(
+      source.match(
+        /return Response\.json\(\{ error: "Server restarting" \}, \{ status: 503 \}\)/g,
+      )?.length,
+    ).toBe(2);
+    expect(source).toContain("export function resumePendingAutomationRuns(");
+    expect(source).toContain("osSessionId: intent.sessionId");
+    expect(source).toContain("acceptedAt: intent.acceptedAt");
+    expect(source).toContain("const startedAt = new Date(acceptedAt)");
+    expect(source).toContain("automationPreparations.has(intent.sessionId)");
+    expect(source).toContain("activeAutomationIntentSessions.has(intent.sessionId)");
+    expect(source).toContain(
+      "activeRunRecords().some((run) => run.osSessionId === intent.sessionId)",
+    );
+    expect(source).toContain("resumePendingAutomationRuns(onSessionCreated)");
+    expect(source).toContain("recordAutomationIntentTerminal(");
+    const streamAdoption = source.indexOf("for await (const event of events)");
+    const terminal = source.indexOf("recordAutomationIntentTerminal(bksId", streamAdoption);
+    const settle = source.indexOf("settleRun(automation.id, bksId", terminal);
+    expect(terminal).toBeLessThan(settle);
+    expect(settle).toBeLessThan(
+      source.indexOf("clearAutomationIntent(bksId)", settle),
+    );
+    expect(source).toContain("if (!hasAutomationIntent(osSessionId))");
+    expect(
+      source.indexOf("automationPreparations.delete(bksId)", streamAdoption),
+    ).toBeGreaterThan(streamAdoption);
+    const cleanup = source.indexOf("} finally {", streamAdoption);
+    expect(
+      source.indexOf("automationPreparations.delete(bksId)", cleanup),
+    ).toBeGreaterThan(cleanup);
+  });
+
+  test("parks new GitHub reviews before claiming their lock", async () => {
+    const source = await read("../agents/github/review.ts");
+    const review = source.indexOf("export async function runReview(");
+    expect(source.indexOf("if (isShuttingDown())", review)).toBeLessThan(
+      source.indexOf('claimLock("review"', review),
+    );
+    expect(source).toContain("preserveRecovery = true");
+    expect(source).toContain("review parked for restart");
+    expect(source).toContain("review repair parked for restart");
+    expect(source).not.toContain(
+      "if (cancellationRequested() || isShuttingDown())",
+    );
+  });
+
+  test("counts accepted automation setup and resumes its durable intent", async () => {
+    const source = await read("../../opensession.ts");
+    expect(source).toContain("activeAutomationPreparationCount(),");
+    expect(source.indexOf("activeAutomationPreparationCount(),")).toBeLessThan(
+      source.indexOf("activeAgentRunCount() - activeDetachedAgentRunCount()"),
+    );
+    expect(source).toContain("resumePendingAutomationRuns(onAutomationSession)");
+  });
+
+  test("does not start a queued boot recovery after shutdown begins", async () => {
+    const source = await read("./agent-runner.ts");
+    const recovery = source.indexOf("const recoveryTask = (");
+    const start = source.indexOf("const start = async () =>", recovery);
+    expect(source.indexOf("if (started || isShuttingDown()) return", start)).toBeGreaterThan(start);
+    expect(source.indexOf("if (started || isShuttingDown()) return", start)).toBeLessThan(
+      source.indexOf("started = true", start),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- park direct, scheduled, event, Slack, retrigger, and webhook automations once graceful shutdown begins
- persist every accepted automation as a stable pre-launch intent and replay it on boot
- count accepted setup through physical stream adoption in the bounded drain
- reject new automation webhooks with 503 during restart
- stop new GitHub reviews before lock/session creation and preserve recoverable state when an existing review crosses the shutdown boundary
- prevent queued boot-recovery tasks from launching after the shutdown snapshot

This addresses a live restart where the draining process grew from two to four in-flight runs by launching a cron automation, two recovered creates, and a PR review after SIGTERM, forcing a manual cgroup kill.

## Verification
- shutdown and restart suite: 40 tests, 152 assertions
- `bun run typecheck`
- module side-effect scan (413 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
