### PR TITLE
Retire settled automation intents during recovery

### DIFF
--- a/packages/core/opensession-server/src/server/automation-intent-recovery.test.ts
+++ b/packages/core/opensession-server/src/server/automation-intent-recovery.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { automationIntentAlreadySettled } from "./automation-intent-recovery";
+
+describe("automation intent recovery", () => {
+  test("recognizes a completed durable run", () => {
+    expect(
+      automationIntentAlreadySettled("session-1", [
+        { sessionId: "session-1", status: "error" },
+      ]),
+    ).toBe(true);
+  });
+
+  test("does not settle a run that still owns execution", () => {
+    expect(
+      automationIntentAlreadySettled("session-1", [
+        { sessionId: "session-1", status: "running" },
+      ]),
+    ).toBe(false);
+  });
+
+  test("does not cross session identities", () => {
+    expect(
+      automationIntentAlreadySettled("session-1", [
+        { sessionId: "session-2", status: "ok" },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/automation-intent-recovery.ts
+++ b/packages/core/opensession-server/src/server/automation-intent-recovery.ts
@@ -1,0 +1,6 @@
+export function automationIntentAlreadySettled(
+  sessionId: string,
+  runs: readonly { sessionId: string; status: "running" | "ok" | "error" }[],
+): boolean {
+  return runs.some((run) => run.sessionId === sessionId && run.status !== "running");
+}

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -79,6 +79,7 @@ import {
   sanitizeAutomationOutputs,
   type AutomationOutput,
 } from "./automation-outputs";
+import { automationIntentAlreadySettled } from "./automation-intent-recovery";
 
 const AUTOMATIONS_DIR = stateDir("automations");
 const SESSIONS_DIR = OPENSESSION_SESSIONS_DIR;
@@ -1207,6 +1208,13 @@ export function resumePendingAutomationRuns(
       ) throw new Error("invalid automation intent");
       const automation = getAutomation(intent.automationId);
       if (!automation) throw new Error(`automation ${intent.automationId} is unavailable`);
+      if (automationIntentAlreadySettled(intent.sessionId, automation.runs || [])) {
+        const completedIntent = clearAutomationIntent(intent.sessionId);
+        if (completedIntent?.deleteAutomationAfterRun)
+          deleteAutomation(automation.id);
+        resumed++;
+        continue;
+      }
       if (intent.terminalAt) {
         settleRun(automation.id, intent.sessionId, {
           status: intent.terminalError ? "error" : "ok",


### PR DESCRIPTION
## Summary
- retire accepted automation intents when their same-session durable run ledger is already terminal
- prevent restart recovery from replaying physically completed automation work
- cover terminal, running, and cross-session recovery decisions

## Verification
- `bun test packages/core/opensession-server/src/server/automation-intent-recovery.test.ts packages/core/opensession-server/src/server/shutdown-intake.test.ts`
- `bun run typecheck`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
