### PR TITLE
Prioritize critical outbox settlement routing

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/actor-routing.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-routing.ts
@@ -92,6 +92,10 @@ export function isPrioritySessionActorRequest(
   const command = request.request.command;
   if (command.kind === "creation_event")
     return command.decision.event === "cancelled";
+  if (command.kind === "core")
+    return ["ack_outbox", "defer_outbox", "fail_outbox"].includes(
+      command.request.op,
+    );
   if (command.kind === "turn")
     return [
       "request_cancel_command",

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
@@ -554,13 +554,16 @@ export async function startSessionKernelService(
     return response;
   }
 
-  async function resolveOutboxSession(id: number): Promise<string> {
+  async function resolveOutboxSession(
+    id: number,
+    urgent = false,
+  ): Promise<string> {
     const response = await sendToSlot(slots[0], {
       t: "call",
       rpcId: crypto.randomUUID(),
       outputBytes: 256 * 1024,
       request: { t: "store", method: "outboxSessionId", args: [id] },
-    });
+    }, false, urgent);
     if (response.t !== "call_result" || response.status !== 1 || !response.body)
       throw new Error(`Outbox ${id} route could not be resolved`);
     const body = JSON.parse(response.body) as { ok: boolean; result?: unknown; error?: string };
@@ -576,7 +579,13 @@ export async function startSessionKernelService(
     if (route.scope === "session")
       return enqueueSession(route.sessionId, request);
     if (route.scope === "outbox")
-      return enqueueSession(await resolveOutboxSession(route.id), request);
+      return enqueueSession(
+        await resolveOutboxSession(
+          route.id,
+          isPrioritySessionActorRequest(request),
+        ),
+        request,
+      );
 
     if (request.t === "hello") return sendToSlot(slots[0], request);
     if (queuedGlobalTurns >= MAX_GLOBAL_TURNS)


### PR DESCRIPTION
## Summary
- classify outbox acknowledgement, deferral, and failure settlement as priority actor turns
- let their catalog route lookup bypass queued ordinary catalog reads
- retain existing bounded priority bursts and reserved mailbox capacity

## Production symptom
During the post-migration reconnect burst, a completed effect's `ack_outbox` waited behind ordinary catalog reads long enough to hit the gateway's synchronous deadline. The actor stayed healthy, but the gateway fail-stopped. Critical settlement now receives the same bounded reserved routing capacity as Stop and steer.

## Verification
- 12 actor-service scheduler/fencing tests
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
