### PR TITLE
Skip run-state hydration in transient read fanout

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/store-host.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.ts
@@ -445,7 +445,7 @@ export class SessionKernelStoreHost {
         try {
           store = new SessionKernelStore(
             sessionKernelSessionDbPath(sessionId, this.isolatedRoot),
-            { readonly: true },
+            { readonly: true, hydrateRunStateCache: false },
           );
         } catch (error) {
           // The first schema-23 read may encounter an additive schema-22 target

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -371,6 +371,7 @@ export type SessionKernelStoreOptions = {
 	readonly?: boolean;
 	allocateOutboxId?: (sessionId: string) => number;
   busyTimeoutMs?: number;
+  hydrateRunStateCache?: boolean;
 };
 
 const SESSION_KERNEL_SESSION_TABLES = [
@@ -425,7 +426,7 @@ export class SessionKernelStore {
 				throw new Error(
 					`Session kernel read mirror schema ${schemaVersion} does not match supported ${SESSION_KERNEL_SCHEMA_VERSION}`,
 				);
-			this.hydrateRunStateCache();
+			if (options.hydrateRunStateCache !== false) this.hydrateRunStateCache();
 			return;
 		}
 		if (path !== ":memory:") {


### PR DESCRIPTION
## Summary
- let transient read-only store handles skip eager run-state hydration
- preserve explicit hydration in `runStates()` and normal per-session read mirrors
- reduce sparse global reads from full state+target queries to only their requested query

## Production evidence
After schema-23 migration, `askEntries` exceeded the synchronous actor budget under live sidebar traffic. Against the 1,951-store production dataset, a combined ask and queued-delivery scan with this change completed in 377 ms and found the expected 10 ask rows and 5 queued-delivery rows.

## Verification
- 12 focused store-host tests
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
