### PR TITLE
Complete the GitHub App credential cutover

### DIFF
--- a/deploy/sandbox/microvm/refresh-sandbox-golden.sh
+++ b/deploy/sandbox/microvm/refresh-sandbox-golden.sh
@@ -60,7 +60,7 @@ compute_pins() {
   (
   cd "$ROOT"
   # Server-env parity: the systemd unit loads ~/.opensession.env
-  # (EnvironmentFile=), and injectToken prefers a live GITHUB_API_TOKEN from
+  # (EnvironmentFile=), and injectCloneCredential resolves the selected live GitHub credential from
   # the environment over persisted config tokens. Load the same file here so
   # the pin computation resolves the clone URL exactly like the server would
   # (a real env var also outranks the repo-local .env bun auto-loads).
@@ -68,7 +68,7 @@ compute_pins() {
     set -a; . "$CFG_HOME/.opensession.env"; set +a
   fi
   HOME="$CFG_HOME" GOLDEN_WANT_CLONE_URL="${1:-}" "$BUN_BIN" -e '
-import { bootstrapSignature, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
+import { bootstrapSignature, injectCloneCredential, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
 import { sandboxConfig } from "./src/server/sandbox/config.ts";
 import { REPO_ROOT } from "./src/runner-host/protocol.ts";
 const cfg = sandboxConfig();
@@ -77,7 +77,7 @@ console.log(cfg.runnerSha || "");
 if (process.env.GOLDEN_WANT_CLONE_URL) {
   let url;
   if (cfg.runnerRepoUrl) {
-    // Mirror bootstrap.ts toHttpsUrl+injectToken for the explicit-URL case.
+    // Mirror bootstrap.ts toHttpsUrl+injectCloneCredential for the explicit-URL case.
     let https = cfg.runnerRepoUrl;
     const scp = https.match(/^git@([^:]+):(.+?)(\.git)?$/);
     const ssh = https.match(/^ssh:\/\/git@([^/]+)\/(.+?)(\.git)?$/);
@@ -86,13 +86,7 @@ if (process.env.GOLDEN_WANT_CLONE_URL) {
     if (!/^https:\/\//.test(https)) {
       throw new Error(`runnerRepoUrl is not https-reachable: ${cfg.runnerRepoUrl}`);
     }
-    const cred = cfg.cloneCredential;
-    if (cred?.type === "https-token") {
-      const live = /^https:\/\/github\.com\//i.test(https) ? process.env.GITHUB_API_TOKEN : undefined;
-      const token = live || cred.token;
-      if (token) https = https.replace(/^https:\/\//, `https://x-access-token:${token}@`);
-    }
-    url = https;
+    url = await injectCloneCredential(https);
   } else {
     url = await remoteCloneUrl({ id: "opensession", repo: REPO_ROOT });
   }

--- a/packages/core/opensession-server/src/agents/slack/github-reviews.ts
+++ b/packages/core/opensession-server/src/agents/slack/github-reviews.ts
@@ -17,7 +17,6 @@ import { GITHUB_REPO } from "./state";
 import { ghRateLimited, noteGhRateLimited } from "../../server/github-limit";
 import { configuredIntegration } from "../../server/config";
 
-const GITHUB_TOKEN = process.env.GITHUB_API_TOKEN;
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 
 // ---------------------------------------------------------------------------
@@ -25,11 +24,13 @@ const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 // ---------------------------------------------------------------------------
 
 export async function githubApi(path: string): Promise<any> {
-  if (!GITHUB_TOKEN) return null;
+  const { githubToken } = await import("../../server/github-app");
+  const token = await githubToken();
+  if (!token) return null;
   try {
     const resp = await fetchWithTimeout(`https://api.github.com${path}`, {
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
     });

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -1,4 +1,5 @@
 import { BASE_PATH } from "../lib/base";
+import { GITHUB_APP_GRANT_PERMISSIONS } from "../../shared/github-app-permissions";
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { Menu } from "../ui/menu";
 import { OptionSelect } from "../ui/select";
@@ -552,10 +553,10 @@ function buildGithubAppCreateUrl(name: string, org: string): string {
     url: "http://localhost:3850",
     public: "false",
     webhook_active: "false",
-    contents: "write",
-    pull_requests: "write",
-    members: "read",
-    metadata: "read",
+    // The canonical grant set — the same permissions the install tokens mint
+    // request, so the App is not born missing `issues` or `checks` (the drift
+    // this builder used to have: no issues, no checks).
+    ...GITHUB_APP_GRANT_PERMISSIONS,
     device_flow_enabled: "true",
   }).toString();
   const base = org.trim()

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -609,6 +609,8 @@ function GithubAppWizard({
   setSlug,
   secret,
   setSecret,
+  privateKey,
+  setPrivateKey,
   onSaveApp,
   saving,
   configured,
@@ -629,6 +631,8 @@ function GithubAppWizard({
   setSlug: (v: string) => void;
   secret: string;
   setSecret: (v: string) => void;
+  privateKey: string;
+  setPrivateKey: (v: string) => void;
   onSaveApp: (appOrg: string) => void;
   saving: boolean;
   configured: boolean;
@@ -891,10 +895,25 @@ function GithubAppWizard({
                   copy it (shown once). Required.
                 </span>
               </div>
-            </div>
-            <div className="text-meta leading-snug text-faint">
-              Ignore GitHub's “generate a private key” banner. Open Session uses
-              device flow and doesn't need one.
+              <div className="flex flex-col gap-1">
+                <label className="text-supporting text-fg">Private key (PEM)</label>
+                <textarea
+                  className={cn(settingsInputClass, "min-h-20 resize-y font-mono")}
+                  value={privateKey}
+                  onChange={(e) => setPrivateKey(e.target.value)}
+                  placeholder="-----BEGIN RSA PRIVATE KEY-----"
+                  aria-label="GitHub App private key (PEM)"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <span className="text-meta leading-snug text-faint">
+                  In <span className="text-dim">Private keys</span>, click{" "}
+                  <span className="text-dim">Generate a private key</span>, then paste
+                  the downloaded .pem here. Lets the bot and PR checks run on the App;
+                  leave blank for sign-in only.
+                </span>
+              </div>
             </div>
             <Modal.Footer>
               <Button
@@ -1022,6 +1041,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
   const [appClientId, setAppClientId] = useState("");
   const [appSlug, setAppSlug] = useState("");
   const [appSecret, setAppSecret] = useState("");
+  const [appPrivateKey, setAppPrivateKey] = useState("");
   const [savingApp, setSavingApp] = useState(false);
   // The guided "create your app on GitHub, then paste + install + connect"
   // wizard, launched from the App option below.
@@ -1103,6 +1123,7 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
     const clientId = appClientId.trim();
     const slug = appSlug.trim();
     const secret = appSecret.trim();
+    const privateKey = appPrivateKey.trim();
     // The secret is required: the device-flow token expires and is refreshed
     // with it, so without one the connection would stop after ~8h.
     if (!clientId || !slug || !secret) return;
@@ -1113,14 +1134,16 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
         method: "POST",
         headers: { "Content-Type": "application/json" },
         // An org owner also records the sign-in intent server-side; a blank org
-        // is a personal, single-user App.
-        body: JSON.stringify({ clientId, slug, secret, appOrg }),
+        // is a personal, single-user App. The private key is optional but is
+        // what lets the bot/agent and checks-read mint installation tokens.
+        body: JSON.stringify({ clientId, slug, secret, appOrg, privateKey }),
       });
       const body = await res.json();
       if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
       setAppClientId("");
       setAppSlug("");
       setAppSecret("");
+      setAppPrivateKey("");
       // getConfig() re-reads on the file change, so the reload shows the App as
       // configured and switches the card to its device-flow connect.
       load();
@@ -1426,6 +1449,8 @@ export function GithubAccounts({ personal = false }: { personal?: boolean } = {}
           setSlug={setAppSlug}
           secret={appSecret}
           setSecret={setAppSecret}
+          privateKey={appPrivateKey}
+          setPrivateKey={setAppPrivateKey}
           onSaveApp={saveApp}
           saving={savingApp}
           configured={data.connectAvailable}

--- a/packages/core/opensession-server/src/frontend/components/SetupIntegrations.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupIntegrations.tsx
@@ -272,6 +272,7 @@ export function GithubAuthCard({
 	const [botCredential, setBotCredential] = useState(github.botCredential);
 	const [clientId, setClientId] = useState("");
 	const [clientSecret, setClientSecret] = useState("");
+	const [privateKey, setPrivateKey] = useState("");
 	const [clearId, setClearId] = useState(false);
 	const [clearSecret, setClearSecret] = useState(false);
 	const [saving, setSaving] = useState(false);
@@ -290,6 +291,7 @@ export function GithubAuthCard({
 		botCredential !== github.botCredential ||
 		clientId.trim() !== "" ||
 		clientSecret.trim() !== "" ||
+		privateKey.trim() !== "" ||
 		idCleared ||
 		secretCleared;
 
@@ -316,10 +318,12 @@ export function GithubAuthCard({
 						: secretCleared
 							? { oauthClientSecret: "" }
 							: {}),
+					...(privateKey.trim() ? { privateKey: privateKey.trim() } : {}),
 				},
 			});
 			setClientId("");
 			setClientSecret("");
+			setPrivateKey("");
 			setClearId(false);
 			setClearSecret(false);
 			toast("GitHub sign-in settings saved");
@@ -429,6 +433,25 @@ export function GithubAuthCard({
 						setClientSecret("");
 					}}
 				/>
+				<label className="flex flex-col gap-1">
+					<span className="text-supporting text-fg">Private key (PEM)</span>
+					<textarea
+						className="min-h-20 w-full resize-y rounded-md border border-line bg-surface px-2.5 py-1.5 font-mono text-supporting text-fg outline-none focus-ring"
+						value={privateKey}
+						onChange={(e) => setPrivateKey(e.target.value)}
+						placeholder="-----BEGIN RSA PRIVATE KEY-----"
+						aria-label="GitHub App private key (PEM)"
+						disabled={saving}
+						autoCapitalize="none"
+						autoComplete="off"
+						spellCheck={false}
+					/>
+					<span className="text-meta leading-snug text-faint">
+						In the App&rsquo;s Private keys, Generate a private key and paste the
+						.pem here. Lets the bot and PR checks run on the App; leave blank for
+						sign-in only.
+					</span>
+				</label>
 				<p className="m-0 text-supporting text-faint">
 					Credentials stay on this server and are never shown back.
 				</p>

--- a/packages/core/opensession-server/src/server/account-health.test.ts
+++ b/packages/core/opensession-server/src/server/account-health.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { selectedGithubCredentialIssues } from "./account-health";
+
+const originalConfig = process.env.OPENSESSION_CONFIG;
+const originalPat = process.env.GITHUB_API_TOKEN;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalConfig === undefined) delete process.env.OPENSESSION_CONFIG;
+  else process.env.OPENSESSION_CONFIG = originalConfig;
+  if (originalPat === undefined) delete process.env.GITHUB_API_TOKEN;
+  else process.env.GITHUB_API_TOKEN = originalPat;
+  globalThis.fetch = originalFetch;
+});
+
+describe("GitHub account health credential selection", () => {
+  test("App mode ignores a retired PAT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-account-health-"));
+    try {
+      const config = join(dir, "config.json");
+      writeFileSync(
+        config,
+        JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.GITHUB_API_TOKEN = "retired-pat";
+      let requests = 0;
+      globalThis.fetch = (async () => {
+        requests += 1;
+        return new Response(null, { status: 401 });
+      }) as unknown as typeof fetch;
+
+      expect(await selectedGithubCredentialIssues()).toEqual([]);
+      expect(requests).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/account-health.ts
+++ b/packages/core/opensession-server/src/server/account-health.ts
@@ -286,6 +286,42 @@ async function githubPatIssues(): Promise<Issue[]> {
   ];
 }
 
+/**
+ * The GitHub App is the credential the bot now rides on most installs. If it is
+ * configured (client id + key) but cannot mint an installation token — a revoked
+ * key, an uninstalled App, a wrong installation owner — every bot gh/PR flow is
+ * down, exactly like a dead PAT. Warn on that. Skipped when no App is set up, so
+ * a PAT-only install is unaffected.
+ */
+async function githubAppIssues(): Promise<Issue[]> {
+  const { githubAppConfigured, githubAppInstallationToken } = await import(
+    "./github-app"
+  );
+  if (!githubAppConfigured()) return [];
+  if (await githubAppInstallationToken()) return [];
+  const agent = personaName();
+  const owner = githubWriteOwners()[0] || "the configured owner";
+  return [
+    {
+      key: "github:app:dead",
+      message:
+        `${agent} here — the GitHub App is configured but cannot mint an ` +
+        `installation token: every bot gh/PR flow is down. Check the App is still ` +
+        `installed on ${owner}'s repositories and that its private key is valid.`,
+      notify: FALLBACK_TEAMMATE,
+    },
+  ];
+}
+
+/** Check only the credential selected for bot traffic. Unselected credentials
+ * may deliberately be absent or retired and must not trigger outage alerts. */
+export async function selectedGithubCredentialIssues(): Promise<Issue[]> {
+  const { githubBotCredentialMode } = await import("./github-app");
+  return githubBotCredentialMode() === "app"
+    ? githubAppIssues()
+    : githubPatIssues();
+}
+
 /** One sweep: detect, dedupe against state, DM, persist. Exported for tests/manual runs. */
 export async function sweepAccountHealth(): Promise<Issue[]> {
   // Repair before detecting: refresh idle codex accounts' ChatGPT tokens so
@@ -293,7 +329,10 @@ export async function sweepAccountHealth(): Promise<Issue[]> {
   await refreshIdleCodexTokens().catch((e) =>
     console.warn("[account-health] codex token refresh failed:", e)
   );
-  const issues = [...detectAccountIssues(), ...(await githubPatIssues())];
+  const issues = [
+    ...detectAccountIssues(),
+    ...(await selectedGithubCredentialIssues()),
+  ];
   const state = readState();
   const now = Date.now();
   const live = new Set(issues.map((i) => i.key));

--- a/packages/core/opensession-server/src/server/gh-attachments.ts
+++ b/packages/core/opensession-server/src/server/gh-attachments.ts
@@ -94,7 +94,7 @@ export async function uploadUserAttachment(
   const cacheKey = [ghRepo, filePath, stat.size, stat.mtimeMs].join("\u0000");
   const cached = uploadCache.get(cacheKey);
   if (cached) return cached;
-  const token = await botGhToken();
+  const token = await botGhToken({ write: true });
   if (!token) return null;
   const repoId = await repoDbId(ghRepo, token);
   if (repoId === null) return null;

--- a/packages/core/opensession-server/src/server/github-app.test.ts
+++ b/packages/core/opensession-server/src/server/github-app.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { githubRepositoryMatchesInstallation } from "./github-app";
+
+describe("repository-scoped App installation identity", () => {
+  test("requires the requested repository owner to match the selected installation", () => {
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession", "TellaHQ")).toBe(true);
+    expect(githubRepositoryMatchesInstallation("acme/opensession", "tellahq")).toBe(false);
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession/extra", "tellahq")).toBe(false);
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession", undefined)).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -282,11 +282,9 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
         },
         body: JSON.stringify({
           repositories: [repo],
-          permissions: {
-            contents: "write",
-            pull_requests: "write",
-            metadata: "read",
-          },
+          // Trusted repository code runs need the same write surface as the
+          // PR agent, including issue comments used by autofix threads.
+          permissions: WRITE_PERMISSIONS,
         }),
       },
     );

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -26,6 +26,7 @@ import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
 import { writeFileAtomic } from "./shared/atomic-write";
 import {
+  GITHUB_APP_CODE_PERMISSIONS as CODE_PERMISSIONS,
   GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
 } from "../shared/github-app-permissions";
@@ -315,9 +316,9 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
         },
         body: JSON.stringify({
           repositories: [repo],
-          // Trusted repository code runs need the same write surface as the
-          // PR agent, including issue comments used by autofix threads.
-          permissions: WRITE_PERMISSIONS,
+          // Trusted repository code runs can push/reply and inspect the
+          // failing checks and Actions logs they are expected to repair.
+          permissions: CODE_PERMISSIONS,
         }),
       },
     );

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -204,11 +204,44 @@ export function writeGithubAppKey(pem: string): void {
 /** Remove only a UI-managed key. An ops-managed path is external authority and
  * must never be mutated by the Settings removal flow. */
 export function removeGithubAppKey(): void {
-  if (process.env.OPENSESSION_GITHUB_APP_KEY)
-    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not removing an ops-managed key");
-  rmSync(keyPath(), { force: true });
+  // The App config may be UI-managed while its key path is ops-managed. In
+  // that mixed mode, preserve the external file but still invalidate tokens.
+  if (!process.env.OPENSESSION_GITHUB_APP_KEY)
+    rmSync(keyPath(), { force: true });
   g.__ghAppTokenCacheRead = null;
   g.__ghAppTokenCacheWrite = null;
+}
+
+/** Keep the key and matching config mutation in one recoverable transaction.
+ * `undefined` leaves the key alone, `null` removes it, and a string replaces
+ * it. If the config commit fails, restore the exact prior key atomically. */
+export async function commitGithubAppKeyMutation<T>(
+  key: string | null | undefined,
+  commitConfig: () => T | Promise<T>,
+): Promise<T> {
+  if (key === undefined || (key === null && process.env.OPENSESSION_GITHUB_APP_KEY)) {
+    if (key === null) {
+      g.__ghAppTokenCacheRead = null;
+      g.__ghAppTokenCacheWrite = null;
+    }
+    return commitConfig();
+  }
+  if (key !== null && process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
+
+  const path = keyPath();
+  const previous = existsSync(path) ? await Bun.file(path).text() : null;
+  if (key === null) removeGithubAppKey();
+  else writeGithubAppKey(key);
+  try {
+    return await commitConfig();
+  } catch (error) {
+    if (previous === null) rmSync(path, { force: true });
+    else writeFileAtomic(path, previous, 0o600);
+    g.__ghAppTokenCacheRead = null;
+    g.__ghAppTokenCacheWrite = null;
+    throw error;
+  }
 }
 
 /**

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -18,19 +18,30 @@
  * same containment story as the App user tokens.
  */
 import { createSign } from "node:crypto";
-import { existsSync, writeFileSync, chmodSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { githubUserAuthSettings } from "./github-auth";
 import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
+import { writeFileAtomic } from "./shared/atomic-write";
 import {
   GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
 } from "../shared/github-app-permissions";
 
-const KEY_PATH =
-  process.env.OPENSESSION_GITHUB_APP_KEY || join(homedir(), ".opensession-github-app.pem");
+let keyPathOverride: string | undefined;
+
+function keyPath(): string {
+  return keyPathOverride ||
+    process.env.OPENSESSION_GITHUB_APP_KEY ||
+    join(homedir(), ".opensession-github-app.pem");
+}
+
+/** Test seam: isolate key mutations from the operator's real key file. */
+export function __setGithubAppKeyPathForTest(path: string | undefined): void {
+  keyPathOverride = path;
+}
 
 type AppTokenCache = {
   token: string;
@@ -75,9 +86,9 @@ export async function githubAppInstallationToken(
   if (cached && cached.expiresAt - Date.now() > 5 * 60_000) return cached.token;
 
   const { clientId } = githubUserAuthSettings();
-  if (!clientId || !existsSync(KEY_PATH)) return null;
+  if (!clientId || !existsSync(keyPath())) return null;
   try {
-    const key = await Bun.file(KEY_PATH).text();
+    const key = await Bun.file(keyPath()).text();
     const jwt = appJwt(clientId, key);
     const headers = { Authorization: `Bearer ${jwt}`, Accept: "application/vnd.github+json" };
 
@@ -174,10 +185,10 @@ export function githubConfiguredCredential(): boolean {
 
 /** Whether a GitHub App can mint installation tokens (client id + private key). */
 export function githubAppConfigured(): boolean {
-  return !!githubUserAuthSettings().clientId && existsSync(KEY_PATH);
+  return !!githubUserAuthSettings().clientId && existsSync(keyPath());
 }
 
-/** Persist the App's private key (0600) at KEY_PATH — the piece the device-flow
+/** Persist the App's private key (0600) at the key path — the piece the device-flow
  *  setup never captured, so installation tokens (bot/agent, checks-read) could
  *  never mint. The App-manifest flow returns this PEM at creation. Drops any
  *  cached installation token, which belonged to a previous key. Honors the
@@ -185,8 +196,17 @@ export function githubAppConfigured(): boolean {
 export function writeGithubAppKey(pem: string): void {
   if (process.env.OPENSESSION_GITHUB_APP_KEY)
     throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
-  writeFileSync(KEY_PATH, pem.endsWith("\n") ? pem : `${pem}\n`, { mode: 0o600 });
-  try { chmodSync(KEY_PATH, 0o600); } catch {}
+  writeFileAtomic(keyPath(), pem.endsWith("\n") ? pem : `${pem}\n`, 0o600);
+  g.__ghAppTokenCacheRead = null;
+  g.__ghAppTokenCacheWrite = null;
+}
+
+/** Remove only a UI-managed key. An ops-managed path is external authority and
+ * must never be mutated by the Settings removal flow. */
+export function removeGithubAppKey(): void {
+  if (process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not removing an ops-managed key");
+  rmSync(keyPath(), { force: true });
   g.__ghAppTokenCacheRead = null;
   g.__ghAppTokenCacheWrite = null;
 }
@@ -208,9 +228,9 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
   const installationId =
     g.__ghAppTokenCacheRead?.installationId || g.__ghAppTokenCacheWrite?.installationId;
   const { clientId } = githubUserAuthSettings();
-  if (!installationId || !clientId || !existsSync(KEY_PATH)) return null;
+  if (!installationId || !clientId || !existsSync(keyPath())) return null;
   try {
-    const key = await Bun.file(KEY_PATH).text();
+    const key = await Bun.file(keyPath()).text();
     const res = await fetch(
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       {

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -18,12 +18,16 @@
  * same containment story as the App user tokens.
  */
 import { createSign } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { githubUserAuthSettings } from "./github-auth";
 import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
+import {
+  GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
+  GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
+} from "../shared/github-app-permissions";
 
 const KEY_PATH =
   process.env.OPENSESSION_GITHUB_APP_KEY || join(homedir(), ".opensession-github-app.pem");
@@ -42,31 +46,13 @@ const g = globalThis as {
   __ghAppTokenWarned?: boolean;
 };
 
-/** Read is strictly weaker than the bot PAT (no write at all). */
-const READ_PERMISSIONS = {
-  checks: "read",
-  statuses: "read",
-  actions: "read",
-  pull_requests: "read",
-  contents: "read",
-  issues: "read",
-  metadata: "read",
-} as const;
-/** Write asks for EXACTLY what the PR agent needs — post reviews and comments
- *  (pull_requests, issues) and push fixes (contents), plus metadata. It does NOT
- *  spread the read set: a mint is all-or-nothing, so requesting a read scope the
- *  App wasn't granted (e.g. checks, which no create flow grants today) would 422
- *  the whole write token even though writes never touch checks. Still
- *  installation-scoped, so an out-of-org write fails at GitHub's side just as the
- *  scoped bot PAT does (security-model.md, GitHub credential scoping). The App
- *  must hold these; if it does not the mint is rejected and the caller falls back
- *  to the PAT. */
-const WRITE_PERMISSIONS = {
-  pull_requests: "write",
-  issues: "write",
-  contents: "write",
-  metadata: "read",
-} as const;
+// READ_PERMISSIONS / WRITE_PERMISSIONS are the canonical sets imported at the
+// top of the file (shared/github-app-permissions) — the same definition the
+// create-app URL grants, so a mint never asks for a scope the App was not
+// granted. Still installation-scoped, so an out-of-org write fails at GitHub's
+// side just as the scoped bot PAT does (security-model.md, GitHub credential
+// scoping). If the App does not hold a set the mint is rejected and the caller
+// falls back to the PAT.
 
 function appJwt(clientId: string, key: string): string {
   const now = Math.floor(Date.now() / 1000);
@@ -189,6 +175,20 @@ export function githubConfiguredCredential(): boolean {
 /** Whether a GitHub App can mint installation tokens (client id + private key). */
 export function githubAppConfigured(): boolean {
   return !!githubUserAuthSettings().clientId && existsSync(KEY_PATH);
+}
+
+/** Persist the App's private key (0600) at KEY_PATH — the piece the device-flow
+ *  setup never captured, so installation tokens (bot/agent, checks-read) could
+ *  never mint. The App-manifest flow returns this PEM at creation. Drops any
+ *  cached installation token, which belonged to a previous key. Honors the
+ *  OPENSESSION_GITHUB_APP_KEY override so an ops-managed key is never clobbered. */
+export function writeGithubAppKey(pem: string): void {
+  if (process.env.OPENSESSION_GITHUB_APP_KEY)
+    throw new Error("OPENSESSION_GITHUB_APP_KEY is set; not overwriting an ops-managed key");
+  writeFileSync(KEY_PATH, pem.endsWith("\n") ? pem : `${pem}\n`, { mode: 0o600 });
+  try { chmodSync(KEY_PATH, 0o600); } catch {}
+  g.__ghAppTokenCacheRead = null;
+  g.__ghAppTokenCacheWrite = null;
 }
 
 /**

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -36,6 +36,7 @@ type AppTokenCache = {
   token: string;
   expiresAt: number; // ms epoch
   installationId: number;
+  installationOwner: string;
 };
 
 const g = globalThis as {
@@ -51,8 +52,7 @@ const g = globalThis as {
 // create-app URL grants, so a mint never asks for a scope the App was not
 // granted. Still installation-scoped, so an out-of-org write fails at GitHub's
 // side just as the scoped bot PAT does (security-model.md, GitHub credential
-// scoping). If the App does not hold a set the mint is rejected and the caller
-// falls back to the PAT.
+// scoping). If the App does not hold a set, minting fails closed in App mode.
 
 function appJwt(clientId: string, key: string): string {
   const now = Math.floor(Date.now() / 1000);
@@ -64,15 +64,19 @@ function appJwt(clientId: string, key: string): string {
 
 /**
  * Installation access token for the app's (sole) installation, or null when
- * the app key/client id isn't configured or minting fails. Fail-soft: callers
- * fall back to the bot PAT.
+ * the app key/client id isn't configured or minting fails. App mode callers
+ * treat null as a closed credential boundary; PAT mode never calls this path.
  */
 export async function githubAppInstallationToken(
   opts: { write?: boolean } = {},
 ): Promise<string | null> {
   const slot = opts.write ? "__ghAppTokenCacheWrite" : "__ghAppTokenCacheRead";
   const cached = g[slot];
-  if (cached && cached.expiresAt - Date.now() > 5 * 60_000) return cached.token;
+  if (
+    cached &&
+    cached.installationOwner &&
+    cached.expiresAt - Date.now() > 5 * 60_000
+  ) return cached.token;
 
   const { clientId } = githubUserAuthSettings();
   if (!clientId || !existsSync(KEY_PATH)) return null;
@@ -91,6 +95,12 @@ export async function githubAppInstallationToken(
       configuredInstallationId ||
       g.__ghAppTokenCacheRead?.installationId ||
       g.__ghAppTokenCacheWrite?.installationId;
+    let installationOwner =
+      g.__ghAppTokenCacheRead?.installationId === installationId
+        ? g.__ghAppTokenCacheRead?.installationOwner
+        : g.__ghAppTokenCacheWrite?.installationId === installationId
+          ? g.__ghAppTokenCacheWrite?.installationOwner
+          : undefined;
     if (!installationId) {
       const res = await fetch("https://api.github.com/app/installations", { headers });
       const installs = (await res.json()) as Array<{ id: number; account?: { login?: string } }>;
@@ -118,6 +128,20 @@ export async function githubAppInstallationToken(
         );
       }
       installationId = selected.id;
+      installationOwner = selected.account?.login;
+    }
+    if (!installationOwner) {
+      const installationRes = await fetch(
+        `https://api.github.com/app/installations/${installationId}`,
+        { headers },
+      );
+      const installation = (await installationRes.json()) as {
+        account?: { login?: string };
+      };
+      installationOwner = installation.account?.login;
+      if (!installationRes.ok || !installationOwner) {
+        throw new Error(`cannot resolve installation owner (${installationRes.status})`);
+      }
     }
 
     const res = await fetch(
@@ -136,6 +160,7 @@ export async function githubAppInstallationToken(
       token: tok.token,
       expiresAt: tok.expires_at ? Date.parse(tok.expires_at) : Date.now() + 55 * 60_000,
       installationId,
+      installationOwner,
     };
     g.__ghAppTokenWarned = false;
     return tok.token;
@@ -198,6 +223,15 @@ export function writeGithubAppKey(pem: string): void {
  * askpass helper immediately after git finishes. It is never persisted in a
  * session file, host spec, URL, transcript, or Runner registry.
  */
+export function githubRepositoryMatchesInstallation(
+  ghRepo: string,
+  installationOwner: string | undefined,
+): boolean {
+  const [owner, repo, extra] = ghRepo.split("/");
+  return !!owner && !!repo && !extra &&
+    !!installationOwner && owner.toLowerCase() === installationOwner.toLowerCase();
+}
+
 export async function githubAppRepositoryToken(ghRepo: string): Promise<string | null> {
   if (githubBotCredentialMode() !== "app") return null;
   const [owner, repo] = ghRepo.split("/");
@@ -205,8 +239,15 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
   // Resolve the installation id through the existing credential path. It keeps
   // installation selection in one place and may populate the shared cache.
   await githubAppInstallationToken();
-  const installationId =
-    g.__ghAppTokenCacheRead?.installationId || g.__ghAppTokenCacheWrite?.installationId;
+  const installation =
+    g.__ghAppTokenCacheRead || g.__ghAppTokenCacheWrite;
+  const installationId = installation?.installationId;
+  if (!githubRepositoryMatchesInstallation(ghRepo, installation?.installationOwner)) {
+    console.warn(
+      `[github-app] refusing repository token for ${ghRepo}: selected installation belongs to ${installation?.installationOwner || "unknown"}`,
+    );
+    return null;
+  }
   const { clientId } = githubUserAuthSettings();
   if (!installationId || !clientId || !existsSync(KEY_PATH)) return null;
   try {

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -31,6 +31,7 @@ import {
   startGithubDeviceFlow,
   validateGithubTokenLogin,
 } from "./github-auth";
+import { botGhToken } from "./github-limit";
 import {
 	ensureAutomationWebSession,
   keypadBearerAuthorized,
@@ -48,6 +49,7 @@ const ENV_KEYS = [
   GITHUB_RUN_AUTH_FILE_ENV,
   "OPENSESSION_WEB_SESSIONS_STORE",
   "KEYPAD_TOKEN",
+  "GITHUB_API_TOKEN",
 ] as const;
 const saved: Record<string, string | undefined> = {};
 for (const k of ENV_KEYS) saved[k] = process.env[k];
@@ -112,6 +114,20 @@ function seedToken(login = "alice", token = "gho_test123"): void {
     }),
   );
 }
+
+
+describe("selected bot credential boundary", () => {
+  test("App mode does not fall back to the PAT or ambient gh login", async () => {
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+    );
+    process.env.OPENSESSION_CONFIG = path;
+    process.env.GITHUB_API_TOKEN = "retired-pat";
+    expect(await botGhToken()).toBeNull();
+  });
+});
 
 describe("githubUserAuthSettings", () => {
   test("off by default (no config)", () => {

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -813,20 +813,31 @@ function projectedGithubAuthEnv(): Record<string, string> {
   }
 }
 
-/** GitHub environment for one interactive run. Besides the API variables, set
- * a process-local Git credential helper so HTTPS remotes can push without
- * persisting the short-lived user token in .git/config or ~/.config/gh. */
-export function githubRunEnv(user?: string | null): Record<string, string> {
-  const auth = githubAuthEnv(user);
-  const projected = Object.keys(auth).length ? auth : projectedGithubAuthEnv();
-  if (!projected.GH_TOKEN) return {};
+function githubProcessEnv(auth: Record<string, string>): Record<string, string> {
+  if (!auth.GH_TOKEN) return {};
   return {
-    ...projected,
+    ...auth,
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_COUNT: "1",
     GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
     GIT_CONFIG_VALUE_0: "!gh auth git-credential",
   };
+}
+
+/** Consume only the private run-scoped file projected by a remote launcher.
+ * Unlike githubRunEnv(), this can never consult a connected human account. */
+export function projectedGithubRunEnv(): Record<string, string> {
+  return githubProcessEnv(projectedGithubAuthEnv());
+}
+
+/** GitHub environment for one interactive run. Besides the API variables, set
+ * a process-local Git credential helper so HTTPS remotes can push without
+ * persisting the short-lived user token in .git/config or ~/.config/gh. */
+export function githubRunEnv(user?: string | null): Record<string, string> {
+  const auth = githubAuthEnv(user);
+  return githubProcessEnv(
+    Object.keys(auth).length ? auth : projectedGithubAuthEnv(),
+  );
 }
 
 export interface GithubCredential {

--- a/packages/core/opensession-server/src/server/github-limit.ts
+++ b/packages/core/opensession-server/src/server/github-limit.ts
@@ -109,14 +109,22 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
   persistBackoff();
   state.probe = (async () => {
     try {
-      const proc = Bun.spawn(
-        ["gh", "api", "rate_limit", "--jq", ".resources.graphql.reset"],
-        { stdout: "pipe", stderr: "ignore" },
-      );
-      const raw = await new Response(proc.stdout).text();
-      if ((await proc.exited) === 0) {
-        const reset = parseInt(raw.trim(), 10) * 1000;
-        if (reset > Date.now()) {
+      // Probe with the operator-selected service credential. Invoking ambient
+      // `gh` here would cross the App cutover through hosts.yml on failures.
+      const { githubToken } = await import("./github-app");
+      const token = await githubToken();
+      if (token) {
+        const response = await fetch("https://api.github.com/rate_limit", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": "opensession",
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        const data = await response.json().catch(() => null) as any;
+        const reset = Number(data?.resources?.graphql?.reset) * 1000;
+        if (response.ok && reset > Date.now()) {
           state.backoffUntil = reset + 30_000;
           persistBackoff();
         }
@@ -131,11 +139,17 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
 
 /**
  * Token for direct api.github.com calls made on the bot's behalf (conditional
- * change probes and the like): the GITHUB_API_TOKEN PAT when configured, else
- * the gh CLI's own token, probed once and cached for the process lifetime.
+ * change probes and the like): the App installation token (or GITHUB_API_TOKEN)
+ * that the REST helpers use, else the gh CLI's own token, probed once and cached
+ * for the process lifetime.
  */
 export async function botGhToken(): Promise<string | null> {
-  if (process.env.GITHUB_API_TOKEN) return process.env.GITHUB_API_TOKEN;
+  const { githubBotCredentialMode, githubToken } = await import("./github-app");
+  const primary = await githubToken();
+  if (primary) return primary;
+  // App mode is an explicit credential boundary. Do not silently resume with
+  // a user login or retired PAT cached by gh when App token minting fails.
+  if (githubBotCredentialMode() === "app") return null;
   if (state.botToken !== undefined) return state.botToken;
   try {
     const proc = Bun.spawn(["gh", "auth", "token"], {

--- a/packages/core/opensession-server/src/server/github-limit.ts
+++ b/packages/core/opensession-server/src/server/github-limit.ts
@@ -143,9 +143,11 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
  * that the REST helpers use, else the gh CLI's own token, probed once and cached
  * for the process lifetime.
  */
-export async function botGhToken(): Promise<string | null> {
+export async function botGhToken(
+  opts: { write?: boolean } = {},
+): Promise<string | null> {
   const { githubBotCredentialMode, githubToken } = await import("./github-app");
-  const primary = await githubToken();
+  const primary = await githubToken(opts);
   if (primary) return primary;
   // App mode is an explicit credential boundary. Do not silently resume with
   // a user login or retired PAT cached by gh when App token minting fails.

--- a/packages/core/opensession-server/src/server/pi-runner-github.test.ts
+++ b/packages/core/opensession-server/src/server/pi-runner-github.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { GITHUB_RUN_AUTH_FILE_ENV } from "./github-auth";
+import { githubCodeRunEnv } from "./pi-runner";
+
+const keys = [
+  "OPENSESSION_CONFIG",
+  "OPENSESSION_GITHUB_AUTH_STORE",
+  "GITHUB_API_TOKEN",
+  GITHUB_RUN_AUTH_FILE_ENV,
+] as const;
+const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of keys) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("recovered GitHub code-run credentials", () => {
+  test("resolves the selected service credential instead of a connected human", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-recovered-github-"));
+    try {
+      const cwd = join(dir, "repo");
+      mkdirSync(cwd);
+      const config = join(dir, "config.json");
+      const users = join(dir, "github-users.json");
+      writeFileSync(
+        config,
+        JSON.stringify({
+          integrations: { github: { botCredential: "pat" } },
+          repos: {
+            app: {
+              repo: cwd,
+              ghRepo: "tellahq/app",
+              defaultBranch: "main",
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        users,
+        JSON.stringify({
+          users: {
+            alice: { login: "alice", token: "human-token", connectedAt: new Date().toISOString() },
+          },
+        }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.OPENSESSION_GITHUB_AUTH_STORE = users;
+      process.env.GITHUB_API_TOKEN = "selected-service-pat";
+      delete process.env[GITHUB_RUN_AUTH_FILE_ENV];
+
+      const env = await githubCodeRunEnv(cwd);
+      expect(env.GH_TOKEN).toBe("selected-service-pat");
+      expect(Object.values(env)).not.toContain("human-token");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("remote recovery consumes only its projected run-scoped file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-projected-github-"));
+    try {
+      const auth = join(dir, "github-auth.json");
+      writeFileSync(auth, JSON.stringify({ GH_TOKEN: "projected-service-token" }));
+      process.env[GITHUB_RUN_AUTH_FILE_ENV] = auth;
+      process.env.GITHUB_API_TOKEN = "unprojected-host-token";
+
+      const env = await githubCodeRunEnv("/remote/unregistered/repo");
+      expect(env.GH_TOKEN).toBe("projected-service-token");
+      expect(Object.values(env)).not.toContain("unprojected-host-token");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -91,7 +91,12 @@ import {
 import { transcriptStore } from "./transcript-store";
 import { transcriptForwarder } from "./transcript-forward";
 import { gitIdentityEnv } from "./shared/user-mappings";
-import { githubRunEnv, githubUserLoginForRun } from "./github-auth";
+import {
+  GITHUB_RUN_AUTH_FILE_ENV,
+  githubRunEnv,
+  githubUserLoginForRun,
+  projectedGithubRunEnv,
+} from "./github-auth";
 import { ensureAgentAwsCredsFile } from "./aws-creds";
 import { buildEngineSwitchHandoffNote } from "./fork-handoff";
 import { piAnthropicTransport, piEngineEnabled } from "./pi-config";
@@ -119,6 +124,18 @@ const g = globalThis as any;
 
 const PROVIDER = "pi" as const;
 export const PI_MODEL_PREFIX = "pi/";
+
+/** Fresh authority for an unattended GitHub code run. Host recovery resolves
+ * the selected service credential from the registered cwd; remote runners can
+ * consume only the private run-scoped file projected by their launcher. */
+export async function githubCodeRunEnv(cwd: string): Promise<Record<string, string>> {
+  if (process.env[GITHUB_RUN_AUTH_FILE_ENV]) return projectedGithubRunEnv();
+  const { repoForPathOrNull } = await import("./worktree");
+  const repo = repoForPathOrNull(cwd);
+  if (!repo || repo.host === "codestorage" || !repo.ghRepo) return {};
+  const { githubServiceCredentialEnv } = await import("./github-app");
+  return githubServiceCredentialEnv(repo.ghRepo);
+}
 
 /** State root: server-owned agentDir, per-unified-session pi session dirs,
  *  and the smoke-turn scratch cwd. Never ~/.pi. */
@@ -1604,7 +1621,9 @@ async function* runPiAttempt(
     const githubCodeRun =
       mode === "code" && baseJournalKind(journal?.kind).startsWith("github-");
     const githubEnv = githubCodeRun
-      ? opts.githubEnv || {}
+      ? opts.githubEnv?.GH_TOKEN
+        ? opts.githubEnv
+        : await githubCodeRunEnv(cwd)
       : interactiveGithub
         ? githubRunEnv(user || author?.name)
         : {};

--- a/packages/core/opensession-server/src/server/pr-images.ts
+++ b/packages/core/opensession-server/src/server/pr-images.ts
@@ -152,7 +152,8 @@ const repoVisibilityCache = new Map<string, boolean>();
 export async function repoIsPrivate(ghRepo: string): Promise<boolean | null> {
   const cached = repoVisibilityCache.get(ghRepo);
   if (cached !== undefined) return cached;
-  const token = process.env.GITHUB_API_TOKEN || process.env.GH_TOKEN;
+  const { botGhToken } = await import("./github-limit");
+  const token = await botGhToken();
   if (!token) return null;
   try {
     const res = await fetch(`https://api.github.com/repos/${ghRepo}`, {

--- a/packages/core/opensession-server/src/server/pr-viewed.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.ts
@@ -42,7 +42,7 @@ async function viewerToken(
 		const credential = githubCredentialForLogin(login);
 		if (credential?.env.GH_TOKEN) return credential.env.GH_TOKEN;
 	}
-	return botGhToken();
+	return botGhToken({ write: true });
 }
 
 async function graphql(

--- a/packages/core/opensession-server/src/server/preview-pool.test.ts
+++ b/packages/core/opensession-server/src/server/preview-pool.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { rebuildInvalidatedPreviewPool } from "./preview-pool";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cloneUrlFor, rebuildInvalidatedPreviewPool } from "./preview-pool";
+import type { Repo } from "./config";
 
 describe("default branch preview-pool rebuild", () => {
   test("does not refill a golden-backed pool when its rebuild fails", async () => {
@@ -32,5 +36,39 @@ describe("default branch preview-pool rebuild", () => {
     await expect(rebuildInvalidatedPreviewPool("daytona", rebuild, refill)).resolves.toBe(true);
     expect(rebuilds).toBe(1);
     expect(refills).toBe(2);
+  });
+});
+
+
+describe("preview pool GitHub credential cutover", () => {
+  test("does not bake an expiring App token into restartable container commands", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-preview-credential-"));
+    const previous = process.env.OPENSESSION_CONFIG;
+    try {
+      const config = join(dir, "config.json");
+      writeFileSync(
+        config,
+        JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      expect(
+        await cloneUrlFor(
+          {
+            id: "opensession",
+            label: "Open Session",
+            repo: "/host/opensession",
+            wtPrefix: "/host/worktrees/opensession",
+            defaultBranch: "main",
+            host: "github",
+            ghRepo: "tellahq/opensession",
+          } satisfies Repo,
+          { longLived: true },
+        ),
+      ).toBeNull();
+    } finally {
+      if (previous === undefined) delete process.env.OPENSESSION_CONFIG;
+      else process.env.OPENSESSION_CONFIG = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/opensession-server/src/server/preview-pool.ts
+++ b/packages/core/opensession-server/src/server/preview-pool.ts
@@ -57,7 +57,7 @@ import { authedRemoteUrl } from "./codestorage/auth";
 import { homeDir, OPENSESSION_SESSIONS_DIR } from "./paths";
 import { isDevInstance } from "./dev-mode";
 import { sandboxConfig } from "./sandbox/config";
-import { shellQuoteWord } from "./sandbox/adapters/bootstrap";
+import { injectCloneCredential, shellQuoteWord } from "./sandbox/adapters/bootstrap";
 import { redactUrl } from "./shared/redact";
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -840,7 +840,7 @@ async function refreshContainerCreds(target: string | PoolContainer): Promise<bo
   return r.ok;
 }
 
-async function cloneUrlFor(
+export async function cloneUrlFor(
   repo: Repo,
   opts?: { longLived?: boolean },
 ): Promise<string | null> {
@@ -855,11 +855,15 @@ async function cloneUrlFor(
     return authedRemoteUrl(repo.csRepo, opts?.longLived ? { ttlSeconds: 30 * 24 * 3600 } : {});
   }
   if (!repo.ghRepo) return null;
-  const cred = sandboxConfig().cloneCredential;
-  if (cred?.type === "https-token" && cred.token) {
-    return `https://x-access-token:${cred.token}@github.com/${repo.ghRepo}.git`;
-  }
-  return `https://github.com/${repo.ghRepo}.git`;
+  const { githubBotCredentialMode } = await import("./github-app");
+  const mode = githubBotCredentialMode();
+  // Installation tokens expire too quickly to bake into a container command
+  // that may restart days later. App-mode warm restarts use the golden tree;
+  // one-shot golden/Daytona operations mint a fresh repository token below.
+  if (opts?.longLived && mode === "app") return null;
+  const plain = `https://github.com/${repo.ghRepo}.git`;
+  const selected = await injectCloneCredential(plain);
+  return mode === "app" && selected === plain ? null : selected;
 }
 
 /** Boot preamble every warm/golden boot runs: lock cleanup + full ports.conf. */
@@ -1017,7 +1021,7 @@ async function warmRoutesPool(repo: Repo, c: PoolContainer): Promise<void> {
 async function spawnDaytonaWarm(repo: Repo): Promise<void> {
   const cloneUrl = await cloneUrlFor(repo);
   if (!cloneUrl) {
-    return console.warn(`[preview-pool] ${repo.id}: daytona backend needs a ghRepo + cloneCredential`);
+    return console.warn(`[preview-pool] ${repo.id}: daytona backend needs a ghRepo + selected GitHub credential`);
   }
   const client = await daytonaClientForPool();
   const scfg = sandboxConfig();
@@ -1081,6 +1085,17 @@ async function spawnDaytonaWarm(repo: Repo): Promise<void> {
       8 * 60_000,
     );
     if (!clone.ok) return void (await fail(`clone: ${clone.out.slice(-400)}`));
+    if (repo.host !== "codestorage") {
+      // git clone persists its authority in remote.origin.url. Remove the
+      // repository-scoped App token before any repository-owned setup/start
+      // code can inspect it.
+      const safeOrigin = `https://github.com/${repo.ghRepo}.git`;
+      const scrub = await poolExec(
+        c,
+        `git -C ${WORKSPACE} remote set-url origin ${shellQuoteWord(safeOrigin)}`,
+      );
+      if (!scrub.ok) return void (await fail(`credential scrub: ${scrub.out.slice(-400)}`));
+    }
 
     for (const rel of SEED_ENV_FILES) {
       const content = envSeedContent(repo, rel);
@@ -1364,9 +1379,9 @@ async function spawnWarmContainer(repo: Repo): Promise<void> {
   const { previewHost, httpsPortFor } = await import("./preview");
   const host = await previewHost();
   const previewUrl = `https://${host}:${httpsPortFor(hostPort)}`;
-  // longLived: this URL is baked into the container's boot command, which the
-  // `docker restart` clean-reboot path re-runs long after spawn — a 1h token
-  // would make that advance fetch fail silently (`|| true`) onto a stale tree.
+  // PAT mode may use its long-lived credential here. App mode deliberately
+  // returns null rather than baking an hour-lived repository token into a boot
+  // command that can be re-run days later.
   const cloneUrl = await cloneUrlFor(repo, { longLived: true });
 
   patchContainer(repo.id, name, {

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { bootstrapUserAuthOnConnect, handleConnectionsRoutes } from "./connections";
+import { __setGithubAppKeyPathForTest } from "../github-app";
 import type { RouteContext } from "./context";
 
 // The GitHub connect routes behave differently by mode: operator mode (web
@@ -30,9 +31,11 @@ beforeEach(() => {
   process.env.OPENSESSION_CONFIG = join(dir, "config.json");
   process.env.OPENSESSION_GITHUB_AUTH_STORE = join(dir, "github-auth.json");
   process.env.OPENSESSION_WEB_SESSIONS_STORE = join(dir, "web-sessions.json");
+  __setGithubAppKeyPathForTest(join(dir, "github-app.pem"));
 });
 
 afterEach(() => {
+  __setGithubAppKeyPathForTest(undefined);
   rmSync(dir, { recursive: true, force: true });
   for (const k of ENV_KEYS) {
     if (saved[k] === undefined) delete process.env[k];
@@ -213,7 +216,10 @@ describe("GitHub App config (simple mode)", () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),
     );
-    // An unrelated github key, to prove the clear is surgical.
+    // A UI-managed key must be removed with the App; an unrelated github
+    // config key proves the config clear remains surgical.
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "old-app-private-key", { mode: 0o600 });
     const path = process.env.OPENSESSION_CONFIG!;
     const cfg = JSON.parse(readFileSync(path, "utf-8"));
     cfg.integrations.github.userPrAuth = false;
@@ -226,6 +232,7 @@ describe("GitHub App config (simple mode)", () => {
     expect(after.integrations.github.oauthClientId).toBeUndefined();
     expect(after.integrations.github.appSlug).toBeUndefined();
     expect(after.integrations.github.userPrAuth).toBe(false);
+    expect(existsSync(keyPath)).toBe(false);
 
     const get = await handleConnectionsRoutes(context(GET, "GET", null));
     expect((await get?.json()).connectAvailable).toBe(false);

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -244,6 +244,20 @@ describe("GitHub App config (simple mode)", () => {
     ).toBe(400);
   });
 
+  test("changing App identity without a new key clears the previous key", async () => {
+    await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-a", slug: "app-a", secret: "shh" }),
+    );
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "app-a-key\n", { mode: 0o600 });
+
+    const response = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-b", slug: "app-b", secret: "shh" }),
+    );
+    expect(response?.status).toBe(200);
+    expect(existsSync(keyPath)).toBe(false);
+  });
+
   test("DELETE clears the App keys but leaves other github config intact", async () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.abc", slug: "my-app", secret: "shh" }),

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -244,6 +244,35 @@ describe("GitHub App config (simple mode)", () => {
     ).toBe(400);
   });
 
+  test("cannot strand selected App bot actions by clearing their key", async () => {
+    const path = process.env.OPENSESSION_CONFIG!;
+    writeFileSync(
+      path,
+      JSON.stringify({
+        integrations: {
+          github: {
+            oauthClientId: "Iv1.app-a",
+            appSlug: "app-a",
+            oauthClientSecret: "shh",
+            botCredential: "app",
+          },
+        },
+      }),
+    );
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "app-a-key\n", { mode: 0o600 });
+
+    const replace = await handleConnectionsRoutes(
+      context(APP, "POST", null, { clientId: "Iv1.app-b", slug: "app-b", secret: "shh" }),
+    );
+    expect(replace?.status).toBe(409);
+    expect(readFileSync(keyPath, "utf-8")).toBe("app-a-key\n");
+
+    const remove = await handleConnectionsRoutes(context(APP, "DELETE", null));
+    expect(remove?.status).toBe(409);
+    expect(readFileSync(keyPath, "utf-8")).toBe("app-a-key\n");
+  });
+
   test("changing App identity without a new key clears the previous key", async () => {
     await handleConnectionsRoutes(
       context(APP, "POST", null, { clientId: "Iv1.app-a", slug: "app-a", secret: "shh" }),

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -3,7 +3,10 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs
 import { tmpdir } from "os";
 import { join } from "path";
 import { bootstrapUserAuthOnConnect, handleConnectionsRoutes } from "./connections";
-import { __setGithubAppKeyPathForTest } from "../github-app";
+import {
+  __setGithubAppKeyPathForTest,
+  commitGithubAppKeyMutation,
+} from "../github-app";
 import type { RouteContext } from "./context";
 
 // The GitHub connect routes behave differently by mode: operator mode (web
@@ -16,6 +19,7 @@ const ENV_KEYS = [
   "OPENSESSION_CONFIG",
   "OPENSESSION_GITHUB_CLIENT_ID",
   "OPENSESSION_GITHUB_APP_SLUG",
+  "OPENSESSION_GITHUB_APP_KEY",
   "OPENSESSION_GITHUB_AUTH_STORE",
   "OPENSESSION_WEB_SESSIONS_STORE",
 ] as const;
@@ -78,6 +82,34 @@ function context(
 }
 
 const DEVICE = "/api/connections/github/device";
+
+
+describe("GitHub App key transaction", () => {
+  test("restores the previous key when config persistence fails", async () => {
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "working-key\n", { mode: 0o600 });
+
+    await expect(
+      commitGithubAppKeyMutation("replacement-key", () => {
+        throw new Error("config volume full");
+      }),
+    ).rejects.toThrow("config volume full");
+    expect(readFileSync(keyPath, "utf-8")).toBe("working-key\n");
+  });
+
+  test("removes config while preserving an ops-managed key", async () => {
+    const keyPath = join(dir, "github-app.pem");
+    writeFileSync(keyPath, "ops-key\n", { mode: 0o600 });
+    process.env.OPENSESSION_GITHUB_APP_KEY = keyPath;
+    let committed = false;
+
+    await commitGithubAppKeyMutation(null, () => {
+      committed = true;
+    });
+    expect(committed).toBe(true);
+    expect(readFileSync(keyPath, "utf-8")).toBe("ops-key\n");
+  });
+});
 
 describe("GitHub connect gating", () => {
   test("simple mode without a configured app rejects the connect (400)", async () => {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -788,11 +788,29 @@ export async function handleConnectionsRoutes(
 				{ error: "clientId, slug and secret are required" },
 				{ status: 400 },
 			);
-		if (privateKey && !/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(privateKey))
-			return Response.json(
-				{ error: "privateKey must be a PEM private key" },
-				{ status: 400 },
-			);
+		if (privateKey) {
+			// A complete PEM block, and it must actually parse — a header-only or
+			// truncated value would otherwise overwrite a working key on disk.
+			const wellFormed =
+				/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+-----END [A-Z ]*PRIVATE KEY-----/.test(
+					privateKey,
+				);
+			let parses = false;
+			if (wellFormed) {
+				try {
+					const { createPrivateKey } = await import("node:crypto");
+					createPrivateKey(privateKey);
+					parses = true;
+				} catch {
+					parses = false;
+				}
+			}
+			if (!parses)
+				return Response.json(
+					{ error: "privateKey must be a valid PEM private key" },
+					{ status: 400 },
+				);
+		}
 		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
 		// we surface that before touching config rather than half-configuring.
 		if (privateKey) {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -818,6 +818,12 @@ export async function handleConnectionsRoutes(
 			const github = githubIntegrationSection(config, true)!;
 			const keyMutation = privateKey ||
 				(github.oauthClientId !== clientId ? null : undefined);
+			if (keyMutation === null && github.botCredential === "app") {
+				return Response.json(
+					{ error: "Switch bot actions to the PAT before changing the GitHub App without a replacement key" },
+					{ status: 409 },
+				);
+			}
 			github.oauthClientId = clientId;
 			github.appSlug = slug;
 			github.oauthClientSecret = secret;
@@ -873,6 +879,12 @@ export async function handleConnectionsRoutes(
 		return withConfigMutationLock(async () => {
 			const config = rawConfig();
 			const github = githubIntegrationSection(config, false);
+			if (github?.botCredential === "app") {
+				return Response.json(
+					{ error: "Switch bot actions to the PAT before removing the GitHub App" },
+					{ status: 409 },
+				);
+			}
 			if (github) {
 				// Drop the repo-App keys and the captured sign-in intent
 				// (appOrg/authOnConnect) — removing the App is also how the wizard

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -811,19 +811,6 @@ export async function handleConnectionsRoutes(
 					{ status: 400 },
 				);
 		}
-		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
-		// we surface that before touching config rather than half-configuring.
-		if (privateKey) {
-			const { writeGithubAppKey } = await import("../github-app");
-			try {
-				writeGithubAppKey(privateKey);
-			} catch (e) {
-				return Response.json(
-					{ error: String((e as Error)?.message || e) },
-					{ status: 409 },
-				);
-			}
-		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {
@@ -847,7 +834,18 @@ export async function handleConnectionsRoutes(
 				delete github.webhookForwardLogin;
 				delete github.webhookForwardLogin;
 			}
-			persistRawConfig(config);
+			try {
+				const { commitGithubAppKeyMutation } = await import("../github-app");
+				await commitGithubAppKeyMutation(
+					privateKey || undefined,
+					() => persistRawConfig(config),
+				);
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
 			return Response.json({ ok: true });
 		});
 	}
@@ -868,15 +866,6 @@ export async function handleConnectionsRoutes(
 				},
 				{ status: 409 },
 			);
-		try {
-			const { removeGithubAppKey } = await import("../github-app");
-			removeGithubAppKey();
-		} catch (e) {
-			return Response.json(
-				{ error: String((e as Error)?.message || e) },
-				{ status: 409 },
-			);
-		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {
@@ -893,7 +882,15 @@ export async function handleConnectionsRoutes(
 				delete github.appOrg;
 				delete github.authOnConnect;
 			}
-			persistRawConfig(config);
+			try {
+				const { commitGithubAppKeyMutation } = await import("../github-app");
+				await commitGithubAppKeyMutation(null, () => persistRawConfig(config));
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
 			return Response.json({ ok: true });
 		});
 	}

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -816,6 +816,8 @@ export async function handleConnectionsRoutes(
 		return withConfigMutationLock(async () => {
 			const config = rawConfig();
 			const github = githubIntegrationSection(config, true)!;
+			const keyMutation = privateKey ||
+				(github.oauthClientId !== clientId ? null : undefined);
 			github.oauthClientId = clientId;
 			github.appSlug = slug;
 			github.oauthClientSecret = secret;
@@ -837,7 +839,7 @@ export async function handleConnectionsRoutes(
 			try {
 				const { commitGithubAppKeyMutation } = await import("../github-app");
 				await commitGithubAppKeyMutation(
-					privateKey || undefined,
+					keyMutation,
 					() => persistRawConfig(config),
 				);
 			} catch (e) {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -868,6 +868,15 @@ export async function handleConnectionsRoutes(
 				},
 				{ status: 409 },
 			);
+		try {
+			const { removeGithubAppKey } = await import("../github-app");
+			removeGithubAppKey();
+		} catch (e) {
+			return Response.json(
+				{ error: String((e as Error)?.message || e) },
+				{ status: 409 },
+			);
+		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -764,6 +764,7 @@ export async function handleConnectionsRoutes(
 			slug?: unknown;
 			secret?: unknown;
 			appOrg?: unknown;
+			privateKey?: unknown;
 		} | null;
 		const clientId =
 			typeof body?.clientId === "string" ? body.clientId.trim() : "";
@@ -772,6 +773,12 @@ export async function handleConnectionsRoutes(
 		// Present ⇒ the App is owned by an org (owner=Organization); empty/absent ⇒
 		// a personal App (single-user).
 		const appOrg = typeof body?.appOrg === "string" ? body.appOrg.trim() : "";
+		// The App's private key (PEM), generated once in the App's settings UI.
+		// Optional here — an App can be configured for per-user sign-in (device
+		// flow, keyless) alone — but it is what lets installation tokens mint, so
+		// without it the bot/agent and checks-read stay on the PAT.
+		const privateKey =
+			typeof body?.privateKey === "string" ? body.privateKey.trim() : "";
 		// The secret is required on the UI config path: the device-flow token
 		// expires and Open Session refreshes it with the secret, so without one
 		// the connection would silently stop working after ~8h. (Env-configured
@@ -781,6 +788,24 @@ export async function handleConnectionsRoutes(
 				{ error: "clientId, slug and secret are required" },
 				{ status: 400 },
 			);
+		if (privateKey && !/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(privateKey))
+			return Response.json(
+				{ error: "privateKey must be a PEM private key" },
+				{ status: 400 },
+			);
+		// Store the key first: if it is env-managed writeGithubAppKey refuses, and
+		// we surface that before touching config rather than half-configuring.
+		if (privateKey) {
+			const { writeGithubAppKey } = await import("../github-app");
+			try {
+				writeGithubAppKey(privateKey);
+			} catch (e) {
+				return Response.json(
+					{ error: String((e as Error)?.message || e) },
+					{ status: 409 },
+				);
+			}
+		}
 		const { rawConfig, persistRawConfig, withConfigMutationLock } =
 			await import("../config-mutation");
 		return withConfigMutationLock(async () => {

--- a/packages/core/opensession-server/src/server/routes/instance-settings.ts
+++ b/packages/core/opensession-server/src/server/routes/instance-settings.ts
@@ -118,11 +118,12 @@ async function githubOrganizationProfile(
 	ctx: RouteContext,
 	login: string,
 ): Promise<Response> {
+	const { githubToken } = await import("../github-app");
 	const tokens = [
 		ctx.authUser?.login
 			? githubCredentialForLogin(ctx.authUser.login)?.env.GH_TOKEN
 			: undefined,
-		process.env.GITHUB_API_TOKEN,
+		await githubToken(),
 	].filter((token): token is string => !!token);
 	const response = await fetchWithTimeout(
 		`https://api.github.com/orgs/${encodeURIComponent(login)}`,

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -106,6 +106,7 @@ describe("GitHub App onboarding link", () => {
 			// The canonical grant set — checks + statuses (the App-only CI rollup)
 			// and issues (PR/issue comments) included, so a created App holds every
 			// scope the installation-token mints request.
+			actions: "read",
 			checks: "read",
 			statuses: "read",
 			contents: "write",

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -112,6 +112,7 @@ describe("GitHub App onboarding link", () => {
 			issues: "write",
 			pull_requests: "write",
 			members: "read",
+			deployments: "read",
 			metadata: "read",
 			device_flow_enabled: "true",
 		});

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -103,6 +103,11 @@ describe("GitHub App onboarding link", () => {
 			url: "https://os.acme.test/",
 			public: "false",
 			webhook_active: "false",
+			// The canonical grant set — checks + statuses (the App-only CI rollup)
+			// and issues (PR/issue comments) included, so a created App holds every
+			// scope the installation-token mints request.
+			checks: "read",
+			statuses: "read",
 			contents: "write",
 			issues: "write",
 			pull_requests: "write",

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -10,6 +10,7 @@ import {
   matchesCodeStorageCheckout,
   normalizeDefaultBranch,
   validGithubFullName,
+  listReposViaAppInstallation,
 } from "./setup-repos";
 
 const originalConfig = process.env.OPENSESSION_CONFIG;
@@ -95,6 +96,35 @@ describe("validGithubFullName", () => {
     // The clone receives the full https URL through an argv array, so a
     // hyphen-prefixed owner cannot become a command flag.
     expect(validGithubFullName("--flag/repo")).toBe(true);
+  });
+});
+
+describe("App installation repository listing", () => {
+  test("uses the installation endpoint rather than a user endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return Response.json({
+        repositories: [
+          {
+            full_name: "tellahq/opensession",
+            private: true,
+            default_branch: "main",
+            pushed_at: "2026-08-24T00:00:00Z",
+          },
+        ],
+      });
+    }) as typeof fetch;
+    try {
+      const repos = await listReposViaAppInstallation("ghs_installation");
+      expect(repos.map((repo) => repo.fullName)).toEqual(["tellahq/opensession"]);
+      expect(urls).toEqual([
+        "https://api.github.com/installation/repositories?per_page=100&page=1",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -164,6 +164,26 @@ async function listReposViaUserRepos(token: string): Promise<PickerRepo[]> {
   return repos.slice(0, REPO_LIST_CAP);
 }
 
+/** GitHub App installation-token path. Installation tokens cannot call the
+ * user endpoints used by PATs and App user tokens. */
+export async function listReposViaAppInstallation(token: string): Promise<PickerRepo[]> {
+  const registered = registeredGhRepos();
+  const repos: PickerRepo[] = [];
+  for (let page = 1; repos.length < REPO_LIST_CAP && page <= 5; page++) {
+    const { ok, body } = await githubJson(
+      token,
+      `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+    );
+    if (!ok || !Array.isArray(body?.repositories)) break;
+    for (const raw of body.repositories) {
+      const repo = toPickerRepo(raw, registered);
+      if (repo) repos.push(repo);
+    }
+    if (body.repositories.length < 100) break;
+  }
+  return repos.slice(0, REPO_LIST_CAP);
+}
+
 /** GitHub App user-token path: union of the token's accessible installations.
  *  Returns null when the token isn't installation-scoped (classic OAuth/PAT)
  *  so the caller can fall back to /user/repos. */
@@ -558,16 +578,22 @@ export async function handleSetupRepoRoutes(
     // user in operator mode, the sole connected account in simple mode), else
     // the bot PAT, else an empty (but well-formed) answer.
     const userCredential = actingGithubCredential(ctx);
-    const token = userCredential?.env.GH_TOKEN || process.env.GITHUB_API_TOKEN;
+    // Bot credential: the App installation token when configured, else the PAT.
+    const { githubBotCredentialMode, githubToken } = await import("../github-app");
+    const botCredential = githubBotCredentialMode();
+    const botToken = userCredential ? null : await githubToken();
+    const token = userCredential?.env.GH_TOKEN || botToken;
     const source: "user" | "bot" | null = userCredential
       ? "user"
-      : process.env.GITHUB_API_TOKEN
+      : botToken
         ? "bot"
         : null;
     if (!token || !source) {
       return Response.json({ source: null, repos: [] });
     }
-    const cacheKey = userCredential ? userCredential.principal : "bot";
+    const cacheKey = userCredential
+      ? userCredential.principal
+      : `bot:${botCredential}`;
     const cached = repoListCache.get(cacheKey);
     if (cached && Date.now() - cached.at < REPO_CACHE_TTL_MS) {
       return Response.json(cached.payload);
@@ -577,8 +603,10 @@ export async function handleSetupRepoRoutes(
       // OAuth) via /user/repos. The installations call itself tells us which
       // kind we have — a non-App token gets an error and we fall back.
       const repos =
-        (source === "user" ? await listReposViaInstallations(token) : null) ??
-        (await listReposViaUserRepos(token));
+        source === "bot" && botCredential === "app"
+          ? await listReposViaAppInstallation(token)
+          : (source === "user" ? await listReposViaInstallations(token) : null) ??
+            (await listReposViaUserRepos(token));
       repos.sort((a, b) => (b.pushedAt || "").localeCompare(a.pushedAt || ""));
       const payload = {
         source,

--- a/packages/core/opensession-server/src/server/routes/setup-team.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.ts
@@ -190,9 +190,10 @@ async function syncGithubOrganizationMembers(ctx: RouteContext): Promise<Respons
   const userCredential = ctx.authUser?.login
     ? githubCredentialForLogin(ctx.authUser.login)
     : null;
+  const { githubToken } = await import("../github-app");
   const credentials = [
     userCredential?.env.GH_TOKEN,
-    process.env.GITHUB_API_TOKEN,
+    await githubToken(),
   ].filter((token, index, all): token is string => !!token && all.indexOf(token) === index);
   if (credentials.length === 0) {
     return Response.json({

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -350,6 +350,7 @@ export async function handleSetupRoutes(
       oauthClientId?: unknown;
       oauthClientSecret?: unknown;
       botCredential?: unknown;
+      privateKey?: unknown;
     } | null;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
       return Response.json({ error: "Invalid JSON body" }, { status: 400 });
@@ -379,13 +380,53 @@ export async function handleSetupRoutes(
         return Response.json({ error: `${field}: ${invalid}` }, { status: 400 });
       }
     }
+    // The private key is a multi-line PEM, so it bypasses validateSetting (single
+    // line). Require a complete block that parses, so a truncated paste cannot
+    // overwrite a working key on disk.
+    const privateKey =
+      typeof body.privateKey === "string" ? body.privateKey.trim() : "";
+    if (privateKey) {
+      const { createPrivateKey } = await import("node:crypto");
+      const wellFormed =
+        /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+-----END [A-Z ]*PRIVATE KEY-----/.test(
+          privateKey,
+        );
+      let parses = false;
+      if (wellFormed) {
+        try {
+          createPrivateKey(privateKey);
+          parses = true;
+        } catch {
+          parses = false;
+        }
+      }
+      if (!parses)
+        return Response.json(
+          { error: "privateKey must be a valid PEM private key" },
+          { status: 400 },
+        );
+    }
     if (
       body.userPrAuth === undefined &&
       body.oauthClientId === undefined &&
       body.oauthClientSecret === undefined &&
-      body.botCredential === undefined
+      body.botCredential === undefined &&
+      !privateKey
     ) {
       return Response.json({ error: "Nothing to change" }, { status: 400 });
+    }
+    // Store the key first: writeGithubAppKey refuses an env-managed key, and we
+    // surface that before writing config rather than half-configuring.
+    if (privateKey) {
+      const { writeGithubAppKey } = await import("../github-app");
+      try {
+        writeGithubAppKey(privateKey);
+      } catch (e) {
+        return Response.json(
+          { error: String((e as Error)?.message || e) },
+          { status: 409 },
+        );
+      }
     }
 
     const { rawConfig, persistRawConfig, withConfigMutationLock } =

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -415,20 +415,6 @@ export async function handleSetupRoutes(
     ) {
       return Response.json({ error: "Nothing to change" }, { status: 400 });
     }
-    // Store the key first: writeGithubAppKey refuses an env-managed key, and we
-    // surface that before writing config rather than half-configuring.
-    if (privateKey) {
-      const { writeGithubAppKey } = await import("../github-app");
-      try {
-        writeGithubAppKey(privateKey);
-      } catch (e) {
-        return Response.json(
-          { error: String((e as Error)?.message || e) },
-          { status: 409 },
-        );
-      }
-    }
-
     const { rawConfig, persistRawConfig, withConfigMutationLock } =
       await import("../config-mutation");
 
@@ -514,7 +500,18 @@ export async function handleSetupRoutes(
         if (value === "") delete github[field]; // empty string clears
         else github[field] = value;
       }
-      persistRawConfig(config);
+      try {
+        const { commitGithubAppKeyMutation } = await import("../github-app");
+        await commitGithubAppKeyMutation(
+          privateKey || undefined,
+          () => persistRawConfig(config),
+        );
+      } catch (e) {
+        return Response.json(
+          { error: String((e as Error)?.message || e) },
+          { status: 409 },
+        );
+      }
       audit({
         kind: "setup_github_update",
         fields: (["userPrAuth", "oauthClientId", "oauthClientSecret", "botCredential"] as const).filter(

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -22,6 +22,7 @@
  */
 
 import { audit } from "../audit";
+import { GITHUB_APP_GRANT_PERMISSIONS } from "../../shared/github-app-permissions";
 import { envRequired, type IntegrationSpec } from "../integrations/registry";
 import { setupAccessSnapshot } from "../setup-access";
 import { requireWorkspaceAdmin } from "../workspace-auth";
@@ -118,11 +119,10 @@ export function buildOnboardingGithubAppCreateUrl(
     url: homepageUrl.trim() || "http://localhost:3850",
     public: "false",
     webhook_active: "false",
-    contents: "write",
-    issues: "write",
-    pull_requests: "write",
-    members: "read",
-    metadata: "read",
+    // The canonical grant set (checks + statuses + issues included) — the same
+    // permissions the installation token mints request, so a created App is
+    // never born missing a scope the server needs.
+    ...GITHUB_APP_GRANT_PERMISSIONS,
     // Undocumented by GitHub, but supported by the new-App form. The onboarding
     // still tells the person to check it in case GitHub ever drops the parameter.
     device_flow_enabled: "true",

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -440,6 +440,13 @@ export async function handleSetupRoutes(
         (nextClientId !== undefined && github.oauthClientId !== nextClientId
           ? null
           : undefined);
+      const effectiveBotCredential = body.botCredential ?? github.botCredential ?? "pat";
+      if (keyMutation === null && effectiveBotCredential === "app") {
+        return Response.json(
+          { error: "Switch bot actions to the PAT before changing the GitHub App without a replacement key" },
+          { status: 409 },
+        );
+      }
 
       // Turning on the sign-in gate must never strand a personal install with
       // nobody who can pass it. Organization onboarding already rosters people

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -435,6 +435,12 @@ export async function handleSetupRoutes(
           : {};
       integrations.github = github;
 
+      const nextClientId = body.oauthClientId;
+      const keyMutation = privateKey ||
+        (nextClientId !== undefined && github.oauthClientId !== nextClientId
+          ? null
+          : undefined);
+
       // Turning on the sign-in gate must never strand a personal install with
       // nobody who can pass it. Organization onboarding already rosters people
       // before enabling the gate; the Settings toggle also serves single-user
@@ -503,7 +509,7 @@ export async function handleSetupRoutes(
       try {
         const { commitGithubAppKeyMutation } = await import("../github-app");
         await commitGithubAppKeyMutation(
-          privateKey || undefined,
+          keyMutation,
           () => persistRawConfig(config),
         );
       } catch (e) {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
   projectRemoteClaudeAccounts,
@@ -8,7 +9,89 @@ import {
   remoteModelProviderId,
   remoteRunNeedsAnthropic,
   remoteRunNeedsOpenai,
+  injectCloneCredential,
+  selectedCloneToken,
+  selectedGithubCloneLiveToken,
+  warmRemoteWorkspace,
 } from "./bootstrap";
+import type { RemoteDriver } from "./bootstrap";
+
+describe("GitHub clone credential cutover", () => {
+  test("App mode never falls back to a persisted PAT", () => {
+    expect(selectedCloneToken(undefined, "retired-pat", true, "app")).toBeUndefined();
+    expect(selectedCloneToken("fresh-app", "retired-pat", true, "app")).toBe("fresh-app");
+    expect(selectedCloneToken(undefined, "active-pat", true, "pat")).toBe("active-pat");
+    expect(selectedCloneToken(undefined, "other-host", false, "app")).toBe("other-host");
+    expect(selectedGithubCloneLiveToken("app", "repo-app", "wide-token")).toBe("repo-app");
+    expect(selectedGithubCloneLiveToken("app", undefined, "wide-token")).toBeUndefined();
+    expect(selectedGithubCloneLiveToken("pat", "unselected-app", "selected-pat")).toBe("selected-pat");
+  });
+
+  test("scrubs a warm origin before repository dependency code runs", async () => {
+    const commands: string[] = [];
+    const driver = {
+      exec: async (command: string) => {
+        commands.push(command);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+
+    await warmRemoteWorkspace(
+      driver as unknown as RemoteDriver,
+      {
+        id: "opensession",
+        repo: "/host/opensession",
+        ghRepo: "tellahq/opensession",
+        defaultBranch: "main",
+      },
+      "test",
+    );
+
+    const scrub = commands.findIndex((command) => command.includes("remote set-url origin"));
+    const deps = commands.findIndex((command) => command.includes("install --frozen-lockfile"));
+    expect(scrub).toBeGreaterThanOrEqual(0);
+    expect(deps).toBeGreaterThan(scrub);
+  });
+
+  test("resolves the selected GitHub credential without a legacy clone credential", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-clone-credential-"));
+    const previous = {
+      config: process.env.OPENSESSION_CONFIG,
+      sandbox: process.env.OPENSESSION_SANDBOX_CONFIG,
+      token: process.env.GITHUB_API_TOKEN,
+    };
+    try {
+      const config = join(dir, "config.json");
+      const sandbox = join(dir, "sandbox.json");
+      writeFileSync(config, JSON.stringify({ integrations: { github: { botCredential: "pat" } } }));
+      writeFileSync(sandbox, JSON.stringify({ provider: "daytona" }));
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.OPENSESSION_SANDBOX_CONFIG = sandbox;
+      process.env.GITHUB_API_TOKEN = "live-selected-token";
+
+      expect(
+        await injectCloneCredential("https://github.com/tellahq/opensession.git"),
+      ).toBe(
+        "https://x-access-token:live-selected-token@github.com/tellahq/opensession.git",
+      );
+      expect(
+        await injectCloneCredential(
+          "https://x-access-token:retired-pat@github.com/tellahq/opensession.git",
+        ),
+      ).toBe(
+        "https://x-access-token:live-selected-token@github.com/tellahq/opensession.git",
+      );
+    } finally {
+      if (previous.config === undefined) delete process.env.OPENSESSION_CONFIG;
+      else process.env.OPENSESSION_CONFIG = previous.config;
+      if (previous.sandbox === undefined) delete process.env.OPENSESSION_SANDBOX_CONFIG;
+      else process.env.OPENSESSION_SANDBOX_CONFIG = previous.sandbox;
+      if (previous.token === undefined) delete process.env.GITHUB_API_TOKEN;
+      else process.env.GITHUB_API_TOKEN = previous.token;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("remote engine credential projection", () => {
   test("every remote provider delegates launch credential projection to bootstrap", () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
@@ -48,7 +48,7 @@ describe("remote repo lifecycle", () => {
 		expect(bootstrapSignature()).toContain("node@24.18.1");
 		expect(bootstrapSignature()).toContain("just@1.43.1");
 		expect(bootstrapSignature()).toContain("gh@2.83.1");
-		expect(bootstrapSignature()).toContain("workspace-runtime-v7");
+		expect(bootstrapSignature()).toContain("workspace-runtime-v8");
 	});
 
 	test("setup is skipped after its durable stamp", async () => {
@@ -190,6 +190,29 @@ describe("remote repo lifecycle", () => {
 		expect(d.commands[1]!.command).toContain("ln -s");
 		expect(d.commands[1]!.command).not.toContain("mount --bind");
 		expect(d.commands[2]!.command).toContain("git clone --filter=blob:none");
+	});
+
+	test("scrubs a short-lived GitHub token after the bounded clone", async () => {
+		const d = driver([
+			{ exitCode: 0, stdout: "none\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "feature/new-ui\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "absent\n" },
+		]);
+		await setupRemoteWorkspace(
+			d.value,
+			"/work/feature",
+			"https://x-access-token:short-lived@github.com/tellahq/opensession.git",
+			"feature/new-ui",
+			"main",
+		);
+
+		const scrub = d.commands.find(({ command }) =>
+			command.startsWith("git remote set-url origin"),
+		);
+		expect(scrub?.command).toContain("https://github.com/tellahq/opensession.git");
+		expect(scrub?.command).not.toContain("short-lived");
 	});
 
 	test("cleans up a failed warm attach before cold-cloning", async () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -592,24 +592,83 @@ function credentialFreeHttpsUrl(httpsUrl: string): string {
   return parsed.toString();
 }
 
-function injectToken(httpsUrl: string): string {
-  const cred = sandboxConfig().cloneCredential;
-  if (cred?.type === "https-token") {
-    // A hosted instance keeps a long-lived, org-scoped bot credential in
-    // GITHUB_API_TOKEN. Prefer it for GitHub clones over the config's token:
-    // GitHub App user tokens expire in ~8h, so persisting one in sandbox.json
-    // makes every fresh Daytona/Modal bootstrap fail days later. Self-hosters
-    // without the env keep the explicit cloneCredential.token behavior, and
-    // non-GitHub origins never receive our GitHub-specific credential.
-    const liveGithubToken = /^https:\/\/github\.com\//i.test(httpsUrl)
-      ? process.env.GITHUB_API_TOKEN
-      : undefined;
-    const token = liveGithubToken || cred.token;
-    if (token) {
-      return httpsUrl.replace(/^https:\/\//, `https://x-access-token:${token}@`);
-    }
+function isGithubHttpsUrl(httpsUrl: string): boolean {
+  try {
+    const parsed = new URL(httpsUrl);
+    return parsed.protocol === "https:" && parsed.hostname.toLowerCase() === "github.com";
+  } catch {
+    return false;
   }
-  return httpsUrl;
+}
+
+/** Pick clone authority without crossing the operator's credential cutover.
+ * In App mode a missing live GitHub token fails closed; the persisted token may
+ * be the retired PAT. Non-GitHub hosts retain their explicit clone credential. */
+export function selectedCloneToken(
+  liveToken: string | undefined,
+  persistedToken: string | undefined,
+  github: boolean,
+  mode: "pat" | "app",
+): string | undefined {
+  return liveToken || (github && mode === "app" ? undefined : persistedToken);
+}
+
+/** App sandboxes require a repository-scoped mint. Never widen a failed mint
+ * to an installation-wide token; PAT mode uses only its selected PAT. */
+export function selectedGithubCloneLiveToken(
+  mode: "pat" | "app",
+  repositoryToken: string | undefined,
+  patToken: string | undefined,
+): string | undefined {
+  return mode === "app" ? repositoryToken : patToken;
+}
+
+export async function injectCloneCredential(httpsUrl: string): Promise<string> {
+  const cred = sandboxConfig().cloneCredential;
+  let parsed: URL;
+  try {
+    parsed = new URL(httpsUrl);
+  } catch {
+    return httpsUrl;
+  }
+  const github =
+    parsed.protocol === "https:" && parsed.hostname.toLowerCase() === "github.com";
+  let token: string | undefined;
+
+  if (github) {
+    // Always discard authority embedded in a persisted GitHub origin before
+    // applying the operator-selected credential.
+    parsed.username = "";
+    parsed.password = "";
+    const repository = parsed.pathname.replace(/^\/+|\.git$/g, "");
+    const {
+      githubAppRepositoryToken,
+      githubBotCredentialMode,
+      githubToken,
+    } = await import("../../github-app");
+    const mode = githubBotCredentialMode();
+    const liveToken = selectedGithubCloneLiveToken(
+      mode,
+      mode === "app"
+        ? (await githubAppRepositoryToken(repository)) || undefined
+        : undefined,
+      mode === "pat" ? (await githubToken()) || undefined : undefined,
+    );
+    token = selectedCloneToken(
+      liveToken,
+      cred?.type === "https-token" ? cred.token : undefined,
+      true,
+      mode,
+    );
+  } else if (cred?.type === "https-token") {
+    // Explicit credentials for non-GitHub hosts keep their existing behavior.
+    token = cred.token;
+  }
+
+  if (!token) return parsed.toString();
+  parsed.username = "x-access-token";
+  parsed.password = token;
+  return parsed.toString();
 }
 
 /**
@@ -647,7 +706,7 @@ export async function remoteCloneUrl(repo: {
       `repo ${repo.id} has no https-reachable origin (origin="${redactUrl(origin) || "none"}") — remote sandboxes clone over https; set an origin or ghRepo`,
     );
   }
-  return injectToken(https);
+  return await injectCloneCredential(https);
 }
 
 /**
@@ -928,7 +987,7 @@ export async function bootstrapRemoteSandbox(
   const runnerCloneUrl = cfg.runnerBundleUrl
     ? undefined
     : cfg.runnerRepoUrl && toHttpsUrl(cfg.runnerRepoUrl)
-      ? injectToken(toHttpsUrl(cfg.runnerRepoUrl)!)
+      ? await injectCloneCredential(toHttpsUrl(cfg.runnerRepoUrl)!)
       : await remoteCloneUrl(runnerRepo);
   const hasRepo = await driver.exec(`test -f ${REMOTE_REPO}/package.json`);
   if (hasRepo.exitCode !== 0) {
@@ -1236,11 +1295,14 @@ export async function warmRemoteWorkspace(
       return false;
     }
   }
+  // Repository code must never observe the short-lived clone token through
+  // remote.origin.url. Scrub before setup hooks or dependency installers run,
+  // including when adopting an existing partially prepared warm checkout.
+  await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
   if (opts?.runSetup) {
     await runRemoteLifecycleHook(driver, dir, "setup", "fresh", repo.id, opts.identity);
   }
   if (opts?.installDeps === false) {
-    await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
     log(opts.runSetup ? "ready (post-setup)" : "ready (clone only)");
     return true;
   }
@@ -1257,7 +1319,6 @@ export async function warmRemoteWorkspace(
   } else {
     log("ready");
   }
-  await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
   return true;
 }
 
@@ -1365,8 +1426,8 @@ export async function setupRemoteWorkspace(
   }
   if (!cloned) {
     console.log(`[sandbox-remote] cloning ${redactUrl(cloneUrl)} into ${cwd}`);
-    // Blobless partial clone: full history/refs but blobs fetched lazily via
-    // the persisted (tokenized) origin URL. A large repo's full .git can be
+    // Blobless partial clone: full history/refs, with later blobs fetched via
+    // a fresh run-scoped credential helper. A large repo's full .git can be
     // ~2.4GB vs ~450MB blobless — on a 10GiB sandbox disk that headroom is
     // the difference between working and ENOSPC (verified live 2026-07-09:
     // full clone died on the default 3GiB disk with an EMPTY git error,
@@ -1412,6 +1473,19 @@ export async function setupRemoteWorkspace(
     }
   }
   mark("branch ready");
+  // Installation tokens expire in about an hour. Keep them only for this
+  // bounded clone/fetch, then leave a credential-free GitHub origin. Every run
+  // projects a fresh token through the process-local credential helper below,
+  // so lazy blob fetches and pushes never depend on a token at rest.
+  if (isGithubHttpsUrl(cloneUrl)) {
+    const safeOrigin = credentialFreeHttpsUrl(cloneUrl);
+    const scrubbed = await driver.exec(
+      `git remote set-url origin ${shellQuoteWord(safeOrigin)}`,
+      { cwd },
+    );
+    if (scrubbed.exitCode !== 0)
+      throw new Error(`could not scrub GitHub clone credential: ${scrubbed.stderr.trim().slice(0, 300)}`);
+  }
   // Per-session only: warm/template preparation never calls this path, so
   // private files are injected after restore and can never land in a shared
   // provider snapshot.
@@ -1636,13 +1710,28 @@ function makeRemoteLauncher(
       ]);
       secureFiles.push(claudeAccountsPath, REMOTE_MCP_CONFIG);
 
-      // Interactive parity for GitHub uses a run-scoped access-token file.
-      // Do not put it in spec.json or the launch command, and never project it
-      // into the fail-closed automation profile. githubRunEnv reads this file
-      // inside the guest and installs a process-local HTTPS credential helper.
-      const githubAuth = automationProfile
+      // GitHub credentials are projected through a private, run-scoped file,
+      // never spec.json, argv, or the persisted origin. Interactive runs prefer
+      // their user's token. GitHub code automations and user-less interactive
+      // runs receive a freshly resolved service credential for this one repo;
+      // every other automation stays credential-free.
+      let githubAuth = automationProfile
         ? {}
         : githubAuthEnv(spec.user || spec.author?.name);
+      const githubCodeAutomation =
+        automationProfile &&
+        spec.mode === "code" &&
+        (spec.journalKind || "").startsWith("github-");
+      if (!githubAuth.GH_TOKEN && (!automationProfile || githubCodeAutomation)) {
+        const origin = await driver.exec("git remote get-url origin", { cwd: spec.cwd });
+        const match = origin.exitCode === 0
+          ? origin.stdout.trim().match(/^https:\/\/github\.com\/(?:x-access-token:[^@]+@)?([^/]+\/[^/]+)$/i)
+          : null;
+        if (match) {
+          const { githubServiceCredentialEnv } = await import("../../github-app");
+          githubAuth = await githubServiceCredentialEnv(match[1].replace(/\.git$/i, ""));
+        }
+      }
       const githubAuthPath = `${dir}/github-auth.json`;
       if (githubAuth.GH_TOKEN) {
         await driver.writeFile(githubAuthPath, JSON.stringify(githubAuth));

--- a/packages/core/opensession-server/src/server/sandbox/config.ts
+++ b/packages/core/opensession-server/src/server/sandbox/config.ts
@@ -252,9 +252,9 @@ export interface SandboxConfig {
   firecrackerMicrovm?: SandboxFirecrackerMicrovmConfig;
   /** Credential-minimal unattended-run profile. */
   automation?: SandboxAutomationConfig;
-  /** Clone auth for remote-provider workspaces + runner bootstrap. On hosted
-   *  GitHub clones, the live GITHUB_API_TOKEN takes precedence so an expiring
-   *  GitHub App user token is never treated as durable sandbox config. */
+  /** Clone auth for remote-provider workspaces + runner bootstrap. The selected
+   *  live GitHub service credential takes precedence; App mode never falls back
+   *  to a persisted token because it may be the retired PAT. */
   cloneCredential?: SandboxCloneCredential;
   /** Warm-on-typing prewarm pool. Absent = defaults, with `enabled` true
    *  whenever a provider with a prewarm adapter is configured. */

--- a/packages/core/opensession-server/src/server/sandbox/prewarm.ts
+++ b/packages/core/opensession-server/src/server/sandbox/prewarm.ts
@@ -574,15 +574,21 @@ async function runPrewarmBootstrap(record: PrewarmRecord, adapter: PrewarmAdapte
           // refresh with "index.lock: File exists". This prewarm sandbox is
           // the clone's only writer, so clearing dead locks before syncing
           // is safe.
-          const refreshed = await driver.exec(
-            `find .git -name "*.lock" -type f -delete 2>/dev/null; ` +
-              `git remote set-url origin ${shellQuoteWord(cloneUrl)} && ` +
-              `git fetch origin ${shellQuoteWord(repo.defaultBranch)} --quiet && ` +
-              `git reset --hard ${shellQuoteWord(`origin/${repo.defaultBranch}`)}`,
-            { cwd: warmDir, timeoutMs: 10 * 60_000 },
-          );
-          if (refreshed.exitCode !== 0) {
-            throw new Error(`could not refresh ${repo.id} project image: ${(refreshed.stderr || refreshed.stdout).trim().slice(0, 300)}`);
+          try {
+            const refreshed = await driver.exec(
+              `find .git -name "*.lock" -type f -delete 2>/dev/null; ` +
+                `git remote set-url origin ${shellQuoteWord(cloneUrl)} && ` +
+                `git fetch origin ${shellQuoteWord(repo.defaultBranch)} --quiet && ` +
+                `git reset --hard ${shellQuoteWord(`origin/${repo.defaultBranch}`)}`,
+              { cwd: warmDir, timeoutMs: 10 * 60_000 },
+            );
+            if (refreshed.exitCode !== 0) {
+              throw new Error(`could not refresh ${repo.id} project image: ${(refreshed.stderr || refreshed.stdout).trim().slice(0, 300)}`);
+            }
+          } finally {
+            // A retained checkout must be safe both before repository setup
+            // runs and between transient refresh retries.
+            await scrubRemoteWarmWorkspaceAuthority(driver, repo, warmDir);
           }
         });
         // Updating source without rerunning setup republishes stale generated
@@ -595,7 +601,6 @@ async function runPrewarmBootstrap(record: PrewarmRecord, adapter: PrewarmAdapte
           provider: entry.provider,
           repoId: repo.id,
         });
-        await scrubRemoteWarmWorkspaceAuthority(driver, repo, warmDir);
       }
     } else if (adapter.prepare) {
       setPrewarmStage(entry, "Preparing project workspace", 40);

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, test, expect } from "bun:test";
 import {
+	GITHUB_APP_CODE_PERMISSIONS,
 	GITHUB_APP_GRANT_PERMISSIONS,
 	GITHUB_APP_READ_PERMISSIONS,
 	GITHUB_APP_WRITE_PERMISSIONS,
@@ -27,6 +28,13 @@ describe("github app permission sets", () => {
 
 	test("the write mint is within the grant", () => {
 		expect(uncoveredScopes(GITHUB_APP_WRITE_PERMISSIONS)).toEqual([]);
+	});
+
+	test("the repository code mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_CODE_PERMISSIONS)).toEqual([]);
+		expect(GITHUB_APP_CODE_PERMISSIONS.actions).toBe("read");
+		expect(GITHUB_APP_CODE_PERMISSIONS.checks).toBe("read");
+		expect(GITHUB_APP_CODE_PERMISSIONS.issues).toBe("write");
 	});
 
 	test("the grant includes the scopes the two capabilities depend on", () => {

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -36,6 +36,8 @@ describe("github app permission sets", () => {
 		expect(GITHUB_APP_GRANT_PERMISSIONS.issues).toBe("write");
 		expect(GITHUB_APP_GRANT_PERMISSIONS.pull_requests).toBe("write");
 		expect(GITHUB_APP_GRANT_PERMISSIONS.contents).toBe("write");
+		expect(GITHUB_APP_READ_PERMISSIONS.members).toBe("read");
+		expect(GITHUB_APP_READ_PERMISSIONS.deployments).toBe("read");
 	});
 
 	test("the write mint carries no read-only scope whose absence would 422 it", () => {

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -1,0 +1,47 @@
+// A GitHub App installation-token mint is all-or-nothing: it succeeds only if
+// every requested scope is a subset of what the App was granted. So each mint
+// set MUST be a subset of the grant set the create-app URL requests. When they
+// drifted apart, real Apps 422'd on every mint and fell back to the bot PAT —
+// which is exactly the bug this pins shut.
+
+import { describe, test, expect } from "bun:test";
+import {
+	GITHUB_APP_GRANT_PERMISSIONS,
+	GITHUB_APP_READ_PERMISSIONS,
+	GITHUB_APP_WRITE_PERMISSIONS,
+} from "./github-app-permissions";
+
+/** A mint scope is covered when the grant holds the same key at an access level
+ *  at least as strong (write covers read). */
+function uncoveredScopes(mint: Record<string, string>): string[] {
+	const rank = (v: string) => (v === "write" ? 2 : v === "read" ? 1 : 0);
+	return Object.entries(mint)
+		.filter(([key, level]) => rank(GITHUB_APP_GRANT_PERMISSIONS[key] ?? "") < rank(level))
+		.map(([key]) => key);
+}
+
+describe("github app permission sets", () => {
+	test("the read mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_READ_PERMISSIONS)).toEqual([]);
+	});
+
+	test("the write mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_WRITE_PERMISSIONS)).toEqual([]);
+	});
+
+	test("the grant includes the scopes the two capabilities depend on", () => {
+		// checks:read is the App-only capability (no PAT can read check runs);
+		// issues+pull_requests+contents:write are the agent's write path.
+		expect(GITHUB_APP_GRANT_PERMISSIONS.checks).toBe("read");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.issues).toBe("write");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.pull_requests).toBe("write");
+		expect(GITHUB_APP_GRANT_PERMISSIONS.contents).toBe("write");
+	});
+
+	test("the write mint carries no read-only scope whose absence would 422 it", () => {
+		// It must not request checks/statuses — writes never touch them, and an
+		// App without them granted would otherwise reject the whole write token.
+		expect(GITHUB_APP_WRITE_PERMISSIONS.checks).toBeUndefined();
+		expect(GITHUB_APP_WRITE_PERMISSIONS.statuses).toBeUndefined();
+	});
+});

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -16,6 +16,7 @@
 /** The full set the App is granted at creation — the create-URL permission
  *  params, and the superset of every mint. */
 export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
+	actions: "read", // workflow runs/logs for trusted autofix diagnosis
 	checks: "read", // CI check runs — App-only; no PAT can read them
 	statuses: "read", // commit statuses, the other half of the status rollup
 	contents: "write", // push fixes, clone
@@ -49,4 +50,14 @@ export const GITHUB_APP_WRITE_PERMISSIONS: Record<string, string> = {
 	issues: "write",
 	contents: "write",
 	metadata: "read",
+};
+
+/** Repository-scoped token projected only to trusted GitHub code workflows.
+ * It can push/reply and inspect the failing checks and workflow logs it must
+ * diagnose, but remains bound to the one owner-verified repository. */
+export const GITHUB_APP_CODE_PERMISSIONS: Record<string, string> = {
+	...GITHUB_APP_WRITE_PERMISSIONS,
+	actions: "read",
+	checks: "read",
+	statuses: "read",
 };

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -1,0 +1,49 @@
+/**
+ * The single source of truth for the GitHub App's permissions.
+ *
+ * One definition renders three ways — the create-app URL (what GitHub grants
+ * the App), the read installation token, and the write installation token — so
+ * they can never drift apart. Drift is exactly what left real Apps missing
+ * `checks` and `issues`: the create builders under-requested, the mints asked
+ * for scopes the App was never granted, and every installation token 422'd and
+ * fell back silently to the bot PAT.
+ *
+ * A mint is all-or-nothing: it succeeds only if every requested scope is a
+ * subset of what the installation holds. So each mint set below is a strict
+ * subset of the grant set, and the grant set is what the create URL requests.
+ */
+
+/** The full set the App is granted at creation — the create-URL permission
+ *  params, and the superset of every mint. */
+export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
+	checks: "read", // CI check runs — App-only; no PAT can read them
+	statuses: "read", // commit statuses, the other half of the status rollup
+	contents: "write", // push fixes, clone
+	pull_requests: "write", // reviews, comments, open/merge
+	issues: "write", // issue and PR comments
+	members: "read", // team roster / attribution
+	metadata: "read", // required baseline
+};
+
+/** Read installation token (pr-info's statusCheckRollup) — the read view of the
+ *  grant. Contents/pull_requests/issues at read, checks/statuses/metadata as
+ *  granted. No `actions`: the rollup needs check runs and statuses, not workflow
+ *  runs, and requesting an ungranted scope would 422 the token. */
+export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
+	checks: "read",
+	statuses: "read",
+	pull_requests: "read",
+	contents: "read",
+	issues: "read",
+	metadata: "read",
+};
+
+/** Write installation token (the PR agent) — exactly what writes need. No
+ *  read-only scopes: their absence must not 422 a token that never touches
+ *  them. */
+export const GITHUB_APP_WRITE_PERMISSIONS: Record<string, string> = {
+	pull_requests: "write",
+	issues: "write",
+	contents: "write",
+	metadata: "read",
+};

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -22,12 +22,13 @@ export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
 	pull_requests: "write", // reviews, comments, open/merge
 	issues: "write", // issue and PR comments
 	members: "read", // team roster / attribution
+	deployments: "read", // Vercel preview deployment + status polling
 	metadata: "read", // required baseline
 };
 
 /** Read installation token (pr-info's statusCheckRollup) — the read view of the
- *  grant. Contents/pull_requests/issues at read, checks/statuses/metadata as
- *  granted. No `actions`: the rollup needs check runs and statuses, not workflow
+ *  grant. Contents/pull_requests/issues at read, plus checks/statuses, members,
+ *  deployments, and metadata as granted. No `actions`: the rollup needs check runs and statuses, not workflow
  *  runs, and requesting an ungranted scope would 422 the token. */
 export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
 	checks: "read",
@@ -35,6 +36,8 @@ export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
 	pull_requests: "read",
 	contents: "read",
 	issues: "read",
+	members: "read",
+	deployments: "read",
 	metadata: "read",
 };
 


### PR DESCRIPTION
Final stage of the GitHub App credential migration. **Stacked on #180 → merged #153.** Supersedes #172 with a clean branch after the lower stacked PR was squash-merged.

## What changes

- Routes remaining GitHub readers and trusted GitHub code runs through the operator-selected credential.
- Uses owner-verified, repository-scoped App tokens for clones and code automation.
- Scrubs ephemeral tokens before repository setup/start hooks and from warm/template/Daytona origins.
- Refreshes service credentials on recovery without falling back to connected human or ambient `gh` credentials.
- Uses `/installation/repositories` for App repository discovery.
- Adds the App scopes needed for organization-member and deployment reads.
- Keeps preview pools and MicroVM paths inside the same fail-closed credential boundary.

## Safe rollout

The stack still defaults `integrations.github.botCredential` to `pat`, so deployment does not change `os.tella.dev` behavior. Provision and validate the App first, then switch **Use the GitHub App for bot actions**. App mode has no hidden PAT fallback.

## Verification

- `bun run typecheck`
- 94 focused GitHub, setup, recovery, sandbox, preview, and lifecycle tests
- `bun scripts/check-module-side-effects.ts` (413 modules clean)
- Final OS review on #172: approved at confidence 5/5 before restacking

Created by [this OS session](https://os.tella.dev/session/os-01a033fd-020d-76bc-be85-60b19b241fbc)
