### PR TITLE
Space review toolbar below workspace tabs

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/PrPanel.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PrPanel.tsx
@@ -227,7 +227,7 @@ interface Props {
   onPageChange?: (page: PrReviewPage) => void;
   /** Move file controls into the identity row and omit the secondary row. */
   compactToolbar?: boolean;
-  /** Remove the desktop inset when no workspace tab strip precedes Review. */
+  /** Legacy caller hint; Review now keeps its desktop top inset either way. */
   flushToolbarTop?: boolean;
 }
 
@@ -340,7 +340,6 @@ export function PrPanel({
   page: controlledPage,
   onPageChange,
   compactToolbar = false,
-  flushToolbarTop = false,
 }: Props) {
   // Local copy of the linked-PR list so link/unlink applies instantly; the
   // sessions list catches up on its next refresh.
@@ -1618,7 +1617,7 @@ export function PrPanel({
         className={`selectable relative flex h-full min-h-0 flex-col bg-surface ${compactToolbar ? "overflow-x-hidden overflow-y-auto" : "overflow-hidden"}`}
         data-review-canvas="true"
       >
-        <ReviewToolbar compact={compactToolbar} flushTop={flushToolbarTop}>
+        <ReviewToolbar compact={compactToolbar}>
           <div className={PR_NO_PR_BAR}>
             {targetPicker}
             {/* Opening the PR is what this state is for, so its action leads
@@ -1910,7 +1909,7 @@ export function PrPanel({
       {/* Desktop always keeps file controls in the identity row, so opening
           the summary only relocates page navigation. Phone keeps one
           edge-to-edge navigation and controls row below the identity. */}
-      <ReviewToolbar compact={compactToolbar} flushTop={flushToolbarTop}>
+      <ReviewToolbar compact={compactToolbar}>
       <TopBar as="header" className="h-10 shrink-0 gap-2.5 px-4 phone:px-3">
         {/* State, in the app's own PR language, filled rather than drawn: the
             tone washes the whole chip and the glyph and word share its ink.

--- a/packages/core/opensession-server/src/frontend/components/pr/ReviewToolbar.tsx
+++ b/packages/core/opensession-server/src/frontend/components/pr/ReviewToolbar.tsx
@@ -10,26 +10,18 @@ import { WS_SUMMARY_REVIEW_BAR_CLEARANCE } from "../../lib/workspace-summary-cla
 export function ReviewToolbar({
   children,
   compact,
-  flushTop = false,
 }: {
   children: ReactNode;
   compact: boolean;
-  /** A lone workspace tab has no strip between the pane header and Review. */
-  flushTop?: boolean;
 }) {
   const placement = compact
     ? `sticky top-0 z-20 desktop:mb-0 desktop:ml-2 desktop:pb-2 ${WS_SUMMARY_REVIEW_BAR_CLEARANCE}`
     : "desktop:mx-2 desktop:mb-2";
-  // File headers pin 61px below the scroll edge. Fill everything between the
-  // toolbar and that edge so its code cannot scroll above its own header.
-  const fileMask = flushTop
-    ? "top-[42px] h-5 -mb-5"
-    : "top-[52px] h-2.5 -mb-2.5";
 
   return (
     <>
       <div
-        className={`relative shrink-0 bg-surface ${flushTop ? "" : "desktop:pt-2.5"} ${placement}`}
+        className={`relative shrink-0 bg-surface desktop:pt-2.5 ${placement}`}
       >
         <div
           className={`relative bg-surface desktop:rounded-lg desktop:border desktop:border-line ${compact ? "desktop:overflow-hidden" : "desktop:overflow-visible"}`}
@@ -38,8 +30,10 @@ export function ReviewToolbar({
         </div>
       </div>
       {compact && (
+        // File headers pin 61px below the scroll edge. Fill everything between
+        // the toolbar and that edge so code cannot scroll above its own header.
         <div
-          className={`pointer-events-none sticky z-[5] mx-2 hidden overflow-clip rounded-t-lg bg-surface desktop:block ${fileMask}`}
+          className="pointer-events-none sticky top-[52px] z-[5] mx-2 hidden h-2.5 -mb-2.5 overflow-clip rounded-t-lg bg-surface desktop:block"
           aria-hidden="true"
         />
       )}


### PR DESCRIPTION
## Summary
- keep the desktop review toolbar inset below the workspace tab bar
- align the sticky code mask with the toolbar's restored top spacing
- leave the phone layout unchanged

## Verification
- `bun -e 'import { buildFrontend } from "./packages/core/opensession-server/src/server/frontend-build.ts"; await buildFrontend();'` (passes in the shared checkout)
- `bun run typecheck` (blocked by the pre-existing missing `NODE_ENV` in `src/server/codex-device-login.ts`)
- captured the affected route at 1728×1079 and 390×844

Created by [this OS session](https://os.tella.dev/session/os-01a03446-80e4-79c1-b46b-fb0c7f2686ce)
