### PR TITLE
Add recent models to native picker

### DIFF
--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -15,6 +15,10 @@ enum NativePreferences {
     private static var pendingLocalWrites = 0
     private static let identityKey = "os1.preferences.identity"
     private static let bucketKey = "os1.preferences.bucket"
+    static let recentModelsStorageKey = "os1.composer.recentModels"
+    static let recentModelsPrefKey = "recent-models"
+    static let recentModelLimit = 12
+    static let recentModelDisplayLimit = 3
 
     static func context() -> Context {
         let config = ServerConfig.shared
@@ -86,6 +90,8 @@ enum NativePreferences {
                 ?? SidebarTools.defaultHiddenJSON
             prefs[SidebarFeeds.prefKey] = defaults.string(forKey: SidebarFeeds.storageKey)
                 ?? "[]"
+            prefs[recentModelsPrefKey] = defaults.string(forKey: recentModelsStorageKey)
+                ?? "[]"
         }
         let previousIdentity = defaults.string(forKey: identityKey)
         let previousBucket = defaults.string(forKey: bucketKey)
@@ -95,6 +101,15 @@ enum NativePreferences {
             prefs["default-model"],
             default: "",
             key: "os1.composer.defaultModel",
+            resetMissing: changedIdentity,
+            in: defaults
+        )
+        // Keep ids this instance does not currently expose. They may become
+        // available again on another workspace or device.
+        set(
+            validatedRecentModels(prefs[recentModelsPrefKey]),
+            default: "[]",
+            key: recentModelsStorageKey,
             resetMissing: changedIdentity,
             in: defaults
         )
@@ -266,6 +281,66 @@ enum NativePreferences {
     /// that is already running. Off until the account says otherwise.
     nonisolated static var liveTypingIsOn: Bool {
         UserDefaults.standard.object(forKey: "os1.transcript.liveTyping") as? Bool ?? false
+    }
+
+    /// Decode the web's newest-first recent-model list. Unknown model ids are
+    /// deliberately retained; only malformed, blank and duplicate entries are
+    /// removed, and storage is capped independently of the three visible rows.
+    static func decodeRecentModels(_ value: String?) -> [String]? {
+        guard let value,
+              let data = value.data(using: .utf8),
+              let values = (try? JSONSerialization.jsonObject(with: data)) as? [Any]
+        else { return nil }
+        var seen = Set<String>()
+        return values.compactMap { value -> String? in
+            guard let id = value as? String,
+                  !id.isEmpty,
+                  seen.insert(id).inserted
+            else { return nil }
+            return id
+        }.prefix(recentModelLimit).map { $0 }
+    }
+
+    static func addingRecentModel(_ id: String, to models: [String]) -> [String] {
+        guard !id.isEmpty else { return Array(models.prefix(recentModelLimit)) }
+        return Array(([id] + models.filter { $0 != id }).prefix(recentModelLimit))
+    }
+
+    static func availableRecentModelIDs(
+        _ models: [String],
+        available: Set<String>
+    ) -> [String] {
+        Array(models.filter(available.contains).prefix(recentModelDisplayLimit))
+    }
+
+    static func recordRecentModel(_ id: String) {
+        guard !id.isEmpty else { return }
+        let defaults = UserDefaults.standard
+        let current = decodeRecentModels(defaults.string(forKey: recentModelsStorageKey)) ?? []
+        let next = addingRecentModel(id, to: current)
+        guard let data = try? JSONEncoder().encode(next) else { return }
+        let raw = String(decoding: data, as: UTF8.self)
+        defaults.set(raw, forKey: recentModelsStorageKey)
+
+        let requestContext = context()
+        beginLocalWrite()
+        Task {
+            defer { endLocalWrite() }
+            guard let response = try? await SettingsAPI.updateUiPrefs(
+                user: requestContext.user,
+                prefs: [recentModelsPrefKey: raw]
+            ) else { return }
+            var confirmed = response
+            if confirmed[recentModelsPrefKey] == nil { confirmed[recentModelsPrefKey] = raw }
+            _ = apply(confirmed, for: requestContext)
+        }
+    }
+
+    private static func validatedRecentModels(_ value: String?) -> String? {
+        guard let models = decodeRecentModels(value),
+              let data = try? JSONEncoder().encode(models)
+        else { return nil }
+        return String(decoding: data, as: UTF8.self)
     }
 
     /// The shape both list-valued prefs share (repo order, hidden sources): a

--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -13,6 +13,7 @@ enum NativePreferences {
 
     private static var generation = 0
     private static var pendingLocalWrites = 0
+    private static var recentModelsWriteTail: Task<Void, Never>?
     private static let identityKey = "os1.preferences.identity"
     private static let bucketKey = "os1.preferences.bucket"
     static let recentModelsStorageKey = "os1.composer.recentModels"
@@ -323,13 +324,19 @@ enum NativePreferences {
         defaults.set(raw, forKey: recentModelsStorageKey)
 
         let requestContext = context()
+        let previousWrite = recentModelsWriteTail
         beginLocalWrite()
-        Task {
+        recentModelsWriteTail = Task {
             defer { endLocalWrite() }
-            guard let response = try? await SettingsAPI.updateUiPrefs(
-                user: requestContext.user,
-                prefs: [recentModelsPrefKey: raw]
-            ) else { return }
+            // Each PUT replaces the whole recent list. Waiting for the prior
+            // selection prevents an older snapshot from landing last.
+            _ = await previousWrite?.value
+            guard context() == requestContext,
+                  let response = try? await SettingsAPI.updateUiPrefs(
+                      user: requestContext.user,
+                      prefs: [recentModelsPrefKey: raw]
+                  )
+            else { return }
             var confirmed = response
             if confirmed[recentModelsPrefKey] == nil { confirmed[recentModelsPrefKey] = raw }
             _ = apply(confirmed, for: requestContext)

--- a/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
+++ b/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
@@ -14,6 +14,7 @@ import SwiftUI
 /// time one of them moves.
 struct ModelSettingsMenu: View {
     @AppStorage("os1.composer.defaultModel") private var preferredModel = ""
+    @AppStorage(NativePreferences.recentModelsStorageKey) private var recentModelsJSON = "[]"
 
     let viewModel: SessionViewModel
     let catalog: ModelCatalog?
@@ -27,19 +28,16 @@ struct ModelSettingsMenu: View {
             UsageMenuSection(usage: viewModel.usage)
         }
         if let catalog {
+            if !recentModels.isEmpty {
+                Section("Recent models") {
+                    ForEach(recentModels) { option in
+                        modelButton(option)
+                    }
+                }
+            }
             Menu {
                 ForEach(catalog.presets + catalog.regular) { option in
-                    let routed = ModelCatalog.routedID(option.id, engine: currentEngine)
-                    Button {
-                        if let routed { viewModel.changeModel(to: routed) }
-                    } label: {
-                        if option.id == ModelCatalog.baseID(currentModel) {
-                            Label(option.displayLabel, systemImage: "checkmark")
-                        } else {
-                            Text(option.displayLabel)
-                        }
-                    }
-                    .disabled(routed == nil)
+                    modelButton(option)
                 }
             } label: {
                 Label("Model · \(catalog.label(for: currentModel))", systemImage: "cpu")
@@ -129,6 +127,36 @@ struct ModelSettingsMenu: View {
 
     private var currentModel: String {
         viewModel.model.isEmpty ? (catalog?.defaultModel ?? "") : viewModel.model
+    }
+
+    private var recentModels: [ModelOption] {
+        guard let catalog,
+              let ids = NativePreferences.decodeRecentModels(recentModelsJSON)
+        else { return [] }
+        let available = Dictionary(
+            catalog.models.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        return NativePreferences.availableRecentModelIDs(
+            ids,
+            available: Set(available.keys)
+        ).compactMap { available[$0] }
+    }
+
+    private func modelButton(_ option: ModelOption) -> some View {
+        let routed = ModelCatalog.routedID(option.id, engine: currentEngine)
+        return Button {
+            guard let routed else { return }
+            viewModel.changeModel(to: routed)
+            NativePreferences.recordRecentModel(option.id)
+        } label: {
+            if option.id == ModelCatalog.baseID(currentModel) {
+                Label(option.displayLabel, systemImage: "checkmark")
+            } else {
+                Text(option.displayLabel)
+            }
+        }
+        .disabled(routed == nil)
     }
 
     private var engineChoices: [ModelEngineOption] {

--- a/packages/clients/ios/OS1Tests/PreferenceHydrationTests.swift
+++ b/packages/clients/ios/OS1Tests/PreferenceHydrationTests.swift
@@ -3,6 +3,41 @@ import XCTest
 
 @MainActor
 final class PreferenceHydrationTests: XCTestCase {
+    func testRecentModelsPromoteWithoutDuplicatesAndCapStorage() {
+        let models = (0...NativePreferences.recentModelLimit).map { "model-\($0)" }
+
+        XCTAssertEqual(
+            NativePreferences.addingRecentModel("model-2", to: models),
+            ["model-2"] + Array(
+                models.filter { $0 != "model-2" }.prefix(NativePreferences.recentModelLimit - 1)
+            )
+        )
+    }
+
+    func testRecentModelsShowThreeAvailableChoicesWithoutDeletingGaps() {
+        let stored = ["unavailable", "one", "two", "also-unavailable", "three", "four"]
+
+        XCTAssertEqual(
+            NativePreferences.availableRecentModelIDs(
+                stored,
+                available: ["one", "two", "three", "four"]
+            ),
+            ["one", "two", "three"]
+        )
+        XCTAssertEqual(stored.first, "unavailable")
+    }
+
+    func testRecentModelsDecodeWebStorageWithoutDroppingUnknownIds() throws {
+        let values: [Any] = ["unknown/future", "available", "available", 3, "", "later"]
+        let raw = String(decoding: try JSONSerialization.data(withJSONObject: values), as: UTF8.self)
+
+        XCTAssertEqual(
+            NativePreferences.decodeRecentModels(raw),
+            ["unknown/future", "available", "later"]
+        )
+        XCTAssertNil(NativePreferences.decodeRecentModels("not-json"))
+    }
+
     func testReplySuggestionsPreferenceUsesWebValues() {
         XCTAssertEqual(NativePreferences.replySuggestionsEnabled("on"), true)
         XCTAssertEqual(NativePreferences.replySuggestionsEnabled("off"), false)

--- a/packages/core/opensession-server/src/server/ui-prefs.test.ts
+++ b/packages/core/opensession-server/src/server/ui-prefs.test.ts
@@ -25,6 +25,17 @@ describe("UI preference limits", () => {
 		expect(shortcuts.length).toBeLessThanOrEqual(maxValueLength("shortcuts"));
 	});
 
+	test("recent models can hold twelve routed model IDs", () => {
+		const recents = JSON.stringify(
+			Array.from(
+				{ length: 12 },
+				(_, index) => `pi/provider-${index}/configured-model-${index}`,
+			),
+		);
+		expect(recents.length).toBeGreaterThan(200);
+		expect(recents.length).toBeLessThanOrEqual(maxValueLength("recent-models"));
+	});
+
 	test("ordinary scalar preferences remain tightly bounded", () => {
 		expect(maxValueLength("turn-activity")).toBe(200);
 	});

--- a/packages/core/opensession-server/src/server/ui-prefs.ts
+++ b/packages/core/opensession-server/src/server/ui-prefs.ts
@@ -19,7 +19,7 @@ import { userStore } from "./shared/user-store";
 // entry count — this is a preferences file, not a datastore.
 const KEY_RE = /^[a-z][a-zA-Z0-9-]{0,40}$/;
 const MAX_VALUE_LEN = 200;
-const LONG_VALUE_KEYS = new Set(["repo-order", "shortcuts"]);
+const LONG_VALUE_KEYS = new Set(["repo-order", "shortcuts", "recent-models"]);
 const MAX_LONG_VALUE_LEN = 16_384;
 const MAX_ENTRIES = 100;
 


### PR DESCRIPTION
## Summary
- hydrate and persist native recent-model history through the shared `recent-models` UI preference
- show up to three available recent choices above the full model submenu
- preserve unknown model IDs, routing behavior, selection checkmarks, and account-scoped caches
- serialize selection writes so rapid changes preserve newest-first server ordering
- allow the shared preference to store all 12 routed model IDs

## Verification
- OS1 iOS Simulator build
- OS1Mac build
- OS1Mac unit tests, 934 passed
- `bun test packages/core/opensession-server/src/server/ui-prefs.test.ts`, 5 passed

Created by [this OS session](https://os.tella.dev/session/bks-04fb4f3a-b670-7d4d-b729-daeabaa8017b)
