### PR TITLE
Let actor decide turn start admission

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -228,6 +228,10 @@ responsive even while a gateway command is waiting on external work.
 
 Registering a new run id increments the session generation. Registering the
 same logical run again, such as a detached host reconnect, keeps its generation.
+Prompt preparation also takes the actor decision before installing any gateway
+reservation. A rejected candidate remains a cancelled local token and cannot
+replace or launch ahead of the actor's current run, even when the gateway lost
+its in-memory projection of that owner.
 
 Schema 14 moves normal and opening-turn terminal outcome persistence behind the
 typed `turn_outcome_project` effect. The actor validates the immutable run id and

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -18,6 +18,7 @@ import {
   type QuarantinedRun,
 } from "./run-journal";
 import {
+  decideRunStateTransition,
   getRunState,
   isRunStateUnsettled,
   transitionRunState,
@@ -879,28 +880,17 @@ function untrackRecovery(run: ActiveRunRecord): void {
 /** Mark a session as starting a run (call synchronously, before any await). */
 export function markSessionStarting(id: string): string {
   const token = `rh-${crypto.randomUUID()}`;
-  const state = getRunState(id);
-  if (
-    sessionRunOwners.has(id) &&
-    (state === "preparing" || state === "starting")
-  ) {
+  const decision = decideRunStateTransition(id, "prompt", { run_key: token });
+  if (!decision.accepted) {
     // Return a distinct rejected token so the caller can requeue without
-    // sharing/unmarking the winner's process reservation.
+    // sharing/unmarking the actor winner's process reservation.
     cancelledRunTokens.add(token);
     return token;
   }
   let tokens = pendingStarts.get(id);
   if (!tokens) pendingStarts.set(id, (tokens = new Set()));
   tokens.add(token);
-  if (
-    !sessionRunOwners.has(id) ||
-    state === "idle" ||
-    state === "stopped" ||
-    state === "failed"
-  ) {
-    sessionRunOwners.set(id, token);
-  }
-  transitionRunState(id, "prompt", { run_key: token });
+  sessionRunOwners.set(id, token);
   return token;
 }
 

--- a/packages/core/opensession-server/src/server/run-state.ts
+++ b/packages/core/opensession-server/src/server/run-state.ts
@@ -64,32 +64,37 @@ export function getRunState(sessionId: string): RunState {
 
 type AuditEmit = (event: Record<string, unknown>) => void;
 
-/**
- * Apply an event through the owning SessionKernel. A defined edge moves the
- * durable state and emits `run_state_transition`; an undefined one leaves the
- * state untouched and emits `run_state_rejected`.
- */
-export function transitionRunState(
+export type RunStateTransitionDecision = {
+	accepted: boolean;
+	from: RunState;
+	to: RunState;
+	reason?: "invalid_transition" | "stale_run";
+	currentRunId?: string;
+	rejectedRunId?: string;
+};
+
+/** Apply one run event and retain the actor's admission decision. */
+export function decideRunStateTransition(
 	sessionId: string,
 	event: RunEvent,
 	detail?: Record<string, unknown>,
 	emit: AuditEmit = audit,
-): RunState {
+): RunStateTransitionDecision {
 	if (detachedRunHost()) {
 		const from = getRunState(sessionId);
-		const to = nextRunState(from, event);
-		if (!to) {
+		const next = nextRunState(from, event);
+		if (!next) {
 			console.warn(`[run-state] rejected: ${event} while ${from} (session ${sessionId})`);
 			emit({ msg: "run_state_rejected", session_id: sessionId, state: from, event, ...detail });
-			return from;
+			return { accepted: false, from, to: from, reason: "invalid_transition" };
 		}
 		detachedHostStates.set(sessionId, {
-			state: to,
+			state: next,
 			since: new Date().toISOString(),
 			lastEvent: event,
 		});
-		emit({ msg: "run_state_transition", session_id: sessionId, from, to, event, ...detail });
-		return to;
+		emit({ msg: "run_state_transition", session_id: sessionId, from, to: next, event, ...detail });
+		return { accepted: true, from, to: next };
 	}
 
 	const runKey = typeof detail?.run_key === "string" ? detail.run_key : undefined;
@@ -119,7 +124,7 @@ export function transitionRunState(
 				...detail,
 			});
 		}
-		return decision.from;
+		return decision;
 	}
 	emit({
 		msg: "run_state_transition",
@@ -129,7 +134,22 @@ export function transitionRunState(
 		event,
 		...detail,
 	});
-	return decision.to;
+	return decision;
+}
+
+/**
+ * Apply an event through the owning SessionKernel. A defined edge moves the
+ * durable state and emits `run_state_transition`; an undefined one leaves the
+ * state untouched and emits `run_state_rejected`.
+ */
+export function transitionRunState(
+	sessionId: string,
+	event: RunEvent,
+	detail?: Record<string, unknown>,
+	emit: AuditEmit = audit,
+): RunState {
+	const decision = decideRunStateTransition(sessionId, event, detail, emit);
+	return decision.accepted ? decision.to : decision.from;
 }
 
 /** Drop tracking for a deleted session. */

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -380,6 +380,24 @@ describe("run journal", () => {
     }
   });
 
+  it("does not let a stale gateway projection replace the actor's start owner", () => {
+    const sessionId = `actor-preparation-winner-${crypto.randomUUID()}`;
+    const firstToken = agent.markSessionStarting(sessionId);
+    agent.unmarkSessionStarting(sessionId, firstToken);
+    const rejectedToken = agent.markSessionStarting(sessionId);
+    try {
+      expect(agent.isAgentSessionCancelled(sessionId, rejectedToken)).toBe(true);
+      expect(agent.currentAgentRunToken(sessionId)).toBeUndefined();
+      expect(sessionKernelStore().runState(sessionId)).toMatchObject({
+        state: "starting",
+        currentRunId: firstToken,
+      });
+    } finally {
+      agent.unmarkSessionStarting(sessionId, rejectedToken);
+      clearRunState(sessionId);
+    }
+  });
+
   it("never launches a rejected concurrent preparation before the actor winner", async () => {
     const sessionId = `preparation-engine-winner-${crypto.randomUUID()}`;
     const fake = makeFakeEngine([{ kind: "clean" }]);


### PR DESCRIPTION
## Summary
- apply the actor's durable prompt admission before installing gateway start ownership
- keep rejected start candidates local-cancelled so stale gateway projections cannot launch over an actor owner
- retain the typed transition decision for callers while preserving the compatibility state API

## Verification
- `bun test packages/core/opensession-server/src/server/zz-run-journal.test.ts packages/core/opensession-server/src/server/session-kernel/ownership.test.ts`
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
