### PR TITLE
Cache sparse global session projections

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
@@ -326,6 +326,41 @@ describe("per-session session kernel storage", () => {
     host.close();
   });
 
+  test("caches sparse global projections and invalidates them after mutations", () => {
+    const path = paths();
+    const host = new SessionKernelStoreHost(path.central, path.isolated);
+    host.call("setAskRecord", ["cache-session", {
+      questionId: "ask-one",
+      questions: [{ question: "First?" }],
+    }]);
+    host.call("setDeliverySlot", [
+      "cache-session",
+      "queued",
+      [{ id: "queue-one", content: "First" }],
+    ]);
+
+    const asks = host.allAskEntries();
+    const deliveries = host.allDeliveryEntries("queued");
+    (asks[0]![1] as { questionId: string }).questionId = "caller-mutated";
+    (deliveries[0]![1] as Array<{ content: string }>)[0]!.content = "caller-mutated";
+    expect(host.allAskEntries()[0]![1]).toMatchObject({ questionId: "ask-one" });
+    expect(host.allDeliveryEntries("queued")[0]![1]).toMatchObject([
+      { id: "queue-one", content: "First" },
+    ]);
+
+    host.call("deleteAskRecord", ["cache-session"]);
+    host.call("setDeliverySlot", [
+      "cache-session",
+      "queued",
+      [{ id: "queue-two", content: "Second" }],
+    ]);
+    expect(host.allAskEntries()).toEqual([]);
+    expect(host.allDeliveryEntries("queued")[0]![1]).toMatchObject([
+      { id: "queue-two", content: "Second" },
+    ]);
+    host.close();
+  });
+
   test("settles only isolated stores that contain pending steers", () => {
     const path = paths();
     const host = new SessionKernelStoreHost(path.central, path.isolated);

--- a/packages/core/opensession-server/src/server/session-kernel/store-host.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.ts
@@ -7,6 +7,7 @@ import {
   type DurableRunState,
   type DurableSessionQuarantine,
   type DurableTimer,
+  type DeliverySlot,
   type SessionKernelStoreApi,
 } from "./store";
 import { sessionKernelStoreRoute } from "./store-routing";
@@ -57,6 +58,11 @@ export class SessionKernelStoreHost {
   private runtimeCursor = "";
   private maintenanceSessionCursor = "";
   private outboxRouteMaintenanceCursor = 0;
+  private askEntriesCache?: Array<[string, unknown]>;
+  private readonly deliveryEntriesCache = new Map<
+    DeliverySlot,
+    Array<[string, unknown]>
+  >();
 
   constructor(
     private readonly centralPath = sessionKernelDbPath(),
@@ -113,15 +119,18 @@ export class SessionKernelStoreHost {
     commandKind: string,
     infrastructure = false,
   ): DurableSessionQuarantine {
-    if (infrastructure && this.isIsolated(sessionId))
-      return this.centralOperation(
-        () => this.central.quarantineSession(sessionId, reason, commandKind),
-      );
-    return this.storeForSession(sessionId, true).quarantineSession(
-      sessionId,
-      reason,
-      commandKind,
-    );
+    const quarantine = infrastructure && this.isIsolated(sessionId)
+      ? this.centralOperation(
+          () => this.central.quarantineSession(sessionId, reason, commandKind),
+        )
+      : this.storeForSession(sessionId, true).quarantineSession(
+          sessionId,
+          reason,
+          commandKind,
+        );
+    this.askEntriesCache = undefined;
+    this.deliveryEntriesCache.clear();
+    return quarantine;
   }
 
   storeForSession(sessionId: string, mutation = false): SessionKernelStore {
@@ -188,6 +197,10 @@ export class SessionKernelStoreHost {
       const centralReleased = this.centralOperation(
         () => this.central.releaseQuarantine(sessionId),
       );
+      if (centralReleased || isolatedReleased) {
+        this.askEntriesCache = undefined;
+        this.deliveryEntriesCache.clear();
+      }
       return centralReleased || isolatedReleased;
     }
     const route = sessionKernelStoreRoute(method, args);
@@ -203,11 +216,16 @@ export class SessionKernelStoreHost {
       ) this.centralOperation(() => this.central.forgetIsolatedOutboxRoute(route.id));
       return result;
     }
-    return this.invoke(
+    const result = this.invoke(
       this.storeForSession(route.sessionId, route.mutation),
       method,
       args,
     );
+    if (route.mutation) {
+      this.askEntriesCache = undefined;
+      this.deliveryEntriesCache.clear();
+    }
+    return result;
   }
 
   allRunStates(): Array<DurableRunState & { sessionId: string }> {
@@ -215,14 +233,24 @@ export class SessionKernelStoreHost {
   }
 
   allAskEntries(): Array<[string, unknown]> {
-    return this.mapReadStores("global:ask-entries", (store) => store.askEntries()).flat();
+    if (this.askEntriesCache) return structuredClone(this.askEntriesCache);
+    const entries = this.mapReadStores(
+      "global:ask-entries",
+      (store) => store.askEntries(),
+    ).flat();
+    this.askEntriesCache = entries;
+    return structuredClone(entries);
   }
 
   allDeliveryEntries(slot: Parameters<SessionKernelStoreApi["deliveryEntries"]>[0]) {
-    return this.mapReadStores(
+    const cached = this.deliveryEntriesCache.get(slot);
+    if (cached) return structuredClone(cached);
+    const entries = this.mapReadStores(
       "global:delivery-entries",
       (store) => store.deliveryEntries(slot),
     ).flat();
+    this.deliveryEntriesCache.set(slot, entries);
+    return structuredClone(entries);
   }
 
   allQuarantinedSessions(limit = 100, offset = 0): DurableSessionQuarantine[] {
@@ -543,11 +571,13 @@ export class SessionKernelStoreHost {
     }
     if (method === "clearAskRecords") {
       this.mapStores("global:clear-asks", (store) => store.clearAskRecords());
+      this.askEntriesCache = undefined;
       return;
     }
     if (method === "clearDeliverySlot") {
       this.mapStores("global:clear-delivery", (store) =>
         store.clearDeliverySlot(args[0] as Parameters<SessionKernelStoreApi["clearDeliverySlot"]>[0]));
+      this.deliveryEntriesCache.clear();
       return;
     }
     if (method === "settlePendingSteers") {
@@ -564,6 +594,7 @@ export class SessionKernelStoreHost {
         );
         if (result.ok) settled += result.value;
       }
+      if (settled > 0) this.deliveryEntriesCache.clear();
       return settled;
     }
     if (method === "retryCompatibleCreationBranchDeadLetters") {


### PR DESCRIPTION
## Summary
- cache sparse global ask and delivery projections in the catalog host
- return defensive copies and invalidate after successful session mutations, quarantine changes, and global clears
- keep cold fanout bounded while making repeated sidebar projection reads constant-time

## Production symptom
After transient read handles were reduced to roughly 360 ms per 1,951-store scan, live reconnect traffic still queued enough repeated `askEntries` scans to exceed the gateway's 10-second RPC deadline. Execution-time lane fencing worked, but client queueing correctly fail-stopped the gateway. This cache removes repeated scans without weakening mutation serialization.

## Verification
- 13 focused store-host tests, including cache isolation and invalidation
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
