### PR TITLE
Complete the GitHub App credential cutover

### DIFF
--- a/deploy/sandbox/microvm/refresh-sandbox-golden.sh
+++ b/deploy/sandbox/microvm/refresh-sandbox-golden.sh
@@ -60,7 +60,7 @@ compute_pins() {
   (
   cd "$ROOT"
   # Server-env parity: the systemd unit loads ~/.opensession.env
-  # (EnvironmentFile=), and injectToken prefers a live GITHUB_API_TOKEN from
+  # (EnvironmentFile=), and injectCloneCredential resolves the selected live GitHub credential from
   # the environment over persisted config tokens. Load the same file here so
   # the pin computation resolves the clone URL exactly like the server would
   # (a real env var also outranks the repo-local .env bun auto-loads).
@@ -68,7 +68,7 @@ compute_pins() {
     set -a; . "$CFG_HOME/.opensession.env"; set +a
   fi
   HOME="$CFG_HOME" GOLDEN_WANT_CLONE_URL="${1:-}" "$BUN_BIN" -e '
-import { bootstrapSignature, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
+import { bootstrapSignature, injectCloneCredential, remoteCloneUrl } from "./src/server/sandbox/adapters/bootstrap.ts";
 import { sandboxConfig } from "./src/server/sandbox/config.ts";
 import { REPO_ROOT } from "./src/runner-host/protocol.ts";
 const cfg = sandboxConfig();
@@ -77,7 +77,7 @@ console.log(cfg.runnerSha || "");
 if (process.env.GOLDEN_WANT_CLONE_URL) {
   let url;
   if (cfg.runnerRepoUrl) {
-    // Mirror bootstrap.ts toHttpsUrl+injectToken for the explicit-URL case.
+    // Mirror bootstrap.ts toHttpsUrl+injectCloneCredential for the explicit-URL case.
     let https = cfg.runnerRepoUrl;
     const scp = https.match(/^git@([^:]+):(.+?)(\.git)?$/);
     const ssh = https.match(/^ssh:\/\/git@([^/]+)\/(.+?)(\.git)?$/);
@@ -86,13 +86,7 @@ if (process.env.GOLDEN_WANT_CLONE_URL) {
     if (!/^https:\/\//.test(https)) {
       throw new Error(`runnerRepoUrl is not https-reachable: ${cfg.runnerRepoUrl}`);
     }
-    const cred = cfg.cloneCredential;
-    if (cred?.type === "https-token") {
-      const live = /^https:\/\/github\.com\//i.test(https) ? process.env.GITHUB_API_TOKEN : undefined;
-      const token = live || cred.token;
-      if (token) https = https.replace(/^https:\/\//, `https://x-access-token:${token}@`);
-    }
-    url = https;
+    url = await injectCloneCredential(https);
   } else {
     url = await remoteCloneUrl({ id: "opensession", repo: REPO_ROOT });
   }

--- a/packages/core/opensession-server/src/agents/github/autofix.ts
+++ b/packages/core/opensession-server/src/agents/github/autofix.ts
@@ -25,6 +25,10 @@ import { LABEL_AUTOFIX, labelAliases, repoForFullName } from "./constants";
 import { personaName } from "../../server/config";
 import type { PrRef, ReviewResult } from "./review";
 import { defaultRepo } from "../../server/config";
+import {
+  resolveGithubCredential,
+  serviceGithubCredential,
+} from "../../server/github-auth";
 
 const MAX_ITERATIONS = 5;
 const WALL_CLOCK_MS = 60 * 60 * 1000; // abandon a loop running longer than an hour
@@ -44,7 +48,11 @@ const REPO = defaultRepo().ghRepo;
 
 async function headSha(headRef: string, ghRepo: string = REPO): Promise<string> {
   try {
-    const raw = await $`gh pr view ${headRef} --repo ${ghRepo} --json headRefOid`.quiet().text();
+    const credential = await resolveGithubCredential(serviceGithubCredential);
+    const raw = await $`gh pr view ${headRef} --repo ${ghRepo} --json headRefOid`
+      .env({ ...process.env, ...credential.env })
+      .quiet()
+      .text();
     return JSON.parse(raw).headRefOid || "";
   } catch {
     return "";

--- a/packages/core/opensession-server/src/agents/slack/github-reviews.ts
+++ b/packages/core/opensession-server/src/agents/slack/github-reviews.ts
@@ -17,7 +17,6 @@ import { GITHUB_REPO } from "./state";
 import { ghRateLimited, noteGhRateLimited } from "../../server/github-limit";
 import { configuredIntegration } from "../../server/config";
 
-const GITHUB_TOKEN = process.env.GITHUB_API_TOKEN;
 const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 
 // ---------------------------------------------------------------------------
@@ -25,11 +24,13 @@ const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN;
 // ---------------------------------------------------------------------------
 
 export async function githubApi(path: string): Promise<any> {
-  if (!GITHUB_TOKEN) return null;
+  const { githubToken } = await import("../../server/github-app");
+  const token = await githubToken();
+  if (!token) return null;
   try {
     const resp = await fetchWithTimeout(`https://api.github.com${path}`, {
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
     });

--- a/packages/core/opensession-server/src/server/account-health.test.ts
+++ b/packages/core/opensession-server/src/server/account-health.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { selectedGithubCredentialIssues } from "./account-health";
+
+const originalConfig = process.env.OPENSESSION_CONFIG;
+const originalPat = process.env.GITHUB_API_TOKEN;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalConfig === undefined) delete process.env.OPENSESSION_CONFIG;
+  else process.env.OPENSESSION_CONFIG = originalConfig;
+  if (originalPat === undefined) delete process.env.GITHUB_API_TOKEN;
+  else process.env.GITHUB_API_TOKEN = originalPat;
+  globalThis.fetch = originalFetch;
+});
+
+describe("GitHub account health credential selection", () => {
+  test("App mode ignores a retired PAT", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-account-health-"));
+    try {
+      const config = join(dir, "config.json");
+      writeFileSync(
+        config,
+        JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.GITHUB_API_TOKEN = "retired-pat";
+      let requests = 0;
+      globalThis.fetch = (async () => {
+        requests += 1;
+        return new Response(null, { status: 401 });
+      }) as unknown as typeof fetch;
+
+      expect(await selectedGithubCredentialIssues()).toEqual([]);
+      expect(requests).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/account-health.ts
+++ b/packages/core/opensession-server/src/server/account-health.ts
@@ -286,6 +286,42 @@ async function githubPatIssues(): Promise<Issue[]> {
   ];
 }
 
+/**
+ * The GitHub App is the credential the bot now rides on most installs. If it is
+ * configured (client id + key) but cannot mint an installation token — a revoked
+ * key, an uninstalled App, a wrong installation owner — every bot gh/PR flow is
+ * down, exactly like a dead PAT. Warn on that. Skipped when no App is set up, so
+ * a PAT-only install is unaffected.
+ */
+async function githubAppIssues(): Promise<Issue[]> {
+  const { githubAppConfigured, githubAppInstallationToken } = await import(
+    "./github-app"
+  );
+  if (!githubAppConfigured()) return [];
+  if (await githubAppInstallationToken()) return [];
+  const agent = personaName();
+  const owner = githubWriteOwners()[0] || "the configured owner";
+  return [
+    {
+      key: "github:app:dead",
+      message:
+        `${agent} here — the GitHub App is configured but cannot mint an ` +
+        `installation token: every bot gh/PR flow is down. Check the App is still ` +
+        `installed on ${owner}'s repositories and that its private key is valid.`,
+      notify: FALLBACK_TEAMMATE,
+    },
+  ];
+}
+
+/** Check only the credential selected for bot traffic. Unselected credentials
+ * may deliberately be absent or retired and must not trigger outage alerts. */
+export async function selectedGithubCredentialIssues(): Promise<Issue[]> {
+  const { githubBotCredentialMode } = await import("./github-app");
+  return githubBotCredentialMode() === "app"
+    ? githubAppIssues()
+    : githubPatIssues();
+}
+
 /** One sweep: detect, dedupe against state, DM, persist. Exported for tests/manual runs. */
 export async function sweepAccountHealth(): Promise<Issue[]> {
   // Repair before detecting: refresh idle codex accounts' ChatGPT tokens so
@@ -293,7 +329,10 @@ export async function sweepAccountHealth(): Promise<Issue[]> {
   await refreshIdleCodexTokens().catch((e) =>
     console.warn("[account-health] codex token refresh failed:", e)
   );
-  const issues = [...detectAccountIssues(), ...(await githubPatIssues())];
+  const issues = [
+    ...detectAccountIssues(),
+    ...(await selectedGithubCredentialIssues()),
+  ];
   const state = readState();
   const now = Date.now();
   const live = new Set(issues.map((i) => i.key));

--- a/packages/core/opensession-server/src/server/gh-attachments.ts
+++ b/packages/core/opensession-server/src/server/gh-attachments.ts
@@ -94,7 +94,7 @@ export async function uploadUserAttachment(
   const cacheKey = [ghRepo, filePath, stat.size, stat.mtimeMs].join("\u0000");
   const cached = uploadCache.get(cacheKey);
   if (cached) return cached;
-  const token = await botGhToken();
+  const token = await botGhToken({ write: true });
   if (!token) return null;
   const repoId = await repoDbId(ghRepo, token);
   if (repoId === null) return null;

--- a/packages/core/opensession-server/src/server/github-app.test.ts
+++ b/packages/core/opensession-server/src/server/github-app.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { githubRepositoryMatchesInstallation } from "./github-app";
+
+describe("repository-scoped App installation identity", () => {
+  test("requires the requested repository owner to match the selected installation", () => {
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession", "TellaHQ")).toBe(true);
+    expect(githubRepositoryMatchesInstallation("acme/opensession", "tellahq")).toBe(false);
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession/extra", "tellahq")).toBe(false);
+    expect(githubRepositoryMatchesInstallation("tellahq/opensession", undefined)).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -26,6 +26,7 @@ import { configuredIntegration } from "./config";
 import { githubGitCredentialEnv } from "./github-git-credential";
 import { writeFileAtomic } from "./shared/atomic-write";
 import {
+  GITHUB_APP_CODE_PERMISSIONS as CODE_PERMISSIONS,
   GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
 } from "../shared/github-app-permissions";
@@ -47,6 +48,7 @@ type AppTokenCache = {
   token: string;
   expiresAt: number; // ms epoch
   installationId: number;
+  installationOwner: string;
 };
 
 const g = globalThis as {
@@ -62,8 +64,7 @@ const g = globalThis as {
 // create-app URL grants, so a mint never asks for a scope the App was not
 // granted. Still installation-scoped, so an out-of-org write fails at GitHub's
 // side just as the scoped bot PAT does (security-model.md, GitHub credential
-// scoping). If the App does not hold a set the mint is rejected and the caller
-// falls back to the PAT.
+// scoping). If the App does not hold a set, minting fails closed in App mode.
 
 function appJwt(clientId: string, key: string): string {
   const now = Math.floor(Date.now() / 1000);
@@ -75,15 +76,19 @@ function appJwt(clientId: string, key: string): string {
 
 /**
  * Installation access token for the app's (sole) installation, or null when
- * the app key/client id isn't configured or minting fails. Fail-soft: callers
- * fall back to the bot PAT.
+ * the app key/client id isn't configured or minting fails. App mode callers
+ * treat null as a closed credential boundary; PAT mode never calls this path.
  */
 export async function githubAppInstallationToken(
   opts: { write?: boolean } = {},
 ): Promise<string | null> {
   const slot = opts.write ? "__ghAppTokenCacheWrite" : "__ghAppTokenCacheRead";
   const cached = g[slot];
-  if (cached && cached.expiresAt - Date.now() > 5 * 60_000) return cached.token;
+  if (
+    cached &&
+    cached.installationOwner &&
+    cached.expiresAt - Date.now() > 5 * 60_000
+  ) return cached.token;
 
   const { clientId } = githubUserAuthSettings();
   if (!clientId || !existsSync(keyPath())) return null;
@@ -102,6 +107,12 @@ export async function githubAppInstallationToken(
       configuredInstallationId ||
       g.__ghAppTokenCacheRead?.installationId ||
       g.__ghAppTokenCacheWrite?.installationId;
+    let installationOwner =
+      g.__ghAppTokenCacheRead?.installationId === installationId
+        ? g.__ghAppTokenCacheRead?.installationOwner
+        : g.__ghAppTokenCacheWrite?.installationId === installationId
+          ? g.__ghAppTokenCacheWrite?.installationOwner
+          : undefined;
     if (!installationId) {
       const res = await fetch("https://api.github.com/app/installations", { headers });
       const installs = (await res.json()) as Array<{ id: number; account?: { login?: string } }>;
@@ -129,6 +140,20 @@ export async function githubAppInstallationToken(
         );
       }
       installationId = selected.id;
+      installationOwner = selected.account?.login;
+    }
+    if (!installationOwner) {
+      const installationRes = await fetch(
+        `https://api.github.com/app/installations/${installationId}`,
+        { headers },
+      );
+      const installation = (await installationRes.json()) as {
+        account?: { login?: string };
+      };
+      installationOwner = installation.account?.login;
+      if (!installationRes.ok || !installationOwner) {
+        throw new Error(`cannot resolve installation owner (${installationRes.status})`);
+      }
     }
 
     const res = await fetch(
@@ -147,6 +172,7 @@ export async function githubAppInstallationToken(
       token: tok.token,
       expiresAt: tok.expires_at ? Date.parse(tok.expires_at) : Date.now() + 55 * 60_000,
       installationId,
+      installationOwner,
     };
     g.__ghAppTokenWarned = false;
     return tok.token;
@@ -251,6 +277,15 @@ export async function commitGithubAppKeyMutation<T>(
  * askpass helper immediately after git finishes. It is never persisted in a
  * session file, host spec, URL, transcript, or Runner registry.
  */
+export function githubRepositoryMatchesInstallation(
+  ghRepo: string,
+  installationOwner: string | undefined,
+): boolean {
+  const [owner, repo, extra] = ghRepo.split("/");
+  return !!owner && !!repo && !extra &&
+    !!installationOwner && owner.toLowerCase() === installationOwner.toLowerCase();
+}
+
 export async function githubAppRepositoryToken(ghRepo: string): Promise<string | null> {
   if (githubBotCredentialMode() !== "app") return null;
   const [owner, repo] = ghRepo.split("/");
@@ -258,8 +293,15 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
   // Resolve the installation id through the existing credential path. It keeps
   // installation selection in one place and may populate the shared cache.
   await githubAppInstallationToken();
-  const installationId =
-    g.__ghAppTokenCacheRead?.installationId || g.__ghAppTokenCacheWrite?.installationId;
+  const installation =
+    g.__ghAppTokenCacheRead || g.__ghAppTokenCacheWrite;
+  const installationId = installation?.installationId;
+  if (!githubRepositoryMatchesInstallation(ghRepo, installation?.installationOwner)) {
+    console.warn(
+      `[github-app] refusing repository token for ${ghRepo}: selected installation belongs to ${installation?.installationOwner || "unknown"}`,
+    );
+    return null;
+  }
   const { clientId } = githubUserAuthSettings();
   if (!installationId || !clientId || !existsSync(keyPath())) return null;
   try {
@@ -274,11 +316,9 @@ export async function githubAppRepositoryToken(ghRepo: string): Promise<string |
         },
         body: JSON.stringify({
           repositories: [repo],
-          permissions: {
-            contents: "write",
-            pull_requests: "write",
-            metadata: "read",
-          },
+          // Trusted repository code runs can push/reply and inspect the
+          // failing checks and Actions logs they are expected to repair.
+          permissions: CODE_PERMISSIONS,
         }),
       },
     );

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -31,6 +31,7 @@ import {
   startGithubDeviceFlow,
   validateGithubTokenLogin,
 } from "./github-auth";
+import { botGhToken } from "./github-limit";
 import {
 	ensureAutomationWebSession,
   keypadBearerAuthorized,
@@ -48,6 +49,7 @@ const ENV_KEYS = [
   GITHUB_RUN_AUTH_FILE_ENV,
   "OPENSESSION_WEB_SESSIONS_STORE",
   "KEYPAD_TOKEN",
+  "GITHUB_API_TOKEN",
 ] as const;
 const saved: Record<string, string | undefined> = {};
 for (const k of ENV_KEYS) saved[k] = process.env[k];
@@ -112,6 +114,20 @@ function seedToken(login = "alice", token = "gho_test123"): void {
     }),
   );
 }
+
+
+describe("selected bot credential boundary", () => {
+  test("App mode does not fall back to the PAT or ambient gh login", async () => {
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+    );
+    process.env.OPENSESSION_CONFIG = path;
+    process.env.GITHUB_API_TOKEN = "retired-pat";
+    expect(await botGhToken()).toBeNull();
+  });
+});
 
 describe("githubUserAuthSettings", () => {
   test("off by default (no config)", () => {

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -26,6 +26,8 @@ import {
   pollGithubDeviceFlow,
   refreshExpiringGithubTokens,
   removeGithubAccount,
+  resolveGithubCredential,
+  serviceGithubCredential,
   soleGithubAccount,
   soleGithubLogin,
   startGithubDeviceFlow,
@@ -126,6 +128,9 @@ describe("selected bot credential boundary", () => {
     process.env.OPENSESSION_CONFIG = path;
     process.env.GITHUB_API_TOKEN = "retired-pat";
     expect(await botGhToken()).toBeNull();
+    await expect(resolveGithubCredential(serviceGithubCredential)).rejects.toThrow(
+      "selected GitHub bot credential is unavailable",
+    );
   });
 });
 

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -854,6 +854,22 @@ export const serviceGithubCredential: GithubCredential = {
   env: {},
 };
 
+/** Materialize the operator-selected credential for server-owned gh calls.
+ * Interactive user credentials pass through unchanged. */
+export async function resolveGithubCredential(
+  credential: GithubCredential,
+  opts: { write?: boolean } = {},
+): Promise<GithubCredential> {
+  if (credential.kind !== "service" || credential.env.GH_TOKEN) return credential;
+  const { githubToken } = await import("./github-app");
+  const token = await githubToken(opts);
+  if (!token) throw new Error("The selected GitHub bot credential is unavailable");
+  return {
+    ...credential,
+    env: githubProcessEnv({ GH_TOKEN: token, GITHUB_TOKEN: token }),
+  };
+}
+
 function credentialForAccount(account: StoredAccount): GithubCredential {
   return {
     kind: "user",

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -813,20 +813,31 @@ function projectedGithubAuthEnv(): Record<string, string> {
   }
 }
 
-/** GitHub environment for one interactive run. Besides the API variables, set
- * a process-local Git credential helper so HTTPS remotes can push without
- * persisting the short-lived user token in .git/config or ~/.config/gh. */
-export function githubRunEnv(user?: string | null): Record<string, string> {
-  const auth = githubAuthEnv(user);
-  const projected = Object.keys(auth).length ? auth : projectedGithubAuthEnv();
-  if (!projected.GH_TOKEN) return {};
+function githubProcessEnv(auth: Record<string, string>): Record<string, string> {
+  if (!auth.GH_TOKEN) return {};
   return {
-    ...projected,
+    ...auth,
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_COUNT: "1",
     GIT_CONFIG_KEY_0: "credential.https://github.com.helper",
     GIT_CONFIG_VALUE_0: "!gh auth git-credential",
   };
+}
+
+/** Consume only the private run-scoped file projected by a remote launcher.
+ * Unlike githubRunEnv(), this can never consult a connected human account. */
+export function projectedGithubRunEnv(): Record<string, string> {
+  return githubProcessEnv(projectedGithubAuthEnv());
+}
+
+/** GitHub environment for one interactive run. Besides the API variables, set
+ * a process-local Git credential helper so HTTPS remotes can push without
+ * persisting the short-lived user token in .git/config or ~/.config/gh. */
+export function githubRunEnv(user?: string | null): Record<string, string> {
+  const auth = githubAuthEnv(user);
+  return githubProcessEnv(
+    Object.keys(auth).length ? auth : projectedGithubAuthEnv(),
+  );
 }
 
 export interface GithubCredential {

--- a/packages/core/opensession-server/src/server/github-limit.ts
+++ b/packages/core/opensession-server/src/server/github-limit.ts
@@ -109,14 +109,22 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
   persistBackoff();
   state.probe = (async () => {
     try {
-      const proc = Bun.spawn(
-        ["gh", "api", "rate_limit", "--jq", ".resources.graphql.reset"],
-        { stdout: "pipe", stderr: "ignore" },
-      );
-      const raw = await new Response(proc.stdout).text();
-      if ((await proc.exited) === 0) {
-        const reset = parseInt(raw.trim(), 10) * 1000;
-        if (reset > Date.now()) {
+      // Probe with the operator-selected service credential. Invoking ambient
+      // `gh` here would cross the App cutover through hosts.yml on failures.
+      const { githubToken } = await import("./github-app");
+      const token = await githubToken();
+      if (token) {
+        const response = await fetch("https://api.github.com/rate_limit", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": "opensession",
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        const data = await response.json().catch(() => null) as any;
+        const reset = Number(data?.resources?.graphql?.reset) * 1000;
+        if (response.ok && reset > Date.now()) {
           state.backoffUntil = reset + 30_000;
           persistBackoff();
         }
@@ -131,11 +139,19 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
 
 /**
  * Token for direct api.github.com calls made on the bot's behalf (conditional
- * change probes and the like): the GITHUB_API_TOKEN PAT when configured, else
- * the gh CLI's own token, probed once and cached for the process lifetime.
+ * change probes and the like): the App installation token (or GITHUB_API_TOKEN)
+ * that the REST helpers use, else the gh CLI's own token, probed once and cached
+ * for the process lifetime.
  */
-export async function botGhToken(): Promise<string | null> {
-  if (process.env.GITHUB_API_TOKEN) return process.env.GITHUB_API_TOKEN;
+export async function botGhToken(
+  opts: { write?: boolean } = {},
+): Promise<string | null> {
+  const { githubBotCredentialMode, githubToken } = await import("./github-app");
+  const primary = await githubToken(opts);
+  if (primary) return primary;
+  // App mode is an explicit credential boundary. Do not silently resume with
+  // a user login or retired PAT cached by gh when App token minting fails.
+  if (githubBotCredentialMode() === "app") return null;
   if (state.botToken !== undefined) return state.botToken;
   try {
     const proc = Bun.spawn(["gh", "auth", "token"], {

--- a/packages/core/opensession-server/src/server/pi-runner-github.test.ts
+++ b/packages/core/opensession-server/src/server/pi-runner-github.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { GITHUB_RUN_AUTH_FILE_ENV } from "./github-auth";
+import { githubCodeRunEnv } from "./pi-runner";
+
+const keys = [
+  "OPENSESSION_CONFIG",
+  "OPENSESSION_GITHUB_AUTH_STORE",
+  "GITHUB_API_TOKEN",
+  GITHUB_RUN_AUTH_FILE_ENV,
+] as const;
+const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of keys) {
+    const value = saved[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("recovered GitHub code-run credentials", () => {
+  test("resolves the selected service credential instead of a connected human", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-recovered-github-"));
+    try {
+      const cwd = join(dir, "repo");
+      mkdirSync(cwd);
+      const config = join(dir, "config.json");
+      const users = join(dir, "github-users.json");
+      writeFileSync(
+        config,
+        JSON.stringify({
+          integrations: { github: { botCredential: "pat" } },
+          repos: {
+            app: {
+              repo: cwd,
+              ghRepo: "tellahq/app",
+              defaultBranch: "main",
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        users,
+        JSON.stringify({
+          users: {
+            alice: { login: "alice", token: "human-token", connectedAt: new Date().toISOString() },
+          },
+        }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.OPENSESSION_GITHUB_AUTH_STORE = users;
+      process.env.GITHUB_API_TOKEN = "selected-service-pat";
+      delete process.env[GITHUB_RUN_AUTH_FILE_ENV];
+
+      const env = await githubCodeRunEnv(cwd);
+      expect(env.GH_TOKEN).toBe("selected-service-pat");
+      expect(Object.values(env)).not.toContain("human-token");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("remote recovery consumes only its projected run-scoped file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-projected-github-"));
+    try {
+      const auth = join(dir, "github-auth.json");
+      writeFileSync(auth, JSON.stringify({ GH_TOKEN: "projected-service-token" }));
+      process.env[GITHUB_RUN_AUTH_FILE_ENV] = auth;
+      process.env.GITHUB_API_TOKEN = "unprojected-host-token";
+
+      const env = await githubCodeRunEnv("/remote/unregistered/repo");
+      expect(env.GH_TOKEN).toBe("projected-service-token");
+      expect(Object.values(env)).not.toContain("unprojected-host-token");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -91,7 +91,12 @@ import {
 import { transcriptStore } from "./transcript-store";
 import { transcriptForwarder } from "./transcript-forward";
 import { gitIdentityEnv } from "./shared/user-mappings";
-import { githubRunEnv, githubUserLoginForRun } from "./github-auth";
+import {
+  GITHUB_RUN_AUTH_FILE_ENV,
+  githubRunEnv,
+  githubUserLoginForRun,
+  projectedGithubRunEnv,
+} from "./github-auth";
 import { ensureAgentAwsCredsFile } from "./aws-creds";
 import { buildEngineSwitchHandoffNote } from "./fork-handoff";
 import { piAnthropicTransport, piEngineEnabled } from "./pi-config";
@@ -119,6 +124,18 @@ const g = globalThis as any;
 
 const PROVIDER = "pi" as const;
 export const PI_MODEL_PREFIX = "pi/";
+
+/** Fresh authority for an unattended GitHub code run. Host recovery resolves
+ * the selected service credential from the registered cwd; remote runners can
+ * consume only the private run-scoped file projected by their launcher. */
+export async function githubCodeRunEnv(cwd: string): Promise<Record<string, string>> {
+  if (process.env[GITHUB_RUN_AUTH_FILE_ENV]) return projectedGithubRunEnv();
+  const { repoForPathOrNull } = await import("./worktree");
+  const repo = repoForPathOrNull(cwd);
+  if (!repo || repo.host === "codestorage" || !repo.ghRepo) return {};
+  const { githubServiceCredentialEnv } = await import("./github-app");
+  return githubServiceCredentialEnv(repo.ghRepo);
+}
 
 /** State root: server-owned agentDir, per-unified-session pi session dirs,
  *  and the smoke-turn scratch cwd. Never ~/.pi. */
@@ -1604,7 +1621,9 @@ async function* runPiAttempt(
     const githubCodeRun =
       mode === "code" && baseJournalKind(journal?.kind).startsWith("github-");
     const githubEnv = githubCodeRun
-      ? opts.githubEnv || {}
+      ? opts.githubEnv?.GH_TOKEN
+        ? opts.githubEnv
+        : await githubCodeRunEnv(cwd)
       : interactiveGithub
         ? githubRunEnv(user || author?.name)
         : {};

--- a/packages/core/opensession-server/src/server/pr-host.ts
+++ b/packages/core/opensession-server/src/server/pr-host.ts
@@ -12,7 +12,11 @@
  * pr-info.ts and are host-agnostic.
  */
 import type { Repo } from "./config";
-import type { GithubCredential } from "./github-auth";
+import {
+  resolveGithubCredential,
+  serviceGithubCredential,
+  type GithubCredential,
+} from "./github-auth";
 import {
 	botGhToken,
 	ghRateLimited,
@@ -155,7 +159,12 @@ export interface PrHost {
 export async function ghJson<T>(args: string[]): Promise<T | null> {
 	if (ghRateLimited()) return null;
 	try {
-		const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+		const credential = await resolveGithubCredential(serviceGithubCredential);
+		const proc = Bun.spawn(["gh", ...args], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, ...credential.env },
+		});
 		const [raw, err] = await Promise.all([
 			new Response(proc.stdout).text(),
 			new Response(proc.stderr).text(),

--- a/packages/core/opensession-server/src/server/pr-images.ts
+++ b/packages/core/opensession-server/src/server/pr-images.ts
@@ -152,7 +152,8 @@ const repoVisibilityCache = new Map<string, boolean>();
 export async function repoIsPrivate(ghRepo: string): Promise<boolean | null> {
   const cached = repoVisibilityCache.get(ghRepo);
   if (cached !== undefined) return cached;
-  const token = process.env.GITHUB_API_TOKEN || process.env.GH_TOKEN;
+  const { botGhToken } = await import("./github-limit");
+  const token = await botGhToken();
   if (!token) return null;
   try {
     const res = await fetch(`https://api.github.com/repos/${ghRepo}`, {

--- a/packages/core/opensession-server/src/server/pr-info.ts
+++ b/packages/core/opensession-server/src/server/pr-info.ts
@@ -14,7 +14,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { audited } from "./audit";
 import { ghRateLimited, noteGhRateLimited, isGhRateLimitMsg } from "./github-limit";
 import { serviceGithubCredential, type GithubCredential } from "./github-auth";
-import { githubAppEnv } from "./github-app";
+import { githubBotCredentialMode, githubToken } from "./github-app";
 import { reviewRequestRemovalSpecs } from "./github-review-requests";
 import { getPrStack, unmergedLayersBelow } from "./pr-stack";
 import type {
@@ -315,6 +315,23 @@ export function seedPrDiff(repo: string, branch: string, data: PrDiffData): void
 const diffInflight: Map<string, Promise<PrDiffData | null>> =
   ((globalThis as any).__prDiffInflight ??= new Map());
 
+async function selectedGhEnv(
+  opts: { write?: boolean } = {},
+): Promise<Record<string, string>> {
+  const token = await githubToken(opts);
+  if (!token) throw new Error("The selected GitHub bot credential is unavailable");
+  return { GH_TOKEN: token, GITHUB_TOKEN: token };
+}
+
+async function resolvedGithubCredential(
+  credential: GithubCredential,
+  opts: { write?: boolean } = {},
+): Promise<GithubCredential> {
+  return credential.kind === "service" && !credential.env.GH_TOKEN
+    ? { ...credential, env: await selectedGhEnv(opts) }
+    : credential;
+}
+
 function spawnGh(args: string[], credential: GithubCredential, stdin?: "pipe") {
   return Bun.spawn(["gh", ...args], {
     ...(stdin ? { stdin } : {}),
@@ -358,8 +375,17 @@ function completePatchPrefix(text: string, truncated: boolean): { patch: string;
   };
 }
 
-async function boundedCommandPatch(argv: string[], limit: number): Promise<{ patch: string; skippedFiles: number }> {
-  const child = Bun.spawn(argv, { stdin: "ignore", stdout: "pipe", stderr: "pipe", env: process.env });
+async function boundedCommandPatch(
+  argv: string[],
+  limit: number,
+  env: Record<string, string> = {},
+): Promise<{ patch: string; skippedFiles: number }> {
+  const child = Bun.spawn(argv, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
   const [output, error] = await Promise.all([
     processPrefix(child.stdout, limit, () => child.kill()),
     processPrefix(child.stderr, 64 * 1024, () => child.kill()),
@@ -396,9 +422,10 @@ async function getMutationPrMeta(
   repo: string,
   credential: GithubCredential,
 ): Promise<MutationPrMeta | null> {
+  const resolvedCredential = await resolvedGithubCredential(credential);
   const proc = spawnGh(
     ["pr", "view", branch, "--repo", repo, "--json", "number,headRefOid,state,isDraft,url"],
-    credential,
+    resolvedCredential,
   );
   const [out, err, code] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -432,8 +459,10 @@ export async function getPrDiff(
 
   const refresh = (async () => {
     try {
+      const ghEnv = await selectedGhEnv();
       const readMeta = async () => JSON.parse(
         await $`gh pr view ${branch} --repo ${repo} --json number,headRefOid,baseRefName,baseRefOid`
+          .env({ ...process.env, ...ghEnv })
           .quiet()
           .text(),
       );
@@ -446,11 +475,15 @@ export async function getPrDiff(
             const bounded = await boundedCommandPatch(
               ["gh", "pr", "diff", String(meta.number), "--repo", repo],
               maxPatchBytes,
+              ghEnv,
             );
             patch = bounded.patch;
             skippedFiles = bounded.skippedFiles;
           } else {
-            patch = await $`gh pr diff ${meta.number} --repo ${repo}`.quiet().text();
+            patch = await $`gh pr diff ${meta.number} --repo ${repo}`
+              .env({ ...process.env, ...ghEnv })
+              .quiet()
+              .text();
           }
         } catch (diffErr: any) {
           // GitHub refuses API diffs over 300 files; reconstruct from the same
@@ -536,6 +569,7 @@ export async function postPrComment(
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
   try {
+    credential = await resolvedGithubCredential(credential, { write: true });
     if (input.path && input.line) {
       const meta = await getMutationPrMeta(branch, repo, credential);
       if (!meta) return { error: "No PR found for this branch" };
@@ -600,6 +634,7 @@ export async function submitPrReview(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
+  credential = await resolvedGithubCredential(credential, { write: true });
   if (!input.comments.length && !input.body?.trim()) {
     return { error: "Nothing to submit" };
   }
@@ -671,6 +706,7 @@ export async function closePr(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string; number: number } | { error: string }> {
+  credential = await resolvedGithubCredential(credential, { write: true });
   const pr = await getMutationPrMeta(branch, repo, credential);
   if (!pr) return { error: "No PR found for this branch" };
   if (pr.state !== "OPEN") return { error: `PR #${pr.number} is ${pr.state.toLowerCase()}, not open` };
@@ -711,6 +747,7 @@ export async function mergePr(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
+  credential = await resolvedGithubCredential(credential, { write: true });
   const pr = await getMutationPrMeta(branch, repo, credential);
   if (!pr) return { error: "No PR found for this branch" };
   if (pr.state !== "OPEN") return { error: `PR #${pr.number} is ${pr.state.toLowerCase()}, not open` };
@@ -786,6 +823,7 @@ export async function editPrReviewers(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true } | { error: string }> {
+  credential = await resolvedGithubCredential(credential, { write: true });
   const args = ["pr", "edit", branch, "--repo", repo];
   if (opts.add) args.push("--add-reviewer", opts.add);
   // A list, because withdrawing a request made on GitHub rather than here can
@@ -822,6 +860,7 @@ export async function prReviewerSpecs(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<string[] | null> {
+  credential = await resolvedGithubCredential(credential);
   const proc = spawnGh(
     ["pr", "view", branch, "--repo", repo, "--json", "reviewRequests"],
     credential,
@@ -858,9 +897,10 @@ export async function updatePrBody(
   repo: string = DEFAULT_REPO()
 ): Promise<{ ok: true; number: number; url: string } | { error: string }> {
   try {
+    const ghEnv = await selectedGhEnv({ write: true });
     const view = Bun.spawn(
       ["gh", "pr", "view", branch, "--repo", repo, "--json", "body,number,url"],
-      { stdout: "pipe", stderr: "pipe" }
+      { stdout: "pipe", stderr: "pipe", env: { ...process.env, ...ghEnv } }
     );
     const [out, viewErr, viewCode] = await Promise.all([
       new Response(view.stdout).text(),
@@ -877,7 +917,7 @@ export async function updatePrBody(
     try {
       const edit = Bun.spawn(
         ["gh", "api", "-X", "PATCH", `repos/${repo}/pulls/${pr.number}`, "--input", tmp],
-        { stdout: "pipe", stderr: "pipe" }
+        { stdout: "pipe", stderr: "pipe", env: { ...process.env, ...ghEnv } }
       );
       const [, editErr, editCode] = await Promise.all([
         new Response(edit.stdout).text(),
@@ -1051,25 +1091,21 @@ async function fetchPrDetails(
     // treating it as "no PR" broke PR actions (PR #4910). Retry transient
     // failures; a genuine "no pull requests found" stays a fast null.
     let raw = "";
-    let appEnv = await githubAppEnv();
+    const selectedEnv = await selectedGhEnv();
+    const appSelected = githubBotCredentialMode() === "app";
     for (let attempt = 1; ; attempt++) {
       const baseFields =
         "number,title,url,state,isDraft,baseRefName,headRefName,headRefOid,additions,deletions,changedFiles,reviewDecision,author,body,mergeable,mergeStateStatus,comments,commits,files,latestReviews,reviewRequests";
-      const includeRollup = !!appEnv || !skipStatusCheckRollup;
+      const includeRollup = appSelected || !skipStatusCheckRollup;
       const fields = includeRollup ? `${baseFields},statusCheckRollup` : baseFields;
       try {
-        const cmd = $`gh pr view ${branch} --repo ${repo} --json ${fields}`;
-        raw = await (appEnv ? cmd.env({ ...process.env, ...appEnv }) : cmd).quiet().text();
+        raw = await $`gh pr view ${branch} --repo ${repo} --json ${fields}`
+          .env({ ...process.env, ...selectedEnv })
+          .quiet()
+          .text();
         break;
       } catch (e: any) {
         const msg = String(e?.stderr || e?.message || e).slice(0, 300);
-        // A minted-but-dead app token (revoked key) must not sink the fetch —
-        // drop to the bot PAT once and re-run the attempt.
-        if (appEnv && /authentication|bad credentials|resource not accessible/i.test(msg)) {
-          console.warn(`[pr-info] app-token gh call failed (${msg.slice(0, 80)}) — falling back to bot credential`);
-          appEnv = null;
-          continue;
-        }
         // Keyed on THIS call's field list, not the global flag — a concurrent
         // fetch may trip the flag while our rollup-carrying request is in
         // flight, and that must not turn our retry into a hard failure.

--- a/packages/core/opensession-server/src/server/pr-info.ts
+++ b/packages/core/opensession-server/src/server/pr-info.ts
@@ -13,7 +13,11 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "fs";
 import { audited } from "./audit";
 import { ghRateLimited, noteGhRateLimited, isGhRateLimitMsg } from "./github-limit";
-import { serviceGithubCredential, type GithubCredential } from "./github-auth";
+import {
+  resolveGithubCredential,
+  serviceGithubCredential,
+  type GithubCredential,
+} from "./github-auth";
 import { githubBotCredentialMode, githubToken } from "./github-app";
 import { reviewRequestRemovalSpecs } from "./github-review-requests";
 import { getPrStack, unmergedLayersBelow } from "./pr-stack";
@@ -323,15 +327,6 @@ async function selectedGhEnv(
   return { GH_TOKEN: token, GITHUB_TOKEN: token };
 }
 
-async function resolvedGithubCredential(
-  credential: GithubCredential,
-  opts: { write?: boolean } = {},
-): Promise<GithubCredential> {
-  return credential.kind === "service" && !credential.env.GH_TOKEN
-    ? { ...credential, env: await selectedGhEnv(opts) }
-    : credential;
-}
-
 function spawnGh(args: string[], credential: GithubCredential, stdin?: "pipe") {
   return Bun.spawn(["gh", ...args], {
     ...(stdin ? { stdin } : {}),
@@ -422,7 +417,7 @@ async function getMutationPrMeta(
   repo: string,
   credential: GithubCredential,
 ): Promise<MutationPrMeta | null> {
-  const resolvedCredential = await resolvedGithubCredential(credential);
+  const resolvedCredential = await resolveGithubCredential(credential);
   const proc = spawnGh(
     ["pr", "view", branch, "--repo", repo, "--json", "number,headRefOid,state,isDraft,url"],
     resolvedCredential,
@@ -569,7 +564,7 @@ export async function postPrComment(
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
   try {
-    credential = await resolvedGithubCredential(credential, { write: true });
+    credential = await resolveGithubCredential(credential, { write: true });
     if (input.path && input.line) {
       const meta = await getMutationPrMeta(branch, repo, credential);
       if (!meta) return { error: "No PR found for this branch" };
@@ -634,7 +629,7 @@ export async function submitPrReview(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
-  credential = await resolvedGithubCredential(credential, { write: true });
+  credential = await resolveGithubCredential(credential, { write: true });
   if (!input.comments.length && !input.body?.trim()) {
     return { error: "Nothing to submit" };
   }
@@ -706,7 +701,7 @@ export async function closePr(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string; number: number } | { error: string }> {
-  credential = await resolvedGithubCredential(credential, { write: true });
+  credential = await resolveGithubCredential(credential, { write: true });
   const pr = await getMutationPrMeta(branch, repo, credential);
   if (!pr) return { error: "No PR found for this branch" };
   if (pr.state !== "OPEN") return { error: `PR #${pr.number} is ${pr.state.toLowerCase()}, not open` };
@@ -747,7 +742,7 @@ export async function mergePr(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true; url?: string } | { error: string }> {
-  credential = await resolvedGithubCredential(credential, { write: true });
+  credential = await resolveGithubCredential(credential, { write: true });
   const pr = await getMutationPrMeta(branch, repo, credential);
   if (!pr) return { error: "No PR found for this branch" };
   if (pr.state !== "OPEN") return { error: `PR #${pr.number} is ${pr.state.toLowerCase()}, not open` };
@@ -823,7 +818,7 @@ export async function editPrReviewers(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true } | { error: string }> {
-  credential = await resolvedGithubCredential(credential, { write: true });
+  credential = await resolveGithubCredential(credential, { write: true });
   const args = ["pr", "edit", branch, "--repo", repo];
   if (opts.add) args.push("--add-reviewer", opts.add);
   // A list, because withdrawing a request made on GitHub rather than here can
@@ -860,7 +855,7 @@ export async function prReviewerSpecs(
   repo: string = DEFAULT_REPO(),
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<string[] | null> {
-  credential = await resolvedGithubCredential(credential);
+  credential = await resolveGithubCredential(credential);
   const proc = spawnGh(
     ["pr", "view", branch, "--repo", repo, "--json", "reviewRequests"],
     credential,

--- a/packages/core/opensession-server/src/server/pr-stack.ts
+++ b/packages/core/opensession-server/src/server/pr-stack.ts
@@ -29,7 +29,11 @@
  * already own their branches and worktrees. There are no stack mutations in
  * the GraphQL schema, so the extension is the only write surface.
  */
-import { serviceGithubCredential, type GithubCredential } from "./github-auth";
+import {
+  resolveGithubCredential,
+  serviceGithubCredential,
+  type GithubCredential,
+} from "./github-auth";
 import { ghRateLimited, noteGhRateLimited, isGhRateLimitMsg } from "./github-limit";
 import { audited } from "./audit";
 import type { PrStack, PrStackLayer } from "./pr-contract";
@@ -133,6 +137,11 @@ export async function getPrStack(
   if (ghRateLimited()) return null;
   const repo = splitRepo(ghRepo);
   if (!repo) return null;
+  try {
+    credential = await resolveGithubCredential(credential);
+  } catch {
+    return null;
+  }
 
   const head = await graphql(
     STACK_QUERY,
@@ -371,6 +380,7 @@ export async function linkPrStack(
   cwd: string,
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true } | { error: string }> {
+  credential = await resolveGithubCredential(credential, { write: true });
   if (prUrls.length < 2)
     return { error: "A stack needs at least two pull requests" };
 
@@ -419,6 +429,7 @@ export async function mergePrStack(
   opts: { method?: "merge" | "squash" | "rebase" } = {},
   credential: GithubCredential = serviceGithubCredential,
 ): Promise<{ ok: true } | { error: string }> {
+  credential = await resolveGithubCredential(credential, { write: true });
   const method = opts.method || "squash";
   return audited(
     {

--- a/packages/core/opensession-server/src/server/pr-viewed.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.ts
@@ -42,7 +42,7 @@ async function viewerToken(
 		const credential = githubCredentialForLogin(login);
 		if (credential?.env.GH_TOKEN) return credential.env.GH_TOKEN;
 	}
-	return botGhToken();
+	return botGhToken({ write: true });
 }
 
 async function graphql(

--- a/packages/core/opensession-server/src/server/preview-pool.test.ts
+++ b/packages/core/opensession-server/src/server/preview-pool.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { rebuildInvalidatedPreviewPool } from "./preview-pool";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { cloneUrlFor, rebuildInvalidatedPreviewPool } from "./preview-pool";
+import type { Repo } from "./config";
 
 describe("default branch preview-pool rebuild", () => {
   test("does not refill a golden-backed pool when its rebuild fails", async () => {
@@ -32,5 +36,39 @@ describe("default branch preview-pool rebuild", () => {
     await expect(rebuildInvalidatedPreviewPool("daytona", rebuild, refill)).resolves.toBe(true);
     expect(rebuilds).toBe(1);
     expect(refills).toBe(2);
+  });
+});
+
+
+describe("preview pool GitHub credential cutover", () => {
+  test("does not bake an expiring App token into restartable container commands", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-preview-credential-"));
+    const previous = process.env.OPENSESSION_CONFIG;
+    try {
+      const config = join(dir, "config.json");
+      writeFileSync(
+        config,
+        JSON.stringify({ integrations: { github: { botCredential: "app" } } }),
+      );
+      process.env.OPENSESSION_CONFIG = config;
+      expect(
+        await cloneUrlFor(
+          {
+            id: "opensession",
+            label: "Open Session",
+            repo: "/host/opensession",
+            wtPrefix: "/host/worktrees/opensession",
+            defaultBranch: "main",
+            host: "github",
+            ghRepo: "tellahq/opensession",
+          } satisfies Repo,
+          { longLived: true },
+        ),
+      ).toBeNull();
+    } finally {
+      if (previous === undefined) delete process.env.OPENSESSION_CONFIG;
+      else process.env.OPENSESSION_CONFIG = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/opensession-server/src/server/preview-pool.ts
+++ b/packages/core/opensession-server/src/server/preview-pool.ts
@@ -57,7 +57,7 @@ import { authedRemoteUrl } from "./codestorage/auth";
 import { homeDir, OPENSESSION_SESSIONS_DIR } from "./paths";
 import { isDevInstance } from "./dev-mode";
 import { sandboxConfig } from "./sandbox/config";
-import { shellQuoteWord } from "./sandbox/adapters/bootstrap";
+import { injectCloneCredential, shellQuoteWord } from "./sandbox/adapters/bootstrap";
 import { redactUrl } from "./shared/redact";
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -840,7 +840,7 @@ async function refreshContainerCreds(target: string | PoolContainer): Promise<bo
   return r.ok;
 }
 
-async function cloneUrlFor(
+export async function cloneUrlFor(
   repo: Repo,
   opts?: { longLived?: boolean },
 ): Promise<string | null> {
@@ -855,11 +855,15 @@ async function cloneUrlFor(
     return authedRemoteUrl(repo.csRepo, opts?.longLived ? { ttlSeconds: 30 * 24 * 3600 } : {});
   }
   if (!repo.ghRepo) return null;
-  const cred = sandboxConfig().cloneCredential;
-  if (cred?.type === "https-token" && cred.token) {
-    return `https://x-access-token:${cred.token}@github.com/${repo.ghRepo}.git`;
-  }
-  return `https://github.com/${repo.ghRepo}.git`;
+  const { githubBotCredentialMode } = await import("./github-app");
+  const mode = githubBotCredentialMode();
+  // Installation tokens expire too quickly to bake into a container command
+  // that may restart days later. App-mode warm restarts use the golden tree;
+  // one-shot golden/Daytona operations mint a fresh repository token below.
+  if (opts?.longLived && mode === "app") return null;
+  const plain = `https://github.com/${repo.ghRepo}.git`;
+  const selected = await injectCloneCredential(plain);
+  return mode === "app" && selected === plain ? null : selected;
 }
 
 /** Boot preamble every warm/golden boot runs: lock cleanup + full ports.conf. */
@@ -1017,7 +1021,7 @@ async function warmRoutesPool(repo: Repo, c: PoolContainer): Promise<void> {
 async function spawnDaytonaWarm(repo: Repo): Promise<void> {
   const cloneUrl = await cloneUrlFor(repo);
   if (!cloneUrl) {
-    return console.warn(`[preview-pool] ${repo.id}: daytona backend needs a ghRepo + cloneCredential`);
+    return console.warn(`[preview-pool] ${repo.id}: daytona backend needs a ghRepo + selected GitHub credential`);
   }
   const client = await daytonaClientForPool();
   const scfg = sandboxConfig();
@@ -1081,6 +1085,17 @@ async function spawnDaytonaWarm(repo: Repo): Promise<void> {
       8 * 60_000,
     );
     if (!clone.ok) return void (await fail(`clone: ${clone.out.slice(-400)}`));
+    if (repo.host !== "codestorage") {
+      // git clone persists its authority in remote.origin.url. Remove the
+      // repository-scoped App token before any repository-owned setup/start
+      // code can inspect it.
+      const safeOrigin = `https://github.com/${repo.ghRepo}.git`;
+      const scrub = await poolExec(
+        c,
+        `git -C ${WORKSPACE} remote set-url origin ${shellQuoteWord(safeOrigin)}`,
+      );
+      if (!scrub.ok) return void (await fail(`credential scrub: ${scrub.out.slice(-400)}`));
+    }
 
     for (const rel of SEED_ENV_FILES) {
       const content = envSeedContent(repo, rel);
@@ -1364,9 +1379,9 @@ async function spawnWarmContainer(repo: Repo): Promise<void> {
   const { previewHost, httpsPortFor } = await import("./preview");
   const host = await previewHost();
   const previewUrl = `https://${host}:${httpsPortFor(hostPort)}`;
-  // longLived: this URL is baked into the container's boot command, which the
-  // `docker restart` clean-reboot path re-runs long after spawn — a 1h token
-  // would make that advance fetch fail silently (`|| true`) onto a stale tree.
+  // PAT mode may use its long-lived credential here. App mode deliberately
+  // returns null rather than baking an hour-lived repository token into a boot
+  // command that can be re-run days later.
   const cloneUrl = await cloneUrlFor(repo, { longLived: true });
 
   patchContainer(repo.id, name, {

--- a/packages/core/opensession-server/src/server/routes/instance-settings.ts
+++ b/packages/core/opensession-server/src/server/routes/instance-settings.ts
@@ -118,11 +118,12 @@ async function githubOrganizationProfile(
 	ctx: RouteContext,
 	login: string,
 ): Promise<Response> {
+	const { githubToken } = await import("../github-app");
 	const tokens = [
 		ctx.authUser?.login
 			? githubCredentialForLogin(ctx.authUser.login)?.env.GH_TOKEN
 			: undefined,
-		process.env.GITHUB_API_TOKEN,
+		await githubToken(),
 	].filter((token): token is string => !!token);
 	const response = await fetchWithTimeout(
 		`https://api.github.com/orgs/${encodeURIComponent(login)}`,

--- a/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-auth.test.ts
@@ -106,12 +106,14 @@ describe("GitHub App onboarding link", () => {
 			// The canonical grant set — checks + statuses (the App-only CI rollup)
 			// and issues (PR/issue comments) included, so a created App holds every
 			// scope the installation-token mints request.
+			actions: "read",
 			checks: "read",
 			statuses: "read",
 			contents: "write",
 			issues: "write",
 			pull_requests: "write",
 			members: "read",
+			deployments: "read",
 			metadata: "read",
 			device_flow_enabled: "true",
 		});

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -10,6 +10,7 @@ import {
   matchesCodeStorageCheckout,
   normalizeDefaultBranch,
   validGithubFullName,
+  listReposViaAppInstallation,
 } from "./setup-repos";
 
 const originalConfig = process.env.OPENSESSION_CONFIG;
@@ -95,6 +96,35 @@ describe("validGithubFullName", () => {
     // The clone receives the full https URL through an argv array, so a
     // hyphen-prefixed owner cannot become a command flag.
     expect(validGithubFullName("--flag/repo")).toBe(true);
+  });
+});
+
+describe("App installation repository listing", () => {
+  test("uses the installation endpoint rather than a user endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return Response.json({
+        repositories: [
+          {
+            full_name: "tellahq/opensession",
+            private: true,
+            default_branch: "main",
+            pushed_at: "2026-08-24T00:00:00Z",
+          },
+        ],
+      });
+    }) as typeof fetch;
+    try {
+      const repos = await listReposViaAppInstallation("ghs_installation");
+      expect(repos.map((repo) => repo.fullName)).toEqual(["tellahq/opensession"]);
+      expect(urls).toEqual([
+        "https://api.github.com/installation/repositories?per_page=100&page=1",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -164,6 +164,26 @@ async function listReposViaUserRepos(token: string): Promise<PickerRepo[]> {
   return repos.slice(0, REPO_LIST_CAP);
 }
 
+/** GitHub App installation-token path. Installation tokens cannot call the
+ * user endpoints used by PATs and App user tokens. */
+export async function listReposViaAppInstallation(token: string): Promise<PickerRepo[]> {
+  const registered = registeredGhRepos();
+  const repos: PickerRepo[] = [];
+  for (let page = 1; repos.length < REPO_LIST_CAP && page <= 5; page++) {
+    const { ok, body } = await githubJson(
+      token,
+      `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+    );
+    if (!ok || !Array.isArray(body?.repositories)) break;
+    for (const raw of body.repositories) {
+      const repo = toPickerRepo(raw, registered);
+      if (repo) repos.push(repo);
+    }
+    if (body.repositories.length < 100) break;
+  }
+  return repos.slice(0, REPO_LIST_CAP);
+}
+
 /** GitHub App user-token path: union of the token's accessible installations.
  *  Returns null when the token isn't installation-scoped (classic OAuth/PAT)
  *  so the caller can fall back to /user/repos. */
@@ -558,16 +578,22 @@ export async function handleSetupRepoRoutes(
     // user in operator mode, the sole connected account in simple mode), else
     // the bot PAT, else an empty (but well-formed) answer.
     const userCredential = actingGithubCredential(ctx);
-    const token = userCredential?.env.GH_TOKEN || process.env.GITHUB_API_TOKEN;
+    // Bot credential: the App installation token when configured, else the PAT.
+    const { githubBotCredentialMode, githubToken } = await import("../github-app");
+    const botCredential = githubBotCredentialMode();
+    const botToken = userCredential ? null : await githubToken();
+    const token = userCredential?.env.GH_TOKEN || botToken;
     const source: "user" | "bot" | null = userCredential
       ? "user"
-      : process.env.GITHUB_API_TOKEN
+      : botToken
         ? "bot"
         : null;
     if (!token || !source) {
       return Response.json({ source: null, repos: [] });
     }
-    const cacheKey = userCredential ? userCredential.principal : "bot";
+    const cacheKey = userCredential
+      ? userCredential.principal
+      : `bot:${botCredential}`;
     const cached = repoListCache.get(cacheKey);
     if (cached && Date.now() - cached.at < REPO_CACHE_TTL_MS) {
       return Response.json(cached.payload);
@@ -577,8 +603,10 @@ export async function handleSetupRepoRoutes(
       // OAuth) via /user/repos. The installations call itself tells us which
       // kind we have — a non-App token gets an error and we fall back.
       const repos =
-        (source === "user" ? await listReposViaInstallations(token) : null) ??
-        (await listReposViaUserRepos(token));
+        source === "bot" && botCredential === "app"
+          ? await listReposViaAppInstallation(token)
+          : (source === "user" ? await listReposViaInstallations(token) : null) ??
+            (await listReposViaUserRepos(token));
       repos.sort((a, b) => (b.pushedAt || "").localeCompare(a.pushedAt || ""));
       const payload = {
         source,

--- a/packages/core/opensession-server/src/server/routes/setup-team.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-team.ts
@@ -190,9 +190,10 @@ async function syncGithubOrganizationMembers(ctx: RouteContext): Promise<Respons
   const userCredential = ctx.authUser?.login
     ? githubCredentialForLogin(ctx.authUser.login)
     : null;
+  const { githubToken } = await import("../github-app");
   const credentials = [
     userCredential?.env.GH_TOKEN,
-    process.env.GITHUB_API_TOKEN,
+    await githubToken(),
   ].filter((token, index, all): token is string => !!token && all.indexOf(token) === index);
   if (credentials.length === 0) {
     return Response.json({

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
   projectRemoteClaudeAccounts,
@@ -8,7 +9,89 @@ import {
   remoteModelProviderId,
   remoteRunNeedsAnthropic,
   remoteRunNeedsOpenai,
+  injectCloneCredential,
+  selectedCloneToken,
+  selectedGithubCloneLiveToken,
+  warmRemoteWorkspace,
 } from "./bootstrap";
+import type { RemoteDriver } from "./bootstrap";
+
+describe("GitHub clone credential cutover", () => {
+  test("App mode never falls back to a persisted PAT", () => {
+    expect(selectedCloneToken(undefined, "retired-pat", true, "app")).toBeUndefined();
+    expect(selectedCloneToken("fresh-app", "retired-pat", true, "app")).toBe("fresh-app");
+    expect(selectedCloneToken(undefined, "active-pat", true, "pat")).toBe("active-pat");
+    expect(selectedCloneToken(undefined, "other-host", false, "app")).toBe("other-host");
+    expect(selectedGithubCloneLiveToken("app", "repo-app", "wide-token")).toBe("repo-app");
+    expect(selectedGithubCloneLiveToken("app", undefined, "wide-token")).toBeUndefined();
+    expect(selectedGithubCloneLiveToken("pat", "unselected-app", "selected-pat")).toBe("selected-pat");
+  });
+
+  test("scrubs a warm origin before repository dependency code runs", async () => {
+    const commands: string[] = [];
+    const driver = {
+      exec: async (command: string) => {
+        commands.push(command);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+
+    await warmRemoteWorkspace(
+      driver as unknown as RemoteDriver,
+      {
+        id: "opensession",
+        repo: "/host/opensession",
+        ghRepo: "tellahq/opensession",
+        defaultBranch: "main",
+      },
+      "test",
+    );
+
+    const scrub = commands.findIndex((command) => command.includes("remote set-url origin"));
+    const deps = commands.findIndex((command) => command.includes("install --frozen-lockfile"));
+    expect(scrub).toBeGreaterThanOrEqual(0);
+    expect(deps).toBeGreaterThan(scrub);
+  });
+
+  test("resolves the selected GitHub credential without a legacy clone credential", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-clone-credential-"));
+    const previous = {
+      config: process.env.OPENSESSION_CONFIG,
+      sandbox: process.env.OPENSESSION_SANDBOX_CONFIG,
+      token: process.env.GITHUB_API_TOKEN,
+    };
+    try {
+      const config = join(dir, "config.json");
+      const sandbox = join(dir, "sandbox.json");
+      writeFileSync(config, JSON.stringify({ integrations: { github: { botCredential: "pat" } } }));
+      writeFileSync(sandbox, JSON.stringify({ provider: "daytona" }));
+      process.env.OPENSESSION_CONFIG = config;
+      process.env.OPENSESSION_SANDBOX_CONFIG = sandbox;
+      process.env.GITHUB_API_TOKEN = "live-selected-token";
+
+      expect(
+        await injectCloneCredential("https://github.com/tellahq/opensession.git"),
+      ).toBe(
+        "https://x-access-token:live-selected-token@github.com/tellahq/opensession.git",
+      );
+      expect(
+        await injectCloneCredential(
+          "https://x-access-token:retired-pat@github.com/tellahq/opensession.git",
+        ),
+      ).toBe(
+        "https://x-access-token:live-selected-token@github.com/tellahq/opensession.git",
+      );
+    } finally {
+      if (previous.config === undefined) delete process.env.OPENSESSION_CONFIG;
+      else process.env.OPENSESSION_CONFIG = previous.config;
+      if (previous.sandbox === undefined) delete process.env.OPENSESSION_SANDBOX_CONFIG;
+      else process.env.OPENSESSION_SANDBOX_CONFIG = previous.sandbox;
+      if (previous.token === undefined) delete process.env.GITHUB_API_TOKEN;
+      else process.env.GITHUB_API_TOKEN = previous.token;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("remote engine credential projection", () => {
   test("every remote provider delegates launch credential projection to bootstrap", () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
@@ -94,6 +94,17 @@ describe("GitHub clone credential cutover", () => {
 });
 
 describe("remote engine credential projection", () => {
+  test("remote GitHub authority comes from server-owned sandbox state", () => {
+    const source = readFileSync(join(import.meta.dir, "bootstrap.ts"), "utf-8");
+    const projection = source.slice(
+      source.indexOf("// GitHub credentials are projected"),
+      source.indexOf("const githubAuthPath"),
+    );
+    expect(projection).toContain("readRemoteState(provider, sandboxId)?.repoId");
+    expect(projection).toContain("getRepo(repoId)");
+    expect(projection).not.toContain("git remote get-url origin");
+  });
+
   test("every remote provider delegates launch credential projection to bootstrap", () => {
     for (const provider of ["daytona", "box", "e2b", "modal"]) {
       const source = readFileSync(join(import.meta.dir, `${provider}.ts`), "utf-8");

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-lifecycle.test.ts
@@ -48,7 +48,7 @@ describe("remote repo lifecycle", () => {
 		expect(bootstrapSignature()).toContain("node@24.18.1");
 		expect(bootstrapSignature()).toContain("just@1.43.1");
 		expect(bootstrapSignature()).toContain("gh@2.83.1");
-		expect(bootstrapSignature()).toContain("workspace-runtime-v7");
+		expect(bootstrapSignature()).toContain("workspace-runtime-v8");
 	});
 
 	test("setup is skipped after its durable stamp", async () => {
@@ -190,6 +190,29 @@ describe("remote repo lifecycle", () => {
 		expect(d.commands[1]!.command).toContain("ln -s");
 		expect(d.commands[1]!.command).not.toContain("mount --bind");
 		expect(d.commands[2]!.command).toContain("git clone --filter=blob:none");
+	});
+
+	test("scrubs a short-lived GitHub token after the bounded clone", async () => {
+		const d = driver([
+			{ exitCode: 0, stdout: "none\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "feature/new-ui\n" },
+			{ exitCode: 0 },
+			{ exitCode: 0, stdout: "absent\n" },
+		]);
+		await setupRemoteWorkspace(
+			d.value,
+			"/work/feature",
+			"https://x-access-token:short-lived@github.com/tellahq/opensession.git",
+			"feature/new-ui",
+			"main",
+		);
+
+		const scrub = d.commands.find(({ command }) =>
+			command.startsWith("git remote set-url origin"),
+		);
+		expect(scrub?.command).toContain("https://github.com/tellahq/opensession.git");
+		expect(scrub?.command).not.toContain("short-lived");
 	});
 
 	test("cleans up a failed warm attach before cold-cloning", async () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -1723,13 +1723,15 @@ function makeRemoteLauncher(
         spec.mode === "code" &&
         (spec.journalKind || "").startsWith("github-");
       if (!githubAuth.GH_TOKEN && (!automationProfile || githubCodeAutomation)) {
-        const origin = await driver.exec("git remote get-url origin", { cwd: spec.cwd });
-        const match = origin.exitCode === 0
-          ? origin.stdout.trim().match(/^https:\/\/github\.com\/(?:x-access-token:[^@]+@)?([^/]+\/[^/]+)$/i)
-          : null;
-        if (match) {
+        // The sandbox origin is mutable by repository setup code. Bind service
+        // authority only to the server-owned repo id recorded at ensure time.
+        const repoId = readRemoteState(provider, sandboxId)?.repoId;
+        const registeredRepo = repoId
+          ? (await import("../../worktree")).getRepo(repoId)
+          : undefined;
+        if (registeredRepo?.host !== "codestorage" && registeredRepo?.ghRepo) {
           const { githubServiceCredentialEnv } = await import("../../github-app");
-          githubAuth = await githubServiceCredentialEnv(match[1].replace(/\.git$/i, ""));
+          githubAuth = await githubServiceCredentialEnv(registeredRepo.ghRepo);
         }
       }
       const githubAuthPath = `${dir}/github-auth.json`;

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -592,24 +592,83 @@ function credentialFreeHttpsUrl(httpsUrl: string): string {
   return parsed.toString();
 }
 
-function injectToken(httpsUrl: string): string {
-  const cred = sandboxConfig().cloneCredential;
-  if (cred?.type === "https-token") {
-    // A hosted instance keeps a long-lived, org-scoped bot credential in
-    // GITHUB_API_TOKEN. Prefer it for GitHub clones over the config's token:
-    // GitHub App user tokens expire in ~8h, so persisting one in sandbox.json
-    // makes every fresh Daytona/Modal bootstrap fail days later. Self-hosters
-    // without the env keep the explicit cloneCredential.token behavior, and
-    // non-GitHub origins never receive our GitHub-specific credential.
-    const liveGithubToken = /^https:\/\/github\.com\//i.test(httpsUrl)
-      ? process.env.GITHUB_API_TOKEN
-      : undefined;
-    const token = liveGithubToken || cred.token;
-    if (token) {
-      return httpsUrl.replace(/^https:\/\//, `https://x-access-token:${token}@`);
-    }
+function isGithubHttpsUrl(httpsUrl: string): boolean {
+  try {
+    const parsed = new URL(httpsUrl);
+    return parsed.protocol === "https:" && parsed.hostname.toLowerCase() === "github.com";
+  } catch {
+    return false;
   }
-  return httpsUrl;
+}
+
+/** Pick clone authority without crossing the operator's credential cutover.
+ * In App mode a missing live GitHub token fails closed; the persisted token may
+ * be the retired PAT. Non-GitHub hosts retain their explicit clone credential. */
+export function selectedCloneToken(
+  liveToken: string | undefined,
+  persistedToken: string | undefined,
+  github: boolean,
+  mode: "pat" | "app",
+): string | undefined {
+  return liveToken || (github && mode === "app" ? undefined : persistedToken);
+}
+
+/** App sandboxes require a repository-scoped mint. Never widen a failed mint
+ * to an installation-wide token; PAT mode uses only its selected PAT. */
+export function selectedGithubCloneLiveToken(
+  mode: "pat" | "app",
+  repositoryToken: string | undefined,
+  patToken: string | undefined,
+): string | undefined {
+  return mode === "app" ? repositoryToken : patToken;
+}
+
+export async function injectCloneCredential(httpsUrl: string): Promise<string> {
+  const cred = sandboxConfig().cloneCredential;
+  let parsed: URL;
+  try {
+    parsed = new URL(httpsUrl);
+  } catch {
+    return httpsUrl;
+  }
+  const github =
+    parsed.protocol === "https:" && parsed.hostname.toLowerCase() === "github.com";
+  let token: string | undefined;
+
+  if (github) {
+    // Always discard authority embedded in a persisted GitHub origin before
+    // applying the operator-selected credential.
+    parsed.username = "";
+    parsed.password = "";
+    const repository = parsed.pathname.replace(/^\/+|\.git$/g, "");
+    const {
+      githubAppRepositoryToken,
+      githubBotCredentialMode,
+      githubToken,
+    } = await import("../../github-app");
+    const mode = githubBotCredentialMode();
+    const liveToken = selectedGithubCloneLiveToken(
+      mode,
+      mode === "app"
+        ? (await githubAppRepositoryToken(repository)) || undefined
+        : undefined,
+      mode === "pat" ? (await githubToken()) || undefined : undefined,
+    );
+    token = selectedCloneToken(
+      liveToken,
+      cred?.type === "https-token" ? cred.token : undefined,
+      true,
+      mode,
+    );
+  } else if (cred?.type === "https-token") {
+    // Explicit credentials for non-GitHub hosts keep their existing behavior.
+    token = cred.token;
+  }
+
+  if (!token) return parsed.toString();
+  parsed.username = "x-access-token";
+  parsed.password = token;
+  return parsed.toString();
 }
 
 /**
@@ -647,7 +706,7 @@ export async function remoteCloneUrl(repo: {
       `repo ${repo.id} has no https-reachable origin (origin="${redactUrl(origin) || "none"}") — remote sandboxes clone over https; set an origin or ghRepo`,
     );
   }
-  return injectToken(https);
+  return await injectCloneCredential(https);
 }
 
 /**
@@ -928,7 +987,7 @@ export async function bootstrapRemoteSandbox(
   const runnerCloneUrl = cfg.runnerBundleUrl
     ? undefined
     : cfg.runnerRepoUrl && toHttpsUrl(cfg.runnerRepoUrl)
-      ? injectToken(toHttpsUrl(cfg.runnerRepoUrl)!)
+      ? await injectCloneCredential(toHttpsUrl(cfg.runnerRepoUrl)!)
       : await remoteCloneUrl(runnerRepo);
   const hasRepo = await driver.exec(`test -f ${REMOTE_REPO}/package.json`);
   if (hasRepo.exitCode !== 0) {
@@ -1236,11 +1295,14 @@ export async function warmRemoteWorkspace(
       return false;
     }
   }
+  // Repository code must never observe the short-lived clone token through
+  // remote.origin.url. Scrub before setup hooks or dependency installers run,
+  // including when adopting an existing partially prepared warm checkout.
+  await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
   if (opts?.runSetup) {
     await runRemoteLifecycleHook(driver, dir, "setup", "fresh", repo.id, opts.identity);
   }
   if (opts?.installDeps === false) {
-    await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
     log(opts.runSetup ? "ready (post-setup)" : "ready (clone only)");
     return true;
   }
@@ -1257,7 +1319,6 @@ export async function warmRemoteWorkspace(
   } else {
     log("ready");
   }
-  await scrubRemoteWarmWorkspaceAuthority(driver, repo, dir);
   return true;
 }
 
@@ -1365,8 +1426,8 @@ export async function setupRemoteWorkspace(
   }
   if (!cloned) {
     console.log(`[sandbox-remote] cloning ${redactUrl(cloneUrl)} into ${cwd}`);
-    // Blobless partial clone: full history/refs but blobs fetched lazily via
-    // the persisted (tokenized) origin URL. A large repo's full .git can be
+    // Blobless partial clone: full history/refs, with later blobs fetched via
+    // a fresh run-scoped credential helper. A large repo's full .git can be
     // ~2.4GB vs ~450MB blobless — on a 10GiB sandbox disk that headroom is
     // the difference between working and ENOSPC (verified live 2026-07-09:
     // full clone died on the default 3GiB disk with an EMPTY git error,
@@ -1412,6 +1473,19 @@ export async function setupRemoteWorkspace(
     }
   }
   mark("branch ready");
+  // Installation tokens expire in about an hour. Keep them only for this
+  // bounded clone/fetch, then leave a credential-free GitHub origin. Every run
+  // projects a fresh token through the process-local credential helper below,
+  // so lazy blob fetches and pushes never depend on a token at rest.
+  if (isGithubHttpsUrl(cloneUrl)) {
+    const safeOrigin = credentialFreeHttpsUrl(cloneUrl);
+    const scrubbed = await driver.exec(
+      `git remote set-url origin ${shellQuoteWord(safeOrigin)}`,
+      { cwd },
+    );
+    if (scrubbed.exitCode !== 0)
+      throw new Error(`could not scrub GitHub clone credential: ${scrubbed.stderr.trim().slice(0, 300)}`);
+  }
   // Per-session only: warm/template preparation never calls this path, so
   // private files are injected after restore and can never land in a shared
   // provider snapshot.
@@ -1636,13 +1710,28 @@ function makeRemoteLauncher(
       ]);
       secureFiles.push(claudeAccountsPath, REMOTE_MCP_CONFIG);
 
-      // Interactive parity for GitHub uses a run-scoped access-token file.
-      // Do not put it in spec.json or the launch command, and never project it
-      // into the fail-closed automation profile. githubRunEnv reads this file
-      // inside the guest and installs a process-local HTTPS credential helper.
-      const githubAuth = automationProfile
+      // GitHub credentials are projected through a private, run-scoped file,
+      // never spec.json, argv, or the persisted origin. Interactive runs prefer
+      // their user's token. GitHub code automations and user-less interactive
+      // runs receive a freshly resolved service credential for this one repo;
+      // every other automation stays credential-free.
+      let githubAuth = automationProfile
         ? {}
         : githubAuthEnv(spec.user || spec.author?.name);
+      const githubCodeAutomation =
+        automationProfile &&
+        spec.mode === "code" &&
+        (spec.journalKind || "").startsWith("github-");
+      if (!githubAuth.GH_TOKEN && (!automationProfile || githubCodeAutomation)) {
+        const origin = await driver.exec("git remote get-url origin", { cwd: spec.cwd });
+        const match = origin.exitCode === 0
+          ? origin.stdout.trim().match(/^https:\/\/github\.com\/(?:x-access-token:[^@]+@)?([^/]+\/[^/]+)$/i)
+          : null;
+        if (match) {
+          const { githubServiceCredentialEnv } = await import("../../github-app");
+          githubAuth = await githubServiceCredentialEnv(match[1].replace(/\.git$/i, ""));
+        }
+      }
       const githubAuthPath = `${dir}/github-auth.json`;
       if (githubAuth.GH_TOKEN) {
         await driver.writeFile(githubAuthPath, JSON.stringify(githubAuth));

--- a/packages/core/opensession-server/src/server/sandbox/config.ts
+++ b/packages/core/opensession-server/src/server/sandbox/config.ts
@@ -252,9 +252,9 @@ export interface SandboxConfig {
   firecrackerMicrovm?: SandboxFirecrackerMicrovmConfig;
   /** Credential-minimal unattended-run profile. */
   automation?: SandboxAutomationConfig;
-  /** Clone auth for remote-provider workspaces + runner bootstrap. On hosted
-   *  GitHub clones, the live GITHUB_API_TOKEN takes precedence so an expiring
-   *  GitHub App user token is never treated as durable sandbox config. */
+  /** Clone auth for remote-provider workspaces + runner bootstrap. The selected
+   *  live GitHub service credential takes precedence; App mode never falls back
+   *  to a persisted token because it may be the retired PAT. */
   cloneCredential?: SandboxCloneCredential;
   /** Warm-on-typing prewarm pool. Absent = defaults, with `enabled` true
    *  whenever a provider with a prewarm adapter is configured. */

--- a/packages/core/opensession-server/src/server/sandbox/prewarm.ts
+++ b/packages/core/opensession-server/src/server/sandbox/prewarm.ts
@@ -574,15 +574,21 @@ async function runPrewarmBootstrap(record: PrewarmRecord, adapter: PrewarmAdapte
           // refresh with "index.lock: File exists". This prewarm sandbox is
           // the clone's only writer, so clearing dead locks before syncing
           // is safe.
-          const refreshed = await driver.exec(
-            `find .git -name "*.lock" -type f -delete 2>/dev/null; ` +
-              `git remote set-url origin ${shellQuoteWord(cloneUrl)} && ` +
-              `git fetch origin ${shellQuoteWord(repo.defaultBranch)} --quiet && ` +
-              `git reset --hard ${shellQuoteWord(`origin/${repo.defaultBranch}`)}`,
-            { cwd: warmDir, timeoutMs: 10 * 60_000 },
-          );
-          if (refreshed.exitCode !== 0) {
-            throw new Error(`could not refresh ${repo.id} project image: ${(refreshed.stderr || refreshed.stdout).trim().slice(0, 300)}`);
+          try {
+            const refreshed = await driver.exec(
+              `find .git -name "*.lock" -type f -delete 2>/dev/null; ` +
+                `git remote set-url origin ${shellQuoteWord(cloneUrl)} && ` +
+                `git fetch origin ${shellQuoteWord(repo.defaultBranch)} --quiet && ` +
+                `git reset --hard ${shellQuoteWord(`origin/${repo.defaultBranch}`)}`,
+              { cwd: warmDir, timeoutMs: 10 * 60_000 },
+            );
+            if (refreshed.exitCode !== 0) {
+              throw new Error(`could not refresh ${repo.id} project image: ${(refreshed.stderr || refreshed.stdout).trim().slice(0, 300)}`);
+            }
+          } finally {
+            // A retained checkout must be safe both before repository setup
+            // runs and between transient refresh retries.
+            await scrubRemoteWarmWorkspaceAuthority(driver, repo, warmDir);
           }
         });
         // Updating source without rerunning setup republishes stale generated
@@ -595,7 +601,6 @@ async function runPrewarmBootstrap(record: PrewarmRecord, adapter: PrewarmAdapte
           provider: entry.provider,
           repoId: repo.id,
         });
-        await scrubRemoteWarmWorkspaceAuthority(driver, repo, warmDir);
       }
     } else if (adapter.prepare) {
       setPrewarmStage(entry, "Preparing project workspace", 40);

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, test, expect } from "bun:test";
 import {
+	GITHUB_APP_CODE_PERMISSIONS,
 	GITHUB_APP_GRANT_PERMISSIONS,
 	GITHUB_APP_READ_PERMISSIONS,
 	GITHUB_APP_WRITE_PERMISSIONS,
@@ -29,6 +30,13 @@ describe("github app permission sets", () => {
 		expect(uncoveredScopes(GITHUB_APP_WRITE_PERMISSIONS)).toEqual([]);
 	});
 
+	test("the repository code mint is within the grant", () => {
+		expect(uncoveredScopes(GITHUB_APP_CODE_PERMISSIONS)).toEqual([]);
+		expect(GITHUB_APP_CODE_PERMISSIONS.actions).toBe("read");
+		expect(GITHUB_APP_CODE_PERMISSIONS.checks).toBe("read");
+		expect(GITHUB_APP_CODE_PERMISSIONS.issues).toBe("write");
+	});
+
 	test("the grant includes the scopes the two capabilities depend on", () => {
 		// checks:read is the App-only capability (no PAT can read check runs);
 		// issues+pull_requests+contents:write are the agent's write path.
@@ -36,6 +44,8 @@ describe("github app permission sets", () => {
 		expect(GITHUB_APP_GRANT_PERMISSIONS.issues).toBe("write");
 		expect(GITHUB_APP_GRANT_PERMISSIONS.pull_requests).toBe("write");
 		expect(GITHUB_APP_GRANT_PERMISSIONS.contents).toBe("write");
+		expect(GITHUB_APP_READ_PERMISSIONS.members).toBe("read");
+		expect(GITHUB_APP_READ_PERMISSIONS.deployments).toBe("read");
 	});
 
 	test("the write mint carries no read-only scope whose absence would 422 it", () => {

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -16,18 +16,20 @@
 /** The full set the App is granted at creation — the create-URL permission
  *  params, and the superset of every mint. */
 export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
+	actions: "read", // workflow runs/logs for trusted autofix diagnosis
 	checks: "read", // CI check runs — App-only; no PAT can read them
 	statuses: "read", // commit statuses, the other half of the status rollup
 	contents: "write", // push fixes, clone
 	pull_requests: "write", // reviews, comments, open/merge
 	issues: "write", // issue and PR comments
 	members: "read", // team roster / attribution
+	deployments: "read", // Vercel preview deployment + status polling
 	metadata: "read", // required baseline
 };
 
 /** Read installation token (pr-info's statusCheckRollup) — the read view of the
- *  grant. Contents/pull_requests/issues at read, checks/statuses/metadata as
- *  granted. No `actions`: the rollup needs check runs and statuses, not workflow
+ *  grant. Contents/pull_requests/issues at read, plus checks/statuses, members,
+ *  deployments, and metadata as granted. No `actions`: the rollup needs check runs and statuses, not workflow
  *  runs, and requesting an ungranted scope would 422 the token. */
 export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
 	checks: "read",
@@ -35,6 +37,8 @@ export const GITHUB_APP_READ_PERMISSIONS: Record<string, string> = {
 	pull_requests: "read",
 	contents: "read",
 	issues: "read",
+	members: "read",
+	deployments: "read",
 	metadata: "read",
 };
 
@@ -46,4 +50,14 @@ export const GITHUB_APP_WRITE_PERMISSIONS: Record<string, string> = {
 	issues: "write",
 	contents: "write",
 	metadata: "read",
+};
+
+/** Repository-scoped token projected only to trusted GitHub code workflows.
+ * It can push/reply and inspect the failing checks and workflow logs it must
+ * diagnose, but remains bound to the one owner-verified repository. */
+export const GITHUB_APP_CODE_PERMISSIONS: Record<string, string> = {
+	...GITHUB_APP_WRITE_PERMISSIONS,
+	actions: "read",
+	checks: "read",
+	statuses: "read",
 };


### PR DESCRIPTION
Final stage of the GitHub App credential migration, based directly on merged #180 and #153. Supersedes #181 after retargeting across the lower squash merge produced a conflict.

## What changes

- Routes remaining GitHub readers and trusted code runs through the selected credential.
- Uses owner-verified, repository-scoped App tokens with the exact read/write capabilities each workflow needs.
- Scrubs ephemeral tokens before repository code and from warm/template/Daytona origins.
- Refreshes service credentials during recovery without connected-human or ambient-`gh` fallback.
- Keeps repository discovery, previews, MicroVMs, health checks, and rate probes inside the same fail-closed boundary.

## Safe rollout

The merged stack still defaults `integrations.github.botCredential` to `pat`. Deploy with PAT mode, provision and validate the App, then switch **Use the GitHub App for bot actions**. App mode has no hidden PAT fallback.

## Verification

- `bun run typecheck`
- Focused GitHub, setup, recovery, sandbox, preview, and lifecycle tests
- `bun scripts/check-module-side-effects.ts` (413 modules clean)
- Equivalent cumulative diff approved on #181 at confidence 5/5

Created by [this OS session](https://os.tella.dev/session/os-01a033fd-020d-76bc-be85-60b19b241fbc)
