### PR TITLE
Close cancel abnormal settlement race

### DIFF
--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -607,7 +607,7 @@ export function beginPromptInterruptEffect(
 	sessionId: string,
 	interruptId: string,
 	runGeneration: number,
-): "execute" | "retry" | "adopt_confirmed" | "settled" {
+): "execute" | "retry" | "adopt_confirmed" | "confirmed" | "settled" {
 	return sessionDelivery({
 		op: "begin_interrupt_effect",
 		sessionId,

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from "fs";
 import { OPENSESSION_SESSIONS_DIR } from "./paths";
 import { } from "./paths";
 import { transitionRunState } from "./run-state";
-import { sessionTurn } from "./session-kernel/kernel";
+import { sessionDelivery, sessionTurn } from "./session-kernel/kernel";
 import { writeJsonAtomic } from "./shared/atomic-write";
 
 // Overridable so a detached run host (src/runner-host/host.ts) journals to its
@@ -357,22 +357,60 @@ export function journalRecordAbnormalCompletion(
     },
   };
   journalSet(failed);
-  if (!process.env.OPENSESSION_RUN_JOURNAL && failed.osSessionId) {
-    try {
-      const cancel = sessionTurn({
-        op: "snapshot",
-        sessionId: failed.osSessionId,
-      }).cancel;
-      // Source completion is positive physical evidence. Once the matching
-      // actor cancel is already settled, retain no zombie owner merely because
-      // the engine omitted its terminal event.
-      if (cancel?.runId === failed.runKey && cancel.phase === "settled")
-        journalClearIfLineage(failed);
-    } catch {
-      // Actor uncertainty retains the abnormal-completion evidence fail closed.
-    }
-  }
+  journalRetireSettledCancelAbnormal(failed.osSessionId, failed.runKey);
   return failed;
+}
+
+/** Retire an exact abnormal-completion owner only after its actor cancel has
+ * settled. Called from both sides of the race: source completion and actor
+ * settlement. Private detached-host journals never consult gateway actor state. */
+function retireCancelAbnormalEvidence(
+  sessionId: string | undefined,
+  runKey: string,
+): boolean {
+  if (process.env.OPENSESSION_RUN_JOURNAL || !sessionId) return false;
+  const current = readRunJournal()[runKey];
+  if (!current?.terminalFailure || current.osSessionId !== sessionId)
+    return false;
+  return journalClearIfLineage(current);
+}
+
+/** Source-side race participant: actor uncertainty retains evidence because
+ * the durable effect will perform the authoritative settlement-side check. */
+export function journalRetireSettledCancelAbnormal(
+  sessionId: string | undefined,
+  runKey: string,
+): boolean {
+  if (process.env.OPENSESSION_RUN_JOURNAL || !sessionId) return false;
+  try {
+    const cancel = sessionTurn({ op: "snapshot", sessionId }).cancel;
+    if (cancel?.runId === runKey && cancel.phase === "settled")
+      return retireCancelAbnormalEvidence(sessionId, runKey);
+  } catch {
+    // The independent interrupt owner may still positively prove settlement.
+  }
+  try {
+    const delivery = sessionDelivery({ op: "snapshot", sessionId });
+    const dispatchedInterrupt = (
+      delivery.dispatch as { interrupt?: typeof delivery.interrupt } | undefined
+    )?.interrupt;
+    const interrupt = delivery.interrupt || dispatchedInterrupt;
+    if (interrupt?.dispatchId === runKey && interrupt.phase === "confirmed")
+      return retireCancelAbnormalEvidence(sessionId, runKey);
+  } catch {
+    // Neither independent actor domain proved settlement; retain evidence.
+  }
+  return false;
+}
+
+/** Settlement-side race participant. The caller has just committed settlement
+ * or read an authoritative `settled` decision, so no second actor snapshot may
+ * turn a successful durable effect into an acknowledged cleanup gap. */
+export function journalRetireCancelledAbnormalAfterSettlement(
+  sessionId: string,
+  runKey: string,
+): boolean {
+  return retireCancelAbnormalEvidence(sessionId, runKey);
 }
 
 export function journalClear(runKey: string): void {

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -64,6 +64,7 @@ import { takeVoiceHandoff } from "./desk-voice";
 import {
 	activeRunRecords,
   journalClearIfLineage,
+  journalRetireCancelledAbnormalAfterSettlement,
 	setJournalSetListener,
 	type ActiveRunRecord,
 } from "./run-journal";
@@ -184,14 +185,26 @@ const interruptExecutorGlobal = globalThis as typeof globalThis & {
 if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
 	registerSessionEffectExecutor("delivery_interrupt_cancel", (item) => {
     const { interruptId, dispatchId, runIds, runGeneration } = item.payload;
+    const retireConfirmedAbnormal = () => {
+      if (dispatchId)
+        journalRetireCancelledAbnormalAfterSettlement(
+          item.sessionId,
+          dispatchId,
+        );
+    };
 		const decision = beginPromptInterruptEffect(
 			item.sessionId,
 			interruptId,
 			runGeneration,
 		);
-		if (decision === "settled") return;
+    if (decision === "settled") return;
+    if (decision === "confirmed") {
+      retireConfirmedAbnormal();
+      return;
+    }
 		if (decision === "adopt_confirmed") {
 			settlePromptInterrupt(item.sessionId, interruptId, "confirmed");
+      retireConfirmedAbnormal();
 			return;
 		}
     const aborted = dispatchId
@@ -200,11 +213,10 @@ if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
 		// A retry follows a durably recorded executing phase. False then means
 		// either the first attempt already cancelled the owner or this retry found
 		// it terminal, so the accepted interrupt is conservatively confirmed.
-		settlePromptInterrupt(
-			item.sessionId,
-			interruptId,
-			aborted || decision === "retry" ? "confirmed" : "not_aborted",
-		);
+    const outcome =
+      aborted || decision === "retry" ? "confirmed" : "not_aborted";
+		settlePromptInterrupt(item.sessionId, interruptId, outcome);
+    if (outcome === "confirmed") retireConfirmedAbnormal();
 	});
 	interruptExecutorGlobal.__opensessionInterruptExecutorRegistered = true;
 }
@@ -230,6 +242,10 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       runGeneration,
     });
     if (decision === "settled") {
+      journalRetireCancelledAbnormalAfterSettlement(
+        item.sessionId,
+        dispatchId,
+      );
       retireAbsentInProcessOwner();
       return;
     }
