### PR TITLE
Keep Stop bookkeeping after a racing creation settlement

### DIFF
--- a/docs/session-kernel-architecture.md
+++ b/docs/session-kernel-architecture.md
@@ -219,7 +219,11 @@ durable stopped turn or its retained cancel receipt before launch and while
 awaiting a detached local owner, so a restart cannot resurrect a cancelled
 opening prompt. Runner, sandbox, and local openings use the same stable token
 for actor admission and physical control, letting Stop reach the exact backend
-without giving up restart adoption.
+without giving up restart adoption. Stop bookkeeping never depends on the
+creation settlement succeeding: a concurrent opening result racing the cancel
+read is logged and skipped, while the durable `prepare_cancel` commit, queue
+persistence, and broadcast always run. Retained cancel receipts fence by exact
+run id and generation, matching the opening they cancelled.
 Non-image create attachments are durably spooled to bounded source references,
 then copied or adopted at deterministic session-owned paths by
 `creation_attachment_stage`; digest crossover fails closed and inline bodies

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -353,17 +353,16 @@ export function requestTurnCancel(
     ...(request.user ? { user: request.user } : {}),
   });
   // The durable Stop committed above must not be undone by a concurrent
-  // creation settlement racing this read (the opening effect may have just
-  // settled failed/succeeded between our snapshot and the reducer write).
-  // Stop bookkeeping below therefore always runs.
+  // creation settlement racing this read: terminal settlements are idempotent
+  // (see settleCreationCancelled), so only genuine invariant failures throw.
+  // Bookkeeping below always runs, even when the error propagates.
   try {
     settleCreationOpeningForStop(sessionId);
-  } catch (e) {
-    console.error(`[stop] Opening creation settlement failed for ${sessionId}:`, e);
+  } finally {
+    stoppedSessions.add(sessionId);
+    persistQueues();
+    broadcastQueue(sessionId);
   }
-  stoppedSessions.add(sessionId);
-  persistQueues();
-  broadcastQueue(sessionId);
   return { requeued: requeued.length };
 }
 

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -352,7 +352,15 @@ export function requestTurnCancel(
     source: request.source,
     ...(request.user ? { user: request.user } : {}),
   });
