### PR TITLE
Bound creation dead-letter recovery fanout

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
@@ -355,6 +355,30 @@ describe("per-session session kernel storage", () => {
     host.close();
   });
 
+  test("skips empty stores when retrying compatible creation dead letters", () => {
+    const path = paths();
+    const host = new SessionKernelStoreHost(path.central, path.isolated);
+    host.call("setRunState", [{
+      sessionId: "empty-creation-session",
+      state: "idle",
+      event: "seed",
+    }]);
+    Object.defineProperty(
+      host.storeForSession("empty-creation-session"),
+      "retryCompatibleCreationBranchDeadLetters",
+      {
+        configurable: true,
+        value: () => {
+          throw new Error("empty stores must not enter the mutation sweep");
+        },
+      },
+    );
+
+    expect(host.call("retryCompatibleCreationBranchDeadLetters", [[], Date.now()]))
+      .toEqual([]);
+    host.close();
+  });
+
   test("recovers isolated wake work from the durable dirty placement", () => {
     const path = paths();
     const first = new SessionKernelStoreHost(path.central, path.isolated);

--- a/packages/core/opensession-server/src/server/session-kernel/store-host.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.ts
@@ -566,13 +566,31 @@ export class SessionKernelStoreHost {
       }
       return settled;
     }
-    if (method === "retryCompatibleCreationBranchDeadLetters")
-      return this.mapStores("global:retry-creation-branches", (store) =>
-        store.retryCompatibleCreationBranchDeadLetters(
-          args[0] as Parameters<SessionKernelStoreApi["retryCompatibleCreationBranchDeadLetters"]>[0],
-          args[1] as number | undefined,
-        ),
-      ).flat();
+    if (method === "retryCompatibleCreationBranchDeadLetters") {
+      const destinations = args[0] as Parameters<
+        SessionKernelStoreApi["retryCompatibleCreationBranchDeadLetters"]
+      >[0];
+      const now = args[1] as number | undefined;
+      const retried = this.central.retryCompatibleCreationBranchDeadLetters(
+        destinations,
+        now,
+      );
+      const candidates = this.mapIsolatedReadStores(
+        "global:find-creation-branch-dead-letters",
+        (store, sessionId) =>
+          store.hasCreationBranchDeadLetters() ? sessionId : undefined,
+      ).filter((sessionId): sessionId is string => sessionId !== undefined);
+      for (const sessionId of candidates) {
+        const result = this.containIsolated(
+          sessionId,
+          "global:retry-creation-branches",
+          () => this.storeForSession(sessionId, true)
+            .retryCompatibleCreationBranchDeadLetters(destinations, now),
+        );
+        if (result.ok) retried.push(...result.value);
+      }
+      return retried;
+    }
     if (method === "deadLetters") {
       const limit = Number(args[0] ?? 100);
       const offset = Number(args[1] ?? 0);

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -4130,6 +4130,20 @@ export class SessionKernelStore {
 		return result.changes > 0;
 	}
 
+	hasCreationBranchDeadLetters(): boolean {
+		return !!this.db.query(
+			`SELECT 1
+			 FROM session_kernel_outbox AS outbox
+			 JOIN session_kernel_creation AS creation
+			   ON creation.session_id = outbox.session_id
+			  AND creation.state = 'preparing'
+			  AND creation.current_effect_id = outbox.effect_key
+			 WHERE outbox.kind = 'creation_branch_prepare'
+			   AND outbox.dead_lettered_at IS NOT NULL
+			 LIMIT 1`,
+		).get();
+	}
+
 	/**
 	 * Re-admit branch effects rejected before physical work by compatibility bugs:
 	 * the former shared-checkout classifier and the old empty-base decoder. The
@@ -4634,6 +4648,7 @@ export type SessionKernelStoreApi = Omit<
 	SessionKernelStore,
 	| "hasSessionDurableState"
 	| "hasPendingSteers"
+	| "hasCreationBranchDeadLetters"
 	| "legacySessionIds"
 	| "migrateLegacySession"
 	| "sessionPlacement"


### PR DESCRIPTION
## Summary
- find isolated stores containing creation-branch dead letters through read-only fanout
- mutate only candidate stores during the compatibility recovery pass
- retain central recovery, durable dirty fencing, and per-session failure containment

## Production symptom
After pending-steer recovery was bounded, the next gateway recovery pass exposed the same all-store write fanout in `retryCompatibleCreationBranchDeadLetters`. With 1,929 isolated databases it exceeded the synchronous actor budget and the gateway correctly fail-stopped.

## Verification
- focused regression proving empty stores do not enter the mutation sweep
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