@@ -240,6 +256,10 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
         cancelId,
         outcome,
       });
+      journalRetireCancelledAbnormalAfterSettlement(
+        item.sessionId,
+        dispatchId,
+      );
       // An explicit prompt may already be parked behind this cancellation.
       // Re-arm delivery only after actor settlement removes the cancel gate.
       watchExternalRunAndDrain(item.sessionId);

--- a/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
@@ -125,7 +125,7 @@ export type DeliveryActorResult<T extends DeliveryActorRequest> =
                     soloId?: string;
                   }
                 : T extends { op: "begin_interrupt_effect" }
-                  ? "execute" | "retry" | "adopt_confirmed" | "settled"
+                  ? "execute" | "retry" | "adopt_confirmed" | "confirmed" | "settled"
                   : T extends { op: "settle_interrupt" }
                     ? boolean
                   : void;

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1565,6 +1565,11 @@ describe("SessionKernel", () => {
 				interruptId: "interrupt-restart-interrupt",
 				outcome: "confirmed",
 			})).toBe(true);
+      expect(recoveredDuringCancel.beginDeliveryInterruptEffect({
+        sessionId: "restart-interrupt",
+        interruptId: "interrupt-restart-interrupt",
+        runGeneration: interrupt?.runGeneration ?? -1,
+      })).toBe("confirmed");
 			expect(recoveredDuringCancel.claimNextDeliveryDispatch({
 				sessionId: "restart-interrupt",
 				promptEntryId: "restart-entry",
@@ -1588,6 +1593,16 @@ describe("SessionKernel", () => {
 				promptEntryId: "retry-entry",
 				stillWorking: true,
 			})).toMatchObject({ kind: "deliver", interrupted: true });
+      const claimedInterrupt = (
+        recoveredAfterClaim.deliverySnapshot("restart-interrupt").dispatch as {
+          interrupt?: { runGeneration: number };
+        }
+      ).interrupt;
+      expect(recoveredAfterClaim.beginDeliveryInterruptEffect({
+        sessionId: "restart-interrupt",
+        interruptId: "interrupt-restart-interrupt",
+        runGeneration: claimedInterrupt?.runGeneration ?? -1,
+      })).toBe("confirmed");
 		} finally {
 			recoveredAfterClaim.close();
 			rmSync(dir, { recursive: true, force: true });

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -438,6 +438,16 @@ describe("single session ownership", () => {
     expect(runSession).toContain('registerSessionEffectExecutor("turn_cancel"');
     expect(runSession).toContain("cancelAgentRunToken(dispatchId)");
     expect(runSession).toContain("cancelAgentRunTokenAndWait(dispatchId)");
+    expect(runSession).toContain(
+      "journalRetireCancelledAbnormalAfterSettlement(",
+    );
+    const interruptSettle = runSession.indexOf(
+      "settlePromptInterrupt(",
+      runSession.indexOf("beginPromptInterruptEffect("),
+    );
+    expect(runSession.indexOf("retireConfirmedAbnormal();", interruptSettle)).toBeGreaterThan(
+      interruptSettle,
+    );
     const agentRunner = read("agent-runner.ts");
     expect(agentRunner).toContain(
       'if (cancelOwnership === "unknown") {',

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2349,15 +2349,18 @@ export class SessionKernelStore {
     sessionId: string;
     interruptId: string;
     runGeneration: number;
-  }): "execute" | "retry" | "adopt_confirmed" | "settled" {
+  }): "execute" | "retry" | "adopt_confirmed" | "confirmed" | "settled" {
     return this.mutateDelivery(
       input.sessionId,
       "delivery_interrupt_effect_started",
       (state) => {
-        const interrupt = state.interrupt;
+        const dispatchInterrupt = (
+          state.dispatch as { interrupt?: DurableDeliveryState["interrupt"] } | undefined
+        )?.interrupt;
+        const interrupt = state.interrupt || dispatchInterrupt;
         if (!interrupt || interrupt.interruptId !== input.interruptId)
           return "settled" as const;
-        if (interrupt.phase === "confirmed") return "settled" as const;
+        if (interrupt.phase === "confirmed") return "confirmed" as const;
         if (
           interrupt.runGeneration !== input.runGeneration ||
           this.runState(input.sessionId).generation !== input.runGeneration
@@ -2366,7 +2369,12 @@ export class SessionKernelStore {
         state.interrupt = { ...interrupt, phase: "executing" };
         return "execute" as const;
       },
-    ).result as "execute" | "retry" | "adopt_confirmed" | "settled";
+    ).result as
+      | "execute"
+      | "retry"
+      | "adopt_confirmed"
+      | "confirmed"
+      | "settled";
   }
 
   settleDeliveryInterrupt(input: {

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -185,6 +185,111 @@ describe("run journal", () => {
     }
   });
 
+  it("retires abnormal ownership when actor settlement wins the reverse race", () => {
+    const sessionId = `cancel-abnormal-reverse-${crypto.randomUUID()}`;
+    const runKey = `rh-${crypto.randomUUID()}`;
+    const store = sessionKernelStore();
+    const record: mod.ActiveRunRecord = {
+      runKey,
+      hostId: runKey,
+      osSessionId: sessionId,
+      cwd: "/tmp",
+      startedAt: new Date().toISOString(),
+    };
+    try {
+      store.applyRunEvent({ sessionId, event: "prompt" });
+      store.applyRunEvent({ sessionId, event: "run_registered", runKey });
+      const generation = store.runState(sessionId).generation;
+      store.prepareTurnCancel({
+        sessionId,
+        cancelId: `stop:${runKey}`,
+        expectedRunId: runKey,
+        expectedGeneration: generation,
+        dispatchId: runKey,
+        requeueIds: [],
+        source: "test",
+      });
+      expect(store.beginTurnCancelEffect({
+        sessionId,
+        cancelId: `stop:${runKey}`,
+        runGeneration: generation,
+      })).toBe("execute");
+      mod.journalSet(record);
+      mod.journalRecordAbnormalCompletion(record);
+      expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(true);
+      store.settleTurnCancel({
+        sessionId,
+        cancelId: `stop:${runKey}`,
+        outcome: "confirmed",
+      });
+      expect(mod.journalRetireSettledCancelAbnormal(sessionId, runKey)).toBe(true);
+      expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(false);
+    } finally {
+      mod.journalClear(runKey);
+      store.clearSession(sessionId);
+    }
+  });
+
+  it("retires confirmed interrupt abnormal ownership in both race orders", () => {
+    const store = sessionKernelStore();
+    for (const sourceFirst of [true, false]) {
+      const sessionId = `interrupt-abnormal-${sourceFirst}-${crypto.randomUUID()}`;
+      const runKey = `rh-${crypto.randomUUID()}`;
+      const interruptId = `interrupt-${crypto.randomUUID()}`;
+      const record: mod.ActiveRunRecord = {
+        runKey,
+        hostId: runKey,
+        osSessionId: sessionId,
+        cwd: "/tmp",
+        startedAt: new Date().toISOString(),
+      };
+      try {
+        store.applyRunEvent({ sessionId, event: "prompt" });
+        store.applyRunEvent({ sessionId, event: "run_registered", runKey });
+        store.setDeliverySlot(sessionId, "queued", [
+          { id: "anchor", content: "interrupt now" },
+        ]);
+        const prepared = store.prepareDeliveryInterrupt({
+          sessionId,
+          interruptId,
+          anchorId: "anchor",
+          dispatchId: runKey,
+        });
+        if (sourceFirst) {
+          expect(store.beginDeliveryInterruptEffect({
+            sessionId,
+            interruptId,
+            runGeneration: prepared.runGeneration,
+          })).toBe("execute");
+          mod.journalSet(record);
+          mod.journalRecordAbnormalCompletion(record);
+          expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
+            true,
+          );
+        }
+        store.settleDeliveryInterrupt({
+          sessionId,
+          interruptId,
+          outcome: "confirmed",
+        });
+        if (sourceFirst) {
+          expect(
+            mod.journalRetireCancelledAbnormalAfterSettlement(sessionId, runKey),
+          ).toBe(true);
+        } else {
+          mod.journalSet(record);
+          mod.journalRecordAbnormalCompletion(record);
+        }
+        expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
+          false,
+        );
+      } finally {
+        mod.journalClear(runKey);
+        store.clearSession(sessionId);
+      }
+    }
+  });
+
 	it("keeps an active cancelled recovery reserved until its worker exits", async () => {
 		const sessionId = `active-recovery-${crypto.randomUUID()}`;
 		let release!: () => void;


### PR DESCRIPTION
## Summary
- check exact cancelled abnormal ownership from both sides of the source-completion versus actor-settlement race
- retire only shared-gateway journals with terminal-failure evidence, matching run identity, settled cancel phase, and matching lineage
- retain private host journals and actor-uncertain evidence fail closed

## Verification
- `bun run typecheck`
- `bun test packages/core/opensession-server/src/server/zz-run-journal.test.ts packages/core/opensession-server/src/server/session-kernel/ownership.test.ts` (71 pass)
- `bun scripts/check-module-side-effects.ts` (414 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
