### PR TITLE
Settle ask answers through the actor aggregate

### DIFF
--- a/packages/core/opensession-server/src/server/asks-restart.test.ts
+++ b/packages/core/opensession-server/src/server/asks-restart.test.ts
@@ -7,6 +7,7 @@ import {
 	pendingAskAwaitingAnswer,
 	pendingAsks,
 	pendingAskTimers,
+	persistPendingAsks,
 	restorePendingAsks,
 	settleRestoredAskAfterRecovery,
 } from "./asks";
@@ -17,6 +18,8 @@ import {
 	type SessionControl,
 } from "./session-control";
 import { setTranscriptForwarder } from "./transcript-forward";
+import { __setSessionsDirForTest, sessionsDir } from "./paths";
+import { sessionAsk } from "./session-kernel";
 import { stripContext } from "./prompt-context";
 
 const SESSION = "os-pending-ask-restart-test";
@@ -284,5 +287,72 @@ describe("pending ask restart persistence", () => {
 		expect(pendingAsks.has(SESSION)).toBe(false);
 		expect(pendingAskTimers.has(SESSION)).toBe(false);
 		expect(JSON.parse(readFileSync(storePath, "utf8"))).toEqual({ asks: [] });
+	});
+
+	test("commit \u2192 crash \u2192 restore \u2192 adopt \u2192 retry keeps answer identity", () => {
+		scratch = mkdtempSync(join(tmpdir(), "os-asks-crash-retry-"));
+		const previousSessionsDir = sessionsDir();
+		__setSessionsDirForTest(scratch);
+		try {
+			const resultPromise = makeAskHandler(SESSION)({ questions: [QUESTION] });
+			const questionId = pendingAsks.get(SESSION)?.questionId ?? null;
+
+			// The actor commits the answer durably; the process crashes before
+			// the gateway resolver runs, so nothing retires the record.
+			expect(
+				sessionAsk({
+					op: "answer",
+					sessionId: SESSION,
+					questionId,
+					answers: { "Which option?": "One" },
+					answeredVia: "req-original",
+				}),
+			).toEqual({ matched: true });
+			// Process loss drops timers and closures, never the durable record.
+			clearTimeout(pendingAskTimers.get(SESSION)?.handle);
+			pendingAskTimers.delete(SESSION);
+
+			// Restart: recovery reads actor authority and projects the
+			// committed answer as answered instead of re-asking.
+			restorePendingAsks({ sessionExists: () => true });
+			restorePendingAsks({ sessionExists: () => true });
+			const restored = pendingAsks.get(SESSION);
+			expect(restored?.answerReceived).toBe(true);
+			expect(restored?.earlyAnswer).toEqual({ "Which option?": "One" });
+			expect(restored?.answer?.requestId).toBe("req-original");
+
+			// The recovered engine re-emits its ask; adoption rewrites the
+			// record and must carry the receipt with it.
+			void makeAskHandler(SESSION)({ questions: [QUESTION] });
+			expect(pendingAsks.get(SESSION)?.answer?.requestId).toBe("req-original");
+
+			// The exact caller retries: replay matched with committed answers.
+			expect(
+				sessionAsk({
+					op: "answer",
+					sessionId: SESSION,
+					questionId,
+					answers: { "Which option?": "Something else" },
+					answeredVia: "req-original",
+				}),
+			).toEqual({
+				matched: true,
+				answers: { "Which option?": "One" },
+			});
+			expect(
+				sessionAsk({
+					op: "answer",
+					sessionId: SESSION,
+					questionId,
+					answers: { "Which option?": "Two" },
+					answeredVia: "req-other",
+				}),
+			).toEqual({ matched: false });
+
+			// The adopted live waiter still wakes with the committed answers.
+			pendingAsks.get(SESSION)?.resolve({ "Which option?": "One" });
+		} finally {
+			__setSessionsDirForTest(previousSessionsDir);
+		}
 	});
 });

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -147,6 +147,7 @@ export function persistPendingAsks(storePath = pendingAskStorePath()): void {
 				...(ask.answerReceived
 					? { answerReceived: true, earlyAnswer: ask.earlyAnswer ?? null }
 					: {}),
+				...(ask.answer ? { answer: ask.answer } : {}),
 			});
 		}
 		writeJsonAtomic(storePath, { asks }, false, 0o600);
