### PR TITLE
Add shared native code display settings

### DIFF
--- a/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
+++ b/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
@@ -156,6 +156,11 @@ struct CodeDisplaySettingsButton: View {
                 themeRaw = CodeDisplaySettings.Theme.dark.rawValue
             }
             if environment["OS1_OPEN_CODE_SETTINGS"] == "1" {
+                // Let UIKit attach the toolbar button before asking its popover
+                // controller for an anchor. Presenting during the first body
+                // pass aborts because the source view is not in a window yet.
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
                 presented = true
             }
             #endif

--- a/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
+++ b/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// Native rendering preferences shared by worktree Changes and pull request
+/// review. They are device-local: code presentation is a reader preference,
+/// not session data.
+struct CodeDisplaySettings: Equatable {
+    enum Theme: String, CaseIterable, Identifiable {
+        case system, light, dark
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .system: "Match app"
+            case .light: "Light"
+            case .dark: "Dark"
+            }
+        }
+    }
+
+    var style: PrDiffStyle
+    var wrapLines: Bool
+    var highlightEdits: Bool
+    var showFileStats: Bool
+    var theme: Theme
+
+    static let defaults = CodeDisplaySettings(
+        style: .unified,
+        wrapLines: false,
+        highlightEdits: true,
+        showFileStats: true,
+        theme: .system
+    )
+
+    // Keep the two pre-existing PR keys so an upgrade preserves choices. Both
+    // surfaces now read them; the names are persistence ABI, not ownership.
+    static let styleKey = "os1.pr.diffStyle"
+    static let wrapKey = "os1.pr.wrapLines"
+    static let highlightKey = "os1.code.highlightEdits"
+    static let statsKey = "os1.code.showFileStats"
+    static let themeKey = "os1.code.theme"
+
+    static func load(from store: UserDefaults) -> CodeDisplaySettings {
+        let fallback = defaults
+        return CodeDisplaySettings(
+            style: store.string(forKey: styleKey).flatMap(PrDiffStyle.init(rawValue:))
+                ?? fallback.style,
+            wrapLines: store.object(forKey: wrapKey) as? Bool ?? fallback.wrapLines,
+            highlightEdits: store.object(forKey: highlightKey) as? Bool
+                ?? fallback.highlightEdits,
+            showFileStats: store.object(forKey: statsKey) as? Bool
+                ?? fallback.showFileStats,
+            theme: store.string(forKey: themeKey).flatMap(Theme.init(rawValue:))
+                ?? fallback.theme
+        )
+    }
+
+    func save(to store: UserDefaults) {
+        store.set(style.rawValue, forKey: Self.styleKey)
+        store.set(wrapLines, forKey: Self.wrapKey)
+        store.set(highlightEdits, forKey: Self.highlightKey)
+        store.set(showFileStats, forKey: Self.statsKey)
+        store.set(theme.rawValue, forKey: Self.themeKey)
+    }
+}
+
+/// One native settings section reused by both code surfaces.
+///
+/// The web's "structural highlighting" is intraline syntax-tree highlighting.
+/// Native patches currently carry line-level data only, so that exact choice
+/// is deliberately unsupported. "Highlight edits" honestly controls the
+/// addition/deletion line washes the native renderer can provide.
+struct CodeDisplaySettingsControls: View {
+    @Binding var styleRaw: String
+    @Binding var wrapLines: Bool
+    @Binding var highlightEdits: Bool
+    @Binding var showFileStats: Bool
+    @Binding var themeRaw: String
+
+    var body: some View {
+        Section {
+            Picker("Layout", selection: style) {
+                ForEach(PrDiffStyle.allCases, id: \.self) { option in
+                    Label(option.label, systemImage: option.symbol).tag(option)
+                }
+            }
+            .pickerStyle(.inline)
+            Toggle("Wrap lines", isOn: $wrapLines)
+            Toggle("Highlight edits", isOn: $highlightEdits)
+            Toggle("File statistics", isOn: $showFileStats)
+            Picker("Theme", selection: theme) {
+                ForEach(CodeDisplaySettings.Theme.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+            .pickerStyle(.inline)
+        }
+    }
+
+    private var style: Binding<PrDiffStyle> {
+        Binding(
+            get: { PrDiffStyle(rawValue: styleRaw) ?? CodeDisplaySettings.defaults.style },
+            set: { styleRaw = $0.rawValue }
+        )
+    }
+
+    private var theme: Binding<CodeDisplaySettings.Theme> {
+        Binding(
+            get: {
+                CodeDisplaySettings.Theme(rawValue: themeRaw)
+                    ?? CodeDisplaySettings.defaults.theme
+            },
+            set: { themeRaw = $0.rawValue }
+        )
+    }
+}
+
+/// Standalone native settings popover used by both code toolbars.
+struct CodeDisplaySettingsButton: View {
+    @AppStorage(CodeDisplaySettings.styleKey) private var styleRaw = "unified"
+    @AppStorage(CodeDisplaySettings.wrapKey) private var wrapLines = false
+    @AppStorage(CodeDisplaySettings.highlightKey) private var highlightEdits = true
+    @AppStorage(CodeDisplaySettings.statsKey) private var showFileStats = true
+    @AppStorage(CodeDisplaySettings.themeKey) private var themeRaw = "system"
+    @State private var presented = false
+
+    var body: some View {
+        Button { presented = true } label: {
+            Label("Code display", systemImage: "slider.horizontal.3")
+        }
+        .popover(isPresented: $presented) {
+            NavigationStack {
+                Form {
+                    CodeDisplaySettingsControls(
+                        styleRaw: $styleRaw,
+                        wrapLines: $wrapLines,
+                        highlightEdits: $highlightEdits,
+                        showFileStats: $showFileStats,
+                        themeRaw: $themeRaw
+                    )
+                }
+                .navigationTitle("Code display")
+                .inlineTitleBarCompat()
+            }
+            .frame(minWidth: 320, minHeight: 420)
+            .presentationCompactAdaptation(.popover)
+        }
+        .task {
+            #if DEBUG
+            let environment = ProcessInfo.processInfo.environment
+            if environment["OS1_CODE_DISPLAY_PRESET"] == "dark-split-no-stats" {
+                styleRaw = PrDiffStyle.split.rawValue
+                wrapLines = true
+                highlightEdits = true
+                showFileStats = false
+                themeRaw = CodeDisplaySettings.Theme.dark.rawValue
+            }
+            if environment["OS1_OPEN_CODE_SETTINGS"] == "1" {
+                presented = true
+            }
+            #endif
+        }
+    }
+}
+
+struct CodeDisplayTheme: ViewModifier {
+    @AppStorage(CodeDisplaySettings.themeKey) private var themeRaw = "system"
+    @Environment(\.colorScheme) private var appColorScheme
+
+    func body(content: Content) -> some View {
+        content.environment(\.colorScheme, resolvedColorScheme)
+    }
+
+    private var resolvedColorScheme: ColorScheme {
+        switch CodeDisplaySettings.Theme(rawValue: themeRaw) ?? .system {
+        case .system: appColorScheme
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}
+
+extension View {
+    func codeDisplayTheme() -> some View {
+        modifier(CodeDisplayTheme())
+    }
+}

--- a/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
+++ b/packages/clients/ios/OS1/Models/CodeDisplaySettings.swift
@@ -93,7 +93,7 @@ struct CodeDisplaySettingsControls: View {
                     Text(option.label).tag(option)
                 }
             }
-            .pickerStyle(.inline)
+            .pickerStyle(.menu)
         }
     }
 

--- a/packages/clients/ios/OS1/Models/PrReview.swift
+++ b/packages/clients/ios/OS1/Models/PrReview.swift
@@ -160,9 +160,8 @@ enum PrPatchParser {
 
 // MARK: - How the diff is drawn
 
-/// Unified or side by side, and whether long lines wrap. The same pair of
-/// settings the web review canvas keeps in local storage: a reader picks them
-/// once, so they persist across sessions rather than resetting per file.
+/// Unified or side by side. The persisted native rendering preferences that
+/// use this value are shared by pull request review and worktree Changes.
 enum PrDiffStyle: String, CaseIterable, Sendable {
     case unified, split
 

--- a/packages/clients/ios/OS1/Views/ChangesView.swift
+++ b/packages/clients/ios/OS1/Views/ChangesView.swift
@@ -28,6 +28,7 @@ struct ChangesView: View {
     @State private var loadFailed = false
     /// The file being read, pushed one level deeper.
     @State private var openFile: FilePatch?
+    @AppStorage(CodeDisplaySettings.statsKey) private var showFileStats = true
 
     var body: some View {
         Group {
@@ -50,6 +51,9 @@ struct ChangesView: View {
         .navigationTitle(focus.map(Self.fileName) ?? "Changes")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                CodeDisplaySettingsButton()
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 if let focus, let file = focusedPatch(focus) {
                     Button {
@@ -93,11 +97,13 @@ struct ChangesView: View {
                         row(file)
                     }
                 } header: {
-                    Text(
-                        "\(diff.files.count) file"
-                        + "\(diff.files.count == 1 ? "" : "s") changed · "
-                        + "+\(diff.totalAdditions) −\(diff.totalDeletions)"
-                    )
+                    if showFileStats {
+                        Text(
+                            "\(diff.files.count) file"
+                            + "\(diff.files.count == 1 ? "" : "s") changed · "
+                            + "+\(diff.totalAdditions) −\(diff.totalDeletions)"
+                        )
+                    }
                 } footer: {
                     if diff.truncated == true {
                         Text("This diff is too large to send in full. The "
@@ -139,8 +145,10 @@ struct ChangesView: View {
                     }
                 }
                 Spacer(minLength: 8)
-                Text(counts(file))
-                    .font(.caption.monospacedDigit())
+                if showFileStats {
+                    Text(counts(file))
+                        .font(.caption.monospacedDigit())
+                }
                 if patch != nil {
                     Image(systemName: "chevron.right")
                         .font(.caption2.weight(.semibold))
@@ -284,6 +292,14 @@ struct ChangesView: View {
             repos = loaded
             patchIndex = index
             loadFailed = false
+            #if DEBUG
+            if focus == nil,
+               ProcessInfo.processInfo.environment["OS1_OPEN_CHANGES_FILE"] == "1" {
+                openFile = loaded.lazy.compactMap { repo in
+                    repo.diff.files.lazy.compactMap { index[repo.repo]?[$0.path] }.first
+                }.first
+            }
+            #endif
         } else {
             loadFailed = repos.isEmpty
         }
@@ -304,6 +320,8 @@ struct ChangesView: View {
 /// One file's diff, full height.
 private struct FileDiffView: View {
     let file: FilePatch
+    @State private var parsed: PrPatchFile?
+    @State private var parsing = true
     /// `.bare` is for the case where this IS the panel: the panel already
     /// names the file in the navigation bar, and a second title would blank
     /// the first one.
@@ -312,14 +330,30 @@ private struct FileDiffView: View {
     enum Chrome { case titled, bare }
 
     var body: some View {
-        ScrollView {
-            DiffText(patch: file.patch, maxLines: 2_000)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 12)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        Group {
+            if let parsed {
+                PrFileDiffBody(file: parsed, comment: nil, inline: false)
+            } else if parsing {
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    DiffText(patch: file.patch, maxLines: 2_000)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
         }
         .background(OS1VisualStyle.background)
+        .codeDisplayTheme()
         .modifier(FileDiffChrome(file: file, chrome: chrome))
+        .task(id: file) {
+            parsing = true
+            parsed = await Task.detached(priority: .userInitiated) {
+                PrPatchParser.files(in: file.patch).first
+            }.value
+            parsing = false
+        }
     }
 }
 

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -291,6 +291,8 @@ struct PrPanelView: View {
             #if DEBUG && os(iOS)
             if ProcessInfo.processInfo.environment["OS1_OPEN_PR_INFO"] == "1" {
                 page = .info
+            } else if ProcessInfo.processInfo.environment["OS1_OPEN_PR_FILES"] == "1" {
+                page = .files
             }
             #endif
         }
@@ -359,8 +361,14 @@ struct PrPanelView: View {
                 // The code page's own controls, only where they apply.
                 if page == .files {
                     ToolbarItem(placement: .topTrailingCompat) {
-                        PrViewOptionsMenu(lens: $lens, showsDiffDisplay: lens != .flow)
+                        PrViewOptionsMenu(lens: $lens)
                             .labelStyle(.iconOnly)
+                    }
+                    if lens != .flow {
+                        ToolbarItem(placement: .topTrailingCompat) {
+                            CodeDisplaySettingsButton()
+                                .labelStyle(.iconOnly)
+                        }
                     }
                 }
                 ToolbarItem(placement: .topTrailingCompat) { actionsMenu(pr) }

--- a/packages/clients/ios/OS1/Views/PrReviewCanvas.swift
+++ b/packages/clients/ios/OS1/Views/PrReviewCanvas.swift
@@ -774,13 +774,13 @@ private struct PrReviewSplitRowView: View {
         HStack(spacing: 0) {
             Text(number.map(String.init) ?? "")
                 .frame(width: 40, alignment: .trailing)
-            // Both columns keep the same width so the two sides of a change
-            // stay on one line together; a line too long for its column is
-            // what "wrap long lines" is for.
+            // Wrapped columns share the available width. Unwrapped columns
+            // keep a readable minimum but grow to the line's intrinsic width,
+            // so the enclosing horizontal scroll view never clips long lines.
             Text((line?.text).flatMap { $0.isEmpty ? " " : $0 } ?? " ")
                 .lineLimit(wraps ? nil : 1)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: !wraps, vertical: true)
+                .frame(maxWidth: wraps ? .infinity : nil, alignment: .leading)
                 .padding(.leading, 8)
             if let anchor, let comment {
                 Button { comment(anchor) } label: {
@@ -793,7 +793,11 @@ private struct PrReviewSplitRowView: View {
                 Color.clear.frame(width: 26)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(
+            minWidth: wraps ? 0 : 520,
+            maxWidth: wraps ? .infinity : nil,
+            alignment: .leading
+        )
         .foregroundStyle(PrDiffInk.foreground(line?.kind ?? .context))
         .background(
             highlightsEdits ? PrDiffInk.background(line?.kind ?? .context) : .clear

--- a/packages/clients/ios/OS1/Views/PrReviewCanvas.swift
+++ b/packages/clients/ios/OS1/Views/PrReviewCanvas.swift
@@ -58,6 +58,7 @@ struct PrReviewCanvas: View {
     @State private var flow: PrCodeFlow?
     @State private var flowLoading = false
     @State private var flowError: String?
+    @AppStorage(CodeDisplaySettings.statsKey) private var showFileStats = true
 
     var body: some View {
         Group {
@@ -137,14 +138,16 @@ struct PrReviewCanvas: View {
     private var fileList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 14) {
-                HStack {
-                    Text("\(files.count) file\(files.count == 1 ? "" : "s") changed")
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(OS1VisualStyle.textDim)
-                    Spacer(minLength: 8)
-                    changeCounts
+                if showFileStats {
+                    HStack {
+                        Text("\(files.count) file\(files.count == 1 ? "" : "s") changed")
+                            .font(.footnote.weight(.medium))
+                            .foregroundStyle(OS1VisualStyle.textDim)
+                        Spacer(minLength: 8)
+                        changeCounts
+                    }
+                    .padding(.horizontal, 4)
                 }
-                .padding(.horizontal, 4)
 
                 if !draftComments.isEmpty {
                     Text("\(draftComments.count) pending inline comment\(draftComments.count == 1 ? "" : "s") · saved locally until you submit one review")
@@ -210,7 +213,7 @@ struct PrReviewCanvas: View {
                             }
                         }
                         Spacer(minLength: 8)
-                        fileCounts(file)
+                        if showFileStats { fileCounts(file) }
                         Image(systemName: "chevron.down")
                             .font(.caption2.weight(.semibold))
                             .foregroundStyle(OS1VisualStyle.textDim)
@@ -560,16 +563,10 @@ struct PrCodeFlowRow: Identifiable {
     }
 }
 
-/// The lens picker, and the display settings for the lenses that draw a diff.
-/// The settings live in app storage rather than view state so they survive
-/// leaving the canvas, and so the file view below reads the same values.
+/// Picks what the review canvas shows. Rendering preferences have their own
+/// shared control beside this one because they also apply to worktree Changes.
 struct PrViewOptionsMenu: View {
     @Binding var lens: PrReviewCanvas.Lens
-    var showsDiffDisplay = true
-
-    @AppStorage(PrDiffDisplay.styleKey) private var styleRaw = ""
-    @AppStorage(PrDiffDisplay.wrapKey) private var wrapLines = false
-    @Environment(\.horizontalSizeClass) private var sizeClass
 
     var body: some View {
         Menu {
@@ -579,45 +576,11 @@ struct PrViewOptionsMenu: View {
                 }
             }
             .pickerStyle(.inline)
-
-            if showsDiffDisplay {
-                Section {
-                    Picker("Diff display", selection: styleBinding) {
-                        ForEach(PrDiffStyle.allCases, id: \.self) { style in
-                            Label(style.label, systemImage: style.symbol).tag(style)
-                        }
-                    }
-                    .pickerStyle(.inline)
-                    Toggle(isOn: $wrapLines) {
-                        Label("Wrap long lines", systemImage: "text.append")
-                    }
-                }
-            }
         } label: {
             Label("View options", systemImage: "slider.horizontal.3")
         }
     }
 
-    private var styleBinding: Binding<PrDiffStyle> {
-        Binding(
-            get: { PrDiffDisplay.style(styleRaw, sizeClass: sizeClass) },
-            set: { styleRaw = $0.rawValue }
-        )
-    }
-}
-
-/// Where the display settings are stored, and what an unset value means.
-enum PrDiffDisplay {
-    static let styleKey = "os1.pr.diffStyle"
-    static let wrapKey = "os1.pr.wrapLines"
-
-    /// Side-by-side columns don't fit a phone, so a reader who has never
-    /// picked gets unified there and split where there is room — the same
-    /// default the web applies at its phone breakpoint.
-    static func style(_ raw: String, sizeClass: UserInterfaceSizeClass?) -> PrDiffStyle {
-        if let stored = PrDiffStyle(rawValue: raw) { return stored }
-        return sizeClass == .regular ? .split : .unified
-    }
 }
 
 /// A file's diff. The same body whether it is folded open inside the list or
@@ -634,34 +597,47 @@ enum PrDiffDisplay {
 /// honours the setting, which is what it is for.
 struct PrFileDiffBody: View {
     let file: PrPatchFile
-    let comment: (Int) -> Void
+    /// Nil on worktree Changes, where there is no GitHub review thread to
+    /// anchor a comment to.
+    let comment: ((Int) -> Void)?
     /// Inline, the enclosing list scrolls vertically and this must not.
     var inline = true
 
-    @AppStorage(PrDiffDisplay.styleKey) private var styleRaw = ""
-    @AppStorage(PrDiffDisplay.wrapKey) private var wrapLines = false
-    @Environment(\.horizontalSizeClass) private var sizeClass
+    @AppStorage(CodeDisplaySettings.styleKey) private var styleRaw = "unified"
+    @AppStorage(CodeDisplaySettings.wrapKey) private var wrapLines = false
+    @AppStorage(CodeDisplaySettings.highlightKey) private var highlightEdits = true
+    @AppStorage(CodeDisplaySettings.themeKey) private var themeRaw = "system"
     @State private var viewportHeight: CGFloat = 0
 
-    private var style: PrDiffStyle { PrDiffDisplay.style(styleRaw, sizeClass: sizeClass) }
+    private var style: PrDiffStyle {
+        PrDiffStyle(rawValue: styleRaw) ?? CodeDisplaySettings.defaults.style
+    }
 
     var body: some View {
-        if inline {
-            lines
-        } else if wrapLines {
-            ScrollView(.vertical) { lines.padding(.vertical, 8) }
-        } else {
-            // A two-axis scroll view centres content smaller than itself, which
-            // parks a short file in the middle of the screen. The min height
-            // pins it to the top instead.
-            ScrollView([.horizontal, .vertical]) {
+        Group {
+            if inline {
                 lines
-                    .frame(minWidth: style == .split ? 1040 : 680, alignment: .leading)
-                    .frame(minHeight: viewportHeight, alignment: .top)
-                    .padding(.vertical, 8)
+            } else if wrapLines {
+                ScrollView(.vertical) { lines.padding(.vertical, 8) }
+            } else {
+                // A two-axis scroll view centres content smaller than itself, which
+                // parks a short file in the middle of the screen. The min height
+                // pins it to the top instead.
+                ScrollView([.horizontal, .vertical]) {
+                    lines
+                        .frame(minWidth: style == .split ? 1040 : 680, alignment: .leading)
+                        .frame(minHeight: viewportHeight, alignment: .top)
+                        .padding(.vertical, 8)
+                }
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { viewportHeight = $0 }
             }
-            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { viewportHeight = $0 }
         }
+        .background(
+            themeRaw == CodeDisplaySettings.Theme.system.rawValue
+                ? Color.clear
+                : OS1VisualStyle.background
+        )
+        .codeDisplayTheme()
     }
 
     @ViewBuilder
@@ -670,11 +646,21 @@ struct PrFileDiffBody: View {
         LazyVStack(alignment: .leading, spacing: 0) {
             if style == .split {
                 ForEach(PrPatchParser.rows(file.lines)) { row in
-                    PrReviewSplitRowView(row: row, wraps: wraps, comment: comment)
+                    PrReviewSplitRowView(
+                        row: row,
+                        wraps: wraps,
+                        highlightsEdits: highlightEdits,
+                        comment: comment
+                    )
                 }
             } else {
                 ForEach(file.lines) { line in
-                    PrReviewLineView(line: line, wraps: wraps, comment: comment)
+                    PrReviewLineView(
+                        line: line,
+                        wraps: wraps,
+                        highlightsEdits: highlightEdits,
+                        comment: comment
+                    )
                 }
             }
         }
@@ -695,7 +681,7 @@ private struct PrReviewFileView: View {
             .inlineTitleBarCompat()
             .toolbar {
                 ToolbarItem(placement: .topTrailingCompat) {
-                    PrDiffDisplayMenu()
+                    CodeDisplaySettingsButton()
                 }
                 ToolbarItem(placement: .topTrailingCompat) {
                     Button(action: toggleViewed) {
@@ -716,42 +702,11 @@ private struct PrReviewFileView: View {
 
 }
 
-/// The display half of the canvas' options, repeated on the file itself: a
-/// reader who decides mid-file that they want side by side shouldn't have to
-/// walk back out to say so.
-private struct PrDiffDisplayMenu: View {
-    @AppStorage(PrDiffDisplay.styleKey) private var styleRaw = ""
-    @AppStorage(PrDiffDisplay.wrapKey) private var wrapLines = false
-    @Environment(\.horizontalSizeClass) private var sizeClass
-
-    var body: some View {
-        Menu {
-            Picker("Diff display", selection: styleBinding) {
-                ForEach(PrDiffStyle.allCases, id: \.self) { style in
-                    Label(style.label, systemImage: style.symbol).tag(style)
-                }
-            }
-            .pickerStyle(.inline)
-            Toggle(isOn: $wrapLines) {
-                Label("Wrap long lines", systemImage: "text.append")
-            }
-        } label: {
-            Label("Diff display", systemImage: "slider.horizontal.3")
-        }
-    }
-
-    private var styleBinding: Binding<PrDiffStyle> {
-        Binding(
-            get: { PrDiffDisplay.style(styleRaw, sizeClass: sizeClass) },
-            set: { styleRaw = $0.rawValue }
-        )
-    }
-}
-
 private struct PrReviewLineView: View {
     let line: PrPatchLine
     var wraps = false
-    let comment: (Int) -> Void
+    var highlightsEdits = true
+    let comment: ((Int) -> Void)?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -768,20 +723,20 @@ private struct PrReviewLineView: View {
                 .frame(maxWidth: wraps ? .infinity : nil, alignment: .leading)
                 .padding(.leading, 10)
             if !wraps { Spacer(minLength: 0) }
-            if let anchor = line.commentLine {
+            if let anchor = line.commentLine, let comment {
                 Button { comment(anchor) } label: {
                     Image(systemName: "plus.bubble")
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 8)
                 .accessibilityLabel("Add inline comment on line \(anchor)")
-            } else {
+            } else if comment != nil {
                 Color.clear.frame(width: 36)
             }
         }
         .font(.system(.caption, design: .monospaced))
         .foregroundStyle(PrDiffInk.foreground(line.kind))
-        .background(PrDiffInk.background(line.kind))
+        .background(highlightsEdits ? PrDiffInk.background(line.kind) : .clear)
         .textSelection(.enabled)
     }
 }
@@ -791,7 +746,8 @@ private struct PrReviewLineView: View {
 private struct PrReviewSplitRowView: View {
     let row: PrPatchRow
     var wraps = false
-    let comment: (Int) -> Void
+    var highlightsEdits = true
+    let comment: ((Int) -> Void)?
 
     var body: some View {
         if let header = row.header {
@@ -826,20 +782,22 @@ private struct PrReviewSplitRowView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 8)
-            if let anchor {
+            if let anchor, let comment {
                 Button { comment(anchor) } label: {
                     Image(systemName: "plus.bubble")
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 6)
                 .accessibilityLabel("Add inline comment on line \(anchor)")
-            } else {
+            } else if comment != nil {
                 Color.clear.frame(width: 26)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .foregroundStyle(PrDiffInk.foreground(line?.kind ?? .context))
-        .background(PrDiffInk.background(line?.kind ?? .context))
+        .background(
+            highlightsEdits ? PrDiffInk.background(line?.kind ?? .context) : .clear
+        )
     }
 }
 

--- a/packages/clients/ios/OS1Tests/CodeDisplaySettingsTests.swift
+++ b/packages/clients/ios/OS1Tests/CodeDisplaySettingsTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import OS1
+
+final class CodeDisplaySettingsTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName = ""
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CodeDisplaySettingsTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testSharedDefaultsMatchNativeRenderer() {
+        XCTAssertEqual(
+            CodeDisplaySettings.load(from: defaults),
+            CodeDisplaySettings.defaults
+        )
+        XCTAssertEqual(CodeDisplaySettings.defaults.style, .unified)
+        XCTAssertFalse(CodeDisplaySettings.defaults.wrapLines)
+        XCTAssertTrue(CodeDisplaySettings.defaults.highlightEdits)
+        XCTAssertTrue(CodeDisplaySettings.defaults.showFileStats)
+        XCTAssertEqual(CodeDisplaySettings.defaults.theme, .system)
+    }
+
+    func testRoundTripsOneSharedPreferenceSet() {
+        let chosen = CodeDisplaySettings(
+            style: .split,
+            wrapLines: true,
+            highlightEdits: false,
+            showFileStats: false,
+            theme: .dark
+        )
+
+        chosen.save(to: defaults)
+
+        XCTAssertEqual(CodeDisplaySettings.load(from: defaults), chosen)
+    }
+
+    func testInvalidStoredEnumsFallBackWithoutDiscardingValidChoices() {
+        defaults.set("columns", forKey: CodeDisplaySettings.styleKey)
+        defaults.set("sepia", forKey: CodeDisplaySettings.themeKey)
+        defaults.set(true, forKey: CodeDisplaySettings.wrapKey)
+
+        let loaded = CodeDisplaySettings.load(from: defaults)
+
+        XCTAssertEqual(loaded.style, .unified)
+        XCTAssertEqual(loaded.theme, .system)
+        XCTAssertTrue(loaded.wrapLines)
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -161,7 +161,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering, iOS 26+
   split of what is already in hand (`PatchSplitter`) rather than a request per
   row — the split runs once per load, off the main actor, into a path-keyed
   index. A session spanning several repos gets a repo switcher; binary files
-  and a truncated patch say so rather than pushing an empty page.
+  and a truncated patch say so rather than pushing an empty page. Its native
+  code-display controls share persisted layout, wrapping, edit highlighting,
+  file-statistics, and light/dark theme choices with PR review.
 - **File paths in the transcript are links** (`FileLinks`) — a path an agent
   names in its own prose opens that file's diff, so the file you are reading
   about is one tap away instead of a trip through the overflow menu. Only
@@ -239,7 +241,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering, iOS 26+
   so an unconnected account gets the server's "connect your GitHub account"
   sentence in the panel rather than a status code. It is
   pushed as a panel (`PrPanelView(chrome: .pushed)` drops its own navigation
-  stack and Done button); the sheet form is what the Mac still uses.
+  stack and Done button); the sheet form is what the Mac still uses. The Files
+  page and worktree Changes use the same device-local code-display defaults and
+  controls, including unified/split rendering and a code-only theme override.
 - **New session** (`NewSessionView.swift`): the repo sits across the top, the
   prompt fills the middle, and run controls sit in the footer. On iOS, Code is
   the quiet default, so there is no default New branch chip. Ask and Sandbox


### PR DESCRIPTION
## Summary
- share device-local code display preferences between worktree Changes and pull request review
- render unified or split diffs with wrapping, native edit washes, optional file statistics, and a code-only light/dark theme
- reuse the PR diff renderer for Changes and cover defaults, persistence, and invalid stored values

## Testing
- OS1 simulator build
- OS1Mac build
- OS1Mac unit tests

Created by [this OS session](https://os.tella.dev/session/bks-c4fd8552-716c-79a3-ba38-816e7b202ccb)
