### PR TITLE
Keep quarantined runs out of boot recovery

### DIFF
--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -25,7 +25,7 @@ import {
 } from "./run-state";
 import type { StreamEvent, ImageInput } from "./run-events";
 import { isShuttingDown } from "./shutdown-state";
-import { sessionTurn } from "./session-kernel/kernel";
+import { sessionIsQuarantined, sessionTurn } from "./session-kernel/kernel";
 // Type-only, so the direct engines stay lazily loaded (see the dispatch table
 // below): this pulls in the contract's signatures, never the SDKs.
 // Static import is deliberate: the pi-runner module itself is cheap (the
@@ -1478,9 +1478,16 @@ export function resumeInterruptedRuns(
   const snapshotSeeds = snapshotLocalHostRuns.filter(
     (run) => !!run.hostId && !run.sandboxId && !run.runnerId,
   );
-  const taken = takeInterruptedRuns(snapshotSeeds).filter(
-    (run) => !deferRecovery?.(run),
-  );
+  // A quarantined actor is intentionally inert until an operator resolves its
+  // ambiguity. Leave its physical journal unclaimed as matching evidence, and
+  // continue recovering unrelated sessions. Detached host-private journals
+  // must never consult shared gateway actor state.
+  const taken = takeInterruptedRuns(
+    snapshotSeeds,
+    process.env.OPENSESSION_RUN_JOURNAL
+      ? undefined
+      : (run) => !!run.osSessionId && sessionIsQuarantined(run.osSessionId),
+  ).filter((run) => !deferRecovery?.(run));
   // A graceful shutdown snapshot is intentionally broader than the shared
   // run journal: it also covers turns that finish during the drain. A local
   // detached host can still be alive even when its shared record disappeared

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -492,7 +492,10 @@ const takenRunKeys: Set<string> = ((globalThis as any).__runJournalTakenKeys ??=
  * losing them. Returned records have claimedAt stripped so a reattach's
  * re-record doesn't persist a stale claim.
  */
-export function takeInterruptedRuns(seedRecords: ActiveRunRecord[] = []): ActiveRunRecord[] {
+export function takeInterruptedRuns(
+  seedRecords: ActiveRunRecord[] = [],
+  deferClaim?: (record: ActiveRunRecord) => boolean,
+): ActiveRunRecord[] {
   const journal = readRunJournal();
   // A graceful-shutdown snapshot can retain a detached local host after its
   // shared record disappeared during process teardown. Fold those records
@@ -507,7 +510,10 @@ export function takeInterruptedRuns(seedRecords: ActiveRunRecord[] = []): Active
     };
   }
   const entries = Object.values(journal).filter(
-    (r) => !isRunActiveInProcess(r.runKey) && !takenRunKeys.has(r.runKey)
+    (r) =>
+      !isRunActiveInProcess(r.runKey) &&
+      !takenRunKeys.has(r.runKey) &&
+      !deferClaim?.(r),
   );
   if (entries.length > 0) {
     const now = new Date().toISOString();

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -92,6 +92,34 @@ describe("run journal", () => {
 		}
 	});
 
+	it("leaves an actor-quarantined run journal unclaimed during boot recovery", () => {
+		const sessionId = `quarantined-recovery-${crypto.randomUUID()}`;
+		const runKey = `run-${crypto.randomUUID()}`;
+		const store = sessionKernelStore();
+		try {
+			mod.journalSet({
+				runKey,
+				osSessionId: sessionId,
+				claudeSessionId: `engine-${crypto.randomUUID()}`,
+				cwd: "/tmp",
+				kind: "prompt",
+				startedAt: new Date().toISOString(),
+			});
+			clearRunState(sessionId);
+			store.quarantineSession(sessionId, "ambiguous prompt acknowledgement", "test");
+
+			expect(agent.resumeInterruptedRuns()).toEqual([]);
+			expect(mod.activeRunRecords()).toContainEqual(
+				expect.objectContaining({ runKey, osSessionId: sessionId }),
+			);
+			expect(getRunState(sessionId)).toBe("idle");
+		} finally {
+			store.releaseQuarantine(sessionId);
+			mod.journalClear(runKey);
+			clearRunState(sessionId);
+		}
+	});
+
 	it("leaves a detached GitHub review journal for its posting workflow", () => {
 		const sessionId = `github-review-${crypto.randomUUID()}`;
 		const runKey = `rh-${crypto.randomUUID()}`;


### PR DESCRIPTION
## Summary
- leave actor-quarantined run journals unclaimed during gateway boot recovery
- continue recovering healthy sessions without clearing ambiguity evidence
- preserve the private detached-host journal boundary

## Verification
- `bun test packages/core/opensession-server/src/server/zz-run-journal.test.ts` (50 pass)
- `git diff --check`
- Full typecheck/module scan are currently blocked by missing unrelated checkout dependencies (`next`, `@tanstack/react-virtual`, `@aws-sdk/client-s3`)

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)