### PR TITLE
Stop deep links landing on the viewer's last session

### DIFF
--- a/packages/core/opensession-server/src/frontend/sw.js
+++ b/packages/core/opensession-server/src/frontend/sw.js
@@ -78,6 +78,13 @@ const NAV_STALL_MS = 5000;
 // matches sw.js itself (no dash) or icons/splash (not js/css).
 const ASSET_RE = /^\/(?:opensession\/|backstage\/)?[\w.]+-\w+\.(?:js|css)$/;
 const API_RE = /^\/(?:opensession\/|backstage\/)?api\//;
+// Server routes that answer a navigation with a REDIRECT rather than the app
+// shell. The stall guard below must never fire on these: they can legitimately
+// take longer than NAV_STALL_MS (a Plain triage boot runs 15-120s), and
+// painting the shell over one strands the document at a URL the router has no
+// route for — which the app then treats as "landed on home" and replaces with
+// the viewer's last session. Let them go straight to the network and redirect.
+const REDIRECT_RE = /^\/(?:opensession\/|backstage\/)?plain-triage\//;
 // A build ships ~a dozen chunks; 80 keeps a few builds' worth before pruning.
 const MAX_ASSETS = 80;
 
@@ -112,7 +119,11 @@ self.addEventListener("fetch", (event) => {
   if (req.method !== "GET") return;
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
-  if (req.mode === "navigate" && !API_RE.test(url.pathname)) {
+  if (
+    req.mode === "navigate" &&
+    !API_RE.test(url.pathname) &&
+    !REDIRECT_RE.test(url.pathname)
+  ) {
     event.respondWith(shellNavigate(req));
   } else if (ASSET_RE.test(url.pathname)) {
     event.respondWith(hashedAsset(req));

--- a/packages/core/opensession-server/src/server/routes/plain.ts
+++ b/packages/core/opensession-server/src/server/routes/plain.ts
@@ -15,13 +15,10 @@ import {
 } from "../session-cache";
 import { type Workspace } from "../workspaces";
 
-// Land a Plain thread in a triage session: reuse the most recent live
-// (non-archived) session already linked to the thread, else kick off the
-// "Plain ticket triage" automation with the same context the webhook event
-// carries and wait (up to 2 min) for its session to boot. Shared by the
-// /plain-triage redirect (Plain support cards) and the JSON API behind the
-// Support view's "Triage this ticket" button.
-async function resolvePlainTriageSession(
+// The most recent live (non-archived) session already triaging this thread,
+// or null when the ticket has never been opened here. A cache read — cheap
+// enough to sit in front of a redirect that must answer immediately.
+async function existingPlainTriageSession(
 	threadId: string,
 ): Promise<string | null> {
 	const existing = (await getCachedSessionsAsync())
@@ -30,7 +27,21 @@ async function resolvePlainTriageSession(
 			(a, b) =>
 				new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime(),
 		)[0];
-	if (existing) return existing.id;
+	return existing ? existing.id : null;
+}
+
+// Land a Plain thread in a triage session: reuse the most recent live
+// (non-archived) session already linked to the thread, else kick off the
+// "Plain ticket triage" automation with the same context the webhook event
+// carries and wait (up to 2 min) for its session to boot. The JSON API behind
+// the Support view's "Triage this ticket" button awaits this; the
+// /plain-triage redirect must NOT (see the handler — a navigation that hangs
+// for minutes gets replaced by the cached app shell and loses its URL).
+async function resolvePlainTriageSession(
+	threadId: string,
+): Promise<string | null> {
+	const existing = await existingPlainTriageSession(threadId);
+	if (existing) return existing;
 
 	const automation = listAutomations().find(
 		(a) => a.eventKey === "plain:thread_created",
@@ -124,18 +135,35 @@ export async function handlePlainRoutes(
 	// exists for this thread, jump straight to it; otherwise start a fresh
 	// triage run with the same context the automation gets on thread_created.
 	// Linked from the Plain support cards.
+	//
+	// This ALWAYS answers immediately. Booting a triage session takes 15-120s,
+	// and a navigation held open that long is not a slow page — the service
+	// worker's stall guard paints the cached app shell over it after 5s, at a
+	// URL the router has no route for, and the app falls back to restoring the
+	// viewer's last session (looks like "the link opened the wrong ticket").
+	// So: hand back the thread-scoped Support view, which renders the real
+	// ticket right away, and let the run boot behind it — the session files
+	// itself under this thread's workspace and appears as a tab there.
 	const plainTriageMatch = path.match(
 		/^\/plain-triage\/([^/]+)$/,
 	);
 	if (plainTriageMatch && req.method === "GET") {
 		const threadId = decodeURIComponent(plainTriageMatch[1]);
-		const sessionId = await resolvePlainTriageSession(threadId);
+		const sessionId = await existingPlainTriageSession(threadId);
+		if (!sessionId) {
+			void resolvePlainTriageSession(threadId).catch((e) =>
+				console.error(`[plain-triage] Background boot for ${threadId} failed:`, e),
+			);
+		}
+		console.log(
+			`[plain-triage] ${threadId} -> ${sessionId ? `session ${sessionId}` : "support view (triage booting)"}`,
+		);
 		return new Response(null, {
 			status: 302,
 			headers: {
 				Location: sessionId
 					? `${publicPrefix}/session/${sessionId}`
-					: `${publicPrefix}/`,
+					: `${publicPrefix}/support/${encodeURIComponent(threadId)}`,
 			},
 		});
 	}

--- a/packages/core/opensession-server/src/server/routes/static-assets.ts
+++ b/packages/core/opensession-server/src/server/routes/static-assets.ts
@@ -32,6 +32,12 @@ export function pwaManifest(publicPrefix: string) {
 		start_url: `${publicPrefix}/`,
 		display: "standalone",
 		display_override: ["window-controls-overlay"],
+		// A link into the app from outside it (a Plain card, a Slack message)
+		// navigates the installed window to that link. Without this the default
+		// is to focus the existing window and ignore the URL, so the deep link
+		// silently lands on whatever was already open — and there is no history
+		// entry behind it, so Back does nothing either.
+		launch_handler: { client_mode: "navigate-existing" },
 		// Match the current dark page and chrome surfaces. WebKit exposes the
 		// manifest background if its standalone window is briefly letterboxed.
 		background_color: "#1c1c1c",


### PR DESCRIPTION
A link into OS from Plain ("Open OS ↗") or Slack could open whatever session the viewer last had open, instead of the ticket or session it named.

## Why

Three separate causes, all ending in the same place. `App.tsx:721-748` restores the last session from `localStorage` on a cold load when the path resolves to the home view — added because iOS evicts standalone PWAs and relaunches them at `start_url`. But `{view: "prs"}` is also `parseRoute`s catch-all for **any** path it does not recognise, so "the deep link did not survive" and "go to my last session" are the same branch.

| # | Cause | Fix |
| --- | --- | --- |
| 1 | `/plain-triage/<id>` holds the navigation open 15-120s while it boots the triage automation; the service worker stall guard paints the cached shell after 5s, stranding the document at a URL the router cannot parse | Route answers immediately |
| 2 | The SW applies its shell fallback to every navigation, including server routes that answer with a redirect | Skip those routes |
| 3 | The manifest declares no `launch_handler`, so a link click focuses the installed window and ignores the URL — nothing navigates, and Back does nothing | `client_mode: navigate-existing` |

## What changed

- **`src/server/routes/plain.ts`** — split the cheap cache lookup (`existingPlainTriageSession`) out of the boot-and-wait (`resolvePlainTriageSession`). The `/plain-triage/<id>` redirect now always answers immediately: an existing linked session still redirects to `/session/<id>`; otherwise the triage run is kicked off in the background and the redirect goes to `/support/<threadId>`, which renders the real ticket right away and gains the session as a tab under the ticket workspace once it boots. The JSON twin behind the Support views "Triage this ticket" button still awaits, since its client shows a progress state. Each resolution is now logged.
- **`src/frontend/sw.js`** — added `REDIRECT_RE` and excluded those paths from `shellNavigate`, so a redirecting route can never be replaced by the cached shell at a URL the router has no route for.
- **`src/server/routes/static-assets.ts`** — `launch_handler: { client_mode: "navigate-existing" }` on the PWA manifest.

## Notes

- Backend change: needs `systemctl restart opensession` after merge. The SW and manifest ship with the frontend rebuild; installed PWAs pick up the new manifest on their next update check.
- `sw.test.ts` passes. The other failures in `src/server/routes/` are missing `node_modules` in the fresh worktree, unrelated to this diff.

Started by Johnny Lin in [this OS session](https://os.tella.dev/session/slack-C0BE8KVFBEX-1787586472.612789)