### PR TITLE
Fence cancel settlement cleanup ownership

### DIFF
--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -241,6 +241,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       cancelId,
       runGeneration,
     });
+    if (decision === "missing") return;
     if (decision === "settled") {
       journalRetireCancelledAbnormalAfterSettlement(
         item.sessionId,
@@ -249,13 +250,14 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       retireAbsentInProcessOwner();
       return;
     }
-    const settle = (outcome: "confirmed" | "not_aborted") => {
-      sessionTurn({
+    const settle = (outcome: "confirmed" | "not_aborted"): boolean => {
+      const settled = sessionTurn({
         op: "settle_cancel",
         sessionId: item.sessionId,
         cancelId,
         outcome,
       });
+      if (!settled) return false;
       journalRetireCancelledAbnormalAfterSettlement(
         item.sessionId,
         dispatchId,
@@ -263,6 +265,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       // An explicit prompt may already be parked behind this cancellation.
       // Re-arm delivery only after actor settlement removes the cancel gate.
       watchExternalRunAndDrain(item.sessionId);
+      return true;
     };
     if (decision === "adopt_confirmed") {
       settle("confirmed");
@@ -274,7 +277,10 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       throw new Error(
         `Could not reconcile executing cancellation ${cancelId} for ${dispatchId}`,
       );
-    settle(cancelledWait || cancelledRun ? "confirmed" : "not_aborted");
+    const settled = settle(
+      cancelledWait || cancelledRun ? "confirmed" : "not_aborted",
+    );
+    if (!settled) return;
     // A pre-engine in-process journal cannot have survived this gateway boot.
     // Retire it only after actor settlement. Detached host/Runner/sandbox
     // records stay for their attached source to complete naturally.

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1504,6 +1504,31 @@ describe("SessionKernel", () => {
         phase: "settled",
         outcome: "confirmed",
       });
+      expect(duringPhysicalCancel.beginTurnCancelEffect({
+        sessionId: "cancel-restart",
+        cancelId: "cancel-one",
+        runGeneration: cancel?.runGeneration ?? -1,
+      })).toBe("settled");
+      const successor = duringPhysicalCancel.runState("cancel-restart");
+      duringPhysicalCancel.prepareTurnCancel({
+        sessionId: "cancel-restart",
+        cancelId: "cancel-two",
+        expectedRunId: "run-two",
+        expectedGeneration: successor.generation,
+        dispatchId: "run-two",
+        requeueIds: [],
+        source: "test",
+      });
+      expect(duringPhysicalCancel.beginTurnCancelEffect({
+        sessionId: "cancel-restart",
+        cancelId: "cancel-one",
+        runGeneration: cancel?.runGeneration ?? -1,
+      })).toBe("missing");
+      expect(duringPhysicalCancel.settleTurnCancel({
+        sessionId: "cancel-restart",
+        cancelId: "cancel-one",
+        outcome: "confirmed",
+      })).toBe(false);
     } finally {
       duringPhysicalCancel.close();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -441,6 +441,20 @@ describe("single session ownership", () => {
     expect(runSession).toContain(
       "journalRetireCancelledAbnormalAfterSettlement(",
     );
+    const turnExecutor = runSession.indexOf(
+      'registerSessionEffectExecutor("turn_cancel"',
+    );
+    const missingCancel = runSession.indexOf(
+      'if (decision === "missing") return;',
+      turnExecutor,
+    );
+    expect(missingCancel).toBeLessThan(
+      runSession.indexOf(
+        "journalRetireCancelledAbnormalAfterSettlement(",
+        missingCancel,
+      ),
+    );
+    expect(runSession).toContain("if (!settled) return false;");
     const interruptSettle = runSession.indexOf(
       "settlePromptInterrupt(",
       runSession.indexOf("beginPromptInterruptEffect("),

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2194,10 +2194,10 @@ export class SessionKernelStore {
     sessionId: string;
     cancelId: string;
     runGeneration: number;
-  }): "execute" | "retry" | "adopt_confirmed" | "settled" {
+  }): "execute" | "retry" | "adopt_confirmed" | "settled" | "missing" {
     const prior = this.turnSnapshot(input.sessionId).cancel;
-    if (!prior || prior.cancelId !== input.cancelId || prior.phase === "settled")
-      return "settled";
+    if (!prior || prior.cancelId !== input.cancelId) return "missing";
+    if (prior.phase === "settled") return "settled";
     if (
       prior.runGeneration !== input.runGeneration ||
       this.runState(input.sessionId).generation !== input.runGeneration

--- a/packages/core/opensession-server/src/server/session-kernel/turn-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/turn-protocol.ts
@@ -46,7 +46,7 @@ export type TurnActorResult<T extends TurnActorRequest> =
           runState: DurableRunState;
         }
       : T extends { op: "begin_cancel_effect" }
-        ? "execute" | "retry" | "adopt_confirmed" | "settled"
+        ? "execute" | "retry" | "adopt_confirmed" | "settled" | "missing"
         : T extends { op: "settle_cancel" }
           ? boolean
           : never;


### PR DESCRIPTION
## Summary
- distinguish an exact already-settled turn cancel from missing or replaced ownership
- skip journal cleanup for stale outbox effects and honor the boolean result of settlement after physical cancellation
- cover exact settled, replacement, missing, and rejected settlement behavior

## Verification
- `bun run typecheck`
- 85 focused kernel and ownership tests
- `bun scripts/check-module-side-effects.ts` (414 modules)
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
