### PR TITLE
Make GitHub automation resilient to GraphQL exhaustion

### DIFF
--- a/packages/core/opensession-server/src/agents/github/autofix.ts
+++ b/packages/core/opensession-server/src/agents/github/autofix.ts
@@ -7,8 +7,7 @@
  * stop while the agent's review would still flag a P0/P1. Removes the label when it
  * finishes.
  */
-import { $ } from "bun";
-import { getPrDetailsFresh, type PrDetails } from "../../server/pr-info";
+import { getPrAutomationDetails, getPrDetailsFresh, type PrDetails } from "../../server/pr-info";
 import { ghBackoffUntil } from "../../server/github-limit";
 import { createWorktreeForPrBranch } from "../../server/worktree";
 import {
@@ -25,10 +24,6 @@ import { LABEL_AUTOFIX, labelAliases, repoForFullName } from "./constants";
 import { personaName } from "../../server/config";
 import type { PrRef, ReviewResult } from "./review";
 import { defaultRepo } from "../../server/config";
-import {
-  resolveGithubCredential,
-  serviceGithubCredential,
-} from "../../server/github-auth";
 
 const MAX_ITERATIONS = 5;
 const WALL_CLOCK_MS = 60 * 60 * 1000; // abandon a loop running longer than an hour
@@ -48,12 +43,7 @@ const REPO = defaultRepo().ghRepo;
 
 async function headSha(headRef: string, ghRepo: string = REPO): Promise<string> {
   try {
-    const credential = await resolveGithubCredential(serviceGithubCredential);
-    const raw = await $`gh pr view ${headRef} --repo ${ghRepo} --json headRefOid`
-      .env({ ...process.env, ...credential.env })
-      .quiet()
-      .text();
-    return JSON.parse(raw).headRefOid || "";
+    return (await getPrAutomationDetails(headRef, ghRepo))?.headRefOid || "";
   } catch {
     return "";
   }

--- a/packages/core/opensession-server/src/agents/github/github-rest.ts
+++ b/packages/core/opensession-server/src/agents/github/github-rest.ts
@@ -12,6 +12,7 @@ import { fetchWithTimeout } from "../../server/shared/fetch-with-timeout";
 import { defaultRepo, githubBotLogins, isGithubBotLogin, personaName } from "../../server/config";
 import { githubConfiguredCredential, githubToken } from "../../server/github-app";
 import { ghRateLimited, isGhRateLimitMsg, noteGhRateLimited } from "../../server/github-limit";
+import { noteGithubGraphqlCall } from "../../server/github-budget";
 /** The PR agent's target — the instance's default repo (config-driven). */
 export const GITHUB_REPO = defaultRepo().ghRepo;
 /** The bot account our token posts as — used to recognise our own comments/events. */
@@ -113,6 +114,7 @@ async function githubGraphQL<T = any>(
   const token = await githubToken({ write: true });
   if (!token) return null;
   if (ghRateLimited()) return null;
+  const started = Date.now();
   try {
     const resp = await fetchWithTimeout("https://api.github.com/graphql", {
       method: "POST",
@@ -124,6 +126,7 @@ async function githubGraphQL<T = any>(
     });
     const json: any = await resp.json().catch(() => null);
     if (!resp.ok || !json || json.errors) {
+      noteGithubGraphqlCall("github-agent:review-threads", Date.now() - started, false);
       const msg = json?.errors?.map((e: any) => e.message).join("; ") || `GitHub GraphQL ${resp.status}`;
       console.warn(`[github] graphql → ${resp.status}: ${msg}`);
       if (json?.errors?.some((e: any) => e.type === "RATE_LIMITED") || isGhRateLimitMsg(msg)) {
@@ -131,8 +134,10 @@ async function githubGraphQL<T = any>(
       }
       return null;
     }
+    noteGithubGraphqlCall("github-agent:review-threads", Date.now() - started, true);
     return json.data as T;
   } catch (e: any) {
+    noteGithubGraphqlCall("github-agent:review-threads", Date.now() - started, false);
     console.warn(`[github] graphql error:`, e);
     return null;
   }

--- a/packages/core/opensession-server/src/agents/github/github-rest.ts
+++ b/packages/core/opensession-server/src/agents/github/github-rest.ts
@@ -90,8 +90,8 @@ export async function githubRequest<T = any>(
         (resp.headers.get("x-ratelimit-remaining") === "0" || isGhRateLimitMsg(String(error)))
       ) {
         const resetHeader = resp.headers.get("x-ratelimit-reset");
-        if (resetHeader) noteGhRateLimited("github-rest", Number(resetHeader) * 1000);
-        else noteGhRateLimited("github-rest");
+        if (resetHeader) noteGhRateLimited("github-rest", Number(resetHeader) * 1000, "rest");
+        else noteGhRateLimited("github-rest", undefined, "rest");
       }
       return { ok: false, status: resp.status, data, error };
     }

--- a/packages/core/opensession-server/src/agents/github/index.ts
+++ b/packages/core/opensession-server/src/agents/github/index.ts
@@ -184,8 +184,8 @@ async function fireRecovery(s: GithubPrState, kind: RecoveryKind): Promise<void>
         inline: p.inline,
         ghRepo: s.ghRepo,
       })
-        .catch((e) => console.error(`[github] dropped-mention recovery failed for PR #${s.prNumber}:`, e))
-        .finally(() => clearPendingMention(s.prNumber, s.ghRepo));
+        .then(() => clearPendingMention(s.prNumber, s.ghRepo))
+        .catch((e) => console.error(`[github] dropped-mention recovery remains queued for PR #${s.prNumber}:`, e));
       return;
     }
   }
@@ -204,6 +204,40 @@ async function fireRecovery(s: GithubPrState, kind: RecoveryKind): Promise<void>
  * every restart. planRecovery picks the outermost live marker; the nested ones
  * belong to runs the resumed one starts again itself.
  */
+async function retryPendingMentions(): Promise<void> {
+  const { ghRateLimited } = await import("../../server/github-limit");
+  if (ghRateLimited("rest")) return;
+  for (const s of listPrStates()) {
+    if (!s.pendingMention || s.activeMention || s.activeRun) continue;
+    const p = s.pendingMention;
+    if (!isTrustedGithubLogin(p.author)) {
+      clearPendingMention(s.prNumber, s.ghRepo);
+      continue;
+    }
+    const { dispatchMention } = await import("./mention");
+    await dispatchMention({
+      prNumber: s.prNumber,
+      kind: p.kind,
+      body: p.body,
+      author: p.author,
+      replyToId: p.replyToId,
+      inline: p.inline,
+      ghRepo: s.ghRepo,
+    }).then(
+      () => clearPendingMention(s.prNumber, s.ghRepo),
+      (error) => console.warn(`[github] pending mention remains queued for PR #${s.prNumber}:`, error),
+    );
+  }
+}
+
+function startPendingMentionRetry(): void {
+  const g = globalThis as any;
+  if (g.__githubPendingMentionRetryTimer) return;
+  const timer = setInterval(() => void retryPendingMentions(), 60_000);
+  timer.unref?.();
+  g.__githubPendingMentionRetryTimer = timer;
+}
+
 async function recoverInterrupted(): Promise<void> {
   for (const s of listPrStates()) {
     const { fire, stale } = planRecovery(s);
@@ -292,6 +326,7 @@ export class GithubAgent implements AgentModule {
     ensureReviewAutomation();
     ensureDocsSyncAutomation();
     await recoverInterrupted();
+    startPendingMentionRetry();
     // Safety net under all of the above: the webhook path is fire-once, so
     // work lost AFTER an event was consumed (debounce killed by a restart,
     // review dead on dry pools, missed delivery) is re-fired by the sweep.

--- a/packages/core/opensession-server/src/agents/github/index.ts
+++ b/packages/core/opensession-server/src/agents/github/index.ts
@@ -36,6 +36,7 @@ import {
   clearRecoveryMarker,
   planRecovery,
   recoveryMarkerAt,
+  readPrState,
   type GithubPrState,
   type RecoveryKind,
 } from "./state";
@@ -224,7 +225,19 @@ async function retryPendingMentions(): Promise<void> {
       inline: p.inline,
       ghRepo: s.ghRepo,
     }).then(
-      () => clearPendingMention(s.prNumber, s.ghRepo),
+      async () => {
+        const stillPending = readPrState(s.prNumber, s.ghRepo)?.pendingMention;
+        if (stillPending?.progressCommentId) {
+          const { editIssueComment, REPLY_MARKER } = await import("./github-rest");
+          await editIssueComment(
+            stillPending.progressCommentId,
+            `${REPLY_MARKER}
+Request accepted.`,
+            s.ghRepo,
+          ).catch(() => {});
+        }
+        clearPendingMention(s.prNumber, s.ghRepo);
+      },
       (error) => console.warn(`[github] pending mention remains queued for PR #${s.prNumber}:`, error),
     );
   }

--- a/packages/core/opensession-server/src/agents/github/mention.ts
+++ b/packages/core/opensession-server/src/agents/github/mention.ts
@@ -7,7 +7,7 @@
  * posts), and only act when the body actually mentions a configured handle — so
  * the bot's replies (which don't mention itself) never re-trigger.
  */
