### PR TITLE
Bound pending steer recovery across session databases

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
@@ -326,6 +326,35 @@ describe("per-session session kernel storage", () => {
     host.close();
   });
 
+  test("settles only isolated stores that contain pending steers", () => {
+    const path = paths();
+    const host = new SessionKernelStoreHost(path.central, path.isolated);
+    host.call("setRunState", [{
+      sessionId: "empty-session",
+      state: "idle",
+      event: "seed",
+    }]);
+    host.call("prepareSteerDelivery", [
+      "pending-session",
+      "steer-one",
+      { id: "steer-one", content: "recover me" },
+    ]);
+    Object.defineProperty(host.storeForSession("empty-session"), "settlePendingSteers", {
+      configurable: true,
+      value: () => {
+        throw new Error("empty stores must not enter the mutation sweep");
+      },
+    });
+
+    expect(host.call("settlePendingSteers", [])).toBe(1);
+    expect(host.storeForSession("pending-session").deliverySnapshot("pending-session"))
+      .toMatchObject({
+        pendingSteers: [],
+        steered: [{ id: "steer-one", content: "recover me" }],
+      });
+    host.close();
+  });
+
   test("recovers isolated wake work from the durable dirty placement", () => {
     const path = paths();
     const first = new SessionKernelStoreHost(path.central, path.isolated);

--- a/packages/core/opensession-server/src/server/session-kernel/store-host.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.ts
@@ -550,11 +550,22 @@ export class SessionKernelStoreHost {
         store.clearDeliverySlot(args[0] as Parameters<SessionKernelStoreApi["clearDeliverySlot"]>[0]));
       return;
     }
-    if (method === "settlePendingSteers")
-      return this.mapStores(
-        "global:settle-pending-steers",
-        (store) => store.settlePendingSteers(),
-      ).reduce((total, settled) => total + settled, 0);
+    if (method === "settlePendingSteers") {
+      let settled = this.central.settlePendingSteers();
+      const candidates = this.mapIsolatedReadStores(
+        "global:find-pending-steers",
+        (store, sessionId) => store.hasPendingSteers() ? sessionId : undefined,
+      ).filter((sessionId): sessionId is string => sessionId !== undefined);
+      for (const sessionId of candidates) {
+        const result = this.containIsolated(
+          sessionId,
+          "global:settle-pending-steers",
+          () => this.storeForSession(sessionId, true).settlePendingSteers(),
+        );
+        if (result.ok) settled += result.value;
+      }
+      return settled;
+    }
     if (method === "retryCompatibleCreationBranchDeadLetters")
       return this.mapStores("global:retry-creation-branches", (store) =>
         store.retryCompatibleCreationBranchDeadLetters(

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2398,6 +2398,12 @@ export class SessionKernelStore {
     return items.length;
   }
 
+  hasPendingSteers(): boolean {
+    return !!this.db.query(
+      "SELECT 1 FROM session_kernel_delivery WHERE pending_steers != '[]' LIMIT 1",
+    ).get();
+  }
+
   settlePendingSteers(): number {
     const rows = this.db.query(
       "SELECT session_id FROM session_kernel_delivery WHERE pending_steers != '[]'",
@@ -4627,6 +4633,7 @@ export class SessionKernelStore {
 export type SessionKernelStoreApi = Omit<
 	SessionKernelStore,
 	| "hasSessionDurableState"
+	| "hasPendingSteers"
 	| "legacySessionIds"
 	| "migrateLegacySession"
 	| "sessionPlacement"


### PR DESCRIPTION
## Summary
- discover isolated session databases with pending steers through a read-only fanout
- mutate only candidate stores instead of opening all session databases for writes during gateway boot
- preserve per-session quarantine and durable-dirty fencing for every recovery mutation

## Production symptom
After the schema-23 cutover, gateway boot timed out while `settle_pending_steers` opened 1,929 isolated databases for mutation. The actor remained healthy and the gateway fail-stopped. Production stays stopped until this fix is merged and deployed.

## Verification
- focused store-host tests, including a regression that rejects mutation of an empty store
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
