### PR TITLE
Retire settled cancelled abnormal journals

### DIFF
--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from "fs";
 import { OPENSESSION_SESSIONS_DIR } from "./paths";
 import { } from "./paths";
 import { transitionRunState } from "./run-state";
+import { sessionTurn } from "./session-kernel/kernel";
 import { writeJsonAtomic } from "./shared/atomic-write";
 
 // Overridable so a detached run host (src/runner-host/host.ts) journals to its
@@ -356,6 +357,21 @@ export function journalRecordAbnormalCompletion(
     },
   };
   journalSet(failed);
+  if (!process.env.OPENSESSION_RUN_JOURNAL && failed.osSessionId) {
+    try {
+      const cancel = sessionTurn({
+        op: "snapshot",
+        sessionId: failed.osSessionId,
+      }).cancel;
+      // Source completion is positive physical evidence. Once the matching
+      // actor cancel is already settled, retain no zombie owner merely because
+      // the engine omitted its terminal event.
+      if (cancel?.runId === failed.runKey && cancel.phase === "settled")
+        journalClearIfLineage(failed);
+    } catch {
+      // Actor uncertainty retains the abnormal-completion evidence fail closed.
+    }
+  }
   return failed;
 }
 

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -174,6 +174,11 @@ describe("run journal", () => {
       // latch before the detached control reconnects.
       expect(agent.reissueDurableRecoveryCancel(recovery)).toBe(false);
       expect(agent.isAgentSessionCancelled(sessionId, runKey)).toBe(true);
+      mod.journalSet(recovery);
+      mod.journalRecordAbnormalCompletion(recovery);
+      expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
+        false,
+      );
     } finally {
       agent.unmarkSessionStarting(sessionId, runKey);
       store.clearSession(sessionId);


### PR DESCRIPTION
## Summary
- retire an abnormal-completion journal when its exact durable turn cancel already settled
- keep detached-host private journals and actor-uncertain evidence unchanged
- prevent cancelled runs that ended without a terminal frame from remaining permanently busy until restart

## Live evidence
A schema-13 Stop canary settled `confirmed` and physically aborted its bash command, but its source ended without a terminal event. The retained `terminalFailure` journal kept the session visibly running despite zero pending/dead-lettered outbox work. This closes that post-settlement cleanup gap.

## Verification
- `bun run typecheck`
- `bun test packages/core/opensession-server/src/server/zz-run-journal.test.ts` (45 pass)
- `bun scripts/check-module-side-effects.ts` (414 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
