### PR TITLE
Wait for bind restart health check

### DIFF
--- a/scripts/lib/bind.test.ts
+++ b/scripts/lib/bind.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { responding } from "./bind";
+
+test("waits for the service health check to become ready", async () => {
+  let requests = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      requests += 1;
+      return new Response(null, { status: requests < 3 ? 503 : 200 });
+    },
+  });
+
+  try {
+    expect(await responding("127.0.0.1", server.port!, 500, 1)).toBe(true);
+    expect(requests).toBe(3);
+  } finally {
+    server.stop(true);
+  }
+});

--- a/scripts/lib/bind.ts
+++ b/scripts/lib/bind.ts
@@ -19,15 +19,29 @@ import { CONFIG_PATH, ENV_PATH } from "./paths";
 import * as service from "./service";
 import { bold, dim, heading, info, ok, warn, wrote, yellow } from "./ui";
 
-async function responding(host: string, port: number): Promise<boolean> {
-  try {
-    const probeHost = host === "0.0.0.0" ? "127.0.0.1" : host;
-    const res = await fetch(`http://${probeHost}:${port}/api/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    return res.ok;
-  } catch {
-    return false;
+export async function responding(
+  host: string,
+  port: number,
+  waitMs = 0,
+  retryIntervalMs = 250,
+): Promise<boolean> {
+  const probeHost = host === "0.0.0.0" ? "127.0.0.1" : host;
+  const deadline = Date.now() + waitMs;
+
+  while (true) {
+    try {
+      const res = await fetch(`http://${probeHost}:${port}/api/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) return true;
+    } catch {
+      // A supervisor can report a successful restart before the new process
+      // has opened its socket. Keep probing during the startup grace period.
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return false;
+    await Bun.sleep(Math.min(retryIntervalMs, remainingMs));
   }
 }
 
@@ -91,8 +105,9 @@ export async function bind(address?: string): Promise<number> {
     } else {
       info(dim("restarting the service so the new bind takes effect ..."));
       if ((await service.control("restart")) !== 0) return 1;
-      if (await responding(target, port)) ok(`listening on ${target}:${port}`);
-      else {
+      if (await responding(target, port, 15_000)) {
+        ok(`listening on ${target}:${port}`);
+      } else {
         warn(`nothing answering on ${target}:${port} yet`, "`opensession logs` to see why");
         return 1;
       }


### PR DESCRIPTION
## Summary
- retry the health probe for up to 15 seconds after restarting the service
- keep the existing immediate probe when no restart is needed
- cover delayed health readiness with a regression test

## Tests
- `bun test scripts/lib/bind.test.ts scripts/lib/service.test.ts`
- `bunx tsc --noEmit --pretty false`

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a03878-2484-7dff-9b69-a26032c72a1d)