-import { getPrDetails, type PrDetails } from "../../server/pr-info";
+import { getPrAutomationDetails, type PrAutomationDetails } from "../../server/pr-info";
 import { listAutomations } from "../../server/automations";
 import { createWorktreeForPrBranch, createWorktreeForFollowup } from "../../server/worktree";
 import {
@@ -133,10 +133,31 @@ export async function handleMention(kind: MentionKind, payload: any): Promise<vo
     },
     ghRepo,
   );
+  // Acknowledge through REST before any metadata/model work. The durable marker
+  // remains queued if dispatch fails, and this comment is reused on retry.
+  const receiptId = await postIssueComment(
+    prNumber,
+    `${REPLY_MARKER}
+Queued @${authorLogin}'s request. I'll retry automatically if GitHub metadata is temporarily unavailable.`,
+    ghRepo,
+  ).catch(() => null);
+  if (receiptId) {
+    const pending = readPrState(prNumber, ghRepo)?.pendingMention;
+    if (pending?.commentId === comment.id)
+      setPendingMention(prNumber, { ...pending, progressCommentId: receiptId }, ghRepo);
+  }
   try {
     await dispatchMention({ prNumber, kind, body, author: authorLogin, replyToId, inline, ghRepo });
-  } finally {
     clearPendingMention(prNumber, ghRepo);
+  } catch (error) {
+    if (receiptId)
+      await editIssueComment(
+        receiptId,
+        `${REPLY_MARKER}
+Queued @${authorLogin}'s request. GitHub metadata is temporarily unavailable, so I'll retry automatically.`,
+        ghRepo,
+      ).catch(() => {});
+    throw error;
   }
 }
 
@@ -209,8 +230,9 @@ export async function runConversationalMention(
     return;
   }
   let headRef = "";
