### PR TITLE
mcp-oauth: explain Vercel's client allowlist rejection

### DIFF
--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -251,6 +251,17 @@ async function ensureServerAuth(
         "Figma does not currently allow Open Session to connect. Its remote MCP server accepts only clients listed in the Figma MCP Catalog.",
       );
     }
+    if (
+      registrationResponse.status === 400 &&
+      registrationText.includes("invalid_redirect_uri") &&
+      registrationUrl.hostname === "vercel.com"
+    ) {
+      // Vercel MCP is a closed program: only clients Vercel has reviewed get
+      // their redirect URI approved (docs/agent-resources/vercel-mcp).
+      throw new Error(
+        "Vercel MCP only connects to AI clients Vercel has approved (Claude Code, ChatGPT, Cursor, …), so it rejects Open Session's callback URL.",
+      );
+    }
     const detail = registrationText.trim().slice(0, 200);
     throw new Error(
       `${name}: client registration failed (HTTP ${registrationResponse.status})${detail ? `: ${detail}` : ""}`,


### PR DESCRIPTION
Vercel MCP only registers OAuth clients Vercel has reviewed (Claude Code, ChatGPT, Cursor, …), so dynamic client registration with our web callback fails with `invalid_redirect_uri`. Surface a clear message instead of the raw registration error, same treatment as the existing Figma catalog case.

Verified against `vercel.com/api/login/oauth/register`: loopback redirects are accepted (HTTP 201), https callbacks are rejected by design.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a033f0-2f6a-7c3d-8a5f-d7c26cd8a420)