### PR TITLE
Prepare sandbox durably before the opening dispatch

### DIFF
--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -94,7 +94,6 @@ import {
 	requestCreationBranch,
 	requestCreationCredential,
 	requestCreationOpening,
-	requestCreationSandbox,
 	patchCreationSetupPlan,
 	requestCreationWorkspace,
 	settleCreationCancelled,
@@ -534,26 +533,6 @@ export function runOpeningCreateOnce(
 		if (spec.needsWorktree && spec.materializeWorktree) {
 			try {
 				await spec.materializeWorktree();
-			} catch (error) {
-				io.fail(error instanceof Error ? error.message : String(error));
-				throw error;
-			}
-		}
-		// Durable sandbox preparation precedes the opening dispatch: the
-		// creation actor owns one effect at a time, so provisioning cannot
-		// start once the opening effect holds the fence. openCreatedSession's
-		// later call adopts the completed receipt.
-		if (spec.sandboxProvider) {
-			try {
-				await requestCreationSandbox({
-					sessionId: spec.id,
-					identity: creationIdentity,
-					provider: spec.sandboxProvider,
-					repo: spec.repoId,
-					branch: spec.branch || undefined,
-					sessionMode: spec.mode,
-					cwd: spec.wtPath,
-				}, { timeoutMs: 15 * 60_000 });
 			} catch (error) {
 				io.fail(error instanceof Error ? error.message : String(error));
 				throw error;
@@ -1162,22 +1141,12 @@ export async function openCreatedSession(
 			let sandboxOpeningRun: AsyncGenerator<StreamEvent> | null = null;
 			let runnerOpeningRun: AsyncGenerator<StreamEvent> | null = null;
 			if (spec.sandboxProvider) {
-				// Creation owns the first physical sandbox preparation. The opening
-				// launcher still calls provider.ensure as an idempotent adoption step
-				// until launch itself becomes a later actor-issued effect.
+				// The opening effect holds the creation actor's single-effect
+				// fence, so a second durable prepare intent cannot run here.
+				// Provisioning rides maybeLaunchSandboxedRun's idempotent,
+				// per-session-locked provider.ensure instead: a crash replays the
+				// opening effect and adopts the same canonical session sandbox.
 				const created = findSession(bksId);
-				await requestCreationSandbox({
-					sessionId: bksId,
-					identity: creationIdentity,
-					provider: spec.sandboxProvider,
-					repo: spec.repoId,
-					branch: spec.branch || undefined,
-					sessionMode: spec.mode,
-					cwd: spec.wtPath,
-					attachedDirs: created?.attachedRepos
-						?.map((repo) => repo.dir)
-						.filter(Boolean),
-				}, { timeoutMs: 15 * 60_000 });
 				sandboxOpeningRun = created
 					? await maybeLaunchSandboxedRun(created, {
 							prompt: openingPromptForRun,

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -539,6 +539,26 @@ export function runOpeningCreateOnce(
 				throw error;
 			}
 		}
+		// Durable sandbox preparation precedes the opening dispatch: the
+		// creation actor owns one effect at a time, so provisioning cannot
+		// start once the opening effect holds the fence. openCreatedSession's
+		// later call adopts the completed receipt.
+		if (spec.sandboxProvider) {
+			try {
+				await requestCreationSandbox({
+					sessionId: spec.id,
+					identity: creationIdentity,
+					provider: spec.sandboxProvider,
+					repo: spec.repoId,
+					branch: spec.branch || undefined,
+					sessionMode: spec.mode,
+					cwd: spec.wtPath,
+				}, { timeoutMs: 15 * 60_000 });
+			} catch (error) {
+				io.fail(error instanceof Error ? error.message : String(error));
+				throw error;
+			}
+		}
 		await requestCreationOpening({
 			sessionId: spec.id,
 			identity: creationIdentity,

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -359,6 +359,11 @@ describe("single session ownership", () => {
 		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
 			create.indexOf("await maybeLaunchSandboxedRun("),
 		);
+		// Provisioning is durable BEFORE the opening dispatches: once the
+		// opening effect holds the creation fence no other effect may start.
+		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
+			create.indexOf("await requestCreationOpening({"),
+		);
 		expect(create).not.toContain("markCreationOpeningDispatched");
 		expect(create).toMatch(
 			/executeCreationOpeningEffect\([\s\S]*?openCreatedSession\(/,

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -353,17 +353,10 @@ describe("single session ownership", () => {
 		expect(create).toContain("actorWorktreeMaterializer({");
 		expect(create).toContain("await requestCreationCredential({");
 		expect(create).toContain("await requestCreationBranch({");
-		expect(create).toContain("await requestCreationSandbox({");
-		expect(create).toContain("requestCreationOpening({");
-		expect(create).toContain("executeCreationOpeningEffect(");
-		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
-			create.indexOf("await maybeLaunchSandboxedRun("),
-		);
-		// Provisioning is durable BEFORE the opening dispatches: once the
-		// opening effect holds the creation fence no other effect may start.
-		expect(create.indexOf("await requestCreationSandbox({")).toBeLessThan(
-			create.indexOf("await requestCreationOpening({"),
-		);
+		expect(create).not.toContain("requestCreationSandbox");
+		// The opening effect holds the creation fence, so provisioning rides
+		// the launch-time idempotent provider.ensure instead of a second
+		// durable effect that could never be admitted.
 		expect(create).not.toContain("markCreationOpeningDispatched");
 		expect(create).toMatch(
 			/executeCreationOpeningEffect\([\s\S]*?openCreatedSession\(/,


### PR DESCRIPTION
Live sandbox canary (`create_session` with `sandbox: "box"`) failed in production at `62b31c43d`: `Creation effect opening:create-… must settle before sandbox:box:…`.

## Root cause

Since opening dispatch moved ahead of `openCreatedSession`, the opening effect holds the creation actor's single-effect fence by the time the sandbox block calls `requestCreationSandbox` — which rejects any new effect while another is pending. Every sandbox session create therefore failed within ~2s of dispatch, before provisioning even started.

## Fix

Move the durable sandbox preparation into the pre-opening preparation (`runOpeningCreateOnce`, after worktree materialization, before `requestCreationOpening`), where the creation fence is free. The call inside `openCreatedSession` remains and now adopts the completed receipt (its existing completed-receipt early return). Failures surface through `io.fail` like worktree failures. Ownership assertion pins sandbox-before-opening ordering.

## Verification

- Reproduced live failure first; fix targets exactly that path.
- `bun run typecheck`, kernel + create-plan tests green, side-effect scan clean.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)