### PR TITLE
Connections: connect MCP servers by pasting an API token

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -98,6 +98,7 @@ const MCP_BLURBS: Record<string, string> = {
   ahrefs: "SEO, keywords & backlink data",
   github: "Repos, issues & pull requests",
   circle: "Community & support workspace",
+  vercel: "Projects, deployments & logs",
 };
 
 const AGENT_BLURBS: Record<string, string> = {
@@ -161,6 +162,9 @@ export function Connections() {
   const [refreshing, setRefreshing] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  // Paste-a-token connect for providers that gate OAuth client registration
+  // (Vercel approves only its own list of AI clients).
+  const [tokenConnect, setTokenConnect] = useState<McpConnection | null>(null);
 
   const load = useCallback(async (force = false) => {
     if (force) setRefreshing(true);
@@ -183,7 +187,12 @@ export function Connections() {
   const [oauthByName, setOauthByName] = useState<
     Record<
       string,
-      { shared?: { connectedBy?: string }; users: string[]; capable?: boolean }
+      {
+        shared?: { connectedBy?: string };
+        users: string[];
+        capable?: boolean;
+        manualToken?: boolean;
+      }
     >
   >({});
   const loadOauth = useCallback(async (servers: McpConnection[]) => {
@@ -441,6 +450,13 @@ export function Connections() {
                             <IconPlus size={16} className="text-faint" />
                             Connect my account
                           </Menu.Item>
+                          {s.transport === "http" &&
+                          oauthByName[s.name]?.manualToken ? (
+                            <Menu.Item onClick={() => setTokenConnect(s)}>
+                              <IconPlus size={16} className="text-faint" />
+                              Connect with API token
+                            </Menu.Item>
+                          ) : null}
                           {(oauthByName[s.name]?.shared ||
                             oauthByName[s.name]?.users.length) ? (
                             <Menu.Item
@@ -485,6 +501,14 @@ export function Connections() {
           <PlainRouter />
         </>
       )}
+      <ConnectTokenDialog
+        server={tokenConnect}
+        onClose={() => setTokenConnect(null)}
+        onConnected={() => {
+          setTokenConnect(null);
+          if (data?.mcpServers) void loadOauth(data.mcpServers);
+        }}
+      />
     </SettingsPanel>
   );
 }
@@ -2031,6 +2055,134 @@ function PlainRouter() {
         </div>
       </SettingsSection>
     </>
+  );
+}
+
+const TOKEN_CONNECT_URLS: Record<string, { url: string; label: string }> = {
+  vercel: {
+    url: "https://vercel.com/account/settings/tokens",
+    label: "vercel.com/account/settings/tokens",
+  },
+};
+
+/**
+ * Paste-a-token connect for providers whose hosted MCP gates OAuth client
+ * registration (Vercel approves only clients it has reviewed). Any teammate
+ * can mint a personal token; the server validates it live against the
+ * provider's API before storing it as a grant.
+ */
+function ConnectTokenDialog({
+  server,
+  onClose,
+  onConnected,
+}: {
+  server: McpConnection | null;
+  onClose: () => void;
+  onConnected: () => void;
+}) {
+  const [scope, setScope] = useState<"shared" | "me">("shared");
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    if (server) {
+      setScope("shared");
+      setToken("");
+      setError(null);
+    }
+  }, [server]);
+  if (!server) return null;
+  const active = server;
+  const tokenPage = TOKEN_CONNECT_URLS[active.name];
+
+  async function connect() {
+    if (!token.trim() || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${BASE_PATH}/api/connections/mcp/${encodeURIComponent(active.name)}/token`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: token.trim(), scope }),
+        },
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+      onConnected();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal.Root
+      open={!!server}
+      onOpenChange={(next) => {
+        if (!next && !saving) onClose();
+      }}
+    >
+      <Modal.Content widthClassName="max-w-[30rem]">
+        <Modal.Header
+          title={`Connect ${displayName(server.name)} with an API token`}
+          description="The token is checked with the provider, then stored for agent runs."
+        />
+        <div className="flex flex-col gap-4">
+          {tokenPage ? (
+            <div className="text-supporting leading-snug text-dim">
+              Create a token at{" "}
+              <a
+                className="underline hover:text-fg"
+                href={tokenPage.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {tokenPage.label}
+              </a>
+              , then paste it here.
+            </div>
+          ) : null}
+          <div className="flex flex-col gap-1.5">
+            <span className="text-supporting text-dim">Connect as</span>
+            <Segmented
+              label="Connect as"
+              size="sm"
+              value={scope}
+              onValueChange={(next) => setScope(next as "shared" | "me")}
+            >
+              <SegmentedOption value="shared">Workspace</SegmentedOption>
+              <SegmentedOption value="me">My account</SegmentedOption>
+            </Segmented>
+          </div>
+          <input
+            type="password"
+            className={cn(settingsInputClass, "font-mono")}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="Paste API token"
+            autoComplete="off"
+            spellCheck={false}
+            aria-label="API token"
+          />
+          {error && <InlineAlert>{error}</InlineAlert>}
+          <Modal.Footer>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              disabled={!token.trim() || saving}
+              onClick={() => void connect()}
+            >
+              {saving ? "Checking" : "Connect"}
+            </Button>
+          </Modal.Footer>
+        </div>
+      </Modal.Content>
+    </Modal.Root>
   );
 }
 

--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -153,6 +153,25 @@ const OAUTH_PRESETS: Record<string, OauthPreset> = {
     }),
     envVar: "SLACK_BOT_TOKEN",
   },
+  vercel: {
+    // Static client from a Vercel integration (vercel.com/dashboard/integrations).
+    // Vercel's MCP rejects dynamic client registration for any callback it has
+    // not approved, so the generic flow can never connect; an integration's
+    // pre-approved redirect URL is the way in.
+    authorize: "https://vercel.com/oauth/authorize",
+    token: "https://vercel.com/api/login/oauth/token",
+    clientIdEnv: "VERCEL_OAUTH_CLIENT_ID",
+    clientSecretEnv: "VERCEL_OAUTH_CLIENT_SECRET",
+    authorizeParams: {
+      // offline_access → refresh token; without it grants die within hours.
+      scope: "openid offline_access",
+    },
+    extract: (res) => ({
+      accessToken: res?.access_token,
+      refreshToken: res?.refresh_token,
+      expiresIn: res?.expires_in,
+    }),
+  },
 };
 
 export function oauthPresetFor(name: string): OauthPreset | undefined {

--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -251,6 +251,17 @@ async function ensureServerAuth(
         "Figma does not currently allow Open Session to connect. Its remote MCP server accepts only clients listed in the Figma MCP Catalog.",
       );
     }
+    if (
+      registrationResponse.status === 400 &&
+      registrationText.includes("invalid_redirect_uri") &&
+      registrationUrl.hostname === "vercel.com"
+    ) {
+      // Vercel MCP is a closed program: only clients Vercel has reviewed get
+      // their redirect URI approved (docs/agent-resources/vercel-mcp).
+      throw new Error(
+        "Vercel MCP only connects to AI clients Vercel has approved (Claude Code, ChatGPT, Cursor, …), so it rejects Open Session's callback URL.",
+      );
+    }
     const detail = registrationText.trim().slice(0, 200);
     throw new Error(
       `${name}: client registration failed (HTTP ${registrationResponse.status})${detail ? `: ${detail}` : ""}`,

--- a/packages/core/opensession-server/src/server/mcp-oauth.ts
+++ b/packages/core/opensession-server/src/server/mcp-oauth.ts
@@ -783,3 +783,63 @@ export function removeMcpOauthGrant(name: string, forUser?: string): boolean {
   writeStore(store);
   return true;
 }
+
+// ── Manual token connect ──────────────────────────────────────────────────
+// Some providers gate OAuth client registration (Vercel approves only its
+// own list of AI clients), but every user can mint a personal API token.
+// A validated pasted token is stored as a grant, so it rides the exact same
+// per-run injection path as an OAuth grant — no separate plumbing.
+
+const TOKEN_VALIDATORS: Record<
+  string,
+  (token: string) => Promise<{ ok: true } | { ok: false; error: string }>
+> = {
+  vercel: async (token) => {
+    const res = await fetch("https://api.vercel.com/v2/user", {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.status === 401 || res.status === 403)
+      return { ok: false, error: "Vercel rejected that token. Create a new one at vercel.com/account/settings/tokens and paste it again." };
+    if (!res.ok)
+      return { ok: false, error: `Could not check the token with Vercel (HTTP ${res.status})` };
+    return { ok: true };
+  },
+};
+
+/** Can this server be connected by pasting a personal API token? */
+export function supportsManualToken(name: string): boolean {
+  return !!TOKEN_VALIDATORS[name];
+}
+
+/** Validate a pasted API token live, then store it as a grant. */
+export async function saveManualMcpGrant(
+  name: string,
+  serverUrl: string,
+  token: string,
+  opts: { connectedBy?: string; forUser?: string } = {},
+): Promise<void> {
+  const validate = TOKEN_VALIDATORS[name];
+  if (!validate) throw new Error(`${name} has no token connect flow`);
+  const checked = await validate(token);
+  if (!checked.ok) throw new Error(checked.error);
+  const teamName = opts.forUser
+    ? resolveTeammate(opts.forUser)?.name
+    : undefined;
+  if (opts.forUser && !teamName)
+    throw new Error(`"${opts.forUser}" doesn't resolve to a configured teammate`);
+  const store = readStore();
+  const entry = store[name] ?? {
+    serverUrl,
+    endpoints: { authorize: "", token: "" },
+    clientInfo: { clientId: "manual-token" },
+  };
+  entry.serverUrl = serverUrl;
+  store[name] = entry;
+  writeGrant(entry, slotFor(teamName), {
+    tokens: { accessToken: token },
+    updatedAt: new Date().toISOString(),
+    ...(opts.connectedBy ? { connectedBy: opts.connectedBy } : {}),
+  });
+  writeStore(store);
+}

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -223,9 +223,12 @@ export async function handleConnectionsRoutes(
 	// has probed yet comes back null, and `pending` is the client's cue to ask
 	// again once the background probe lands.
 	if (path === "/api/connections/mcp-oauth" && req.method === "GET") {
-		const { cachedOauthCapable, mcpOauthStatus, oauthPresetFor } = await import(
-			"../mcp-oauth"
-		);
+		const {
+			cachedOauthCapable,
+			mcpOauthStatus,
+			oauthPresetFor,
+			supportsManualToken,
+		} = await import("../mcp-oauth");
 		const servers = Object.entries(readMcpConfig().mcpServers).map(
 			([name, cfg]: [string, any]) => {
 				const status = mcpOauthStatus(name);
@@ -242,7 +245,12 @@ export async function handleConnectionsRoutes(
 						: oauthTarget
 							? cachedOauthCapable(oauthTarget)
 							: false;
-				return { name, capable: capable ?? null, ...status };
+				return {
+					name,
+					capable: capable ?? null,
+					manualToken: supportsManualToken(name) && !!cfg?.url,
+					...status,
+				};
 			},
 		);
 		return Response.json({
@@ -340,6 +348,52 @@ export async function handleConnectionsRoutes(
 				{ status: 502 },
 			);
 		}
+	}
+
+	// Connect by pasting a personal API token (providers that gate OAuth
+	// client registration but let any user mint a token, e.g. Vercel).
+	const mcpTokenMatch = path.match(
+		/^\/api\/connections\/mcp\/([^/]+)\/token$/,
+	);
+	if (mcpTokenMatch && req.method === "POST") {
+		const name = decodeURIComponent(mcpTokenMatch[1]);
+		const body = (await req.json().catch(() => ({}))) as {
+			token?: string;
+			scope?: string;
+		};
+		const token = typeof body.token === "string" ? body.token.trim() : "";
+		if (!token) return Response.json({ error: "Paste an API token" }, { status: 400 });
+		const cfg = readMcpConfig().mcpServers[name] as
+			| { url?: string; oauthUrl?: string }
+			| undefined;
+		const target = cfg?.url || cfg?.oauthUrl;
+		if (!target)
+			return Response.json(
+				{ error: "Not a remote MCP server" },
+				{ status: 400 },
+			);
+		const forUser =
+			body.scope === "me"
+				? ctx.authUser?.login || ctx.authUser?.name || undefined
+				: undefined;
+		if (body.scope === "me" && !forUser)
+			return Response.json(
+				{ error: "Sign in to connect your own account" },
+				{ status: 401 },
+			);
+		try {
+			const { saveManualMcpGrant } = await import("../mcp-oauth");
+			await saveManualMcpGrant(name, target, token, {
+				connectedBy: ctx.authUser?.login || ctx.authUser?.name,
+				...(forUser ? { forUser } : {}),
+			});
+		} catch (e: any) {
+			return Response.json(
+				{ error: e?.message || String(e) },
+				{ status: 400 },
+			);
+		}
+		return Response.json({ ok: true });
 	}
 
 	const mcpDelMatch = path.match(


### PR DESCRIPTION
Stacks on #174 (Vercel OAuth preset + allowlist rejection message). Works with or without that PR merged.

**The problem this solves**: a user-initiated connect flow that works today. Vercel's hosted MCP gates OAuth client registration to clients Vercel has reviewed, so the browser-consent path is blocked no matter what we build. But every Vercel user can mint a personal API token themselves.

**The flow**:
1. Connections → Vercel menu → **Connect with API token**
2. Dialog links to vercel.com/account/settings/tokens; the person creates and pastes a token
3. Server validates it live against `api.vercel.com/v2/user` (401/403 rejected with a helpful message)
4. Stored as a grant — shared (workspace) or per user — riding the exact same per-run bearer injection as OAuth grants, so Disconnect/badges/status all work unchanged

**Design note**: validators are per-name (`TOKEN_VALIDATORS` in mcp-oauth.ts); only Vercel ships one, so the menu item appears only where validation exists — no unvalidated secret storage.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a033f0-2f6a-7c3d-8a5f-d7c26cd8a420)