### PR TITLE
Vercel integration: OAuth preset + clear allowlist rejection message

### DIFF
--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -153,6 +153,25 @@ const OAUTH_PRESETS: Record<string, OauthPreset> = {
     }),
     envVar: "SLACK_BOT_TOKEN",
   },
+  vercel: {
+    // Static client from a Vercel integration (vercel.com/dashboard/integrations).
+    // Vercel's MCP rejects dynamic client registration for any callback it has
+    // not approved, so the generic flow can never connect; an integration's
+    // pre-approved redirect URL is the way in.
+    authorize: "https://vercel.com/oauth/authorize",
+    token: "https://vercel.com/api/login/oauth/token",
+    clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
+    clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
+    authorizeParams: {
+      // offline_access → refresh token; without it grants die within hours.
+      scope: "openid offline_access",
+    },
+    extract: (res) => ({
+      accessToken: res?.access_token,
+      refreshToken: res?.refresh_token,
+      expiresIn: res?.expires_in,
+    }),
+  },
 };
 
 export function oauthPresetFor(name: string): OauthPreset | undefined {

--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -251,6 +251,17 @@ async function ensureServerAuth(
         "Figma does not currently allow Open Session to connect. Its remote MCP server accepts only clients listed in the Figma MCP Catalog.",
       );
     }
+    if (
+      registrationResponse.status === 400 &&
+      registrationText.includes("invalid_redirect_uri") &&
+      registrationUrl.hostname === "vercel.com"
+    ) {
+      // Vercel MCP is a closed program: only clients Vercel has reviewed get
+      // their redirect URI approved (docs/agent-resources/vercel-mcp).
+      throw new Error(
+        "Vercel MCP only connects to AI clients Vercel has approved (Claude Code, ChatGPT, Cursor, …), so it rejects Open Session's callback URL.",
+      );
+    }
     const detail = registrationText.trim().slice(0, 200);
     throw new Error(
       `${name}: client registration failed (HTTP ${registrationResponse.status})${detail ? `: ${detail}` : ""}`,


### PR DESCRIPTION
Supersedes #173 (includes that commit).

**Why**: Vercel's hosted MCP only registers OAuth clients Vercel has reviewed, so dynamic registration with our web callback fails `invalid_redirect_uri`. Verified live: loopback redirects are accepted (HTTP 201), https callbacks rejected.

**What**:
1. Surface a clear message for the rejection (same treatment as the Figma catalog case).
2. Add a `vercel` OAuth preset using a static client from a [Vercel integration](https://vercel.com/dashboard/integrations/new) (`VERCEL_OAUTH_CLIENT_ID` / `VERCEL_OAUTH_CLIENT_SECRET` env, callback `{base}/api/connections/mcp-oauth/callback`), mirroring the slack preset. Requests `offline_access` so grants get refresh tokens. Inert until the env vars exist.

**User flow once credentials are set**: Connections → Vercel → Connect (workspace | my account) → Vercel consent → grant stored per user and injected as a bearer token on the `mcp.vercel.com` HTTP entry in runs.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a033f0-2f6a-7c3d-8a5f-d7c26cd8a420)