### PR TITLE
Keep quarantined recovery session-local

### DIFF
--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -25,7 +25,7 @@ import {
 } from "./run-state";
 import type { StreamEvent, ImageInput } from "./run-events";
 import { isShuttingDown } from "./shutdown-state";
-import { sessionTurn } from "./session-kernel/kernel";
+import { sessionKernelStore, sessionTurn } from "./session-kernel/kernel";
 // Type-only, so the direct engines stay lazily loaded (see the dispatch table
 // below): this pulls in the contract's signatures, never the SDKs.
 // Static import is deliberate: the pi-runner module itself is cheap (the
@@ -1478,9 +1478,12 @@ export function resumeInterruptedRuns(
   const snapshotSeeds = snapshotLocalHostRuns.filter(
     (run) => !!run.hostId && !run.sandboxId && !run.runnerId,
   );
-  const taken = takeInterruptedRuns(snapshotSeeds).filter(
-    (run) => !deferRecovery?.(run),
-  );
+  const taken = takeInterruptedRuns(
+    snapshotSeeds,
+    (run) =>
+      !run.osSessionId ||
+      !sessionKernelStore().quarantinedSession(run.osSessionId),
+  ).filter((run) => !deferRecovery?.(run));
   // A graceful shutdown snapshot is intentionally broader than the shared
   // run journal: it also covers turns that finish during the drain. A local
   // detached host can still be alive even when its shared record disappeared

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -492,7 +492,10 @@ const takenRunKeys: Set<string> = ((globalThis as any).__runJournalTakenKeys ??=
  * losing them. Returned records have claimedAt stripped so a reattach's
  * re-record doesn't persist a stale claim.
  */
-export function takeInterruptedRuns(seedRecords: ActiveRunRecord[] = []): ActiveRunRecord[] {
+export function takeInterruptedRuns(
+  seedRecords: ActiveRunRecord[] = [],
+  shouldTake: (record: ActiveRunRecord) => boolean = () => true,
+): ActiveRunRecord[] {
   const journal = readRunJournal();
   // A graceful-shutdown snapshot can retain a detached local host after its
   // shared record disappeared during process teardown. Fold those records
@@ -507,7 +510,10 @@ export function takeInterruptedRuns(seedRecords: ActiveRunRecord[] = []): Active
     };
   }
   const entries = Object.values(journal).filter(
-    (r) => !isRunActiveInProcess(r.runKey) && !takenRunKeys.has(r.runKey)
+    (r) =>
+      !isRunActiveInProcess(r.runKey) &&
+      !takenRunKeys.has(r.runKey) &&
+      shouldTake(r),
   );
   if (entries.length > 0) {
     const now = new Date().toISOString();

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -1213,8 +1213,19 @@ describe("SessionKernel", () => {
 			effectId,
 		})).toMatchObject({ accepted: true, to: "failed" });
 
-		// This is the first later send. Its queue mutation repairs the missed
-		// creation ack, so claiming the follow-up cannot remain parked forever.
+		// Explicit settlement must observe and clear its own completed creation
+		// dispatch instead of the generic stale-dispatch repair clearing it first.
+		expect(store.ackDeliveryDispatch(sessionId, promptEntryId)).toBe(true);
+		expect(store.deliverySnapshot(sessionId).dispatch).toBeUndefined();
+
+		// If the process died before that explicit ack, the first later send still
+		// repairs the retained dispatch so the follow-up cannot remain parked.
+		store.claimDeliveryDispatch({
+			sessionId,
+			items: [{ id: "opening", content: "start" }],
+			promptEntryId,
+			kind: "create",
+		});
 		store.setDeliverySlot(sessionId, "queued", [
 			{ id: "follow-up", content: "try again" },
 		]);

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2213,7 +2213,12 @@ export class SessionKernelStore {
       const openingEffectId = dispatch?.promptEntryId
         ? `opening:${dispatch.promptEntryId}`
         : undefined;
-      if (dispatch?.kind === "create" && openingEffectId) {
+      if (
+        kind !== "delivery_dispatch_acknowledged" &&
+        kind !== "delivery_dispatch_failed" &&
+        dispatch?.kind === "create" &&
+        openingEffectId
+      ) {
         const creation = this.creationState(sessionId);
         if (
           creation &&

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -1012,6 +1012,21 @@ describe("run journal", () => {
 		expect(mod.takeInterruptedRuns()).toEqual([]);
 	});
 
+	it("leaves filtered recovery journals unclaimed for a later boot", () => {
+		mod.journalSet({
+			runKey: "quarantined-run",
+			osSessionId: "quarantined-session",
+			prompt: "preserve me",
+			cwd: "/tmp",
+			startedAt: new Date().toISOString(),
+		});
+
+		expect(mod.takeInterruptedRuns([], () => false)).toEqual([]);
+		const [preserved] = mod.activeRunRecords();
+		expect(preserved.runKey).toBe("quarantined-run");
+		expect(preserved.claimedAt).toBeUndefined();
+	});
+
 	it("defers actor-owned opening journals to the durable effect executor", () => {
 		mod.journalSet({
 			runKey: "opening-run",


### PR DESCRIPTION
## Summary
- let explicit dispatch acknowledgement clear a terminal creation dispatch before generic stale cleanup runs
- filter quarantined interrupted-run journals before claiming or transitioning them during boot
- preserve filtered journals unclaimed so releasing the session allows a later boot to recover them

## Production symptom
The live create canary exposed two linked containment failures. Generic stale-dispatch repair cleared a completed create dispatch immediately before `ackDeliveryDispatch` checked it, deterministically quarantining successful creates. That quarantined session's interrupted journal was then transitioned before boot recovery's sanitizer, causing a gateway restart loop. Both operations now remain session-local and resumable.

## Verification
- terminal creation dispatch explicit-ack and stale-repair regression
- quarantined journal filtering/preservation regression
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
