### PR TITLE
Fix create session mailbox deadlock

### DIFF
--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -73,7 +73,6 @@ import {
 	tombstoneSessionKernel,
 } from "../session-kernel";
 import {
-	canonicalCommandPayload,
 	sessionIdForRequest,
 } from "../session-request-id";
 import { suggestBranchName } from "../suggest-branch";
@@ -857,20 +856,8 @@ export async function handleSessionsRoutes(
 			const requestId = suppliedRequestId || crypto.randomUUID();
 			const actorScope = ctx.authUser?.login || actor || "anonymous";
 			const targetId = sessionIdForRequest(actorScope, requestId);
-			const accepted = await sessionKernel(targetId).dispatchLegacy(
-				legacyGatewayEffect("create_session", {
-					requestId,
-					payload: {
-						targetId,
-						hash: new Bun.CryptoHasher("sha256")
-							.update(canonicalCommandPayload(body))
-							.digest("hex"),
-					},
-					source: "rest",
-					replaySafe: true,
-				}),
-				async () => {
-					return getSessionControl().createSession({
+			const duplicate = !!sessionKernel(targetId).creationState();
+			const created = await getSessionControl().createSession({
 						id: targetId,
 						requestId,
 						requestScope: actorScope,
@@ -900,10 +887,9 @@ export async function handleSessionsRoutes(
 				...(imageUrls.length ? { images: imageUrls } : {}),
 				...(files?.length ? { files } : {}),
 				user: actor,
-					});
-				},);
-			return Response.json({ id: accepted.result.id,
-				...(accepted.duplicate ? { duplicate: true } : {}), });
+			});
+			return Response.json({ id: created.id,
+				...(duplicate ? { duplicate: true } : {}), });
 		} catch (e) {
 			return Response.json(
 				{ error: e instanceof Error ? e.message : String(e) },

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -407,27 +407,14 @@ registerSessionControl({
 		const requestId = input.requestId || randomUUIDv7();
 		const actorScope = input.requestScope || input.user || "automation";
 		const requestedId = input.id || sessionIdForRequest(actorScope, requestId);
-		const commandOwner = requestedId;
 		const ownedInput: CreateSessionOpts = {
 			...input,
 			id: requestedId,
 			requestId,
 		};
-		if (!sessionKernelOwnsCurrentCommand(commandOwner)) {
-			const identity = new Bun.CryptoHasher("sha256")
-				.update(canonicalCommandPayload(ownedInput))
-				.digest("hex");
-			const accepted = await sessionKernel(commandOwner).dispatchLegacy(
-				legacyGatewayEffect("create_session", {
-					requestId,
-					payload: { targetId: requestedId, identity },
-					source: "session_control",
-					replaySafe: true,
-				}),
-				() => getSessionControl().createSession(ownedInput),
-			);
-			return accepted.result;
-		}
+		// The creation FSM below is the durable/idempotent owner. Do not put a
+		// second create_session command around it: the outer command would wait for
+		// projection while the opening effect waits for its session-file command.
 		const {
 			prompt,
 			branch,

--- a/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
@@ -16,7 +16,6 @@ import type {
 export const LEGACY_GATEWAY_EFFECT_OPERATIONS = Object.freeze([
   "answer_question",
   "cancel_session",
-  "create_session",
   "delete_session",
   "session_file_updated",
   "submit_prompt",
@@ -24,7 +23,7 @@ export const LEGACY_GATEWAY_EFFECT_OPERATIONS = Object.freeze([
   "websocket_command",
 ] as const);
 
-export const LEGACY_GATEWAY_EFFECT_SITE_BASELINE = 8;
+export const LEGACY_GATEWAY_EFFECT_SITE_BASELINE = 6;
 
 export type LegacyGatewayEffectOperation =
   (typeof LEGACY_GATEWAY_EFFECT_OPERATIONS)[number];

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -32,7 +32,6 @@ describe("single session ownership", () => {
 		expect(LEGACY_GATEWAY_EFFECT_OPERATIONS).toEqual([
 			"answer_question",
 			"cancel_session",
-			"create_session",
 			"delete_session",
 			"session_file_updated",
 			"submit_prompt",
@@ -255,13 +254,20 @@ describe("single session ownership", () => {
 		expect(source.match(/deliverAsk\(/g)?.length).toBe(2);
 	});
 
-	test("create and cancel retries keep stable ownership targets", () => {
+	test("creation uses its FSM without nesting inside a legacy mailbox", () => {
 		const ws = read("ws-handlers.ts");
 		expect(ws).toContain('legacyGatewayEffect("websocket_command"');
 		expect(ws).toContain("sessionIdForRequest");
 		expect(ws).toContain('typeof msg.sessionId === "string"');
+		const mailboxCommands = ws.slice(
+			ws.indexOf("const kernelCommands"),
+			ws.indexOf("const requestId"),
+		);
 		const routes = read("routes/sessions.ts");
-		expect(routes).toContain('legacyGatewayEffect("create_session"');
+		const wiring = read("session-control-wiring.ts");
+		expect(mailboxCommands).not.toContain('"create_session"');
+		expect(routes).not.toContain('legacyGatewayEffect("create_session"');
+		expect(wiring).not.toContain('legacyGatewayEffect("create_session"');
 		expect(routes).toContain("id: targetId");
 		expect(read("../../../protocol/src/session.ts")).toContain(
 			'type: "cancel"; sessionId?: string; requestId?: string',

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -536,8 +536,10 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 			"reorder_queued_prompt",
 			"cancel",
 			"answer_question",
-				"create_session",
 		]);
+		// Creation already has its own durable FSM and outbox. Wrapping it in a
+		// websocket_command holds the per-session mailbox while the opening effect
+		// tries to enter session_file_updated, so neither command can finish.
 		const requestId =
 				typeof msg.requestId === "string" && msg.requestId
 					? msg.requestId.slice(0, 200)


### PR DESCRIPTION
## Summary
- keep WebSocket session creation outside the legacy per-session mailbox
- remove redundant create-session mailbox wrappers from REST and session control
- rely on the dedicated durable creation FSM for idempotency and recovery

## Root cause
The outer create command waited for the session projection while the opening effect waited for an inner `session_file_updated` command on the same mailbox. Both commands remained `processing`, leaving the UI on “Setting up workspace”.

## Verification
- `bun test packages/core/opensession-server/src/server/session-kernel/ownership.test.ts`
- focused creation/kernel actor tests
- `bun run typecheck`