-  settleCreationOpeningForStop(sessionId);
+  // The durable Stop committed above must not be undone by a concurrent
+  // creation settlement racing this read (the opening effect may have just
+  // settled failed/succeeded between our snapshot and the reducer write).
+  // Stop bookkeeping below therefore always runs.
+  try {
+    settleCreationOpeningForStop(sessionId);
+  } catch (e) {
+    console.error(`[stop] Opening creation settlement failed for ${sessionId}:`, e);
+  }
   stoppedSessions.add(sessionId);
   persistQueues();
   broadcastQueue(sessionId);

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -659,7 +659,16 @@ async function restorePlannedOpening(sessionId: string): Promise<{
 export function settleStoppedCreationOpening(item: CreationOpeningEffectItem): boolean {
 	const kernel = sessionKernel(item.sessionId);
 	const turn = sessionTurn({ op: "snapshot", sessionId: item.sessionId });
-	if (kernel.runState().state !== "stopped" && !turn.cancel) return false;
+	// Exact cancel identity, matching openingTurnWasCancelled(): a retained
+	// receipt fences only the exact run it cancelled. `stopped` alone still
+	// fences because creation is single-shot — while it is opening_dispatched
+	// the opening turn is the only run Stop could have targeted.
+	const cancel = turn.cancel;
+	const exactCancel =
+		cancel != null &&
+		cancel.runId === item.payload.runId &&
+		cancel.runGeneration === item.payload.runGeneration;
+	if (kernel.runState().state !== "stopped" && !exactCancel) return false;
 	settleCreationCancelled(
 		item.sessionId,
 		item.payload.creationIdentity,

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -660,13 +660,16 @@ export function settleStoppedCreationOpening(item: CreationOpeningEffectItem): b
 	const kernel = sessionKernel(item.sessionId);
 	const turn = sessionTurn({ op: "snapshot", sessionId: item.sessionId });
 	// Exact cancel identity, matching openingTurnWasCancelled(): a retained
-	// receipt fences only the exact run it cancelled. `stopped` alone still
-	// fences because creation is single-shot — while it is opening_dispatched
-	// the opening turn is the only run Stop could have targeted.
+	// receipt fences only the exact run it cancelled. The receipt records the
+	// admitted physical token derived from the effect payload, so recompute it
+	// here. `stopped` alone still fences because creation is single-shot —
+	// while it is opening_dispatched the opening turn is the only run Stop
+	// could have targeted.
 	const cancel = turn.cancel;
 	const exactCancel =
 		cancel != null &&
-		cancel.runId === item.payload.runId &&
+		cancel.runId ===
+			runnerOpeningHostId(item.payload.runId, item.payload.runGeneration) &&
 		cancel.runGeneration === item.payload.runGeneration;
 	if (kernel.runState().state !== "stopped" && !exactCancel) return false;
 	settleCreationCancelled(

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -995,8 +995,12 @@ export async function openCreatedSession(
       throw new Error("Opening turn is already owned by another preparation");
     }
 		const admittedRun = sessionKernel(bksId).runState();
-		if (admittedRun.currentRunId !== startToken)
+		if (admittedRun.currentRunId !== startToken) {
+			// Release the process reservation before failing: this throw lands
+			// outside the inner try/finally that would otherwise unmark it.
+			unmarkSessionStarting(bksId, startToken);
 			throw new Error("Opening turn lost actor admission before preparation");
+		}
 		startGeneration = admittedRun.generation;
 		const pendingAttach = spec.attachRepos?.repos.length
 			? spec.attachRepos

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -320,6 +320,90 @@ describe("creation opening intents", () => {
     }
   });
 
+  test("Stop racing a terminal opening result stays idempotent", () => {
+    const raced = {
+      ...opening,
+      sessionId: "create-raced-opening",
+      identity: "request-raced-opening",
+    };
+    const { store, kernel } = harness(raced.sessionId);
+    try {
+      // The opening effect settles a terminal between Stop's snapshot and its
+      // reducer write. The cancellation must no-op on the terminal receipt
+      // instead of throwing and failing an already-committed Stop.
+      store.applyCreationEvent({
+        sessionId: raced.sessionId,
+        identity: raced.identity,
+        event: "plan",
+      });
+      store.applyCreationEvent({
+        sessionId: raced.sessionId,
+        identity: raced.identity,
+        event: "preparation_started",
+      });
+      store.applyCreationEvent({
+        sessionId: raced.sessionId,
+        identity: raced.identity,
+        event: "opening_dispatched",
+        openingPlan: { prompt: "opening" },
+        nextEffectId: `opening:${raced.openingPromptEntryId}`,
+        effect: {
+          kind: "creation_opening_turn",
+          effectKey: `opening:${raced.openingPromptEntryId}`,
+          payload: {
+            creationIdentity: raced.identity,
+            creationGeneration: 1,
+            openingPromptEntryId: raced.openingPromptEntryId,
+            runId: raced.runId,
+            runGeneration: 1,
+            mode: "adopt_or_launch" as const,
+          },
+        },
+      });
+      store.applyCreationEvent({
+        sessionId: raced.sessionId,
+        identity: raced.identity,
+        event: "succeeded",
+        effectId: `opening:${raced.openingPromptEntryId}`,
+      });
+      expect(
+        settleCreationCancelled(
+          raced.sessionId,
+          raced.identity,
+          kernel,
+          `opening:${raced.openingPromptEntryId}`,
+        ).state,
+      ).toBe("ready");
+    } finally {
+      store.close();
+    }
+
+    const failed = {
+      ...opening,
+      sessionId: "create-raced-failed",
+      identity: "request-raced-failed",
+    };
+    const failedHarness = harness(failed.sessionId);
+    try {
+      settleCreationFailed(
+        failed.sessionId,
+        failed.identity,
+        new Error("setup failed"),
+        failedHarness.kernel,
+      );
+      expect(
+        settleCreationCancelled(
+          failed.sessionId,
+          failed.identity,
+          failedHarness.kernel,
+          `opening:${failed.openingPromptEntryId}`,
+        ).state,
+      ).toBe("failed");
+    } finally {
+      failedHarness.store.close();
+    }
+  });
+
   test("keeps a timed-out opening durable without emitting another launch", async () => {
     const { store, kernel } = harness(opening.sessionId);
     try {

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -165,7 +165,15 @@ export function settleCreationCancelled(
   const existing = kernel.creationState();
   if (existing?.identity !== undefined && existing.identity !== identity)
     throw new Error("Create request identity crossed durable session ownership");
-  if (existing?.state === "cancelled") return existing;
+  // Terminal states are idempotent, mirroring settleCreationSucceeded/
+  // settleCreationFailed: a Stop racing an opening result must not throw —
+  // the terminal receipt already owns the lifecycle.
+  if (
+    existing?.state === "cancelled" ||
+    existing?.state === "ready" ||
+    existing?.state === "failed"
+  )
+    return existing;
   ensureCreationPlanned(sessionId, identity, kernel);
   const settled = kernel.applyCreationEvent({
     identity,

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -622,15 +622,24 @@ describe("single session ownership", () => {
 			"try {\n    settleCreationOpeningForStop(sessionId);",
 			cancelPrepared,
 		);
-		const stopBookkept = runSession.indexOf("stoppedSessions.add(sessionId)", cancelPrepared);
+		const bookkeeping = runSession.indexOf("} finally {", settleGuarded);
 		expect(cancelPrepared).toBeGreaterThan(0);
 		expect(settleGuarded).toBeGreaterThan(cancelPrepared);
-		expect(stopBookkept).toBeGreaterThan(settleGuarded);
-		// A concurrent opening settlement racing the Stop must never undo the
-		// committed durable cancel or skip queue persistence/broadcast.
-		expect(runSession.slice(settleGuarded, stopBookkept)).toContain("catch");
-		// A retained cancel receipt fences only the exact run it cancelled.
-		expect(create).toContain("cancel.runId === item.payload.runId");
+		expect(bookkeeping).toBeGreaterThan(settleGuarded);
+		// A racing opening settlement must never undo the committed durable
+		// cancel or skip queue persistence/broadcast — but genuine invariant
+		// failures still propagate after the bookkeeping ran.
+		const bookkeptInFinally = runSession.indexOf(
+			"stoppedSessions.add(sessionId)",
+			bookkeeping,
+		);
+		expect(bookkeptInFinally).toBeGreaterThan(bookkeeping);
+		// A retained cancel receipt fences only the exact run it cancelled:
+		// the receipt records the admitted physical token, deterministically
+		// derived from the effect payload's logical run id and generation.
+		expect(create).toContain(
+			"runnerOpeningHostId(item.payload.runId, item.payload.runGeneration)",
+		);
 		expect(create).toContain(
 			"cancel.runGeneration === item.payload.runGeneration",
 		);

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -634,6 +634,17 @@ describe("single session ownership", () => {
 		expect(create).toContain(
 			"cancel.runGeneration === item.payload.runGeneration",
 		);
+		// Losing actor admission releases the process reservation it just took.
+		const admissionLoss = create.indexOf(
+			'"Opening turn lost actor admission before preparation"',
+		);
+		const unmarkBeforeThrow = create.lastIndexOf(
+			"unmarkSessionStarting(bksId, startToken);",
+			admissionLoss,
+		);
+		expect(admissionLoss).toBeGreaterThan(0);
+		expect(unmarkBeforeThrow).toBeGreaterThan(0);
+		expect(unmarkBeforeThrow).toBeLessThan(admissionLoss);
 		for (const backend of [
 			"host-client.ts",
 			"runner-session.ts",

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -618,12 +618,22 @@ describe("single session ownership", () => {
 		expect(create).toContain("isAgentSessionCancelled(bksId, startToken)");
 		const runSession = read("run-session.ts");
 		const cancelPrepared = runSession.indexOf('op: "prepare_cancel"');
-		const creationCancelled = runSession.indexOf(
-			"settleCreationOpeningForStop(sessionId)",
+		const settleGuarded = runSession.indexOf(
+			"try {\n    settleCreationOpeningForStop(sessionId);",
 			cancelPrepared,
 		);
+		const stopBookkept = runSession.indexOf("stoppedSessions.add(sessionId)", cancelPrepared);
 		expect(cancelPrepared).toBeGreaterThan(0);
-		expect(creationCancelled).toBeGreaterThan(cancelPrepared);
+		expect(settleGuarded).toBeGreaterThan(cancelPrepared);
+		expect(stopBookkept).toBeGreaterThan(settleGuarded);
+		// A concurrent opening settlement racing the Stop must never undo the
+		// committed durable cancel or skip queue persistence/broadcast.
+		expect(runSession.slice(settleGuarded, stopBookkept)).toContain("catch");
+		// A retained cancel receipt fences only the exact run it cancelled.
+		expect(create).toContain("cancel.runId === item.payload.runId");
+		expect(create).toContain(
+			"cancel.runGeneration === item.payload.runGeneration",
+		);
 		for (const backend of [
 			"host-client.ts",
 			"runner-session.ts",


### PR DESCRIPTION
Follow-up to #191 (merged `541b8e1f9`).

## Problem

`requestTurnCancel()` called `settleCreationOpeningForStop()` unguarded after the durable `prepare_cancel` commit. Each kernel round-trip can interleave other actor work, so an opening effect settling `failed`/`succeeded` between the cancel commit and the creation reducer write makes the settlement throw (`stale_effect`, `invalid_transition`, or identity mismatch). That throw skipped `stoppedSessions.add`, `persistQueues()`, and `broadcastQueue()`, so a Stop that durably committed surfaced as an error and its requeued prompts were not persisted or broadcast.

## Fix

- Wrap the opening settlement in try/catch inside `requestTurnCancel()`: the durable Stop always completes its local bookkeeping; a racing settlement is logged and skipped.
- Tighten `settleStoppedCreationOpening()` to exact cancel identity: a retained receipt fences only when `cancel.runId`/`cancel.runGeneration` match the effect payload, matching `openingTurnWasCancelled()` and `settleRecoveredCreationOpening()`.
- Extend ownership ordering assertions for both fences; update the architecture doc.

## Verification

- 174 focused kernel/ownership/creation/journal tests pass.
- `bun run typecheck`, 415-module side-effect scan, and `git diff --check` clean.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)