### PR TITLE
Bind sandbox launch identity to the admitted run token

### DIFF
--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -799,6 +799,13 @@ export class HostHandle {
     return this.ctl.hostId;
   }
 
+  /** True once cancellation was requested (stop backstop may still be
+   *  running) or the handle already finished. Launchers check this right
+   *  after dispatch so a cancelled launch never attaches. */
+  get cancelled(): boolean {
+    return this.stopRequested || this.endedClean;
+  }
+
   setHostChangeHandler(handler: (hostId: string) => void): void {
     this.onHostChanged = handler;
   }

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -1670,7 +1670,10 @@ export async function maybeLaunchSandboxedRun(
 			? portableWorkspacePresetRun(workspacePreset)
 			: undefined;
 		const spec: RunHostSpec = {
-			hostId: `rh-${randomUUIDv7()}`,
+			// Bind the physical sandbox host to the admitted run token, exactly like
+			// the Runner and local paths: exact-token Stop must reach the live host,
+			// and restart adoption must reattach under the same durable identity.
+			hostId: opts.startToken || `rh-${randomUUIDv7()}`,
 			osSessionId: session.id,
 			prompt: opts.prompt,
 			promptEntryId: opts.promptEntryId,

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2156,13 +2156,17 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         mark("spec written");
         // A crash after journal admission must recover from the full spec.
         journalSet(record);
+        // Construct (and register) the control BEFORE dispatch so exact-token
+        // Stop reaches the launching host: cancelAgentRunTokenAndWait sees
+        // hostRunBusy(token) during the launch await, and cancelHost's stop
+        // backstop plus the cancelled startup marker fence the dispatch race.
+        handle = new HostHandle(dir, spec, callbacks, launcher);
         await launcher.launch(spec.hostId, dir, () => {
           record.launchPhase = "launching";
           journalSet(record);
         });
         record.launchPhase = "started";
         journalSet(record);
-        handle = new HostHandle(dir, spec, callbacks, launcher);
         await handle.connectWithWait(45_000);
         mark("host attached");
       } catch (error) {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2180,7 +2180,11 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         // of handing an ended handle to uncertain-launch reconciliation.
         if (
           record.launchPhase === "prepared" ||
-          error instanceof HostLaunchNotDispatchedError
+          error instanceof HostLaunchNotDispatchedError ||
+          // A stop backstop that proved absence during the launch/connect
+          // await already finished this handle: retire it like a
+          // never-dispatched launch instead of reconciling an ended owner.
+          handle?.ended === true
         ) {
           journalClearIfLineage(record);
           handle?.abandon();

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -104,6 +104,7 @@ import { writeJsonAtomic } from "../../shared/atomic-write";
 import { createWorkloadIdentityEnv, type WorkloadIdentityContext } from "../../workload-identity";
 import {
   HostHandle,
+  HostLaunchNotDispatchedError,
   reconcileUncertainHostEvents,
   type HandleCallbacks,
   type HostLauncher,
@@ -2167,6 +2168,10 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         });
         record.launchPhase = "started";
         journalSet(record);
+        if (handle.cancelled)
+          throw new HostLaunchNotDispatchedError(
+            `${spec.hostId} was cancelled while launching`,
+          );
         await handle.connectWithWait(45_000);
         mark("host attached");
       } catch (error) {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2175,7 +2175,13 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         await handle.connectWithWait(45_000);
         mark("host attached");
       } catch (error) {
-        if (record.launchPhase === "prepared") {
+        // A cancelled launch is provably absent (startup marker or stop
+        // backstop), exactly like a never-dispatched one: retire it instead
+        // of handing an ended handle to uncertain-launch reconciliation.
+        if (
+          record.launchPhase === "prepared" ||
+          error instanceof HostLaunchNotDispatchedError
+        ) {
           journalClearIfLineage(record);
           handle?.abandon();
           unregisterRunToken(spec.rpcToken);

--- a/packages/core/opensession-server/src/server/sandbox/docker.ts
+++ b/packages/core/opensession-server/src/server/sandbox/docker.ts
@@ -1208,6 +1208,10 @@ function makeDockerSandbox(
         record.launchPhase = "started";
         journalSet(record);
         mark("host exec dispatched");
+        if (handle.cancelled)
+          throw new HostLaunchNotDispatchedError(
+            `${spec.hostId} was cancelled while launching`,
+          );
         await handle.connectWithWait(30_000);
         mark("host attached");
       } catch (error) {

--- a/packages/core/opensession-server/src/server/sandbox/docker.ts
+++ b/packages/core/opensession-server/src/server/sandbox/docker.ts
@@ -1196,6 +1196,11 @@ function makeDockerSandbox(
       const mark = (step: string) =>
         console.log(`[sandbox] launch ${spec.hostId.slice(0, 11)}: ${step} (+${Date.now() - t0}ms)`);
       try {
+        // Construct (and register) the control BEFORE dispatch so exact-token
+        // Stop reaches the launching host: cancelAgentRunTokenAndWait sees
+        // hostRunBusy(token) during the launch await, and cancelHost's stop
+        // backstop plus the cancelled startup marker fence the dispatch race.
+        handle = new HostHandle(dir, spec, callbacks, launcher);
         await launcher.launch(spec.hostId, dir, () => {
           record.launchPhase = "launching";
           journalSet(record);
@@ -1203,7 +1208,6 @@ function makeDockerSandbox(
         record.launchPhase = "started";
         journalSet(record);
         mark("host exec dispatched");
-        handle = new HostHandle(dir, spec, callbacks, launcher);
         await handle.connectWithWait(30_000);
         mark("host attached");
       } catch (error) {

--- a/packages/core/opensession-server/src/server/sandbox/docker.ts
+++ b/packages/core/opensession-server/src/server/sandbox/docker.ts
@@ -1217,7 +1217,11 @@ function makeDockerSandbox(
       } catch (error) {
         const definitelyNotDispatched =
           record.launchPhase === "prepared" ||
-          error instanceof HostLaunchNotDispatchedError;
+          error instanceof HostLaunchNotDispatchedError ||
+          // A stop backstop that proved absence during the launch/connect
+          // await already finished this handle: retire it like a
+          // never-dispatched launch instead of reconciling an ended owner.
+          handle?.ended === true;
         if (definitelyNotDispatched) {
           journalClearIfLineage(record);
           handle?.abandon();

--- a/packages/core/opensession-server/src/server/sandbox/local.ts
+++ b/packages/core/opensession-server/src/server/sandbox/local.ts
@@ -100,6 +100,9 @@ function makeLocalSandbox(cwd: string): Sandbox {
           osSessionId: spec.osSessionId,
           kind: spec.journalKind || "prompt",
         },
+        // spec.hostId is the admitted run token (see maybeLaunchSandboxedRun);
+        // carrying it keeps exact-token Stop latching working in-process.
+        startToken: spec.hostId,
         onAskUser: cb?.onAskUser,
       });
       // In-process runs register their own control handles keyed by session

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -616,6 +616,14 @@ describe("single session ownership", () => {
 		expect(create).toContain("startToken = markSessionStarting(");
 		expect(create).toContain("hostId: startToken");
 		expect(create).toContain("isAgentSessionCancelled(bksId, startToken)");
+		// Sandbox launches bind the physical host to the admitted token so
+		// exact-token Stop reaches the live host (mirrors the Runner path).
+		expect(read("run-session.ts")).toContain(
+			"hostId: opts.startToken || `rh-${randomUUIDv7()}`",
+		);
+		expect(read("sandbox/local.ts")).toContain(
+			"startToken: spec.hostId",
+		);
 		const runSession = read("run-session.ts");
 		const cancelPrepared = runSession.indexOf('op: "prepare_cancel"');
 		const creationCancelled = runSession.indexOf(


### PR DESCRIPTION
Same defect class as the Runner opening P1 fixed in #191, found while re-verifying its assumption across backends.

## Problem

`maybeLaunchSandboxedRun` minted a random `hostId` for the physical sandbox host and never registered the admitted run token anywhere the exact-token cancel path can see:

- `spec.hostId` (and therefore the journal `runKey`, host-registry keys, and recovery identity) was random.
- Nothing added `startToken` to `activeSessionRunTokens`, so `agentRunTokenLatched(startToken)` stayed false.
- `hostCancel(startToken)` missed (the control registers under session/host ids).

Consequence: Stop during a live sandbox turn — opening or normal prompt, any provider — could not reach the physical host. `cancelAgentRunTokenAndWait` spun to its 120s timeout and threw, leaving the turn_cancel effect retrying while the remote/in-sandbox agent kept executing tools until natural completion. The local in-process sandbox path (`sandbox/local.ts`) also dropped the token on the floor when delegating to `runAgent`.

## Fix

- `maybeLaunchSandboxedRun` now uses `hostId: opts.startToken || random`, mirroring `spawnHostRun` and the Runner path: journal, registry, and recovery all key on the admitted token.
- `sandbox/local.ts` passes `startToken: spec.hostId` into `runAgent` so in-process latch/cancel works.
- Ownership assertions cover both bindings.

## Verification

- `bun run typecheck`, focused ownership/run-state/journal tests, 415-module side-effect scan, `git diff --check` clean.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)