### PR TITLE
Recover schema-22 creation dispatches before persistence

### DIFF
--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -457,15 +457,17 @@ export function restorePersistedQueueState(options: {
 		}
 		for (const [sessionId, dispatch] of promptDispatches) {
 			if (!restorable(sessionId)) continue;
+			const creationOwned =
+				dispatch.kind === "create" &&
+				(options.creationOwnsPrompt?.(sessionId, dispatch.promptEntryId) ||
+					!options.journalOwnsPrompt(sessionId, dispatch.promptEntryId));
+			// Creation dispatches intentionally precede the session file. The actor
+			// opening plan and effect remain their recovery authority in this window.
+			if (creationOwned) continue;
 			if (!options.sessionExists(sessionId)) {
 				promptDispatches.delete(sessionId);
 				continue;
 			}
-			if (
-				dispatch.kind === "create" &&
-				(options.creationOwnsPrompt?.(sessionId, dispatch.promptEntryId) ||
-					!options.journalOwnsPrompt(sessionId, dispatch.promptEntryId))
-			) continue;
 			if (options.journalOwnsPrompt(sessionId, dispatch.promptEntryId))
 				acknowledgePromptDispatch(sessionId, dispatch.promptEntryId, false);
 			else failPromptDispatch(sessionId, dispatch.promptEntryId, false);

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -610,9 +610,43 @@ async function restorePlannedOpening(sessionId: string): Promise<{
 	const legacyPlan = actorPlan ? undefined : readCreatePlanForRecovery(sessionId);
 	const openingPlan = actorPlan ?? legacyPlan?.resolved;
 	const identity = actorPlan ? creation!.identity : legacyPlan?.identity;
-	const dispatch = promptDispatches.get(sessionId);
-	if (!openingPlan || !identity || dispatch?.kind !== "create") return null;
+	if (!openingPlan || !identity) return null;
 	const restored = restoreResolvedCreate<ResolvedCreate>(openingPlan);
+	let dispatch = promptDispatches.get(sessionId);
+	if (
+		!dispatch &&
+		actorPlan &&
+		creation?.state === "opening_dispatched" &&
+		typeof restored.openingPromptEntryId === "string" &&
+		restored.openingPromptEntryId &&
+		typeof restored.openingPrompt === "string"
+	) {
+		// A pre-schema-22 recovery pass could remove the create dispatch before
+		// the session file existed. The opening plan is write-once and carries the
+		// exact prompt identity, so restore that same actor receipt before launch.
+		const promptEntryId = restored.openingPromptEntryId;
+		const openingPrompt = restored.openingPrompt;
+		const recoveredDispatch = {
+			promptEntryId,
+			items: [
+				{
+					content: openingPrompt,
+					user: restored.user,
+					...(restored.images?.length
+						? {
+								images: restored.images.map(
+									(image) => `data:${image.mediaType};base64,${image.data}`,
+								),
+							}
+						: {}),
+				},
+			],
+			kind: "create" as const,
+		};
+		promptDispatches.set(sessionId, recoveredDispatch);
+		dispatch = recoveredDispatch;
+	}
+	if (dispatch?.kind !== "create") return null;
 	const restoredGitEnv = githubCredentialForPrincipal(restored.gitPrincipal)?.env;
 	if (
 		typeof restored.wtPath !== "string" ||

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -264,7 +264,9 @@ export function sessionKernelActorActive(): boolean {
 
 export function sessionIsQuarantined(sessionId: string): boolean {
   if (state.actor) return !!state.actor.quarantinedSession(sessionId);
-  return !!compatibilityStoreForTest("quarantine read").quarantinedSession(sessionId);
+  if (process.env.NODE_ENV === "test")
+    return !!sessionKernelStore().quarantinedSession(sessionId);
+  throw new Error("Session quarantine reads require the authoritative actor");
 }
 
 export function sessionKernelStore(): SessionKernelStoreApi {


### PR DESCRIPTION
## Summary
- preserve actor-owned create dispatches while the session file intentionally does not exist yet
- reconstruct an exact missing create dispatch from the write-once opening plan before replaying its durable effect
- keep quarantine reads fail-closed through the actor while retaining the explicit test adapter

## Production impact
Schema 22 exposed a restart window where queue recovery removed a create dispatch before `openCreatedSession` persisted the session file. The opening effect remained durable but could not restore its actor plan. Three review-session creates currently show this retry. The recovery uses the same opening prompt entry ID and does not invent a new execution identity.

## Verification
- `bun run typecheck`
- 194 queue/create/kernel tests
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
