### PR TITLE
Stop warning for parked prompts during recovery

### DIFF
--- a/packages/core/opensession-server/src/server/run-state.test.ts
+++ b/packages/core/opensession-server/src/server/run-state.test.ts
@@ -274,6 +274,40 @@ describe("transitionRunState (stateful wrapper)", () => {
 		}
 	});
 
+	test("parked prompts during recovery reject silently; other rejections warn", () => {
+		const id = sid();
+		const events: Record<string, unknown>[] = [];
+		const warnings: string[] = [];
+		const original = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+		try {
+			transitionRunState(id, "boot_journal_found", undefined, (e) =>
+				events.push(e),
+			);
+			expect(getRunState(id)).toBe("interrupted");
+			// The designed park: rejected, audited, but not warned.
+			transitionRunState(id, "prompt", undefined, (e) => events.push(e));
+			expect(getRunState(id)).toBe("interrupted");
+			expect(events.at(-1)).toMatchObject({
+				msg: "run_state_rejected",
+				state: "interrupted",
+				event: "prompt",
+			});
+			expect(warnings).toHaveLength(0);
+			// Unexpected rejections still warn.
+			transitionRunState(id, "ask_resolved", undefined, (e) =>
+				events.push(e),
+			);
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0]).toContain("ask_resolved while interrupted");
+		} finally {
+			console.warn = original;
+			clearRunState(id);
+		}
+	});
+
 	test("unknown session defaults to idle; clearRunState drops tracking", () => {
 		const id = sid();
 		expect(getRunState(id)).toBe("idle");

--- a/packages/core/opensession-server/src/server/run-state.ts
+++ b/packages/core/opensession-server/src/server/run-state.ts
@@ -113,9 +113,18 @@ export function decideRunStateTransition(
 				state: decision.from,
 			});
 		} else {
-			console.warn(
-				`[run-state] rejected: ${event} while ${decision.from} (session ${sessionId})`,
-			);
+			// Boot-drained prompts park here while restart recovery still owns
+			// the session (interrupted/reattaching). That is the designed
+			// fail-closed fence, not a defect — one warning per parked prompt
+			// per boot is noise, so only unexpected rejections warn.
+			const parkedPrompt =
+				event === "prompt" &&
+				(decision.from === "interrupted" ||
+					decision.from === "reattaching");
+			if (!parkedPrompt)
+				console.warn(
+					`[run-state] rejected: ${event} while ${decision.from} (session ${sessionId})`,
+				);
 			emit({
 				msg: "run_state_rejected",
 				session_id: sessionId,


### PR DESCRIPTION
Follow-up from the `[run-state] rejected: prompt while interrupted` investigation (32 occurrences in 6 hours, all at boot).

## Diagnosis

Every occurrence is the designed fail-closed park: queued prompts re-drain at boot while restart recovery holds their sessions `interrupted`/`reattaching`; `markSessionStarting` correctly rejects and re-parks them. The messages are correct fencing — but one `console.warn` per parked prompt per boot is noise (bursts of 7-8 per restart), and they read as defects in logs.

## Fix

`decideRunStateTransition` still emits the `run_state_rejected` audit event for every rejection, but only warns for rejections that are not the expected parked-prompt case (`prompt` while `interrupted`/`reattaching`). Test covers both: silent park with audit, loud warning for a genuinely unexpected rejection.

## Verification

- `bun run typecheck`, run-state tests (30 pass), side-effect scan, `git diff --check`.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)