@@ -582,23 +583,19 @@ export function restorePendingAsks(
         ...(ask.escalatedPersonName
           ? { escalatedPersonName: ask.escalatedPersonName }
           : {}),
-        ...(ask.answerReceived
-          ? { answerReceived: true, earlyAnswer: ask.earlyAnswer ?? null }
+        ...(ask.answerReceived || ask.answer
+          ? {
+              answerReceived: true,
+              earlyAnswer:
+                ask.earlyAnswer ?? ask.answer?.answers ?? null,
+            }
           : {}),
+        ...(ask.answer ? { answer: ask.answer } : {}),
         // A crash between the actor's durable answer commit and the gateway
         // resolver leaves answerReceived unset; project the committed answer
         // so recovery consumes it instead of re-asking. The answer rides the
         // restored record so its retry identity survives the rewrite.
-        ...((ask as { answer?: { requestId: string; answers: Record<string, string> | null } })
-          .answer && !ask.answerReceived
-          ? {
-              answerReceived: true,
-              earlyAnswer:
-                (ask as unknown as {
-                  answer: { answers: Record<string, string> | null };
-                }).answer.answers ?? null,
-            }
-          : {}),
+        ...(ask.answer ? { answer: ask.answer } : {}),
       })),
     };
   } else {
@@ -639,10 +636,13 @@ export function restorePendingAsks(
 			...(saved.escalatedPersonName
 				? { escalatedPersonName: saved.escalatedPersonName }
 				: {}),
-			...(saved.answerReceived
+			...(saved.answerReceived || saved.answer
 				? {
 						answerReceived: true,
-						earlyAnswer: saved.earlyAnswer ?? null,
+						earlyAnswer:
+							saved.earlyAnswer ??
+							saved.answer?.answers ??
+							null,
 					}
 				: {}),
 			...(saved.answer ? { answer: saved.answer } : {}),
@@ -819,6 +819,9 @@ export function makeAskHandler(sessionId: string) {
 								earlyAnswer: existing!.earlyAnswer ?? null,
 							}
 						: {}),
+					// Preserve the durable answer receipt across adoption so retry
+					// identity and the committed payload survive the rewrite.
+					...(adopted && existing!.answer ? { answer: existing!.answer } : {}),
 					...(adopted && existing!.storePath
 						? { storePath: existing!.storePath }
 						: {}),

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -580,6 +580,19 @@ export function restorePendingAsks(
         ...(ask.answerReceived
           ? { answerReceived: true, earlyAnswer: ask.earlyAnswer ?? null }
           : {}),
+        // A crash between the actor's durable answer commit and the gateway
+        // resolver leaves answerReceived unset; project the committed answer
+        // so recovery consumes it instead of re-asking.
+        ...((ask as { answer?: { answers: Record<string, string> | null } })
+          .answer && !ask.answerReceived
+          ? {
+              answerReceived: true,
+              earlyAnswer:
+                (ask as unknown as {
+                  answer: { answers: Record<string, string> | null };
+                }).answer.answers ?? null,
+            }
+          : {}),
       })),
     };
   } else {

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -61,6 +61,10 @@ export interface PendingAsk {
 	escalationWaitStarted?: boolean;
 	answerReceived?: boolean;
 	earlyAnswer?: Record<string, string> | null;
+	/** Durable answer receipt recorded by the actor before the gateway
+	 * resolver ran. Preserved through restore so retry identity and the
+	 * committed payload survive a restart. */
+	answer?: { requestId: string; answers: Record<string, string> | null };
 	restored?: boolean;
 	/** Test/isolated-instance seam; live asks use pendingAskStorePath(). */
 	storePath?: string;
@@ -96,6 +100,7 @@ type PersistedPendingAsk = {
 	escalatedPersonName?: string;
 	answerReceived?: boolean;
 	earlyAnswer?: Record<string, string> | null;
+	answer?: { requestId: string; answers: Record<string, string> | null };
 };
 
 type PendingAskTimer = {
@@ -582,8 +587,9 @@ export function restorePendingAsks(
           : {}),
         // A crash between the actor's durable answer commit and the gateway
         // resolver leaves answerReceived unset; project the committed answer
-        // so recovery consumes it instead of re-asking.
-        ...((ask as { answer?: { answers: Record<string, string> | null } })
+        // so recovery consumes it instead of re-asking. The answer rides the
+        // restored record so its retry identity survives the rewrite.
+        ...((ask as { answer?: { requestId: string; answers: Record<string, string> | null } })
           .answer && !ask.answerReceived
           ? {
               answerReceived: true,
@@ -639,6 +645,7 @@ export function restorePendingAsks(
 						earlyAnswer: saved.earlyAnswer ?? null,
 					}
 				: {}),
+			...(saved.answer ? { answer: saved.answer } : {}),
 			restored: true,
 			storePath,
 			resolve: (answers) =>

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -18,7 +18,7 @@
 import { AUTO_CONTINUE_USER } from "./auto-continue";
 import { personaName } from "./config";
 import { currentAgentRunToken, isAgentSessionBusy, steerAgentRun } from "./agent-runner";
-import { pendingAskAwaitingAnswer } from "./asks";
+import { pendingAskAwaitingAnswer, pendingAsks } from "./asks";
 import { relinkAskThreads } from "./human-asks";
 import { SESSION_EFFORTS, type SessionEffort, providerFor, resolveModel } from "./models";
 import { configuredInteractiveDefaultModel } from "./model-catalog";
@@ -56,6 +56,7 @@ import {
 	requestCreationBranch,
 	requestCreationCredential,
 	requestCreationWorkspace,
+	sessionAsk,
 	sessionKernel,
 	sessionKernelOwnsCurrentCommand,
   sessionTurn,
@@ -152,23 +153,23 @@ registerSessionControl({
 	},
 
 	answerQuestion: async (id, answers, opts) => {
-		const requestId = opts?.requestId || randomUUIDv7();
 		const questionId = pendingAskAwaitingAnswer(id)?.questionId || null;
-		const accepted = await sessionKernel(id).dispatchLegacy(
-			legacyGatewayEffect("answer_question", {
-				requestId,
-				payload: { questionId, answers },
-				source: "session_control",
-				replaySafe: true,
-			}),
-			() => {
-				const pending = pendingAskAwaitingAnswer(id);
-				if (!pending || pending.questionId !== questionId) return false;
-				pending.resolve(answers && typeof answers === "object" ? answers : null);
-				return true;
-			},
-		);
-		return accepted.result;
+		// The actor settles the durable ask aggregate directly; the gateway
+		// waiter is resolved from the committed result. No compatibility
+		// mailbox entry: the aggregate itself makes replay idempotent.
+		const settled = sessionAsk({
+			op: "answer",
+			sessionId: id,
+			questionId,
+			answers,
+		});
+		if (!settled.matched) return false;
+		const pending = pendingAsks.get(id) as
+			| { questionId?: string; resolve?: (value: unknown) => void }
+			| undefined;
+		if (pending?.resolve && pending.questionId === questionId)
+			pending.resolve(answers && typeof answers === "object" ? answers : null);
+		return true;
 	},
 
 	deliverToSession: async (id, content, user, opts) => {

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -153,21 +153,27 @@ registerSessionControl({
 	},
 
 	answerQuestion: async (id, answers, opts) => {
+		const requestId = opts?.requestId || randomUUIDv7();
 		const questionId = pendingAskAwaitingAnswer(id)?.questionId || null;
-		// The actor settles the durable ask aggregate directly; the gateway
-		// waiter is resolved from the committed result. No compatibility
-		// mailbox entry: the aggregate itself makes replay idempotent.
+		// The actor records the answer durably under the caller's retry
+		// identity; the aggregate makes replay idempotent. The gateway-side
+		// resolver then runs its live side effects (escalation cancel,
+		// broadcast, tool-promise wake) — it owns the answerReceived flag.
 		const settled = sessionAsk({
 			op: "answer",
 			sessionId: id,
 			questionId,
 			answers,
+			answeredVia: requestId,
 		});
 		if (!settled.matched) return false;
 		const pending = pendingAsks.get(id) as
 			| { questionId?: string; resolve?: (value: unknown) => void }
 			| undefined;
-		if (pending?.resolve && pending.questionId === questionId)
+		if (
+			pending?.resolve &&
+			(questionId === null || pending.questionId === questionId)
+		)
 			pending.resolve(answers && typeof answers === "object" ? answers : null);
 		return true;
 	},

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -167,6 +167,10 @@ registerSessionControl({
 			answeredVia: requestId,
 		});
 		if (!settled.matched) return false;
+		// An exact retry must wake the waiter with the already-committed
+		// answers, never the retry call's payload.
+		const effective =
+			settled.answers ?? (answers && typeof answers === "object" ? answers : null);
 		const pending = pendingAsks.get(id) as
 			| { questionId?: string; resolve?: (value: unknown) => void }
 			| undefined;
@@ -174,7 +178,7 @@ registerSessionControl({
 			pending?.resolve &&
 			(questionId === null || pending.questionId === questionId)
 		)
-			pending.resolve(answers && typeof answers === "object" ? answers : null);
+			pending.resolve(effective);
 		return true;
 	},
 

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -656,6 +656,18 @@ class RemoteStore implements SessionKernelStoreApi {
   setAskRecord(sessionId: string, value: unknown) {
     this.actor.decideAsk({ op: "set", sessionId, value });
   }
+  answerAskRecord(
+    sessionId: string,
+    questionId: string | null,
+    answers: Record<string, string> | null,
+  ) {
+    return this.actor.decideAsk({
+      op: "answer",
+      sessionId,
+      questionId,
+      answers,
+    });
+  }
   deleteAskRecord(sessionId: string) {
     return this.actor.decideAsk({ op: "delete", sessionId });
   }

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -660,12 +660,14 @@ class RemoteStore implements SessionKernelStoreApi {
     sessionId: string,
     questionId: string | null,
     answers: Record<string, string> | null,
+    answeredVia: string,
   ) {
     return this.actor.decideAsk({
       op: "answer",
       sessionId,
       questionId,
       answers,
+      answeredVia,
     });
   }
   deleteAskRecord(sessionId: string) {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -388,6 +388,12 @@ export function startSessionKernelActorWorker(): void {
           else if (ask.op === "entries") result = store.askEntries();
           else if (ask.op === "set")
             result = store.setAskRecord(ask.sessionId, ask.value);
+          else if (ask.op === "answer")
+            result = store.answerAskRecord(
+              ask.sessionId,
+              ask.questionId,
+              ask.answers,
+            );
           else if (ask.op === "delete")
             result = store.deleteAskRecord(ask.sessionId);
           else result = store.clearAskRecords();

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -393,6 +393,7 @@ export function startSessionKernelActorWorker(): void {
               ask.sessionId,
               ask.questionId,
               ask.answers,
+              ask.answeredVia,
             );
           else if (ask.op === "delete")
             result = store.deleteAskRecord(ask.sessionId);

--- a/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
@@ -3,6 +3,12 @@ export type AskActorRequest =
   | { op: "entries" }
   | { op: "set"; sessionId: string; value: unknown }
   | { op: "delete"; sessionId: string }
+  | {
+      op: "answer";
+      sessionId: string;
+      questionId: string | null;
+      answers: Record<string, string> | null;
+    }
   | { op: "clear" };
 
 export type AskActorResult<T extends AskActorRequest> = T extends {
@@ -13,4 +19,6 @@ export type AskActorResult<T extends AskActorRequest> = T extends {
     ? Array<[string, unknown]>
     : T extends { op: "delete" }
       ? boolean
-      : void;
+      : T extends { op: "answer" }
+        ? { matched: boolean }
+        : void;

--- a/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
@@ -8,6 +8,7 @@ export type AskActorRequest =
       sessionId: string;
       questionId: string | null;
       answers: Record<string, string> | null;
+      answeredVia: string;
     }
   | { op: "clear" };
 

--- a/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ask-protocol.ts
@@ -21,5 +21,5 @@ export type AskActorResult<T extends AskActorRequest> = T extends {
     : T extends { op: "delete" }
       ? boolean
       : T extends { op: "answer" }
-        ? { matched: boolean }
+        ? { matched: boolean; answers?: Record<string, string> | null }
         : void;

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -99,6 +99,7 @@ export function sessionAsk<T extends AskActorRequest>(
       request.sessionId,
       request.questionId,
       request.answers,
+      request.answeredVia,
     );
   else if (request.op === "delete")
     result = store.deleteAskRecord(request.sessionId);

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -94,6 +94,12 @@ export function sessionAsk<T extends AskActorRequest>(
   else if (request.op === "entries") result = store.askEntries();
   else if (request.op === "set")
     result = store.setAskRecord(request.sessionId, request.value);
+  else if (request.op === "answer")
+    result = store.answerAskRecord(
+      request.sessionId,
+      request.questionId,
+      request.answers,
+    );
   else if (request.op === "delete")
     result = store.deleteAskRecord(request.sessionId);
   else result = store.clearAskRecords();

--- a/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/lifecycle-protocol.ts
@@ -15,7 +15,6 @@ import type {
  * this adapter unless a reviewer deliberately changes both fences.
  */
 export const LEGACY_GATEWAY_EFFECT_OPERATIONS = Object.freeze([
-  "answer_question",
   "cancel_session",
   "delete_session",
   "session_file_updated",
@@ -24,7 +23,7 @@ export const LEGACY_GATEWAY_EFFECT_OPERATIONS = Object.freeze([
   "websocket_command",
 ] as const);
 
-export const LEGACY_GATEWAY_EFFECT_SITE_BASELINE = 6;
+export const LEGACY_GATEWAY_EFFECT_SITE_BASELINE = 5;
 
 export type LegacyGatewayEffectOperation =
   (typeof LEGACY_GATEWAY_EFFECT_OPERATIONS)[number];

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -48,6 +48,9 @@ describe("single session ownership", () => {
 		expect(read("queue-state.ts")).toContain("new EphemeralSessionSet");
 		expect(read("asks.ts")).toContain("new AskOwnedMap");
 		expect(read("asks.ts")).toContain("new EphemeralSessionMap");
+		// A committed durable answer survives restore: the projection maps it
+		// to answered state and the rewrite carries its retry identity.
+		expect(read("asks.ts")).toContain("saved.answer ? { answer: saved.answer }");
 		expect(read("queue-state.ts") + read("asks.ts")).not.toContain("SessionOwnedMap");
 		expect(read("session-kernel/kernel.ts")).not.toContain("getRuntime<");
 		expect(read("session-kernel/kernel.ts")).not.toContain("setRuntime<");

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -30,7 +30,6 @@ describe("single session ownership", () => {
 		}, 0);
 		expect(sites).toBe(LEGACY_GATEWAY_EFFECT_SITE_BASELINE);
 		expect(LEGACY_GATEWAY_EFFECT_OPERATIONS).toEqual([
-			"answer_question",
 			"cancel_session",
 			"delete_session",
 			"session_file_updated",
@@ -372,7 +371,10 @@ describe("single session ownership", () => {
 		expect(create).not.toMatch(/\bcreateWorktreeForExistingBranch\(/);
 		expect(create).toContain("spec.openingPromptEntryId");
 		expect(wiring).toContain('legacyGatewayEffect("cancel_session"');
-		expect(wiring).toContain('legacyGatewayEffect("answer_question"');
+		// Ask answers settle through the typed actor aggregate, not the
+		// compatibility mailbox.
+		expect(wiring).not.toContain('legacyGatewayEffect("answer_question"');
+		expect(wiring).toContain('op: "answer",');
 		const tools = read("../agents/slack/sessions-tools.ts");
 		expect(tools).toContain("durableToolRequestId");
 		expect(tools).toContain('durableToolRequestId(ctx, "create_session", extra');

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1760,7 +1760,14 @@ export class SessionKernelStore {
       | undefined;
     if (!record) return { matched: false };
     if (record.answer)
-      return { matched: record.answer.requestId === answeredVia };
+      return {
+        matched: record.answer.requestId === answeredVia,
+        // An exact replay must resolve with the already-committed answers,
+        // never the retry call's payload.
+        ...(record.answer.requestId === answeredVia
+          ? { answers: record.answer.answers }
+          : {}),
+      };
     if (questionId !== null && (record.questionId ?? null) !== questionId)
       return { matched: false };
     this.setAskRecord(sessionId, {

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1741,26 +1741,31 @@ export class SessionKernelStore {
     this.mutateAskRecord(sessionId, value);
   }
 
-  /** Settle one pending ask durably. Idempotent on replay: an already
-   * answered record with the same question reports matched without
-   * re-mutating, so the original caller's true result replays. */
+  /** Settle one pending ask durably under the caller's retry identity.
+   * Idempotent: the same requestId replays matched; a different caller
+   * against an already-answered ask is rejected. The gateway-side
+   * `answerReceived` flag is deliberately left to the resolvers, whose
+   * side effects (escalation cancel, broadcast, persistence) read it. */
   answerAskRecord(
     sessionId: string,
     questionId: string | null,
     answers: Record<string, string> | null,
+    answeredVia: string,
   ): { matched: boolean } {
     const record = this.askSnapshot(sessionId) as
-      | { questionId?: string; answerReceived?: boolean }
+      | {
+          questionId?: string;
+          answer?: { requestId: string; answers: Record<string, string> | null };
+        }
       | undefined;
     if (!record) return { matched: false };
-    if (record.answerReceived)
-      return { matched: (record.questionId ?? null) === questionId };
+    if (record.answer)
+      return { matched: record.answer.requestId === answeredVia };
     if (questionId !== null && (record.questionId ?? null) !== questionId)
       return { matched: false };
     this.setAskRecord(sessionId, {
       ...record,
-      answerReceived: true,
-      earlyAnswer: answers,
+      answer: { requestId: answeredVia, answers },
     });
     return { matched: true };
   }

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1741,6 +1741,30 @@ export class SessionKernelStore {
     this.mutateAskRecord(sessionId, value);
   }
 
+  /** Settle one pending ask durably. Idempotent on replay: an already
+   * answered record with the same question reports matched without
+   * re-mutating, so the original caller's true result replays. */
+  answerAskRecord(
+    sessionId: string,
+    questionId: string | null,
+    answers: Record<string, string> | null,
+  ): { matched: boolean } {
+    const record = this.askSnapshot(sessionId) as
+      | { questionId?: string; answerReceived?: boolean }
+      | undefined;
+    if (!record) return { matched: false };
+    if (record.answerReceived)
+      return { matched: (record.questionId ?? null) === questionId };
+    if (questionId !== null && (record.questionId ?? null) !== questionId)
+      return { matched: false };
+    this.setAskRecord(sessionId, {
+      ...record,
+      answerReceived: true,
+      earlyAnswer: answers,
+    });
+    return { matched: true };
+  }
+
   deleteAskRecord(sessionId: string): boolean {
     return this.mutateAskRecord(sessionId, undefined);
   }


### PR DESCRIPTION
Item 1 slice of the migration: `answer_question` leaves the compatibility mailbox.

## Change

`answerQuestion` now settles the durable ask aggregate directly via a typed actor op (`sessionAsk({op:"answer", ...})`) instead of wrapping a gateway closure in `dispatchLegacy`. The aggregate makes replay idempotent (an already-answered record with the same question reports `matched:true` without re-mutating; a question-id mismatch reports `matched:false`), and the gateway waiter is resolved from the committed result exactly as before.

Shrinks the legacy gateway effect fence: `answer_question` removed from `LEGACY_GATEWAY_EFFECT_OPERATIONS`, site baseline 6 → 5.

## Verification

- New store tests: matched settle, mismatch rejection, replay idempotency, unknown session.
- Full kernel + asks test suites green; typecheck; side-effect scan; fence assertions updated to the smaller budget.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)