### PR TITLE
Show the GitHub App as the active integration credential

### DIFF
--- a/packages/core/opensession-server/src/server/routes/setup-github-app-status.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-github-app-status.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleSetupRoutes } from "./setup";
+import type { RouteContext } from "./context";
+
+const saved = {
+  home: process.env.HOME,
+  config: process.env.OPENSESSION_CONFIG,
+  envFile: process.env.OPENSESSION_ENV_FILE,
+  token: process.env.GITHUB_API_TOKEN,
+  enabled: process.env.ENABLE_GITHUB_AGENT,
+};
+const dirs: string[] = [];
+
+function restore(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  restore("HOME", saved.home);
+  restore("OPENSESSION_CONFIG", saved.config);
+  restore("OPENSESSION_ENV_FILE", saved.envFile);
+  restore("GITHUB_API_TOKEN", saved.token);
+  restore("ENABLE_GITHUB_AGENT", saved.enabled);
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("GitHub integration status", () => {
+  test("does not require the retired PAT when the selected App credential is configured", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-github-app-status-"));
+    dirs.push(dir);
+    const state = join(dir, ".opensession");
+    mkdirSync(state);
+    const config = join(state, "config.json");
+    const envFile = join(dir, ".opensession.env");
+    writeFileSync(
+      config,
+      JSON.stringify({
+        integrations: {
+          github: {
+            enabled: true,
+            botCredential: "app",
+            oauthClientId: "Iv-test-client",
+          },
+        },
+        identity: { team: [{ name: "Admin", github: "admin", admin: true }] },
+      }),
+    );
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(
+      join(state, "github-app.pem"),
+      privateKey.export({ format: "pem", type: "pkcs8" }),
+      { mode: 0o600 },
+    );
+    writeFileSync(envFile, "ENABLE_GITHUB_AGENT=true\n");
+    process.env.HOME = dir;
+    process.env.OPENSESSION_CONFIG = config;
+    process.env.OPENSESSION_ENV_FILE = envFile;
+    process.env.ENABLE_GITHUB_AGENT = "true";
+    delete process.env.GITHUB_API_TOKEN;
+
+    const url = new URL("http://localhost/api/setup/status");
+    const context: RouteContext = {
+      req: new Request(url),
+      url,
+      path: url.pathname,
+      publicPrefix: "",
+      authUser: { login: "admin", name: "Admin" },
+    };
+    const response = await handleSetupRoutes(context);
+    expect(response?.status).toBe(200);
+    const body = await response?.json() as any;
+    const github = body.integrations.find((item: any) => item.id === "github");
+    expect(github.missingRequired).toEqual([]);
+    expect(github.env.find((item: any) => item.name === "GITHUB_API_TOKEN")).toMatchObject({
+      present: false,
+      required: false,
+      description: "legacy PAT; not used while the GitHub App is selected",
+    });
+  });
+});

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -45,12 +45,25 @@ async function integrationSnapshot(
     envValues && name in envValues
       ? envValues[name] !== ""
       : !!process.env[name];
-  const env = spec.env.map((e) => ({
-    name: e.name,
-    required: envRequired(e, present),
-    description: e.description,
-    present: present(e.name),
-  }));
+  let githubAppSuppliesBotCredential = false;
+  if (spec.id === "github") {
+    const { githubAppConfigured, githubBotCredentialMode } =
+      await import("../github-app");
+    githubAppSuppliesBotCredential =
+      githubBotCredentialMode() === "app" && githubAppConfigured();
+  }
+  const env = spec.env.map((e) => {
+    const retiredGithubPat =
+      e.name === "GITHUB_API_TOKEN" && githubAppSuppliesBotCredential;
+    return {
+      name: e.name,
+      required: retiredGithubPat ? false : envRequired(e, present),
+      description: retiredGithubPat
+        ? "legacy PAT; not used while the GitHub App is selected"
+        : e.description,
+      present: present(e.name),
+    };
+  });
   // Registry links are static; instance-dependent ones are computed here.
   const links = [...(spec.links ?? [])];
   if (spec.id === "grafana") {


### PR DESCRIPTION
## Summary

- treat the selected GitHub App as the GitHub integration credential
- stop reporting the deliberately retired PAT as missing
- explain that the PAT field is legacy while App mode is selected
- cover the App-only setup snapshot with a regression test

## Testing

- `bun test packages/core/opensession-server/src/server/routes/setup-github-app-status.test.ts`
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by John Soutar in [this OS session](https://os.tella.dev/session/os-01a033fd-020d-76bc-be85-60b19b241fbc)