### PR TITLE
Provision the GitHub App credential safely

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -1,4 +1,5 @@
 import { BASE_PATH } from "../lib/base";
+import { GITHUB_APP_GRANT_PERMISSIONS } from "../../shared/github-app-permissions";
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { Menu } from "../ui/menu";
 import { OptionSelect } from "../ui/select";
@@ -552,10 +553,10 @@ function buildGithubAppCreateUrl(name: string, org: string): string {
     url: "http://localhost:3850",
     public: "false",
     webhook_active: "false",
-    contents: "write",
-    pull_requests: "write",
-    members: "read",
-    metadata: "read",
+    // The canonical grant set — the same permissions the install tokens mint
+    // request, so the App is not born missing `issues` or `checks` (the drift
+    // this builder used to have: no issues, no checks).
+    ...GITHUB_APP_GRANT_PERMISSIONS,
     device_flow_enabled: "true",
   }).toString();
   const base = org.trim()

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -609,6 +609,8 @@ function GithubAppWizard({
   setSlug,
   secret,
   setSecret,
+  privateKey,
+  setPrivateKey,
   onSaveApp,
   saving,
   configured,
@@ -629,6 +631,8 @@ function GithubAppWizard({
   setSlug: (v: string) => void;
   secret: string;
   setSecret: (v: string) => void;
+  privateKey: string;
+  setPrivateKey: (v: string) => void;
   onSaveApp: (appOrg: string) => void;
   saving: boolean;
   configured: boolean;
@@ -891,10 +895,25 @@ function GithubAppWizard({
                   copy it (shown once). Required.
                 </span>
               </div>
-            </div>
-            <div className="text-meta leading-snug text-faint">
-              Ignore GitHub's “generate a private key” banner. Open Session uses
-              device flow and doesn't need one.
+              <div className="flex flex-col gap-1">
+                <label className="text-supporting text-fg">Private key (PEM)</label>
+                <textarea
+                  className={cn(settingsInputClass, "min-h-20 resize-y font-mono")}
+                  value={privateKey}
+                  onChange={(e) => setPrivateKey(e.target.value)}
+                  placeholder="-----BEGIN RSA PRIVATE KEY-----"
+                  aria-label="GitHub App private key (PEM)"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <span className="text-meta leading-snug text-faint">
+                  In <span className="text-dim">Private keys</span>, click{" "}
+                  <span className="text-dim">Generate a private key</span>, then paste
+                  the downloaded .pem here. Lets the bot and PR checks run on the App;
+                  leave blank for sign-in only.
+                </span>
+              </div>
             </div>
             <Modal.Footer>
               <Button
@@ -1022,6 +1041,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
   const [appClientId, setAppClientId] = useState("");
   const [appSlug, setAppSlug] = useState("");
   const [appSecret, setAppSecret] = useState("");
+  const [appPrivateKey, setAppPrivateKey] = useState("");
   const [savingApp, setSavingApp] = useState(false);
   // The guided "create your app on GitHub, then paste + install + connect"
   // wizard, launched from the App option below.
@@ -1103,6 +1123,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
     const clientId = appClientId.trim();
     const slug = appSlug.trim();
     const secret = appSecret.trim();
+    const privateKey = appPrivateKey.trim();
     // The secret is required: the device-flow token expires and is refreshed
     // with it, so without one the connection would stop after ~8h.
     if (!clientId || !slug || !secret) return;
@@ -1113,14 +1134,16 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
         method: "POST",
         headers: { "Content-Type": "application/json" },
         // An org owner also records the sign-in intent server-side; a blank org
-        // is a personal, single-user App.
-        body: JSON.stringify({ clientId, slug, secret, appOrg }),
+        // is a personal, single-user App. The private key is optional but is
+        // what lets the bot/agent and checks-read mint installation tokens.
+        body: JSON.stringify({ clientId, slug, secret, appOrg, privateKey }),
       });
       const body = await res.json();
       if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
       setAppClientId("");
       setAppSlug("");
       setAppSecret("");
+      setAppPrivateKey("");
       // getConfig() re-reads on the file change, so the reload shows the App as
       // configured and switches the card to its device-flow connect.
       load();
@@ -1426,6 +1449,8 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
           setSlug={setAppSlug}
           secret={appSecret}
           setSecret={setAppSecret}
+          privateKey={appPrivateKey}
+          setPrivateKey={setAppPrivateKey}
           onSaveApp={saveApp}
           saving={savingApp}
           configured={data.connectAvailable}

--- a/packages/core/opensession-server/src/frontend/components/SetupIntegrations.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupIntegrations.tsx
@@ -272,6 +272,7 @@ export function GithubAuthCard({
 	const [botCredential, setBotCredential] = useState(github.botCredential);
 	const [clientId, setClientId] = useState("");
 	const [clientSecret, setClientSecret] = useState("");
+	const [privateKey, setPrivateKey] = useState("");
 	const [clearId, setClearId] = useState(false);
 	const [clearSecret, setClearSecret] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -290,6 +291,7 @@ export function GithubAuthCard({
 		botCredential !== github.botCredential ||
 		clientId.trim() !== "" ||
 		clientSecret.trim() !== "" ||
+		privateKey.trim() !== "" ||
 		idCleared ||
 		secretCleared;
 
@@ -316,10 +318,12 @@ export function GithubAuthCard({
 						: secretCleared
 							? { oauthClientSecret: "" }
 							: {}),
+					...(privateKey.trim() ? { privateKey: privateKey.trim() } : {}),
 				},
 			});
 			setClientId("");
 			setClientSecret("");
+			setPrivateKey("");
 			setClearId(false);
 			setClearSecret(false);
 			toast("GitHub sign-in settings saved");
@@ -429,6 +433,25 @@ export function GithubAuthCard({
 						setClientSecret("");
 					}}
 				/>
+				<label className="flex flex-col gap-1">
+					<span className="text-supporting text-fg">Private key (PEM)</span>
+					<textarea
+						className="min-h-20 w-full resize-y rounded-md border border-line bg-surface px-2.5 py-1.5 font-mono text-supporting text-fg outline-none focus-ring"
+						value={privateKey}
+						onChange={(e) => setPrivateKey(e.target.value)}
+						placeholder="-----BEGIN RSA PRIVATE KEY-----"
+						aria-label="GitHub App private key (PEM)"
+						disabled={saving}
+						autoCapitalize="none"
+						autoComplete="off"
+						spellCheck={false}
+					/>
+					<span className="text-meta leading-snug text-faint">
+						In the App&rsquo;s Private keys, Generate a private key and paste the
+						.pem here. Lets the bot and PR checks run on the App; leave blank for
+						sign-in only.
+					</span>
+				</label>
 				<p className="m-0 text-supporting text-faint">
 					Credentials stay on this server and are never shown back.
 				</p>

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -204,11 +204,44 @@ export function writeGithubAppKey(pem: string): void {
 /** Remove only a UI-managed key. An ops-managed path is external authority and
  * must never be mutated by the Settings removal flow. */
 export function removeGithubAppKey(): void {
-  if (process.env.OPENSESSION_GITHUB_APP_KEY)
-    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not removing an ops-managed key");
-  rmSync(keyPath(), { force: true });
+  // The App config may be UI-managed while its key path is ops-managed. In
+  // that mixed mode, preserve the external file but still invalidate tokens.
+  if (!process.env.OPENSESSION_GITHUB_APP_KEY)
+    rmSync(keyPath(), { force: true });
   g.__ghAppTokenCacheRead = null;
   g.__ghAppTokenCacheWrite = null;
+}
+
+/** Keep the key and matching config mutation in one recoverable transaction.
+ * `undefined` leaves the key alone, `null` removes it, and a string replaces
+ * it. If the config commit fails, restore the exact prior key atomically. */
+export async function commitGithubAppKeyMutation<T>(
+  key: string | null | undefined,
+  commitConfig: () => T | Promise<T>,
+): Promise<T> {
+  if (key === undefined || (key === null && process.env.OPENSESSION_GITHUB_APP_KEY)) {
+    if (key === null) {
+      g.__ghAppTokenCacheRead = null;
+      g.__ghAppTokenCacheWrite = null;
+    }
+    return commitConfig();
+  }
+  if (key !== null && process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
+
+  const path = keyPath();
+  const previous = existsSync(path) ? await Bun.file(path).text() : null;
+  if (key === null) removeGithubAppKey();
+  else writeGithubAppKey(key);
+  try {
+    return await commitConfig();
+  } catch (error) {
+    if (previous === null) rmSync(path, { force: true });
+    else writeFileAtomic(path, previous, 0o600);
+    g.__ghAppTokenCacheRead = null;
+    g.__ghAppTokenCacheWrite = null;
+    throw error;
+  }
 }
 
 /**

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -18,19 +18,30 @@
  * same containment story as the App user tokens.
  */
 import { createSign } from "node:crypto";
-import { existsSync, writeFileSync, chmodSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { githubUserAuthSettings } from "./github-auth";
 import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
+import { writeFileAtomic } from "./shared/atomic-write";
 import {
   GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
 } from "../shared/github-app-permissions";
 
-const KEY_PATH =
-  process.env.OPENSESSION_GITHUB_APP_KEY || join(homedir(), ".opensession-github-app.pem");
+let keyPathOverride: string | undefined;
+
+function keyPath(): string {
+  return keyPathOverride ||
+    process.env.OPENSESSION_GITHUB_APP_KEY ||
+    join(homedir(), ".opensession-github-app.pem");
+}
+
+/** Test seam: isolate key mutations from the operator's real key file. */
+export function __setGithubAppKeyPathForTest(path: string | undefined): void {
+  keyPathOverride = path;
+}
 
 type AppTokenCache = {
   token: string;
@@ -75,9 +86,9 @@ export async function githubAppInstallationToken(
   if (cached && cached.expiresAt - Date.now() > 5 * 60_000) return cached.token;
 
   const { clientId } = githubUserAuthSettings();
-  if (!clientId || !existsSync(KEY_PATH)) return null;
+  if (!clientId || !existsSync(keyPath())) return null;
   try {
-    const key = await Bun.file(KEY_PATH).text();
+    const key = await Bun.file(keyPath()).text();
     const jwt = appJwt(clientId, key);
     const headers = { Authorization: `Bearer ${jwt}`, Accept: "application/vnd.github+json" };
 
@@ -174,10 +185,10 @@ export function githubConfiguredCredential(): boolean {
 
 /** Whether a GitHub App can mint installation tokens (client id + private key). */
 export function githubAppConfigured(): boolean {
-  return !!githubUserAuthSettings().clientId && existsSync(KEY_PATH);
+  return !!githubUserAuthSettings().clientId && existsSync(keyPath());
 }
 
-/** Persist the App's private key (0600) at KEY_PATH — the piece the device-flow
+/** Persist the App's private key (0600) at the key path — the piece the device-flow
  *  setup never captured, so installation tokens (bot/agent, checks-read) could
  *  never mint. The App-manifest flow returns this PEM at creation. Drops any
  *  cached installation token, which belonged to a previous key. Honors the
@@ -185,8 +196,17 @@ export function githubAppConfigured(): boolean {
 export function writeGithubAppKey(pem: string): void {
   if (process.env.OPENSESSION_GITHUB_APP_KEY)
     throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
-  writeFileSync(KEY_PATH, pem.endsWith("\n") ? pem : `${pem}\n`, { mode: 0o600 });
-  try { chmodSync(KEY_PATH, 0o600); } catch {}
+  writeFileAtomic(keyPath(), pem.endsWith("\n") ? pem : `${pem}\n`, 0o600);
+  g.__ghAppTokenCacheRead = null;
+  g.__ghAppTokenCacheWrite = null;
+}
+
+/** Remove only a UI-managed key. An ops-managed path is external authority and
+ * must never be mutated by the Settings removal flow. */
+export function removeGithubAppKey(): void {
+  if (process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not removing an ops-managed key");
+  rmSync(keyPath(), { force: true });
   g.__ghAppTokenCacheRead = null;
   g.__ghAppTokenCacheWrite = null;
 }
@@ -208,9 +228,9 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
   const installationId =
     g.__ghAppTokenCacheRead?.installationId || g.__ghAppTokenCacheWrite?.installationId;
   const { clientId } = githubUserAuthSettings();
-  if (!installationId || !clientId || !existsSync(KEY_PATH)) return null;
+  if (!installationId || !clientId || !existsSync(keyPath())) return null;
   try {
-    const key = await Bun.file(KEY_PATH).text();
+    const key = await Bun.file(keyPath()).text();
     const res = await fetch(
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       {

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -18,12 +18,16 @@
  * same containment story as the App user tokens.
  */
 import { createSign } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { githubUserAuthSettings } from "./github-auth";
 import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
+import {
+  GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
+  GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
+} from "../shared/github-app-permissions";
 
 const KEY_PATH =
   process.env.OPENSESSION_GITHUB_APP_KEY || join(homedir(), ".opensession-github-app.pem");
@@ -42,31 +46,13 @@ const g = globalThis as {
   __ghAppTokenWarned?: boolean;
 };
 
-/** Read is strictly weaker than the bot PAT (no write at all). */
-const READ_PERMISSIONS = {
-  checks: "read",
-  statuses: "read",
-  actions: "read",
-  pull_requests: "read",
-  contents: "read",
-  issues: "read",
-  metadata: "read",
-} as const;
-/** Write asks for EXACTLY what the PR agent needs — post reviews and comments
- *  (pull_requests, issues) and push fixes (contents), plus metadata. It does NOT
- *  spread the read set: a mint is all-or-nothing, so requesting a read scope the
- *  App wasn't granted (e.g. checks, which no create flow grants today) would 422
- *  the whole write token even though writes never touch checks. Still
- *  installation-scoped, so an out-of-org write fails at GitHub's side just as the
- *  scoped bot PAT does (security-model.md, GitHub credential scoping). The App
- *  must hold these; if it does not the mint is rejected and the caller falls back
- *  to the PAT. */
-const WRITE_PERMISSIONS = {
-  pull_requests: "write",
-  issues: "write",
-  contents: "write",
-  metadata: "read",
-} as const;
+// READ_PERMISSIONS / WRITE_PERMISSIONS are the canonical sets imported at the
+// top of the file (shared/github-app-permissions) — the same definition the
+// create-app URL grants, so a mint never asks for a scope the App was not
+// granted. Still installation-scoped, so an out-of-org write fails at GitHub's
+// side just as the scoped bot PAT does (security-model.md, GitHub credential
+// scoping). If the App does not hold a set the mint is rejected and the caller
+// falls back to the PAT.
 
 function appJwt(clientId: string, key: string): string {
   const now = Math.floor(Date.now() / 1000);
@@ -189,6 +175,20 @@ export function githubConfiguredCredential(): boolean {
 /** Whether a GitHub App can mint installation tokens (client id + private key). */
 export function githubAppConfigured(): boolean {
   return !!githubUserAuthSettings().clientId && existsSync(KEY_PATH);
+}
+
+/** Persist the App's private key (0600) at KEY_PATH — the piece the device-flow
+ *  setup never captured, so installation tokens (bot/agent, checks-read) could
+ *  never mint. The App-manifest flow returns this PEM at creation. Drops any
+ *  cached installation token, which belonged to a previous key. Honors the
+ *  OPENSESSION_GITHUB_APP_KEY override so an ops-managed key is never clobbered. */
+export function writeGithubAppKey(pem: string): void {
+  if (process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
+  writeFileSync(KEY_PATH, pem.endsWith("\n") ? pem : `${pem}\n`, { mode: 0o600 });
+  try { chmodSync(KEY_PATH, 0o600); } catch {}
+  g.__ghAppTokenCacheRead = null;
+  g.__ghAppTokenCacheWrite = null;
 }
 
 /**

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { bootstrapUserAuthOnConnect, handleConnectionsRoutes } from "./connections";
+import { __setGithubAppKeyPathForTest } from "../github-app";
 import type { RouteContext } from "./context";
 
 // The GitHub connect routes behave differently by mode: operator mode (web
@@ -30,9 +31,11 @@ beforeEach(() => {
   process.env.OPENSESSION_CONFIG = join(dir, "config.json");
   process.env.OPENSESSION_GITHUB_AUTH_STORE = join(dir, "github-auth.json");
   process.env.OPENSESSION_WEB_SESSIONS_STORE = join(dir, "web-sessions.json");
+  __setGithubAppKeyPathForTest(join(dir, "github-app.pem"));
 });
 
 afterEach(() => {
+  __setGithubAppKeyPathForTest(undefined);
   rmSync(dir, { recursive: true, force: true });
   for (const k of ENV_KEYS) {
     if (saved[k] === undefined) delete process.env[k];
@@ -213,7 +216,10 @@ describe("GitHub App config (simple mode)", () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),
     );
-    // An unrelated github key, to prove the clear is surgical.
+    // A UI-managed key must be removed with the App; an unrelated github
+    // config key proves the config clear remains surgical.
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "old-app-private-key", { mode: 0o600 });
     const path = process.env.OPENSESSION_CONFIG!;
     const cfg = JSON.parse(readFileSync(path, "utf-8"));
     cfg.integrations.github.userPrAuth = false;
@@ -226,6 +232,7 @@ describe("GitHub App config (simple mode)", () => {
     expect(after.integrations.github.oauthClientId).toBeUndefined();
     expect(after.integrations.github.appSlug).toBeUndefined();
     expect(after.integrations.github.userPrAuth).toBe(false);
+    expect(existsSync(keyPath)).toBe(false);
 
     const get = await handleConnectionsRoutes(context(GET, "GET", null));
     expect((await get?.json()).connectAvailable).toBe(false);

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -244,6 +244,20 @@ describe("GitHub App config (simple mode)", () => {
     ).toBe(400);
   });
 
+  test("changing App identity without a new key clears the previous key", async () => {
+    await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-a", slug: "app-a", secret: "shh" }),
+    );
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "app-a-key\n", { mode: 0o600 });
+
+    const response = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-b", slug: "app-b", secret: "shh" }),
+    );
+    expect(response?.status).toBe(200);
+    expect(existsSync(keyPath)).toBe(false);
+  });
+
   test("DELETE clears the App keys but leaves other github config intact", async () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -244,6 +244,35 @@ describe("GitHub App config (simple mode)", () => {
     ).toBe(400);
   });
 
+  test("cannot strand selected App bot actions by clearing their key", async () => {
+    const path = process.env.OPENSESSION_CONFIG!;
+    writeFileSync(
+      path,
+      JSON.stringify({
+        integrations: {
+          github: {
+            oauthClientId: "Iv1.app-a",
+            appSlug: "app-a",
+            oauthClientSecret: "shh",
+            botCredential: "app",
+          },
+        },
+      }),
+    );
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "app-a-key\n", { mode: 0o600 });
+
+    const replace = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-b", slug: "app-b", secret: "shh" }),
+    );
+    expect(replace?.status).toBe(409);
+    expect(readFileSync(keyPath, "utf-8")).toBe("app-a-key\n");
+
+    const remove = await handleConnectionsRoutes(context(APP, "DELETE", null));
+    expect(remove?.status).toBe(409);
+    expect(readFileSync(keyPath, "utf-8")).toBe("app-a-key\n");
+  });
+
   test("changing App identity without a new key clears the previous key", async () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.app-a", slug: "app-a", secret: "shh" }),

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -3,7 +3,10 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs
 import { tmpdir } from "os";
 import { join } from "path";
 import { bootstrapUserAuthOnConnect, handleConnectionsRoutes } from "./connections";
-import { __setGithubAppKeyPathForTest } from "../github-app";
+import {
+  __setGithubAppKeyPathForTest,
+  commitGithubAppKeyMutation,
+} from "../github-app";
 import type { RouteContext } from "./context";
 
 // The GitHub connect routes behave differently by mode: operator mode (web
@@ -16,6 +19,7 @@ const ENV_KEYS = [
   "OPENSESSION_CONFIG",
   "OPENSESSION_GITHUB_CLIENT_ID",
   "OPENSESSION_GITHUB_APP_SLUG",
+  "OPENSESSION_GITHUB_APP_KEY",
   "OPENSESSION_GITHUB_AUTH_STORE",
   "OPENSESSION_WEB_SESSIONS_STORE",
 ] as const;
@@ -78,6 +82,34 @@ function context(
 }
 
 const DEVICE = "/api/connections/github/device";
+
+
+describe("GitHub App key transaction", () => {
+  test("restores the previous key when config persistence fails", async () => {
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "working-key\n", { mode: 0o600 });
+
+    await expect(
+      commitGithubAppKeyMutation("replacement-key", () => {
+        throw new Error("config volume full");
+      }),
+    ).rejects.toThrow("config volume full");
+    expect(readFileSync(keyPath, "utf-8")).toBe("working-key\n");
+  });
+
+  test("removes config while preserving an ops-managed key", async () => {
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "ops-key\n", { mode: 0o600 });
+    process.env.OPENSESSION_GITHUB_APP_KEY = keyPath;
+    let committed = false;
+
+    await commitGithubAppKeyMutation(null, () => {
+      committed = true;
+    });
+    expect(committed).toBe(true);
+    expect(readFileSync(keyPath, "utf-8")).toBe("ops-key\n");
+  });
+});
 
 describe("GitHub connect gating", () => {
   test("simple mode without a configured app rejects the connect (400)", async () => {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -788,11 +788,29 @@ export async function handleConnectionsRoutes(
 				{ error: "clientId, slug and secret are required" },
 				{ status: 400 },
 			);
-		if (privateKey && !/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(privateKey))
-			return Response.json(
-				{ error: "privateKey must be a PEM private key" },
-				{ status: 400 },
-			);
+		if (privateKey) {
+			// A complete PEM block, and it must actually parse — a header-only or
+			// truncated value would otherwise overwrite a working key on disk.
+			const wellFormed =
+				/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+-----END [A-Z ]*PRIVATE KEY-----/.test(
+					privateKey,
+				);
+			let parses = false;
+			if (wellFormed) {
+				try {
+					const { createPrivateKey } = await import("node:crypto");
+					createPrivateKey(privateKey);
+					parses = true;
+				} catch {
+					parses = false;
+				}
+			}
+			if (!parses)
+				return Response.json(
+					{ error: "privateKey must be a valid PEM private key" },
+					{ status: 400 },
+				);
+		}
 		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
 		// we surface that before touching config rather than half-configuring.
 		if (privateKey) {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -818,6 +818,12 @@ export async function handleConnectionsRoutes(
 			const github = githubIntegrationSection(config, true)!;
 			const keyMutation = privateKey ||
 				(github.oauthClientId !== clientId ? null : undefined);
+			if (keyMutation === null && github.botCredential === "app") {
+				return Response.json(
+					{ error: "Switch bot actions to the PAT before changing the GitHub App without a replacement key" },
+					{ status: 409 },
+				);
+			}
 			github.oauthClientId = clientId;
 			github.appSlug = slug;
 			github.oauthClientSecret = secret;
@@ -873,6 +879,12 @@ export async function handleConnectionsRoutes(
 		return withConfigMutationLock(async () => {
 			const config = rawConfig();
 			const github = githubIntegrationSection(config, false);
+			if (github?.botCredential === "app") {
+				return Response.json(
+					{ error: "Switch bot actions to the PAT before removing the GitHub App" },
+					{ status: 409 },
+				);
+			}
 			if (github) {
 				// Drop the repo-App keys and the captured sign-in intent
 				// (appOrg/authOnConnect) — removing the App is also how the wizard

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -811,19 +811,6 @@ export async function handleConnectionsRoutes(
 					{ status: 400 },
 				);
 		}
-		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
-		// we surface that before touching config rather than half-configuring.
-		if (privateKey) {
-			const { writeGithubAppKey } = await import("../github-app");
-			try {
-				writeGithubAppKey(privateKey);
-			} catch (e) {
-				return Response.json(
-					{ error: String((e as Error)?.message || e) },
-					{ status: 409 },
-				);
-			}
-		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {
@@ -847,7 +834,18 @@ export async function handleConnectionsRoutes(
 				delete github.webhookForwardLogin;
 				delete github.webhookForwardLogin;
 			}
-			persistRawConfig(config);
+			try {
+				const { commitGithubAppKeyMutation } = await import("../github-app");
+				await commitGithubAppKeyMutation(
+					privateKey || undefined,
+					() => persistRawConfig(config),
+				);
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
 			return Response.json({ ok: true });
 		});
 	}
@@ -868,15 +866,6 @@ export async function handleConnectionsRoutes(
 				},
 				{ status: 409 },
 			);
-		try {
-			const { removeGithubAppKey } = await import("../github-app");
-			removeGithubAppKey();
-		} catch (e) {
-			return Response.json(
-				{ error: String((e as Error)?.message || e) },
-				{ status: 409 },
-			);
-		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {
@@ -893,7 +882,15 @@ export async function handleConnectionsRoutes(
 				delete github.appOrg;
 				delete github.authOnConnect;
 			}
-			persistRawConfig(config);
+			try {
+				const { commitGithubAppKeyMutation } = await import("../github-app");
+				await commitGithubAppKeyMutation(null, () => persistRawConfig(config));
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
 			return Response.json({ ok: true });
 		});
 	}

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -816,6 +816,8 @@ export async function handleConnectionsRoutes(
 		return withConfigMutationLock(async () => {
 			const config = rawConfig();
 			const github = githubIntegrationSection(config, true)!;
+			const keyMutation = privateKey ||
+				(github.oauthClientId !== clientId ? null : undefined);
 			github.oauthClientId = clientId;
 			github.appSlug = slug;
 			github.oauthClientSecret = secret;
@@ -837,7 +839,7 @@ export async function handleConnectionsRoutes(
 			try {
 				const { commitGithubAppKeyMutation } = await import("../github-app");
 				await commitGithubAppKeyMutation(
-					privateKey || undefined,
+					keyMutation,
 					() => persistRawConfig(config),
 				);
 			} catch (e) {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -868,6 +868,15 @@ export async function handleConnectionsRoutes(
 				},
 				{ status: 409 },
 			);
+		try {
+			const { removeGithubAppKey } = await import("../github-app");
+			removeGithubAppKey();
+		} catch (e) {
+			return Response.json(
+				{ error: String((e as Error)?.message || e) },
+				{ status: 409 },
+			);
+		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -764,6 +764,7 @@ export async function handleConnectionsRoutes(
 			slug?: unknown;
 			secret?: unknown;
 			appOrg?: unknown;
+			privateKey?: unknown;
 		} | null;
 		const clientId =
 			typeof body?.clientId === "string" ? body.clientId.trim() : "";
@@ -772,6 +773,12 @@ export async function handleConnectionsRoutes(
 		// Present ⇒ the App is owned by an org (owner=Organization); empty/absent ⇒
 		// a personal App (single-user).
 		const appOrg = typeof body?.appOrg === "string" ? body.appOrg.trim() : "";
+		// The App's private key (PEM), generated once in the App's settings UI.
+		// Optional here — an App can be configured for per-user sign-in (device
+		// flow, keyless) alone — but it is what lets installation tokens mint, so
+		// without it the bot/agent and checks-read stay on the PAT.
+		const privateKey =
+			typeof body?.privateKey === "string" ? body.privateKey.trim() : "";
 		// The secret is required on the UI config path: the device-flow token
 		// expires and Open Session refreshes it with the secret, so without one
 		// the connection would silently stop working after ~8h. (Env-configured
@@ -781,6 +788,24 @@ export async function handleConnectionsRoutes(
 				{ error: "clientId, slug and secret are required" },
 				{ status: 400 },
 			);
+		if (privateKey && !/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(privateKey))
+			return Response.json(
+				{ error: "privateKey must be a PEM private key" },
+				{ status: 400 },
+			);
+		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
+		// we surface that before touching config rather than half-configuring.
+		if (privateKey) {
+			const { writeGithubAppKey } = await import("../github-app");
+			try {
+				writeGithubAppKey(privateKey);
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
+		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -103,6 +103,11 @@ describe("GitHub App onboarding link", () => {
 			url: "https://os.acme.test/",
 			public: "false",
 			webhook_active: "false",
+			// The canonical grant set — checks + statuses (the App-only CI rollup)
+			// and issues (PR/issue comments) included, so a created App holds every
+			// scope the installation-token mints request.
+			checks: "read",
+			statuses: "read",
 			contents: "write",
 			issues: "write",
 			pull_requests: "write",

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -350,6 +350,7 @@ export async function handleSetupRoutes(
       oauthClientId?: unknown;
       oauthClientSecret?: unknown;
       botCredential?: unknown;
+      privateKey?: unknown;
     } | null;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -379,13 +380,53 @@ export async function handleSetupRoutes(
         return Response.json({ error: `${field}: ${invalid}` }, { status: 400 });
       }
     }
+    // The private key is a multi-line PEM, so it bypasses validateSetting (single
+    // line). Require a complete block that parses, so a truncated paste cannot
+    // overwrite a working key on disk.
+    const privateKey =
+      typeof body.privateKey === "string" ? body.privateKey.trim() : "";
+    if (privateKey) {
+      const { createPrivateKey } = await import("node:crypto");
+      const wellFormed =
+        /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+-----END [A-Z ]*PRIVATE KEY-----/.test(
+          privateKey,
+        );
+      let parses = false;
+      if (wellFormed) {
+        try {
+          createPrivateKey(privateKey);
+          parses = true;
+        } catch {
+          parses = false;
+        }
+      }
+      if (!parses)
+        return Response.json(
+          { error: "privateKey must be a valid PEM private key" },
+          { status: 400 },
+        );
+    }
     if (
       body.userPrAuth === undefined &&
       body.oauthClientId === undefined &&
       body.oauthClientSecret === undefined &&
-      body.botCredential === undefined
+      body.botCredential === undefined &&
+      !privateKey
     ) {
       return Response.json({ error: "Nothing to change" }, { status: 400 });
+    }
+    // Store the key first: writeGithubAppKey refuses an env-managed key, and we
+    // surface that before writing config rather than half-configuring.
+    if (privateKey) {
+      const { writeGithubAppKey } = await import("../github-app");
+      try {
+        writeGithubAppKey(privateKey);
+      } catch (e) {
+        return Response.json(
+          { error: String((e as Error)?.message || e) },
+          { status: 409 },
+        );
+      }
     }
 
     const { rawConfig, persistRawConfig, withConfigMutationLock } =

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -415,20 +415,6 @@ export async function handleSetupRoutes(
     ) {
       return Response.json({ error: "Nothing to change" }, { status: 400 });
     }
-    // Store the key first: writeGithubAppKey refuses an env-managed key, and we
-    // surface that before writing config rather than half-configuring.
-    if (privateKey) {
-      const { writeGithubAppKey } = await import("../github-app");
-      try {
-        writeGithubAppKey(privateKey);
-      } catch (e) {
-        return Response.json(
-          { error: String((e as Error)?.message || e) },
-          { status: 409 },
-        );
-      }
-    }
-
     const { rawConfig, persistRawConfig, withConfigMutationLock } =
       await import("../config-mutation");
 
@@ -514,7 +500,18 @@ export async function handleSetupRoutes(
         if (value === "") delete github[field]; // empty string clears
         else github[field] = value;
       }
-      persistRawConfig(config);
+      try {
+        const { commitGithubAppKeyMutation } = await import("../github-app");
+        await commitGithubAppKeyMutation(
+          privateKey || undefined,
+          () => persistRawConfig(config),
+        );
+      } catch (e) {
+        return Response.json(
+          { error: String((e as Error)?.message || e) },
+          { status: 409 },
+        );
+      }
       audit({
         kind: "setup_github_update",
         fields: (["userPrAuth", "oauthClientId", "oauthClientSecret", "botCredential"] as const).filter(

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -22,6 +22,7 @@
  */
 
 import { audit } from "../audit";
+import { GITHUB_APP_GRANT_PERMISSIONS } from "../../shared/github-app-permissions";
 import { envRequired, type IntegrationSpec } from "../integrations/registry";
 import { setupAccessSnapshot } from "../setup-access";
 import { requireWorkspaceAdmin } from "../workspace-auth";
@@ -118,11 +119,10 @@ export function buildOnboardingGithubAppCreateUrl(
     url: homepageUrl.trim() || "http://localhost:3850",
     public: "false",
     webhook_active: "false",
-    contents: "write",
-    issues: "write",
-    pull_requests: "write",
-    members: "read",
-    metadata: "read",
+    // The canonical grant set (checks + statuses + issues included) — the same
+    // permissions the installation token mints request, so a created App is
+    // never born missing a scope the server needs.
+    ...GITHUB_APP_GRANT_PERMISSIONS,
     // Undocumented by GitHub, but supported by the new-App form. The onboarding
     // still tells the person to check it in case GitHub ever drops the parameter.
     device_flow_enabled: "true",

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -440,6 +440,13 @@ export async function handleSetupRoutes(
         (nextClientId !== undefined && github.oauthClientId !== nextClientId
           ? null
           : undefined);
+      const effectiveBotCredential = body.botCredential ?? github.botCredential ?? "pat";
+      if (keyMutation === null && effectiveBotCredential === "app") {
+        return Response.json(
+          { error: "Switch bot actions to the PAT before changing the GitHub App without a replacement key" },
+          { status: 409 },
+        );
+      }
 
       // Turning on the sign-in gate must never strand a personal install with
       // nobody who can pass it. Organization onboarding already rosters people

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -435,6 +435,12 @@ export async function handleSetupRoutes(
           : {};
       integrations.github = github;
 
+      const nextClientId = body.oauthClientId;
+      const keyMutation = privateKey ||
+        (nextClientId !== undefined && github.oauthClientId !== nextClientId
+          ? null
+          : undefined);
+
       // Turning on the sign-in gate must never strand a personal install with
       // nobody who can pass it. Organization onboarding already rosters people
       // before enabling the gate; the Settings toggle also serves single-user
@@ -503,7 +509,7 @@ export async function handleSetupRoutes(
       try {
         const { commitGithubAppKeyMutation } = await import("../github-app");
         await commitGithubAppKeyMutation(
-          privateKey || undefined,
+          keyMutation,
           () => persistRawConfig(config),
         );
       } catch (e) {

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -1,0 +1,47 @@
+// A GitHub App installation-token mint is all-or-nothing: it succeeds only if
+// every requested scope is a subset of what the App was granted. So each mint
+// set MUST be a subset of the grant set the create-app URL requests. When they
+// drifted apart, real Apps 422'd on every mint and fell back to the bot PAT —
+// which is exactly the bug this pins shut.
+
+import { describe, test, expect } from "bun:test";
+import {
+	GITHUB_APP_GRANT_PERMISSIONS,
+	GITHUB_APP_READ_PERMISSIONS,
+	GITHUB_APP_WRITE_PERMISSIONS,
+} from "./github-app-permissions";
+
+/** A mint scope is covered when the grant holds the same key at an access level
+ *  at least as strong (write covers read). */
+function uncoveredScopes(mint: Record<string, string>): string[] {
+	const rank = (v: string) => (v === "write" ? 2 : v === "read" ? 1 : 0);
+	return Object.entries(mint)
+		.filter(([key, level]) => rank(GITHUB_APP_GRANT_PERMISSIONS[key] ?? "") < rank(level))
+		.map(([key]) => key);
+}
+
+describe("github app permission sets", () => {
+	test("the read mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_READ_PERMISSIONS)).toEqual([]);
+	});
+
+	test("the write mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_WRITE_PERMISSIONS)).toEqual([]);
+	});
+
+	test("the grant includes the scopes the two capabilities depend on", () => {
+		// checks:read is the App-only capability (no PAT can read check runs);
+		// issues+pull_requests+contents:write are the agent's write path.
+		expect(GITHUB_APP_GRANT_PERMISSIONS.checks).toBe("read");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.issues).toBe("write");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.pull_requests).toBe("write");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.contents).toBe("write");
+	});
+
+	test("the write mint carries no read-only scope whose absence would 422 it", () => {
+		// It must not request checks/statuses — writes never touch them, and an
+		// App without them granted would otherwise reject the whole write token.
+		expect(GITHUB_APP_WRITE_PERMISSIONS.checks).toBeUndefined();
+		expect(GITHUB_APP_WRITE_PERMISSIONS.statuses).toBeUndefined();
+	});
+});

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -1,0 +1,49 @@
+/**
+ * The single source of truth for the GitHub App's permissions.
+ *
+ * One definition renders three ways — the create-app URL (what GitHub grants
+ * the App), the read installation token, and the write installation token — so
+ * they can never drift apart. Drift is exactly what left real Apps missing
+ * `checks` and `issues`: the create builders under-requested, the mints asked
+ * for scopes the App was never granted, and every installation token 422'd and
+ * fell back silently to the bot PAT.
+ *
+ * A mint is all-or-nothing: it succeeds only if every requested scope is a
+ * subset of what the installation holds. So each mint set below is a strict
+ * subset of the grant set, and the grant set is what the create URL requests.
+ */
+
+/** The full set the App is granted at creation — the create-URL permission
+ *  params, and the superset of every mint. */
+export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
+	checks: "read", // CI check runs — App-only; no PAT can read them
+	statuses: "read", // commit statuses, the other half of the status rollup
+	contents: "write", // push fixes, clone
+	pull_requests: "write", // reviews, comments, open/merge
+	issues: "write", // issue and PR comments
+	members: "read", // team roster / attribution
+	metadata: "read", // required baseline
+};
+
+/** Read installation token (pr-info's statusCheckRollup) — the read view of the
+ *  grant. Contents/pull_requests/issues at read, checks/statuses/metadata as
+ *  granted. No `actions`: the rollup needs check runs and statuses, not workflow
+ *  runs, and requesting an ungranted scope would 422 the token. */
+export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
+	checks: "read",
+	statuses: "read",
+	pull_requests: "read",
+	contents: "read",
+	issues: "read",
+	metadata: "read",
+};
+
+/** Write installation token (the PR agent) — exactly what writes need. No
+ *  read-only scopes: their absence must not 422 a token that never touches
+ *  them. */
+export const GITHUB_APP_WRITE_PERMISSIONS: Record<string, string> = {
+	pull_requests: "write",
+	issues: "write",
+	contents: "write",
+	metadata: "read",
+};


### PR DESCRIPTION
Second stage of the GitHub App credential migration, now based directly on merged #153. Supersedes #157 after GitHub's stacked squash left that branch conflicting.

## What changes

- Uses the canonical GitHub App permission sets for grants and token mints.
- Adds private-key validation and storage during setup.
- Accepts the private key from both App setup surfaces.
- Preserves the explicit PAT-default credential cutover introduced by #153.

## Verification

- `bun run typecheck`
- GitHub App permission, setup auth, and credential-toggle tests

Created by [this OS session](https://os.tella.dev/session/os-01a033fd-020d-76bc-be85-60b19b241fbc)
