### PR TITLE
Keep actor polling timeouts retryable

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   SessionKernelActorClient,
   SessionKernelQuarantinedError,
+  isFatalSessionKernelAsyncTimeout,
 } from "./actor-client";
 import {
   __setSessionKernelStoreForTest,
@@ -30,6 +31,32 @@ async function actor(): Promise<SessionKernelActorClient> {
 }
 
 describe("session kernel actor boundary", () => {
+  test("keeps polling timeouts retryable while fencing handshake ambiguity", () => {
+    expect(isFatalSessionKernelAsyncTimeout({
+      t: "runtime_work",
+      rpcId: "runtime",
+      now: 0,
+      timerKinds: [],
+      effectKinds: [],
+      limit: 1,
+    })).toBe(false);
+    expect(isFatalSessionKernelAsyncTimeout({ t: "stats", rpcId: "stats" }))
+      .toBe(false);
+    expect(isFatalSessionKernelAsyncTimeout({ t: "maintain", rpcId: "maintain" }))
+      .toBe(false);
+    expect(isFatalSessionKernelAsyncTimeout({
+      t: "hello",
+      rpcId: "hello",
+      version: 23,
+    })).toBe(true);
+    expect(isFatalSessionKernelAsyncTimeout({
+      t: "acknowledge",
+      rpcId: "ack",
+      sessionId: "session",
+      requestId: "request",
+    })).toBe(true);
+  });
+
   test("reads per-session quarantine state through the actor", async () => {
     const host = await actor();
     installSessionKernelActor(host);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -67,6 +67,12 @@ export class SessionKernelQuarantinedError extends SessionKernelActorError {
   }
 }
 
+export function isFatalSessionKernelAsyncTimeout(
+  request: KernelActorAsyncRequest,
+): boolean {
+  return request.t === "hello" || request.t === "acknowledge";
+}
+
 type Pending = {
   resolve: (value: KernelActorAsyncResponse) => void;
   reject: (error: Error) => void;
@@ -407,11 +413,14 @@ export class SessionKernelActorClient {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(request.rpcId);
-        const error = new Error(
-          `Session kernel actor timed out handling ${request.t}`,
-        );
-        this.markDead(error);
-        reject(error);
+        const message = `Session kernel actor timed out handling ${request.t}`;
+        if (isFatalSessionKernelAsyncTimeout(request)) {
+          const error = new Error(message);
+          this.markDead(error);
+          reject(error);
+          return;
+        }
+        reject(new SessionKernelActorError(message, true));
       }, 15_000);
       this.pending.set(request.rpcId, {
         resolve: (value) => {


### PR DESCRIPTION
## Summary
- keep runtime-work, stats, and maintenance timeouts retryable in the gateway actor client
- preserve fatal fencing for handshake and command-acknowledgement ambiguity
- let delayed global barriers drain without poisoning otherwise healthy session lanes

## Production symptom
During the post-migration reconnect burst, `runtime_work` waited behind the global barrier for more than 15 seconds. The actor service stayed healthy, but the gateway client marked the entire actor dead. Polling operations are idempotent and periodic, so their local deadline now rejects that poll without terminating the actor client.

## Verification
- 22 focused actor-client tests
- `bun run typecheck`
- `bun scripts/check-module-side-effects.ts`
- `git diff --check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)
