### PR TITLE
Fence derived one-shots during shutdown

### DIFF
--- a/packages/core/opensession-server/src/server/one-shot.ts
+++ b/packages/core/opensession-server/src/server/one-shot.ts
@@ -15,6 +15,7 @@ import {
   runPi,
 } from "./pi-runner";
 import { toPiModel, type SessionEffort } from "./models";
+import { isShuttingDown } from "./shutdown-state";
 
 const DEFAULT_ONESHOT_MODEL = "pi/anthropic/claude-haiku-4-5";
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -93,6 +94,11 @@ export async function oneShotDetailed(
   // One-shots are real model calls. Import-heavy test suites rely on their
   // deterministic fallback paths and must never spend a model turn.
   if (process.env.NODE_ENV === "test") return { text: null, error: null };
+  // Derived one-shots have deterministic fallbacks and no caller-owned durable
+  // intent. Once shutdown starts, both new calls and calls waiting on bounded
+  // capacity must park instead of creating fresh model work during the drain.
+  if (isShuttingDown())
+    return { text: null, error: "server restarting" };
 
   const model = oneShotModel(opts.model);
   const label = opts.label || "oneshot";
@@ -107,6 +113,10 @@ export async function oneShotDetailed(
   }
 
   const releaseSlot = await acquireOneShotSlot();
+  if (isShuttingDown()) {
+    releaseSlot();
+    return { text: null, error: "server restarting" };
+  }
   mkdirSync(ONESHOT_CWD, { recursive: true });
   const runKey = `oneshot-${crypto.randomUUID()}`;
   const sessionDir = `${PI_STATE_DIR}/sessions/${runKey}`;

--- a/packages/core/opensession-server/src/server/shutdown-intake.test.ts
+++ b/packages/core/opensession-server/src/server/shutdown-intake.test.ts
@@ -69,6 +69,19 @@ describe("shutdown intake fence", () => {
     expect(source).toContain("resumePendingAutomationRuns(onAutomationSession)");
   });
 
+  test("does not launch derived one-shots after shutdown or a capacity wait", async () => {
+    const source = await read("./one-shot.ts");
+    const detailed = source.indexOf("export async function oneShotDetailed(");
+    const firstFence = source.indexOf("if (isShuttingDown())", detailed);
+    const acquire = source.indexOf("await acquireOneShotSlot()", firstFence);
+    const secondFence = source.indexOf("if (isShuttingDown())", acquire);
+    const launch = source.indexOf("for await (const event of runPi(", secondFence);
+    expect(firstFence).toBeGreaterThan(detailed);
+    expect(firstFence).toBeLessThan(acquire);
+    expect(acquire).toBeLessThan(secondFence);
+    expect(secondFence).toBeLessThan(launch);
+  });
+
   test("does not start a queued boot recovery after shutdown begins", async () => {
     const source = await read("./agent-runner.ts");
     const recovery = source.indexOf("const recoveryTask = (");


### PR DESCRIPTION
## Summary
- stop fail-soft derived one-shot model calls from entering after shutdown starts
- recheck shutdown after bounded-capacity waits so queued maintenance cannot launch during drain
- cover both intake boundaries in the graceful-shutdown regression suite

## Verification
- `bun run typecheck`
- `bun test packages/core/opensession-server/src/server/shutdown-intake.test.ts`
- `bun scripts/check-module-side-effects.ts` (413 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
