### PR TITLE
Add native Undo for sent Slack messages

### DIFF
--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -195,7 +195,8 @@ enum ServerEvent: Sendable {
                     requestId: requestId,
                     status: status,
                     channel: channel,
-                    permalink: frame.permalink
+                    permalink: frame.permalink,
+                    ts: frame.ts
                 )
             )
         case "workflow_update":
@@ -261,6 +262,22 @@ struct SlackComposeReceipt: Equatable, Sendable, Identifiable {
     let status: Status
     let channel: Channel?
     let permalink: String?
+    /// Slack's message timestamp. Older servers omit it, so Undo stays unavailable.
+    let ts: String?
+
+    init(
+        requestId: String,
+        status: Status,
+        channel: Channel?,
+        permalink: String?,
+        ts: String? = nil
+    ) {
+        self.requestId = requestId
+        self.status = status
+        self.channel = channel
+        self.permalink = permalink
+        self.ts = ts
+    }
 
     var id: String { requestId }
 }
@@ -457,6 +474,7 @@ private struct RawFrame: Decodable {
     let status: String?
     let channel: WireSlackChannel?
     let permalink: String?
+    let ts: String?
     let run: WorkflowRun?
     let repo: String?
     let branch: String?

--- a/packages/clients/ios/OS1/Networking/SlackAPI.swift
+++ b/packages/clients/ios/OS1/Networking/SlackAPI.swift
@@ -21,6 +21,8 @@ enum SlackAPI {
         let status: String
         let channel: Channel?
         let permalink: String?
+        /// Optional for compatibility with servers predating sent-message Undo.
+        let ts: String?
     }
 
     private struct UploadResponse: Decodable, Sendable {
@@ -128,6 +130,15 @@ enum SlackAPI {
             ]
         )
         return try JSONDecoder().decode(ComposerResponse.self, from: data)
+    }
+
+    static func undoComposer(sessionId: String, channelId: String, ts: String) async throws {
+        let session = encodePath(sessionId)
+        _ = try await request(
+            "/api/sessions/\(session)/slack-composer/undo",
+            method: "POST",
+            body: ["channel": channelId, "ts": ts]
+        )
     }
 
     static func cancelComposer(sessionId: String, requestId: String) async throws {

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -92,6 +92,9 @@ final class SessionViewModel {
     private(set) var replySuggestions: [ReplySuggestion] = []
     private(set) var pendingSlackComposer: SlackComposeRequest?
     private(set) var slackComposeReceipt: SlackComposeReceipt?
+    /// The request id currently being removed from Slack. Keeping the receipt
+    /// visible while this is set makes a failed Undo recoverable.
+    private(set) var undoingSlackComposeReceiptId: String?
     private(set) var connectionState: ConnectionState = .connecting
     private(set) var isLoadingConversation = true
     /// A watch that never receives transcript_init is not a loading state
@@ -130,6 +133,34 @@ final class SessionViewModel {
         slackComposeReceipt = receipt
     }
 
+    /// Delete the sent message with the same person's Slack grant. The receipt
+    /// disappears only after success, so a rejected request can be retried.
+    func undoSlackComposeReceipt() async {
+        guard let receipt = slackComposeReceipt,
+              receipt.status == .sent,
+              let channelId = receipt.channel?.id,
+              let ts = receipt.ts,
+              undoingSlackComposeReceiptId == nil
+        else { return }
+
+        undoingSlackComposeReceiptId = receipt.requestId
+        defer {
+            if undoingSlackComposeReceiptId == receipt.requestId {
+                undoingSlackComposeReceiptId = nil
+            }
+        }
+        do {
+            try await slackComposerUndoer(session.id, channelId, ts)
+            if slackComposeReceipt?.requestId == receipt.requestId {
+                slackComposeReceipt = nil
+            }
+            notice = "Removed from Slack"
+        } catch {
+            notice = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+        }
+    }
+
     // ── Pull request ──
     /// PR details for the session's branch (toolbar chip + PR panel).
     /// nil until the first fetch lands — the chip falls back to the sessions
@@ -141,6 +172,7 @@ final class SessionViewModel {
     private var prTask: Task<Void, Never>?
     private var prLoadGeneration = 0
     private let prLoader: @MainActor (String) async throws -> PrDetails?
+    private let slackComposerUndoer: @MainActor (String, String, String) async throws -> Void
     private var notesTask: Task<Void, Never>?
 
     // ── Workflow runs ──
@@ -406,6 +438,9 @@ final class SessionViewModel {
         prLoader: @escaping @MainActor (String) async throws -> PrDetails? = {
             try await OS1API.pr(sessionId: $0)
         },
+        slackComposerUndoer: @escaping @MainActor (String, String, String) async throws -> Void = {
+            try await SlackAPI.undoComposer(sessionId: $0, channelId: $1, ts: $2)
+        },
         workflowLoader: @escaping @MainActor (String) async throws -> [WorkflowRun] = {
             try await OS1API.workflowRuns(sessionId: $0)
         }
@@ -415,6 +450,7 @@ final class SessionViewModel {
         self.outbox = outbox
         self.conversationLoadTimeout = conversationLoadTimeout
         self.prLoader = prLoader
+        self.slackComposerUndoer = slackComposerUndoer
         self.workflowLoader = workflowLoader
         self.isRunning = session.isRunning ?? false
         self.usage = session.usage

--- a/packages/clients/ios/OS1/Views/PrSlackShareSheet.swift
+++ b/packages/clients/ios/OS1/Views/PrSlackShareSheet.swift
@@ -371,7 +371,8 @@ struct PrSlackShareSheet: View {
                         channel: response.channel.map {
                             .init(id: $0.id, name: $0.name)
                         },
-                        permalink: response.permalink
+                        permalink: response.permalink,
+                        ts: response.ts
                     ))
                 } else if request.merged {
                     var screenshots: [String] = []

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -850,6 +850,15 @@ struct SessionView: View {
                    openPanel.isAvailable {
                     openPanel(.changes(sessionId: viewModel.session.id))
                 }
+                if ProcessInfo.processInfo.environment["OS1_SHOW_SLACK_RECEIPT"] == "1" {
+                    viewModel.resolveSlackComposer(SlackComposeReceipt(
+                        requestId: "screenshot-slack-receipt",
+                        status: .sent,
+                        channel: .init(id: "C123", name: "shipping"),
+                        permalink: "https://slack.com",
+                        ts: "1700000000.000000"
+                    ))
+                }
                 #endif
             }
             .onDisappear {
@@ -1328,9 +1337,13 @@ struct SessionView: View {
                 .transcriptTail(true)
         }
         if let receipt = viewModel.slackComposeReceipt {
-            SlackComposeReceiptRow(receipt: receipt)
-                .id("slack-receipt-\(receipt.id)")
-                .transcriptTail(true)
+            SlackComposeReceiptRow(
+                receipt: receipt,
+                isUndoing: viewModel.undoingSlackComposeReceiptId == receipt.id,
+                onUndo: { await viewModel.undoSlackComposeReceipt() }
+            )
+            .id("slack-receipt-\(receipt.id)")
+            .transcriptTail(true)
         }
         // A small child at the end keeps a single giant lazy transcript block
         // realized when the reader lands at the bottom. It is not the scroll
@@ -1519,6 +1532,8 @@ private extension View {
 
 private struct SlackComposeReceiptRow: View {
     let receipt: SlackComposeReceipt
+    let isUndoing: Bool
+    let onUndo: () async -> Void
 
     var body: some View {
         HStack(spacing: 6) {
@@ -1538,6 +1553,15 @@ private struct SlackComposeReceiptRow: View {
                     Link("Open in Slack", destination: url)
                         .underline()
                 }
+                if receipt.channel != nil, receipt.ts != nil {
+                    Text("·").foregroundStyle(OS1VisualStyle.textFaint)
+                    Button(isUndoing ? "Undoing…" : "Undo") {
+                        Task { await onUndo() }
+                    }
+                    .buttonStyle(.plain)
+                    .underline()
+                    .disabled(isUndoing)
+                }
             } else {
                 Text("Slack message cancelled")
             }
@@ -1545,7 +1569,6 @@ private struct SlackComposeReceiptRow: View {
         .font(.footnote)
         .foregroundStyle(OS1VisualStyle.textDim)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
     }
 }
 

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -194,8 +194,8 @@ final class ServerEventTests: XCTestCase {
         }
     }
 
-    func testSlackComposerSentReceiptDecodesDestinationAndPermalink() {
-        let json = #"{"type":"slack_composer_resolved","sessionId":"bks-1","requestId":"slack-1","status":"sent","channel":{"id":"C123","name":"shipping"},"permalink":"https://tella.slack.com/archives/C123/p1700000000000000"}"#
+    func testSlackComposerSentReceiptDecodesDestinationPermalinkAndTimestamp() {
+        let json = #"{"type":"slack_composer_resolved","sessionId":"bks-1","requestId":"slack-1","status":"sent","channel":{"id":"C123","name":"shipping"},"permalink":"https://tella.slack.com/archives/C123/p1700000000000000","ts":"1700000000.000000"}"#
         guard case .slackComposerResolved(let sessionId, let receipt) = parse(json) else {
             return XCTFail("expected .slackComposerResolved")
         }
@@ -207,6 +207,16 @@ final class ServerEventTests: XCTestCase {
             receipt.permalink,
             "https://tella.slack.com/archives/C123/p1700000000000000"
         )
+        XCTAssertEqual(receipt.ts, "1700000000.000000")
+    }
+
+    func testOlderSlackComposerSentReceiptDecodesWithoutTimestamp() {
+        guard case .slackComposerResolved(_, let receipt) = parse(
+            #"{"type":"slack_composer_resolved","sessionId":"bks-1","requestId":"slack-old","status":"sent","channel":{"id":"C123","name":"shipping"}}"#
+        ) else {
+            return XCTFail("expected .slackComposerResolved")
+        }
+        XCTAssertNil(receipt.ts)
     }
 
     func testSlackComposerCancelledReceiptDecodesWithoutDestination() {

--- a/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
@@ -259,6 +259,93 @@ final class SessionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.slackComposeReceipt, current)
     }
 
+    func testSlackReceiptUndoSendsItsTargetOnceAndClearsOnlyAfterSuccess() async {
+        var calls: [(session: String, channel: String, ts: String)] = []
+        var release: CheckedContinuation<Void, Error>?
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            slackComposerUndoer: { session, channel, ts in
+                calls.append((session, channel, ts))
+                try await withCheckedThrowingContinuation {
+                    release = $0
+                }
+            }
+        )
+        let receipt = SlackComposeReceipt(
+            requestId: "slack-undo",
+            status: .sent,
+            channel: .init(id: "C123", name: "shipping"),
+            permalink: nil,
+            ts: "1700000000.000000"
+        )
+        viewModel.resolveSlackComposer(receipt)
+
+        let firstTap = Task { await viewModel.undoSlackComposeReceipt() }
+        await Task.yield()
+        XCTAssertEqual(viewModel.undoingSlackComposeReceiptId, receipt.id)
+        XCTAssertEqual(calls.count, 1)
+
+        await viewModel.undoSlackComposeReceipt()
+        XCTAssertEqual(calls.count, 1, "a second tap must not issue another delete")
+        XCTAssertEqual(viewModel.slackComposeReceipt, receipt)
+
+        release?.resume()
+        await firstTap.value
+        XCTAssertNil(viewModel.slackComposeReceipt)
+        XCTAssertNil(viewModel.undoingSlackComposeReceiptId)
+        XCTAssertEqual(viewModel.notice, "Removed from Slack")
+        XCTAssertEqual(calls.first?.session, "bks-1")
+        XCTAssertEqual(calls.first?.channel, "C123")
+        XCTAssertEqual(calls.first?.ts, "1700000000.000000")
+    }
+
+    func testFailedSlackReceiptUndoKeepsReceiptAndReportsTheError() async {
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            slackComposerUndoer: { _, _, _ in
+                throw NSError(
+                    domain: "SlackUndoTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Slack refused the delete"]
+                )
+            }
+        )
+        let receipt = SlackComposeReceipt(
+            requestId: "slack-undo",
+            status: .sent,
+            channel: .init(id: "C123", name: "shipping"),
+            permalink: nil,
+            ts: "1700000000.000000"
+        )
+        viewModel.resolveSlackComposer(receipt)
+
+        await viewModel.undoSlackComposeReceipt()
+
+        XCTAssertEqual(viewModel.slackComposeReceipt, receipt)
+        XCTAssertNil(viewModel.undoingSlackComposeReceiptId)
+        XCTAssertEqual(viewModel.notice, "Slack refused the delete")
+    }
+
+    func testSlackReceiptWithoutTimestampCannotBeUndone() async {
+        var called = false
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            slackComposerUndoer: { _, _, _ in called = true }
+        )
+        let receipt = SlackComposeReceipt(
+            requestId: "slack-old",
+            status: .sent,
+            channel: .init(id: "C123", name: "shipping"),
+            permalink: nil
+        )
+        viewModel.resolveSlackComposer(receipt)
+
+        await viewModel.undoSlackComposeReceipt()
+
+        XCTAssertFalse(called)
+        XCTAssertEqual(viewModel.slackComposeReceipt, receipt)
+    }
+
     func testResyncDropsCachedPartialPrefixOfOffscreenCompletion() {
         let viewModel = makeViewModel()
         viewModel.handle(.sessionStatus(sessionId: "bks-1", isRunning: true))


### PR DESCRIPTION
## Summary
- retain optional Slack message timestamps from composer responses and socket receipts
- offer a guarded native Undo action that calls the sent-message delete route
- preserve failed receipts for retry and report both success and failure
- cover timestamp compatibility and Undo state transitions with focused tests

## Verification
- OS1 iOS simulator build passed
- OS1Mac build passed
- OS1Mac test suite passed

Created by [this OS session](https://os.tella.dev/session/bks-73befb05-dac2-7247-b963-0712ecc6af47)