+  let runOwnsRecovery = false;
   try {
-    const details = await getPrDetails(String(prNumber), ghRepo || undefined);
+    const details = await getPrAutomationDetails(String(prNumber), ghRepo || undefined);
     if (!details) return;
     // Merged/closed PR: you can't push to it, but a mention like "fix this in a
     // follow-up PR" (Kent's case) should still spin up a session — off a fresh
@@ -235,9 +257,10 @@ export async function runConversationalMention(
     const prior = readPrState(prNumber, ghRepo);
     // Reuse the progress comment only when recovering an interrupted run.
     const reuseId = recovering ? prior?.activeMention?.progressCommentId : undefined;
+    const pendingReceiptId = readPrState(prNumber, ghRepo)?.pendingMention?.progressCommentId;
     const progressId = await postOrEditComment(
       prNumber,
-      reuseId,
+      reuseId ?? pendingReceiptId,
       `${REPLY_MARKER}\n🔄 On it — working on @${args.author}'s request… · ${link}`,
       ghRepo,
     );
@@ -260,6 +283,8 @@ export async function runConversationalMention(
       },
       ghRepo,
     );
+
+    runOwnsRecovery = true;
 
     // Code mode in the PR-branch worktree so the agent can make + push changes if asked.
     const worktreeDir = await createWorktreeForPrBranch(
@@ -305,6 +330,9 @@ export async function runConversationalMention(
     }
   } catch (e) {
     console.error(`[github] mention reply error for PR #${prNumber}:`, e);
+    // Before activeMention takes ownership, leave pendingMention durable and
+    // tell the receipt path to retry. Once owned, existing recovery semantics apply.
+    if (!runOwnsRecovery) throw e;
   } finally {
     // Clear recovery state on completion; a killed process leaves it set so the
     // github agent re-runs the mention on startup.
@@ -327,7 +355,7 @@ export async function runConversationalMention(
  */
 async function runFollowupMention(
   args: ConversationalMentionArgs,
-  details: PrDetails,
+  details: PrAutomationDetails,
 ): Promise<void> {
   const { prNumber, ghRepo } = args;
   const baseRef = details.baseRefName || "main";

--- a/packages/core/opensession-server/src/agents/github/mention.ts
+++ b/packages/core/opensession-server/src/agents/github/mention.ts
@@ -143,11 +143,21 @@ Queued @${authorLogin}'s request. I'll retry automatically if GitHub metadata is
   ).catch(() => null);
   if (receiptId) {
     const pending = readPrState(prNumber, ghRepo)?.pendingMention;
-    if (pending?.commentId === comment.id)
+    if (pending && pending.commentId === comment.id) {
       setPendingMention(prNumber, { ...pending, progressCommentId: receiptId }, ghRepo);
+    }
   }
   try {
     await dispatchMention({ prNumber, kind, body, author: authorLogin, replyToId, inline, ghRepo });
+    const stillPending = readPrState(prNumber, ghRepo)?.pendingMention;
+    if (receiptId && stillPending?.commentId === comment.id) {
+      await editIssueComment(
+        receiptId,
+        `${REPLY_MARKER}
+Request accepted.`,
+        ghRepo,
+      ).catch(() => {});
+    }
     clearPendingMention(prNumber, ghRepo);
   } catch (error) {
     if (receiptId)

--- a/packages/core/opensession-server/src/agents/github/reconcile.ts
+++ b/packages/core/opensession-server/src/agents/github/reconcile.ts
@@ -46,7 +46,7 @@ export function reconcileEnabled(): boolean {
 
 /** One sweep pass over every configured repo. Exported for tests/manual runs. */
 export async function reconcileOpenPrs(): Promise<void> {
-  if (!reconcileEnabled() || ghRateLimited()) return;
+  if (!reconcileEnabled() || ghRateLimited("rest")) return;
   const { resolveReviewConfig, fireReview, fireAutoFix, hasPendingDebouncedReview } = await import(
     "./webhook"
   );

--- a/packages/core/opensession-server/src/agents/github/review.ts
+++ b/packages/core/opensession-server/src/agents/github/review.ts
@@ -8,10 +8,9 @@
 import { isGithubBotLogin, personaName } from "../../server/config";
 import { isShuttingDown } from "../../server/shutdown-state";
 import {
-  getPrDetails,
-  getPrDetailsFresh,
+  getPrAutomationDetails,
   getPrDiff,
-  type PrDetails,
+  type PrAutomationDetails,
 } from "../../server/pr-info";
 import {
   activeRunCancellationRequested,
@@ -253,7 +252,7 @@ export async function runReview(
 
     // Look up by number before publishing the session link. If details are
     // unavailable, no worker exists and the next delivery remains retryable.
-    const details = await getPrDetails(pr.number ? String(pr.number) : pr.headRef, pr.ghRepo || undefined);
+    const details = await getPrAutomationDetails(pr.number ? String(pr.number) : pr.headRef, pr.ghRepo || undefined);
     if (!details) {
       console.warn(`[github] no PR details for #${pr.number} (${pr.headRef}); review not started`);
       return null;
@@ -530,8 +529,8 @@ export async function runReview(
     // Never publish an assessment against a different commit from the one the
     // worktree and prompt were pinned to. A push while the review was running
     // gets its own webhook/reconcile review; this result is now stale.
-    const latestPr = await getPrDetailsFresh(
-      pr.headRef,
+    const latestPr = await getPrAutomationDetails(
+      pr.number ? String(pr.number) : pr.headRef,
       pr.ghRepo || undefined,
     );
     if (
@@ -653,7 +652,7 @@ function composeInlineBody(f: Finding): string {
 
 async function postReview(
   pr: PrRef,
-  details: PrDetails,
+  details: PrAutomationDetails,
   parsed: ReviewOutput | null,
   rawText: string,
   runError?: string,

--- a/packages/core/opensession-server/src/agents/github/state.ts
+++ b/packages/core/opensession-server/src/agents/github/state.ts
@@ -65,8 +65,6 @@ export interface GithubPrState {
   pendingAutoFix?: {
     requestedBy: string;
     receivedAt: string;
-    /** REST-posted receipt, reused as the run progress comment after a retry. */
-    progressCommentId?: number;
   };
   /** Review → owning-session fix rounds (handoff.ts); cleared when a review
    *  comes back satisfied or the PR closes. */

--- a/packages/core/opensession-server/src/agents/github/state.ts
+++ b/packages/core/opensession-server/src/agents/github/state.ts
@@ -65,6 +65,8 @@ export interface GithubPrState {
   pendingAutoFix?: {
     requestedBy: string;
     receivedAt: string;
+    /** REST-posted receipt, reused as the run progress comment after a retry. */
+    progressCommentId?: number;
   };
   /** Review → owning-session fix rounds (handoff.ts); cleared when a review
    *  comes back satisfied or the PR closes. */
@@ -129,6 +131,8 @@ export interface GithubPrState {
     replyToId?: number;
     inline?: { path: string; line?: number; diffHunk?: string };
     receivedAt: string;
+    /** REST-posted receipt, reused as the run progress comment after a retry. */
+    progressCommentId?: number;
   };
   updatedAt: string;
 }

--- a/packages/core/opensession-server/src/agents/slack/github-reviews.ts
+++ b/packages/core/opensession-server/src/agents/slack/github-reviews.ts
@@ -38,8 +38,8 @@ export async function githubApi(path: string): Promise<any> {
       console.warn(`[slack] GitHub API ${path}: ${resp.status}`);
       if ((resp.status === 403 || resp.status === 429) && resp.headers.get("x-ratelimit-remaining") === "0") {
         const resetHeader = resp.headers.get("x-ratelimit-reset");
-        if (resetHeader) noteGhRateLimited("slack-github", Number(resetHeader) * 1000);
-        else noteGhRateLimited("slack-github");
+        if (resetHeader) noteGhRateLimited("slack-github", Number(resetHeader) * 1000, "rest");
+        else noteGhRateLimited("slack-github", undefined, "rest");
       }
       return null;
     }
@@ -64,7 +64,7 @@ export async function pollForVercelPreview(
 
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise((r) => setTimeout(r, interval));
-    if (ghRateLimited()) return; // best-effort nicety — abandon rather than burn the backoff window
+    if (ghRateLimited("rest")) return; // best-effort nicety — abandon rather than burn the backoff window
     try {
       // Get the PR's head commit SHA
       const pr = await githubApi(`/repos/${GITHUB_REPO}/pulls/${prNumber}`);

--- a/packages/core/opensession-server/src/server/analytics.ts
+++ b/packages/core/opensession-server/src/server/analytics.ts
@@ -490,9 +490,17 @@ async function fetchRepoPrs(repoId: string, ghRepo: string, fromDate: string): P
 	// search ceiling): a busy repo alone can open 400+ PRs in a 30-day window.
 	for (const search of [`created:>=${fromDate}`, `merged:>=${fromDate}`]) {
 		try {
-			const raw = await $`gh pr list --repo ${ghRepo} --state all --limit 1000 --search ${search} --json ${fields}`
-				.quiet()
-				.text();
+			const queryStarted = Date.now();
+			let raw: string;
+			try {
+				raw = await $`gh pr list --repo ${ghRepo} --state all --limit 1000 --search ${search} --json ${fields}`
+					.quiet()
+					.text();
+				noteGithubGraphqlCall("analytics:pr-list", Date.now() - queryStarted, true, { ambient: true });
+			} catch (error) {
+				noteGithubGraphqlCall("analytics:pr-list", Date.now() - queryStarted, false, { ambient: true });
+				throw error;
+			}
 			for (const pr of JSON.parse(raw)) {
 				seen.set(pr.number, {
 					repo: repoId,

--- a/packages/core/opensession-server/src/server/analytics.ts
+++ b/packages/core/opensession-server/src/server/analytics.ts
@@ -21,7 +21,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync,
 import { $ } from "bun";
 import { isNativeSessionId, OPENSESSION_SESSIONS_DIR, stateDir, statePath } from "./paths";
 import { configuredRepos, defaultRepo, githubBotLogins } from "./config";
-import { ghRateLimited, isGhRateLimitMsg, noteGhRateLimited } from "./github-limit";
+import { noteGithubGraphqlCall } from "./github-budget";
 import { readFeedback } from "../agents/github/feedback";
 import type { FeedbackRecord } from "../agents/github/feedback-gates";
 import { gitIdentityFor } from "./shared/user-mappings";
@@ -481,7 +481,6 @@ async function fetchRepoPrs(repoId: string, ghRepo: string, fromDate: string): P
 		if (disk) prCache.set(key, (cached = { at: disk.at, prs: disk.data }));
 	}
 	if (cached && Date.now() - cached.at < PR_CACHE_TTL_MS) return cached.prs;
-	if (ghRateLimited() && cached) return cached.prs; // serve stale during a backoff window
 
 	const fields = "number,title,url,state,createdAt,mergedAt,headRefName";
 	const seen = new Map<number, AnalyticsPr>();
@@ -510,7 +509,6 @@ async function fetchRepoPrs(repoId: string, ghRepo: string, fromDate: string): P
 		} catch (e) {
 			failed = true;
 			console.error(`[analytics] gh pr list failed for ${ghRepo}:`, e);
-			if (isGhRateLimitMsg(String((e as any)?.stderr || e))) noteGhRateLimited("analytics");
 		}
 	}
 	// A failed search means `seen` is partial — serve it (or the stale cache)
@@ -592,7 +590,6 @@ async function fetchRepoFactoryPrs(repoId: string, ghRepo: string, fromDate: str
 		if (disk) factoryCache.set(key, (cached = { at: disk.at, prs: disk.data }));
 	}
 	if (cached && Date.now() - cached.at < FACTORY_CACHE_TTL_MS) return cached.prs;
-	if (ghRateLimited() && cached) return cached.prs;
 
 	const prs: FactoryPr[] = [];
 	const q = `repo:${ghRepo} is:pr is:merged merged:>=${fromDate}`;
@@ -601,7 +598,15 @@ async function fetchRepoFactoryPrs(repoId: string, ghRepo: string, fromDate: str
 		while (prs.length < FACTORY_PR_CAP) {
 			const args = ["api", "graphql", "-f", `query=${FACTORY_QUERY}`, "-f", `q=${q}`];
 			if (cursor) args.push("-f", `cursor=${cursor}`);
-			const raw = await $`gh ${args}`.quiet().text();
+			const queryStarted = Date.now();
+			let raw: string;
+			try {
+				raw = await $`gh ${args}`.quiet().text();
+				noteGithubGraphqlCall("analytics:factory", Date.now() - queryStarted, true, { ambient: true });
+			} catch (error) {
+				noteGithubGraphqlCall("analytics:factory", Date.now() - queryStarted, false, { ambient: true });
+				throw error;
+			}
 			const search = JSON.parse(raw)?.data?.search;
 			for (const pr of search?.nodes || []) {
 				if (!pr?.number) continue;
@@ -634,7 +639,6 @@ async function fetchRepoFactoryPrs(repoId: string, ghRepo: string, fromDate: str
 		}
 	} catch (e) {
 		console.error(`[analytics] factory pr fetch failed for ${ghRepo}:`, e);
-		if (isGhRateLimitMsg(String((e as any)?.stderr || e))) noteGhRateLimited("analytics");
 		return cached?.prs ?? [];
 	}
 	factoryCache.set(key, { at: Date.now(), prs });

--- a/packages/core/opensession-server/src/server/github-budget.ts
+++ b/packages/core/opensession-server/src/server/github-budget.ts
@@ -1,0 +1,59 @@
+/** Lightweight, credential-safe GitHub API budget telemetry. */
+import { githubBotCredentialMode, githubToken } from "./github-app";
+
+type Sample = { calls: number; failures: number; durationMs: number };
+const samples = new Map<string, Sample>();
+let lastLogAt = 0;
+let probe: Promise<void> | null = null;
+
+/**
+ * Count a GraphQL consumer and periodically snapshot the installation bucket.
+ * Logs consumer labels, aggregate timings, and numeric quota only. Tokens,
+ * query variables, repository data, and response bodies are never logged.
+ */
+export function noteGithubGraphqlCall(
+  consumer: string,
+  durationMs: number,
+  ok: boolean,
+  opts: { ambient?: boolean } = {},
+): void {
+  const key = `${opts.ambient ? "ambient" : "service"}:${consumer}`;
+  const sample = samples.get(key) || { calls: 0, failures: 0, durationMs: 0 };
+  sample.calls++;
+  sample.durationMs += Math.max(0, durationMs);
+  if (!ok) sample.failures++;
+  samples.set(key, sample);
+  if (Date.now() - lastLogAt < 60_000 || probe) return;
+  lastLogAt = Date.now();
+  probe = (async () => {
+    let budget = "budget=unavailable";
+    try {
+      const token = await githubToken();
+      if (token) {
+        const response = await fetch("https://api.github.com/rate_limit", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": "opensession-budget",
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+        const json = (await response.json().catch(() => null)) as any;
+        const gql = json?.resources?.graphql;
+        if (response.ok && gql)
+          budget = `remaining=${gql.remaining}/${gql.limit} used=${gql.used} reset=${new Date(Number(gql.reset) * 1000).toISOString()}`;
+      }
+    } catch {}
+    const totals = [...samples.entries()]
+      .map(
+        ([label, value]) =>
+          `${label}{calls=${value.calls},failures=${value.failures},durationMs=${Math.round(value.durationMs)}}`,
+      )
+      .join(" ");
+    console.log(
+      `[github-budget] graphql credential=${githubBotCredentialMode()} ${budget} consumers=${totals || "none"}`,
+    );
+    samples.clear();
+    probe = null;
+  })();
+}

--- a/packages/core/opensession-server/src/server/github-limit.test.ts
+++ b/packages/core/opensession-server/src/server/github-limit.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  __setGhBackoffForTest,
+  ghBackoffUntil,
+  ghRateLimited,
+} from "./github-limit";
+
+let restoreGraphql = 0;
+let restoreRest = 0;
+afterEach(() => {
+  __setGhBackoffForTest(restoreGraphql, "graphql");
+  __setGhBackoffForTest(restoreRest, "rest");
+});
+
+describe("GitHub rate-limit resources", () => {
+  test("GraphQL exhaustion does not suppress REST", () => {
+    restoreGraphql = __setGhBackoffForTest(Date.now() + 60_000, "graphql");
+    restoreRest = __setGhBackoffForTest(0, "rest");
+
+    expect(ghRateLimited("graphql")).toBe(true);
+    expect(ghBackoffUntil("graphql")).toBeGreaterThan(Date.now());
+    expect(ghRateLimited("rest")).toBe(false);
+    expect(ghBackoffUntil("rest")).toBe(0);
+  });
+
+  test("REST exhaustion does not suppress GraphQL", () => {
+    restoreGraphql = __setGhBackoffForTest(0, "graphql");
+    restoreRest = __setGhBackoffForTest(Date.now() + 60_000, "rest");
+
+    expect(ghRateLimited("graphql")).toBe(false);
+    expect(ghRateLimited("rest")).toBe(true);
+  });
+});

--- a/packages/core/opensession-server/src/server/github-limit.ts
+++ b/packages/core/opensession-server/src/server/github-limit.ts
@@ -1,45 +1,44 @@
 /**
- * Shared GitHub rate-limit gate.
+ * Per-resource GitHub rate-limit gates.
  *
- * Every server-side GitHub caller (gh CLI spawns and direct api.github.com
- * fetches) reports rate-limit failures here and consults the gate before
- * firing, so one exhausted quota pauses ALL pollers together instead of each
- * one independently burning doomed calls into the same bot account's window.
- * Callers with cached data keep serving their stale snapshot for the duration;
- * callers without any answer fast with a friendly error instead of spawning gh.
- *
- * State parks on globalThis so a `bun --hot` reload keeps an active backoff
- * window instead of resetting it and re-firing everything at once — and the
- * backoff window is ALSO persisted to disk, because a real `systemctl restart`
- * used to forget it and boot the PR-cache warm sweep straight into the
- * exhausted window (2026-07-23: restarts every ~10min kept the GraphQL quota
- * pinned at 0 for hours).
+ * GitHub meters REST (`core`) and GraphQL independently. App installation and
+ * App user tokens share those installation buckets, so exhausting GraphQL must
+ * pause GraphQL consumers without suppressing healthy REST acknowledgements,
+ * metadata reads, comments, or writes. Backoffs survive process restarts.
  */
-
 import { existsSync, readFileSync } from "fs";
 import { writeFileAtomic } from "./shared/atomic-write";
 import { stateDir } from "./paths";
 
 const PERSIST_PATH = stateDir("github-limit.json");
+export type GithubRateResource = "graphql" | "rest";
 
 interface GhLimitState {
-  /** Epoch ms until which GitHub calls should not be attempted. 0 = clear. */
-  backoffUntil: number;
-  probe: Promise<void> | null;
-  /** Cached `gh auth token` output for direct REST calls (null = probed, none). */
+  backoffUntil: Record<GithubRateResource, number>;
+  probe: Record<GithubRateResource, Promise<void> | null>;
   botToken: string | null | undefined;
 }
 
-const state: GhLimitState = ((globalThis as any).__osGhLimitState ||= (() => {
-  const s: GhLimitState = { backoffUntil: 0, probe: null, botToken: undefined };
+const state: GhLimitState = ((globalThis as any).__osGhLimitStateV2 ||= (() => {
+  const s: GhLimitState = {
+    backoffUntil: { graphql: 0, rest: 0 },
+    probe: { graphql: null, rest: null },
+    botToken: undefined,
+  };
   try {
     if (existsSync(PERSIST_PATH)) {
       const parsed = JSON.parse(readFileSync(PERSIST_PATH, "utf-8"));
-      if (typeof parsed?.backoffUntil === "number" && parsed.backoffUntil > Date.now()) {
-        s.backoffUntil = parsed.backoffUntil;
-        console.error(
-          `[github-limit] resuming persisted backoff until ${new Date(s.backoffUntil).toISOString()}`,
-        );
+      // Migrate the old global gate conservatively to GraphQL. It was almost
+      // always set by gh porcelain, and must not keep suppressing healthy REST.
+      const saved = parsed?.resources || { graphql: parsed?.backoffUntil };
+      for (const resource of ["graphql", "rest"] as const) {
+        const until = saved?.[resource];
+        if (typeof until === "number" && until > Date.now()) {
+          s.backoffUntil[resource] = until;
+          console.error(
+            `[github-limit] resuming persisted ${resource} backoff until ${new Date(until).toISOString()}`,
+          );
+        }
       }
     }
   } catch {}
@@ -48,69 +47,54 @@ const state: GhLimitState = ((globalThis as any).__osGhLimitState ||= (() => {
 
 function persistBackoff(): void {
   try {
-    writeFileAtomic(PERSIST_PATH, JSON.stringify({ backoffUntil: state.backoffUntil }) + "\n");
+    writeFileAtomic(PERSIST_PATH, JSON.stringify({ resources: state.backoffUntil }) + "\n");
   } catch {}
 }
 
-export function ghRateLimited(): boolean {
-  return Date.now() < state.backoffUntil;
+/** Defaults to GraphQL for existing gh-pr callers. REST callers must opt in. */
+export function ghRateLimited(resource: GithubRateResource = "graphql"): boolean {
+  return Date.now() < state.backoffUntil[resource];
 }
 
-/** Epoch ms the current backoff ends, or 0 when no backoff is active. */
-export function ghBackoffUntil(): number {
-  return ghRateLimited() ? state.backoffUntil : 0;
+export function ghBackoffUntil(resource: GithubRateResource = "graphql"): number {
+  return ghRateLimited(resource) ? state.backoffUntil[resource] : 0;
 }
 
-/**
- * Test seam (bun tests only): open or clear the backoff window WITHOUT
- * persisting it. Tests that seed a PR-cache snapshot need the gate closed, or
- * a live `gh` refresh lands mid-test and replaces the snapshot with whatever
- * GitHub actually returns — which is also a real network call from a unit
- * test. noteGhRateLimited is the wrong tool for that: it writes the backoff to
- * disk, and `stateDir` resolves against the HOME captured at module load, so a
- * test would pause the running server's GitHub polling for an hour. Returns
- * the previous value so afterAll can restore it.
- */
-export function __setGhBackoffForTest(untilEpochMs: number): number {
-  const prev = state.backoffUntil;
-  state.backoffUntil = untilEpochMs;
+export function __setGhBackoffForTest(
+  untilEpochMs: number,
+  resource: GithubRateResource = "graphql",
+): number {
+  const prev = state.backoffUntil[resource];
+  state.backoffUntil[resource] = untilEpochMs;
   return prev;
 }
 
-/** True when a gh CLI / API error message is a rate-limit rejection. */
 export function isGhRateLimitMsg(msg: string): boolean {
   return /rate limit|secondary limit|abuse detection/i.test(msg);
 }
 
-/**
- * Record that GitHub rejected a call for rate limiting. When the caller knows
- * the reset time (REST's x-ratelimit-reset header), it passes it; otherwise we
- * probe `gh api rate_limit` for the GraphQL reset — rate_limit itself is REST
- * (core quota), so it usually still answers when GraphQL, which nearly all of
- * our polling runs on, is exhausted. A 15-minute fallback covers the probe
- * failing too (core quota can be gone as well).
- */
-export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
+/** Record a rejection against only the resource that rejected the request. */
+export function noteGhRateLimited(
+  source: string,
+  resetEpochMs?: number,
+  resource: GithubRateResource = "graphql",
+): void {
   if (resetEpochMs && resetEpochMs > Date.now()) {
-    // Cap at 2h in case a caller feeds us a bogus far-future reset.
     const until = Math.min(resetEpochMs + 30_000, Date.now() + 2 * 3600_000);
-    if (until > state.backoffUntil) {
-      state.backoffUntil = until;
+    if (until > state.backoffUntil[resource]) {
+      state.backoffUntil[resource] = until;
       persistBackoff();
       console.error(
-        `[github-limit] ${source}: rate-limited; pausing GitHub calls until ${new Date(until).toISOString()}`,
+        `[github-limit] ${source}: ${resource} rate-limited; pausing ${resource} calls until ${new Date(until).toISOString()}`,
       );
     }
     return;
   }
-  if (ghRateLimited() || state.probe) return;
-  // Fallback first, in case the probe below fails.
-  state.backoffUntil = Date.now() + 15 * 60_000;
+  if (ghRateLimited(resource) || state.probe[resource]) return;
+  state.backoffUntil[resource] = Date.now() + 15 * 60_000;
   persistBackoff();
-  state.probe = (async () => {
+  state.probe[resource] = (async () => {
     try {
-      // Probe with the operator-selected service credential. Invoking ambient
-      // `gh` here would cross the App cutover through hosts.yml on failures.
       const { githubToken } = await import("./github-app");
       const token = await githubToken();
       if (token) {
@@ -123,41 +107,29 @@ export function noteGhRateLimited(source: string, resetEpochMs?: number): void {
           signal: AbortSignal.timeout(10_000),
         });
         const data = await response.json().catch(() => null) as any;
-        const reset = Number(data?.resources?.graphql?.reset) * 1000;
+        const key = resource === "rest" ? "core" : "graphql";
+        const reset = Number(data?.resources?.[key]?.reset) * 1000;
         if (response.ok && reset > Date.now()) {
-          state.backoffUntil = reset + 30_000;
+          state.backoffUntil[resource] = reset + 30_000;
           persistBackoff();
         }
       }
     } catch {}
     console.error(
-      `[github-limit] ${source}: rate-limited; pausing GitHub calls until ${new Date(state.backoffUntil).toISOString()}`,
+      `[github-limit] ${source}: ${resource} rate-limited; pausing ${resource} calls until ${new Date(state.backoffUntil[resource]).toISOString()}`,
     );
-    state.probe = null;
+    state.probe[resource] = null;
   })();
 }
 
-/**
- * Token for direct api.github.com calls made on the bot's behalf (conditional
- * change probes and the like): the App installation token (or GITHUB_API_TOKEN)
- * that the REST helpers use, else the gh CLI's own token, probed once and cached
- * for the process lifetime.
- */
-export async function botGhToken(
-  opts: { write?: boolean } = {},
-): Promise<string | null> {
+export async function botGhToken(opts: { write?: boolean } = {}): Promise<string | null> {
   const { githubBotCredentialMode, githubToken } = await import("./github-app");
   const primary = await githubToken(opts);
   if (primary) return primary;
-  // App mode is an explicit credential boundary. Do not silently resume with
-  // a user login or retired PAT cached by gh when App token minting fails.
   if (githubBotCredentialMode() === "app") return null;
   if (state.botToken !== undefined) return state.botToken;
   try {
-    const proc = Bun.spawn(["gh", "auth", "token"], {
-      stdout: "pipe",
-      stderr: "ignore",
-    });
+    const proc = Bun.spawn(["gh", "auth", "token"], { stdout: "pipe", stderr: "ignore" });
     const raw = await new Response(proc.stdout).text();
     state.botToken = (await proc.exited) === 0 && raw.trim() ? raw.trim() : null;
   } catch {

--- a/packages/core/opensession-server/src/server/github-review-requests.ts
+++ b/packages/core/opensession-server/src/server/github-review-requests.ts
@@ -79,7 +79,7 @@ export async function fetchReviewTeamLogins(
   const key = `${owner.toLowerCase()}/${teamSlug.toLowerCase()}`;
   const cached = reviewTeamCache.get(key);
   if (cached?.expiresAt && cached.expiresAt > Date.now()) return cached.logins;
-  if (ghRateLimited()) return cached?.logins || null;
+  if (ghRateLimited("rest")) return cached?.logins || null;
   const token = await botGhToken();
   if (!token) return cached?.logins || null;
 
@@ -106,6 +106,7 @@ export async function fetchReviewTeamLogins(
           noteGhRateLimited(
             "pr-review-team",
             Number.isFinite(reset) ? reset : undefined,
+            "rest",
           );
         }
         return cached?.logins || null;

--- a/packages/core/opensession-server/src/server/pr-cache.ts
+++ b/packages/core/opensession-server/src/server/pr-cache.ts
@@ -176,7 +176,7 @@ function reviewMutationKey(
 // state root changed — a test's scratch HOME, a demo instance's state dir —
 // is read from the right place by an explicit loadPrCacheSnapshot() call.
 const prCacheFile = () => statePath(".opensession-pr-cache.json");
-const PR_CACHE_VERSION = 4;
+const PR_CACHE_VERSION = 5;
 const probeEtags = new Map<string, string>(); // ghRepo → last seen ETag
 const lastFullRefresh = new Map<string, number>(); // repo id → epoch ms
 /**
@@ -190,7 +190,7 @@ export function loadPrCacheSnapshot(): void {
 try {
   const parsed = JSON.parse(readFileSync(prCacheFile(), "utf8"));
   const raw: Record<string, Record<string, PrInfo>> =
-    ([2, 3, PR_CACHE_VERSION].includes(parsed?.version)) && parsed?.repos
+    ([2, 3, 4, PR_CACHE_VERSION].includes(parsed?.version)) && parsed?.repos
       ? parsed.repos
       : parsed;
   prCache.data = new Map(
@@ -204,9 +204,12 @@ try {
   // timestamps so the current shape refills immediately.
   if (parsed?.version === PR_CACHE_VERSION) {
     const now = Date.now();
-    for (const repo of prRepos()) {
+    let durableRepos = 0;
+    const repos = prRepos();
+    for (const repo of repos) {
       if (!prCache.data.has(repo.id)) continue;
       if (parsed.recentLimits?.[repo.id] !== repo.recentLimit) continue;
+      if (parsed.openLimits?.[repo.id] !== repo.openLimit) continue;
       const etag = parsed.probeEtags?.[repo.ghRepo];
       if (typeof etag === "string" && etag) probeEtags.set(repo.ghRepo, etag);
       const refreshedAt = parsed.lastFullRefresh?.[repo.id];
@@ -217,8 +220,13 @@ try {
         refreshedAt <= now + 60_000
       ) {
         lastFullRefresh.set(repo.id, refreshedAt);
+        if (now - refreshedAt < PROBE_MAX_SKIP_MS) durableRepos++;
       }
     }
+    // Keep the snapshot hot across a restart only when every configured repo is
+    // represented with the current query bounds and a recent full refresh.
+    // Otherwise first access reconciles immediately, preserving multi-repo correctness.
+    if (repos.length > 0 && durableRepos === repos.length) prCache.ts = now;
   }
 } catch {}
 }
@@ -232,6 +240,7 @@ function persistPrCache(data: Map<string, Map<string, PrInfo>>) {
       version: PR_CACHE_VERSION,
       repos: obj,
       recentLimits: Object.fromEntries(prRepos().map((repo) => [repo.id, repo.recentLimit])),
+      openLimits: Object.fromEntries(prRepos().map((repo) => [repo.id, repo.openLimit])),
       probeEtags: Object.fromEntries(probeEtags),
       lastFullRefresh: Object.fromEntries(lastFullRefresh),
     }, false);

--- a/packages/core/opensession-server/src/server/pr-cache.ts
+++ b/packages/core/opensession-server/src/server/pr-cache.ts
@@ -177,6 +177,7 @@ function reviewMutationKey(
 // is read from the right place by an explicit loadPrCacheSnapshot() call.
 const prCacheFile = () => statePath(".opensession-pr-cache.json");
 const PR_CACHE_VERSION = 5;
+const DURABLE_CACHE_MAX_AGE_MS = 30 * 60_000;
 const probeEtags = new Map<string, string>(); // ghRepo → last seen ETag
 const lastFullRefresh = new Map<string, number>(); // repo id → epoch ms
 /**
@@ -220,7 +221,7 @@ try {
         refreshedAt <= now + 60_000
       ) {
         lastFullRefresh.set(repo.id, refreshedAt);
-        if (now - refreshedAt < PROBE_MAX_SKIP_MS) durableRepos++;
+        if (now - refreshedAt < DURABLE_CACHE_MAX_AGE_MS) durableRepos++;
       }
     }
     // Keep the snapshot hot across a restart only when every configured repo is

--- a/packages/core/opensession-server/src/server/pr-host.ts
+++ b/packages/core/opensession-server/src/server/pr-host.ts
@@ -283,6 +283,7 @@ export const githubPrHost: PrHost = {
 				noteGhRateLimited(
 					"pr-cache-rest",
 					Number.isFinite(reset) ? reset : undefined,
+					"rest",
 				);
 			}
 			return { changed: true, cursor };

--- a/packages/core/opensession-server/src/server/pr-host.ts
+++ b/packages/core/opensession-server/src/server/pr-host.ts
@@ -47,6 +47,7 @@ import type {
 } from "./pr-contract";
 export type { PrHostCapabilities } from "./pr-contract";
 import { fetchWithTimeout } from "./shared/fetch-with-timeout";
+import { noteGithubGraphqlCall } from "./github-budget";
 
 /** One row of the bulk `gh pr list` refresh (sessions.ts). `latestReviews`
  *  and `body` are only populated by listOpenPrs — see the field comments. */
@@ -156,8 +157,10 @@ export interface PrHost {
 
 /** Run `gh` and parse its JSON output; null on any failure (also flags shared
  *  rate-limit backoff). Moved from sessions.ts — same behavior. */
-export async function ghJson<T>(args: string[]): Promise<T | null> {
+export async function ghJson<T>(args: string[], consumer = "gh-json"): Promise<T | null> {
 	if (ghRateLimited()) return null;
+	const started = Date.now();
+	let ok = false;
 	try {
 		const credential = await resolveGithubCredential(serviceGithubCredential);
 		const proc = Bun.spawn(["gh", ...args], {
@@ -174,9 +177,12 @@ export async function ghJson<T>(args: string[]): Promise<T | null> {
 			return null;
 		}
 		if (!raw.trim()) return null;
+		ok = true;
 		return JSON.parse(raw) as T;
 	} catch {
 		return null;
+	} finally {
+		noteGithubGraphqlCall(consumer, Date.now() - started, ok);
 	}
 }
 
@@ -227,7 +233,7 @@ export const githubPrHost: PrHost = {
 			String(opts.limit),
 			"--json",
 			`${BULK_FIELDS},latestReviews,body`,
-		]),
+		], "pr-cache:list-open"),
 	// sort:updated-desc, not gh's default creation order: a PR created long ago
 	// that merges today must enter this window immediately, or the sweep drops
 	// its row and the session renders as having no PR at all.
@@ -245,7 +251,7 @@ export const githubPrHost: PrHost = {
 			String(opts.limit),
 			"--json",
 			BULK_FIELDS,
-		]),
+		], "pr-cache:list-recent"),
 
 	// Conditional GET (If-None-Match) on the most recently updated PR: 304 =
 	// the repo's PR set is untouched, and GitHub documents that 304s on

--- a/packages/core/opensession-server/src/server/pr-info.test.ts
+++ b/packages/core/opensession-server/src/server/pr-info.test.ts
@@ -178,3 +178,18 @@ describe("ghApiErrorMessage", () => {
     expect(ghApiErrorMessage("", "", "gh api failed")).toBe("gh api failed");
   });
 });
+
+describe("durable PR detail restart grace", () => {
+  test("does not replay an expired rich refresh immediately after boot", async () => {
+    const { shouldRefreshPrDetails } = await import("./pr-info");
+    const now = 1_000_000;
+    expect(shouldRefreshPrDetails(now - 6 * 60_000, now, now - 30_000)).toBe(false);
+    expect(shouldRefreshPrDetails(now - 6 * 60_000, now, now - 11 * 60_000)).toBe(true);
+  });
+
+  test("keeps a still-fresh durable row fresh regardless of process age", async () => {
+    const { shouldRefreshPrDetails } = await import("./pr-info");
+    const now = 1_000_000;
+    expect(shouldRefreshPrDetails(now - 60_000, now, 0)).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/pr-info.ts
+++ b/packages/core/opensession-server/src/server/pr-info.ts
@@ -52,6 +52,75 @@ export type {
   PrStaging,
 } from "./pr-contract";
 
+export interface PrAutomationDetails {
+  number: number;
+  title: string;
+  url: string;
+  state: "OPEN" | "MERGED" | "CLOSED";
+  isDraft: boolean;
+  baseRefName: string;
+  headRefName: string;
+  headRefOid: string;
+  author: string;
+}
+
+/**
+ * Minimum PR metadata needed to acknowledge and queue event-driven work.
+ * REST on purpose: review and @mention intake must remain available when the
+ * installation's independently-metered GraphQL bucket is empty.
+ */
+export async function getPrAutomationDetails(
+  selector: string,
+  repo: string = DEFAULT_REPO(),
+): Promise<PrAutomationDetails | null> {
+  if (ghRateLimited("rest")) throw new Error(GH_REST_RATE_LIMIT_MESSAGE);
+  const token = await githubToken();
+  if (!token) throw new Error("The selected GitHub bot credential is unavailable");
+  const numeric = /^\d+$/.test(selector);
+  const path = numeric
+    ? `/repos/${repo}/pulls/${selector}`
+    : `/repos/${repo}/pulls?state=all&head=${encodeURIComponent(`${repo.split("/")[0]}:${selector}`)}&per_page=1`;
+  const started = Date.now();
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "opensession",
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+  const body = await response.json().catch(() => null) as any;
+  console.log(
+    `[github-budget] lane=rest consumer=pr-automation status=${response.status} durationMs=${Date.now() - started} remaining=${response.headers.get("x-ratelimit-remaining") || "unknown"}`,
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    const message = String(body?.message || `GitHub REST ${response.status}`);
+    if (
+      (response.status === 403 || response.status === 429) &&
+      (response.headers.get("x-ratelimit-remaining") === "0" || isGhRateLimitMsg(message))
+    ) {
+      const reset = Number(response.headers.get("x-ratelimit-reset")) * 1000;
+      noteGhRateLimited("pr-automation", Number.isFinite(reset) ? reset : undefined, "rest");
+    }
+    throw new Error(prApiErrorMessage(message));
+  }
+  const pr = Array.isArray(body) ? body[0] : body;
+  if (!pr) return null;
+  return {
+    number: pr.number,
+    title: pr.title || `PR #${pr.number}`,
+    url: pr.html_url || "",
+    state: pr.merged_at ? "MERGED" : String(pr.state || "closed").toUpperCase(),
+    isDraft: !!pr.draft,
+    baseRefName: pr.base?.ref || "",
+    headRefName: pr.head?.ref || "",
+    headRefOid: pr.head?.sha || "",
+    author: pr.user?.login || "",
+  };
+}
+
 export function latestWorkflowChecks(checks: PrCheck[]): PrCheck[] {
   const latest = new Map<string, PrCheck>();
   const statusContexts: PrCheck[] = [];
@@ -255,6 +324,21 @@ const cache = new Map<string, { data: PrDetails | null; ts: number }>();
 // GraphQL budget (2026-07-23). Action gates that must not act on stale data
 // use getPrDetailsFresh, which bypasses this cache entirely.
 const TTL = 5 * 60_000;
+// A durable snapshot is deliberately allowed to stay stale during the first
+// ten minutes of a process. Webhooks and the bulk REST/ETag cache keep
+// open/merge state coherent; delaying rich GraphQL revalidation prevents a
+// restart loop from replaying one expensive detail query per open UI/session.
+const RESTART_REFRESH_GRACE_MS = 10 * 60_000;
+const detailsSnapshotLoadedAt = Date.now();
+
+export function shouldRefreshPrDetails(
+  entryTs: number,
+  now = Date.now(),
+  loadedAt = detailsSnapshotLoadedAt,
+): boolean {
+  if (now - entryTs < TTL) return false;
+  return now - loadedAt >= RESTART_REFRESH_GRACE_MS;
+}
 
 // The details cache is snapshotted to disk (debounced) and seeded on boot —
 // without this, a restart during a GitHub outage or rate-limit window boots
@@ -441,7 +525,7 @@ export async function getPrDiff(
 ): Promise<PrDiffData | null> {
   const key = cacheKey(repo, branch);
   const hit = maxPatchBytes ? undefined : diffCache.get(key);
-  if (hit && Date.now() - hit.ts < TTL) return hit.data;
+  if (hit && !shouldRefreshPrDetails(hit.ts)) return hit.data;
   const inflightKey = maxPatchBytes ? `${key}\0bounded:${maxPatchBytes}` : key;
   const running = diffInflight.get(inflightKey);
   if (running) return running;
@@ -950,7 +1034,7 @@ export async function getPrDetails(
 ): Promise<PrDetails | null> {
   const key = cacheKey(repo, branch);
   const hit = cache.get(key);
-  if (hit && Date.now() - hit.ts < TTL) return hit.data;
+  if (hit && !shouldRefreshPrDetails(hit.ts)) return hit.data;
   // Known backoff window: serve any cached answer, and with nothing cached
   // fail fast with the friendly message rather than spawning a doomed gh call.
   if (ghRateLimited()) {
@@ -999,7 +1083,9 @@ export function isNoPrError(msg: string): boolean {
 }
 
 export const GH_RATE_LIMIT_MESSAGE =
-  "GitHub's API rate limit has been reached. Try again after it resets.";
+  "GitHub GraphQL is rate-limited. Cached pull request data will refresh after it resets.";
+export const GH_REST_RATE_LIMIT_MESSAGE =
+  "GitHub REST is rate-limited. This pull request action will retry after it resets.";
 
 export function prApiErrorMessage(msg: string): string {
   if (/rate limit/i.test(msg)) return GH_RATE_LIMIT_MESSAGE;

--- a/packages/core/opensession-server/src/server/pr-info.ts
+++ b/packages/core/opensession-server/src/server/pr-info.ts
@@ -20,6 +20,7 @@ import {
 } from "./github-auth";
 import { githubBotCredentialMode, githubToken } from "./github-app";
 import { reviewRequestRemovalSpecs } from "./github-review-requests";
+import { noteGithubGraphqlCall } from "./github-budget";
 import { getPrStack, unmergedLayersBelow } from "./pr-stack";
 import type {
   MergeMethod,
@@ -52,17 +53,7 @@ export type {
   PrStaging,
 } from "./pr-contract";
 
-export interface PrAutomationDetails {
-  number: number;
-  title: string;
-  url: string;
-  state: "OPEN" | "MERGED" | "CLOSED";
-  isDraft: boolean;
-  baseRefName: string;
-  headRefName: string;
-  headRefOid: string;
-  author: string;
-}
+export type PrAutomationDetails = PrDetails;
 
 /**
  * Minimum PR metadata needed to acknowledge and queue event-driven work.
@@ -108,16 +99,51 @@ export async function getPrAutomationDetails(
   }
   const pr = Array.isArray(body) ? body[0] : body;
   if (!pr) return null;
+  const key = cacheKey(repo, pr.head?.ref || selector);
+  const cached = cache.get(key)?.data;
+  const state: PrDetails["state"] = pr.merged_at
+    ? "MERGED"
+    : pr.state === "open"
+      ? "OPEN"
+      : "CLOSED";
   return {
+    ...(cached || {
+      number: pr.number,
+      title: "",
+      url: "",
+      state,
+      isDraft: false,
+      baseRefName: "",
+      headRefName: "",
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+      reviewDecision: "",
+      author: "",
+      body: "",
+      checks: [],
+      comments: [],
+      commits: [],
+      files: [],
+      reviewers: [],
+      mergeable: "UNKNOWN",
+      mergeStateStatus: "",
+      staging: null,
+    }),
     number: pr.number,
     title: pr.title || `PR #${pr.number}`,
     url: pr.html_url || "",
-    state: pr.merged_at ? "MERGED" : String(pr.state || "closed").toUpperCase(),
+    state,
     isDraft: !!pr.draft,
     baseRefName: pr.base?.ref || "",
     headRefName: pr.head?.ref || "",
     headRefOid: pr.head?.sha || "",
+    additions: Number(pr.additions) || cached?.additions || 0,
+    deletions: Number(pr.deletions) || cached?.deletions || 0,
+    changedFiles: Number(pr.changed_files) || cached?.changedFiles || 0,
     author: pr.user?.login || "",
+    body: typeof pr.body === "string" ? pr.body : cached?.body || "",
+    mergeable: pr.mergeable === true ? "MERGEABLE" : pr.mergeable === false ? "CONFLICTING" : cached?.mergeable || "UNKNOWN",
   };
 }
 
@@ -1083,7 +1109,7 @@ export function isNoPrError(msg: string): boolean {
 }
 
 export const GH_RATE_LIMIT_MESSAGE =
-  "GitHub GraphQL is rate-limited. Cached pull request data will refresh after it resets.";
+  "GitHub's API rate limit has been reached. Try again after it resets.";
 export const GH_REST_RATE_LIMIT_MESSAGE =
   "GitHub REST is rate-limited. This pull request action will retry after it resets.";
 
@@ -1179,13 +1205,16 @@ async function fetchPrDetails(
         "number,title,url,state,isDraft,baseRefName,headRefName,headRefOid,additions,deletions,changedFiles,reviewDecision,author,body,mergeable,mergeStateStatus,comments,commits,files,latestReviews,reviewRequests";
       const includeRollup = appSelected || !skipStatusCheckRollup;
       const fields = includeRollup ? `${baseFields},statusCheckRollup` : baseFields;
+      const queryStarted = Date.now();
       try {
         raw = await $`gh pr view ${branch} --repo ${repo} --json ${fields}`
           .env({ ...process.env, ...selectedEnv })
           .quiet()
           .text();
+        noteGithubGraphqlCall("pr-info:details", Date.now() - queryStarted, true);
         break;
       } catch (e: any) {
+        noteGithubGraphqlCall("pr-info:details", Date.now() - queryStarted, false);
         const msg = String(e?.stderr || e?.message || e).slice(0, 300);
         // Keyed on THIS call's field list, not the global flag — a concurrent
         // fetch may trip the flag while our rollup-carrying request is in

--- a/packages/core/opensession-server/src/server/pr-info.ts
+++ b/packages/core/opensession-server/src/server/pr-info.ts
@@ -551,44 +551,70 @@ export async function getPrDiff(
 ): Promise<PrDiffData | null> {
   const key = cacheKey(repo, branch);
   const hit = maxPatchBytes ? undefined : diffCache.get(key);
-  if (hit && !shouldRefreshPrDetails(hit.ts)) return hit.data;
+  if (hit && Date.now() - hit.ts < TTL) return hit.data;
   const inflightKey = maxPatchBytes ? `${key}\0bounded:${maxPatchBytes}` : key;
   const running = diffInflight.get(inflightKey);
   if (running) return running;
   // Known backoff window: stale answer if we have one, fast friendly failure
   // if we don't — never a doomed gh spawn.
-  if (ghRateLimited()) {
+  if (ghRateLimited("rest")) {
     if (hit) return hit.data;
-    throw new Error(GH_RATE_LIMIT_MESSAGE);
+    throw new Error(GH_REST_RATE_LIMIT_MESSAGE);
   }
 
   const refresh = (async () => {
     try {
-      const ghEnv = await selectedGhEnv();
-      const readMeta = async () => JSON.parse(
-        await $`gh pr view ${branch} --repo ${repo} --json number,headRefOid,baseRefName,baseRefOid`
-          .env({ ...process.env, ...ghEnv })
-          .quiet()
-          .text(),
-      );
+      const token = await githubToken();
+      if (!token) throw new Error("The selected GitHub bot credential is unavailable");
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "opensession",
+      };
+      const readMeta = async (): Promise<{
+        number: number;
+        headRefOid: string;
+        baseRefName: string;
+        baseRefOid: string;
+      }> => {
+        const numeric = /^\d+$/.test(branch);
+        const path = numeric
+          ? `/repos/${repo}/pulls/${branch}`
+          : `/repos/${repo}/pulls?state=all&head=${encodeURIComponent(`${repo.split("/")[0]}:${branch}`)}&per_page=1`;
+        const response = await fetch(`https://api.github.com${path}`, {
+          headers: { ...headers, Accept: "application/vnd.github+json" },
+          signal: AbortSignal.timeout(10_000),
+        });
+        const body = await response.json().catch(() => null) as any;
+        if (!response.ok) throw new Error(String(body?.message || `GitHub REST ${response.status}`));
+        const pr = Array.isArray(body) ? body[0] : body;
+        if (!pr) throw new Error("no pull requests found");
+        return {
+          number: pr.number,
+          headRefOid: pr.head?.sha || "",
+          baseRefName: pr.base?.ref || "",
+          baseRefOid: pr.base?.sha || "",
+        };
+      };
       for (let attempt = 0; attempt < 2; attempt++) {
         const meta = await readMeta();
         let patch: string;
         let skippedFiles = 0;
         try {
+          const controller = new AbortController();
+          const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${meta.number}`, {
+            headers: { ...headers, Accept: "application/vnd.github.v3.diff" },
+            signal: AbortSignal.any([controller.signal, AbortSignal.timeout(30_000)]),
+          });
+          if (!response.ok) throw new Error(await response.text().catch(() => `GitHub REST ${response.status}`));
+          if (!response.body) throw new Error("GitHub returned an empty PR diff");
           if (maxPatchBytes) {
-            const bounded = await boundedCommandPatch(
-              ["gh", "pr", "diff", String(meta.number), "--repo", repo],
-              maxPatchBytes,
-              ghEnv,
-            );
-            patch = bounded.patch;
-            skippedFiles = bounded.skippedFiles;
+            const bounded = await processPrefix(response.body, maxPatchBytes, () => controller.abort());
+            const complete = completePatchPrefix(bounded.text, bounded.truncated);
+            patch = complete.patch;
+            skippedFiles = complete.skippedFiles;
           } else {
-            patch = await $`gh pr diff ${meta.number} --repo ${repo}`
-              .env({ ...process.env, ...ghEnv })
-              .quiet()
-              .text();
+            patch = await response.text();
           }
         } catch (diffErr: any) {
           // GitHub refuses API diffs over 300 files; reconstruct from the same
@@ -626,7 +652,7 @@ export async function getPrDiff(
     } catch (e: any) {
       const msg = String(e?.stderr || e?.message || e).slice(0, 300);
       if (!isNoPrError(msg)) {
-        if (isGhRateLimitMsg(msg)) noteGhRateLimited("pr-info");
+        if (isGhRateLimitMsg(msg)) noteGhRateLimited("pr-diff", undefined, "rest");
         console.warn(`[pr-info] gh pr diff ${branch} (${repo}) failed: ${msg}`);
         if (hit) return hit.data; // stale beats an error
         throw new Error(prApiErrorMessage(msg));

--- a/packages/core/opensession-server/src/server/pr-stack.ts
+++ b/packages/core/opensession-server/src/server/pr-stack.ts
@@ -36,6 +36,7 @@ import {
 } from "./github-auth";
 import { ghRateLimited, noteGhRateLimited, isGhRateLimitMsg } from "./github-limit";
 import { audited } from "./audit";
+import { noteGithubGraphqlCall } from "./github-budget";
 import type { PrStack, PrStackLayer } from "./pr-contract";
 export type { PrStack, PrStackLayer } from "./pr-contract";
 
@@ -211,7 +212,9 @@ async function graphql(
   const args = ["api", "graphql", "-f", `query=${query}`];
   for (const [k, v] of Object.entries(strings)) args.push("-f", `${k}=${v}`);
   for (const [k, v] of Object.entries(numbers)) args.push("-F", `${k}=${v}`);
+  const started = Date.now();
   const { code, out, err } = await runGh(args, credential);
+  noteGithubGraphqlCall("pr-stack", Date.now() - started, code === 0);
   if (code !== 0) {
     const msg = String(err || "gh api graphql failed").slice(0, 300);
     if (isUnknownFieldMsg(msg)) {

--- a/packages/core/opensession-server/src/server/pr-viewed.test.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.test.ts
@@ -3,14 +3,17 @@ import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { getPrViewedFiles } from "./pr-viewed";
+import { __setGhBackoffForTest } from "./github-limit";
 import type { RouteContext } from "./routes/context";
 
 const savedConfig = process.env.OPENSESSION_CONFIG;
 const savedStore = process.env.OPENSESSION_GITHUB_AUTH_STORE;
 const realFetch = globalThis.fetch;
 let dir = "";
+let savedGraphqlBackoff = 0;
 
 beforeEach(() => {
+  savedGraphqlBackoff = __setGhBackoffForTest(0, "graphql");
   dir = mkdtempSync(join(tmpdir(), "os-pr-viewed-test-"));
   process.env.OPENSESSION_CONFIG = join(dir, "config.json");
   process.env.OPENSESSION_GITHUB_AUTH_STORE = join(dir, "github-auth.json");
@@ -33,6 +36,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  __setGhBackoffForTest(savedGraphqlBackoff, "graphql");
   globalThis.fetch = realFetch;
   rmSync(dir, { recursive: true, force: true });
   if (savedConfig === undefined) delete process.env.OPENSESSION_CONFIG;

--- a/packages/core/opensession-server/src/server/pr-viewed.ts
+++ b/packages/core/opensession-server/src/server/pr-viewed.ts
@@ -12,7 +12,8 @@
 
 import type { RouteContext } from "./routes/context";
 import { githubCredentialForLogin, githubUserLoginForRun } from "./github-auth";
-import { botGhToken } from "./github-limit";
+import { botGhToken, ghRateLimited, isGhRateLimitMsg, noteGhRateLimited } from "./github-limit";
+import { noteGithubGraphqlCall } from "./github-budget";
 import { githubMutationCredential } from "./routes/github-credential";
 import { fetchWithTimeout } from "./shared/fetch-with-timeout";
 
@@ -50,6 +51,8 @@ async function graphql(
 	query: string,
 	variables: Record<string, unknown>,
 ): Promise<any> {
+	if (ghRateLimited()) throw new Error("GitHub GraphQL is rate-limited");
+	const started = Date.now();
 	const res = await fetchWithTimeout(
 		"https://api.github.com/graphql",
 		{
@@ -63,9 +66,12 @@ async function graphql(
 		15_000,
 	);
 	const data = (await res.json().catch(() => null)) as any;
-	if (!res.ok || !data || data.errors?.length) {
+	const ok = res.ok && !!data && !data.errors?.length;
+	noteGithubGraphqlCall("pr-viewed", Date.now() - started, ok);
+	if (!ok) {
 		const message =
 			data?.errors?.[0]?.message || data?.message || `GitHub HTTP ${res.status}`;
+		if (isGhRateLimitMsg(message)) noteGhRateLimited("pr-viewed");
 		throw new Error(message);
 	}
 	return data.data;


### PR DESCRIPTION
## Summary

- split persisted GitHub backoff into independent GraphQL and REST lanes, including migration of the old global backoff into GraphQL only
- preserve valid bulk and rich PR snapshots across restart storms, while retaining webhook write-throughs, ETag reconciliation, query-bound validation, and per-repo cache keys
- move review and @mention metadata and diff intake to REST so an empty GraphQL bucket cannot discard healthy automation work
- acknowledge mentions immediately, persist their receipts, and retry queued work every minute and after restart
- add credential-safe per-consumer GraphQL call and installation-budget telemetry; analytics is explicitly labeled ambient and no longer changes the App backoff

## Investigation and measured behavior

Production on 2026-08-25 had 665 durable rich-detail rows and 10 configured bulk-cache repositories. Restarts replayed stale detail refreshes and reset the process-local suppression of expensive GraphQL paths. The installation reached 9,892/9,900 GraphQL requests while REST had used only 24/9,900. Logs then showed reviews and mentions failing in `getPrDetails` behind the global backoff. Analytics factory queries were confirmed to use ambient `gh`, not the selected App environment.

Before:
- a cold process could immediately fan out up to 665 rich detail refreshes as panels and sessions resumed
- a bulk cold refresh issued two GraphQL list queries per configured repository, 20 calls for the measured 10-repo instance
- review intake and mention replies entered `getPrDetails` and failed before visible acknowledgement when GraphQL was exhausted
- one GraphQL rejection paused REST comments, metadata reads, reconciliation, team lookup, and preview polling too

After:
- rich detail refreshes are deferred for a 10-minute restart grace, so repeated restarts issue 0 immediate detail GraphQL refreshes from the durable snapshot
- a versioned bulk snapshot with matching open/recent bounds and all repositories refreshed within 30 minutes remains hot, so repeated restarts issue 0 immediate bulk GraphQL list calls; webhooks and later conditional REST probes preserve open/merge correctness
- review metadata, head verification, and PR patches use REST; mentions receive a durable visible receipt before dispatch
- GraphQL and REST backoffs are persisted and enforced independently
- budget logs aggregate calls, failures, duration, credential lane, and installation remaining/used/reset by named consumer without queries, variables, response bodies, or credentials

## Validation

- `bun run typecheck`
- `bun test packages/core/opensession-server/src/agents/github packages/core/opensession-server/src/server/pr-cache.test.ts packages/core/opensession-server/src/server/pr-cache-staleness.test.ts packages/core/opensession-server/src/server/pr-info.test.ts packages/core/opensession-server/src/server/github-limit.test.ts` (140 passed)
- `bun scripts/check-module-side-effects.ts` (417 modules clean)
- `git diff --check origin/main...HEAD`

## Rollout

Do not deploy from this PR. After merge, deploy with a normal backend restart. The existing version 4 bulk snapshot intentionally performs one compatibility refresh and is then persisted as version 5; subsequent restarts within the validity window reuse it. Watch `[github-budget]` and `[github-limit]` logs through one GraphQL reset window, and verify queued mention receipts transition from queued to progress/completion. No PAT fallback is introduced: App mode still fails closed, code tokens remain repository-scoped, and interactive PR creation continues to use the connected human credential.

Created by [this OS session](https://os.tella.dev/session/bks-a34b64df-f2a8-711f-bcf1-1a089316c253)