### PR TITLE
Make the gateway-facing kernel facade async

### DIFF
--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -176,8 +176,8 @@ let agents: AgentModule[] = (g.__agents as AgentModule[] | undefined) ?? [];
 // live maps and skip this branch.
 if (!g.__opensessionBooted && !isDevInstance()) {
 	initHumanAsks();
-	restorePendingAsks();
-	hydratePersistedQueueState();
+	await restorePendingAsks();
+	await hydratePersistedQueueState();
 }
 
 console.log(`Starting Open Session server on ${HOST}:${PORT}...`);
@@ -888,7 +888,7 @@ if (!g.__opensessionBooted) {
 		}
 		resumeDrainedSessions(new Set(resumedIds), shutdownRecords);
 		// Re-deliver messages that were queued/steered when the process went down.
-		restorePromptQueues(new Set(resumedIds));
+		await restorePromptQueues(new Set(resumedIds));
 		const ownedSessionIds = new Set(
 			activeRunRecords()
 				.map((run) => run.osSessionId)

--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -777,19 +777,7 @@ if (!g.__opensessionBooted) {
 					const failed =
 						terminalEvent.type === "error" ||
 						!!terminalEvent.usageLimitExhausted;
-					if (recoveredRun?.promptEntryId) {
-						await settleRecoveredCreationOpening(
-							bksSessionId,
-							recoveredRun.promptEntryId,
-							failed
-								? terminalEvent.content ||
-									terminalEvent.result ||
-									"Recovered opening run failed"
-								: undefined,
-							recoveredRun.runKey,
-						);
-					}
-					recordRunOutcome(
+					await recordRunOutcome(
 						bksSessionId,
 						failed
 							? terminalEvent.content ||
@@ -814,6 +802,18 @@ if (!g.__opensessionBooted) {
 								: undefined,
 						},
 					);
+					if (recoveredRun?.promptEntryId) {
+						await settleRecoveredCreationOpening(
+							bksSessionId,
+							recoveredRun.promptEntryId,
+							failed
+								? terminalEvent.content ||
+									terminalEvent.result ||
+									"Recovered opening run failed"
+								: undefined,
+							recoveredRun.runKey,
+						);
+					}
 					// The in-process settleRun died with the restart — close the
 					// automation ledger entry here or it stays "running" forever.
 					settleResumedAutomationRun(

--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -771,14 +771,14 @@ if (!g.__opensessionBooted) {
 		void (async () => {
 		try {
 		const shutdownRecords = readActiveShutdownSnapshot();
-		const resumedIds = resumeInterruptedRuns(
-			(bksSessionId, terminalEvent, recoveredRun) => {
+		const resumedIds = await resumeInterruptedRuns(
+			async (bksSessionId, terminalEvent, recoveredRun) => {
 				if (bksSessionId && terminalEvent) {
 					const failed =
 						terminalEvent.type === "error" ||
 						!!terminalEvent.usageLimitExhausted;
 					if (recoveredRun?.promptEntryId) {
-						settleRecoveredCreationOpening(
+						await settleRecoveredCreationOpening(
 							bksSessionId,
 							recoveredRun.promptEntryId,
 							failed
@@ -895,7 +895,7 @@ if (!g.__opensessionBooted) {
 				.filter((id): id is string => !!id),
 		);
 		for (const id of resumedIds) ownedSessionIds.add(id);
-		const staleKernelOwners = reconcileSessionKernelOwnership(ownedSessionIds);
+		const staleKernelOwners = await reconcileSessionKernelOwnership(ownedSessionIds);
 		if (staleKernelOwners.length)
 			console.warn(
 				`[session-kernel] Settled ${staleKernelOwners.length} session(s) without a recoverable run owner`,

--- a/packages/core/opensession-server/src/agents/github/run.ts
+++ b/packages/core/opensession-server/src/agents/github/run.ts
@@ -551,14 +551,16 @@ export async function runGithubAgent(opts: GithubRunOpts): Promise<GithubRunResu
     }
   } catch (e: any) {
     errorMsg = e.message || String(e);
-  } finally {
-    if (recoveredRun && !recoveryUncertain) journalClearIfLineage(recoveredRun);
   }
 
   await persist(engineSessionId);
   // An uncertain host still owns the turn. Settling the visible run or clearing
-  // its journal here would let a retry overlap it.
-  if (!recoveryUncertain) recordRunOutcome(bksId, errorMsg || null);
+  // its journal here would let a retry overlap it. A settled run keeps its
+  // recovery record until durable outcome projection completes.
+  if (!recoveryUncertain) {
+    await recordRunOutcome(bksId, errorMsg || null);
+    if (recoveredRun) journalClearIfLineage(recoveredRun);
+  }
   return {
     bksId,
     text,

--- a/packages/core/opensession-server/src/agents/github/run.ts
+++ b/packages/core/opensession-server/src/agents/github/run.ts
@@ -316,7 +316,7 @@ async function discardGithubRunRecord(
     throw new GithubRunRecoveryUncertainError(run.hostId || run.runKey);
   }
   if (events) {
-    cancelAgentRun(bksId, run.claudeSessionId, run.runKey);
+    void cancelAgentRun(bksId, run.claudeSessionId, run.runKey);
     for await (const _event of events) {}
   }
   journalClearIfLineage(run);

--- a/packages/core/opensession-server/src/agents/github/session-notify.test.ts
+++ b/packages/core/opensession-server/src/agents/github/session-notify.test.ts
@@ -32,11 +32,10 @@ function summary(input: Partial<SessionSummary> & Pick<SessionSummary, "id">): S
 
 describe("GitHub session notification matching", () => {
   test("does not treat a shared checkout HEAD as every session's branch", () => {
-    const shared = summary({ id: "shared-session" });
-    const actualSharedHead = Bun.spawnSync(["git", "-C", defaultRepo().repo, "branch", "--show-current"])
-      .stdout.toString().trim();
-    expect(actualSharedHead).not.toBe("");
-    expect(matchSessions(controlWith([shared]), defaultRepo().id, actualSharedHead)).toEqual([]);
+    const shared = summary({ id: "shared-session", branch: "recorded-branch" });
+    expect(matchSessions(controlWith([shared]), defaultRepo().id, "shared-checkout-head")).toEqual(
+      [],
+    );
   });
 
   test("still follows actual HEAD for an isolated worktree", () => {

--- a/packages/core/opensession-server/src/agents/linear/session.ts
+++ b/packages/core/opensession-server/src/agents/linear/session.ts
@@ -399,7 +399,7 @@ export async function runAgentHeadless(
     session?.lastActiveUser?.email || session?.issueCreator?.email || undefined;
 
   abortController.signal.addEventListener("abort", () => {
-    cancelAgentRun(claudeSessionId);
+    void cancelAgentRun(claudeSessionId);
   });
 
   try {

--- a/packages/core/opensession-server/src/agents/plain/handlers.ts
+++ b/packages/core/opensession-server/src/agents/plain/handlers.ts
@@ -670,7 +670,7 @@ export async function handleWebhook(payload: PlainWebhookPayload): Promise<Respo
   // Archive triage sessions when their ticket is done
   if (eventType === "thread.thread_status_transitioned" && thread.status === "DONE") {
     const { archiveSessionsForThread } = await import("../../server/plain-archive");
-    const n = archiveSessionsForThread(thread.id);
+    const n = await archiveSessionsForThread(thread.id);
     if (n > 0) console.log(`[plain] Archived ${n} session(s) for done thread ${thread.id}`);
   }
 

--- a/packages/core/opensession-server/src/agents/slack/handlers.ts
+++ b/packages/core/opensession-server/src/agents/slack/handlers.ts
@@ -958,7 +958,10 @@ export async function processMessage(
   };
   registerSessionMcpServers(bksId, inProcessMcp);
 
-  const onAbort = () => cancelAgentRun(resultSessionId, bksId);
+  const onAbort = () => {
+    void cancelAgentRun(resultSessionId, bksId);
+    return true;
+  };
   abortController.signal.addEventListener("abort", onAbort, { once: true });
 
   // Vercel-preview detection (was a Claude PostToolUse hook): track bash

--- a/packages/core/opensession-server/src/agents/slack/humans-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/humans-tools.ts
@@ -201,7 +201,7 @@ export function createHumansMcpServer(ctx: HumansToolContext) {
             // Whoever answers first wins: a UI answer resolves the ask, which
             // settles the await below; the card is retracted once the wait
             // ends either way.
-            const card = offerAskCard(
+            const card = await offerAskCard(
               ctx.sessionId,
               [
                 {
@@ -227,7 +227,7 @@ export function createHumansMcpServer(ctx: HumansToolContext) {
               }
               return text(`${person.name} replied:\n\n${answer}`);
             } finally {
-              card.close();
+              await card.close();
             }
           }
 

--- a/packages/core/opensession-server/src/agents/slack/index.ts
+++ b/packages/core/opensession-server/src/agents/slack/index.ts
@@ -345,7 +345,7 @@ export async function dispatchSlackInteractive(payload: any): Promise<void> {
     );
     if (stopPrefix) {
       const bksId = actionId.slice(stopPrefix.length);
-      const didCancel = cancelAgentRun(bksId);
+      const didCancel = await cancelAgentRun(bksId);
 
       const msgChannel = payload.channel?.id;
       const msgTs = payload.message?.ts;

--- a/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
@@ -680,7 +680,7 @@ export function createSessionsMcpServer(
           const current = getSessionControl().getSession(sessionId);
           const result =
             args.kind === "timer"
-              ? registerTimerAgentWait({
+              ? await registerTimerAgentWait({
                   sessionId,
                   user: ctx.createdBy,
                   seconds: args.seconds ?? Number.NaN,

--- a/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
@@ -687,7 +687,7 @@ export function createSessionsMcpServer(
                   prompt: args.prompt,
                   waitId,
                 })
-              : registerPrChecksAgentWait({
+              : await registerPrChecksAgentWait({
                   sessionId,
                   user: ctx.createdBy,
                   repo: args.repo || current?.repo || "",
@@ -738,7 +738,7 @@ export function createSessionsMcpServer(
         async () => {
           const sessionId = ctx.currentSessionId;
           if (!sessionId) return text("This run has no Open Session id.");
-          const cancelled = cancelAgentWait(sessionId);
+          const cancelled = await cancelAgentWait(sessionId);
           if (cancelled)
             audit({ msg: "agent_wait_cancelled", session_id: sessionId });
           return text(

--- a/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
@@ -1047,7 +1047,7 @@ export function createSessionsMcpServer(
               );
             }
           } catch {}
-          const res = migrateSessionEngine(args.sessionId, args.model, ctx.createdBy);
+          const res = await migrateSessionEngine(args.sessionId, args.model, ctx.createdBy);
           if (!res.ok) return text(res.error);
           return text(
             `Migrated \`${res.sessionId}\` to ${res.to}` +

--- a/packages/core/opensession-server/src/runner-host/host.ts
+++ b/packages/core/opensession-server/src/runner-host/host.ts
@@ -303,7 +303,7 @@ function handleClientMsg(msg: ClientToHostMsg): void {
     }
     case "cancel": {
       log("cancel requested");
-      cancelAgentRun(spec.osSessionId, meta.engineSessionId);
+      void cancelAgentRun(spec.osSessionId, meta.engineSessionId);
       break;
     }
     case "shutdown": {

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -1484,12 +1484,12 @@ export async function resumeInterruptedRuns(
   const snapshotSeeds = snapshotLocalHostRuns.filter(
     (run) => !!run.hostId && !run.sandboxId && !run.runnerId,
   );
-  const taken = takeInterruptedRuns(
+  const taken = (await takeInterruptedRuns(
     snapshotSeeds,
     (run) =>
       !run.osSessionId ||
       !sessionKernelStore().quarantinedSession(run.osSessionId),
-  ).filter((run) => !deferRecovery?.(run));
+  )).filter((run) => !deferRecovery?.(run));
   // A graceful shutdown snapshot is intentionally broader than the shared
   // run journal: it also covers turns that finish during the drain. A local
   // detached host can still be alive even when its shared record disappeared

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -415,7 +415,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<StreamEvent>
     ["idle", "stopped", "failed", "starting"].includes(
       getRunState(osSessionId),
     )
-  ) transitionRunState(osSessionId, "prompt", { run_key: runToken });
+  ) await transitionRunState(osSessionId, "prompt", { run_key: runToken });
   for (const alias of runAliases) {
     let tokens = activeSessionRunTokens.get(alias);
     if (!tokens) activeSessionRunTokens.set(alias, (tokens = new Set()));
@@ -473,7 +473,7 @@ export async function* runAgent(opts: RunAgentOpts): AsyncGenerator<StreamEvent>
     ) {
       const failed =
         terminalEvent.type === "error" || !!terminalEvent.usageLimitExhausted;
-      transitionRunState(osSessionId, failed ? "run_failed" : "turn_end", {
+      await transitionRunState(osSessionId, failed ? "run_failed" : "turn_end", {
         run_key: runToken,
         source: "runner_terminal",
       });
@@ -877,11 +877,11 @@ function untrackRecovery(run: ActiveRunRecord): void {
   }
 }
 
-/** Mark a session as starting a run (call synchronously, before any await). */
-export function markSessionStarting(
+/** Mark a session as starting a run before launching physical work. */
+export async function markSessionStarting(
   id: string,
   token = `rh-${crypto.randomUUID()}`,
-): string {
+): Promise<string> {
   if (
     sessionRunOwners.get(id) === token ||
     pendingStarts.get(id)?.has(token)
@@ -890,7 +890,7 @@ export function markSessionStarting(
     cancelledRunTokens.add(rejected);
     return rejected;
   }
-  const decision = decideRunStateTransition(id, "prompt", { run_key: token });
+  const decision = await decideRunStateTransition(id, "prompt", { run_key: token });
   if (!decision.accepted) {
     // Return a distinct rejected token so the caller can requeue without
     // sharing/unmarking the actor winner's process reservation.
@@ -1093,10 +1093,10 @@ export function isAgentRunTokenAdmitted(runToken: string): boolean {
   );
 }
 
-export function cancelAgentRunToken(runToken: string): boolean {
+export async function cancelAgentRunToken(runToken: string): Promise<boolean> {
   const admitted = isAgentRunTokenAdmitted(runToken);
   cancelledRunTokens.add(runToken);
-  const cancelled = cancelAgentRun(runToken);
+  const cancelled = await cancelAgentRun(runToken);
   if (!cancelled && !admitted) cancelledRunTokens.delete(runToken);
   return cancelled || admitted;
 }
@@ -1109,19 +1109,19 @@ export async function cancelAgentRunTokenAndWait(
   runToken: string,
   timeoutMs = 120_000,
 ): Promise<boolean> {
-  if (!cancelAgentRunToken(runToken)) return false;
+  if (!await cancelAgentRunToken(runToken)) return false;
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     // A running source owns a token-aware cancellation latch even before its
     // engine handle appears; a host control can receive the exact frame now.
     if (agentRunTokenLatched(runToken)) {
       // runAgent's immutable shouldCancel closure now owns the latch.
-      cancelAgentRun(runToken);
+      await cancelAgentRun(runToken);
       return true;
     }
     if (
       (isPiSessionBusy(runToken) || hostRunBusy(runToken)) &&
-      cancelAgentRun(runToken)
+      await cancelAgentRun(runToken)
     ) return true;
     // No pending launch and no recovery owner means setup observed the latch
     // and unwound, or recovery positively settled absence.
@@ -1134,13 +1134,13 @@ export async function cancelAgentRunTokenAndWait(
       throw new Error(`Timed out reconciling cancelled dispatch ${runToken}`);
     // Boot recovery may attach after this effect starts. Re-issue against the
     // immutable token so the newly registered control is cancelled immediately.
-    cancelAgentRun(runToken);
+    await cancelAgentRun(runToken);
     await Bun.sleep(50);
   }
 }
 
 /** Cancel a run; returns true if anything was cancelled. */
-export function cancelAgentRun(...ids: Array<string | null | undefined>): boolean {
+export async function cancelAgentRun(...ids: Array<string | null | undefined>): Promise<boolean> {
   let cancelled = false;
   for (const id of ids) {
     if (!id) continue;
@@ -1158,7 +1158,7 @@ export function cancelAgentRun(...ids: Array<string | null | undefined>): boolea
     if (legacyPending) legacyCancelledSessions().add(id);
     if (!pendingTokens.size && !activeTokens.size && !legacyPending) continue;
     if (isRunStateUnsettled(getRunState(id)))
-      transitionRunState(id, "cancel", { source: "run_cancelled_preparation" });
+      await transitionRunState(id, "cancel", { source: "run_cancelled_preparation" });
     cancelled = true;
   }
   const records = new Map<string, ActiveRunRecord>();
@@ -1186,7 +1186,7 @@ export function cancelAgentRun(...ids: Array<string | null | undefined>): boolea
     // after this cancellation request; retiring ownership here would create a
     // window where a successor could start while the predecessor still works.
     if (run.osSessionId && isRunStateUnsettled(getRunState(run.osSessionId)))
-      transitionRunState(run.osSessionId, "cancel", {
+      await transitionRunState(run.osSessionId, "cancel", {
         run_key: run.runKey,
         source: "run_cancelled",
       });
@@ -1200,7 +1200,7 @@ export async function cancelAgentRunAndWait(
   ids: Array<string | null | undefined>,
   timeoutMs = 10_000,
 ): Promise<boolean> {
-  cancelAgentRun(...ids);
+  await cancelAgentRun(...ids);
   const deadline = Date.now() + timeoutMs;
   while (ids.some((id) => !!id && isAgentSessionBusy(id!))) {
     if (Date.now() >= deadline) return false;
@@ -1242,13 +1242,13 @@ export function durableCancelOwnsRecovery(run: ActiveRunRecord): boolean {
   return durableCancelRecoveryOwnership(run) === "owned";
 }
 
-export function reissueDurableRecoveryCancel(run: ActiveRunRecord): boolean {
+export async function reissueDurableRecoveryCancel(run: ActiveRunRecord): Promise<boolean> {
   if (!durableCancelOwnsRecovery(run)) return false;
   // Keep the immutable latch live even when the original outbox already
   // settled before a gateway crash. Once recovery attaches a control under
   // this run key, repeated calls deliver cancellation to that exact owner.
   cancelledRunTokens.add(run.runKey);
-  return cancelAgentRun(run.runKey);
+  return await cancelAgentRun(run.runKey);
 }
 
 function settleDurableCancelForAbsentOwner(run: ActiveRunRecord): boolean {
@@ -1268,21 +1268,22 @@ function settleDurableCancelForAbsentOwner(run: ActiveRunRecord): boolean {
   return true;
 }
 
-export function resumeInterruptedRuns(
+export async function resumeInterruptedRuns(
   onResumed?: (
     osSessionId?: string,
     terminalEvent?: StreamEvent,
     run?: ActiveRunRecord,
-  ) => void,
+  ) => void | Promise<void>,
   askHandlerFor?: (osSessionId: string) => AskHandler | undefined,
   inProcessMcpFor?: (osSessionId: string, user?: string) => Record<string, unknown> | undefined,
   reposNoteFor?: (osSessionId: string) => string | undefined,
   onEvent?: (osSessionId: string, event: StreamEvent) => void,
   snapshotLocalHostRuns: ActiveRunRecord[] = [],
   deferRecovery?: (run: ActiveRunRecord) => boolean,
-): string[] {
+): Promise<string[]> {
   const resumed: string[] = [];
   const settledRunKeys = new Set<string>();
+  const settlingRunKeys = new Set<string>();
   const rememberHandledSession = (run: ActiveRunRecord) => {
     if (run.osSessionId && !resumed.includes(run.osSessionId))
       resumed.push(run.osSessionId);
@@ -1295,44 +1296,45 @@ export function resumeInterruptedRuns(
       console.error(`[runner] Recovered event observer failed for ${run.runKey}:`, e);
     }
   };
-  const settleRecovery = (run: ActiveRunRecord, event: StreamEvent): boolean => {
-    if (settledRunKeys.has(run.runKey)) return false;
-    settledRunKeys.add(run.runKey);
+  const settleRecovery = async (run: ActiveRunRecord, event: StreamEvent): Promise<boolean> => {
+    if (settledRunKeys.has(run.runKey) || settlingRunKeys.has(run.runKey))
+      return false;
+    settlingRunKeys.add(run.runKey);
     rememberHandledSession(run);
     try {
       emitRecoveryEvent(run, event);
       try {
-        onResumed?.(run.osSessionId, event, run);
+        await onResumed?.(run.osSessionId, event, run);
       } catch (e) {
         console.error(`[runner] Recovery settlement callback failed for ${run.runKey}:`, e);
       }
-    } finally {
       if (run.osSessionId) {
         const cancel = sessionKernelStore().turnSnapshot(run.osSessionId).cancel;
         if (cancel?.runId === run.runKey && cancel.phase !== "settled")
-          sessionTurn({
+          await sessionTurn({
             op: "settle_cancel",
             sessionId: run.osSessionId,
             cancelId: cancel.cancelId,
             outcome: "confirmed",
-          }).catch((error) =>
-            console.error(`[runner] Failed to settle recovery cancellation for ${run.runKey}:`, error),
-          );
+          });
       }
       if (run.osSessionId && isRunStateUnsettled(getRunState(run.osSessionId))) {
         const failed = event.type === "error" || !!event.usageLimitExhausted;
-        transitionRunState(run.osSessionId, failed ? "run_failed" : "turn_end", {
+        await transitionRunState(run.osSessionId, failed ? "run_failed" : "turn_end", {
           run_key: run.runKey,
           source: "recovery_fallback_settlement",
         });
       }
       journalClear(run.runKey);
+      settledRunKeys.add(run.runKey);
       if (!activeRecoveryWorkerRunKeys.has(run.runKey)) untrackRecovery(run);
+      return true;
+    } finally {
+      settlingRunKeys.delete(run.runKey);
     }
-    return true;
   };
-  const reportRecoveryFailure = (run: ActiveRunRecord, content: string) => {
-    settleRecovery(run, {
+  const reportRecoveryFailure = async (run: ActiveRunRecord, content: string) => {
+    await settleRecovery(run, {
       type: "error",
       content,
       model: run.model,
@@ -1429,7 +1431,7 @@ export function resumeInterruptedRuns(
           // failures, so this is only the last-resort guard.
           console.error(`[runner] Recovery worker crashed for ${run.runKey}:`, error);
           if (!settledRunKeys.has(run.runKey))
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery stopped unexpectedly. Send the prompt again to continue.",
             );
@@ -1489,13 +1491,13 @@ export function resumeInterruptedRuns(
   journalQuarantine(quarantined);
   for (const entry of quarantined) {
     if (!entry.notify || !entry.run.osSessionId) continue;
-    reportRecoveryFailure(entry.run, recoveryQuarantineMessage(entry));
+    await reportRecoveryFailure(entry.run, recoveryQuarantineMessage(entry));
   }
   const recoveryTasks: Array<() => Promise<void>> = [];
 
   for (const run of interrupted) {
     if (run.terminalFailure) {
-      reportRecoveryFailure(run, run.terminalFailure.content);
+      await reportRecoveryFailure(run, run.terminalFailure.content);
       continue;
     }
     // Detached review turns are consumed by the GitHub agent's persisted
@@ -1513,7 +1515,7 @@ export function resumeInterruptedRuns(
     if (run.kind?.startsWith("github-")) {
       rememberHandledSession(run);
       journalClear(run.runKey);
-      if (run.osSessionId) transitionRunState(run.osSessionId, "turn_end");
+      if (run.osSessionId) await transitionRunState(run.osSessionId, "turn_end");
       continue;
     }
     // Slack runs journal (their bks session id feeds the in-process MCP proxy
@@ -1522,7 +1524,7 @@ export function resumeInterruptedRuns(
     if (run.kind?.startsWith("slack")) {
       rememberHandledSession(run);
       journalClear(run.runKey);
-      if (run.osSessionId) transitionRunState(run.osSessionId, "turn_end");
+      if (run.osSessionId) await transitionRunState(run.osSessionId, "turn_end");
       continue;
     }
     // Workflow fan-out agents ("workflow", plus -resume/-rerun suffixes): the
@@ -1532,7 +1534,7 @@ export function resumeInterruptedRuns(
     if (run.kind?.startsWith("workflow")) {
       rememberHandledSession(run);
       journalClear(run.runKey);
-      if (run.osSessionId) transitionRunState(run.osSessionId, "turn_end");
+      if (run.osSessionId) await transitionRunState(run.osSessionId, "turn_end");
       continue;
     }
     // Runner hosts are persistent, outbound-dial run hosts just like remote
@@ -1552,7 +1554,7 @@ export function resumeInterruptedRuns(
           });
           if (await checkpointStoppedRecovery(run)) return;
           if (!events) {
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery could not reconnect to the interrupted Runner. Check its connection, then send the prompt again.",
             );
@@ -1565,12 +1567,12 @@ export function resumeInterruptedRuns(
             if (await checkpointStoppedRecovery(run)) return;
             markRecoveryProgress(run, event);
             if (event.type === "done" || event.type === "error") {
-              terminalSeen = settleRecovery(run, event) || terminalSeen;
+              terminalSeen = (await settleRecovery(run, event)) || terminalSeen;
             } else emitRecoveryEvent(run, event);
           }
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen) {
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery ended before the Runner returned a final result. Send the prompt again to continue.",
             );
@@ -1579,7 +1581,7 @@ export function resumeInterruptedRuns(
           console.error(`[runner] Runner resume failed for ${run.runKey}:`, error);
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen) {
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery failed while reconnecting to the Runner. Check its connection, then send the prompt again.",
             );
@@ -1641,7 +1643,7 @@ export function resumeInterruptedRuns(
             console.warn(
               `[runner] Sandbox ${run.sandboxId} for interrupted run ${run.runKey} is gone — the session's next prompt recreates it`
             );
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery could not reconnect to the interrupted sandbox. Send the prompt again to continue.",
             );
@@ -1655,13 +1657,13 @@ export function resumeInterruptedRuns(
             if (await checkpointStoppedRecovery(run)) return;
             markRecoveryProgress(run, event);
             if (event.type === "done" || event.type === "error") {
-              terminalSeen = settleRecovery(run, event) || terminalSeen;
+              terminalSeen = (await settleRecovery(run, event)) || terminalSeen;
               recordRecovery(event.type === "done" ? "ok" : "failed", event.type);
             } else emitRecoveryEvent(run, event);
           }
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen) {
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery ended before the interrupted sandbox returned a final result. Send the prompt again to continue.",
             );
@@ -1672,7 +1674,7 @@ export function resumeInterruptedRuns(
           console.error(`[runner] Sandbox resume failed for ${run.runKey}:`, e);
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen)
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery failed while reconnecting to the interrupted sandbox. Send the prompt again to continue.",
             );
@@ -1696,7 +1698,7 @@ export function resumeInterruptedRuns(
           if (await checkpointStoppedRecovery(run)) return;
           Object.assign(run, journalStartRecovery(run));
           if (run.osSessionId && !durableCancelOwnsRecovery(run))
-            transitionRunState(run.osSessionId, "reattach_start", { run_key: run.runKey });
+            await transitionRunState(run.osSessionId, "reattach_start", { run_key: run.runKey });
           const resumeLocalHost =
             localHostResumeForTest ??
             (await import("./host-client")).resumeLocalHostRun;
@@ -1718,7 +1720,7 @@ export function resumeInterruptedRuns(
             return;
           }
           if (run.osSessionId && !durableCancelOwnsRecovery(run))
-            transitionRunState(
+            await transitionRunState(
               run.osSessionId,
               reattached ? "reattach_ok" : "reattach_fail",
               { run_key: run.runKey },
@@ -1733,14 +1735,14 @@ export function resumeInterruptedRuns(
             // the stopped turn as a fresh engine run.
             if (settleDurableCancelForAbsentOwner(run)) return;
             if (!run.prompt && !run.claudeSessionId) {
-              reportRecoveryFailure(
+              await reportRecoveryFailure(
                 run,
                 "Restart recovery could not reconnect to the detached run host and had nothing to resume. Send the prompt again to continue.",
               );
               return;
             }
             if (run.osSessionId)
-              transitionRunState(run.osSessionId, "resume_reprompt", { run_key: run.runKey });
+              await transitionRunState(run.osSessionId, "resume_reprompt", { run_key: run.runKey });
             // The replacement reuses this proven-absent lineage key so terminal
             // projection remains fenced to the actor owner. Drop the host record.
             journalClear(run.runKey);
@@ -1791,12 +1793,12 @@ export function resumeInterruptedRuns(
             if (await checkpointStoppedRecovery(run)) return;
             markRecoveryProgress(run, event);
             if (event.type === "done" || event.type === "error") {
-              terminalSeen = settleRecovery(run, event) || terminalSeen;
+              terminalSeen = (await settleRecovery(run, event)) || terminalSeen;
             } else emitRecoveryEvent(run, event);
           }
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen && recoveryStillOwnsJournal(run)) {
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery ended before the detached run host returned a final result. Send the prompt again to continue.",
             );
@@ -1805,7 +1807,7 @@ export function resumeInterruptedRuns(
           console.error(`[runner] Local host resume failed for ${run.runKey}:`, e);
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen && recoveryStillOwnsJournal(run))
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery failed while reconnecting to the detached run host. Send the prompt again to continue.",
             );
@@ -1822,7 +1824,7 @@ export function resumeInterruptedRuns(
         console.warn(
           `[runner] Interrupted run ${run.runKey} (${run.kind || "unknown"}) had no engine session and no saved prompt — cannot resume`
         );
-        reportRecoveryFailure(
+        await reportRecoveryFailure(
           run,
           "Restart recovery could not continue this turn because it had not saved an engine session or original prompt. Send the prompt again to continue.",
         );
@@ -1839,7 +1841,7 @@ export function resumeInterruptedRuns(
           if (await checkpointStoppedRecovery(run)) return;
           Object.assign(run, journalStartRecovery(run));
           if (run.osSessionId)
-            transitionRunState(run.osSessionId, "resume_reprompt", {
+            await transitionRunState(run.osSessionId, "resume_reprompt", {
               run_key: run.runKey,
             });
           // The replacement reuses this proven-absent lineage key. Drop the
@@ -1889,12 +1891,12 @@ export function resumeInterruptedRuns(
             if (await checkpointStoppedRecovery(run)) return;
             markRecoveryProgress(run, event);
             if (event.type === "done" || event.type === "error") {
-              terminalSeen = settleRecovery(run, event) || terminalSeen;
+              terminalSeen = (await settleRecovery(run, event)) || terminalSeen;
             } else emitRecoveryEvent(run, event);
           }
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen)
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery ended before the interrupted turn returned a final result. Send the prompt again to continue.",
             );
@@ -1902,7 +1904,7 @@ export function resumeInterruptedRuns(
           console.error(`[runner] Re-run failed for ${run.runKey}:`, e);
           if (await checkpointStoppedRecovery(run)) return;
           if (!terminalSeen)
-            reportRecoveryFailure(
+            await reportRecoveryFailure(
               run,
               "Restart recovery failed while restarting the interrupted turn. Send the prompt again to continue.",
             );
@@ -1924,7 +1926,7 @@ export function resumeInterruptedRuns(
             : `[runner] Resuming interrupted ${run.kind || "run"} ${run.osSessionId || run.runKey} (started ${run.startedAt}, model ${run.model || "default"})`
         );
         if (run.osSessionId && !repairingRecoveredResult)
-          transitionRunState(run.osSessionId, "resume_reprompt", { run_key: run.runKey });
+          await transitionRunState(run.osSessionId, "resume_reprompt", { run_key: run.runKey });
         if (await checkpointStoppedRecovery(run)) return;
         // The continuation reuses this proven-absent lineage key. Drop the
         // claimed record only now, AFTER the reattach probe settled: dying
@@ -1977,12 +1979,12 @@ export function resumeInterruptedRuns(
           if (await checkpointStoppedRecovery(run)) return;
           markRecoveryProgress(run, event);
           if (event.type === "done" || event.type === "error") {
-            recoverySettled = settleRecovery(run, event) || recoverySettled;
+            recoverySettled = (await settleRecovery(run, event)) || recoverySettled;
           } else emitRecoveryEvent(run, event);
         }
         if (await checkpointStoppedRecovery(run)) return;
         if (!recoverySettled)
-          reportRecoveryFailure(
+          await reportRecoveryFailure(
             run,
             "Restart recovery ended before the interrupted turn returned a final result. Send the prompt again to continue.",
           );
@@ -1990,7 +1992,7 @@ export function resumeInterruptedRuns(
         console.error(`[runner] Resume failed for ${run.runKey}:`, e);
         if (await checkpointStoppedRecovery(run)) return;
         if (!recoverySettled)
-          reportRecoveryFailure(
+          await reportRecoveryFailure(
             run,
             "Restart recovery failed while continuing the interrupted turn. Send the prompt again to continue.",
           );

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -1042,10 +1042,18 @@ export function interruptAndSteerAgentRun(
   images?: ImageInput[]
 ): boolean {
   for (const id of ids) {
-    if (!id) continue;
-    if (hostInterruptSteer(id, text, images)) return true;
+    if (id && interruptAndSteerAgentRunToken(id, text, images)) return true;
   }
   return false;
+}
+
+/** Interrupt and steer one immutable dispatch token, never a reusable alias. */
+export function interruptAndSteerAgentRunToken(
+  runToken: string,
+  text: string,
+  images?: ImageInput[],
+): boolean {
+  return hostInterruptSteer(runToken, text, images);
 }
 
 /** Immutable dispatch identity for the run currently admitted under an alias.

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -1230,10 +1230,7 @@ function durableCancelRecoveryOwnership(
 ): "owned" | "none" | "unknown" {
   if (!run.osSessionId) return "none";
   try {
-    return sessionTurn({
-      op: "snapshot",
-      sessionId: run.osSessionId,
-    }).cancel?.runId === run.runKey
+    return sessionKernelStore().turnSnapshot(run.osSessionId).cancel?.runId === run.runKey
       ? "owned"
       : "none";
   } catch {
@@ -1256,19 +1253,18 @@ export function reissueDurableRecoveryCancel(run: ActiveRunRecord): boolean {
 
 function settleDurableCancelForAbsentOwner(run: ActiveRunRecord): boolean {
   if (!run.osSessionId) return false;
-  const cancel = sessionTurn({
-    op: "snapshot",
-    sessionId: run.osSessionId,
-  }).cancel;
+  const cancel = sessionKernelStore().turnSnapshot(run.osSessionId).cancel;
   if (cancel?.runId !== run.runKey) return false;
-  if (cancel.phase !== "settled")
+  if (cancel.phase !== "settled") {
     sessionTurn({
       op: "settle_cancel",
       sessionId: run.osSessionId,
       cancelId: cancel.cancelId,
       outcome: "confirmed",
-    });
-  journalClearIfLineage(run);
+    }).then(() => journalClearIfLineage(run)).catch((error) =>
+      console.error(`[runner] Failed to settle recovered cancellation for ${run.runKey}:`, error),
+    );
+  } else journalClearIfLineage(run);
   return true;
 }
 
@@ -1312,17 +1308,16 @@ export function resumeInterruptedRuns(
       }
     } finally {
       if (run.osSessionId) {
-        const cancel = sessionTurn({
-          op: "snapshot",
-          sessionId: run.osSessionId,
-        }).cancel;
+        const cancel = sessionKernelStore().turnSnapshot(run.osSessionId).cancel;
         if (cancel?.runId === run.runKey && cancel.phase !== "settled")
           sessionTurn({
             op: "settle_cancel",
             sessionId: run.osSessionId,
             cancelId: cancel.cancelId,
             outcome: "confirmed",
-          });
+          }).catch((error) =>
+            console.error(`[runner] Failed to settle recovery cancellation for ${run.runKey}:`, error),
+          );
       }
       if (run.osSessionId && isRunStateUnsettled(getRunState(run.osSessionId))) {
         const failed = event.type === "error" || !!event.usageLimitExhausted;

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -980,23 +980,24 @@ export function steerAgentRun(
   ids: Array<string | null | undefined>,
   text: string,
   images?: ImageInput[],
-
   steerId?: string
 ): boolean {
   for (const id of ids) {
-    if (!id) continue;
-    if (steerPiRun(id, text, images, steerId)) return true;
-
-    // Images ride the host frame too (protocol ClientToHostMsg.steer). This
-    // used to bail on any attachment, which read as "pi can't steer images"
-    // — it can; only the RPC frame was text-only. Once every local run moved
-    // into a detached host that guard covered every case, so no message with
-    // a screenshot could be steered at all.
-
-    if (hostSteer(id, text, images, steerId)) return true;
-
+    if (id && steerAgentRunToken(id, text, images, steerId)) return true;
   }
   return false;
+}
+
+/** Steer only one immutable dispatch token, never a reusable session alias. */
+export function steerAgentRunToken(
+  runToken: string,
+  text: string,
+  images?: ImageInput[],
+  steerId?: string,
+): boolean {
+  if (steerPiRun(runToken, text, images, steerId)) return true;
+  // Images ride the host frame too (protocol ClientToHostMsg.steer).
+  return hostSteer(runToken, text, images, steerId);
 }
 
 /** Retract one accepted steer only while it remains behind the engine's next

--- a/packages/core/opensession-server/src/server/agent-waits.ts
+++ b/packages/core/opensession-server/src/server/agent-waits.ts
@@ -106,9 +106,9 @@ export function getAgentWait(sessionId: string): AgentWait | undefined {
 		: undefined;
 }
 
-export function cancelAgentWait(sessionId: string): boolean {
+export async function cancelAgentWait(sessionId: string): Promise<boolean> {
 	if (!getAgentWait(sessionId)) return false;
-	sessionKernel(sessionId).cancelTimer(TIMER_ID);
+	await sessionKernel(sessionId).cancelTimer(TIMER_ID);
 	return true;
 }
 
@@ -151,7 +151,7 @@ export async function registerTimerAgentWait(input: {
 	return { ok: true, wait, replaced: !!current };
 }
 
-export function registerPrChecksAgentWait(input: {
+export async function registerPrChecksAgentWait(input: {
 	sessionId: string;
 	user: string;
 	repo: string;
@@ -162,7 +162,7 @@ export function registerPrChecksAgentWait(input: {
 	settleSeconds?: number;
 	waitId?: string;
 	now?: number;
-}): AgentWaitRegistration {
+}): Promise<AgentWaitRegistration> {
 	const sessionId = input.sessionId.trim();
 	const repo = input.repo.trim();
 	const branch = input.branch.trim();
@@ -203,7 +203,7 @@ export function registerPrChecksAgentWait(input: {
 	};
 	const current = getAgentWait(sessionId);
 	if (current?.id === wait.id) return { ok: true, wait: current, replaced: false };
-	sessionKernel(sessionId).scheduleTimer({
+	await sessionKernel(sessionId).scheduleTimer({
 		timerId: TIMER_ID,
 		kind: TIMER_KIND,
 		dueAt: Math.min(wait.deadlineAt, now + pollSeconds * 1000),
@@ -290,11 +290,11 @@ export function agentWaitWakePrompt(wait: AgentWait, message: string): string {
 const defaultHandlerDeps: AgentWaitHandlerDeps = {
 	now: () => Date.now(),
 	getPrDetails: getPrDetailsFresh,
-	schedule: (wait, dueAt) => {
+	schedule: async (wait, dueAt) => {
 		// A cancel or replacement can land while a GitHub request is in flight.
 		// Never let that stale response recreate the old wait over the newer one.
 		if (getAgentWait(wait.sessionId)?.id !== wait.id) return;
-		sessionKernel(wait.sessionId).scheduleTimer({
+		await sessionKernel(wait.sessionId).scheduleTimer({
 			timerId: TIMER_ID,
 			kind: TIMER_KIND,
 			dueAt,

--- a/packages/core/opensession-server/src/server/agent-waits.ts
+++ b/packages/core/opensession-server/src/server/agent-waits.ts
@@ -112,14 +112,14 @@ export function cancelAgentWait(sessionId: string): boolean {
 	return true;
 }
 
-export function registerTimerAgentWait(input: {
+export async function registerTimerAgentWait(input: {
 	sessionId: string;
 	user: string;
 	prompt?: string;
 	seconds: number;
 	waitId?: string;
 	now?: number;
-}): AgentWaitRegistration {
+}): Promise<AgentWaitRegistration> {
 	const sessionId = input.sessionId.trim();
 	if (!sessionId) return { ok: false, error: "Current session id is required." };
 	if (!Number.isFinite(input.seconds) || input.seconds < MIN_TIMER_SECONDS)
@@ -142,7 +142,7 @@ export function registerTimerAgentWait(input: {
 	};
 	const current = getAgentWait(sessionId);
 	if (current?.id === wait.id) return { ok: true, wait: current, replaced: false };
-	sessionKernel(sessionId).scheduleTimer({
+	await sessionKernel(sessionId).scheduleTimer({
 		timerId: TIMER_ID,
 		kind: TIMER_KIND,
 		dueAt: wait.dueAt,

--- a/packages/core/opensession-server/src/server/asks-restart.test.ts
+++ b/packages/core/opensession-server/src/server/asks-restart.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import {
 	makeAskHandler,
 	pendingAskAwaitingAnswer,
+	pendingAskAwaitingAnswerSync,
 	pendingAsks,
 	pendingAskTimers,
 	persistPendingAsks,
@@ -220,6 +221,7 @@ describe("pending ask restart persistence", () => {
 		// The recovery record stays durable until the run host adopts it, but a
 		// reconnecting web or native client must not receive the card again.
 		expect(await pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
+		expect(pendingAskAwaitingAnswerSync(SESSION)).toBeUndefined();
 		const persisted = JSON.parse(readFileSync(storePath, "utf8"));
 		expect(persisted.asks[0]).toMatchObject({
 			questionId: "q-early",
@@ -245,6 +247,7 @@ describe("pending ask restart persistence", () => {
 			earlyAnswer: { "Which option?": "One" },
 		});
 		expect(await pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
+		expect(pendingAskAwaitingAnswerSync(SESSION)).toBeUndefined();
 		expect(pendingAskTimers.has(SESSION)).toBe(false);
 		expect(sent).not.toContainEqual(expect.objectContaining({ type: "ask_question" }));
 

--- a/packages/core/opensession-server/src/server/asks-restart.test.ts
+++ b/packages/core/opensession-server/src/server/asks-restart.test.ts
@@ -31,10 +31,10 @@ const QUESTION = {
 
 let scratch = "";
 
-function resetState(): void {
+async function resetState(): Promise<void> {
 	for (const timer of pendingAskTimers.values()) clearTimeout(timer.handle);
 	pendingAskTimers.clear();
-	pendingAsks.clear();
+	await pendingAsks.clear();
 	sessionWatchers.delete(SESSION);
 	if (scratch) rmSync(scratch, { recursive: true, force: true });
 	scratch = "";
@@ -43,7 +43,7 @@ function resetState(): void {
 afterEach(resetState);
 
 describe("pending ask restart persistence", () => {
-	test("restores the card and keeps the original escalation deadline", () => {
+	test("restores the card and keeps the original escalation deadline", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-asks-restart-"));
 		const storePath = join(scratch, "pending-asks.json");
 		const askedAt = Date.now() - 60_000;
@@ -78,7 +78,7 @@ describe("pending ask restart persistence", () => {
 		);
 
 		expect(
-			restorePendingAsks({
+			await restorePendingAsks({
 				storePath,
 				now: askedAt + 60_000,
 				sessionExists: (id) => id === SESSION,
@@ -119,7 +119,7 @@ describe("pending ask restart persistence", () => {
 				],
 			}),
 		);
-		restorePendingAsks({ storePath, sessionExists: () => true });
+		await restorePendingAsks({ storePath, sessionExists: () => true });
 
 		const resultPromise = makeAskHandler(SESSION)({ questions: [QUESTION] });
 		await Bun.sleep(0);
@@ -128,7 +128,7 @@ describe("pending ask restart persistence", () => {
 			askedAt,
 		});
 		expect(pendingAsks.get(SESSION)?.restored).toBeUndefined();
-		pendingAsks.get(SESSION)?.resolve({ "Which option?": "Two" });
+		await pendingAsks.get(SESSION)?.resolve({ "Which option?": "Two" });
 
 		expect(await resultPromise).toEqual({
 			behavior: "allow",
@@ -138,7 +138,7 @@ describe("pending ask restart persistence", () => {
 			},
 		});
 		expect(pendingAsks.get(SESSION)).toMatchObject({ answerReceived: true });
-		settleRestoredAskAfterRecovery(SESSION);
+		await settleRestoredAskAfterRecovery(SESSION);
 		expect(pendingAsks.has(SESSION)).toBe(false);
 		expect(JSON.parse(readFileSync(storePath, "utf8"))).toEqual({ asks: [] });
 	});
@@ -159,8 +159,8 @@ describe("pending ask restart persistence", () => {
 				],
 			}),
 		);
-		restorePendingAsks({ storePath, sessionExists: () => true });
-		pendingAsks.get(SESSION)?.resolve({ "Which option?": "One" });
+		await restorePendingAsks({ storePath, sessionExists: () => true });
+		await pendingAsks.get(SESSION)?.resolve({ "Which option?": "One" });
 
 		expect(pendingAsks.get(SESSION)).toMatchObject({
 			questionId: "q-early",
@@ -178,7 +178,7 @@ describe("pending ask restart persistence", () => {
 		});
 		for (const timer of pendingAskTimers.values()) clearTimeout(timer.handle);
 		pendingAskTimers.clear();
-		pendingAsks.clear();
+		await pendingAsks.clear();
 		const sent: unknown[] = [];
 		sessionWatchers.set(
 			SESSION,
@@ -189,7 +189,7 @@ describe("pending ask restart persistence", () => {
 				} as never,
 			]),
 		);
-		restorePendingAsks({ storePath, sessionExists: () => true });
+		await restorePendingAsks({ storePath, sessionExists: () => true });
 		expect(pendingAsks.get(SESSION)).toMatchObject({
 			answerReceived: true,
 			earlyAnswer: { "Which option?": "One" },
@@ -206,7 +206,7 @@ describe("pending ask restart persistence", () => {
 			},
 		});
 		expect(pendingAsks.get(SESSION)).toMatchObject({ answerReceived: true });
-		settleRestoredAskAfterRecovery(SESSION);
+		await settleRestoredAskAfterRecovery(SESSION);
 		expect(pendingAsks.has(SESSION)).toBe(false);
 		expect(JSON.parse(readFileSync(storePath, "utf8"))).toEqual({ asks: [] });
 	});
@@ -229,7 +229,7 @@ describe("pending ask restart persistence", () => {
 				],
 			}),
 		);
-		restorePendingAsks({ storePath, sessionExists: () => true });
+		await restorePendingAsks({ storePath, sessionExists: () => true });
 
 		const previousControl = tryGetSessionControl();
 		const deliveries: string[] = [];
@@ -248,7 +248,7 @@ describe("pending ask restart persistence", () => {
 		});
 		setTranscriptForwarder((_sessionId, batch) => lines.push(...batch));
 		try {
-			expect(settleRestoredAskAfterRecovery(SESSION)).toBe(true);
+			expect(await settleRestoredAskAfterRecovery(SESSION)).toBe(true);
 			await Bun.sleep(0);
 		} finally {
 			registerSessionControl(previousControl as SessionControl);
@@ -264,7 +264,7 @@ describe("pending ask restart persistence", () => {
 		expect(stripContext(deliveries[0])).toBe("");
 	});
 
-	test("retires a restored card when recovery ends without adopting it", () => {
+	test("retires a restored card when recovery ends without adopting it", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-asks-terminal-"));
 		const storePath = join(scratch, "pending-asks.json");
 		writeFileSync(
@@ -280,16 +280,16 @@ describe("pending ask restart persistence", () => {
 				],
 			}),
 		);
-		restorePendingAsks({ storePath, sessionExists: () => true });
+		await restorePendingAsks({ storePath, sessionExists: () => true });
 
-		settleRestoredAskAfterRecovery(SESSION);
+		await settleRestoredAskAfterRecovery(SESSION);
 
 		expect(pendingAsks.has(SESSION)).toBe(false);
 		expect(pendingAskTimers.has(SESSION)).toBe(false);
 		expect(JSON.parse(readFileSync(storePath, "utf8"))).toEqual({ asks: [] });
 	});
 
-	test("commit \u2192 crash \u2192 restore \u2192 adopt \u2192 retry keeps answer identity", () => {
+	test("commit \u2192 crash \u2192 restore \u2192 adopt \u2192 retry keeps answer identity", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-asks-crash-retry-"));
 		const previousSessionsDir = sessionsDir();
 		__setSessionsDirForTest(scratch);
@@ -300,7 +300,7 @@ describe("pending ask restart persistence", () => {
 			// The actor commits the answer durably; the process crashes before
 			// the gateway resolver runs, so nothing retires the record.
 			expect(
-				sessionAsk({
+				await sessionAsk({
 					op: "answer",
 					sessionId: SESSION,
 					questionId,
@@ -314,8 +314,8 @@ describe("pending ask restart persistence", () => {
 
 			// Restart: recovery reads actor authority and projects the
 			// committed answer as answered instead of re-asking.
-			restorePendingAsks({ sessionExists: () => true });
-			restorePendingAsks({ sessionExists: () => true });
+			await restorePendingAsks({ sessionExists: () => true });
+			await restorePendingAsks({ sessionExists: () => true });
 			const restored = pendingAsks.get(SESSION);
 			expect(restored?.answerReceived).toBe(true);
 			expect(restored?.earlyAnswer).toEqual({ "Which option?": "One" });
@@ -328,7 +328,7 @@ describe("pending ask restart persistence", () => {
 
 			// The exact caller retries: replay matched with committed answers.
 			expect(
-				sessionAsk({
+				await sessionAsk({
 					op: "answer",
 					sessionId: SESSION,
 					questionId,
@@ -340,7 +340,7 @@ describe("pending ask restart persistence", () => {
 				answers: { "Which option?": "One" },
 			});
 			expect(
-				sessionAsk({
+				await sessionAsk({
 					op: "answer",
 					sessionId: SESSION,
 					questionId,
@@ -350,7 +350,7 @@ describe("pending ask restart persistence", () => {
 			).toEqual({ matched: false });
 
 			// The adopted live waiter still wakes with the committed answers.
-			pendingAsks.get(SESSION)?.resolve({ "Which option?": "One" });
+			await pendingAsks.get(SESSION)?.resolve({ "Which option?": "One" });
 		} finally {
 			__setSessionsDirForTest(previousSessionsDir);
 		}

--- a/packages/core/opensession-server/src/server/asks-restart.test.ts
+++ b/packages/core/opensession-server/src/server/asks-restart.test.ts
@@ -169,7 +169,7 @@ describe("pending ask restart persistence", () => {
 		});
 		// The recovery record stays durable until the run host adopts it, but a
 		// reconnecting web or native client must not receive the card again.
-		expect(pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
+		expect(await pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
 		const persisted = JSON.parse(readFileSync(storePath, "utf8"));
 		expect(persisted.asks[0]).toMatchObject({
 			questionId: "q-early",
@@ -194,7 +194,7 @@ describe("pending ask restart persistence", () => {
 			answerReceived: true,
 			earlyAnswer: { "Which option?": "One" },
 		});
-		expect(pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
+		expect(await pendingAskAwaitingAnswer(SESSION)).toBeUndefined();
 		expect(pendingAskTimers.has(SESSION)).toBe(false);
 		expect(sent).not.toContainEqual(expect.objectContaining({ type: "ask_question" }));
 

--- a/packages/core/opensession-server/src/server/asks-restart.test.ts
+++ b/packages/core/opensession-server/src/server/asks-restart.test.ts
@@ -43,6 +43,56 @@ async function resetState(): Promise<void> {
 afterEach(resetState);
 
 describe("pending ask restart persistence", () => {
+	test("rejects the ask when its initial durable write fails", async () => {
+		const originalSet = pendingAsks.set.bind(pendingAsks);
+		(pendingAsks as any).set = async () => {
+			throw new Error("initial ask write failed");
+		};
+		try {
+			await expect(makeAskHandler(SESSION)({ questions: [QUESTION] }))
+				.rejects.toThrow("initial ask write failed");
+		} finally {
+			(pendingAsks as any).set = originalSet;
+		}
+	});
+
+	test("keeps an ask answer retryable when its durable write fails", async () => {
+		const originalSet = pendingAsks.set.bind(pendingAsks);
+		let writes = 0;
+		let cardReady!: () => void;
+		const ready = new Promise<void>((resolve) => {
+			cardReady = resolve;
+		});
+		sessionWatchers.set(SESSION, new Set([{
+			data: { watchingSessionId: SESSION, user: "Test" },
+			send: (payload: string) => {
+				if (JSON.parse(payload).type === "ask_question") cardReady();
+			},
+		} as never]));
+		(pendingAsks as any).set = async (sessionId: string, value: any) => {
+			writes += 1;
+			if (writes === 2) throw new Error("answer write failed");
+			return await originalSet(sessionId, value);
+		};
+		try {
+			const result = makeAskHandler(SESSION)({ questions: [QUESTION] });
+			await ready;
+			const ask = pendingAsks.get(SESSION)!;
+			await expect(ask.resolve({ "Which option?": "One" }))
+				.rejects.toThrow("answer write failed");
+			expect(writes).toBe(2);
+			await ask.resolve({ "Which option?": "One" });
+			expect(await result).toEqual({
+				behavior: "allow",
+				updatedInput: {
+					questions: [QUESTION],
+					answers: { "Which option?": "One" },
+				},
+			});
+		} finally {
+			(pendingAsks as any).set = originalSet;
+		}
+	});
 	test("restores the card and keeps the original escalation deadline", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-asks-restart-"));
 		const storePath = join(scratch, "pending-asks.json");

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -81,6 +81,16 @@ export async function pendingAskAwaitingAnswer(
 	return pending?.answerReceived ? undefined : pending;
 }
 
+/** Sync projection variant for read-only summary surfaces that cannot await.
+ * Applies the same answerReceived filter so an answered-but-not-yet-adopted
+ * recovery record is never projected back as an actionable question. */
+export function pendingAskAwaitingAnswerSync(
+	sessionId: string,
+): PendingAsk | undefined {
+	const pending = pendingAsks.get(sessionId);
+	return pending?.answerReceived ? undefined : pending;
+}
+
 /** One actor snapshot for list rendering, instead of one RPC per session. */
 export function pendingAskIdsAwaitingAnswer(): Set<string> {
 	const ids = new Set<string>();

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -705,6 +705,7 @@ export async function offerAskCard(
 ): Promise<{ close: () => Promise<void> }> {
 	const questionId = crypto.randomUUID();
 	let settled = false;
+	let settling: Promise<void> | undefined;
 	const retract = async () => {
 		if (pendingAsks.get(sessionId)?.questionId === questionId) {
 			await pendingAsks.delete(sessionId);
@@ -715,16 +716,29 @@ export async function offerAskCard(
 			questionId,
 		});
 	};
+	const settle = (
+		a: Record<string, string> | null,
+		notify: boolean,
+	): Promise<void> => {
+		if (settled) return Promise.resolve();
+		if (settling) return settling;
+		const attempt = (async () => {
+			await retract();
+			settled = true;
+			if (notify) {
+				recordAskAnswer(sessionId, questions, a);
+				onAnswer(a);
+			}
+		})();
+		settling = attempt.finally(() => {
+			if (!settled) settling = undefined;
+		});
+		return settling;
+	};
 	await pendingAsks.set(sessionId, {
 		questionId,
 		questions,
-		resolve: async (a) => {
-			if (settled) return;
-			settled = true;
-			await retract();
-			recordAskAnswer(sessionId, questions, a);
-			onAnswer(a);
-		},
+		resolve: (a) => settle(a, true),
 	});
 	broadcastToSession(sessionId, {
 		type: "ask_question",
@@ -733,11 +747,7 @@ export async function offerAskCard(
 		questions,
 	});
 	return {
-		close: async () => {
-			if (settled) return;
-			settled = true;
-			await retract();
-		},
+		close: () => settle(null, false),
 	};
 }
 
@@ -781,105 +791,120 @@ export function makeAskHandler(sessionId: string) {
 		let settled = false;
 		let escalatedAskId = adopted ? existing!.escalatedAskId || null : null;
 
-		const answers = await new Promise<Record<string, string> | null>(
-			async (resolve) => {
-				const finish = async (a: Record<string, string> | null) => {
-					if (settled) return;
-					settled = true;
-					await clearAskTimer(sessionId);
-					const durableAnswer = pendingAsks.get(sessionId);
-					if (durableAnswer?.questionId === questionId) {
-						durableAnswer.answerReceived = true;
-						durableAnswer.earlyAnswer = a;
-						await pendingAsks.set(sessionId, durableAnswer);
-						persistPendingAsks(durableAnswer.storePath);
-					}
-					// Before the card goes: the transcript's only trace of it.
-					recordAskAnswer(sessionId, questions, a);
-					await transitionRunState(sessionId, "ask_resolved", {
-						answered: a !== null,
-					});
-					// If the web UI answered after we'd already pinged Slack, retract the
-					// Slack ask so the teammate isn't left answering a moot question.
-					if (escalatedAskId) cancelAsk(escalatedAskId);
-					resolve(a);
-				};
-
-				const ask: PendingAsk = {
-					questionId,
-					questions,
-					durable: true,
-					askedAt,
-					...(adopted && existing!.escalatedAskId
-						? { escalatedAskId: existing!.escalatedAskId }
-						: {}),
-					...(adopted && existing!.escalatedPersonName
-						? { escalatedPersonName: existing!.escalatedPersonName }
-						: {}),
-					...(adopted && existing!.escalationWaitStarted
-						? { escalationWaitStarted: true }
-						: {}),
-					...(adopted && existing!.answerReceived
-						? {
-								answerReceived: true,
-								earlyAnswer: existing!.earlyAnswer ?? null,
-							}
-						: {}),
-					// Preserve the durable answer receipt across adoption so retry
-					// identity and the committed payload survive the rewrite.
-					...(adopted && existing!.answer ? { answer: existing!.answer } : {}),
-					...(adopted && existing!.storePath
-						? { storePath: existing!.storePath }
-						: {}),
-					resolve: async (a) => finish(a),
-				};
-				await pendingAsks.set(sessionId, ask);
-				persistPendingAsks(ask.storePath);
-				await transitionRunState(sessionId, "ask_posed");
-				if (ask.answerReceived) {
-					queueMicrotask(() => {
-            void Promise.resolve(ask.resolve(ask.earlyAnswer ?? null)).catch((error) => {
-              console.error(`[asks] Failed to resolve early answer for ${sessionId}:`, error);
-            });
-          });
-				} else {
-					await armAskEscalation(sessionId, ask, questions);
-					broadcastToSession(sessionId, {
-						type: "ask_question",
-						sessionId,
-						questionId,
-						questions,
-					});
-				}
-				// Phone buzz: Web Push to the session owner's registered devices
-				// (opt-in per device in Settings → Notifications). Best-effort —
-				// never lets a push hiccup affect the ask flow. Deduped on the
-				// question text: a restart resumes ask-blocked runs, which re-ask
-				// the same question — that re-ask must not buzz again.
-				if (!adopted && !ask.answerReceived) void (async () => {
-					try {
-						const s = findSession(sessionId);
-						if (!s?.startedBy) return;
-						const { sendPushToUser } = await import("./push");
-						const { createHash } = await import("node:crypto");
-						const qHash = createHash("sha256")
-							.update(questions.map((q) => q.question).join("\n"))
-							.digest("hex")
-							.slice(0, 16);
-						await sendPushToUser(
-							s.startedBy,
-							{
-								title: `${personaName()} needs input`,
-								body: `${s.title || sessionId} — ${questions[0]?.question || "a question is waiting"}`.slice(0, 180,),
-								url: `/session/${encodeURIComponent(sessionId)}`,
-								tag: `ask-${sessionId}`,
-							},
-							{ dedupeKey: `ask:${sessionId}:${qHash}` },
-						);
-					} catch {}
-				})();
+		let resolveAnswers!: (answers: Record<string, string> | null) => void;
+		let rejectAnswers!: (error: unknown) => void;
+		const answersPromise = new Promise<Record<string, string> | null>(
+			(resolve, reject) => {
+				resolveAnswers = resolve;
+				rejectAnswers = reject;
 			},
 		);
+		let finishing: Promise<void> | undefined;
+		const finish = (a: Record<string, string> | null): Promise<void> => {
+			if (settled) return Promise.resolve();
+			if (finishing) return finishing;
+			const attempt = (async () => {
+				await clearAskTimer(sessionId);
+				const durableAnswer = pendingAsks.get(sessionId);
+				if (durableAnswer?.questionId === questionId) {
+					durableAnswer.answerReceived = true;
+					durableAnswer.earlyAnswer = a;
+					await pendingAsks.set(sessionId, durableAnswer);
+					persistPendingAsks(durableAnswer.storePath);
+				}
+				await transitionRunState(sessionId, "ask_resolved", {
+					answered: a !== null,
+				});
+				settled = true;
+				// Before the card goes: the transcript's only trace of it.
+				recordAskAnswer(sessionId, questions, a);
+				// If the web UI answered after we'd already pinged Slack, retract the
+				// Slack ask so the teammate isn't left answering a moot question.
+				if (escalatedAskId) cancelAsk(escalatedAskId);
+				resolveAnswers(a);
+			})();
+			finishing = attempt.finally(() => {
+				if (!settled) finishing = undefined;
+			});
+			return finishing;
+		};
+
+		const ask: PendingAsk = {
+			questionId,
+			questions,
+			durable: true,
+			askedAt,
+			...(adopted && existing!.escalatedAskId
+				? { escalatedAskId: existing!.escalatedAskId }
+				: {}),
+			...(adopted && existing!.escalatedPersonName
+				? { escalatedPersonName: existing!.escalatedPersonName }
+				: {}),
+			...(adopted && existing!.escalationWaitStarted
+				? { escalationWaitStarted: true }
+				: {}),
+			...(adopted && existing!.answerReceived
+				? {
+						answerReceived: true,
+						earlyAnswer: existing!.earlyAnswer ?? null,
+					}
+				: {}),
+			// Preserve the durable answer receipt across adoption so retry
+			// identity and the committed payload survive the rewrite.
+			...(adopted && existing!.answer ? { answer: existing!.answer } : {}),
+			...(adopted && existing!.storePath
+				? { storePath: existing!.storePath }
+				: {}),
+			resolve: finish,
+		};
+		try {
+			await pendingAsks.set(sessionId, ask);
+			persistPendingAsks(ask.storePath);
+			await transitionRunState(sessionId, "ask_posed");
+			if (ask.answerReceived) {
+				queueMicrotask(() => {
+					void finish(ask.earlyAnswer ?? null).catch(rejectAnswers);
+				});
+			} else {
+				await armAskEscalation(sessionId, ask, questions);
+				broadcastToSession(sessionId, {
+					type: "ask_question",
+					sessionId,
+					questionId,
+					questions,
+				});
+			}
+			// Phone buzz: Web Push to the session owner's registered devices
+			// (opt-in per device in Settings → Notifications). Best-effort —
+			// never lets a push hiccup affect the ask flow. Deduped on the
+			// question text: a restart resumes ask-blocked runs, which re-ask
+			// the same question — that re-ask must not buzz again.
+			if (!adopted && !ask.answerReceived) void (async () => {
+				try {
+					const s = findSession(sessionId);
+					if (!s?.startedBy) return;
+					const { sendPushToUser } = await import("./push");
+					const { createHash } = await import("node:crypto");
+					const qHash = createHash("sha256")
+						.update(questions.map((q) => q.question).join("\n"))
+						.digest("hex")
+						.slice(0, 16);
+					await sendPushToUser(
+						s.startedBy,
+						{
+							title: `${personaName()} needs input`,
+							body: `${s.title || sessionId} — ${questions[0]?.question || "a question is waiting"}`.slice(0, 180,),
+							url: `/session/${encodeURIComponent(sessionId)}`,
+							tag: `ask-${sessionId}`,
+						},
+						{ dedupeKey: `ask:${sessionId}:${qHash}` },
+					);
+				} catch {}
+			})();
+		} catch (error) {
+			rejectAnswers(error);
+		}
+		const answers = await answersPromise;
 
 		broadcastToSession(sessionId, {
 			type: "ask_resolved",

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -74,10 +74,10 @@ export const pendingAsks = new AskOwnedMap<PendingAsk>();
 /** The durable map may retain a restored ask after its answer arrives, until
  * the detached run host reconnects and adopts that answer. That recovery
  * record is not still actionable and must never be projected back as a card. */
-export function pendingAskAwaitingAnswer(
+export async function pendingAskAwaitingAnswer(
 	sessionId: string,
-): PendingAsk | undefined {
-	const pending = pendingAsks.get(sessionId);
+): Promise<PendingAsk | undefined> {
+	const pending = await pendingAsks.getAsync(sessionId);
 	return pending?.answerReceived ? undefined : pending;
 }
 
@@ -164,7 +164,7 @@ async function clearAskTimer(sessionId: string): Promise<void> {
 }
 
 async function retirePendingAsk(sessionId: string, questionId: string): Promise<void> {
-	clearAskTimer(sessionId);
+	await clearAskTimer(sessionId);
 	const ask = pendingAsks.get(sessionId);
 	if (ask?.questionId === questionId) {
 		await pendingAsks.delete(sessionId);
@@ -206,7 +206,7 @@ async function resolveRestoredAsk(
 ): Promise<void> {
 	const ask = pendingAsks.get(sessionId);
 	if (ask?.questionId !== questionId || ask.answerReceived) return;
-	clearAskTimer(sessionId);
+	await clearAskTimer(sessionId);
 	ask.answerReceived = true;
 	ask.earlyAnswer = answers;
 	await pendingAsks.set(sessionId, ask);
@@ -441,27 +441,33 @@ function waitForEscalatedAnswer(
 	if (!stored || stored.state === "answered" || stored.state === "cancelled") {
 		const answer = stored?.state === "answered" ? stored.answer || null : null;
 		queueMicrotask(() => {
-			const current = pendingAsks.get(sessionId);
-			if (current?.questionId !== questionId) return;
-			current.resolve(
-				answer == null ? null : slackAnswerToAnswers(questions, answer),
-			);
+      void (async () => {
+        const current = pendingAsks.get(sessionId);
+        if (current?.questionId !== questionId) return;
+        await current.resolve(
+          answer == null ? null : slackAnswerToAnswers(questions, answer),
+        );
+      })().catch((error) => {
+        console.error(`[asks] Failed to resolve restored Slack answer for ${sessionId}:`, error);
+      });
 		});
 		return;
 	}
-	void awaitBlockingAnswer(askId).then((slackAnswer) => {
+	void awaitBlockingAnswer(askId).then(async (slackAnswer) => {
 		const current = pendingAsks.get(sessionId);
 		if (current?.questionId !== questionId) return;
 		if (slackAnswer == null) {
-			current.resolve(null);
+			await current.resolve(null);
 			return;
 		}
 		broadcastToSession(sessionId, {
 			type: "notice",
 			message: `💬 **${personName}** answered (via Slack): ${slackAnswer}`,
 		});
-		current.resolve(slackAnswerToAnswers(questions, slackAnswer));
-	});
+		await current.resolve(slackAnswerToAnswers(questions, slackAnswer));
+	}).catch((error) => {
+    console.error(`[asks] Failed to resolve Slack answer for ${sessionId}:`, error);
+  });
 }
 
 async function escalatePendingAsk(
@@ -496,7 +502,7 @@ async function escalatePendingAsk(
 		return;
 	}
 	if (!escalated) {
-		latest.resolve(null);
+		await latest.resolve(null);
 		return;
 	}
 	latest.escalatedAskId = escalated.askId;
@@ -525,7 +531,7 @@ async function armAskEscalation(
 	questions: AskQuestionInput[],
 	now = Date.now(),
 ): Promise<void> {
-	clearAskTimer(sessionId);
+	await clearAskTimer(sessionId);
 	if (!ask.askedAt) return;
 	if (ask.escalatedAskId) {
 		if (!ask.escalationWaitStarted) {
@@ -658,7 +664,7 @@ export async function restorePendingAsks(
 		};
 		await pendingAsks.set(saved.sessionId, ask);
 		if (!ask.answerReceived) {
-      armAskEscalation(saved.sessionId, ask, saved.questions, options.now);
+      await armAskEscalation(saved.sessionId, ask, saved.questions, options.now);
 			broadcastToSession(saved.sessionId, {
 				type: "ask_question",
 				sessionId: saved.sessionId,
@@ -780,7 +786,7 @@ export function makeAskHandler(sessionId: string) {
 				const finish = async (a: Record<string, string> | null) => {
 					if (settled) return;
 					settled = true;
-					clearAskTimer(sessionId);
+					await clearAskTimer(sessionId);
 					const durableAnswer = pendingAsks.get(sessionId);
 					if (durableAnswer?.questionId === questionId) {
 						durableAnswer.answerReceived = true;
@@ -790,7 +796,7 @@ export function makeAskHandler(sessionId: string) {
 					}
 					// Before the card goes: the transcript's only trace of it.
 					recordAskAnswer(sessionId, questions, a);
-					transitionRunState(sessionId, "ask_resolved", {
+					await transitionRunState(sessionId, "ask_resolved", {
 						answered: a !== null,
 					});
 					// If the web UI answered after we'd already pinged Slack, retract the
@@ -829,11 +835,15 @@ export function makeAskHandler(sessionId: string) {
 				};
 				await pendingAsks.set(sessionId, ask);
 				persistPendingAsks(ask.storePath);
-				transitionRunState(sessionId, "ask_posed");
+				await transitionRunState(sessionId, "ask_posed");
 				if (ask.answerReceived) {
-					queueMicrotask(() => ask.resolve(ask.earlyAnswer ?? null));
+					queueMicrotask(() => {
+            void Promise.resolve(ask.resolve(ask.earlyAnswer ?? null)).catch((error) => {
+              console.error(`[asks] Failed to resolve early answer for ${sessionId}:`, error);
+            });
+          });
 				} else {
-					armAskEscalation(sessionId, ask, questions);
+					await armAskEscalation(sessionId, ask, questions);
 					broadcastToSession(sessionId, {
 						type: "ask_question",
 						sessionId,

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -156,11 +156,11 @@ export function persistPendingAsks(storePath = pendingAskStorePath()): void {
 	}
 }
 
-function clearAskTimer(sessionId: string): void {
+async function clearAskTimer(sessionId: string): Promise<void> {
 	const timer = pendingAskTimers.get(sessionId);
 	if (timer) clearTimeout(timer.handle);
 	pendingAskTimers.delete(sessionId);
-	sessionKernel(sessionId).cancelTimer("ask_escalation");
+	await sessionKernel(sessionId).cancelTimer("ask_escalation");
 }
 
 async function retirePendingAsk(sessionId: string, questionId: string): Promise<void> {
@@ -519,12 +519,12 @@ registerSessionTimerHandler("ask_escalation", async (timer) => {
 	await escalatePendingAsk(timer.sessionId, payload.questionId);
 });
 
-function armAskEscalation(
+async function armAskEscalation(
 	sessionId: string,
 	ask: PendingAsk,
 	questions: AskQuestionInput[],
 	now = Date.now(),
-): void {
+): Promise<void> {
 	clearAskTimer(sessionId);
 	if (!ask.askedAt) return;
 	if (ask.escalatedAskId) {
@@ -541,7 +541,7 @@ function armAskEscalation(
 		return;
 	}
 	const dueAt = ask.askedAt + ASK_UI_TIMEOUT_MS;
-	sessionKernel(sessionId).scheduleTimer({
+	await sessionKernel(sessionId).scheduleTimer({
 		timerId: "ask_escalation",
 		kind: "ask_escalation",
 		dueAt,

--- a/packages/core/opensession-server/src/server/asks.ts
+++ b/packages/core/opensession-server/src/server/asks.ts
@@ -52,7 +52,7 @@ import type { AskQuestion as AskQuestionInput } from "@tellahq/opensession-proto
 export interface PendingAsk {
 	questionId: string;
 	questions: unknown[];
-	resolve: (answers: Record<string, string> | null) => void;
+	resolve: (answers: Record<string, string> | null) => void | Promise<void>;
 	/** Only run-blocking asks are durable. offerAskCard is restored by human-asks. */
 	durable?: boolean;
 	askedAt?: number;
@@ -69,7 +69,7 @@ export interface PendingAsk {
 	/** Test/isolated-instance seam; live asks use pendingAskStorePath(). */
 	storePath?: string;
 }
-export const pendingAsks: Map<string, PendingAsk> = new AskOwnedMap();
+export const pendingAsks = new AskOwnedMap<PendingAsk>();
 
 /** The durable map may retain a restored ask after its answer arrives, until
  * the detached run host reconnects and adopts that answer. That recovery
@@ -84,7 +84,7 @@ export function pendingAskAwaitingAnswer(
 /** One actor snapshot for list rendering, instead of one RPC per session. */
 export function pendingAskIdsAwaitingAnswer(): Set<string> {
 	const ids = new Set<string>();
-	for (const [sessionId, value] of sessionAsk({ op: "entries" })) {
+	for (const [sessionId, value] of sessionKernelStore().askEntries()) {
 		const pending = value as { answerReceived?: boolean } | undefined;
 		if (!pending?.answerReceived) ids.add(sessionId);
 	}
@@ -163,11 +163,11 @@ function clearAskTimer(sessionId: string): void {
 	sessionKernel(sessionId).cancelTimer("ask_escalation");
 }
 
-function retirePendingAsk(sessionId: string, questionId: string): void {
+async function retirePendingAsk(sessionId: string, questionId: string): Promise<void> {
 	clearAskTimer(sessionId);
 	const ask = pendingAsks.get(sessionId);
 	if (ask?.questionId === questionId) {
-		pendingAsks.delete(sessionId);
+		await pendingAsks.delete(sessionId);
 		persistPendingAsks(ask.storePath);
 	}
 }
@@ -198,18 +198,18 @@ function fallbackAnswerContext(
  * adopted engine re-emits its ask, makeAskHandler replaces this resolver with
  * the live one. An answer that wins that race still follows the ordinary
  * steer/queue path instead of disappearing. */
-function resolveRestoredAsk(
+async function resolveRestoredAsk(
 	sessionId: string,
 	questionId: string,
 	questions: AskQuestionInput[],
 	answers: Record<string, string> | null,
-): void {
+): Promise<void> {
 	const ask = pendingAsks.get(sessionId);
 	if (ask?.questionId !== questionId || ask.answerReceived) return;
 	clearAskTimer(sessionId);
 	ask.answerReceived = true;
 	ask.earlyAnswer = answers;
-	pendingAsks.set(sessionId, ask);
+	await pendingAsks.set(sessionId, ask);
 	if (ask.escalatedAskId) cancelAsk(ask.escalatedAskId);
 	persistPendingAsks(ask.storePath);
 	broadcastToSession(sessionId, {
@@ -222,16 +222,16 @@ function resolveRestoredAsk(
 	// promise instead of turning the answer into an unrelated user prompt.
 }
 
-export function settleRestoredAskAfterRecovery(sessionId: string): boolean {
+export async function settleRestoredAskAfterRecovery(sessionId: string): Promise<boolean> {
 	const ask = pendingAsks.get(sessionId);
 	if (!ask) return false;
 	if (!ask.restored) {
-		if (ask.answerReceived) retirePendingAsk(sessionId, ask.questionId);
+		if (ask.answerReceived) await retirePendingAsk(sessionId, ask.questionId);
 		return false;
 	}
 	const answers = ask.answerReceived ? (ask.earlyAnswer ?? null) : null;
 	if (!answers) {
-		retirePendingAsk(sessionId, ask.questionId);
+		await retirePendingAsk(sessionId, ask.questionId);
 		if (ask.escalatedAskId) cancelAsk(ask.escalatedAskId);
 		broadcastToSession(sessionId, {
 			type: "ask_resolved",
@@ -257,12 +257,12 @@ export function settleRestoredAskAfterRecovery(sessionId: string): boolean {
 				deliveryId: `restored-ask-answer:${ask.questionId}`,
 			},
 		)
-		.then((result) => {
+		.then(async (result) => {
 			if (result.status === "error") return;
 			// The continuation is now durably admitted under its stable id. Only
 			// now may the answered card and recovery intent be retired.
 			recordAskAnswer(sessionId, questions, answers);
-			retirePendingAsk(sessionId, ask.questionId);
+			await retirePendingAsk(sessionId, ask.questionId);
 			if (ask.escalatedAskId) cancelAsk(ask.escalatedAskId);
 			broadcastToSession(sessionId, {
 				type: "ask_resolved",
@@ -474,7 +474,7 @@ async function escalatePendingAsk(
 	if (current.escalatedAskId) {
 		if (!current.escalationWaitStarted) {
 			current.escalationWaitStarted = true;
-			pendingAsks.set(sessionId, current);
+			await pendingAsks.set(sessionId, current);
 			waitForEscalatedAnswer(
 				sessionId,
 				questionId,
@@ -502,7 +502,7 @@ async function escalatePendingAsk(
 	latest.escalatedAskId = escalated.askId;
 	latest.escalatedPersonName = escalated.personName;
 	latest.escalationWaitStarted = true;
-	pendingAsks.set(sessionId, latest);
+	await pendingAsks.set(sessionId, latest);
 	persistPendingAsks(latest.storePath);
 	waitForEscalatedAnswer(
 		sessionId,
@@ -559,13 +559,13 @@ function armAskEscalation(
 /** Restore run-blocking cards after a real process restart. The durable entry
  * stays display state only until the adopted engine re-emits the ask and
  * makeAskHandler adopts its original question id and askedAt. */
-export function restorePendingAsks(
+export async function restorePendingAsks(
   options: {
 	storePath?: string;
 	now?: number;
 	sessionExists?: (sessionId: string) => boolean;
   } = {},
-): number {
+): Promise<number> {
 	const storePath = options.storePath ?? pendingAskStorePath();
   const kernelStore = sessionKernelStore();
   const actorAuthority =
@@ -648,7 +648,7 @@ export function restorePendingAsks(
 			...(saved.answer ? { answer: saved.answer } : {}),
 			restored: true,
 			storePath,
-			resolve: (answers) =>
+			resolve: async (answers) =>
 				resolveRestoredAsk(
 					saved.sessionId,
 					saved.questionId,
@@ -656,7 +656,7 @@ export function restorePendingAsks(
 					answers,
 				),
 		};
-		pendingAsks.set(saved.sessionId, ask);
+		await pendingAsks.set(saved.sessionId, ask);
 		if (!ask.answerReceived) {
       armAskEscalation(saved.sessionId, ask, saved.questions, options.now);
 			broadcastToSession(saved.sessionId, {
@@ -692,16 +692,16 @@ export function restorePendingAsks(
  * like an SSO login) without interrupting the run. Answering calls `onAnswer`
  * once; closing retracts the card and never calls it.
  */
-export function offerAskCard(
+export async function offerAskCard(
 	sessionId: string,
 	questions: AskQuestionInput[],
 	onAnswer: (answers: Record<string, string> | null) => void,
-): { close: () => void } {
+): Promise<{ close: () => Promise<void> }> {
 	const questionId = crypto.randomUUID();
 	let settled = false;
-	const retract = () => {
+	const retract = async () => {
 		if (pendingAsks.get(sessionId)?.questionId === questionId) {
-			pendingAsks.delete(sessionId);
+			await pendingAsks.delete(sessionId);
 		}
 		broadcastToSession(sessionId, {
 			type: "ask_resolved",
@@ -709,13 +709,13 @@ export function offerAskCard(
 			questionId,
 		});
 	};
-	pendingAsks.set(sessionId, {
+	await pendingAsks.set(sessionId, {
 		questionId,
 		questions,
-		resolve: (a) => {
+		resolve: async (a) => {
 			if (settled) return;
 			settled = true;
-			retract();
+			await retract();
 			recordAskAnswer(sessionId, questions, a);
 			onAnswer(a);
 		},
@@ -727,10 +727,10 @@ export function offerAskCard(
 		questions,
 	});
 	return {
-		close: () => {
+		close: async () => {
 			if (settled) return;
 			settled = true;
-			retract();
+			await retract();
 		},
 	};
 }
@@ -763,7 +763,7 @@ export function makeAskHandler(sessionId: string) {
 			!!existing.durable &&
 			sameQuestions(existing.questions, questions);
 		if (existing?.restored && !adopted) {
-			retirePendingAsk(sessionId, existing.questionId);
+			await retirePendingAsk(sessionId, existing.questionId);
 			broadcastToSession(sessionId, {
 				type: "ask_resolved",
 				sessionId,
@@ -776,8 +776,8 @@ export function makeAskHandler(sessionId: string) {
 		let escalatedAskId = adopted ? existing!.escalatedAskId || null : null;
 
 		const answers = await new Promise<Record<string, string> | null>(
-			(resolve) => {
-				const finish = (a: Record<string, string> | null) => {
+			async (resolve) => {
+				const finish = async (a: Record<string, string> | null) => {
 					if (settled) return;
 					settled = true;
 					clearAskTimer(sessionId);
@@ -785,7 +785,7 @@ export function makeAskHandler(sessionId: string) {
 					if (durableAnswer?.questionId === questionId) {
 						durableAnswer.answerReceived = true;
 						durableAnswer.earlyAnswer = a;
-						pendingAsks.set(sessionId, durableAnswer);
+						await pendingAsks.set(sessionId, durableAnswer);
 						persistPendingAsks(durableAnswer.storePath);
 					}
 					// Before the card goes: the transcript's only trace of it.
@@ -825,9 +825,9 @@ export function makeAskHandler(sessionId: string) {
 					...(adopted && existing!.storePath
 						? { storePath: existing!.storePath }
 						: {}),
-					resolve: (a) => finish(a),
+					resolve: async (a) => finish(a),
 				};
-				pendingAsks.set(sessionId, ask);
+				await pendingAsks.set(sessionId, ask);
 				persistPendingAsks(ask.storePath);
 				transitionRunState(sessionId, "ask_posed");
 				if (ask.answerReceived) {

--- a/packages/core/opensession-server/src/server/demo/index.ts
+++ b/packages/core/opensession-server/src/server/demo/index.ts
@@ -46,14 +46,14 @@ function offerDemoAsk(state: DemoState): void {
   const sessionId = DEMO_ASK_SESSION_ID;
   const questions = demoAskQuestions() as AskQuestionInput[];
   recordEngineSessionOwner(DEMO_ASK_ENGINE_SESSION_ID, sessionId);
-  offerAskCard(sessionId, questions, (answers) => {
+  offerAskCard(sessionId, questions, async (answers) => {
     try {
       if (answers) {
         // Land the answer in the transcript through the real engine write
         // path (import-first gate pulls the seeded jsonl history in), so the
         // Answer flow visibly completes end-to-end.
         const picked = Object.values(answers).join("; ");
-        appendTranscriptEntries(DEMO_ASK_ENGINE_SESSION_ID, [
+        await appendTranscriptEntries(DEMO_ASK_ENGINE_SESSION_ID, [
           transcriptLineUser(`[Demo viewer] ${picked}`),
           transcriptLineAssistantText(
             `Noted — going with **${picked}**. I'll draft the rollout plan on that basis. (Demo session: the card re-arms in a moment.)`,

--- a/packages/core/opensession-server/src/server/demo/index.ts
+++ b/packages/core/opensession-server/src/server/demo/index.ts
@@ -141,7 +141,7 @@ export async function startDemo(): Promise<void> {
   }
 
   try {
-    startDemoReplayer();
+    await startDemoReplayer();
   } catch (e) {
     console.error("[demo] replayer start failed:", e);
   }

--- a/packages/core/opensession-server/src/server/demo/replay.ts
+++ b/packages/core/opensession-server/src/server/demo/replay.ts
@@ -65,7 +65,7 @@ export async function startDemoReplayer(): Promise<void> {
   // never tries to merge nonexistent history.
   recordEngineSessionOwner(ocId, sessionId);
   if (transcriptStore().needsImport(sessionId)) {
-    transcriptStore().importLegacyTranscript(sessionId, [], "live-only", null);
+    await transcriptStore().importLegacyTranscript(sessionId, [], "live-only", null);
   }
 
   // Busy-mark + FSM: prompt → starting, run_registered → running.
@@ -75,31 +75,31 @@ export async function startDemoReplayer(): Promise<void> {
   const script = demoReplayScript();
   let step = 0;
 
-  const tick = () => {
+  const tick = async () => {
     if (!state.running) return;
     try {
       if (step >= script.length) {
         step = 0;
-        state.timer = setTimeout(tick, LOOP_REST_MS);
+        state.timer = setTimeout(() => void tick(), LOOP_REST_MS);
         return;
       }
       const lines = script[step]();
       if (step === 0) {
         // Loop restart: authoritatively replace (reset:true on the bus) so
         // watchers drop the previous loop instead of merging into it.
-        transcriptStore().replaceTranscriptEvents(
+        await transcriptStore().replaceTranscriptEvents(
           sessionId,
           parseJsonlLines(lines.map((l) => JSON.stringify(l))),
         );
       } else {
-        appendTranscriptEntries(ocId, lines);
+        await appendTranscriptEntries(ocId, lines);
       }
       touchNativeSession(sessionId, {});
       step++;
     } catch (e) {
       console.error("[demo] replay step failed:", e);
     }
-    state.timer = setTimeout(tick, STEP_MS);
+    state.timer = setTimeout(() => void tick(), STEP_MS);
   };
-  tick();
+  void tick();
 }

--- a/packages/core/opensession-server/src/server/demo/replay.ts
+++ b/packages/core/opensession-server/src/server/demo/replay.ts
@@ -50,7 +50,7 @@ interface DemoReplayState {
 
 const g = globalThis as { __osDemoReplay?: DemoReplayState };
 
-export function startDemoReplayer(): void {
+export async function startDemoReplayer(): Promise<void> {
   const state: DemoReplayState = (g.__osDemoReplay ??= {
     timer: null,
     running: false,
@@ -69,8 +69,8 @@ export function startDemoReplayer(): void {
   }
 
   // Busy-mark + FSM: prompt → starting, run_registered → running.
-  markSessionStarting(sessionId);
-  transitionRunState(sessionId, "run_registered", { demo: true });
+  await markSessionStarting(sessionId);
+  await transitionRunState(sessionId, "run_registered", { demo: true });
 
   const script = demoReplayScript();
   let step = 0;

--- a/packages/core/opensession-server/src/server/desk-state.ts
+++ b/packages/core/opensession-server/src/server/desk-state.ts
@@ -26,7 +26,7 @@
  * feature): everything here is work the user themselves started, surfaced only
  * when they summon the Desk.
  */
-import { pendingAskAwaitingAnswer } from "./asks";
+import { pendingAsks } from "./asks";
 import { listAsks as listHumanAsks } from "./human-asks";
 import { findSession, getCachedSessions } from "./session-cache";
 import { getReads, isUnread } from "./reads";
@@ -120,7 +120,7 @@ function isRunningSession(s: UnifiedSession): boolean {
 
 /** Flatten a pending AskUserQuestion payload into one line + its options. */
 function askSummary(sessionId: string): DeskWorkItem["question"] | undefined {
-	const pending = pendingAskAwaitingAnswer(sessionId);
+	const pending = pendingAsks.get(sessionId);
 	if (!pending) return undefined;
 	const questions = (pending.questions || []) as Array<{
 		question?: unknown;

--- a/packages/core/opensession-server/src/server/desk-state.ts
+++ b/packages/core/opensession-server/src/server/desk-state.ts
@@ -26,7 +26,7 @@
  * feature): everything here is work the user themselves started, surfaced only
  * when they summon the Desk.
  */
-import { pendingAsks } from "./asks";
+import { pendingAskAwaitingAnswerSync } from "./asks";
 import { listAsks as listHumanAsks } from "./human-asks";
 import { findSession, getCachedSessions } from "./session-cache";
 import { getReads, isUnread } from "./reads";
@@ -120,7 +120,7 @@ function isRunningSession(s: UnifiedSession): boolean {
 
 /** Flatten a pending AskUserQuestion payload into one line + its options. */
 function askSummary(sessionId: string): DeskWorkItem["question"] | undefined {
-	const pending = pendingAsks.get(sessionId);
+	const pending = pendingAskAwaitingAnswerSync(sessionId);
 	if (!pending) return undefined;
 	const questions = (pending.questions || []) as Array<{
 		question?: unknown;

--- a/packages/core/opensession-server/src/server/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/desk-voice.ts
@@ -506,7 +506,9 @@ export function mirrorVoiceEntries(
 		content: e.text,
 		timestamp: now,
 	}));
-	transcriptStore().appendTranscriptEvents(sessionId, tes);
+	void transcriptStore().appendTranscriptEvents(sessionId, tes).catch((error) => {
+    console.error(`[desk-voice] Failed to mirror voice entries for ${sessionId}:`, error);
+  });
 	appendHandoff(
 		sessionId,
 		entries.map((e) => ({
@@ -525,10 +527,12 @@ export function mirrorVoiceToolCall(
 	result: unknown,
 ): void {
 	const { sessionId } = ensureDeskSession(user);
-	transcriptStore().appendTranscriptEvents(
+	void transcriptStore().appendTranscriptEvents(
 		sessionId,
 		voiceToolTranscriptEntries(callId, name, args, result),
-	);
+	).catch((error) => {
+    console.error(`[desk-voice] Failed to mirror tool call for ${sessionId}:`, error);
+  });
 	appendHandoff(sessionId, [
 		{
 			id: `voice-act-${callId}`,

--- a/packages/core/opensession-server/src/server/file-watcher.ts
+++ b/packages/core/opensession-server/src/server/file-watcher.ts
@@ -29,17 +29,24 @@ const watches: Map<string, WatchState> = ((globalThis as any).__transcriptWatche
 // whose message has landed must clear NOW, not at run end, or it shows as
 // still-queued and a mid-run restart would re-deliver it). On globalThis so
 // hot reloads re-register cleanly; read at call time.
-type AppendListener = (sessionId: string, entries: TranscriptEntry[]) => void;
+type AppendListener = (
+  sessionId: string,
+  entries: TranscriptEntry[],
+) => void | Promise<void>;
 export function setTranscriptAppendListener(fn: AppendListener): void {
   (globalThis as any).__transcriptAppendListener = fn;
 }
 function notifyAppendListener(sessionId: string | undefined, entries: TranscriptEntry[]) {
   if (!sessionId || entries.length === 0) return;
   const fn = (globalThis as any).__transcriptAppendListener as AppendListener | undefined;
+  if (!fn) return;
   try {
-    fn?.(sessionId, entries);
-  } catch {
+    void Promise.resolve(fn(sessionId, entries)).catch((error) => {
+      console.warn("[file-watcher] transcript append listener failed:", error);
+    });
+  } catch (error) {
     // Reconcile is best-effort; never let it break transcript delivery.
+    console.warn("[file-watcher] transcript append listener failed:", error);
   }
 }
 

--- a/packages/core/opensession-server/src/server/file-watcher.ts
+++ b/packages/core/opensession-server/src/server/file-watcher.ts
@@ -96,17 +96,17 @@ function getFileSize(path: string): number {
  * runs the import itself. A feed failure flags the session store-degraded
  * and never breaks legacy delivery.
  */
-function feedTranscriptStore(
+async function feedTranscriptStore(
   sessionId: string | undefined,
   entries: TranscriptEntry[],
   reset = false
-): void {
+): Promise<void> {
   if (!sessionId || (!reset && entries.length === 0)) return;
   try {
     const store = transcriptStore();
     if (!store.hasImported(sessionId)) return;
-    if (reset) store.replaceTranscriptEvents(sessionId, entries);
-    else store.appendTranscriptEvents(sessionId, entries);
+    if (reset) await store.replaceTranscriptEvents(sessionId, entries);
+    else await store.appendTranscriptEvents(sessionId, entries);
   } catch (e) {
     markTranscriptStoreDegraded(sessionId);
     console.warn(`[file-watcher] v2 store feed failed for ${sessionId}:`, e);
@@ -120,7 +120,7 @@ export interface FilePollDeps {
     sessionId: string | undefined,
     entries: TranscriptEntry[],
     reset?: boolean
-  ): void;
+  ): unknown | Promise<void>;
 }
 
 const pollDeps: FilePollDeps = {
@@ -173,7 +173,10 @@ export function pollTranscriptFile(
   if (entries.length === 0 && !reset) return;
 
   deps.notify(state.sessionId, entries);
-  deps.feed(state.sessionId, entries, reset);
+  void Promise.resolve(deps.feed(state.sessionId, entries, reset)).catch((error) => {
+    if (state.sessionId) markTranscriptStoreDegraded(state.sessionId);
+    console.warn(`[file-watcher] v2 store feed failed for ${state.sessionId}:`, error);
+  });
 
   // endOffset + rev = the client's resume cursor: on reconnect it re-watches
   // with sinceOffset/sinceRev and the gap since this exact byte is replayed

--- a/packages/core/opensession-server/src/server/host-client.test.ts
+++ b/packages/core/opensession-server/src/server/host-client.test.ts
@@ -391,10 +391,10 @@ describe("HostHandle model recovery", () => {
 		expect(handle.ended).toBe(true);
 	});
 
-	test("applies proxied transcript frames in the server store", () => {
+	test("applies proxied transcript frames in the server store", async () => {
 		const root = mkdtempSync(join(tmpdir(), "host-client-transcript-test-"));
 		roots.push(root);
-		const store = new TranscriptStore(join(root, "transcripts.db"));
+		const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
 		const previous = __setTranscriptStoreForTest(store);
 		const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
 		const previousKernel = __setSessionKernelStoreForTest(kernelStore);
@@ -412,6 +412,7 @@ describe("HostHandle model recovery", () => {
 				engineSessionId: spec.osSessionId,
 				lines: [transcriptLineUser("hello", "prompt-1")],
 			});
+      await handle.waitForPendingProjections();
 
 			expect(store.readTail(spec.osSessionId, 10).entries).toMatchObject([
 				{ id: "prompt-1", type: "user", content: "hello" },
@@ -424,10 +425,46 @@ describe("HostHandle model recovery", () => {
 		}
 	});
 
-	test("applies transcript frames after the run settled (reattach backfill)", () => {
+  test("serializes consecutive transcript frames through exact actor receipts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "host-client-transcript-order-test-"));
+    roots.push(root);
+    const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
+    const previous = __setTranscriptStoreForTest(store);
+    const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
+    const previousKernel = __setSessionKernelStoreForTest(kernelStore);
+    const spec: RunHostSpec = {
+      hostId: "rh-transcript-order",
+      osSessionId: "os-transcript-order",
+      prompt: "test",
+      cwd: "/tmp",
+    };
+    registerTestRun(spec.osSessionId, spec.hostId);
+    const handle = makeHandle(spec);
+    try {
+      for (const [id, content] of [["prompt-1", "first"], ["prompt-2", "second"]]) {
+        (handle as any).handleMsg({
+          t: "transcript",
+          engineSessionId: spec.osSessionId,
+          lines: [transcriptLineUser(content, id)],
+        });
+      }
+      await handle.waitForPendingProjections();
+      expect(store.readTail(spec.osSessionId, 10).entries).toMatchObject([
+        { id: "prompt-1", content: "first" },
+        { id: "prompt-2", content: "second" },
+      ]);
+    } finally {
+      (handle as any).finish();
+      __setTranscriptStoreForTest(previous);
+      __setSessionKernelStoreForTest(previousKernel);
+      kernelStore.close();
+    }
+  });
+
+	test("applies transcript frames after the run settled (reattach backfill)", async () => {
 		const root = mkdtempSync(join(tmpdir(), "host-client-settled-transcript-test-"));
 		roots.push(root);
-		const store = new TranscriptStore(join(root, "transcripts.db"));
+		const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
 		const previous = __setTranscriptStoreForTest(store);
 		const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
 		const previousKernel = __setSessionKernelStoreForTest(kernelStore);
@@ -449,6 +486,7 @@ describe("HostHandle model recovery", () => {
 				engineSessionId: spec.osSessionId,
 				lines: [transcriptLineUser("late summary", "prompt-late")],
 			});
+      await handle.waitForPendingProjections();
 			expect(store.readTail(spec.osSessionId, 10).entries).toMatchObject([
 				{ id: "prompt-late", type: "user", content: "late summary" },
 			]);
@@ -463,7 +501,7 @@ describe("HostHandle model recovery", () => {
 	test("rejects transcript frames while a different live run owns the session", () => {
 		const root = mkdtempSync(join(tmpdir(), "host-client-superseded-transcript-test-"));
 		roots.push(root);
-		const store = new TranscriptStore(join(root, "transcripts.db"));
+		const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
 		const previous = __setTranscriptStoreForTest(store);
 		const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
 		const previousKernel = __setSessionKernelStoreForTest(kernelStore);
@@ -493,7 +531,7 @@ describe("HostHandle model recovery", () => {
 	test("rejects transcript frames from a stale host generation", () => {
 		const root = mkdtempSync(join(tmpdir(), "host-client-stale-transcript-test-"));
 		roots.push(root);
-		const store = new TranscriptStore(join(root, "transcripts.db"));
+		const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
 		const previous = __setTranscriptStoreForTest(store);
 		const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
 		const previousKernel = __setSessionKernelStoreForTest(kernelStore);
@@ -691,7 +729,7 @@ describe("HostHandle model recovery", () => {
         },
       }),
     };
-    const transcriptStore = new TranscriptStore(join(root, "transcripts.db"));
+    const transcriptStore = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
     const previousTranscript = __setTranscriptStoreForTest(transcriptStore);
     const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
     const previousKernel = __setSessionKernelStoreForTest(kernelStore);
@@ -717,6 +755,7 @@ describe("HostHandle model recovery", () => {
       engineSessionId: spec.osSessionId,
       lines: [transcriptLineUser("after respawn", "prompt-respawn")],
     });
+    await handle.waitForPendingProjections();
     expect(transcriptStore.readTail(spec.osSessionId, 10).entries).toMatchObject([
       { id: "prompt-respawn", content: "after respawn" },
     ]);

--- a/packages/core/opensession-server/src/server/host-client.test.ts
+++ b/packages/core/opensession-server/src/server/host-client.test.ts
@@ -425,6 +425,55 @@ describe("HostHandle model recovery", () => {
 		}
 	});
 
+  test("closes after an end frame that follows a failed transcript projection", async () => {
+    const root = mkdtempSync(join(tmpdir(), "host-client-projection-failure-test-"));
+    roots.push(root);
+    const store = new TranscriptStore(join(root, "transcripts.db"), { actorOwned: true });
+    (store as any).appendTranscriptEvents = async () => {
+      throw new Error("projection rejected");
+    };
+    const previous = __setTranscriptStoreForTest(store);
+    const kernelStore = new SessionKernelStore(join(root, "kernel.db"));
+    const previousKernel = __setSessionKernelStoreForTest(kernelStore);
+    const spec: RunHostSpec = {
+      hostId: "rh-projection-failure",
+      osSessionId: "os-projection-failure",
+      prompt: "test",
+      cwd: "/tmp",
+    };
+    registerTestRun(spec.osSessionId, spec.hostId);
+    const handle = makeHandle(spec);
+    const events = handle.events();
+    try {
+      (handle as any).handleMsg({
+        t: "transcript",
+        engineSessionId: spec.osSessionId,
+        lines: [transcriptLineUser("hello", "prompt-1")],
+      });
+      (handle as any).handleMsg({
+        t: "end",
+        done: { type: "done", result: "finished" },
+      });
+
+      expect((await events.next()).value).toMatchObject({
+        type: "error",
+        content: "Run host projection failed: projection rejected",
+      });
+      expect((await events.next()).value).toMatchObject({
+        type: "done",
+        result: "finished",
+      });
+      expect((await events.next()).done).toBe(true);
+      await expect(handle.waitForPendingProjections()).rejects.toThrow("projection rejected");
+      expect(handle.ended).toBe(true);
+    } finally {
+      (handle as any).finish();
+      __setTranscriptStoreForTest(previous);
+      __setSessionKernelStoreForTest(previousKernel);
+      kernelStore.close();
+    }
+  });
+
   test("serializes consecutive transcript frames through exact actor receipts", async () => {
     const root = mkdtempSync(join(tmpdir(), "host-client-transcript-order-test-"));
     roots.push(root);

--- a/packages/core/opensession-server/src/server/host-client.test.ts
+++ b/packages/core/opensession-server/src/server/host-client.test.ts
@@ -444,12 +444,23 @@ describe("HostHandle model recovery", () => {
     registerTestRun(spec.osSessionId, spec.hostId);
     const handle = makeHandle(spec);
     const events = handle.events();
+    let steerFailures = 0;
+    (handle as any).cb.onSteerFailed = () => steerFailures++;
     try {
       (handle as any).handleMsg({
         t: "transcript",
         engineSessionId: spec.osSessionId,
         lines: [transcriptLineUser("hello", "prompt-1")],
       });
+      await (handle as any).projectionTail;
+      expect((handle as any).projectionTail).toBeUndefined();
+
+      // The failure is permanent even after the active tail has drained.
+      (handle as any).handleMsg({ t: "steer_failed", text: "late frame" });
+      await (handle as any).projectionTail;
+      expect(steerFailures).toBe(0);
+
+      // Terminal cleanup still runs through the permanent failed fence.
       (handle as any).handleMsg({
         t: "end",
         done: { type: "done", result: "finished" },

--- a/packages/core/opensession-server/src/server/host-client.test.ts
+++ b/packages/core/opensession-server/src/server/host-client.test.ts
@@ -198,7 +198,7 @@ describe("local run-host capability", () => {
     expect(localRunHostsSupported("linux", true, () => null)).toBe(false);
   });
 
-  test("keeps a fresh host out of the boot recovery claim", () => {
+  test("keeps a fresh host out of the boot recovery claim", async () => {
     const hostId = `rh-${crypto.randomUUID()}`;
     const osSessionId = `os-${crypto.randomUUID()}`;
     const spec: RunHostSpec = {
@@ -225,7 +225,7 @@ describe("local run-host capability", () => {
 
     try {
       expect(hostRunBusy(hostId)).toBe(true);
-      expect(takeInterruptedRuns()).toEqual([]);
+      expect(await takeInterruptedRuns()).toEqual([]);
     } finally {
       handle.abandon();
       __setActiveRunsPathForTest(previousJournal);

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -1054,10 +1054,14 @@ export class HostHandle {
     return false;
   }
 
-  private enqueueProjectionFrame(operation: () => void | Promise<void>): void {
+  private enqueueProjectionFrame(
+    operation: () => void | Promise<void>,
+    runAfterFailure = false,
+  ): void {
     const prior = this.projectionTail ?? Promise.resolve();
     const current = prior.then(async () => {
-      if (this.projectionFailure) throw this.projectionFailure;
+      if (this.projectionFailure && !runAfterFailure)
+        throw this.projectionFailure;
       await operation();
     });
     const observed = current.catch((error) => {
@@ -1083,7 +1087,9 @@ export class HostHandle {
 
   private handleMsg(msg: HostToClientMsg): void {
     if (msg.t !== "transcript" && this.projectionTail) {
-      this.enqueueProjectionFrame(() => this.handleMsgNow(msg));
+      // End is cleanup, not another projection. It must close the stream even
+      // when the transcript projection ahead of it failed.
+      this.enqueueProjectionFrame(() => this.handleMsgNow(msg), msg.t === "end");
       return;
     }
     this.handleMsgNow(msg);

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -52,7 +52,7 @@ import {
   type ImageInput,
 } from "./run-events";
 import type { TranscriptEntry } from "./types";
-import { applyForwardedTranscript } from "./transcript-persistence";
+import { applyForwardedTranscriptStrict } from "./transcript-persistence";
 import { sameProcess } from "./process-identity";
 import type { GitIdentity } from "./shared/user-mappings";
 import { modelSupportsSteer, providerFor } from "./models";
@@ -802,6 +802,8 @@ export class HostHandle {
   >();
   private respawns = 0;
   private stopRequested = false;
+  private projectionTail: Promise<void> | undefined;
+  private projectionFailure: unknown;
   private readonly ctl: HostRunControl;
   private onHostChanged?: (hostId: string) => void | Promise<void>;
   engineSessionId?: string;
@@ -1052,7 +1054,42 @@ export class HostHandle {
     return false;
   }
 
+  private enqueueProjectionFrame(operation: () => void | Promise<void>): void {
+    const prior = this.projectionTail ?? Promise.resolve();
+    const current = prior.then(async () => {
+      if (this.projectionFailure) throw this.projectionFailure;
+      await operation();
+    });
+    const observed = current.catch((error) => {
+      if (!this.projectionFailure) {
+        this.projectionFailure = error;
+        this.queue.push({
+          type: "error",
+          content: `Run host projection failed: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    });
+    this.projectionTail = observed;
+    void observed.finally(() => {
+      if (this.projectionTail === observed) this.projectionTail = undefined;
+    });
+  }
+
+  /** Completion fence for transcript frames and every later host frame. */
+  async waitForPendingProjections(): Promise<void> {
+    await this.projectionTail;
+    if (this.projectionFailure) throw this.projectionFailure;
+  }
+
   private handleMsg(msg: HostToClientMsg): void {
+    if (msg.t !== "transcript" && this.projectionTail) {
+      this.enqueueProjectionFrame(() => this.handleMsgNow(msg));
+      return;
+    }
+    this.handleMsgNow(msg);
+  }
+
+  private handleMsgNow(msg: HostToClientMsg): void {
     switch (msg.t) {
       case "hello": {
         if (!this.acceptsSideEffectFrame("hello")) break;
@@ -1120,7 +1157,13 @@ export class HostHandle {
         // Transcript frames bypass the StreamEvent queue, so fence them here
         // against the same run generation as ordinary host events.
         if (!this.acceptsSideEffectFrame("transcript")) break;
-        applyForwardedTranscript(this.spec.osSessionId, msg.engineSessionId, msg.lines);
+        this.enqueueProjectionFrame(() =>
+          applyForwardedTranscriptStrict(
+            this.spec.osSessionId,
+            msg.engineSessionId,
+            msg.lines,
+          )
+        );
         break;
       case "steer_failed":
         if (this.acceptsSideEffectFrame("steer_failed"))

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -478,7 +478,7 @@ async function spawnHostRun(
   try {
     // Persist before launch. If opensession restarts between systemd-run and
     // socket attachment, the boot sweep can still find the surviving host.
-    journalSet(hostedRunRecord(spec));
+    await journalSet(hostedRunRecord(spec));
     try {
       await launchHostUnit(hostId, dir);
     } catch (error) {
@@ -1512,7 +1512,7 @@ export async function resumeLocalHostRun(
     if (recovery.kind === "uncertain") return "uncertain";
     if (recovery.kind === "resume") {
       run.claudeSessionId = recovery.engineSessionId;
-      journalSet({ ...run, claimedAt: undefined });
+      await journalSet({ ...run, claimedAt: undefined });
     }
     return null;
   }
@@ -1546,7 +1546,7 @@ export async function resumeLocalHostRun(
     if (recovery.kind === "uncertain") return "uncertain";
     if (recovery.kind === "resume") {
       run.claudeSessionId = recovery.engineSessionId;
-      journalSet({ ...run, claimedAt: undefined });
+      await journalSet({ ...run, claimedAt: undefined });
     }
     return null;
   }
@@ -1584,7 +1584,7 @@ export async function resumeLocalHostRun(
     if (recovery.kind === "uncertain") return "uncertain";
     if (recovery.kind === "resume") {
       run.claudeSessionId = recovery.engineSessionId;
-      journalSet({ ...run, claimedAt: undefined });
+      await journalSet({ ...run, claimedAt: undefined });
     }
     return null;
   }
@@ -1606,7 +1606,7 @@ export async function resumeLocalHostRun(
           if (shouldPersistModelSwitch(event)) run.selectedModel = event.toModel;
           changed = true;
         }
-        if (changed) journalSet({ ...run, claimedAt: undefined });
+        if (changed) await journalSet({ ...run, claimedAt: undefined });
         yield event;
       }
     } finally {

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -1086,9 +1086,14 @@ export class HostHandle {
   }
 
   private handleMsg(msg: HostToClientMsg): void {
-    if (msg.t !== "transcript" && this.projectionTail) {
+    if (
+      msg.t !== "transcript" &&
+      (this.projectionTail || this.projectionFailure)
+    ) {
       // End is cleanup, not another projection. It must close the stream even
-      // when the transcript projection ahead of it failed.
+      // when the transcript projection ahead of it failed. Every other frame
+      // remains fenced after the failed tail settles: projectionFailure is a
+      // permanent authority failure for this handle, not just queue state.
       this.enqueueProjectionFrame(() => this.handleMsgNow(msg), msg.t === "end");
       return;
     }

--- a/packages/core/opensession-server/src/server/human-asks.ts
+++ b/packages/core/opensession-server/src/server/human-asks.ts
@@ -149,8 +149,8 @@ function isTerminal(a: HumanAsk): boolean {
  * async — a late teammate reply then still steers into the (resumed) session
  * instead of vanishing. Re-arm timers for scheduled { atIso } deliveries.
  */
-function enqueueAskDelivery(a: HumanAsk, skipUi = false): void {
-  sessionKernel(a.sessionId).enqueueEffect(
+async function enqueueAskDelivery(a: HumanAsk, skipUi = false): Promise<void> {
+  await sessionKernel(a.sessionId).enqueueEffect(
     "human_ask_deliver",
     { askId: a.id, skipUi },
     `${a.id}:${skipUi || !a.uiFirst ? "slack" : "ui"}`,
@@ -360,7 +360,7 @@ function offerAskInUi(a: HumanAsk, windowMs: number): void {
     try {
       const { offerAskCard } = await import("./asks");
       if (asks.get(a.id)?.state !== "scheduled" || uiOffers.get(a.id) !== entry) return;
-      const card = offerAskCard(
+      const card = await offerAskCard(
         a.sessionId,
         [
           {
@@ -379,10 +379,10 @@ function offerAskInUi(a: HumanAsk, windowMs: number): void {
         },
       );
       if (uiOffers.get(a.id) !== entry) {
-        card.close(); // resolved while the card was being built
+        await card.close(); // resolved while the card was being built
         return;
       }
-      entry.close = card.close;
+      entry.close = () => { card.close().catch((error) => console.error(`[human-asks] UI offer close failed for ${a.id}:`, error)); };
     } catch (e) {
       console.error(`[human-asks] UI offer failed for ${a.id}:`, e);
     }

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -1658,7 +1658,7 @@ async function* runPiAttempt(
     );
     walk.promptEntryId ??= String(userLine.uuid);
     if (journal?.osSessionId) {
-      journalSet(
+      await journalSet(
         buildRunJournalRecord(opts, {
           runKey,
           osSessionId: journal.osSessionId,
@@ -2434,7 +2434,7 @@ async function* runPiAttempt(
     // Journal upgrade: the record now carries the engine id (still no
     // serverKey — boot must take the continuation re-prompt path).
     if (journal?.osSessionId) {
-      journalSet(
+      await journalSet(
         buildRunJournalRecord(opts, {
           runKey,
           osSessionId: journal.osSessionId,

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -722,7 +722,9 @@ function piAppend(engineSessionId: string, lines: Record<string, unknown>[]): vo
     forward(engineSessionId, lines);
     return;
   }
-  appendTranscriptEntries(engineSessionId, lines);
+  void appendTranscriptEntries(engineSessionId, lines).catch((error) => {
+    console.error(`[pi] Transcript append failed for ${engineSessionId}:`, error);
+  });
 }
 
 /** Store one batch of normalized entries under the pi session id. Requires

--- a/packages/core/opensession-server/src/server/plain-archive.ts
+++ b/packages/core/opensession-server/src/server/plain-archive.ts
@@ -35,11 +35,11 @@ function activePlainSessions(): Array<{ path: string; data: NativeSessionFile }>
  * "My sessions". No-op for non-opensession sessions (no session file). Returns true
  * if a flag was cleared.
  */
-export function clearSessionFileArchive(id: string): boolean {
+export async function clearSessionFileArchive(id: string): Promise<boolean> {
   const path = `${SESSIONS_DIR}/${id}.json`;
   if (!existsSync(path)) return false;
   try {
-    return executeSessionProjection(id, "plain_archive_clear", () => {
+    return await executeSessionProjection(id, "plain_archive_clear", () => {
       const data = JSON.parse(readFileSync(path, "utf-8")) as NativeSessionFile;
       if (!data.archived && !data.archivedAt) return false;
       const { archived, archivedAt, archivedReason, ...rest } = data;
@@ -52,11 +52,11 @@ export function clearSessionFileArchive(id: string): boolean {
 }
 
 /** Mark every session tied to this thread as archived. Returns count. */
-export function archiveSessionsForThread(threadId: string): number {
+export async function archiveSessionsForThread(threadId: string): Promise<number> {
   let archived = 0;
   for (const { path, data } of activePlainSessions()) {
     if (data.plainThreadId !== threadId) continue;
-    executeSessionProjection(data.id, "plain_archive_set", () =>
+    await executeSessionProjection(data.id, "plain_archive_set", () =>
       writeJsonAtomic(path, {
         ...data,
         archived: true,
@@ -104,7 +104,7 @@ export function startPlainArchiveSweep(onChange?: () => void): void {
     let archived = 0;
     for (const threadId of threadIds) {
       const status = await fetchThreadStatus(threadId);
-      if (status === "DONE") archived += archiveSessionsForThread(threadId);
+      if (status === "DONE") archived += await archiveSessionsForThread(threadId);
     }
     if (archived > 0) {
       console.log(`[plain-archive] Archived ${archived} session(s) for done tickets`);

--- a/packages/core/opensession-server/src/server/queue-state-restart.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-restart.test.ts
@@ -22,10 +22,10 @@ import { sessionWatchers } from "./ws-hub";
 const SESSION = "os-steer-restart-test";
 let scratch = "";
 
-afterEach(() => {
-	promptQueues.clear();
-	promptDispatches.clear();
-	steeredReceipts.clear();
+afterEach(async () => {
+	await promptQueues.clear();
+	await promptDispatches.clear();
+	await steeredReceipts.clear();
 	sessionWatchers.delete(SESSION);
 	if (scratch) rmSync(scratch, { recursive: true, force: true });
 	scratch = "";
@@ -49,7 +49,7 @@ describe("steer receipt restart persistence", () => {
 			}),
 		);
 
-		expect(hydratePersistedQueueState(storePath)).toBe(3);
+		expect(await hydratePersistedQueueState(storePath)).toBe(3);
 		expect(promptQueues.get(SESSION)?.map((item) => item.id)).toEqual(["queued"]);
 		expect(steeredReceipts.get(SESSION)?.map((item) => item.id)).toEqual([
 			"steered",
@@ -58,7 +58,7 @@ describe("steer receipt restart persistence", () => {
 
 		const queue = promptQueues.get(SESSION) || [];
 		queue.push({ id: "new", content: "after boot" });
-		promptQueues.set(SESSION, queue);
+		await promptQueues.set(SESSION, queue);
 		persistQueues(storePath);
 		const persisted = JSON.parse(await Bun.file(storePath).text());
 		expect(persisted.queued[SESSION].map((item: { id: string }) => item.id)).toEqual([
@@ -69,7 +69,7 @@ describe("steer receipt restart persistence", () => {
 		expect(persisted.dispatching[SESSION].promptEntryId).toBe("prompt-entry");
 	});
 
-	test("restores undelivered receipts without turning them into queued prompts", () => {
+	test("restores undelivered receipts without turning them into queued prompts", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-steer-restart-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -96,7 +96,7 @@ describe("steer receipt restart persistence", () => {
 			]),
 		);
 
-		const restored = restorePersistedQueueState({
+		const restored = await restorePersistedQueueState({
 			storePath,
 			sessionExists: (id) => id === SESSION,
 			journalOwnsPrompt: () => false,
@@ -120,7 +120,7 @@ describe("steer receipt restart persistence", () => {
 			steered: [{ id: "pending" }],
 		});
 
-		expect(requeueSteerReceipts(SESSION, [], false)).toBe(1);
+		expect(await requeueSteerReceipts(SESSION, [], false)).toBe(1);
 		expect(promptQueues.get(SESSION)?.map((item) => item.id)).toEqual([
 			"pending",
 			"queued",
@@ -128,7 +128,7 @@ describe("steer receipt restart persistence", () => {
 		expect(steeredReceipts.has(SESSION)).toBe(false);
 	});
 
-	test("requeues a receipt when no recovered run owns its delivery", () => {
+	test("requeues a receipt when no recovered run owns its delivery", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-steer-orphan-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -140,7 +140,7 @@ describe("steer receipt restart persistence", () => {
 			}),
 		);
 
-		const restored = restorePersistedQueueState({
+		const restored = await restorePersistedQueueState({
 			storePath,
 			sessionExists: () => true,
 			journalOwnsPrompt: () => false,
@@ -158,7 +158,7 @@ describe("steer receipt restart persistence", () => {
 		expect(steeredReceipts.has(SESSION)).toBe(false);
 	});
 
-	test("an ordinary multi-item dispatch keeps its identity after a crash", () => {
+	test("an ordinary multi-item dispatch keeps its identity after a crash", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-ordinary-dispatch-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -175,7 +175,7 @@ describe("steer receipt restart persistence", () => {
 				},
 			}),
 		);
-		const restored = restorePersistedQueueState({
+		const restored = await restorePersistedQueueState({
 			storePath,
 			sessionExists: () => true,
 			journalOwnsPrompt: () => false,
@@ -186,18 +186,18 @@ describe("steer receipt restart persistence", () => {
 		expect(restored.queuedCount).toBe(2);
 		expect(promptQueues.get(SESSION)?.[0]?.promptEntryId).toBe("ordinary-entry");
 		expect(promptDispatches.has(SESSION)).toBe(false);
-		expect(deleteQueuedPrompt(SESSION, "ordinary-one", undefined, false)).toBe(
+		expect(await deleteQueuedPrompt(SESSION, "ordinary-one", undefined, false)).toBe(
 			true,
 		);
-		const interruptId = preparePromptInterrupt(
+		const interruptId = await preparePromptInterrupt(
 			SESSION,
 			"ordinary-two",
 			SESSION,
 			"ordinary-two",
 		);
-		settlePromptInterrupt(SESSION, interruptId, "confirmed");
+		await settlePromptInterrupt(SESSION, interruptId, "confirmed");
 		expect(
-			beginNextPromptDispatch(SESSION, {}, false),
+			await beginNextPromptDispatch(SESSION, {}, false),
 		).toMatchObject({
 			kind: "deliver",
 			promptEntryId: "ordinary-entry",
@@ -207,26 +207,26 @@ describe("steer receipt restart persistence", () => {
 		});
 	});
 
-	test("production boot restores an unjournaled interrupt with its dispatch", () => {
+	test("production boot restores an unjournaled interrupt with its dispatch", async () => {
 		sessionKernelStore().markDeliveryMigrationComplete();
-		promptQueues.set(SESSION, [
+		await promptQueues.set(SESSION, [
 			{ id: "interrupt", content: "send now", hold: true },
 		]);
-		promptQueues.set(`${SESSION}-unrelated`, [
+		await promptQueues.set(`${SESSION}-unrelated`, [
 			{ id: "unrelated", content: "must never be globally cleared" },
 		]);
-		const interruptId = preparePromptInterrupt(
+		const interruptId = await preparePromptInterrupt(
 			SESSION,
 			"interrupt",
 			SESSION,
 			"interrupt",
 		);
-		settlePromptInterrupt(SESSION, interruptId, "confirmed");
+		await settlePromptInterrupt(SESSION, interruptId, "confirmed");
 		expect(
-			beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
+			await beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
 		).toMatchObject({ kind: "deliver", interrupted: true });
 
-		const restored = restorePersistedQueueState({
+		const restored = await restorePersistedQueueState({
 			sessionExists: () => true,
 			journalOwnsPrompt: () => false,
 			runOwnsSteers: () => false,
@@ -238,7 +238,7 @@ describe("steer receipt restart persistence", () => {
 			{ id: "unrelated" },
 		]);
 		expect(
-			beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
+			await beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
 		).toMatchObject({
 			kind: "deliver",
 			interrupted: true,
@@ -246,7 +246,7 @@ describe("steer receipt restart persistence", () => {
 		});
 	});
 
-	test("a cold restart preserves an actor-owned create dispatch even after journaling", () => {
+	test("a cold restart preserves an actor-owned create dispatch even after journaling", async () => {
 		scratch = mkdtempSync(join(tmpdir(), "os-create-dispatch-adopt-"));
 		const storePath = join(scratch, "prompt-queues.json");
 		writeFileSync(
@@ -261,7 +261,7 @@ describe("steer receipt restart persistence", () => {
 				},
 			}),
 		);
-		const restored = restorePersistedQueueState({
+		const restored = await restorePersistedQueueState({
 			storePath,
 			sessionExists: () => true,
 			journalOwnsPrompt: () => true,
@@ -279,7 +279,7 @@ describe("steer receipt restart persistence", () => {
 		});
 	});
 
-	test("matches duplicate and substring receipts one-for-one", () => {
+	test("matches duplicate and substring receipts one-for-one", async () => {
 		const receipts = [
 			{ id: "first", content: "same", user: "Kent" },
 			{ id: "second", content: "same", user: "Kent" },

--- a/packages/core/opensession-server/src/server/queue-state-steer-failed.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-steer-failed.test.ts
@@ -9,16 +9,16 @@ import { steeredReceipts, takeSteerReceiptForText } from "./queue-state";
 
 const SESSION = "bks-steer-failed-test";
 
-afterEach(() => {
-	steeredReceipts.clear();
+afterEach(async () => {
+	await steeredReceipts.clear();
 });
 
-test("takes back the receipt a bounced steer echoes, keeping content raw", () => {
-	steeredReceipts.set(SESSION, [
+test("takes back the receipt a bounced steer echoes, keeping content raw", async () => {
+	await steeredReceipts.set(SESSION, [
 		{ id: "r1", content: "we also have webhooks so maybe similar?", user: "Michiel" },
 	]);
 	// What the host echoes is the attributed string steerQueuedPrompt composed.
-	const item = takeSteerReceiptForText(
+	const item = await takeSteerReceiptForText(
 		SESSION,
 		"[Michiel] we also have webhooks so maybe similar?",
 		false,
@@ -31,33 +31,33 @@ test("takes back the receipt a bounced steer echoes, keeping content raw", () =>
 	expect(steeredReceipts.has(SESSION)).toBe(false);
 });
 
-test("matches an unattributed steer by its raw text", () => {
-	steeredReceipts.set(SESSION, [{ id: "r1", content: "no attribution here" }]);
-	expect(takeSteerReceiptForText(SESSION, "no attribution here", false)?.id).toBe(
+test("matches an unattributed steer by its raw text", async () => {
+	await steeredReceipts.set(SESSION, [{ id: "r1", content: "no attribution here" }]);
+	expect((await takeSteerReceiptForText(SESSION, "no attribution here", false))?.id).toBe(
 		"r1",
 	);
 	expect(steeredReceipts.has(SESSION)).toBe(false);
 });
 
-test("leaves unrelated receipts in place", () => {
-	steeredReceipts.set(SESSION, [{ id: "r1", content: "first", user: "Michiel" }]);
+test("leaves unrelated receipts in place", async () => {
+	await steeredReceipts.set(SESSION, [{ id: "r1", content: "first", user: "Michiel" }]);
 	expect(
-		takeSteerReceiptForText(SESSION, "[Michiel] second", false),
+		await takeSteerReceiptForText(SESSION, "[Michiel] second", false),
 	).toBeUndefined();
 	expect(steeredReceipts.get(SESSION)?.map((i) => i.id)).toEqual(["r1"]);
 });
 
-test("retires exactly one of two identical steers", () => {
-	steeredReceipts.set(SESSION, [
+test("retires exactly one of two identical steers", async () => {
+	await steeredReceipts.set(SESSION, [
 		{ id: "r1", content: "same message", user: "Michiel" },
 		{ id: "r2", content: "same message", user: "Michiel" },
 	]);
-	expect(takeSteerReceiptForText(SESSION, "[Michiel] same message", false)?.id).toBe(
+	expect((await takeSteerReceiptForText(SESSION, "[Michiel] same message", false))?.id).toBe(
 		"r1",
 	);
 	expect(steeredReceipts.get(SESSION)?.map((i) => i.id)).toEqual(["r2"]);
 });
 
-test("reports nothing for a session with no receipts", () => {
-	expect(takeSteerReceiptForText(SESSION, "anything", false)).toBeUndefined();
+test("reports nothing for a session with no receipts", async () => {
+	expect(await takeSteerReceiptForText(SESSION, "anything", false)).toBeUndefined();
 });

--- a/packages/core/opensession-server/src/server/queue-state-update.test.ts
+++ b/packages/core/opensession-server/src/server/queue-state-update.test.ts
@@ -25,9 +25,9 @@ import { agentActor, workerActor } from "./session-actors";
 const SESSION = "os-queue-state-update-test";
 const PNG = "data:image/png;base64,iVBORw0KGgo=";
 describe("takeQueuedPrompt", () => {
-	beforeEach(() => {
-		promptDispatches.clear();
-		promptQueues.set(SESSION, [
+	beforeEach(async () => {
+		await promptDispatches.clear();
+		await promptQueues.set(SESSION, [
 			{
 				id: "q1",
 				content: "first",
@@ -39,16 +39,16 @@ describe("takeQueuedPrompt", () => {
 		]);
 	});
 
-	test("selects and claims through the compatibility actor store", () => {
-		const interruptId = preparePromptInterrupt(SESSION, "q2", SESSION, "q2");
-    expect(preparePromptInterrupt(SESSION, "q2", SESSION, "q2")).toBe(
+	test("selects and claims through the compatibility actor store", async () => {
+		const interruptId = await preparePromptInterrupt(SESSION, "q2", SESSION, "q2");
+    expect(await preparePromptInterrupt(SESSION, "q2", SESSION, "q2")).toBe(
       interruptId,
     );
-    expect(() =>
+    await expect(
       preparePromptInterrupt(SESSION, "q2", "another-dispatch", "q2"),
-    ).toThrow("reused with another payload");
-		settlePromptInterrupt(SESSION, interruptId, "confirmed");
-		const claim = beginNextPromptDispatch(
+    ).rejects.toThrow("reused with another payload");
+		await settlePromptInterrupt(SESSION, interruptId, "confirmed");
+		const claim = await beginNextPromptDispatch(
 			SESSION,
 			{ stillWorking: true },
 			false,
@@ -68,12 +68,12 @@ describe("takeQueuedPrompt", () => {
 		]);
 	});
 
-	test("prepares an interrupt from an already-steered receipt", () => {
-		promptQueues.delete(SESSION);
-		steeredReceipts.set(SESSION, [
+	test("prepares an interrupt from an already-steered receipt", async () => {
+		await promptQueues.delete(SESSION);
+		await steeredReceipts.set(SESSION, [
 			{ id: "steered", content: "accepted but unread", hold: true },
 		]);
-		const interruptId = preparePromptInterrupt(
+		const interruptId = await preparePromptInterrupt(
 			SESSION,
 			"steered",
 			SESSION,
@@ -81,9 +81,9 @@ describe("takeQueuedPrompt", () => {
 		);
 		expect(promptQueues.get(SESSION)).toMatchObject([{ id: "steered" }]);
 		expect(steeredReceipts.get(SESSION)).toBeUndefined();
-		settlePromptInterrupt(SESSION, interruptId, "confirmed");
+		await settlePromptInterrupt(SESSION, interruptId, "confirmed");
 		expect(
-			beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
+			await beginNextPromptDispatch(SESSION, { stillWorking: true }, false),
 		).toMatchObject({
 			kind: "deliver",
 			interrupted: true,
@@ -91,8 +91,8 @@ describe("takeQueuedPrompt", () => {
 		});
 	});
 
-	test("keeps a selected prompt durable until the runner acknowledges it", () => {
-		const promptEntryId = beginPromptDispatch(
+	test("keeps a selected prompt durable until the runner acknowledges it", async () => {
+		const promptEntryId = await beginPromptDispatch(
 			SESSION,
 			[{ id: "q1", content: "first", user: "Kent" }],
 			"entry-1",
@@ -104,14 +104,14 @@ describe("takeQueuedPrompt", () => {
 			items: [{ id: "q1", content: "first", user: "Kent" }],
 		});
 
-		acknowledgePromptDispatch(SESSION, "other-entry", false);
+		await acknowledgePromptDispatch(SESSION, "other-entry", false);
 		expect(promptDispatches.has(SESSION)).toBe(true);
-		acknowledgePromptDispatch(SESSION, "entry-1", false);
+		await acknowledgePromptDispatch(SESSION, "entry-1", false);
 		expect(promptDispatches.has(SESSION)).toBe(false);
 	});
 
-	test("atomically removes and returns the complete payload", () => {
-		expect(takeQueuedPrompt(SESSION, "q1", "Kent", false)).toMatchObject({
+	test("atomically removes and returns the complete payload", async () => {
+		expect(await takeQueuedPrompt(SESSION, "q1", "Kent", false)).toMatchObject({
 			id: "q1",
 			content: "first",
 			images: [PNG],
@@ -120,24 +120,24 @@ describe("takeQueuedPrompt", () => {
 		expect(promptQueues.get(SESSION)?.map((item) => item.id)).toEqual(["q2"]);
 	});
 
-	test("only the original sender can take a row", () => {
-		expect(takeQueuedPrompt(SESSION, "q1", "Michiel", false)).toBeUndefined();
+	test("only the original sender can take a row", async () => {
+		expect(await takeQueuedPrompt(SESSION, "q1", "Michiel", false)).toBeUndefined();
 		expect(promptQueues.get(SESSION)?.map((item) => item.id)).toEqual(["q1", "q2"]);
 	});
 
-	test("routed and context-carrying rows remain queue-owned", () => {
-		promptQueues.set(SESSION, [
+	test("routed and context-carrying rows remain queue-owned", async () => {
+		await promptQueues.set(SESSION, [
 			{ id: "q1", content: "Slack", user: "Kent", slackReplyTo: { channel: "C1", threadTs: "1" } },
 			{ id: "q2", content: "Context", user: "Kent", contextSessions: ["os-other"] },
 		]);
-		expect(takeQueuedPrompt(SESSION, "q1", "Kent", false)).toBeUndefined();
-		expect(takeQueuedPrompt(SESSION, "q2", "Kent", false)).toBeUndefined();
+		expect(await takeQueuedPrompt(SESSION, "q1", "Kent", false)).toBeUndefined();
+		expect(await takeQueuedPrompt(SESSION, "q2", "Kent", false)).toBeUndefined();
 	});
 });
 
 describe("automated turns are not user messages", () => {
-	test("keeps review work queued without exposing it to clients", () => {
-		promptQueues.set(SESSION, [
+	test("keeps review work queued without exposing it to clients", async () => {
+		await promptQueues.set(SESSION, [
 			{ id: "human", content: "Please fix this", user: "Kent" },
 			{
 				id: "review",
@@ -147,7 +147,7 @@ describe("automated turns are not user messages", () => {
 			},
 		]);
 
-		expect(queueDisplayState(SESSION).queued.map((item) => item.id)).toEqual([
+		expect((await queueDisplayState(SESSION)).queued.map((item) => item.id)).toEqual([
 			"human",
 		]);
 		expect(clientVisibleQueuedCount(SESSION)).toBe(1);
@@ -158,36 +158,36 @@ describe("automated turns are not user messages", () => {
 		]);
 	});
 
-	test("hides context-only system steers even without an auto-continue sender", () => {
+	test("hides context-only system steers even without an auto-continue sender", async () => {
 		const backgroundWait = {
 			id: "background-wait",
 			content:
 				'<opensession:context source="background-wait">Continue after the timer.</opensession:context>',
 		};
-		promptQueues.set(SESSION, [backgroundWait]);
-		steeredReceipts.set(SESSION, [backgroundWait]);
+		await promptQueues.set(SESSION, [backgroundWait]);
+		await steeredReceipts.set(SESSION, [backgroundWait]);
 
 		expect(clientVisibleQueuedCount(SESSION)).toBe(0);
-		expect(queueDisplayState(SESSION)).toEqual({ queued: [], steered: [] });
+		expect(await queueDisplayState(SESSION)).toEqual({ queued: [], steered: [] });
 		// Presentation filtering must not remove the runner-owned delivery.
 		expect(promptQueues.get(SESSION)).toEqual([backgroundWait]);
 		expect(steeredReceipts.get(SESSION)).toEqual([backgroundWait]);
 	});
 
-	test("keeps auto-continues queued without exposing them to clients", () => {
+	test("keeps auto-continues queued without exposing them to clients", async () => {
 		const autoContinue = {
 			id: "auto-continue",
 			content: "<opensession:context>Continue working.</opensession:context>",
 			user: AUTO_CONTINUE_USER,
 		};
-		promptQueues.set(SESSION, [
+		await promptQueues.set(SESSION, [
 			{ id: "human", content: "Please continue", user: "Kent" },
 			autoContinue,
 		]);
-		steeredReceipts.set(SESSION, [autoContinue]);
+		await steeredReceipts.set(SESSION, [autoContinue]);
 
 		expect(clientVisibleQueuedCount(SESSION)).toBe(1);
-		expect(queueDisplayState(SESSION)).toEqual({
+		expect(await queueDisplayState(SESSION)).toEqual({
 			queued: [
 			{
 				id: "human",
@@ -208,8 +208,8 @@ describe("automated turns are not user messages", () => {
 });
 
 describe("steer delivery acknowledgement", () => {
-	test("retires the exact receipt even when its context is absent from the transcript", () => {
-		steeredReceipts.set(SESSION, [
+	test("retires the exact receipt even when its context is absent from the transcript", async () => {
+		await steeredReceipts.set(SESSION, [
 			{
 				id: "hidden",
 				content:
@@ -218,24 +218,24 @@ describe("steer delivery acknowledgement", () => {
 			{ id: "human", content: "Keep this receipt", user: "Kent" },
 		]);
 
-		expect(acknowledgeSteerDelivery(SESSION, "hidden", false)).toBe(true);
+		expect(await acknowledgeSteerDelivery(SESSION, "hidden", false)).toBe(true);
 		expect(steeredReceipts.get(SESSION)?.map((item) => item.id)).toEqual([
 			"human",
 		]);
-		expect(acknowledgeSteerDelivery(SESSION, "missing", false)).toBe(false);
+		expect(await acknowledgeSteerDelivery(SESSION, "missing", false)).toBe(false);
 	});
 });
 
 describe("takeSteeredPrompt", () => {
-	beforeEach(() => {
-		steeredReceipts.set(SESSION, [
+	beforeEach(async () => {
+		await steeredReceipts.set(SESSION, [
 			{ id: "s1", content: "first", user: "Kent", images: [PNG] },
 			{ id: "s2", content: "same", user: "Kent" },
 		]);
 	});
 
-	test("removes one exact pending steer with its complete payload", () => {
-		expect(takeSteeredPrompt(SESSION, "s1", "Kent", false)).toMatchObject({
+	test("removes one exact pending steer with its complete payload", async () => {
+		expect(await takeSteeredPrompt(SESSION, "s1", "Kent", false)).toMatchObject({
 			id: "s1",
 			content: "first",
 			images: [PNG],
@@ -243,8 +243,8 @@ describe("takeSteeredPrompt", () => {
 		expect(steeredReceipts.get(SESSION)?.map((item) => item.id)).toEqual(["s2"]);
 	});
 
-	test("only the original sender can take a steer", () => {
-		expect(takeSteeredPrompt(SESSION, "s1", "Michiel", false)).toBeUndefined();
+	test("only the original sender can take a steer", async () => {
+		expect(await takeSteeredPrompt(SESSION, "s1", "Michiel", false)).toBeUndefined();
 		expect(steeredReceipts.get(SESSION)?.map((item) => item.id)).toEqual(["s1", "s2"]);
 	});
 });
@@ -252,7 +252,7 @@ describe("takeSteeredPrompt", () => {
 describe("delegated messages are not user messages", () => {
 	const WORKER = "os-019fe194-5fbe-7000-a81e-d0a656ad77f4";
 
-	test("a worker's report to its parent is queue-owned, not editable", () => {
+	test("a worker's report to its parent is queue-owned, not editable", async () => {
 		// It rides the same queue as human sends because it drives the parent's
 		// next turn, but nobody typed it — so it gets none of the composer's
 		// gestures, and no teammate can pull it back into their draft.
@@ -261,13 +261,13 @@ describe("delegated messages are not user messages", () => {
 		expect(isEditableQueueItem(report)).toBe(false);
 	});
 
-	test("a person's message stays editable", () => {
+	test("a person's message stays editable", async () => {
 		const mine = { id: "q1", content: "ship it", user: "Kent" };
 		expect(isWorkerQueueItem(mine)).toBe(false);
 		expect(isEditableQueueItem(mine)).toBe(true);
 	});
 
-	test("a workflow result never enters the client message surface", () => {
+	test("a workflow result never enters the client message surface", async () => {
 		const workflowSession = `${SESSION}-workflow`;
 		const result = {
 			id: "workflow:wf-1:done",
@@ -278,21 +278,21 @@ describe("delegated messages are not user messages", () => {
 		expect(isWorkflowQueueItem(result)).toBe(true);
 		expect(isEditableQueueItem(result)).toBe(false);
 
-		promptQueues.set(workflowSession, [result]);
-		steeredReceipts.set(workflowSession, [result]);
+		await promptQueues.set(workflowSession, [result]);
+		await steeredReceipts.set(workflowSession, [result]);
 		expect(clientVisibleQueuedCount(workflowSession)).toBe(0);
-		expect(queueDisplayState(workflowSession)).toEqual({
+		expect(await queueDisplayState(workflowSession)).toEqual({
 			queued: [],
 			steered: [],
 		});
 		// Filtering is presentation-only: delivery still owns the nudge.
 		expect(promptQueues.get(workflowSession)).toEqual([result]);
 		expect(steeredReceipts.get(workflowSession)).toEqual([result]);
-		promptQueues.delete(workflowSession);
-		steeredReceipts.delete(workflowSession);
+		await promptQueues.delete(workflowSession);
+		await steeredReceipts.delete(workflowSession);
 	});
 
-	test("a peer agent message is delegated but not a worker report", () => {
+	test("a peer agent message is delegated but not a worker report", async () => {
 		const message = { content: "ping", user: agentActor(WORKER) };
 		expect(isDelegatedQueueItem(message)).toBe(true);
 		expect(isWorkerQueueItem(message)).toBe(false);
@@ -300,7 +300,7 @@ describe("delegated messages are not user messages", () => {
 		expect(isWorkerQueueItem({ content: "worker looks stuck", user: "Kent" })).toBe(false);
 	});
 
-	test("the sender the queue keeps still classifies as a worker report", () => {
+	test("the sender the queue keeps still classifies as a worker report", async () => {
 		// The queue stores content and user separately; the UI reads them back
 		// through the same classifier the transcript uses, so the two cannot
 		// disagree about what a row is.

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -31,6 +31,7 @@ import {
 	sessionKernelStore,
   sessionTurn,
 } from "./session-kernel";
+import type { DurableSteerTarget } from "./session-kernel/store";
 
 export type QueueItem = {
 	id?: string;
@@ -809,21 +810,28 @@ export async function broadcastQueue(sessionId: string): Promise<void> {
 export async function prepareQueuedSteer(
 	sessionId: string,
 	itemId: string,
+	target: DurableSteerTarget,
 	directItem?: QueueItem,
 ): Promise<QueueItem | undefined> {
 	return await sessionDelivery({
 		op: "prepare_steer",
 		sessionId,
 		itemId,
+		target,
 		...(directItem ? { item: directItem } : {}),
 	}) as QueueItem | undefined;
 }
 
-export async function acceptQueuedSteer(sessionId: string, itemId: string): Promise<boolean> {
+export async function acceptQueuedSteer(
+	sessionId: string,
+	itemId: string,
+	target: DurableSteerTarget,
+): Promise<boolean> {
 	const accepted = await sessionDelivery({
 		op: "accept_steer",
 		sessionId,
 		itemId,
+		target,
 	});
 	if (accepted) {
 		persistQueues();
@@ -832,11 +840,16 @@ export async function acceptQueuedSteer(sessionId: string, itemId: string): Prom
 	return accepted;
 }
 
-export async function rejectQueuedSteer(sessionId: string, itemId: string): Promise<boolean> {
+export async function rejectQueuedSteer(
+	sessionId: string,
+	itemId: string,
+	target: DurableSteerTarget,
+): Promise<boolean> {
 	const rejected = await sessionDelivery({
 		op: "reject_steer",
 		sessionId,
 		itemId,
+		target,
 	});
 	if (rejected) {
 		persistQueues();

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -65,7 +65,7 @@ export type QueueItem = {
    * minutes. */
 	steeredAt?: number;
 };
-export const promptQueues: Map<string, QueueItem[]> = new DeliveryOwnedMap(
+export const promptQueues = new DeliveryOwnedMap<QueueItem[]>(
 	"queued",
 );
 
@@ -78,7 +78,7 @@ export type PromptDispatch = {
 	items: QueueItem[];
 	kind?: "create";
 };
-export const promptDispatches: Map<string, PromptDispatch> = new DeliveryOwnedMap(
+export const promptDispatches = new DeliveryOwnedMap<PromptDispatch>(
 	"dispatch"
 );
 
@@ -152,23 +152,23 @@ function queueActorMatches(item: QueueItem, actor?: string): boolean {
 
 /** Atomically remove an ordinary human message so a client can put its full
  * payload back in the normal composer. Routed/system items stay queue-owned. */
-export function takeQueuedPrompt(
+export async function takeQueuedPrompt(
 	sessionId: string,
 	queueId: string,
 	actor?: string,
 	effects = true,
-): QueueItem | undefined {
+): Promise<QueueItem | undefined> {
 	const queue = promptQueues.get(sessionId);
 	if (!queue) return;
 	const index = queue.findIndex((candidate) => candidate.id === queueId);
 	const item = queue[index];
 	if (!isEditableQueueItem(item) || !item || !queueActorMatches(item, actor)) return;
 	queue.splice(index, 1);
-	if (queue.length > 0) promptQueues.set(sessionId, queue);
-	else promptQueues.delete(sessionId);
+	if (queue.length > 0) await promptQueues.set(sessionId, queue);
+	else await promptQueues.delete(sessionId);
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return item;
 }
@@ -189,22 +189,22 @@ export function editableSteerReceipt(
 /** Remove a steer receipt only after the engine confirms the exact message is
  * still pending. The caller owns that ordering; this function owns auth and
  * durable receipt state. */
-export function takeSteeredPrompt(
+export async function takeSteeredPrompt(
 	sessionId: string,
 	queueId: string,
 	actor?: string,
 	effects = true,
-): QueueItem | undefined {
+): Promise<QueueItem | undefined> {
 	const item = editableSteerReceipt(sessionId, queueId, actor);
 	if (!item) return;
 	const steered = steeredReceipts.get(sessionId);
 	if (!steered) return;
 	const next = steered.filter((candidate) => candidate.id !== queueId);
-	if (next.length > 0) steeredReceipts.set(sessionId, next);
-	else steeredReceipts.delete(sessionId);
+	if (next.length > 0) await steeredReceipts.set(sessionId, next);
+	else await steeredReceipts.delete(sessionId);
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return item;
 }
@@ -214,7 +214,7 @@ export function takeSteeredPrompt(
 // their turn lands they're invisible on reload, so we keep a display-only
 // receipt here: shown as "folded in" in the UI and reconciled away once the real
 // transcript entry appears. Cleared when the run finishes (or is cancelled).
-export const steeredReceipts: Map<string, QueueItem[]> = new DeliveryOwnedMap(
+export const steeredReceipts = new DeliveryOwnedMap<QueueItem[]>(
 	"steered",
 );
 
@@ -228,7 +228,7 @@ export const stoppedSessions = new EphemeralSessionSet();
 /** Durable Stop ownership survives a gateway restart until an explicit prompt
  * advances the actor run state out of `stopped`. */
 export function isUserStopped(sessionId: string): boolean {
-  const cancel = sessionTurn({ op: "snapshot", sessionId }).cancel;
+  const cancel = sessionKernelStore().turnSnapshot(sessionId).cancel;
   return (
     stoppedSessions.has(sessionId) ||
     sessionKernel(sessionId).runState().state === "stopped" ||
@@ -310,7 +310,7 @@ export function persistQueues(storePath = QUEUE_STORE): void {
 			sessionKernelStore().deliveryMigrationComplete()
 		)
 			return;
-		const entries = (m: Map<string, QueueItem[]>) =>
+		const entries = (m: Iterable<[string, QueueItem[]]>) =>
 			Object.fromEntries(
 				[...m]
 					.map(([k, v]) => [k, queueWithIds(v)] as const)
@@ -365,12 +365,12 @@ function readPersistedQueueState(storePath: string,): PersistedQueueState | null
 
 /** Load raw durable maps before the server accepts writes. Ownership and
  * transcript reconciliation happen after recovery identifies adopted runs. */
-export function hydratePersistedQueueState(storePath = QUEUE_STORE): number {
+export async function hydratePersistedQueueState(storePath = QUEUE_STORE): Promise<number> {
   const kernelStore = sessionKernelStore();
   const migrateToKernel = storePath === QUEUE_STORE;
   if (migrateToKernel && kernelStore.deliveryMigrationComplete()) {
     removeLegacyQueueStore(storePath);
-    sessionDelivery({ op: "settle_pending_steers" });
+    await sessionDelivery({ op: "settle_pending_steers" });
     return (
       [...promptQueues.values(), ...steeredReceipts.values()].reduce(
         (count, items) => count + items.length,
@@ -387,18 +387,18 @@ export function hydratePersistedQueueState(storePath = QUEUE_STORE): number {
   }
 	const data = readPersistedQueueState(storePath);
 	if (!data) return 0;
-	promptQueues.clear();
-	steeredReceipts.clear();
-	promptDispatches.clear();
+	await promptQueues.clear();
+	await steeredReceipts.clear();
+	await promptDispatches.clear();
 	for (const [sessionId, items] of Object.entries(data.queued || {})) {
-		if (items?.length) promptQueues.set(sessionId, queueWithIds(items, sessionId));
+		if (items?.length) await promptQueues.set(sessionId, queueWithIds(items, sessionId));
 	}
 	for (const [sessionId, items] of Object.entries(data.steered || {})) {
-		if (items?.length) steeredReceipts.set(sessionId, queueWithIds(items, sessionId));
+		if (items?.length) await steeredReceipts.set(sessionId, queueWithIds(items, sessionId));
 	}
 	for (const [sessionId, dispatch] of Object.entries(data.dispatching || {})) {
 		if (dispatch?.promptEntryId && dispatch.items?.length) {
-			promptDispatches.set(sessionId, {
+			await promptDispatches.set(sessionId, {
 				promptEntryId: dispatch.promptEntryId,
 				items: queueWithIds(dispatch.items, sessionId),
 				...(dispatch.kind === "create" ? { kind: "create" as const } : {}),
@@ -420,7 +420,7 @@ export function hydratePersistedQueueState(storePath = QUEUE_STORE): number {
 /** Restore queue-owned state without deciding when queued prompts should drain.
  * The caller supplies journal/session/transcript facts and arms drains for the
  * returned queuedSessionIds. */
-export function restorePersistedQueueState(options: {
+export async function restorePersistedQueueState(options: {
 	storePath?: string;
 	sessionExists: (sessionId: string) => boolean;
 	sessionQuarantined?: (sessionId: string) => boolean;
@@ -429,7 +429,7 @@ export function restorePersistedQueueState(options: {
 	runOwnsSteers: (sessionId: string) => boolean;
 	deliveredUserTexts: (sessionId: string) => string[];
 	effects?: boolean;
-}): { queuedSessionIds: string[]; queuedCount: number; steeredCount: number } {
+}): Promise<{ queuedSessionIds: string[]; queuedCount: number; steeredCount: number }> {
 	const storePath = options.storePath ?? QUEUE_STORE;
 	const actorOwned =
 		storePath === QUEUE_STORE &&
@@ -453,7 +453,7 @@ export function restorePersistedQueueState(options: {
 		const restorable = (sessionId: string) => !options.sessionQuarantined?.(sessionId);
 		for (const [sessionId] of promptQueues) {
 			if (!restorable(sessionId)) continue;
-			if (!options.sessionExists(sessionId)) promptQueues.delete(sessionId);
+			if (!options.sessionExists(sessionId)) await promptQueues.delete(sessionId);
 		}
 		for (const [sessionId, dispatch] of promptDispatches) {
 			if (!restorable(sessionId)) continue;
@@ -465,35 +465,35 @@ export function restorePersistedQueueState(options: {
 			// opening plan and effect remain their recovery authority in this window.
 			if (creationOwned) continue;
 			if (!options.sessionExists(sessionId)) {
-				promptDispatches.delete(sessionId);
+				await promptDispatches.delete(sessionId);
 				continue;
 			}
 			if (options.journalOwnsPrompt(sessionId, dispatch.promptEntryId))
-				acknowledgePromptDispatch(sessionId, dispatch.promptEntryId, false);
-			else failPromptDispatch(sessionId, dispatch.promptEntryId, false);
+				await acknowledgePromptDispatch(sessionId, dispatch.promptEntryId, false);
+			else await failPromptDispatch(sessionId, dispatch.promptEntryId, false);
 		}
 
 		let steeredCount = 0;
 		for (const [sessionId, items] of steeredReceipts) {
 			if (!restorable(sessionId)) continue;
 			if (!options.sessionExists(sessionId)) {
-				steeredReceipts.delete(sessionId);
+				await steeredReceipts.delete(sessionId);
 				continue;
 			}
 			const delivered = options.deliveredUserTexts(sessionId);
 			const pending = queueWithIds(undeliveredSteers(items, delivered), sessionId);
 			if (options.runOwnsSteers(sessionId)) {
-				if (pending.length) steeredReceipts.set(sessionId, pending);
-				else steeredReceipts.delete(sessionId);
+				if (pending.length) await steeredReceipts.set(sessionId, pending);
+				else await steeredReceipts.delete(sessionId);
 				steeredCount += pending.length;
-			} else requeueSteerReceipts(sessionId, delivered);
+			} else await requeueSteerReceipts(sessionId, delivered);
 		}
 		if (options.effects !== false) {
 			persistQueues(storePath);
 			for (const sessionId of new Set([
 				...promptQueues.keys(),
 				...steeredReceipts.keys(),
-			])) if (restorable(sessionId)) broadcastQueue(sessionId);
+			])) if (restorable(sessionId)) await broadcastQueue(sessionId);
 		}
 		const queuedSessionIds = [...promptQueues.keys()].filter(restorable);
 		return {
@@ -556,12 +556,12 @@ export function restorePersistedQueueState(options: {
 		queued.set(sessionId, [...items, ...(queued.get(sessionId) || [])]);
 	}
 
-	promptQueues.clear();
-	steeredReceipts.clear();
-	promptDispatches.clear();
+	await promptQueues.clear();
+	await steeredReceipts.clear();
+	await promptDispatches.clear();
 	for (const [sessionId, dispatch] of preservedDispatches)
-		promptDispatches.set(sessionId, dispatch);
-	for (const [sessionId, items] of queued) promptQueues.set(sessionId, items);
+		await promptDispatches.set(sessionId, dispatch);
+	for (const [sessionId, items] of queued) await promptQueues.set(sessionId, items);
 
 	let steeredCount = 0;
 	for (const [sessionId, items] of Object.entries(data.steered || {})) {
@@ -570,11 +570,11 @@ export function restorePersistedQueueState(options: {
 		const pending = queueWithIds(undeliveredSteers(items, delivered), sessionId);
 		if (!pending.length) continue;
 		if (options.runOwnsSteers(sessionId)) {
-			steeredReceipts.set(sessionId, pending);
+			await steeredReceipts.set(sessionId, pending);
 			steeredCount += pending.length;
 		} else {
 			queued.set(sessionId, [...pending, ...(queued.get(sessionId) || [])]);
-			promptQueues.set(sessionId, queued.get(sessionId)!);
+			await promptQueues.set(sessionId, queued.get(sessionId)!);
 		}
 	}
 
@@ -584,7 +584,7 @@ export function restorePersistedQueueState(options: {
 			...promptQueues.keys(),
 			...steeredReceipts.keys(),
 		])) {
-			broadcastQueue(sessionId);
+			await broadcastQueue(sessionId);
 		}
 	}
 	return {
@@ -598,16 +598,16 @@ export function restorePersistedQueueState(options: {
 }
 
 /** Persist the interrupt before attempting its physical cancellation. */
-export function preparePromptInterrupt(
+export async function preparePromptInterrupt(
 	sessionId: string,
 	anchorId: string,
   dispatchId: string,
 	soloId?: string,
-): string {
+): Promise<string> {
   const interruptId = `interrupt:${new Bun.CryptoHasher("sha256")
     .update(`${sessionId}\0${anchorId}`)
     .digest("hex")}`;
-	sessionDelivery({
+	await sessionDelivery({
 		op: "prepare_interrupt",
 		sessionId,
 		interruptId,
@@ -618,11 +618,11 @@ export function preparePromptInterrupt(
 	return interruptId;
 }
 
-export function beginPromptInterruptEffect(
+export async function beginPromptInterruptEffect(
 	sessionId: string,
 	interruptId: string,
 	runGeneration: number,
-): "execute" | "retry" | "adopt_confirmed" | "confirmed" | "settled" {
+): Promise<"execute" | "retry" | "adopt_confirmed" | "confirmed" | "settled"> {
 	return sessionDelivery({
 		op: "begin_interrupt_effect",
 		sessionId,
@@ -631,12 +631,12 @@ export function beginPromptInterruptEffect(
 	});
 }
 
-export function settlePromptInterrupt(
+export async function settlePromptInterrupt(
 	sessionId: string,
 	interruptId: string,
 	outcome: "confirmed" | "not_aborted",
-): void {
-	const settled = sessionDelivery({
+): Promise<void> {
+	const settled = await sessionDelivery({
 		op: "settle_interrupt",
 		sessionId,
 		interruptId,
@@ -647,13 +647,13 @@ export function settlePromptInterrupt(
 }
 
 /** Let the actor select and claim the next queue batch in one transaction. */
-export function beginNextPromptDispatch(
+export async function beginNextPromptDispatch(
 	sessionId: string,
 	opts: {
 		stillWorking?: boolean;
 	},
 	effects = true,
-):
+): Promise<
 	| { kind: "empty" }
 	| { kind: "hold"; heldCount: number }
 	| {
@@ -661,8 +661,9 @@ export function beginNextPromptDispatch(
 			promptEntryId: string;
 			batch: QueueItem[];
 			interrupted: boolean;
-		} {
-	const claimed = sessionDelivery({
+		}
+> {
+	const claimed = await sessionDelivery({
 		op: "claim_next_dispatch",
 		sessionId,
 		promptEntryId: crypto.randomUUID(),
@@ -682,17 +683,17 @@ export function beginNextPromptDispatch(
  * runner work. The caller has already removed the batch from promptQueues, so
  * this single persistence point records either the old queued copy (if we die
  * before it) or the dispatching copy (if we die after it). */
-export function beginPromptDispatch(
+export async function beginPromptDispatch(
 	sessionId: string,
 	items: QueueItem[],
 	promptEntryId = items.length === 1 ? items[0]?.promptEntryId : undefined,
 	effects = true,
 	kind?: "create",
 	requireQueued = false,
-): string {
+): Promise<string> {
 	const id = promptEntryId || crypto.randomUUID();
 	const durableItems = queueWithIds(items, sessionId);
-  sessionDelivery({
+  await sessionDelivery({
     op: "claim_dispatch",
     sessionId,
     items: durableItems,
@@ -706,38 +707,38 @@ export function beginPromptDispatch(
 
 /** The engine's active-run journal is now durable, so it owns recovery and the
  * intake dispatch record can be removed. */
-export function acknowledgePromptDispatch(
+export async function acknowledgePromptDispatch(
 	sessionId: string | undefined,
 	promptEntryId: string | undefined,
 	effects = true,
-): void {
+): Promise<void> {
 	if (!sessionId || !promptEntryId) return;
-  const acknowledged = sessionDelivery({
+  const acknowledged = await sessionDelivery({
     op: "ack_dispatch",
     sessionId,
     promptEntryId,
   });
   if (acknowledged && effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 }
 
 /** A runner failed before it adopted the dispatch. Restore its exact batch
  * atomically ahead of later queued work. */
-export function failPromptDispatch(
+export async function failPromptDispatch(
   sessionId: string,
   promptEntryId: string,
   effects = true,
-): boolean {
-  const restored = sessionDelivery({
+): Promise<boolean> {
+  const restored = await sessionDelivery({
     op: "fail_dispatch",
     sessionId,
     promptEntryId,
   });
   if (restored && effects) {
     persistQueues();
-    broadcastQueue(sessionId);
+    await broadcastQueue(sessionId);
   }
   return restored;
 }
@@ -766,10 +767,7 @@ export function clientVisibleQueuedCount(sessionId: string): number {
 /** One actor snapshot for list rendering, instead of one RPC per session. */
 export function clientVisibleQueuedCounts(): Map<string, number> {
 	const counts = new Map<string, number>();
-	for (const [sessionId, value] of sessionDelivery({
-		op: "entries",
-		slot: "queued",
-	})) {
+	for (const [sessionId, value] of sessionKernelStore().deliveryEntries("queued")) {
 		const items = value as QueueItem[];
 		const visible = items.filter(isClientVisibleQueueItem).length;
 		if (visible) counts.set(sessionId, visible);
@@ -777,11 +775,11 @@ export function clientVisibleQueuedCounts(): Map<string, number> {
 	return counts;
 }
 
-export function queueDisplayState(sessionId: string) {
+export async function queueDisplayState(sessionId: string) {
 	const queued = queueWithIds(promptQueues.get(sessionId));
 	const steered = queueWithIds(steeredReceipts.get(sessionId));
-	if (queued.length > 0) promptQueues.set(sessionId, queued);
-	if (steered.length > 0) steeredReceipts.set(sessionId, steered);
+	if (queued.length > 0) await promptQueues.set(sessionId, queued);
+	if (steered.length > 0) await steeredReceipts.set(sessionId, steered);
 	// Display copy only: automated turns remain in the internal queue until
 	// dispatch but never enter a client's message surface. Strip fenced
 	// <opensession:context> blocks from the remaining human-authored rows. The
@@ -798,23 +796,23 @@ export function queueDisplayState(sessionId: string) {
 	return { queued: forDisplay(queued), steered: forDisplay(steered) };
 }
 
-export function broadcastQueue(sessionId: string) {
+export async function broadcastQueue(sessionId: string): Promise<void> {
 	broadcastToSession(sessionId, {
 		type: "queue_update",
 		sessionId,
-		...queueDisplayState(sessionId),
+		...await queueDisplayState(sessionId),
 	});
 }
 
 /** Move one queued item into an actor-owned pending steer before touching the
  * runner. A crash after this point recovers it as an ambiguous steer receipt
  * instead of delivering the same message again. */
-export function prepareQueuedSteer(
+export async function prepareQueuedSteer(
 	sessionId: string,
 	itemId: string,
 	directItem?: QueueItem,
-): QueueItem | undefined {
-	return sessionDelivery({
+): Promise<QueueItem | undefined> {
+	return await sessionDelivery({
 		op: "prepare_steer",
 		sessionId,
 		itemId,
@@ -822,28 +820,28 @@ export function prepareQueuedSteer(
 	}) as QueueItem | undefined;
 }
 
-export function acceptQueuedSteer(sessionId: string, itemId: string): boolean {
-	const accepted = sessionDelivery({
+export async function acceptQueuedSteer(sessionId: string, itemId: string): Promise<boolean> {
+	const accepted = await sessionDelivery({
 		op: "accept_steer",
 		sessionId,
 		itemId,
 	});
 	if (accepted) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return accepted;
 }
 
-export function rejectQueuedSteer(sessionId: string, itemId: string): boolean {
-	const rejected = sessionDelivery({
+export async function rejectQueuedSteer(sessionId: string, itemId: string): Promise<boolean> {
+	const rejected = await sessionDelivery({
 		op: "reject_steer",
 		sessionId,
 		itemId,
 	});
 	if (rejected) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return rejected;
 }
@@ -851,29 +849,29 @@ export function rejectQueuedSteer(sessionId: string, itemId: string): boolean {
 /** Retire one exact receipt when the engine reports that it crossed the step
  * boundary. This is authoritative even when the delivered message is fenced
  * system context that transcript parsing intentionally hides. */
-export function acknowledgeSteerDelivery(
+export async function acknowledgeSteerDelivery(
 	sessionId: string,
 	steerId: string,
 	effects = true,
-): boolean {
+): Promise<boolean> {
 	const steered = steeredReceipts.get(sessionId);
 	if (!steered?.some((item) => item.id === steerId)) return false;
 	const remaining = steered.filter((item) => item.id !== steerId);
-	if (remaining.length > 0) steeredReceipts.set(sessionId, remaining);
-	else steeredReceipts.delete(sessionId);
+	if (remaining.length > 0) await steeredReceipts.set(sessionId, remaining);
+	else await steeredReceipts.delete(sessionId);
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return true;
 }
 
 /** Clear a session's steer receipts once the run that owned them is done. */
-export function clearSteerReceipts(sessionId: string): void {
+export async function clearSteerReceipts(sessionId: string): Promise<void> {
 	if (!steeredReceipts.has(sessionId)) return;
-	steeredReceipts.delete(sessionId);
+	await steeredReceipts.delete(sessionId);
 	persistQueues();
-	broadcastQueue(sessionId);
+	await broadcastQueue(sessionId);
 }
 
 /**
@@ -897,11 +895,11 @@ export function clearSteerReceipts(sessionId: string): void {
  * watchers see one consistent update rather than a moment with the message
  * in neither place.
  */
-export function takeSteerReceiptForText(
+export async function takeSteerReceiptForText(
 	sessionId: string,
 	text: string,
 	effects = true,
-): QueueItem | undefined {
+): Promise<QueueItem | undefined> {
 	const steered = steeredReceipts.get(sessionId);
 	if (!steered?.length) return undefined;
 	const wanted = text.trim();
@@ -913,11 +911,11 @@ export function takeSteerReceiptForText(
 	});
 	if (index < 0) return undefined;
 	const [item] = steered.splice(index, 1);
-	if (steered.length > 0) steeredReceipts.set(sessionId, steered);
-	else steeredReceipts.delete(sessionId);
+	if (steered.length > 0) await steeredReceipts.set(sessionId, steered);
+	else await steeredReceipts.delete(sessionId);
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return item;
 }
@@ -979,10 +977,10 @@ export function undeliveredSteers(
 	});
 }
 
-function reconcileSteerReceiptsOnAppend(
+async function reconcileSteerReceiptsOnAppend(
 	sessionId: string,
 	entries: TranscriptEntry[],
-): void {
+): Promise<void> {
 	const steered = steeredReceipts.get(sessionId);
 	if (!steered?.length) return;
 	const users = entries
@@ -991,10 +989,10 @@ function reconcileSteerReceiptsOnAppend(
 	if (users.length === 0) return;
 	const remaining = undeliveredSteers(steered, users);
 	if (remaining.length === steered.length) return;
-	if (remaining.length > 0) steeredReceipts.set(sessionId, remaining);
-	else steeredReceipts.delete(sessionId);
+	if (remaining.length > 0) await steeredReceipts.set(sessionId, remaining);
+	else await steeredReceipts.delete(sessionId);
 	persistQueues();
-	broadcastQueue(sessionId);
+	await broadcastQueue(sessionId);
 }
 
 setTranscriptAppendListener(reconcileSteerReceiptsOnAppend);
@@ -1017,22 +1015,22 @@ setAppendHook(reconcileSteerReceiptsOnAppend);
  * that already landed are dropped instead of requeued; only steers the
  * engine never got (a failed fire-and-forget POST) go back into the queue.
  */
-export function requeueSteerReceipts(
+export async function requeueSteerReceipts(
 	sessionId: string,
 	deliveredUserTexts?: string[],
 	effects = true,
-): number {
+): Promise<number> {
 	const steered = steeredReceipts.get(sessionId);
 	if (!steered?.length) return 0;
 	const undelivered = undeliveredSteers(steered, deliveredUserTexts || []);
-	sessionDelivery({
+	await sessionDelivery({
 		op: "requeue_steers",
 		sessionId,
 		items: undelivered,
 	});
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return undelivered.length;
 }
@@ -1056,22 +1054,22 @@ export function queuedPromptIndex(
 	return -1;
 }
 
-export function deleteQueuedPrompt(
+export async function deleteQueuedPrompt(
 	sessionId: string,
 	queueId?: string,
 	queueIndex?: number,
 	effects = true,
-): boolean {
+): Promise<boolean> {
 	const queue = promptQueues.get(sessionId);
 	if (queue) {
 		const index = queuedPromptIndex(queue, queueId, queueIndex);
 		if (index >= 0) {
 			const next = queue.filter((_, i) => i !== index);
-			if (next.length > 0) promptQueues.set(sessionId, next);
-			else promptQueues.delete(sessionId);
+			if (next.length > 0) await promptQueues.set(sessionId, next);
+			else await promptQueues.delete(sessionId);
 			if (effects) {
 				persistQueues();
-				broadcastQueue(sessionId);
+				await broadcastQueue(sessionId);
 			}
 			return true;
 		}
@@ -1085,11 +1083,11 @@ export function deleteQueuedPrompt(
 		const index = (steered || []).findIndex((item) => item.id === queueId);
 		if (steered && index >= 0) {
 			const next = steered.filter((_, i) => i !== index);
-			if (next.length > 0) steeredReceipts.set(sessionId, next);
-			else steeredReceipts.delete(sessionId);
+			if (next.length > 0) await steeredReceipts.set(sessionId, next);
+			else await steeredReceipts.delete(sessionId);
 			if (effects) {
 				persistQueues();
-				broadcastQueue(sessionId);
+				await broadcastQueue(sessionId);
 			}
 			return true;
 		}
@@ -1099,13 +1097,13 @@ export function deleteQueuedPrompt(
 
 /** Compatibility path for clients shipped before queued messages moved back
  * into the normal composer. Current clients use takeQueuedPrompt instead. */
-export function updateQueuedPrompt(
+export async function updateQueuedPrompt(
 	sessionId: string,
 	queueId: string | undefined,
 	queueIndex: number | undefined,
 	content: string,
 	images?: string[],
-): boolean {
+): Promise<boolean> {
 	const queue = promptQueues.get(sessionId);
 	if (!queue) return false;
 	const index = queuedPromptIndex(queue, queueId, queueIndex);
@@ -1124,10 +1122,10 @@ export function updateQueuedPrompt(
 	) {
 		queue.splice(index, 1);
 	}
-	if (queue.length > 0) promptQueues.set(sessionId, queue);
-	else promptQueues.delete(sessionId);
+	if (queue.length > 0) await promptQueues.set(sessionId, queue);
+	else await promptQueues.delete(sessionId);
 	persistQueues();
-	broadcastQueue(sessionId);
+	await broadcastQueue(sessionId);
 	return true;
 }
 
@@ -1139,11 +1137,11 @@ export function updateQueuedPrompt(
  * (unknown session, <2 items, or an order that doesn't change anything) return
  * false without a broadcast.
  */
-export function reorderQueuedPrompt(
+export async function reorderQueuedPrompt(
 	sessionId: string,
 	order: string[],
 	effects = true,
-): boolean {
+): Promise<boolean> {
 	const queue = promptQueues.get(sessionId);
 	if (!queue || queue.length < 2) return false;
 	const byId = new Map(
@@ -1163,10 +1161,10 @@ export function reorderQueuedPrompt(
 	}
 	// Same references in the same slots ⇒ nothing moved.
 	if (next.every((item, i) => item === queue[i])) return false;
-	promptQueues.set(sessionId, next);
+	await promptQueues.set(sessionId, next);
 	if (effects) {
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 	}
 	return true;
 }

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -245,7 +245,7 @@ export function isUserStopped(sessionId: string): boolean {
  * is parked forever and reads as lost (most visible right after a create, when
  * the opening turn is stopped before it settles).
  */
-export function liftUserStop(sessionId: string): void {
+export async function liftUserStop(sessionId: string): Promise<void> {
   stoppedSessions.delete(sessionId);
   if (sessionKernel(sessionId).runState().state === "stopped")
     // Intake only releases the durable Stop latch. The later physical run
@@ -253,7 +253,7 @@ export function liftUserStop(sessionId: string): void {
     // Advancing to `starting` here makes the intake busy-check observe its own
     // half-created run, queue the message, and wait forever for an engine owner
     // that was never started.
-    sessionKernel(sessionId).applyRunEvent({ event: "stop_lifted" });
+    await sessionKernel(sessionId).applyRunEvent({ event: "stop_lifted" });
 }
 
 // Both maps are persisted to disk so a real restart/crash (not just a hot
@@ -776,10 +776,9 @@ export function clientVisibleQueuedCounts(): Map<string, number> {
 }
 
 export async function queueDisplayState(sessionId: string) {
-	const queued = queueWithIds(promptQueues.get(sessionId));
-	const steered = queueWithIds(steeredReceipts.get(sessionId));
-	if (queued.length > 0) await promptQueues.set(sessionId, queued);
-	if (steered.length > 0) await steeredReceipts.set(sessionId, steered);
+	const snapshot = await sessionDelivery({ op: "snapshot", sessionId });
+	const queued = queueWithIds(snapshot.queued as QueueItem[]);
+	const steered = queueWithIds(snapshot.steered as QueueItem[]);
 	// Display copy only: automated turns remain in the internal queue until
 	// dispatch but never enter a client's message surface. Strip fenced
 	// <opensession:context> blocks from the remaining human-authored rows. The

--- a/packages/core/opensession-server/src/server/queued-steer.test.ts
+++ b/packages/core/opensession-server/src/server/queued-steer.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import {
+  prepareAndSteerQueuedPrompt,
+  type QueuedSteerDeps,
+} from "./queued-steer";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test("rejects a prepared steer when a replacement run wins during actor await", async () => {
+  let target = { token: "run-old", runId: "run-old", generation: 4 };
+  const prepared = deferred<{ id: string; content: string }>();
+  const steered: string[] = [];
+  const rejected: string[] = [];
+  const deps: QueuedSteerDeps = {
+    target: () => target,
+    prepare: async () => prepared.promise,
+    steer: (token) => {
+      steered.push(token);
+      return true;
+    },
+    accept: async () => true,
+    reject: async (_sessionId, itemId) => {
+      rejected.push(itemId);
+      return true;
+    },
+  };
+
+  const result = prepareAndSteerQueuedPrompt({
+    sessionId: "session-1",
+    itemId: "item-1",
+    text: "hello",
+  }, deps);
+  target = { token: "run-new", runId: "run-new", generation: 5 };
+  prepared.resolve({ id: "item-1", content: "hello" });
+
+  expect(await result).toBe("rejected");
+  expect(steered).toEqual([]);
+  expect(rejected).toEqual(["item-1"]);
+});
+
+test("steers and accepts only the captured immutable run token", async () => {
+  const steered: string[] = [];
+  const deps: QueuedSteerDeps = {
+    target: () => ({ token: "run-exact", runId: "run-exact", generation: 2 }),
+    prepare: async () => ({ id: "item-1", content: "hello" }),
+    steer: (token) => {
+      steered.push(token);
+      return true;
+    },
+    accept: async () => true,
+    reject: async () => true,
+  };
+  expect(await prepareAndSteerQueuedPrompt({
+    sessionId: "session-1",
+    itemId: "item-1",
+    text: "hello",
+  }, deps)).toBe("steered");
+  expect(steered).toEqual(["run-exact"]);
+});

--- a/packages/core/opensession-server/src/server/queued-steer.test.ts
+++ b/packages/core/opensession-server/src/server/queued-steer.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+  prepareAndInterruptQueuedPrompt,
   prepareAndSteerQueuedPrompt,
   type QueuedSteerDeps,
 } from "./queued-steer";
@@ -42,6 +43,51 @@ test("rejects a prepared steer when a replacement run wins during actor await", 
   expect(await result).toBe("rejected");
   expect(steered).toEqual([]);
   expect(rejected).toEqual(["item-1"]);
+});
+
+test("surfaces an unconfirmed fenced rejection", async () => {
+  let target = { token: "run-old", runId: "run-old", generation: 4 };
+  const deps: QueuedSteerDeps = {
+    target: () => target,
+    prepare: async () => ({ id: "item-1", content: "hello" }),
+    steer: () => true,
+    accept: async () => true,
+    reject: async () => false,
+  };
+  const result = prepareAndSteerQueuedPrompt({
+    sessionId: "session-1",
+    itemId: "item-1",
+    text: "hello",
+  }, deps);
+  target = { token: "run-new", runId: "run-new", generation: 5 };
+
+  await expect(result).rejects.toThrow("fenced rejection");
+});
+
+test("does not interrupt a successor that wins during actor preparation", async () => {
+  let target = { token: "run-old", runId: "run-old", generation: 4 };
+  const prepared = deferred<{ id: string; content: string }>();
+  const interrupted: string[] = [];
+  const deps: QueuedSteerDeps = {
+    target: () => target,
+    prepare: async () => prepared.promise,
+    steer: (token) => {
+      interrupted.push(token);
+      return true;
+    },
+    accept: async () => true,
+    reject: async () => true,
+  };
+  const result = prepareAndInterruptQueuedPrompt({
+    sessionId: "session-1",
+    itemId: "item-1",
+    text: "hello",
+  }, deps);
+  target = { token: "run-new", runId: "run-new", generation: 5 };
+  prepared.resolve({ id: "item-1", content: "hello" });
+
+  expect(await result).toBe("target_changed");
+  expect(interrupted).toEqual([]);
 });
 
 test("steers and accepts only the captured immutable run token", async () => {

--- a/packages/core/opensession-server/src/server/queued-steer.ts
+++ b/packages/core/opensession-server/src/server/queued-steer.ts
@@ -1,4 +1,8 @@
-import { currentAgentRunToken, steerAgentRunToken } from "./agent-runner";
+import {
+  currentAgentRunToken,
+  interruptAndSteerAgentRunToken,
+  steerAgentRunToken,
+} from "./agent-runner";
 import {
   acceptQueuedSteer,
   prepareQueuedSteer,
@@ -19,6 +23,7 @@ export type QueuedSteerDeps = {
   prepare(
     sessionId: string,
     itemId: string,
+    target: QueuedSteerFence,
     directItem?: QueueItem,
   ): Promise<QueueItem | undefined>;
   steer(
@@ -27,8 +32,16 @@ export type QueuedSteerDeps = {
     images: ImageInput[] | undefined,
     itemId: string,
   ): boolean;
-  accept(sessionId: string, itemId: string): Promise<boolean>;
-  reject(sessionId: string, itemId: string): Promise<boolean>;
+  accept(
+    sessionId: string,
+    itemId: string,
+    target: QueuedSteerFence,
+  ): Promise<boolean>;
+  reject(
+    sessionId: string,
+    itemId: string,
+    target: QueuedSteerFence,
+  ): Promise<boolean>;
 };
 
 const queuedSteerDeps: QueuedSteerDeps = {
@@ -67,17 +80,57 @@ export async function prepareAndSteerQueuedPrompt(
 ): Promise<"steered" | "rejected" | "not_prepared"> {
   const before = deps.target(input.sessionId);
   if (!before) return "not_prepared";
-  const prepared = await deps.prepare(input.sessionId, input.itemId, input.item);
+  const prepared = await deps.prepare(
+    input.sessionId,
+    input.itemId,
+    before,
+    input.item,
+  );
   if (!prepared) return "not_prepared";
   if (!sameFence(before, deps.target(input.sessionId))) {
-    await deps.reject(input.sessionId, input.itemId);
+    if (!await deps.reject(input.sessionId, input.itemId, before))
+      throw new Error("Pending steer changed before fenced rejection");
     return "rejected";
   }
   if (!deps.steer(before.token, input.text, input.images, input.itemId)) {
-    await deps.reject(input.sessionId, input.itemId);
+    if (!await deps.reject(input.sessionId, input.itemId, before))
+      throw new Error("Pending steer changed before fenced rejection");
     return "rejected";
   }
-  if (!await deps.accept(input.sessionId, input.itemId))
+  if (!await deps.accept(input.sessionId, input.itemId, before))
     throw new Error("Pending steer changed before runner acceptance");
   return "steered";
+}
+
+/** Prepare durably, then interrupt only the immutable run captured before await. */
+export async function prepareAndInterruptQueuedPrompt(
+  input: {
+    sessionId: string;
+    itemId: string;
+    text: string;
+    images?: ImageInput[];
+  },
+  deps: QueuedSteerDeps = {
+    ...queuedSteerDeps,
+    steer: (token, text, images) =>
+      interruptAndSteerAgentRunToken(token, text, images),
+  },
+): Promise<"interrupted" | "target_changed" | "unsupported" | "not_prepared"> {
+  const before = deps.target(input.sessionId);
+  if (!before) return "not_prepared";
+  const prepared = await deps.prepare(input.sessionId, input.itemId, before);
+  if (!prepared) return "not_prepared";
+  if (!sameFence(before, deps.target(input.sessionId))) {
+    if (!await deps.reject(input.sessionId, input.itemId, before))
+      throw new Error("Pending interrupt steer changed before fenced rejection");
+    return "target_changed";
+  }
+  if (!deps.steer(before.token, input.text, input.images, input.itemId)) {
+    if (!await deps.reject(input.sessionId, input.itemId, before))
+      throw new Error("Pending interrupt steer changed before fenced rejection");
+    return "unsupported";
+  }
+  if (!await deps.accept(input.sessionId, input.itemId, before))
+    throw new Error("Pending interrupt steer changed before runner acceptance");
+  return "interrupted";
 }

--- a/packages/core/opensession-server/src/server/queued-steer.ts
+++ b/packages/core/opensession-server/src/server/queued-steer.ts
@@ -1,0 +1,83 @@
+import { currentAgentRunToken, steerAgentRunToken } from "./agent-runner";
+import {
+  acceptQueuedSteer,
+  prepareQueuedSteer,
+  rejectQueuedSteer,
+  type QueueItem,
+} from "./queue-state";
+import type { ImageInput } from "./run-events";
+import { sessionKernel } from "./session-kernel";
+
+type QueuedSteerFence = {
+  token: string;
+  runId: string;
+  generation: number;
+};
+
+export type QueuedSteerDeps = {
+  target(sessionId: string): QueuedSteerFence | undefined;
+  prepare(
+    sessionId: string,
+    itemId: string,
+    directItem?: QueueItem,
+  ): Promise<QueueItem | undefined>;
+  steer(
+    token: string,
+    text: string,
+    images: ImageInput[] | undefined,
+    itemId: string,
+  ): boolean;
+  accept(sessionId: string, itemId: string): Promise<boolean>;
+  reject(sessionId: string, itemId: string): Promise<boolean>;
+};
+
+const queuedSteerDeps: QueuedSteerDeps = {
+  target(sessionId) {
+    const token = currentAgentRunToken(sessionId);
+    const run = sessionKernel(sessionId).runState();
+    if (!token || !run.currentRunId) return undefined;
+    return { token, runId: run.currentRunId, generation: run.generation };
+  },
+  prepare: prepareQueuedSteer,
+  steer: steerAgentRunToken,
+  accept: acceptQueuedSteer,
+  reject: rejectQueuedSteer,
+};
+
+function sameFence(
+  before: QueuedSteerFence,
+  after: QueuedSteerFence | undefined,
+): boolean {
+  return !!after &&
+    after.token === before.token &&
+    after.runId === before.runId &&
+    after.generation === before.generation;
+}
+
+/** Prepare durably, then steer only the immutable run captured before await. */
+export async function prepareAndSteerQueuedPrompt(
+  input: {
+    sessionId: string;
+    itemId: string;
+    item?: QueueItem;
+    text: string;
+    images?: ImageInput[];
+  },
+  deps: QueuedSteerDeps = queuedSteerDeps,
+): Promise<"steered" | "rejected" | "not_prepared"> {
+  const before = deps.target(input.sessionId);
+  if (!before) return "not_prepared";
+  const prepared = await deps.prepare(input.sessionId, input.itemId, input.item);
+  if (!prepared) return "not_prepared";
+  if (!sameFence(before, deps.target(input.sessionId))) {
+    await deps.reject(input.sessionId, input.itemId);
+    return "rejected";
+  }
+  if (!deps.steer(before.token, input.text, input.images, input.itemId)) {
+    await deps.reject(input.sessionId, input.itemId);
+    return "rejected";
+  }
+  if (!await deps.accept(input.sessionId, input.itemId))
+    throw new Error("Pending steer changed before runner acceptance");
+  return "steered";
+}

--- a/packages/core/opensession-server/src/server/routes/automations.ts
+++ b/packages/core/opensession-server/src/server/routes/automations.ts
@@ -181,7 +181,7 @@ export async function handleAutomationsRoutes(
 		const { deleteScheduledPrompt } = await import(
 			"../../server/scheduled-prompts"
 		);
-		return deleteScheduledPrompt(schedDelMatch[1])
+		return await deleteScheduledPrompt(schedDelMatch[1])
 			? Response.json({ ok: true })
 			: Response.json({ error: "Not found" }, { status: 404 });
 	}

--- a/packages/core/opensession-server/src/server/routes/pr.ts
+++ b/packages/core/opensession-server/src/server/routes/pr.ts
@@ -1076,7 +1076,7 @@ export async function handlePrRoutes(
           : undefined);
       let stopped = false;
       if (reviewSession && targetRunId) {
-        requestTurnCancel(bksId, reviewSession, {
+        await requestTurnCancel(bksId, reviewSession, {
           cancelId: `pr-review-stop:${runTarget.generation}:${targetRunId}`,
           expectedRunId: targetRunId,
           expectedGeneration: runTarget.generation,

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -1887,7 +1887,7 @@ export async function handleSessionsRoutes(
 			// nested compatibility write re-enters through a fresh kernel and is fenced
 			// as a late writer, leaving a visible but immutable ghost session behind.
 			deleteSession(session);
-			tombstoneSessionKernel(session.id);
+			await tombstoneSessionKernel(session.id);
 			await finishDeletion();
 			return { status: 200, body: { ok: true } };
 		} catch (e: any) {

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -16,7 +16,7 @@ import {
 import { archiveOlderThan, isArchivedId, setArchived, unpinArchivedSessions, } from "../archive";
 import { audit } from "../audit";
 import {
-	pendingAsks,
+	pendingAskAwaitingAnswerSync,
 	pendingAskIdsAwaitingAnswer,
 } from "../asks";
 import { transcriptMatchSnippet } from "../jsonl-parser";
@@ -426,7 +426,7 @@ function enrichSession(
 		waitingForInput: signals
 			? signals.waitingForInput.has(s.id)
 			: !!sessionProjectionOr(
-					() => pendingAsks.get(s.id),
+					() => pendingAskAwaitingAnswerSync(s.id),
 					undefined,
 				),
 		queuedCount: signals

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -1479,7 +1479,7 @@ export async function handleSessionsRoutes(
           : undefined);
       if (targetRunId) {
         try {
-          requestTurnCancel(session.id, session, {
+          await requestTurnCancel(session.id, session, {
             cancelId: `archive-stop:${session.id}:${targetRunId}:${target.generation}`,
             expectedRunId: targetRunId,
             expectedGeneration: target.generation,
@@ -1844,7 +1844,7 @@ export async function handleSessionsRoutes(
     let deleteExecuting = false;
     let deletePhysicalFinished = false;
 		try {
-      const plan = sessionGatewayCommand({
+      const plan = await sessionGatewayCommand({
         op: "request",
         sessionId: session.id,
         requestId: deleteRequestId,
@@ -1895,7 +1895,7 @@ export async function handleSessionsRoutes(
 		}
 			});
       deletePhysicalFinished = true;
-      sessionGatewayCommand({
+      await sessionGatewayCommand({
         op: "complete",
         sessionId: session.id,
         requestId: deleteRequestId,
@@ -1905,7 +1905,7 @@ export async function handleSessionsRoutes(
 			return Response.json(result.body, { status: result.status });
 		} catch (error) {
       if (deleteExecuting && !deletePhysicalFinished)
-        sessionGatewayCommand({
+        await sessionGatewayCommand({
           op: "fail",
           sessionId: session.id,
           requestId: deleteRequestId,

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -1499,7 +1499,7 @@ export async function handleSessionsRoutes(
         }
       }
     }
-		executeSessionProjection(sessionId, "archive_override", () =>
+		await executeSessionProjection(sessionId, "archive_override", () =>
 			setArchived(sessionId, archived),
 		);
 		// Plain done-tickets are archived via a file-level flag, not the
@@ -1530,7 +1530,7 @@ export async function handleSessionsRoutes(
 		const body = await req.json().catch(() => ({}));
 		const title =
 			typeof body?.title === "string" ? body.title.trim().slice(0, 80) : "";
-		executeSessionProjection(sessionId, "title_override", () =>
+		await executeSessionProjection(sessionId, "title_override", () =>
 			setTitleOverride(sessionId, title || null),
 		);
 		invalidateSessionsCache();
@@ -1550,7 +1550,7 @@ export async function handleSessionsRoutes(
 			return Response.json({ error: "Session not found" }, { status: 404 });
 		const body = await req.json().catch(() => ({}));
 		const status = isManualStatus(body?.status) ? body.status : null;
-		executeSessionProjection(sessionId, "status_override", () =>
+		await executeSessionProjection(sessionId, "status_override", () =>
 			setStatusOverride(sessionId, status),
 		);
 		invalidateSessionsCache();
@@ -1687,7 +1687,7 @@ export async function handleSessionsRoutes(
 				} else mirroredToGithub = true;
 			}
 		}
-		executeSessionProjection(sessionId, "review_request", () =>
+		await executeSessionProjection(sessionId, "review_request", () =>
 			setReviewRequest(
 				sessionId,
 				reviewer
@@ -1774,10 +1774,10 @@ export async function handleSessionsRoutes(
 		// the DB file existing — NOT the flag — so a kill-switch window can't
 		// leave resurrectable rows behind for deterministic session ids
 		// (bks-ghpr-*). Best-effort: a store hiccup must never block deletion.
-		const purgeTranscriptRows = (id: string) => {
+		const purgeTranscriptRows = async (id: string) => {
 			try {
 				if (existsSync(transcriptDbPath()))
-					transcriptStore().deleteSessionTranscript(id);
+					await transcriptStore().deleteSessionTranscript(id);
 			} catch {}
 			try {
 				searchIndex().remove(`session:${id}`);
@@ -1791,7 +1791,7 @@ export async function handleSessionsRoutes(
 					console.warn(`[runners] Workspace retained after deleting ${session.id}:`, error,),
 				);
 			}
-			purgeTranscriptRows(session.id);
+			await purgeTranscriptRows(session.id);
 			invalidateSessionsCache();
 			// Tear down the session's sandbox (container + engine-state volumes,
 			// and in volume-workspace mode the workspace volume itself; that data
@@ -1886,7 +1886,7 @@ export async function handleSessionsRoutes(
 			// Tombstoning first drops this active kernel from the map, so deleteSession's
 			// nested compatibility write re-enters through a fresh kernel and is fenced
 			// as a late writer, leaving a visible but immutable ghost session behind.
-			deleteSession(session);
+			await deleteSession(session);
 			await tombstoneSessionKernel(session.id);
 			await finishDeletion();
 			return { status: 200, body: { ok: true } };

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -16,7 +16,7 @@ import {
 import { archiveOlderThan, isArchivedId, setArchived, unpinArchivedSessions, } from "../archive";
 import { audit } from "../audit";
 import {
-	pendingAskAwaitingAnswer,
+	pendingAsks,
 	pendingAskIdsAwaitingAnswer,
 } from "../asks";
 import { transcriptMatchSnippet } from "../jsonl-parser";
@@ -426,7 +426,7 @@ function enrichSession(
 		waitingForInput: signals
 			? signals.waitingForInput.has(s.id)
 			: !!sessionProjectionOr(
-					() => pendingAskAwaitingAnswer(s.id),
+					() => pendingAsks.get(s.id),
 					undefined,
 				),
 		queuedCount: signals

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from "fs";
 import { OPENSESSION_SESSIONS_DIR } from "./paths";
 import { } from "./paths";
 import { transitionRunState } from "./run-state";
-import { sessionDelivery, sessionTurn } from "./session-kernel/kernel";
+import { sessionDelivery, sessionKernelStore, sessionTurn } from "./session-kernel/kernel";
 import { writeJsonAtomic } from "./shared/atomic-write";
 
 // Overridable so a detached run host (src/runner-host/host.ts) journals to its
@@ -383,14 +383,14 @@ export function journalRetireSettledCancelAbnormal(
 ): boolean {
   if (process.env.OPENSESSION_RUN_JOURNAL || !sessionId) return false;
   try {
-    const cancel = sessionTurn({ op: "snapshot", sessionId }).cancel;
+    const cancel = sessionKernelStore().turnSnapshot(sessionId).cancel;
     if (cancel?.runId === runKey && cancel.phase === "settled")
       return retireCancelAbnormalEvidence(sessionId, runKey);
   } catch {
     // The independent interrupt owner may still positively prove settlement.
   }
   try {
-    const delivery = sessionDelivery({ op: "snapshot", sessionId });
+    const delivery = sessionKernelStore().deliverySnapshot(sessionId);
     const dispatchedInterrupt = (
       delivery.dispatch as { interrupt?: typeof delivery.interrupt } | undefined
     )?.interrupt;

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -20,12 +20,14 @@ let ACTIVE_RUNS_PATH =
   `${OPENSESSION_SESSIONS_DIR}/active-runs.json`;
 let activeRunAliases = new Set<string>();
 let activeRunAliasesInitialized = false;
-let onJournalSet: ((record: ActiveRunRecord) => void) | undefined;
+let onJournalSet:
+  | ((record: ActiveRunRecord) => void | Promise<void>)
+  | undefined;
 
 /** Register the in-process acknowledgement for a prompt intake record. Kept as
  * a callback so this low-level journal stays independent of queue state. */
 export function setJournalSetListener(
-	listener: ((record: ActiveRunRecord) => void) | undefined,
+	listener: ((record: ActiveRunRecord) => void | Promise<void>) | undefined,
 ): void {
 	onJournalSet = listener;
 }
@@ -217,7 +219,16 @@ export function buildRunJournalRecord(
   };
 }
 
-export function journalSet(record: ActiveRunRecord): void {
+type JournalRunStateTransition = (
+  sessionId: string,
+  event: Parameters<typeof transitionRunState>[1],
+  meta?: Parameters<typeof transitionRunState>[2],
+) => Promise<unknown>;
+
+export async function journalSet(
+  record: ActiveRunRecord,
+  transition: JournalRunStateTransition = transitionRunState,
+): Promise<void> {
   const journal = readRunJournal();
   const prior = journal[record.runKey];
   const rejournal = !!prior;
@@ -233,14 +244,14 @@ export function journalSet(record: ActiveRunRecord): void {
   };
   writeRunJournal(journal);
   try {
-    onJournalSet?.(journal[record.runKey] || record);
+    await onJournalSet?.(journal[record.runKey] || record);
   } catch (e) {
     console.error("[runner] Failed to acknowledge prompt dispatch:", e);
   }
   // A fallback hop re-journals the same runKey mid-run — that's the running
   // self-edge, not a new registration, so keep the event but tag it.
   if (record.osSessionId)
-    void transitionRunState(record.osSessionId, "run_registered", {
+    await transition(record.osSessionId, "run_registered", {
       run_key: record.runKey,
       kind: record.kind,
       rejournal: rejournal || undefined,
@@ -344,10 +355,10 @@ export function journalMarkRecoveryAttached(record: ActiveRunRecord): ActiveRunR
   return returned;
 }
 
-export function journalRecordAbnormalCompletion(
+export async function journalRecordAbnormalCompletion(
   record: ActiveRunRecord,
   content = "Physical run ended without a terminal event",
-): ActiveRunRecord {
+): Promise<ActiveRunRecord> {
   const failed: ActiveRunRecord = {
     ...record,
     terminalFailure: {
@@ -356,7 +367,7 @@ export function journalRecordAbnormalCompletion(
       at: new Date().toISOString(),
     },
   };
-  journalSet(failed);
+  await journalSet(failed);
   journalRetireSettledCancelAbnormal(failed.osSessionId, failed.runKey);
   return failed;
 }
@@ -492,10 +503,11 @@ const takenRunKeys: Set<string> = ((globalThis as any).__runJournalTakenKeys ??=
  * losing them. Returned records have claimedAt stripped so a reattach's
  * re-record doesn't persist a stale claim.
  */
-export function takeInterruptedRuns(
+export async function takeInterruptedRuns(
   seedRecords: ActiveRunRecord[] = [],
   shouldTake: (record: ActiveRunRecord) => boolean = () => true,
-): ActiveRunRecord[] {
+  transition: JournalRunStateTransition = transitionRunState,
+): Promise<ActiveRunRecord[]> {
   const journal = readRunJournal();
   // A graceful-shutdown snapshot can retain a detached local host after its
   // shared record disappeared during process teardown. Fold those records
@@ -525,7 +537,7 @@ export function takeInterruptedRuns(
   }
   for (const r of entries) {
     if (r.osSessionId)
-      void transitionRunState(r.osSessionId, "boot_journal_found", {
+      await transition(r.osSessionId, "boot_journal_found", {
         run_key: r.runKey,
         kind: r.kind,
       });

--- a/packages/core/opensession-server/src/server/run-journal.ts
+++ b/packages/core/opensession-server/src/server/run-journal.ts
@@ -240,7 +240,7 @@ export function journalSet(record: ActiveRunRecord): void {
   // A fallback hop re-journals the same runKey mid-run — that's the running
   // self-edge, not a new registration, so keep the event but tag it.
   if (record.osSessionId)
-    transitionRunState(record.osSessionId, "run_registered", {
+    void transitionRunState(record.osSessionId, "run_registered", {
       run_key: record.runKey,
       kind: record.kind,
       rejournal: rejournal || undefined,
@@ -525,7 +525,7 @@ export function takeInterruptedRuns(
   }
   for (const r of entries) {
     if (r.osSessionId)
-      transitionRunState(r.osSessionId, "boot_journal_found", {
+      void transitionRunState(r.osSessionId, "boot_journal_found", {
         run_key: r.runKey,
         kind: r.kind,
       });

--- a/packages/core/opensession-server/src/server/run-outcome-projection.test.ts
+++ b/packages/core/opensession-server/src/server/run-outcome-projection.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+  __setRunOutcomeProjectorForTest,
+  recordRunOutcome,
+} from "./session-cache";
+
+afterEach(() => {
+  __setRunOutcomeProjectorForTest(undefined);
+});
+
+test("recordRunOutcome waits for physical projection completion", async () => {
+  const gate = Promise.withResolvers<void>();
+  __setRunOutcomeProjectorForTest(async () => {
+    await gate.promise;
+  });
+  const projection = recordRunOutcome("outcome-wait", null);
+  let completed = false;
+  void projection.then(() => {
+    completed = true;
+  });
+
+  await Promise.resolve();
+  expect(completed).toBe(false);
+  gate.resolve();
+  await projection;
+  expect(completed).toBe(true);
+});
+
+test("recordRunOutcome exposes physical projection rejection", async () => {
+  __setRunOutcomeProjectorForTest(async () => {
+    throw new Error("outcome projection rejected");
+  });
+
+  await expect(recordRunOutcome("outcome-rejection", null)).rejects.toThrow(
+    "outcome projection rejected",
+  );
+});

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -179,6 +179,7 @@ import {
 	settleCreationFailed,
 	settleCreationSucceeded,
 	sessionIsQuarantined,
+  sessionDelivery,
 	sessionKernel,
 	sessionKernelStore,
   sessionTurn,
@@ -244,8 +245,8 @@ if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
 			return;
 		}
     const aborted = dispatchId
-      ? cancelAgentRunToken(dispatchId)
-      : cancelAgentRun(...(runIds || []));
+      ? await cancelAgentRunToken(dispatchId)
+      : await cancelAgentRun(...(runIds || []));
 		// A retry follows a durably recorded executing phase. False then means
 		// either the first attempt already cancelled the owner or this retry found
 		// it terminal, so the accepted interrupt is conservatively confirmed.
@@ -370,7 +371,7 @@ export async function requestTurnCancel(
   // (see settleCreationCancelled), so only genuine invariant failures throw.
   // Bookkeeping below always runs, even when the error propagates.
   try {
-    settleCreationOpeningForStop(sessionId);
+    await settleCreationOpeningForStop(sessionId);
   } finally {
     stoppedSessions.add(sessionId);
     persistQueues();
@@ -388,7 +389,7 @@ export async function settleCreationOpeningForStop(sessionId: string): Promise<b
 		!effectId?.startsWith("opening:")
 	)
 		return false;
-	settleCreationCancelled(
+	await settleCreationCancelled(
 		sessionId,
 		creation.identity,
 		kernel,
@@ -423,14 +424,14 @@ export async function settleRecoveredCreationOpening(
 		return false;
 	const cancel = sessionKernelStore().turnSnapshot(sessionId).cancel;
 	if (runId && cancel?.runId === runId) {
-		settleCreationCancelled(
+		await settleCreationCancelled(
 			sessionId,
 			creation.identity,
 			sessionKernel(sessionId),
 			effectId,
 		);
 	} else if (failure) {
-		settleCreationFailed(
+		await settleCreationFailed(
 			sessionId,
 			creation.identity,
 			new Error(failure),
@@ -438,7 +439,7 @@ export async function settleRecoveredCreationOpening(
 			effectId,
 		);
 	} else {
-		settleCreationSucceeded(
+		await settleCreationSucceeded(
 			sessionId,
 			creation.identity,
 			sessionKernel(sessionId),
@@ -523,35 +524,25 @@ export function runningChildCount(sessionId: string): number {
 /** Append a message to a session's drainable queue and persist + broadcast.
  *  `front` puts it ahead of everything already queued — used by the run-end
  *  actor queue hold so its auto-continue delivers before queued user messages. */
-export function enqueuePrompt(
+export async function enqueuePrompt(
 	sessionId: string,
 	item: QueueItem,
 	opts?: { front?: boolean },
-): void {
-	const queue = promptQueues.get(sessionId) || [];
+): Promise<void> {
 	const owned = durableQueueItem(sessionId, queueItem(item));
-	// A durable command can be replayed after the queue write committed but
-	// before its command receipt did. Stable ids make that retry an adoption,
-	// not a second prompt.
-	const committed =
-		!owned.id || !queue.some((queued) => queued.id === owned.id)
-			? (() => {
-				if (opts?.front) queue.unshift(owned);
-				else queue.push(owned);
-				return promptQueues.set(sessionId, queue);
-			})()
-			: Promise.resolve();
-	committed
-		.then(async () => {
-			persistQueues();
-			await broadcastQueue(sessionId);
-			// Queueing is a delivery promise, not just a UI state. Arm the idle
-			// watcher only after the durable queue write commits.
-			watchExternalRunAndDrain(sessionId);
-		})
-		.catch((error) =>
-			console.error(`[queue] Failed to enqueue prompt for ${sessionId}:`, error),
-		);
+	// Actor-owned enqueue makes concurrent producers atomic. Stable ids make a
+	// replay after commit an adoption rather than a second prompt.
+	await sessionDelivery({
+		op: "enqueue",
+		sessionId,
+		item: owned,
+		front: opts?.front,
+	});
+	persistQueues();
+	await broadcastQueue(sessionId);
+	// Queueing is a delivery promise, not just a UI state. Arm the idle
+	// watcher only after the durable queue write commits.
+	watchExternalRunAndDrain(sessionId);
 }
 
 /**
@@ -587,7 +578,7 @@ export async function requeueFailedSteer(
 		content: prefix && text.startsWith(prefix) ? text.slice(prefix.length) : text,
 		user,
 	};
-	enqueuePrompt(sessionId, item, { front: true });
+	await enqueuePrompt(sessionId, item, { front: true });
 	watchExternalRunAndDrain(sessionId);
 }
 
@@ -629,9 +620,9 @@ export async function steerQueuedPrompt(
 			item.user,
 			parseImageDataUrls(item.images || []),
 			files,
-		).catch((e) => {
+		).catch(async (e) => {
 			console.error(`[queue] Steer-deliver failed for ${sessionId}:`, e);
-			enqueuePrompt(sessionId, item);
+			await enqueuePrompt(sessionId, item);
 		});
 		return true;
 	}
@@ -1826,7 +1817,7 @@ export async function maybeLaunchSandboxedRun(
  * Callers own delivery: the prompt path drains via runSessionPromptAndDrain,
  * the create path arms watchExternalRunAndDrain when this returns true.
  */
-export function maybeQueueAutoContinue(opts: {
+export async function maybeQueueAutoContinue(opts: {
 	sessionId: string;
 	assistantText: string;
 	toolUseCount: number;
@@ -1834,7 +1825,7 @@ export function maybeQueueAutoContinue(opts: {
 	runFailure: string | null;
 	/** Skip the lookup when the caller already holds the session. */
 	session?: UnifiedSession | null;
-}): boolean {
+}): Promise<boolean> {
 	const { sessionId, assistantText, toolUseCount, endedWithError, runFailure } = opts;
 	// When a turn that plainly announced a next step is NOT nudged, record why:
 	// 2026-08-03 bks-019fc75f ended on "Now let me correlate…" with no nudge and
@@ -1898,7 +1889,7 @@ export function maybeQueueAutoContinue(opts: {
 					message:
 						"The interrupted turn never read the latest message(s) — auto-continuing so they're addressed.",
 				});
-				enqueuePrompt(
+				await enqueuePrompt(
 					sessionId,
 					{
 						content: wrapContext(ORPHANED_STEER_PROMPT, "auto-continue"),
@@ -1927,7 +1918,7 @@ export function maybeQueueAutoContinue(opts: {
 						message:
 							"Turn was cut short by an engine stall — auto-continuing (state preserved).",
 					});
-					enqueuePrompt(
+					await enqueuePrompt(
 						sessionId,
 						{
 							content: wrapContext(WEDGE_RETRY_PROMPT, "auto-continue"),
@@ -1971,7 +1962,7 @@ export function maybeQueueAutoContinue(opts: {
 	// strip <opensession:context> from user text and skip the then-empty entry,
 	// while the engine still sees the full instruction. The notice above (and
 	// the audit event) are the human-visible trace.
-	enqueuePrompt(
+	await enqueuePrompt(
 		sessionId,
 		{
 			content: wrapContext(
@@ -2030,7 +2021,7 @@ export async function runSessionPrompt(
 	// title gen, upload staging) register the run with the runner — otherwise two
 	// racing prompts both pass isAgentSessionBusy and the loser's message is
 	// dropped as a "Session is busy" error toast.
-	const startToken = markSessionStarting(sessionId);
+	const startToken = await markSessionStarting(sessionId);
   if (currentAgentRunToken(sessionId) !== startToken) {
     // A queue-drain caller restores its own claimed dispatch in the catch
     // below. A direct sandbox dispatch was created here and must be restored
@@ -2038,7 +2029,7 @@ export async function runSessionPrompt(
     if (!promptEntryId && durablePromptEntryId) {
       await failPromptDispatch(sessionId, durablePromptEntryId);
     } else if (!durablePromptEntryId) {
-      enqueuePrompt(sessionId, {
+      await enqueuePrompt(sessionId, {
         content,
         user,
         ...(images?.length
@@ -2078,7 +2069,7 @@ export async function runSessionPrompt(
 		// run-state watchdog flags. Settle it; later throws have their own
 		// terminal transitions and are left alone.
 		if (getRunState(sessionId) === "starting")
-			transitionRunState(sessionId, "start_failed", {
+			await transitionRunState(sessionId, "start_failed", {
 				source: "prompt_throw",
 				error: String(e),
 			});
@@ -2949,7 +2940,7 @@ async function runSessionPromptInner(
 				// the tail below (steer-receipt clearing, stream_done) belongs to the
 				// run that actually owns the session.
 				if (event.content === "Session is busy") {
-					enqueuePrompt(sessionId, { content, user });
+					await enqueuePrompt(sessionId, { content, user });
 					watchExternalRunAndDrain(sessionId);
 					broadcastToSession(sessionId, {
 						type: "notice",
@@ -3069,7 +3060,7 @@ async function runSessionPromptInner(
 
 	// Announce-then-stop guard (shared with the create path — see
 	// maybeQueueAutoContinue). runSessionPromptAndDrain delivers what it queues.
-	maybeQueueAutoContinue({
+	await maybeQueueAutoContinue({
 		sessionId,
 		session,
 		assistantText,

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -2494,7 +2494,7 @@ async function runSessionPromptInner(
 				? " Daytona: if the launch failed because the sandbox could not dial back, check callbackBaseUrl and your org tier's egress (docs/self-hosting-sandboxes.md)."
 				: "");
 		broadcastToSession(sessionId, { type: "error", sessionId, message: msg });
-		recordRunOutcome(
+		await recordRunOutcome(
 			session.id,
 			msg,
 			startToken
@@ -2997,7 +2997,7 @@ async function runSessionPromptInner(
 	// transcript as a system chip. finalSessionId wins over the session file's
 	// id: a run that rotated to a fresh engine session mid-turn must write the
 	// chip into the transcript the conversation actually continues in.
-	recordRunOutcome(session.id, runFailure, {
+	await recordRunOutcome(session.id, runFailure, {
 		engineSessionId: finalSessionId || session.claudeSessionId || undefined,
 		noticePersisted: failureNoticePersisted,
 		noticeLabel: failureNoticeLabel,

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -23,7 +23,6 @@ import {
   currentAgentRunToken,
   isAgentRunTokenAdmitted,
 	engineFamily,
-	interruptAndSteerAgentRun,
 	restartContinuationPrompt,
 	type StreamEvent,
 } from "./agent-runner";
@@ -155,7 +154,10 @@ import {
 	undeliveredSteers,
 	type QueueItem,
 } from "./queue-state";
-import { prepareAndSteerQueuedPrompt } from "./queued-steer";
+import {
+	prepareAndInterruptQueuedPrompt,
+	prepareAndSteerQueuedPrompt,
+} from "./queued-steer";
 import { isShuttingDown } from "./shutdown-state";
 import {
 	parseImageDataUrls,
@@ -688,11 +690,15 @@ export async function interruptQueuedPrompt(
 	if (!queue) return false;
 	const index = queuedPromptIndex(queue, queueId, queueIndex);
 	if (index < 0) return false;
-	const [item] = queue.splice(index, 1);
+	let item = queue[index];
 	if (!item) return false;
-	if (isGitHubQueueItem(item) || (Array.isArray(item.files) && item.files.length > 0)) {
-		queue.splice(index, 0, item);
+	if (isGitHubQueueItem(item) || (Array.isArray(item.files) && item.files.length > 0))
 		return false;
+	if (!item.id) {
+		item = queueItem(item);
+		queue[index] = item;
+		await promptQueues.set(sessionId, queue);
+		persistQueues();
 	}
 	const attributed =
 		item.user && !isContextOnly(item.content)
@@ -705,37 +711,19 @@ export async function interruptQueuedPrompt(
 			session.codexThreadId,
 			session.id,
 		)
-	) {
-		queue.splice(index, 0, item);
-		return false;
-	}
-	if (
-		!interruptAndSteerAgentRun(
-			[session.claudeSessionId, session.codexThreadId, session.id],
-			attributed,
-			images,
-		)
-	) {
-		// No in-band interrupt-and-steer (pi): keep the item queued — it's
-		// the durable record — and abort the turn so the drain delivers it right
-		// away. Mark it (by id) as the solo delivery so the drain delivers ONLY
-		// this item; every other queued item stays put and drains at the next
-		// natural stopping point instead of being swept into this batch. Kept at
-		// its original position so the queue doesn't visibly reshuffle.
-		const solo = queueItem(item);
-		queue.splice(index, 0, solo);
-		await promptQueues.set(sessionId, queue);
-		persistQueues();
-		await broadcastQueue(sessionId);
-		return await abortTurnAndDrain(sessionId, session, solo.id);
-	}
-	// No steer receipt: an interrupt delivers almost immediately, so the
-	// transcript entry is the record (same treatment as a direct interrupt send).
-	if (queue.length > 0) await promptQueues.set(sessionId, queue);
-	else await promptQueues.delete(sessionId);
-	persistQueues();
-	await broadcastQueue(sessionId);
-	return true;
+	) return false;
+	const interrupt = await prepareAndInterruptQueuedPrompt({
+		sessionId,
+		itemId: item.id!,
+		text: attributed,
+		images,
+	});
+	if (interrupt === "interrupted") return true;
+	if (interrupt !== "unsupported") return false;
+	// No in-band interrupt-and-steer (pi): the fenced rejection restored the
+	// durable queue item. Abort the exact current turn so the drain delivers
+	// only this item immediately; every other prompt stays queued.
+	return await abortTurnAndDrain(sessionId, session, item.id!);
 }
 
 /**

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -2922,7 +2922,7 @@ async function runSessionPromptInner(
 					const ocId = finalSessionId || session.claudeSessionId;
 					if (ocId) {
 						try {
-							appendTranscriptEntries(ocId, [
+							await appendTranscriptEntries(ocId, [
 								transcriptLineRunnerNotice(
 									cacheMissNotice(event.usage?.cacheCreationTokens),
 								),

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -22,7 +22,6 @@ import {
   cancelAgentRunTokenAndWait,
   currentAgentRunToken,
   isAgentRunTokenAdmitted,
-	steerAgentRun,
 	engineFamily,
 	interruptAndSteerAgentRun,
 	restartContinuationPrompt,
@@ -147,9 +146,6 @@ import {
 	promptQueues,
 	queuedPromptIndex,
 	queueItem,
-	acceptQueuedSteer,
-	prepareQueuedSteer,
-	rejectQueuedSteer,
 	requeueSteerReceipts,
 	restorePersistedQueueState,
 	steeredReceipts,
@@ -159,6 +155,7 @@ import {
 	undeliveredSteers,
 	type QueueItem,
 } from "./queue-state";
+import { prepareAndSteerQueuedPrompt } from "./queued-steer";
 import { isShuttingDown } from "./shutdown-state";
 import {
 	parseImageDataUrls,
@@ -639,21 +636,13 @@ export async function steerQueuedPrompt(
 			? `[${item.user}] ${item.content}`
 			: item.content;
 	const images = parseImageDataUrls(item.images || []);
-	if (!item.id || !(await prepareQueuedSteer(sessionId, item.id))) return false;
-	if (
-		!steerAgentRun(
-			[session.claudeSessionId, session.codexThreadId, session.id],
-			attributed,
-			images,
-			item.id,
-		)
-	) {
-		await rejectQueuedSteer(sessionId, item.id);
-		return false;
-	}
-	if (!await acceptQueuedSteer(sessionId, item.id))
-		throw new Error("Pending steer changed before runner acceptance");
-	return true;
+	if (!item.id) return false;
+	return (await prepareAndSteerQueuedPrompt({
+		sessionId,
+		itemId: item.id,
+		text: attributed,
+		images,
+	})) === "steered";
 }
 
 /**

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -180,6 +180,7 @@ import {
 	settleCreationSucceeded,
 	sessionIsQuarantined,
 	sessionKernel,
+	sessionKernelStore,
   sessionTurn,
 } from "./session-kernel";
 
@@ -191,7 +192,7 @@ const interruptExecutorGlobal = globalThis as typeof globalThis & {
 if (!interruptExecutorGlobal.__opensessionTurnOutcomeProjectionExecutorRegistered) {
   registerSessionEffectExecutor("turn_outcome_project", async (item) => {
     const projection = item.payload;
-    const decision = sessionTurn({
+    const decision = await sessionTurn({
       op: "begin_outcome_projection",
       sessionId: item.sessionId,
       projectionId: projection.projectionId,
@@ -206,7 +207,7 @@ if (!interruptExecutorGlobal.__opensessionTurnOutcomeProjectionExecutorRegistere
       projection,
       true,
     );
-    const settled = sessionTurn({
+    const settled = await sessionTurn({
       op: "settle_outcome_projection",
       sessionId: item.sessionId,
       projectionId: projection.projectionId,
@@ -218,7 +219,7 @@ if (!interruptExecutorGlobal.__opensessionTurnOutcomeProjectionExecutorRegistere
   interruptExecutorGlobal.__opensessionTurnOutcomeProjectionExecutorRegistered = true;
 }
 if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
-	registerSessionEffectExecutor("delivery_interrupt_cancel", (item) => {
+	registerSessionEffectExecutor("delivery_interrupt_cancel", async (item) => {
     const { interruptId, dispatchId, runIds, runGeneration } = item.payload;
     const retireConfirmedAbnormal = () => {
       if (dispatchId)
@@ -227,7 +228,7 @@ if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
           dispatchId,
         );
     };
-		const decision = beginPromptInterruptEffect(
+		const decision = await beginPromptInterruptEffect(
 			item.sessionId,
 			interruptId,
 			runGeneration,
@@ -238,7 +239,7 @@ if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
       return;
     }
 		if (decision === "adopt_confirmed") {
-			settlePromptInterrupt(item.sessionId, interruptId, "confirmed");
+			await settlePromptInterrupt(item.sessionId, interruptId, "confirmed");
       retireConfirmedAbnormal();
 			return;
 		}
@@ -250,7 +251,7 @@ if (!interruptExecutorGlobal.__opensessionInterruptExecutorRegistered) {
 		// it terminal, so the accepted interrupt is conservatively confirmed.
     const outcome =
       aborted || decision === "retry" ? "confirmed" : "not_aborted";
-		settlePromptInterrupt(item.sessionId, interruptId, outcome);
+		await settlePromptInterrupt(item.sessionId, interruptId, outcome);
     if (outcome === "confirmed") retireConfirmedAbnormal();
 	});
 	interruptExecutorGlobal.__opensessionInterruptExecutorRegistered = true;
@@ -270,7 +271,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
         !isAgentRunTokenAdmitted(dispatchId)
       ) journalClearIfLineage(owner);
     };
-    const decision = sessionTurn({
+    const decision = await sessionTurn({
       op: "begin_cancel_effect",
       sessionId: item.sessionId,
       cancelId,
@@ -285,8 +286,8 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       retireAbsentInProcessOwner();
       return;
     }
-    const settle = (outcome: "confirmed" | "not_aborted"): boolean => {
-      const settled = sessionTurn({
+    const settle = async (outcome: "confirmed" | "not_aborted"): Promise<boolean> => {
+      const settled = await sessionTurn({
         op: "settle_cancel",
         sessionId: item.sessionId,
         cancelId,
@@ -303,7 +304,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       return true;
     };
     if (decision === "adopt_confirmed") {
-      settle("confirmed");
+      await settle("confirmed");
       return;
     }
     const cancelledWait = cancelAgentWait(item.sessionId);
@@ -312,7 +313,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       throw new Error(
         `Could not reconcile executing cancellation ${cancelId} for ${dispatchId}`,
       );
-    const settled = settle(
+    const settled = await settle(
       cancelledWait || cancelledRun ? "confirmed" : "not_aborted",
     );
     if (!settled) return;
@@ -334,12 +335,12 @@ export type TurnCancelRequest = {
 
 /** Commit Stop ownership before its physical cancel, atomically parking any
  * undelivered steer receipts with the stopped run generation. */
-export function requestTurnCancel(
+export async function requestTurnCancel(
   sessionId: string,
   session: UnifiedSession,
   request: TurnCancelRequest,
-): { requeued: number } {
-  const existingCancel = sessionTurn({ op: "snapshot", sessionId }).cancel;
+): Promise<{ requeued: number }> {
+  const existingCancel = sessionKernelStore().turnSnapshot(sessionId).cancel;
   const exactReplay =
     existingCancel?.cancelId === request.cancelId &&
     existingCancel.runId === request.expectedRunId &&
@@ -353,7 +354,7 @@ export function requestTurnCancel(
     requeued
       .map((item) => item.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-  sessionTurn({
+  await sessionTurn({
     op: "prepare_cancel",
     sessionId,
     cancelId: request.cancelId,
@@ -373,12 +374,12 @@ export function requestTurnCancel(
   } finally {
     stoppedSessions.add(sessionId);
     persistQueues();
-    broadcastQueue(sessionId);
+    await broadcastQueue(sessionId);
   }
   return { requeued: exactReplay ? exactReplay.requeueIds.length : requeued.length };
 }
 
-export function settleCreationOpeningForStop(sessionId: string): boolean {
+export async function settleCreationOpeningForStop(sessionId: string): Promise<boolean> {
 	const kernel = sessionKernel(sessionId);
 	const creation = kernel.creationState();
 	const effectId = creation?.currentEffectId;
@@ -393,7 +394,7 @@ export function settleCreationOpeningForStop(sessionId: string): boolean {
 		kernel,
 		effectId,
 	);
-	acknowledgePromptDispatch(sessionId, effectId.slice("opening:".length));
+	await acknowledgePromptDispatch(sessionId, effectId.slice("opening:".length));
 	return true;
 }
 
@@ -406,12 +407,12 @@ export function creationOwnsPrompt(sessionId: string, promptEntryId: string): bo
 }
 
 /** Settle an actor-owned opening recovered by the generic local-run adopter. */
-export function settleRecoveredCreationOpening(
+export async function settleRecoveredCreationOpening(
 	sessionId: string,
 	promptEntryId: string,
 	failure?: string,
 	runId?: string,
-): boolean {
+): Promise<boolean> {
 	const creation = sessionKernel(sessionId).creationState();
 	const effectId = `opening:${promptEntryId}`;
 	if (
@@ -420,7 +421,7 @@ export function settleRecoveredCreationOpening(
 		creation.state !== "opening_dispatched"
 	)
 		return false;
-	const cancel = sessionTurn({ op: "snapshot", sessionId }).cancel;
+	const cancel = sessionKernelStore().turnSnapshot(sessionId).cancel;
 	if (runId && cancel?.runId === runId) {
 		settleCreationCancelled(
 			sessionId,
@@ -444,21 +445,21 @@ export function settleRecoveredCreationOpening(
 			effectId,
 		);
 	}
-	acknowledgePromptDispatch(sessionId, promptEntryId);
+	await acknowledgePromptDispatch(sessionId, promptEntryId);
 	return true;
 }
 
 // The runner writes its active-run journal before it can call an engine. Once
 // that journal names this prompt entry, normal boot recovery owns it and the
 // queue's pre-dispatch record is no longer needed.
-setJournalSetListener((record) => {
+setJournalSetListener(async (record) => {
 	if (
 		record.osSessionId &&
 		record.promptEntryId &&
 		creationOwnsPrompt(record.osSessionId, record.promptEntryId)
 	)
 		return;
-	acknowledgePromptDispatch(record.osSessionId, record.promptEntryId);
+	await acknowledgePromptDispatch(record.osSessionId, record.promptEntryId);
 });
 import { audit } from "./audit";
 import { githubCredentialForLogin, githubCredentialForRun } from "./github-auth";
@@ -532,17 +533,25 @@ export function enqueuePrompt(
 	// A durable command can be replayed after the queue write committed but
 	// before its command receipt did. Stable ids make that retry an adoption,
 	// not a second prompt.
-	if (!owned.id || !queue.some((queued) => queued.id === owned.id)) {
-		if (opts?.front) queue.unshift(owned);
-		else queue.push(owned);
-		promptQueues.set(sessionId, queue);
-	}
-	persistQueues();
-	broadcastQueue(sessionId);
-	// Queueing is a delivery promise, not just a UI state. Arm the idle watcher
-	// here so every queued message drains after the current run, even if a caller
-	// forgets to do that explicitly or the session becomes idle between checks.
-	watchExternalRunAndDrain(sessionId);
+	const committed =
+		!owned.id || !queue.some((queued) => queued.id === owned.id)
+			? (() => {
+				if (opts?.front) queue.unshift(owned);
+				else queue.push(owned);
+				return promptQueues.set(sessionId, queue);
+			})()
+			: Promise.resolve();
+	committed
+		.then(async () => {
+			persistQueues();
+			await broadcastQueue(sessionId);
+			// Queueing is a delivery promise, not just a UI state. Arm the idle
+			// watcher only after the durable queue write commits.
+			watchExternalRunAndDrain(sessionId);
+		})
+		.catch((error) =>
+			console.error(`[queue] Failed to enqueue prompt for ${sessionId}:`, error),
+		);
 }
 
 /**
@@ -562,14 +571,14 @@ export function enqueuePrompt(
  * ahead of anything queued behind it, and the steer is the only reason it
  * left the queue at all.
  */
-export function requeueFailedSteer(
+export async function requeueFailedSteer(
 	sessionId: string,
 	text: string,
 	user?: string,
-): void {
+): Promise<void> {
 	// effects=false: the enqueue below persists and broadcasts both maps, so
 	// watchers never see a frame with the message in neither of them.
-	const receipt = takeSteerReceiptForText(sessionId, text, false);
+	const receipt = await takeSteerReceiptForText(sessionId, text, false);
 	// No receipt (a steer recorded by a path that keeps none, or one already
 	// reconciled away): fall back to the echoed text, minus the prefix this
 	// run composed, so content stays the raw message either way.
@@ -582,11 +591,11 @@ export function requeueFailedSteer(
 	watchExternalRunAndDrain(sessionId);
 }
 
-export function steerQueuedPrompt(
+export async function steerQueuedPrompt(
 	sessionId: string,
 	queueId?: string,
 	queueIndex?: number,
-): boolean {
+): Promise<boolean> {
 	const session = findSession(sessionId);
 	const queue = promptQueues.get(sessionId);
 	if (!session || !queue) return false;
@@ -605,11 +614,11 @@ export function steerQueuedPrompt(
 		// Idle-but-queued (typically held behind running child workers): "steer"
 		// means "get this in front of the agent now" — deliver it as its own
 		// turn immediately. The rest of the queue keeps its hold.
-		if (queue.length > 0) promptQueues.set(sessionId, queue);
-		else promptQueues.delete(sessionId);
+		if (queue.length > 0) await promptQueues.set(sessionId, queue);
+		else await promptQueues.delete(sessionId);
 		stoppedSessions.delete(sessionId);
 		persistQueues();
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 		const files =
 			Array.isArray(item.files) && item.files.length > 0
 				? item.files
@@ -639,7 +648,7 @@ export function steerQueuedPrompt(
 			? `[${item.user}] ${item.content}`
 			: item.content;
 	const images = parseImageDataUrls(item.images || []);
-	if (!item.id || !prepareQueuedSteer(sessionId, item.id)) return false;
+	if (!item.id || !(await prepareQueuedSteer(sessionId, item.id))) return false;
 	if (
 		!steerAgentRun(
 			[session.claudeSessionId, session.codexThreadId, session.id],
@@ -648,10 +657,10 @@ export function steerQueuedPrompt(
 			item.id,
 		)
 	) {
-		rejectQueuedSteer(sessionId, item.id);
+		await rejectQueuedSteer(sessionId, item.id);
 		return false;
 	}
-	if (!acceptQueuedSteer(sessionId, item.id))
+	if (!await acceptQueuedSteer(sessionId, item.id))
 		throw new Error("Pending steer changed before runner acceptance");
 	return true;
 }
@@ -664,11 +673,11 @@ export function steerQueuedPrompt(
  * again would double-deliver), while a queued item is folded in through the
  * interrupt-and-steer path. False = still queued, nothing was interrupted.
  */
-export function interruptQueuedPrompt(
+export async function interruptQueuedPrompt(
 	sessionId: string,
 	queueId?: string,
 	queueIndex?: number,
-): boolean {
+): Promise<boolean> {
 	const session = findSession(sessionId);
 	if (!session) return false;
 	const receipt = queueId
@@ -693,7 +702,7 @@ export function interruptQueuedPrompt(
 		// instead of being swept into this forced one. The INTERRUPT_STEER_NOTE
 		// frames the delivery as a mid-task steer so the model resumes the
 		// interrupted work rather than acknowledge-and-parking.
-		return abortTurnAndDrain(sessionId, session, receipt.id);
+		return await abortTurnAndDrain(sessionId, session, receipt.id);
 	}
 	const queue = promptQueues.get(sessionId);
 	if (!queue) return false;
@@ -735,17 +744,17 @@ export function interruptQueuedPrompt(
 		// its original position so the queue doesn't visibly reshuffle.
 		const solo = queueItem(item);
 		queue.splice(index, 0, solo);
-		promptQueues.set(sessionId, queue);
+		await promptQueues.set(sessionId, queue);
 		persistQueues();
-		broadcastQueue(sessionId);
-		return abortTurnAndDrain(sessionId, session, solo.id);
+		await broadcastQueue(sessionId);
+		return await abortTurnAndDrain(sessionId, session, solo.id);
 	}
 	// No steer receipt: an interrupt delivers almost immediately, so the
 	// transcript entry is the record (same treatment as a direct interrupt send).
-	if (queue.length > 0) promptQueues.set(sessionId, queue);
-	else promptQueues.delete(sessionId);
+	if (queue.length > 0) await promptQueues.set(sessionId, queue);
+	else await promptQueues.delete(sessionId);
 	persistQueues();
-	broadcastQueue(sessionId);
+	await broadcastQueue(sessionId);
 	return true;
 }
 
@@ -758,9 +767,9 @@ export function interruptQueuedPrompt(
  * after resumeInterruptedRuns so a session being resumed reads as busy and the
  * watcher waits it out instead of starting a colliding run.
  */
-export function restorePromptQueues(resumedSessionIds: Set<string>): void {
+export async function restorePromptQueues(resumedSessionIds: Set<string>): Promise<void> {
 	const active = activeRunRecords();
-	const restored = restorePersistedQueueState({
+	const restored = await restorePersistedQueueState({
 		sessionExists: (sessionId) => !!findSession(sessionId),
 		// Preserve quarantined queue state without projecting or mutating it. A
 		// quarantine is intentionally inert until an operator releases it.
@@ -915,7 +924,7 @@ const recoveredSlackScanners = new Map<
 >();
 const recoveredFeedStarted: Set<string> = (g.__recoveredFeedStarted ??= new Set());
 
-export function recordRecoveredRunEvent(osSessionId: string, event: StreamEvent): void {
+export async function recordRecoveredRunEvent(osSessionId: string, event: StreamEvent): Promise<void> {
 	const session = findSession(osSessionId);
 	if (!session) return;
 	if (session.source !== "opensession") {
@@ -1074,15 +1083,15 @@ export function recordRecoveredRunEvent(osSessionId: string, event: StreamEvent)
 	if (event.type === "done" || event.type === "error") {
 		recoveredFeedStarted.delete(osSessionId);
 		if (event.type === "done") {
-			clearSteerReceipts(osSessionId);
+			await clearSteerReceipts(osSessionId);
 		} else {
-			const requeued = requeueSteerReceipts(
+			const requeued = await requeueSteerReceipts(
 				osSessionId,
 				engineUserTexts(session),
 			);
 			if (requeued > 0) watchExternalRunAndDrain(osSessionId);
 		}
-		if (settleRestoredAskAfterRecovery(osSessionId)) {
+		if (await settleRestoredAskAfterRecovery(osSessionId)) {
 			watchExternalRunAndDrain(osSessionId);
 		}
 		broadcastToSession(osSessionId, {
@@ -1247,7 +1256,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
 		// Selection, interrupt consumption, and claim are one actor reduction.
 		// Queue contents cannot change between choosing a batch and durable
 		// dispatch ownership, and a crash cannot lose or duplicate the interrupt.
-		const claim = beginNextPromptDispatch(sessionId, {
+		const claim = await beginNextPromptDispatch(sessionId, {
 			stillWorking: runningChildCount(sessionId) > 0,
 		});
 		if (claim.kind === "empty") continue;
@@ -1265,7 +1274,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
 		}
 		queueHoldNotified.delete(sessionId);
 		const { batch, promptEntryId, interrupted } = claim;
-		broadcastQueue(sessionId);
+		await broadcastQueue(sessionId);
 		let combined = batch
 			.map((m) =>
 				batch.length > 1 && m.user ? `[${m.user}] ${m.content}` : m.content,
@@ -1304,7 +1313,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
 		} catch (e) {
 			// The batch was already spliced out and persisted away — put it back at
 			// the front of the queue so a throw doesn't lose the messages.
-			failPromptDispatch(sessionId, promptEntryId);
+			await failPromptDispatch(sessionId, promptEntryId);
 			throw e;
 		}
 	}
@@ -1380,7 +1389,7 @@ export function watchExternalRunAndDrain(sessionId: string): void {
  * the fenced effect proves the owner was not abortable, it records
  * `not_aborted` and the message stays queued for the natural stopping point.
  */
-export function abortTurnAndDrain(
+export async function abortTurnAndDrain(
 	sessionId: string,
 	session: {
 		claudeSessionId?: string | null;
@@ -1393,7 +1402,7 @@ export function abortTurnAndDrain(
 	soloId?: string,
 	/** The queued item that fences even a whole-batch composer interrupt. */
 	anchorId?: string,
-): boolean {
+): Promise<boolean> {
 	const interruptAnchorId = anchorId || soloId;
 	if (!interruptAnchorId)
 		throw new Error("Interrupted prompt is missing its durable queue identity");
@@ -1404,7 +1413,7 @@ export function abortTurnAndDrain(
     sessionKernel(sessionId).runState().currentRunId ||
     currentAgentRunToken(sessionId);
   if (!dispatchId) return false;
-  preparePromptInterrupt(sessionId, interruptAnchorId, dispatchId, soloId);
+  await preparePromptInterrupt(sessionId, interruptAnchorId, dispatchId, soloId);
 	stoppedSessions.delete(sessionId);
 	watchExternalRunAndDrain(sessionId);
 	return true;
@@ -2000,7 +2009,7 @@ export async function runSessionPrompt(
 	// so a restart during provisioning requeues the complete prompt.
 	let durablePromptEntryId = promptEntryId;
 	if (!durablePromptEntryId && findSession(sessionId)?.sandbox) {
-		durablePromptEntryId = beginPromptDispatch(sessionId, [
+		durablePromptEntryId = await beginPromptDispatch(sessionId, [
 			{
 				content,
 				user,
@@ -2027,7 +2036,7 @@ export async function runSessionPrompt(
     // below. A direct sandbox dispatch was created here and must be restored
     // before surfacing the deferral.
     if (!promptEntryId && durablePromptEntryId) {
-      failPromptDispatch(sessionId, durablePromptEntryId);
+      await failPromptDispatch(sessionId, durablePromptEntryId);
     } else if (!durablePromptEntryId) {
       enqueuePrompt(sessionId, {
         content,
@@ -2062,7 +2071,7 @@ export async function runSessionPrompt(
 		);
 		// Sandboxes and non-standard runners may not create an active-run journal.
 		// A completed turn is nevertheless a safe acknowledgement of its dispatch.
-		acknowledgePromptDispatch(sessionId, durablePromptEntryId);
+		await acknowledgePromptDispatch(sessionId, durablePromptEntryId);
 	} catch (e) {
 		// A throw before the run registered (workspace revive, session-note
 		// build, …) would strand the FSM in "starting" forever — the wedge the
@@ -2077,7 +2086,7 @@ export async function runSessionPrompt(
 		// start failure retires that recovery record. A queue drain passes its own
 		// dispatch in and must retain it for the caller to restore atomically.
 		if (!promptEntryId)
-			acknowledgePromptDispatch(sessionId, durablePromptEntryId);
+			await acknowledgePromptDispatch(sessionId, durablePromptEntryId);
 		throw e;
 	} finally {
 		unmarkSessionStarting(sessionId, startToken);
@@ -2865,7 +2874,7 @@ async function runSessionPromptInner(
 				// Exact engine acknowledgement, consumed internally. Context-only
 				// system steers are intentionally absent from the visible transcript,
 				// so transcript matching alone cannot retire their receipts.
-				if (event.steerId) acknowledgeSteerDelivery(sessionId, event.steerId);
+				if (event.steerId) await acknowledgeSteerDelivery(sessionId, event.steerId);
 				break;
 			case "usage_snapshot":
 				// Live mid-run cost/context — same fold as `done`, recomputed from
@@ -3038,7 +3047,7 @@ async function runSessionPromptInner(
 	// a restart killed the SDK stream mid-turn), a steered message may NOT have
 	// been delivered yet — keep the receipt so persistQueues/restorePromptQueues
 	// can re-deliver it on the next boot instead of silently dropping it.
-	if (!endedWithError) clearSteerReceipts(sessionId);
+	if (!endedWithError) await clearSteerReceipts(sessionId);
 
 	broadcastToSession(sessionId, { type: "stream_done", sessionId });
 	broadcastToSession(sessionId, {

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -307,7 +307,7 @@ if (!interruptExecutorGlobal.__opensessionTurnCancelExecutorRegistered) {
       await settle("confirmed");
       return;
     }
-    const cancelledWait = cancelAgentWait(item.sessionId);
+    const cancelledWait = await cancelAgentWait(item.sessionId);
     const cancelledRun = await cancelAgentRunTokenAndWait(dispatchId);
     if (!cancelledRun && decision === "retry")
       throw new Error(

--- a/packages/core/opensession-server/src/server/run-state.test.ts
+++ b/packages/core/opensession-server/src/server/run-state.test.ts
@@ -232,11 +232,11 @@ describe("engine death settles through interrupted", () => {
 describe("transitionRunState (stateful wrapper)", () => {
 	const sid = () => `test-${crypto.randomUUID()}`;
 
-	test("legal transition updates the map and emits run_state_transition", () => {
+	test("legal transition updates the map and emits run_state_transition", async () => {
 		const id = sid();
 		const events: Record<string, unknown>[] = [];
 		try {
-			const to = transitionRunState(id, "prompt", { user: "test" }, (e) =>
+			const to = await transitionRunState(id, "prompt", { user: "test" }, (e) =>
 				events.push(e),
 			);
 			expect(to).toBe("starting");
@@ -252,15 +252,15 @@ describe("transitionRunState (stateful wrapper)", () => {
 			});
 			expect(runStates.get(id)?.lastEvent).toBe("prompt");
 		} finally {
-			clearRunState(id);
+			await clearRunState(id);
 		}
 	});
 
-	test("rejected transition leaves state untouched and emits run_state_rejected", () => {
+	test("rejected transition leaves state untouched and emits run_state_rejected", async () => {
 		const id = sid();
 		const events: Record<string, unknown>[] = [];
 		try {
-			const to = transitionRunState(id, "turn_end", undefined, (e) =>
+			const to = await transitionRunState(id, "turn_end", undefined, (e) =>
 				events.push(e),
 			);
 			expect(to).toBe("idle");
@@ -273,11 +273,11 @@ describe("transitionRunState (stateful wrapper)", () => {
 				event: "turn_end",
 			});
 		} finally {
-			clearRunState(id);
+			await clearRunState(id);
 		}
 	});
 
-	test("parked prompts during recovery reject silently; other rejections warn", () => {
+	test("parked prompts during recovery reject silently; other rejections warn", async () => {
 		const id = sid();
 		const events: Record<string, unknown>[] = [];
 		const warnings: string[] = [];
@@ -286,12 +286,12 @@ describe("transitionRunState (stateful wrapper)", () => {
 			warnings.push(args.join(" "));
 		};
 		try {
-			transitionRunState(id, "boot_journal_found", undefined, (e) =>
+			await transitionRunState(id, "boot_journal_found", undefined, (e) =>
 				events.push(e),
 			);
 			expect(getRunState(id)).toBe("interrupted");
 			// The designed park: rejected, audited, but not warned.
-			transitionRunState(id, "prompt", undefined, (e) => events.push(e));
+			await transitionRunState(id, "prompt", undefined, (e) => events.push(e));
 			expect(getRunState(id)).toBe("interrupted");
 			expect(events.at(-1)).toMatchObject({
 				msg: "run_state_rejected",
@@ -300,23 +300,23 @@ describe("transitionRunState (stateful wrapper)", () => {
 			});
 			expect(warnings).toHaveLength(0);
 			// Unexpected rejections still warn.
-			transitionRunState(id, "ask_resolved", undefined, (e) =>
+			await transitionRunState(id, "ask_resolved", undefined, (e) =>
 				events.push(e),
 			);
 			expect(warnings).toHaveLength(1);
 			expect(warnings[0]).toContain("ask_resolved while interrupted");
 		} finally {
 			console.warn = original;
-			clearRunState(id);
+			await clearRunState(id);
 		}
 	});
 
-	test("unknown session defaults to idle; clearRunState drops tracking", () => {
+	test("unknown session defaults to idle; clearRunState drops tracking", async () => {
 		const id = sid();
 		expect(getRunState(id)).toBe("idle");
-		transitionRunState(id, "prompt", undefined, () => {});
+		await transitionRunState(id, "prompt", undefined, () => {});
 		expect(getRunState(id)).toBe("starting");
-		clearRunState(id);
+		await clearRunState(id);
 		expect(getRunState(id)).toBe("idle");
 	});
 });

--- a/packages/core/opensession-server/src/server/run-state.ts
+++ b/packages/core/opensession-server/src/server/run-state.ts
@@ -74,12 +74,12 @@ export type RunStateTransitionDecision = {
 };
 
 /** Apply one run event and retain the actor's admission decision. */
-export function decideRunStateTransition(
+export async function decideRunStateTransition(
 	sessionId: string,
 	event: RunEvent,
 	detail?: Record<string, unknown>,
 	emit: AuditEmit = audit,
-): RunStateTransitionDecision {
+): Promise<RunStateTransitionDecision> {
 	if (detachedRunHost()) {
 		const from = getRunState(sessionId);
 		const next = nextRunState(from, event);
@@ -98,7 +98,7 @@ export function decideRunStateTransition(
 	}
 
 	const runKey = typeof detail?.run_key === "string" ? detail.run_key : undefined;
-	const decision = sessionKernel(sessionId).applyRunEvent({
+	const decision = await sessionKernel(sessionId).applyRunEvent({
 		event,
 		detail,
 		runKey,
@@ -151,13 +151,13 @@ export function decideRunStateTransition(
  * durable state and emits `run_state_transition`; an undefined one leaves the
  * state untouched and emits `run_state_rejected`.
  */
-export function transitionRunState(
+export async function transitionRunState(
 	sessionId: string,
 	event: RunEvent,
 	detail?: Record<string, unknown>,
 	emit: AuditEmit = audit,
-): RunState {
-	const decision = decideRunStateTransition(sessionId, event, detail, emit);
+): Promise<RunState> {
+	const decision = await decideRunStateTransition(sessionId, event, detail, emit);
 	return decision.accepted ? decision.to : decision.from;
 }
 

--- a/packages/core/opensession-server/src/server/run-state.ts
+++ b/packages/core/opensession-server/src/server/run-state.ts
@@ -162,7 +162,7 @@ export function transitionRunState(
 }
 
 /** Drop tracking for a deleted session. */
-export function clearRunState(sessionId: string): void {
+export async function clearRunState(sessionId: string): Promise<void> {
 	if (detachedRunHost()) detachedHostStates.delete(sessionId);
-	else clearSessionKernel(sessionId);
+	else await clearSessionKernel(sessionId);
 }

--- a/packages/core/opensession-server/src/server/runner-session.ts
+++ b/packages/core/opensession-server/src/server/runner-session.ts
@@ -181,7 +181,7 @@ export async function maybeLaunchRunnerRun(
 			launchState.phase === "rejected" ? "prepared" : launchState.phase,
 		startedAt: priorRun?.startedAt ?? new Date().toISOString(),
 	};
-	journalSet(run);
+	await journalSet(run);
 	registerRunToken(rpcToken, { sessionId: session.id, user: opts.user });
 	registerRunWsHost(hostId, wsToken);
 	const hostSpecs = new Map<string, RunHostSpec>([[hostId, spec]]);
@@ -229,13 +229,13 @@ export async function maybeLaunchRunnerRun(
 			launchState = { ...launchState, phase: "launching" };
 			writeJsonAtomic(launchStatePath, launchState);
 			run = { ...run, launchPhase: "launching" };
-			journalSet(run);
+			await journalSet(run);
 			await launcher.launch(hostId, hostDir);
       if (opts.shouldCancel?.()) handle.requestCancel();
 			launchState = { ...launchState, phase: "started" };
 			writeJsonAtomic(launchStatePath, launchState);
 			run = { ...run, launchPhase: "started" };
-			journalSet(run);
+			await journalSet(run);
 		} else {
 			const alive =
 				runnerHostAlive(hostId) &&
@@ -254,7 +254,7 @@ export async function maybeLaunchRunnerRun(
 				launchState = { ...launchState, phase: "started" };
 				writeJsonAtomic(launchStatePath, launchState);
 				run = { ...run, launchPhase: "started" };
-				journalSet(run);
+				await journalSet(run);
 			}
 		}
 		await handle.connectWithWait(20_000);
@@ -271,7 +271,7 @@ export async function maybeLaunchRunnerRun(
 				sourceCompleted = true;
 			} finally {
         if (sourceCompleted && sawTerminal) journalClear(run.runKey);
-				else if (sourceCompleted) journalRecordAbnormalCompletion(run);
+				else if (sourceCompleted) await journalRecordAbnormalCompletion(run);
 				setRunnerWorkload(runner.id, undefined, session.id);
 			}
 		})() as RunnerEvents;

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2005,7 +2005,7 @@ async function* withRunJournal(
   record: ActiveRunRecord,
   touch: () => void,
 ): AsyncGenerator<StreamEvent> {
-  journalSet(record);
+  await journalSet(record);
   touch();
   let sourceCompleted = false;
   let sawTerminal = false;
@@ -2013,13 +2013,13 @@ async function* withRunJournal(
     for await (const ev of events) {
       if (ev.type === "init" && ev.sessionId && ev.sessionId !== record.claudeSessionId) {
         record.claudeSessionId = ev.sessionId;
-        journalSet(record);
+        await journalSet(record);
       }
       if (ev.type === "model_switch" && ev.toModel) {
         record.model = ev.toModel;
         record.transientFallback = ev.temporaryFallback === true;
         if (shouldPersistModelSwitch(ev)) record.selectedModel = ev.toModel;
-        journalSet(record);
+        await journalSet(record);
       }
       if (ev.type === "done" || ev.type === "error") sawTerminal = true;
       yield ev;
@@ -2027,7 +2027,7 @@ async function* withRunJournal(
     sourceCompleted = true;
   } finally {
     if (sourceCompleted && sawTerminal) journalClear(record.runKey);
-    else if (sourceCompleted) journalRecordAbnormalCompletion(record);
+    else if (sourceCompleted) await journalRecordAbnormalCompletion(record);
     touch();
   }
 }
@@ -2119,18 +2119,18 @@ export function makeRemoteSandbox(parts: RemoteSandboxParts): Sandbox {
         await launcher.writeSpec!(dir, spec);
         mark("spec written");
         // A crash after journal admission must recover from the full spec.
-        journalSet(record);
+        await journalSet(record);
         // Construct (and register) the control BEFORE dispatch so exact-token
         // Stop reaches the launching host: cancelAgentRunTokenAndWait sees
         // hostRunBusy(token) during the launch await, and cancelHost's stop
         // backstop plus the cancelled startup marker fence the dispatch race.
         handle = new HostHandle(dir, spec, callbacks, launcher);
-        await launcher.launch(spec.hostId, dir, () => {
+        await launcher.launch(spec.hostId, dir, async () => {
           record.launchPhase = "launching";
-          journalSet(record);
+          await journalSet(record);
         });
         record.launchPhase = "started";
-        journalSet(record);
+        await journalSet(record);
         if (handle.cancelled)
           throw new HostLaunchNotDispatchedError(
             `${spec.hostId} was cancelled while launching`,

--- a/packages/core/opensession-server/src/server/sandbox/docker.ts
+++ b/packages/core/opensession-server/src/server/sandbox/docker.ts
@@ -1080,7 +1080,7 @@ async function* withRunJournal(
   events: AsyncGenerator<StreamEvent>,
   record: ActiveRunRecord,
 ): AsyncGenerator<StreamEvent> {
-  journalSet(record);
+  await journalSet(record);
   touchStateActivity(record.sandboxId!);
   let sawDone = false;
   let sawTerminal = false;
@@ -1089,13 +1089,13 @@ async function* withRunJournal(
     for await (const ev of events) {
       if (ev.type === "init" && ev.sessionId && ev.sessionId !== record.claudeSessionId) {
         record.claudeSessionId = ev.sessionId;
-        journalSet(record);
+        await journalSet(record);
       }
       if (ev.type === "model_switch" && ev.toModel) {
         record.model = ev.toModel;
         record.transientFallback = ev.temporaryFallback === true;
         if (shouldPersistModelSwitch(ev)) record.selectedModel = ev.toModel;
-        journalSet(record);
+        await journalSet(record);
       }
       if (ev.type === "done") sawDone = true;
       if (ev.type === "done" || ev.type === "error") sawTerminal = true;
@@ -1104,7 +1104,7 @@ async function* withRunJournal(
     sourceCompleted = true;
   } finally {
     if (sourceCompleted && sawTerminal) journalClear(record.runKey);
-    else if (sourceCompleted) journalRecordAbnormalCompletion(record);
+    else if (sourceCompleted) await journalRecordAbnormalCompletion(record);
     touchStateActivity(record.sandboxId!);
     if (sawDone) schedulePostRunSnapshot(record.sandboxId!);
   }
@@ -1187,7 +1187,7 @@ function makeDockerSandbox(
       writeJsonAtomic(`${dir}/${HOST_SPEC_NAME}`, spec);
       // The complete recovery spec must exist before the journal listener can
       // acknowledge the create dispatch, but ownership must precede launch.
-      journalSet(record);
+      await journalSet(record);
       let handle: HostHandle | undefined;
       let uncertainLaunch = false;
       // Per-step marks: a stalled await in this chain is otherwise silent
@@ -1201,12 +1201,12 @@ function makeDockerSandbox(
         // hostRunBusy(token) during the launch await, and cancelHost's stop
         // backstop plus the cancelled startup marker fence the dispatch race.
         handle = new HostHandle(dir, spec, callbacks, launcher);
-        await launcher.launch(spec.hostId, dir, () => {
+        await launcher.launch(spec.hostId, dir, async () => {
           record.launchPhase = "launching";
-          journalSet(record);
+          await journalSet(record);
         });
         record.launchPhase = "started";
-        journalSet(record);
+        await journalSet(record);
         mark("host exec dispatched");
         if (handle.cancelled)
           throw new HostLaunchNotDispatchedError(

--- a/packages/core/opensession-server/src/server/sandbox/local.ts
+++ b/packages/core/opensession-server/src/server/sandbox/local.ts
@@ -115,7 +115,10 @@ function makeLocalSandbox(cwd: string): Sandbox {
         steer: (text, images) => steerAgentRun(ids, text, images),
         interruptSteer: (text, images) =>
           interruptAndSteerAgentRun(ids, text, images),
-        cancel: () => cancelAgentRun(...ids),
+        cancel: () => {
+          void cancelAgentRun(...ids);
+          return true;
+        },
       };
     },
 

--- a/packages/core/opensession-server/src/server/scheduled-prompts.ts
+++ b/packages/core/opensession-server/src/server/scheduled-prompts.ts
@@ -60,8 +60,8 @@ function removeFromListing(id: string): boolean {
 	return true;
 }
 
-function schedule(prompt: ScheduledPrompt): void {
-	sessionKernel(prompt.sessionId).scheduleTimer({
+async function schedule(prompt: ScheduledPrompt): Promise<void> {
+	await sessionKernel(prompt.sessionId).scheduleTimer({
 		timerId: prompt.id,
 		kind: TIMER_KIND,
 		dueAt: Date.parse(prompt.at),
@@ -130,11 +130,11 @@ export function createScheduledPrompt(input: {
 	return prompt;
 }
 
-export function deleteScheduledPrompt(id: string): boolean {
+export async function deleteScheduledPrompt(id: string): Promise<boolean> {
 	const prompt = readStore().prompts.find((candidate) => candidate.id === id);
 	if (!prompt) return false;
 	const removed = removeFromListing(id);
-	if (removed) sessionKernel(prompt.sessionId).cancelTimer(prompt.id);
+	if (removed) await sessionKernel(prompt.sessionId).cancelTimer(prompt.id);
 	return removed;
 }
 

--- a/packages/core/opensession-server/src/server/session-cache.ts
+++ b/packages/core/opensession-server/src/server/session-cache.ts
@@ -40,11 +40,10 @@ import { writeJsonAtomic } from "./shared/atomic-write";
 import type { UnifiedSession, NativeSessionFile } from "./types";
 import {
   sessionDeliveryProjection,
-  sessionGatewayCommandAsync,
+  sessionGatewayCommand,
   sessionKernel,
   sessionKernelStore,
   sessionKernelActorActive,
-  sessionKernelStore,
   sessionTurn,
 } from "./session-kernel";
 import { withSessionMutationLock } from "./session-mutation-lock";

--- a/packages/core/opensession-server/src/server/session-cache.ts
+++ b/packages/core/opensession-server/src/server/session-cache.ts
@@ -752,6 +752,18 @@ export type RunOutcomeProjectionOptions = {
 	projectedAt?: string;
 };
 
+let runOutcomeProjectorForTest:
+	| typeof applyRunOutcomeProjection
+	| undefined;
+
+export function __setRunOutcomeProjectorForTest(
+	projector: typeof applyRunOutcomeProjection | undefined,
+): typeof applyRunOutcomeProjection | undefined {
+	const previous = runOutcomeProjectorForTest;
+	runOutcomeProjectorForTest = projector;
+	return previous;
+}
+
 export async function recordRunOutcome(
 	sessionId: string,
 	errorMessage: string | null,
@@ -792,7 +804,11 @@ export async function recordRunOutcome(
 		!process.env.OPENSESSION_RUN_JOURNAL
 	)
 		throw new Error("Turn outcome projection requires the authoritative actor");
-	void applyRunOutcomeProjection(id, errorMessage, opts);
+	await (runOutcomeProjectorForTest ?? applyRunOutcomeProjection)(
+		id,
+		errorMessage,
+		opts,
+	);
 }
 
 /** Idempotent destination-side implementation for actor-issued projections. */

--- a/packages/core/opensession-server/src/server/session-cache.ts
+++ b/packages/core/opensession-server/src/server/session-cache.ts
@@ -42,6 +42,7 @@ import {
   sessionDeliveryProjection,
   sessionGatewayCommandAsync,
   sessionKernel,
+  sessionKernelStore,
   sessionKernelActorActive,
   sessionKernelStore,
   sessionTurn,
@@ -336,7 +337,7 @@ export function isRunSettled(sessionId: string): boolean {
 	}
 	// Queue authority lives in the actor. Read its per-session delivery snapshot
 	// directly rather than reaching through queue-state's former global map.
-	if (sessionDeliveryProjection(id).queued.length > 0)
+	if (sessionKernelStore().deliverySnapshot(id).queued.length > 0)
 		return false;
 	return true;
 }
@@ -462,7 +463,7 @@ export function updateSessionFile(
 ): Promise<void> {
   return withSessionMutationLock(sessionId, async () => {
     const requestId = `session-file:${crypto.randomUUID()}`;
-    const plan = await sessionGatewayCommandAsync({
+    const plan = await sessionGatewayCommand({
       op: "request",
       sessionId,
       requestId,
@@ -487,7 +488,7 @@ export function updateSessionFile(
 		}
 		invalidateSessionsCache();
       physicalFinished = true;
-      await sessionGatewayCommandAsync({
+      await sessionGatewayCommand({
         op: "complete",
         sessionId,
         requestId,
@@ -495,15 +496,14 @@ export function updateSessionFile(
         result: null,
       });
     } catch (error) {
-      if (!physicalFinished)
-        await sessionGatewayCommandAsync({
-          op: "fail",
-          sessionId,
-          requestId,
-          operation: "session_file_updated",
-          error: error instanceof Error ? error.message : String(error),
-          retryable: false,
-        });
+      if (!physicalFinished) await sessionGatewayCommand({
+        op: "fail",
+        sessionId,
+        requestId,
+        operation: "session_file_updated",
+        error: error instanceof Error ? error.message : String(error),
+        retryable: false,
+      });
       throw error;
     }
 	});
@@ -752,11 +752,11 @@ export type RunOutcomeProjectionOptions = {
 	projectedAt?: string;
 };
 
-export function recordRunOutcome(
+export async function recordRunOutcome(
 	sessionId: string,
 	errorMessage: string | null,
 	opts?: RunOutcomeProjectionOptions,
-): void {
+): Promise<void> {
 	const session = findSession(sessionId);
 	const id = session?.id || sessionId;
 	// runAgent settles every journal-owned run on its terminal event. Keep this
@@ -769,7 +769,7 @@ export function recordRunOutcome(
 	if (opts?.projectionId && opts.runId && sessionKernelActorActive()) {
 		const runGeneration =
 			opts.runGeneration ?? sessionKernel(id).runState().generation;
-		sessionTurn({
+		await sessionTurn({
 			op: "prepare_outcome_projection",
 			sessionId: id,
 			projectionId: opts.projectionId,

--- a/packages/core/opensession-server/src/server/session-cache.ts
+++ b/packages/core/opensession-server/src/server/session-cache.ts
@@ -763,7 +763,7 @@ export async function recordRunOutcome(
 	// persistence choke point compatible with non-runner callers without
 	// emitting a false double-teardown rejection for the normal path.
 	if (isRunStateUnsettled(getRunState(id)))
-		transitionRunState(id, errorMessage ? "run_failed" : "turn_end", {
+		await transitionRunState(id, errorMessage ? "run_failed" : "turn_end", {
 			...(opts?.runId ? { run_key: opts.runId } : {}),
 		});
 	if (opts?.projectionId && opts.runId && sessionKernelActorActive()) {

--- a/packages/core/opensession-server/src/server/session-cache.ts
+++ b/packages/core/opensession-server/src/server/session-cache.ts
@@ -698,10 +698,10 @@ export const runErrors: Map<string, { message: string; at: string }> =
  *
  * `require` rather than a static import: pi-transcript lazily requires
  * this module back (its own cycle-breaker), and the transcript write must be
- * synchronous so it lands before the client re-reads the transcript.
- * Never throws — a dead transcript store must not break outcome recording.
+ * ordered so it lands before the client re-reads the transcript.
+ * Never throws unless strict projection ownership requires fail-closed behavior.
  */
-function persistRunFailureNotice(
+async function persistRunFailureNotice(
 	sessionId: string,
 	engineSessionId: string | null | undefined,
 	message: string,
@@ -709,7 +709,7 @@ function persistRunFailureNotice(
 	projectionId?: string,
 	projectedAt?: string,
 	strict = false,
-): void {
+): Promise<void> {
 	try {
 		const m = require("./transcript-persistence") as typeof import("./transcript-persistence");
 		const line = m.transcriptLineRunnerNotice(
@@ -718,13 +718,13 @@ function persistRunFailureNotice(
 			projectedAt,
 		);
 		if (strict)
-			m.applyForwardedTranscriptStrict(
+			await m.applyForwardedTranscriptStrict(
 				sessionId,
 				engineSessionId || sessionId,
 				[line],
 			);
 		else
-			m.applyForwardedTranscript(sessionId, engineSessionId || sessionId, [line]);
+			await m.applyForwardedTranscript(sessionId, engineSessionId || sessionId, [line]);
 	} catch (error) {
 		if (strict) throw error;
 	}
@@ -819,7 +819,7 @@ export async function applyRunOutcomeProjection(
 					: session?.codexThreadId
 						? "codex"
 						: "claude");
-			persistRunFailureNotice(
+			await persistRunFailureNotice(
 				id,
 				opts?.engineSessionId ||
 					(session ? engineSessionIdFor(session, provider) : undefined),

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -83,7 +83,7 @@ function buildSummary(s: UnifiedSession): SessionSummary {
 	// External runs (CLI in tmux, another process) show as running via PID but
 	// aren't in our activeRuns — observe-only, can't steer/cancel them.
 	const runningExternal = !!s.isRunning && !busyHere;
-	const pending = pendingAskAwaitingAnswer(s.id);
+	const pending = pendingAsks.get(s.id);
 	const queuedCount = promptQueues.get(s.id)?.length || 0;
 
 	let state: SessionState;
@@ -151,7 +151,7 @@ registerSessionControl({
 
 	answerQuestion: async (id, answers, opts) => {
 		const requestId = opts?.requestId || randomUUIDv7();
-		const questionId = pendingAskAwaitingAnswer(id)?.questionId || null;
+		const questionId = (await pendingAskAwaitingAnswer(id))?.questionId || null;
 		// The actor records the answer durably under the caller's retry
 		// identity; the aggregate makes replay idempotent. The gateway-side
 		// resolver then runs its live side effects (escalation cancel,
@@ -169,13 +169,13 @@ registerSessionControl({
 		const effective =
 			settled.answers ?? (answers && typeof answers === "object" ? answers : null);
 		const pending = pendingAsks.get(id) as
-			| { questionId?: string; resolve?: (value: unknown) => void }
+			| { questionId?: string; resolve?: (value: unknown) => void | Promise<void> }
 			| undefined;
 		if (
 			pending?.resolve &&
 			(questionId === null || pending.questionId === questionId)
 		)
-			pending.resolve(effective);
+			await pending.resolve(effective);
 		return true;
 	},
 
@@ -250,7 +250,7 @@ registerSessionControl({
 			// prior Stop here rather than inside the run the Stop prevents: the busy
 			// branch below only enqueues, and drainQueue parks at the latch, which
 			// would leave the message queued forever.
-			liftUserStop(id);
+			await liftUserStop(id);
 
 			const attributed = user ? `[${user}] ${content}` : content;
 			// Disk-staged files can only be supplied to a fresh turn. Never fold them
@@ -311,7 +311,7 @@ registerSessionControl({
 						deliveryId,
 					};
 				}
-				enqueuePrompt(id, {
+				await enqueuePrompt(id, {
 					id: deliveryId,
 					content,
 					user,
@@ -345,7 +345,7 @@ registerSessionControl({
 
 			// Every accepted prompt is durable before any engine or workspace wake.
 			// A crash after this write but before dispatch replays the same queue id.
-			enqueuePrompt(id, {
+			await enqueuePrompt(id, {
 				id: deliveryId,
 				content,
 				user,
@@ -523,7 +523,7 @@ registerSessionControl({
 					new Date(durableCreation.updatedAt).toISOString(),
 			};
 		}
-		let createPlan = actorCreationSetupPlan(bksId, createIdentity);
+		let createPlan = await actorCreationSetupPlan(bksId, createIdentity);
 		if (
 			completedCreate?.claudeSessionId ||
 			completedCreate?.codexThreadId
@@ -710,7 +710,7 @@ registerSessionControl({
 					else {
 						sessionBranch = await branchNameFromPrompt(prompt);
 						sessionBranch = await resolveUniqueBranch(sessionBranch, repo.id);
-						createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+						createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 							branch: sessionBranch,
 						});
 					}
@@ -837,7 +837,7 @@ registerSessionControl({
 				const plannedWorkspaceId =
 					createPlan.workspaceId || createPlanWorkspaceId(bksId);
 				if (!createPlan.workspaceId)
-					createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+					createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 						workspaceId: plannedWorkspaceId,
 					});
 				const branchForWs = wsParent?.branch || sessionBranch;
@@ -886,7 +886,7 @@ registerSessionControl({
 		const attachmentSources =
 			createPlan.attachments ?? prepareCreationAttachmentSources(bksId, rawFiles);
 		if (!createPlan.attachments && attachmentSources.length)
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 				attachments: attachmentSources,
 			});
 		for (const attachment of attachmentSources)
@@ -1082,7 +1082,7 @@ ${createMentionsNote}`;
 				}
 			: computedSpec;
 		if (!createPlan.resolved) {
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 				resolved: snapshotOpeningCreate(computedSpec),
 			});
 		}

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -17,12 +17,13 @@
 
 import { AUTO_CONTINUE_USER } from "./auto-continue";
 import { personaName } from "./config";
-import { currentAgentRunToken, isAgentSessionBusy, steerAgentRun } from "./agent-runner";
+import { currentAgentRunToken, isAgentSessionBusy } from "./agent-runner";
 import { pendingAskAwaitingAnswer, pendingAsks } from "./asks";
 import { relinkAskThreads } from "./human-asks";
 import { SESSION_EFFORTS, type SessionEffort, providerFor, resolveModel } from "./models";
 import { configuredInteractiveDefaultModel } from "./model-catalog";
-import { deliveryQueueState, durableQueueItem, liftUserStop, promptQueues, acceptQueuedSteer, prepareQueuedSteer, rejectQueuedSteer } from "./queue-state";
+import { deliveryQueueState, durableQueueItem, liftUserStop, promptQueues } from "./queue-state";
+import { prepareAndSteerQueuedPrompt } from "./queued-steer";
 import { drainQueue, enqueuePrompt, requestTurnCancel, runSessionPrompt, sessionMentionsNote, watchExternalRunAndDrain } from "./run-session";
 import { creationAttachmentPath, parseImageDataUrls, prepareCreationAttachmentSources, withUploadsNote } from "./uploads";
 import { type Sandbox } from "./sandbox";
@@ -284,32 +285,28 @@ registerSessionControl({
 						...(opts?.hold ? { hold: true } : {}),
 						...(opts?.reviewHandoff ? { reviewHandoff: true } : {}),
 					});
-					if (!prepareQueuedSteer(id, deliveryId, steerItem)) {
-						throw new Error("Delivery changed before steer preparation");
-					}
-					if (
-						steerAgentRun(
-							[session.claudeSessionId, session.codexThreadId, session.id],
-							attributed,
-							opts?.images,
-							deliveryId,
-						)
-					) {
-						if (!await acceptQueuedSteer(id, deliveryId))
-							throw new Error("Pending steer changed before runner acceptance");
+					const steerResult = await prepareAndSteerQueuedPrompt({
+						sessionId: id,
+						itemId: deliveryId,
+						item: steerItem,
+						text: attributed,
+						images: opts?.images,
+					});
+					if (steerResult === "steered") {
 						return {
 							status: "steered" as const,
 							message: "Folded into the running turn.",
 							deliveryId,
 						};
 					}
-					await rejectQueuedSteer(id, deliveryId);
-					watchExternalRunAndDrain(id);
-					return {
-						status: "queued" as const,
-						message: "Queued behind the current run.",
-						deliveryId,
-					};
+					if (steerResult === "rejected") {
+						watchExternalRunAndDrain(id);
+						return {
+							status: "queued" as const,
+							message: "Queued behind the current run.",
+							deliveryId,
+						};
+					}
 				}
 				await enqueuePrompt(id, {
 					id: deliveryId,

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -18,7 +18,7 @@
 import { AUTO_CONTINUE_USER } from "./auto-continue";
 import { personaName } from "./config";
 import { currentAgentRunToken, isAgentSessionBusy } from "./agent-runner";
-import { pendingAskAwaitingAnswer, pendingAsks } from "./asks";
+import { pendingAskAwaitingAnswer, pendingAskAwaitingAnswerSync, pendingAsks } from "./asks";
 import { relinkAskThreads } from "./human-asks";
 import { SESSION_EFFORTS, type SessionEffort, providerFor, resolveModel } from "./models";
 import { configuredInteractiveDefaultModel } from "./model-catalog";
@@ -84,7 +84,7 @@ function buildSummary(s: UnifiedSession): SessionSummary {
 	// External runs (CLI in tmux, another process) show as running via PID but
 	// aren't in our activeRuns — observe-only, can't steer/cancel them.
 	const runningExternal = !!s.isRunning && !busyHere;
-	const pending = pendingAsks.get(s.id);
+	const pending = pendingAskAwaitingAnswerSync(s.id);
 	const queuedCount = promptQueues.get(s.id)?.length || 0;
 
 	let state: SessionState;

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -55,7 +55,7 @@ import {
 	requestCreationCredential,
 	requestCreationWorkspace,
 	sessionAsk,
-	sessionDeliveryAsync,
+	sessionDelivery,
 	sessionKernel,
   sessionTurn,
 } from "./session-kernel";
@@ -156,7 +156,7 @@ registerSessionControl({
 		// identity; the aggregate makes replay idempotent. The gateway-side
 		// resolver then runs its live side effects (escalation cancel,
 		// broadcast, tool-promise wake) — it owns the answerReceived flag.
-		const settled = sessionAsk({
+		const settled = await sessionAsk({
 			op: "answer",
 			sessionId: id,
 			questionId,
@@ -295,7 +295,7 @@ registerSessionControl({
 							deliveryId,
 						)
 					) {
-						if (!acceptQueuedSteer(id, deliveryId))
+						if (!await acceptQueuedSteer(id, deliveryId))
 							throw new Error("Pending steer changed before runner acceptance");
 						return {
 							status: "steered" as const,
@@ -303,7 +303,7 @@ registerSessionControl({
 							deliveryId,
 						};
 					}
-					rejectQueuedSteer(id, deliveryId);
+					await rejectQueuedSteer(id, deliveryId);
 					watchExternalRunAndDrain(id);
 					return {
 						status: "queued" as const,
@@ -363,7 +363,7 @@ registerSessionControl({
 				deliveryId,
 			};
 		};
-		const plan = await sessionDeliveryAsync({
+		const plan = await sessionDelivery({
 			op: "request_submit_command",
 			sessionId: id,
 			requestId: deliveryId,
@@ -381,7 +381,7 @@ registerSessionControl({
 		try {
 			const result = await deliverOwned();
       submitPhysicalFinished = true;
-			return await sessionDeliveryAsync({
+			return await sessionDelivery({
 				op: "complete_submit_command",
 				sessionId: id,
 				requestId: deliveryId,
@@ -390,7 +390,7 @@ registerSessionControl({
 		} catch (error) {
 			if (error instanceof SessionDeliveryError) {
         submitPhysicalFinished = true;
-				await sessionDeliveryAsync({
+				await sessionDelivery({
 					op: "complete_submit_command",
 					sessionId: id,
 					requestId: deliveryId,
@@ -398,20 +398,19 @@ registerSessionControl({
 				});
 				return error.result;
 			}
-      if (!submitPhysicalFinished)
-				await sessionDeliveryAsync({
-					op: "fail_submit_command",
-					sessionId: id,
-					requestId: deliveryId,
-					error: error instanceof Error ? error.message : String(error),
-				});
+      if (!submitPhysicalFinished) await sessionDelivery({
+				op: "fail_submit_command",
+				sessionId: id,
+				requestId: deliveryId,
+				error: error instanceof Error ? error.message : String(error),
+			});
 			throw error;
 		}
 	},
 
 	cancelSession: async (id, opts) => {
 		const requestId = opts?.requestId || randomUUIDv7();
-		const plan = sessionTurn({
+		const plan = await sessionTurn({
 			op: "request_cancel_command",
 			sessionId: id,
 			requestId,
@@ -423,28 +422,28 @@ registerSessionControl({
 			const currentSession = findSession(id);
 			if (!currentSession) {
         cancelPhysicalFinished = true;
-				return sessionTurn({
+				return await sessionTurn({
 					op: "complete_cancel_command",
 					sessionId: id,
 					requestId,
 					result: false,
 				});
 			}
-			requestTurnCancel(id, currentSession, {
+			await requestTurnCancel(id, currentSession, {
 				cancelId: `stop:${requestId}`,
 				expectedRunId: plan.targetRunId,
 				expectedGeneration: plan.targetRunGeneration,
 				source: "session_control",
 			});
       cancelPhysicalFinished = true;
-			return sessionTurn({
+			return await sessionTurn({
 				op: "complete_cancel_command",
 				sessionId: id,
 				requestId,
 				result: true,
 			});
 		} catch (error) {
-      if (!cancelPhysicalFinished) sessionTurn({
+      if (!cancelPhysicalFinished) await sessionTurn({
 				op: "fail_cancel_command",
 				sessionId: id,
 				requestId,

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -101,6 +101,7 @@ import {
 	settleCreationFailed,
 	settleCreationSucceeded,
 	sessionKernel,
+	sessionKernelStore,
 	sessionTurn,
 } from "./session-kernel";
 import { AUTO_REPO, ensureAskCheckout, ensureScratchDir, getRepo, isRegisteredWorktree, listWorktrees, NO_REPO, repoForPath, repoForPathOrNull, resolveUniqueBranch, sharedCheckoutForNewSessions, worktreeHeadBranch, worktreePathFor, } from "./worktree";
@@ -508,28 +509,28 @@ export function runOpeningCreateOnce(
 	}
 	// Validate and bound actor recovery input before accepting the prompt dispatch.
 	const openingPlan = snapshotOpeningPlan(spec);
-	const openingPromptEntryId = beginPromptDispatch(
-		spec.id,
-		[
-			{
-				content: spec.openingPrompt,
-				user: spec.user,
-				...(spec.images?.length
-					? {
-							images: spec.images.map(
-								(image) => `data:${image.mediaType};base64,${image.data}`,
-							),
-						}
-					: {}),
-			},
-		],
+	const done = (async () => {
+		const openingPromptEntryId = await beginPromptDispatch(
+			spec.id,
+			[
+				{
+					content: spec.openingPrompt,
+					user: spec.user,
+					...(spec.images?.length
+						? {
+								images: spec.images.map(
+									(image) => `data:${image.mediaType};base64,${image.data}`,
+								),
+							}
+						: {}),
+				},
+			],
 		spec.openingPromptEntryId,
 		true,
 		"create",
-	);
-	if (openingPromptEntryId !== spec.openingPromptEntryId)
-		throw new Error("Opening prompt identity changed before actor dispatch");
-	const done = (async () => {
+		);
+		if (openingPromptEntryId !== spec.openingPromptEntryId)
+			throw new Error("Opening prompt identity changed before actor dispatch");
 		// The creation actor owns one physical effect at a time. Materialize the
 		// primary worktree before dispatching the long-running opening effect;
 		// otherwise openCreatedSession would try to emit a branch effect while the
@@ -709,9 +710,9 @@ async function restorePlannedOpening(sessionId: string): Promise<{
 	};
 }
 
-export function settleStoppedCreationOpening(item: CreationOpeningEffectItem): boolean {
+export async function settleStoppedCreationOpening(item: CreationOpeningEffectItem): Promise<boolean> {
 	const kernel = sessionKernel(item.sessionId);
-	const turn = sessionTurn({ op: "snapshot", sessionId: item.sessionId });
+	const turn = sessionKernelStore().turnSnapshot(item.sessionId);
 	// Exact cancel identity, matching openingTurnWasCancelled(): a retained
 	// receipt fences only the exact run it cancelled. The receipt records the
 	// admitted physical token derived from the effect payload, so recompute it
@@ -731,7 +732,7 @@ export function settleStoppedCreationOpening(item: CreationOpeningEffectItem): b
 		kernel,
 		item.effectKey,
 	);
-	acknowledgePromptDispatch(
+	await acknowledgePromptDispatch(
 		item.sessionId,
 		item.payload.openingPromptEntryId,
 	);
@@ -753,7 +754,7 @@ export async function executeCreationOpeningEffect(
 			state.state === "cancelled") &&
 		state.completedEffectIds.includes(item.effectKey)
 	) {
-		acknowledgePromptDispatch(
+		await acknowledgePromptDispatch(
 			item.sessionId,
 			item.payload.openingPromptEntryId,
 		);
@@ -761,7 +762,7 @@ export async function executeCreationOpeningEffect(
 			clearCreatePlan(item.sessionId);
 		return;
 	}
-	if (settleStoppedCreationOpening(item)) return;
+	if (await settleStoppedCreationOpening(item)) return;
 	if (
 		state.state !== "opening_dispatched" ||
 		state.currentEffectId !== item.effectKey
@@ -780,7 +781,7 @@ export async function executeCreationOpeningEffect(
 			sessionKernel(item.sessionId),
 			item.effectKey,
 		);
-		acknowledgePromptDispatch(
+		await acknowledgePromptDispatch(
 			item.sessionId,
 			item.payload.openingPromptEntryId,
 		);
@@ -801,7 +802,7 @@ export async function executeCreationOpeningEffect(
 					recovered?.state === "cancelled") &&
 				recovered.completedEffectIds.includes(item.effectKey)
 			) {
-				acknowledgePromptDispatch(
+				await acknowledgePromptDispatch(
 					item.sessionId,
 					item.payload.openingPromptEntryId,
 				);
@@ -809,7 +810,7 @@ export async function executeCreationOpeningEffect(
 					clearCreatePlan(item.sessionId);
 				return;
 			}
-			if (settleStoppedCreationOpening(item)) return;
+			if (await settleStoppedCreationOpening(item)) return;
 			if (
 				!recovered ||
 				recovered.identity !== item.payload.creationIdentity ||
@@ -832,7 +833,7 @@ export async function executeCreationOpeningEffect(
 		throw new Error("Opening effect actor-plan identity changed during recovery");
 	if (restored.spec.openingPromptEntryId !== item.payload.openingPromptEntryId)
 		throw new Error("Opening effect prompt identity changed during recovery");
-	if (settleStoppedCreationOpening(item)) return;
+	if (await settleStoppedCreationOpening(item)) return;
 	await openCreatedSession(
 		restored.spec,
 		restored.io,
@@ -915,7 +916,7 @@ export async function openCreatedSession(
 	let startGeneration = 0;
 	const openingTurnWasCancelled = (): boolean => {
 		if (!startToken || startGeneration < 1) return false;
-		const cancel = sessionTurn({ op: "snapshot", sessionId: bksId }).cancel;
+		const cancel = sessionKernelStore().turnSnapshot(bksId).cancel;
 		return (
 			cancel?.runId === startToken &&
 			cancel.runGeneration === startGeneration
@@ -1064,7 +1065,7 @@ export async function openCreatedSession(
 		const preparingEnvironment = spec.needsWorktree || Boolean(pendingAttach) || Boolean(spec.sandboxProvider) || Boolean(spec.runnerTarget);
 		if (preparingEnvironment) preparingWorkspaces.add(bksId);
 		try {
-			openingPromptEntryId = beginPromptDispatch(bksId, [
+			openingPromptEntryId = await beginPromptDispatch(bksId, [
 				{
 					content: spec.openingPrompt,
 					user: spec.user,
@@ -1294,7 +1295,7 @@ export async function openCreatedSession(
 						creationEffectId,
 					);
 				creationSettled = true;
-				acknowledgePromptDispatch(bksId, openingPromptEntryId);
+				await acknowledgePromptDispatch(bksId, openingPromptEntryId);
 			};
 			for await (const event of sandboxOpeningRun ?? runnerOpeningRun ?? runAgent({
 				prompt: openingPromptForRun,
@@ -1363,7 +1364,7 @@ export async function openCreatedSession(
 				// follow-up ladder. Consume Pi's exact boundary acknowledgement here
 				// too, including context-only steers that transcript parsing hides.
 				if (event.type === "steer_delivered" && event.steerId) {
-					acknowledgeSteerDelivery(bksId, event.steerId);
+					await acknowledgeSteerDelivery(bksId, event.steerId);
 				}
 				if (event.type === "init") {
 					engineSessionId = event.sessionId || "";
@@ -1569,7 +1570,7 @@ export async function openCreatedSession(
 				undefined,
 				creationEffectId,
 			);
-			acknowledgePromptDispatch(bksId, openingPromptEntryId);
+			await acknowledgePromptDispatch(bksId, openingPromptEntryId);
 			if (announced) {
 				io.emit({ type: "stream_done" });
 				io.emit({ type: "session_status", isRunning: false });
@@ -1618,7 +1619,7 @@ export async function openCreatedSession(
 			undefined,
 			creationEffectId,
 		);
-		acknowledgePromptDispatch(bksId, openingPromptEntryId);
+		await acknowledgePromptDispatch(bksId, openingPromptEntryId);
 		for (const record of activeRunRecords()) {
 			if (
 				record.osSessionId === bksId &&

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -468,16 +468,16 @@ export async function waitForCreatedSessionProjection(
 	}
 }
 
-export function actorCreationSetupPlan(
+export async function actorCreationSetupPlan(
 	sessionId: string,
 	identity: string,
-): CreationSetupPlan {
-	const state = ensureCreationPlanned(sessionId, identity);
+): Promise<CreationSetupPlan> {
+	const state = await ensureCreationPlanned(sessionId, identity);
 	if (state.setupPlan || !["planned", "preparing"].includes(state.state))
 		return (state.setupPlan ?? {}) as CreationSetupPlan;
 	const legacy = readCreatePlan(sessionId, identity);
 	if (!legacy) return {};
-	return patchCreationSetupPlan(sessionId, identity, {
+	return await patchCreationSetupPlan(sessionId, identity, {
 		...(legacy.branch ? { branch: legacy.branch } : {}),
 		...(legacy.workspaceId ? { workspaceId: legacy.workspaceId } : {}),
 		...(legacy.attachments ? { attachments: legacy.attachments } : {}),
@@ -645,7 +645,7 @@ async function restorePlannedOpening(sessionId: string): Promise<{
 			],
 			kind: "create" as const,
 		};
-		promptDispatches.set(sessionId, recoveredDispatch);
+		await promptDispatches.set(sessionId, recoveredDispatch);
 		dispatch = recoveredDispatch;
 	}
 	if (dispatch?.kind !== "create") return null;
@@ -726,7 +726,7 @@ export async function settleStoppedCreationOpening(item: CreationOpeningEffectIt
 			runnerOpeningHostId(item.payload.runId, item.payload.runGeneration) &&
 		cancel.runGeneration === item.payload.runGeneration;
 	if (kernel.runState().state !== "stopped" && !exactCancel) return false;
-	settleCreationCancelled(
+	await settleCreationCancelled(
 		item.sessionId,
 		item.payload.creationIdentity,
 		kernel,
@@ -774,7 +774,7 @@ export async function executeCreationOpeningEffect(
 			run.promptEntryId === item.payload.openingPromptEntryId,
 	);
 	if (openingJournal?.terminalFailure) {
-		settleCreationFailed(
+		await settleCreationFailed(
 			item.sessionId,
 			item.payload.creationIdentity,
 			new Error(openingJournal.terminalFailure.content),
@@ -1041,7 +1041,7 @@ export async function openCreatedSession(
 		// engine is up. The starting mark keeps a prompt typed in that
 		// window from double-starting a run (same race as
 		// runSessionPrompt).
-		startToken = markSessionStarting(
+		startToken = await markSessionStarting(
 			bksId,
 			openingRun
 				? runnerOpeningHostId(openingRun.runId, openingRun.generation)
@@ -1281,14 +1281,14 @@ export async function openCreatedSession(
 				// the generator's next item. Backend generator finally blocks may now
 				// retire their journal/host only after the actor has the receipt.
 				if (openingTurnWasCancelled())
-					settleCreationCancelled(
+					await settleCreationCancelled(
 						bksId,
 						creationIdentity,
 						undefined,
 						creationEffectId,
 					);
 				else
-					settleCreationSucceeded(
+					await settleCreationSucceeded(
 						bksId,
 						creationIdentity,
 						undefined,
@@ -1539,7 +1539,7 @@ export async function openCreatedSession(
 			// here too. Nothing wraps this run in runSessionPromptAndDrain, so a
 			// queued nudge needs the drain watcher to deliver it.
 			if (
-				maybeQueueAutoContinue({
+				await maybeQueueAutoContinue({
 					sessionId: bksId,
 					assistantText,
 					toolUseCount,
@@ -1564,7 +1564,7 @@ export async function openCreatedSession(
 			return;
 		}
 		if (openingTurnWasCancelled()) {
-			settleCreationCancelled(
+			await settleCreationCancelled(
 				bksId,
 				creationIdentity,
 				undefined,
@@ -1612,7 +1612,7 @@ export async function openCreatedSession(
 		} else {
 			io.fail(e.message || String(e));
 		}
-		settleCreationFailed(
+		await settleCreationFailed(
 			bksId,
 			creationIdentity,
 			e,
@@ -1742,7 +1742,7 @@ export async function handleCreateSessionMessage(
 		finishCreate();
 		return response;
 	}
-	let createPlan = actorCreationSetupPlan(bksId, createIdentity);
+	let createPlan = await actorCreationSetupPlan(bksId, createIdentity);
 	if (
 		recoveringSession?.claudeSessionId ||
 		recoveringSession?.codexThreadId
@@ -1943,7 +1943,7 @@ export async function handleCreateSessionMessage(
 		const plannedWorkspaceId =
 			createPlan.workspaceId || createPlanWorkspaceId(bksId);
 		if (!createPlan.workspaceId)
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 				workspaceId: plannedWorkspaceId,
 			});
 		// A code create landing on a branch whose worktree an existing
@@ -2197,7 +2197,7 @@ export async function handleCreateSessionMessage(
 			const plannedWorkspaceId =
 				createPlan.workspaceId || createPlanWorkspaceId(bksId);
 			if (!createPlan.workspaceId)
-				createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+				createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 					workspaceId: plannedWorkspaceId,
 				});
 			await requestCreationWorkspace({
@@ -2239,7 +2239,7 @@ export async function handleCreateSessionMessage(
 		const attachmentSources =
 			createPlan.attachments ?? prepareCreationAttachmentSources(bksId, msg.files);
 		if (!createPlan.attachments && attachmentSources.length)
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 				attachments: attachmentSources,
 			});
 		for (const attachment of attachmentSources)
@@ -2332,7 +2332,7 @@ export async function handleCreateSessionMessage(
 		}
 
 		if (branch && branch !== createPlan.branch)
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, { branch });
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, { branch });
 		const computedSpec: ResolvedCreate = {
 			id: bksId,
 			title,
@@ -2476,7 +2476,7 @@ export async function handleCreateSessionMessage(
 				}
 			: computedSpec;
 		if (!createPlan.resolved) {
-			createPlan = patchCreationSetupPlan(bksId, createIdentity, {
+			createPlan = await patchCreationSetupPlan(bksId, createIdentity, {
 				resolved: snapshotOpeningCreate(computedSpec),
 			});
 		}

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -1270,7 +1270,7 @@ export async function openCreatedSession(
 					);
 				if (latestUsage)
 					await touchNativeSession(bksId, { usage: latestUsage });
-				recordRunOutcome(bksId, runFailure, {
+				await recordRunOutcome(bksId, runFailure, {
 					engineSessionId,
 					noticePersisted: failureNoticePersisted,
 					runId: startToken,
@@ -1514,7 +1514,7 @@ export async function openCreatedSession(
 						record.promptEntryId === openingPromptEntryId &&
 						!record.terminalFailure
 					)
-						journalRecordAbnormalCompletion(record);
+						await journalRecordAbnormalCompletion(record);
 				}
 				throw new Error("Opening run ended without a terminal event");
 			}
@@ -1593,6 +1593,12 @@ export async function openCreatedSession(
 					},
 				});
 			}
+			// Persist before terminal delivery or creation settlement. A failed
+			// outcome projection leaves recovery evidence intact for retry.
+			await recordRunOutcome(
+				bksId,
+				`Session setup failed: ${e.message || String(e)}`,
+			);
 			io.emit({ type: "error", message: e.message || String(e) });
 			io.emit({ type: "stream_done" });
 			io.emit({
@@ -1600,15 +1606,6 @@ export async function openCreatedSession(
 				message: `Session setup failed: ${e.message || String(e)}`,
 			});
 			io.emit({ type: "session_status", isRunning: false });
-			// Persist the failure on the session file too — the live
-			// events above are gone on reload, and a setup-failed session
-			// (e.g. `git worktree add` refusing a branch name that
-			// collides with an existing `name/...` ref) otherwise shows
-			// as an inexplicably empty session (bks-019f472f, 2026-07-09).
-			recordRunOutcome(
-				bksId,
-				`Session setup failed: ${e.message || String(e)}`,
-			);
 		} else {
 			io.fail(e.message || String(e));
 		}

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -565,6 +565,92 @@ describe("session kernel actor boundary", () => {
     })).toThrow("actor stopped");
   });
 
+  test("classifies structured quarantine failures on the async path", async () => {
+    class StructuredErrorWorker {
+      listeners = new Map<string, (event: MessageEvent) => void>();
+      addEventListener(type: string, listener: (event: MessageEvent) => void) {
+        this.listeners.set(type, listener);
+      }
+      removeEventListener() {}
+      postMessage(message: { rpcId: string }) {
+        const body = JSON.stringify({
+          ok: false,
+          code: "session_quarantined",
+          sessionId: "async-quarantine",
+          error: "settlement is quarantined",
+        });
+        queueMicrotask(() => this.listeners.get("message")?.({
+          data: {
+            t: "call_result",
+            rpcId: message.rpcId,
+            status: -1,
+            length: body.length,
+            body,
+          },
+        } as MessageEvent));
+      }
+      terminate() {}
+    }
+    const host = new SessionKernelActorClient(
+      new StructuredErrorWorker() as unknown as Worker,
+    );
+    client = host;
+
+    await expect(host.decideGatewayAsync({
+      op: "request",
+      sessionId: "async-quarantine",
+      requestId: "request",
+      operation: "websocket_command",
+    })).rejects.toBeInstanceOf(SessionKernelQuarantinedError);
+  });
+
+  test("marks structured actor-fatal failures dead on the async path", async () => {
+    class StructuredErrorWorker {
+      listeners = new Map<string, (event: MessageEvent) => void>();
+      addEventListener(type: string, listener: (event: MessageEvent) => void) {
+        this.listeners.set(type, listener);
+      }
+      removeEventListener() {}
+      postMessage(message: { rpcId: string }) {
+        const body = JSON.stringify({
+          ok: false,
+          code: "actor_fatal",
+          error: "actor authority failed",
+        });
+        queueMicrotask(() => this.listeners.get("message")?.({
+          data: {
+            t: "call_result",
+            rpcId: message.rpcId,
+            status: -1,
+            length: body.length,
+            body,
+          },
+        } as MessageEvent));
+      }
+      terminate() {}
+    }
+    const fatal: Error[] = [];
+    const host = new SessionKernelActorClient(
+      new StructuredErrorWorker() as unknown as Worker,
+      (error) => fatal.push(error),
+    );
+    client = host;
+
+    await expect(host.decideGatewayAsync({
+      op: "request",
+      sessionId: "async-fatal",
+      requestId: "request",
+      operation: "websocket_command",
+    })).rejects.toThrow("actor authority failed");
+    expect(fatal).toHaveLength(1);
+    await expect(host.decideGatewayAsync({
+      op: "request",
+      sessionId: "async-fatal",
+      requestId: "later",
+      operation: "websocket_command",
+    })).rejects.toThrow("actor authority failed");
+  });
+
   test("quarantines one session after ambiguous typed settlement", async () => {
     const host = await actor();
     host.decideGateway({

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -780,15 +780,15 @@ describe("session kernel actor boundary", () => {
 
   test("delivery mutations invalidate projections without fetching a snapshot", async () => {
     const host = await actor();
-    const original = host.decideDelivery.bind(host);
+    const original = host.decideDeliveryAsync.bind(host);
     let snapshotCalls = 0;
-    host.decideDelivery = ((request) => {
+    host.decideDeliveryAsync = (async (request) => {
       if (request.op === "snapshot") snapshotCalls += 1;
       return original(request);
-    }) as typeof host.decideDelivery;
+    }) as typeof host.decideDeliveryAsync;
     installSessionKernelActor(host);
 
-    sessionDelivery({
+    await sessionDelivery({
       op: "set",
       sessionId: "small-mutation-reply",
       slot: "queued",
@@ -796,7 +796,7 @@ describe("session kernel actor boundary", () => {
     });
     expect(snapshotCalls).toBe(0);
     expect(
-      sessionDelivery({ op: "snapshot", sessionId: "small-mutation-reply" })
+      (await sessionDelivery({ op: "snapshot", sessionId: "small-mutation-reply" }))
         .revision,
     ).toBe(1);
     expect(snapshotCalls).toBe(1);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.test.ts
@@ -401,6 +401,53 @@ describe("session kernel actor boundary", () => {
     });
   });
 
+  test("does not replay a mutation whose committed response exceeds the buffer", async () => {
+    const host = await actor();
+    const sessionId = "large-async-dispatch";
+    const content = "x".repeat(300 * 1024);
+    await host.decideDeliveryAsync({
+      op: "set",
+      sessionId,
+      slot: "queued",
+      value: [{ id: "large", content }],
+    });
+    const claimed = await host.decideDeliveryAsync({
+      op: "claim_next_dispatch",
+      sessionId,
+      promptEntryId: "large-entry",
+    });
+    expect(claimed).toMatchObject({
+      kind: "deliver",
+      promptEntryId: "large-entry",
+      items: [{ id: "large", content }],
+    });
+    expect(host.store.deliverySnapshot(sessionId)).toMatchObject({
+      queued: [],
+      dispatch: {
+        promptEntryId: "large-entry",
+        items: [{ id: "large", content }],
+      },
+    });
+  });
+
+  test("atomically preserves concurrent queue enqueues", async () => {
+    const host = await actor();
+    const sessionId = "concurrent-enqueues";
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        host.decideDeliveryAsync({
+          op: "enqueue",
+          sessionId,
+          item: { id: `item-${index}`, content: `prompt-${index}` },
+        })
+      ),
+    );
+    const snapshot = await host.decideDeliveryAsync({ op: "snapshot", sessionId });
+    expect(snapshot.queued).toHaveLength(20);
+    expect(new Set((snapshot.queued as Array<{ id: string }>).map((item) => item.id)).size)
+      .toBe(20);
+  });
+
   test("hydrates persisted run state into the gateway projection", async () => {
     const host = await actor();
     host.callStore("setRunState", [

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -298,18 +298,6 @@ export class SessionKernelActorClient {
     );
   }
 
-  async decideCoreAsync<T extends CoreActorRequest>(
-    request: T,
-  ): Promise<CoreActorResult<T>> {
-    return this.callAsync<CoreActorResult<T>>(
-      {
-        t: "reduce",
-        command: { kind: "core", commandId: crypto.randomUUID(), request },
-      },
-      `core ${request.op}`,
-    );
-  }
-
   decideGateway<T extends GatewayCommandRequest>(
     request: T,
   ): GatewayCommandResult<T> {
@@ -587,18 +575,6 @@ export class SessionKernelActorClient {
     );
   }
 
-  decideGatewayAsync<T extends GatewayCommandRequest>(
-    request: T,
-  ): Promise<GatewayCommandResult<T>> {
-    return this.callAsync<GatewayCommandResult<T>>(
-      {
-        t: "reduce",
-        command: { kind: "gateway", commandId: crypto.randomUUID(), request },
-      },
-      `gateway ${request.operation} ${request.op}`,
-    );
-  }
-
   async decideDeliveryAsync<T extends DeliveryActorRequest>(
     request: T,
   ): Promise<DeliveryActorResult<T>> {
@@ -615,6 +591,8 @@ export class SessionKernelActorClient {
       },
       `delivery ${request.op}`,
     );
+    if (request.op === "snapshot" || request.op === "entries")
+      return response as DeliveryActorResult<T>;
     return (response as DeliveryMutationReply<DeliveryActorResult<T>>).result;
   }
 

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -346,27 +346,6 @@ export class SessionKernelActorClient {
     return (response as DeliveryMutationReply<DeliveryActorResult<T>>).result;
   }
 
-  async decideDeliveryAsync<T extends DeliveryActorRequest>(
-    request: T,
-  ): Promise<DeliveryActorResult<T>> {
-    if (request.op === "snapshot") return this.decideDelivery(request);
-    if (request.op === "entries") return this.decideDelivery(request);
-    const response = await this.callAsync<
-      DeliveryActorResult<T> | DeliveryMutationReply<DeliveryActorResult<T>>
-    >(
-      {
-        t: "reduce",
-        command: {
-          kind: "delivery",
-          commandId: crypto.randomUUID(),
-          request,
-        },
-      },
-      `delivery ${request.op}`,
-    );
-    return (response as DeliveryMutationReply<DeliveryActorResult<T>>).result;
-  }
-
   decideAgentOperation(request: AgentOperationRequest): AgentOperationResult {
     return this.callSync<AgentOperationResult>(
       { t: "reduce", command: { kind: "agent_operation", commandId: request.identity.operationId, request } },

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -447,6 +447,213 @@ export class SessionKernelActorClient {
     return result;
   }
 
+  /**
+   * Awaited store/reduce RPC over the posted-message transport. Unlike
+   * callSync this never blocks the gateway event loop; callers await.
+   */
+  callAsync<TResult>(
+    request:
+      | { t: "store"; method: string; args: unknown[] }
+      | { t: "reduce"; command: SessionActorReducerCommand },
+    label: string,
+    large = false,
+  ): Promise<TResult> {
+    if (this.deadError) return Promise.reject(this.deadError);
+    const rpcId = crypto.randomUUID();
+    return new Promise<TResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(rpcId);
+        reject(
+          new SessionKernelActorError(
+            `Session kernel actor timed out handling ${label}`,
+            true,
+          ),
+        );
+      }, 15_000);
+      const parse = (value: unknown): TResult => {
+        const response = value as {
+          status: number;
+          body?: string;
+          length?: number;
+        };
+        if (response.status !== 1 || !response.body)
+          throw new SessionKernelActorError(
+            `Session kernel ${label} returned no result`,
+            true,
+          );
+        const body = JSON.parse(response.body) as {
+          ok: boolean;
+          result?: TResult;
+          error?: string;
+          code?: string;
+          sessionId?: string;
+        };
+        if (!body.ok) {
+          const message = body.error || `Session kernel ${label} failed`;
+          if (body.code === "session_quarantined" && body.sessionId)
+            throw new SessionKernelQuarantinedError(body.sessionId, message);
+          const error = new SessionKernelActorError(message, false);
+          if (body.code === "actor_fatal") this.markDead(error);
+          throw error;
+        }
+        return body.result as TResult;
+      };
+      this.pending.set(rpcId, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          try {
+            resolve(parse(value));
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      try {
+        this.worker.postMessage({ ...request, rpcId });
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(rpcId);
+        const failure = error instanceof Error ? error : new Error(String(error));
+        this.markDead(failure);
+        reject(failure);
+      }
+    });
+  }
+
+  async decideAskAsync<T extends AskActorRequest>(
+    request: T,
+  ): Promise<AskActorResult<T>> {
+    return this.callAsync<AskActorResult<T>>(
+      {
+        t: "reduce",
+        command: { kind: "ask", commandId: crypto.randomUUID(), request },
+      },
+      `ask ${request.op}`,
+    );
+  }
+
+  async decideTurnAsync<T extends TurnActorRequest>(
+    request: T,
+  ): Promise<TurnActorResult<T>> {
+    const result = await this.callAsync<TurnActorResult<T>>(
+      {
+        t: "reduce",
+        command: { kind: "turn", commandId: crypto.randomUUID(), request },
+      },
+      `turn ${request.op}`,
+    );
+    if (request.op === "prepare_cancel")
+      (this.store as RemoteStore).noteRunState(
+        request.sessionId,
+        (
+          result as TurnActorResult<
+            Extract<TurnActorRequest, { op: "prepare_cancel" }>
+          >
+        ).runState,
+      );
+    else if (
+      request.op === "prepare_outcome_projection" ||
+      request.op === "settle_outcome_projection"
+    )
+      (this.store as RemoteStore).noteChange(request.sessionId);
+    return result;
+  }
+
+  decideTimerAsync<T extends TimerActorRequest>(
+    request: T,
+  ): Promise<TimerActorResult<T>> {
+    return this.callAsync<TimerActorResult<T>>(
+      {
+        t: "reduce",
+        command: { kind: "timer", commandId: crypto.randomUUID(), request },
+      },
+      `timer ${request.op}`,
+    );
+  }
+
+  decideCoreAsync<T extends CoreActorRequest>(
+    request: T,
+  ): Promise<CoreActorResult<T>> {
+    return this.callAsync<CoreActorResult<T>>(
+      {
+        t: "reduce",
+        command: { kind: "core", commandId: crypto.randomUUID(), request },
+      },
+      `core ${request.op}`,
+    );
+  }
+
+  decideGatewayAsync<T extends GatewayCommandRequest>(
+    request: T,
+  ): Promise<GatewayCommandResult<T>> {
+    return this.callAsync<GatewayCommandResult<T>>(
+      {
+        t: "reduce",
+        command: { kind: "gateway", commandId: crypto.randomUUID(), request },
+      },
+      `gateway ${request.operation} ${request.op}`,
+    );
+  }
+
+  async decideDeliveryAsync<T extends DeliveryActorRequest>(
+    request: T,
+  ): Promise<DeliveryActorResult<T>> {
+    const response = await this.callAsync<
+      DeliveryActorResult<T> | DeliveryMutationReply<DeliveryActorResult<T>>
+    >(
+      {
+        t: "reduce",
+        command: {
+          kind: "delivery",
+          commandId: crypto.randomUUID(),
+          request,
+        },
+      },
+      `delivery ${request.op}`,
+    );
+    return (response as DeliveryMutationReply<DeliveryActorResult<T>>).result;
+  }
+
+  async decideCreationEventAsync(
+    decision: CreationEventDecision,
+  ): Promise<CreationEventDecisionResult> {
+    return this.callAsync<CreationEventDecisionResult>(
+      {
+        t: "reduce",
+        command: {
+          kind: "creation_event",
+          commandId: crypto.randomUUID(),
+          decision,
+        },
+      },
+      "creation event decision",
+      true,
+    );
+  }
+
+  async decideRunEventAsync(
+    decision: RunEventDecision,
+  ): Promise<RunEventDecisionResult> {
+    const result = await this.callAsync<RunEventDecisionResult>(
+      {
+        t: "reduce",
+        command: {
+          kind: "run_event",
+          commandId: crypto.randomUUID(),
+          decision,
+        },
+      },
+      "run event decision",
+    );
+    if (result.accepted)
+      (this.store as RemoteStore).noteRunState(decision.sessionId, result.state);
+    return result;
+  }
+
   callStore<TResult>(method: string, args: unknown[]): TResult {
     return this.callSync<TResult>(
       { t: "store", method, args },

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -596,6 +596,31 @@ export class SessionKernelActorClient {
     return (response as DeliveryMutationReply<DeliveryActorResult<T>>).result;
   }
 
+  async decideAgentHostSupervisionAsync<T extends AgentHostSupervisionRequest>(
+    request: T,
+  ): Promise<T extends AgentHostPlanRegistration
+    ? AgentHostPlanRegistrationResult
+    : AgentHostSupervisionResult> {
+    return this.callAsync<
+      AgentHostPlanRegistrationResult | AgentHostSupervisionResult
+    >(
+      {
+        t: "reduce",
+        command: {
+          kind: "agent_host_supervision",
+          commandId:
+            request.op === "register_plan"
+              ? request.registrationId
+              : request.claimId,
+          request,
+        },
+      },
+      "Agent Host supervision claim",
+    ) as Promise<T extends AgentHostPlanRegistration
+      ? AgentHostPlanRegistrationResult
+      : AgentHostSupervisionResult>;
+  }
+
   async decideCreationEventAsync(
     decision: CreationEventDecision,
   ): Promise<CreationEventDecisionResult> {
@@ -1154,6 +1179,9 @@ class RemoteStore implements SessionKernelStoreApi {
   }
   setDeliverySlot(sessionId: string, slot: DeliverySlot, value: unknown) {
     this.actor.decideDelivery({ op: "set", sessionId, slot, value });
+  }
+  enqueueDelivery(sessionId: string, item: unknown, front?: boolean) {
+    return this.actor.decideDelivery({ op: "enqueue", sessionId, item, front });
   }
   deleteDeliverySlot(sessionId: string, slot: DeliverySlot) {
     return this.actor.decideDelivery({ op: "delete", sessionId, slot });

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -760,37 +760,6 @@ export class SessionKernelActorClient {
     return response.result as TResult;
   }
 
-  private async callAsync<TResult>(
-    request: SyncRequest,
-    label: string,
-  ): Promise<TResult> {
-    const response = await this.request({
-      ...request,
-      rpcId: crypto.randomUUID(),
-    });
-    if (response.t !== "call_result" || !response.body)
-      throw new SessionKernelActorError(
-        `Invalid async ${label} response`,
-        true,
-      );
-    const body = JSON.parse(response.body) as {
-      ok: boolean;
-      result?: TResult;
-      error?: string;
-      code?: string;
-      sessionId?: string;
-    };
-    if (!body.ok) {
-      const message = body.error || `Session kernel ${label} failed`;
-      if (body.code === "session_quarantined" && body.sessionId)
-        throw new SessionKernelQuarantinedError(body.sessionId, message);
-      const error = new SessionKernelActorError(message, false);
-      if (body.code === "actor_fatal") this.markDead(error);
-      throw error;
-    }
-    return body.result as TResult;
-  }
-
   terminate(): void {
     this.store.close();
     this.markDead(new Error("Session kernel actor stopped"), false);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-client.ts
@@ -16,6 +16,7 @@ import {
   type DurableOutboxItem,
   type DeliverySlot,
   type DurableRunState,
+  type DurableSteerTarget,
   type DurableTimer,
   type RunEventDecision,
   type RunEventDecisionResult,
@@ -464,7 +465,7 @@ export class SessionKernelActorClient {
           body?: string;
           length?: number;
         };
-        if (response.status !== 1 || !response.body)
+        if (!response.body)
           throw new SessionKernelActorError(
             `Session kernel ${label} returned no result`,
             true,
@@ -1189,19 +1190,43 @@ class RemoteStore implements SessionKernelStoreApi {
   clearDeliverySlot(slot: DeliverySlot) {
     this.actor.decideDelivery({ op: "clear_slot", slot });
   }
-  prepareSteerDelivery(sessionId: string, itemId: string, item?: unknown) {
+  prepareSteerDelivery(
+    sessionId: string,
+    itemId: string,
+    target: DurableSteerTarget,
+    item?: unknown,
+  ) {
     return this.actor.decideDelivery({
       op: "prepare_steer",
       sessionId,
       itemId,
+      target,
       item,
     });
   }
-  acceptSteerDelivery(sessionId: string, itemId: string) {
-    return this.actor.decideDelivery({ op: "accept_steer", sessionId, itemId });
+  acceptSteerDelivery(
+    sessionId: string,
+    itemId: string,
+    target: DurableSteerTarget,
+  ) {
+    return this.actor.decideDelivery({
+      op: "accept_steer",
+      sessionId,
+      itemId,
+      target,
+    });
   }
-  rejectSteerDelivery(sessionId: string, itemId: string) {
-    return this.actor.decideDelivery({ op: "reject_steer", sessionId, itemId });
+  rejectSteerDelivery(
+    sessionId: string,
+    itemId: string,
+    target: DurableSteerTarget,
+  ) {
+    return this.actor.decideDelivery({
+      op: "reject_steer",
+      sessionId,
+      itemId,
+      target,
+    });
   }
   settlePendingSteers() {
     return this.actor.decideDelivery({ op: "settle_pending_steers" });

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
@@ -316,6 +316,59 @@ describe("session kernel actor service", () => {
     });
   });
 
+  test("returns the first committed mutation result when it exceeds the service buffer", async () => {
+    const sessionId = "large-service-dispatch";
+    const content = "x".repeat(9 * 1024 * 1024);
+    const seeded = await rpc({
+      t: "call",
+      rpcId: "seed-large-service-dispatch",
+      outputBytes: 256 * 1024,
+      request: {
+        t: "reduce",
+        command: {
+          kind: "delivery",
+          commandId: "seed-large-service-dispatch",
+          request: {
+            op: "set",
+            sessionId,
+            slot: "queued",
+            value: [{ id: "large", content }],
+          },
+        },
+      },
+    });
+    expect(seeded).toMatchObject({ t: "call_result", status: 1 });
+
+    const claimed = await rpc({
+      t: "call",
+      rpcId: "claim-large-service-dispatch",
+      outputBytes: 8 * 1024 * 1024,
+      request: {
+        t: "reduce",
+        command: {
+          kind: "delivery",
+          commandId: "claim-large-service-dispatch",
+          request: {
+            op: "claim_next_dispatch",
+            sessionId,
+            promptEntryId: "large-entry",
+          },
+        },
+      },
+    });
+    expect(claimed).toMatchObject({ t: "call_result", status: 1 });
+    expect(JSON.parse(claimed.body)).toMatchObject({
+      ok: true,
+      result: {
+        result: {
+          kind: "deliver",
+          promptEntryId: "large-entry",
+          items: [{ id: "large", content }],
+        },
+      },
+    });
+  });
+
   test("a locked session database does not block another session mailbox", async () => {
     for (const sessionId of ["locked-pool-session", "healthy-pool-session"]) {
       const created = await rpc({

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -16,7 +16,7 @@ import {
 import { isDeliveryReadRequest } from "./delivery-protocol";
 import type { SessionActorReducerCommand } from "./lifecycle-protocol";
 import { isReadReducer, sessionActorReducerRoute } from "./actor-routing";
-import { sessionKernelStoreRoute } from "./store-routing";
+import { READ_METHODS, sessionKernelStoreRoute } from "./store-routing";
 
 class SessionQuarantinedError extends Error {
   readonly code = "session_quarantined";
@@ -59,8 +59,9 @@ export function startSessionKernelActorWorker(): void {
     self.postMessage(message);
   }
 
-  function syncStore(request: KernelActorSyncRequest): void {
+  function syncStore(request: KernelActorSyncRequest): string | undefined {
     const control = new Int32Array(request.control);
+    let overflowBody: string | undefined;
     const output = new Uint8Array(request.output);
     let store = host.central;
     let requestSessionId: string | undefined;
@@ -103,6 +104,12 @@ export function startSessionKernelActorWorker(): void {
               delivery.sessionId,
               delivery.slot,
               delivery.value,
+            );
+          else if (delivery.op === "enqueue")
+            result = store.enqueueDelivery(
+              delivery.sessionId,
+              delivery.item,
+              delivery.front,
             );
           else if (delivery.op === "delete")
             result = store.deleteDeliverySlot(delivery.sessionId, delivery.slot);
@@ -258,10 +265,10 @@ export function startSessionKernelActorWorker(): void {
         }
         result = host.call(request.method, request.args);
       }
-      const bytes = new TextEncoder().encode(
-        JSON.stringify({ ok: true, result }),
-      );
+      const body = JSON.stringify({ ok: true, result });
+      const bytes = new TextEncoder().encode(body);
       if (bytes.length > output.length) {
+        overflowBody = body;
         // Large read-only snapshots retry with an exactly-sized buffer. Mutating
         // calls are never retried by the client, so this signal cannot repeat a
         // committed reduction.
@@ -324,24 +331,30 @@ export function startSessionKernelActorWorker(): void {
       if (failStop) queueMicrotask(() => self.close());
     }
     Atomics.notify(control, 0);
+    return overflowBody;
   }
 
   function asyncCall(request: KernelActorClientCallRequest): void {
     // Bounded allocation with an exactly-sized retry: most results are small,
     // so starting at max response size would churn hundreds of MiB per call.
-    // Status 2 means the encoded result needs more space; only large read
-    // snapshots produce it (mutating reductions always fit small buffers and
-    // are never retried by callers).
+    // A status-2 response is safe to replay only for a provable read. A
+    // mutation may already have committed before its encoded result overflowed.
+    const retryableRead = request.t === "reduce"
+      ? isReadReducer(request.command)
+      : READ_METHODS.has(request.method);
     let outputBytes = 256 * 1024;
     for (;;) {
       const control = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
       const output = new SharedArrayBuffer(outputBytes);
-      syncStore({ ...request, control, output } as unknown as KernelActorSyncRequest);
+      const overflowBody = syncStore(
+        { ...request, control, output } as unknown as KernelActorSyncRequest,
+      );
       const view = new Int32Array(control);
       const status = Atomics.load(view, 0) as -1 | 1 | 2;
       const length = Atomics.load(view, 1);
       if (
         status === 2 &&
+        retryableRead &&
         length > outputBytes &&
         length <= SESSION_KERNEL_MAX_RESPONSE_BYTES
       ) {
@@ -351,15 +364,17 @@ export function startSessionKernelActorWorker(): void {
       post({
         t: "call_result",
         rpcId: request.rpcId,
-        status,
+        status: status === 2 && !retryableRead ? 1 : status,
         length,
-        ...(status === 2
-          ? {}
-          : {
-              body: new TextDecoder().decode(
-                new Uint8Array(output, 0, Math.min(length, output.byteLength)),
-              ),
-            }),
+        ...(status === 2 && !retryableRead
+          ? { body: overflowBody }
+          : status === 2
+            ? {}
+            : {
+                body: new TextDecoder().decode(
+                  new Uint8Array(output, 0, Math.min(length, output.byteLength)),
+                ),
+              }),
       });
       return;
     }
@@ -377,17 +392,24 @@ export function startSessionKernelActorWorker(): void {
     }
     const control = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
     const output = new SharedArrayBuffer(outputBytes);
-    syncStore({ ...request.request, control, output } as KernelActorSyncRequest);
+    const retryableRead = request.request.t === "reduce"
+      ? isReadReducer(request.request.command)
+      : READ_METHODS.has(request.request.method);
+    const overflowBody = syncStore(
+      { ...request.request, control, output } as KernelActorSyncRequest,
+    );
     const view = new Int32Array(control);
     const status = Atomics.load(view, 0) as -1 | 1 | 2;
     const length = Atomics.load(view, 1);
     post({
       t: "call_result",
       rpcId: request.rpcId,
-      status,
+      status: status === 2 && !retryableRead ? 1 : status,
       length,
-      ...(status === 2
-        ? {}
+      ...(status === 2 && !retryableRead
+        ? { body: overflowBody }
+        : status === 2
+          ? {}
         : {
             body: new TextDecoder().decode(
               new Uint8Array(output, 0, Math.min(length, outputBytes)),

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -327,25 +327,42 @@ export function startSessionKernelActorWorker(): void {
   }
 
   function asyncCall(request: KernelActorClientCallRequest): void {
-    const control = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
-    const output = new SharedArrayBuffer(SESSION_KERNEL_MAX_RESPONSE_BYTES);
-    syncStore({ ...request, control, output } as unknown as KernelActorSyncRequest);
-    const view = new Int32Array(control);
-    const status = Atomics.load(view, 0) as -1 | 1 | 2;
-    const length = Atomics.load(view, 1);
-    post({
-      t: "call_result",
-      rpcId: request.rpcId,
-      status,
-      length,
-      ...(status === 2
-        ? {}
-        : {
-            body: new TextDecoder().decode(
-              new Uint8Array(output, 0, Math.min(length, output.byteLength)),
-            ),
-          }),
-    });
+    // Bounded allocation with an exactly-sized retry: most results are small,
+    // so starting at max response size would churn hundreds of MiB per call.
+    // Status 2 means the encoded result needs more space; only large read
+    // snapshots produce it (mutating reductions always fit small buffers and
+    // are never retried by callers).
+    let outputBytes = 256 * 1024;
+    for (;;) {
+      const control = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+      const output = new SharedArrayBuffer(outputBytes);
+      syncStore({ ...request, control, output } as unknown as KernelActorSyncRequest);
+      const view = new Int32Array(control);
+      const status = Atomics.load(view, 0) as -1 | 1 | 2;
+      const length = Atomics.load(view, 1);
+      if (
+        status === 2 &&
+        length > outputBytes &&
+        length <= SESSION_KERNEL_MAX_RESPONSE_BYTES
+      ) {
+        outputBytes = length;
+        continue;
+      }
+      post({
+        t: "call_result",
+        rpcId: request.rpcId,
+        status,
+        length,
+        ...(status === 2
+          ? {}
+          : {
+              body: new TextDecoder().decode(
+                new Uint8Array(output, 0, Math.min(length, output.byteLength)),
+              ),
+            }),
+      });
+      return;
+    }
   }
 
   function serviceCall(request: KernelActorServiceCall): void {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -119,17 +119,20 @@ export function startSessionKernelActorWorker(): void {
             result = store.prepareSteerDelivery(
               delivery.sessionId,
               delivery.itemId,
+              delivery.target,
               delivery.item,
             );
           else if (delivery.op === "accept_steer")
             result = store.acceptSteerDelivery(
               delivery.sessionId,
               delivery.itemId,
+              delivery.target,
             );
           else if (delivery.op === "reject_steer")
             result = store.rejectSteerDelivery(
               delivery.sessionId,
               delivery.itemId,
+              delivery.target,
             );
           else if (delivery.op === "settle_pending_steers")
             result = host.call("settlePendingSteers", []);

--- a/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-worker.ts
@@ -8,6 +8,7 @@ import {
   SESSION_KERNEL_MAX_RESPONSE_BYTES,
   isCriticalSettlementCommand,
   type KernelActorAsyncRequest,
+  type KernelActorClientCallRequest,
   type KernelActorServiceCall,
   type KernelActorServiceResponse,
   type KernelActorSyncRequest,
@@ -325,6 +326,28 @@ export function startSessionKernelActorWorker(): void {
     Atomics.notify(control, 0);
   }
 
+  function asyncCall(request: KernelActorClientCallRequest): void {
+    const control = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+    const output = new SharedArrayBuffer(SESSION_KERNEL_MAX_RESPONSE_BYTES);
+    syncStore({ ...request, control, output } as unknown as KernelActorSyncRequest);
+    const view = new Int32Array(control);
+    const status = Atomics.load(view, 0) as -1 | 1 | 2;
+    const length = Atomics.load(view, 1);
+    post({
+      t: "call_result",
+      rpcId: request.rpcId,
+      status,
+      length,
+      ...(status === 2
+        ? {}
+        : {
+            body: new TextDecoder().decode(
+              new Uint8Array(output, 0, Math.min(length, output.byteLength)),
+            ),
+          }),
+    });
+  }
+
   function serviceCall(request: KernelActorServiceCall): void {
     const outputBytes = Math.floor(request.outputBytes);
     if (outputBytes <= 0 || outputBytes > SESSION_KERNEL_MAX_RESPONSE_BYTES) {
@@ -367,7 +390,8 @@ export function startSessionKernelActorWorker(): void {
       return;
     }
     if (request.t === "store" || request.t === "reduce") {
-      syncStore(request);
+      if ("control" in request) syncStore(request);
+      else asyncCall(request);
       return;
     }
     if (request.t === "hello") {

--- a/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
@@ -121,7 +121,7 @@ describe("agent wait registration", () => {
       repo: "example",
       branch: "feature",
     });
-    expect(cancelAgentWait("s1")).toBe(true);
+    expect(await cancelAgentWait("s1")).toBe(true);
     expect(getAgentWait("s1")).toBeUndefined();
   });
 

--- a/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
@@ -81,8 +81,8 @@ const running = {
 };
 
 describe("agent wait registration", () => {
-  test("stores one durable timer and replaces it idempotently", () => {
-    const first = registerTimerAgentWait({
+  test("stores one durable timer and replaces it idempotently", async () => {
+    const first = await registerTimerAgentWait({
       sessionId: "s1",
       user: "Jaap",
       seconds: 60,
@@ -96,7 +96,7 @@ describe("agent wait registration", () => {
       dueAt: 61_000,
     });
 
-    const duplicate = registerTimerAgentWait({
+    const duplicate = await registerTimerAgentWait({
       sessionId: "s1",
       user: "Jaap",
       seconds: 120,
@@ -125,8 +125,8 @@ describe("agent wait registration", () => {
     expect(getAgentWait("s1")).toBeUndefined();
   });
 
-  test("wakes with hidden system context rather than a user message", () => {
-    const registered = registerTimerAgentWait({
+  test("wakes with hidden system context rather than a user message", async () => {
+    const registered = await registerTimerAgentWait({
       sessionId: "s1",
       user: "Jaap",
       seconds: 60,
@@ -146,16 +146,16 @@ describe("agent wait registration", () => {
     expect(prompt).not.toContain("[Jaap]");
   });
 
-  test("rejects timer waits outside the safe bounds", () => {
+  test("rejects timer waits outside the safe bounds", async () => {
     expect(
-      registerTimerAgentWait({
+      await registerTimerAgentWait({
         sessionId: "s1",
         user: "Jaap",
         seconds: 5,
       }),
     ).toMatchObject({ ok: false });
     expect(
-      registerTimerAgentWait({
+      await registerTimerAgentWait({
         sessionId: "s1",
         user: "Jaap",
         seconds: 24 * 60 * 60 + 1,
@@ -165,7 +165,7 @@ describe("agent wait registration", () => {
 });
 
 describe("PR check settlement", () => {
-  test("classifies checks and fences settlement to the current head", () => {
+  test("classifies checks and fences settlement to the current head", async () => {
     expect(prCheckSettlement(details([passing, failing, running]))).toMatchObject({
       settled: false,
       total: 3,

--- a/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/agent-waits.test.ts
@@ -106,7 +106,7 @@ describe("agent wait registration", () => {
     expect(duplicate).toMatchObject({ ok: true, replaced: false });
     expect(getAgentWait("s1")).toMatchObject({ dueAt: 61_000 });
 
-    const replacement = registerPrChecksAgentWait({
+    const replacement = await registerPrChecksAgentWait({
       sessionId: "s1",
       user: "Jaap",
       repo: "example",

--- a/packages/core/opensession-server/src/server/session-kernel/ask-map.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ask-map.ts
@@ -1,4 +1,4 @@
-import { sessionAsk } from "./kernel";
+import { sessionAsk, sessionKernelStore } from "./kernel";
 import { immutableCopy } from "./immutable-copy";
 
 const globalResolvers = globalThis as typeof globalThis & {
@@ -23,21 +23,22 @@ function splitValue(value: unknown): {
 }
 
 /** Durable ask facts in the actor, merged with gateway-only resolver closures. */
-export class AskOwnedMap<V> implements Map<string, V> {
+export class AskOwnedMap<V> {
   readonly [Symbol.toStringTag] = "AskOwnedMap";
   get size(): number {
-    return sessionAsk({ op: "entries" }).length;
+    return sessionKernelStore().askEntries().length;
   }
-  clear(): void {
-    sessionAsk({ op: "clear" });
+  async clear(): Promise<void> {
+    await sessionAsk({ op: "clear" });
     runtimeFields.clear();
   }
-  delete(sessionId: string): boolean {
+  async delete(sessionId: string): Promise<boolean> {
+    const deleted = await sessionAsk({ op: "delete", sessionId });
     runtimeFields.delete(sessionId);
-    return sessionAsk({ op: "delete", sessionId });
+    return deleted;
   }
   get(sessionId: string): V | undefined {
-    const durable = sessionAsk({ op: "snapshot", sessionId });
+    const durable = sessionKernelStore().askSnapshot(sessionId);
     if (durable === undefined) return undefined;
     return immutableCopy({
       ...(durable as Record<string, unknown>),
@@ -45,17 +46,17 @@ export class AskOwnedMap<V> implements Map<string, V> {
     } as V);
   }
   has(sessionId: string): boolean {
-    return sessionAsk({ op: "snapshot", sessionId }) !== undefined;
+    return sessionKernelStore().askSnapshot(sessionId) !== undefined;
   }
-  set(sessionId: string, value: V): this {
+  async set(sessionId: string, value: V): Promise<this> {
     const { durable, ephemeral } = splitValue(value);
+    await sessionAsk({ op: "set", sessionId, value: durable });
     if (Object.keys(ephemeral).length) runtimeFields.set(sessionId, ephemeral);
     else runtimeFields.delete(sessionId);
-    sessionAsk({ op: "set", sessionId, value: durable });
     return this;
   }
   private list(): Array<[string, V]> {
-    return sessionAsk({ op: "entries" }).map(([sessionId]) => [
+    return sessionKernelStore().askEntries().map(([sessionId]) => [
       sessionId,
       this.get(sessionId)!,
     ]);
@@ -64,17 +65,13 @@ export class AskOwnedMap<V> implements Map<string, V> {
     return this.list()[Symbol.iterator]();
   }
   keys(): MapIterator<string> {
-    return this.list()
-      .map(([key]) => key)
-      [Symbol.iterator]();
+    return this.list().map(([key]) => key)[Symbol.iterator]();
   }
   values(): MapIterator<V> {
-    return this.list()
-      .map(([, value]) => value)
-      [Symbol.iterator]();
+    return this.list().map(([, value]) => value)[Symbol.iterator]();
   }
   forEach(
-    callbackfn: (value: V, key: string, map: Map<string, V>) => void,
+    callbackfn: (value: V, key: string, map: AskOwnedMap<V>) => void,
     thisArg?: unknown,
   ): void {
     for (const [key, value] of this.list())

--- a/packages/core/opensession-server/src/server/session-kernel/ask-map.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ask-map.ts
@@ -39,6 +39,13 @@ export class AskOwnedMap<V> {
   }
   get(sessionId: string): V | undefined {
     const durable = sessionKernelStore().askSnapshot(sessionId);
+    return this.mergeRuntimeFields(sessionId, durable);
+  }
+  async getAsync(sessionId: string): Promise<V | undefined> {
+    const durable = await sessionAsk({ op: "snapshot", sessionId });
+    return this.mergeRuntimeFields(sessionId, durable);
+  }
+  private mergeRuntimeFields(sessionId: string, durable: unknown): V | undefined {
     if (durable === undefined) return undefined;
     return immutableCopy({
       ...(durable as Record<string, unknown>),

--- a/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-effect-executors.ts
@@ -54,13 +54,13 @@ export class CreationEffectIndeterminateError extends Error {
 type WorkspaceExecutorDependencies = {
   getWorkspace: typeof getWorkspace;
   createWorkspace: typeof createWorkspace;
-  result: (item: CreationWorkspaceEffectItem) => CreationEventDecisionResult;
+  result: (item: CreationWorkspaceEffectItem) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
   afterDestinationAccepted?: (workspace: Workspace) => void;
 };
 
 function defaultResult(
   item: CreationWorkspaceEffectItem,
-): CreationEventDecisionResult {
+): Promise<CreationEventDecisionResult> {
   return sessionKernel(item.sessionId).applyCreationEvent({
     identity: item.payload.creationIdentity,
     event: "preparation_started",
@@ -125,7 +125,7 @@ export async function executeCreationWorkspacePrepare(
     });
   }
   dependencies.afterDestinationAccepted?.(workspace);
-  const result = dependencies.result(item);
+  const result = await dependencies.result(item);
   if (result.accepted || result.reason === "stale_effect") return;
   throw new CreationEffectIndeterminateError(
     `Workspace effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
@@ -154,13 +154,13 @@ type BranchExecutorDependencies = {
     project: string,
     path: string,
   ) => Promise<boolean>;
-  result: (item: CreationBranchEffectItem) => CreationEventDecisionResult;
+  result: (item: CreationBranchEffectItem) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
   afterDestinationAccepted?: (worktreePath: string) => void;
 };
 
 function defaultBranchResult(
   item: CreationBranchEffectItem,
-): CreationEventDecisionResult {
+): Promise<CreationEventDecisionResult> {
   return sessionKernel(item.sessionId).applyCreationEvent({
     identity: item.payload.creationIdentity,
     event: "preparation_started",
@@ -280,7 +280,7 @@ export async function executeCreationBranchPrepare(
       `Branch ${payload.branch} materialized at an unexpected destination`,
     );
   dependencies.afterDestinationAccepted?.(acceptedPath);
-  const result = dependencies.result(item);
+  const result = await dependencies.result(item);
   if (result.accepted || result.reason === "stale_effect") return;
   throw new CreationEffectIndeterminateError(
     `Branch effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
@@ -292,14 +292,14 @@ type SandboxExecutorDependencies = {
     provider: string,
     spec: SandboxSessionSpec,
   ) => Promise<Pick<Sandbox, "id" | "provider">>;
-  result: (item: CreationSandboxEffectItem, sandboxId: string) => CreationEventDecisionResult;
+  result: (item: CreationSandboxEffectItem, sandboxId: string) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
   afterDestinationAccepted?: (sandbox: Pick<Sandbox, "id" | "provider">) => void;
 };
 
 function defaultSandboxResult(
   item: CreationSandboxEffectItem,
   sandboxId: string,
-): CreationEventDecisionResult {
+): Promise<CreationEventDecisionResult> {
   return sessionKernel(item.sessionId).applyCreationEvent({
     identity: item.payload.creationIdentity,
     event: "preparation_started",
@@ -350,7 +350,7 @@ export async function executeCreationSandboxPrepare(
       `Sandbox ${sandbox.id} was returned by another provider`,
     );
   dependencies.afterDestinationAccepted?.(sandbox);
-  const result = dependencies.result(item, sandbox.id);
+  const result = await dependencies.result(item, sandbox.id);
   if (result.accepted || result.reason === "stale_effect") return;
   throw new CreationEffectIndeterminateError(
     `Sandbox effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
@@ -359,13 +359,13 @@ export async function executeCreationSandboxPrepare(
 
 type CredentialExecutorDependencies = {
   resolveCredential: (principal: string) => Promise<GithubCredential | null>;
-  result: (item: CreationCredentialEffectItem) => CreationEventDecisionResult;
+  result: (item: CreationCredentialEffectItem) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
   afterResolved?: (credential: GithubCredential) => void;
 };
 
 function defaultCredentialResult(
   item: CreationCredentialEffectItem,
-): CreationEventDecisionResult {
+): Promise<CreationEventDecisionResult> {
   return sessionKernel(item.sessionId).applyCreationEvent({
     identity: item.payload.creationIdentity,
     event: "preparation_started",
@@ -397,7 +397,7 @@ export async function executeCreationCredentialResolve(
       `Credential selector ${item.payload.principal} resolved to another principal`,
     );
   dependencies.afterResolved?.(credential);
-  const result = dependencies.result(item);
+  const result = await dependencies.result(item);
   if (result.accepted || result.reason === "stale_effect") return;
   throw new CreationEffectIndeterminateError(
     `Credential effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,
@@ -411,7 +411,7 @@ type AttachmentExecutorDependencies = {
   ) =>
     | { name: string; path: string }
     | Promise<{ name: string; path: string }>;
-  result: (item: CreationAttachmentEffectItem) => CreationEventDecisionResult;
+  result: (item: CreationAttachmentEffectItem) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
   afterDestinationAccepted?: (path: string) => void;
 };
 
@@ -439,7 +439,7 @@ export async function executeCreationAttachmentStage(
     digest: item.payload.digest,
   });
   dependencies.afterDestinationAccepted?.(staged.path);
-  const result = dependencies.result(item);
+  const result = await dependencies.result(item);
   if (result.accepted || result.reason === "stale_effect") return;
   throw new CreationEffectIndeterminateError(
     `Attachment effect ${item.effectId} result was rejected: ${result.reason || "unknown"}`,

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.test.ts
@@ -52,13 +52,13 @@ const branchInput = {
 };
 
 describe("creation setup plan", () => {
-  test("persists write-once setup decisions in the actor", () => {
+  test("persists write-once setup decisions in the actor", async () => {
     const sessionId = "create-setup-plan";
     const identity = "create-setup-request";
     const { store, kernel } = harness(sessionId);
     try {
       expect(
-        patchCreationSetupPlan(
+        await patchCreationSetupPlan(
           sessionId,
           identity,
           { branch: "feature/stable" },
@@ -66,21 +66,21 @@ describe("creation setup plan", () => {
         ),
       ).toEqual({ branch: "feature/stable" });
       expect(
-        patchCreationSetupPlan(
+        await patchCreationSetupPlan(
           sessionId,
           identity,
           { workspaceId: "ws-stable" },
           kernel,
         ),
       ).toEqual({ branch: "feature/stable", workspaceId: "ws-stable" });
-      expect(() =>
+      await expect(
         patchCreationSetupPlan(
           sessionId,
           identity,
           { branch: "feature-crossover" },
           kernel,
         ),
-      ).toThrow("setup_plan_conflict");
+      ).rejects.toThrow("setup_plan_conflict");
       expect(store.creationState(sessionId)?.setupPlan).toEqual({
         branch: "feature/stable",
         workspaceId: "ws-stable",
@@ -100,10 +100,10 @@ describe("creation setup plan", () => {
 });
 
 describe("creation lifecycle intents", () => {
-  test("records terminal setup failure without launching an opening", () => {
+  test("records terminal setup failure without launching an opening", async () => {
     const { store, kernel } = harness("create-failed-lifecycle");
     try {
-      const failed = settleCreationFailed(
+      const failed = await settleCreationFailed(
         "create-failed-lifecycle",
         "request-failed",
         new Error("workspace refused"),
@@ -111,12 +111,12 @@ describe("creation lifecycle intents", () => {
       );
       expect(failed.state).toBe("failed");
       expect(
-        settleCreationFailed(
+        (await settleCreationFailed(
           "create-failed-lifecycle",
           "request-failed",
           "duplicate",
           kernel,
-        ).state,
+        )).state,
       ).toBe("failed");
     } finally {
       store.close();
@@ -295,8 +295,8 @@ describe("creation opening intents", () => {
     };
     const { store, kernel } = harness(cancelled.sessionId);
     try {
-      setTimeout(() => {
-        settleCreationCancelled(
+      setTimeout(async () => {
+        await settleCreationCancelled(
           cancelled.sessionId,
           cancelled.identity,
           kernel,
@@ -320,7 +320,7 @@ describe("creation opening intents", () => {
     }
   });
 
-  test("Stop racing a terminal opening result stays idempotent", () => {
+  test("Stop racing a terminal opening result stays idempotent", async () => {
     const raced = {
       ...opening,
       sessionId: "create-raced-opening",
@@ -367,12 +367,12 @@ describe("creation opening intents", () => {
         effectId: `opening:${raced.openingPromptEntryId}`,
       });
       expect(
-        settleCreationCancelled(
+        (await settleCreationCancelled(
           raced.sessionId,
           raced.identity,
           kernel,
           `opening:${raced.openingPromptEntryId}`,
-        ).state,
+        )).state,
       ).toBe("ready");
     } finally {
       store.close();
@@ -385,19 +385,19 @@ describe("creation opening intents", () => {
     };
     const failedHarness = harness(failed.sessionId);
     try {
-      settleCreationFailed(
+      await settleCreationFailed(
         failed.sessionId,
         failed.identity,
         new Error("setup failed"),
         failedHarness.kernel,
       );
       expect(
-        settleCreationCancelled(
+        (await settleCreationCancelled(
           failed.sessionId,
           failed.identity,
           failedHarness.kernel,
           `opening:${failed.openingPromptEntryId}`,
-        ).state,
+        )).state,
       ).toBe("failed");
     } finally {
       failedHarness.store.close();

--- a/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/creation-intents.ts
@@ -1,5 +1,5 @@
 import { sessionKernel } from "./kernel";
-import type { DurableCreationState } from "./store";
+import type { CreationEventDecisionResult, DurableCreationState } from "./store";
 
 export type CreationWorkspaceIntent = {
   sessionId: string;
@@ -77,10 +77,12 @@ export type CreationOpeningIntent = {
   openingPlan: Record<string, unknown>;
 };
 
-type CreationIntentKernel = Pick<
-  ReturnType<typeof sessionKernel>,
-  "creationState" | "applyCreationEvent"
->;
+type CreationIntentKernel = {
+  creationState: ReturnType<typeof sessionKernel>["creationState"];
+  applyCreationEvent: (
+    input: Parameters<ReturnType<typeof sessionKernel>["applyCreationEvent"]>[0],
+  ) => CreationEventDecisionResult | Promise<CreationEventDecisionResult>;
+};
 
 type CreationIntentOptions = {
   kernel?: CreationIntentKernel;
@@ -100,14 +102,14 @@ function assertIdentity(
     throw new Error("Session creation has already been cancelled");
 }
 
-export function patchCreationSetupPlan(
+export async function patchCreationSetupPlan(
   sessionId: string,
   identity: string,
   patch: Partial<CreationSetupPlan>,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
-): CreationSetupPlan {
-  const state = ensureCreationPlanned(sessionId, identity, kernel);
-  const decided = kernel.applyCreationEvent({
+): Promise<CreationSetupPlan> {
+  const state = await ensureCreationPlanned(sessionId, identity, kernel);
+  const decided = await kernel.applyCreationEvent({
     identity,
     event: "plan",
     planPatch: patch,
@@ -119,32 +121,32 @@ export function patchCreationSetupPlan(
   return (decided.state.setupPlan ?? state.setupPlan ?? {}) as CreationSetupPlan;
 }
 
-export function ensureCreationPlanned(
+export async function ensureCreationPlanned(
   sessionId: string,
   identity: string,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
-): DurableCreationState {
+): Promise<DurableCreationState> {
   const existing = kernel.creationState();
   if (existing) {
     assertIdentity(existing, identity);
     return existing;
   }
-  const planned = kernel.applyCreationEvent({ identity, event: "plan" });
+  const planned = await kernel.applyCreationEvent({ identity, event: "plan" });
   if (!planned.accepted || !planned.state)
     throw new Error(`Creation plan was rejected: ${planned.reason || "unknown"}`);
   return planned.state;
 }
 
-export function settleCreationSucceeded(
+export async function settleCreationSucceeded(
   sessionId: string,
   identity: string,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
   effectId?: string,
-): DurableCreationState {
-  const state = ensureCreationPlanned(sessionId, identity, kernel);
+): Promise<DurableCreationState> {
+  const state = await ensureCreationPlanned(sessionId, identity, kernel);
   if (state.state === "ready") return state;
   assertIdentity(state, identity);
-  const settled = kernel.applyCreationEvent({
+  const settled = await kernel.applyCreationEvent({
     identity,
     event: "succeeded",
     effectId,
@@ -156,12 +158,12 @@ export function settleCreationSucceeded(
   return settled.state;
 }
 
-export function settleCreationCancelled(
+export async function settleCreationCancelled(
   sessionId: string,
   identity: string,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
   effectId?: string,
-): DurableCreationState {
+): Promise<DurableCreationState> {
   const existing = kernel.creationState();
   if (existing?.identity !== undefined && existing.identity !== identity)
     throw new Error("Create request identity crossed durable session ownership");
@@ -174,8 +176,8 @@ export function settleCreationCancelled(
     existing?.state === "failed"
   )
     return existing;
-  ensureCreationPlanned(sessionId, identity, kernel);
-  const settled = kernel.applyCreationEvent({
+  await ensureCreationPlanned(sessionId, identity, kernel);
+  const settled = await kernel.applyCreationEvent({
     identity,
     event: "cancelled",
     effectId,
@@ -188,20 +190,20 @@ export function settleCreationCancelled(
   return settled.state;
 }
 
-export function settleCreationFailed(
+export async function settleCreationFailed(
   sessionId: string,
   identity: string,
   error: unknown,
   kernel: CreationIntentKernel = sessionKernel(sessionId),
   effectId?: string,
-): DurableCreationState {
+): Promise<DurableCreationState> {
   const existing = kernel.creationState();
   if (existing?.identity !== undefined && existing.identity !== identity)
     throw new Error("Create request identity crossed durable session ownership");
   if (existing?.state === "failed" || existing?.state === "cancelled")
     return existing;
-  ensureCreationPlanned(sessionId, identity, kernel);
-  const settled = kernel.applyCreationEvent({
+  await ensureCreationPlanned(sessionId, identity, kernel);
+  const settled = await kernel.applyCreationEvent({
     identity,
     event: "failed",
     effectId,
@@ -220,7 +222,7 @@ export async function requestCreationAttachment(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `attachment:${input.attachmentId}`;
   if (state.completedEffectIds.includes(effectId)) return state;
   if (state.currentEffectId && state.currentEffectId !== effectId)
@@ -228,7 +230,7 @@ export async function requestCreationAttachment(
       `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
     );
   if (!state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
       nextEffectId: effectId,
@@ -274,7 +276,7 @@ export async function requestCreationOpening(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `opening:${input.openingPromptEntryId}`;
   const deadline = Date.now() + (options.timeoutMs ?? 24 * 60 * 60_000);
   if (state.state === "ready") return state;
@@ -300,7 +302,7 @@ export async function requestCreationOpening(
   if (state.state === "cancelled")
     throw new Error("Session creation was cancelled before opening dispatch");
   if (state.state === "planned") {
-    const preparing = kernel.applyCreationEvent({
+    const preparing = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
     });
@@ -311,7 +313,7 @@ export async function requestCreationOpening(
     state = preparing.state;
   }
   if (state.state === "preparing" && !state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "opening_dispatched",
       openingPlan: input.openingPlan,
@@ -364,7 +366,7 @@ export async function requestCreationWorkspace(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `workspace:${input.workspaceId}`;
   if (state.completedEffectIds.includes(effectId)) return state;
   if (state.currentEffectId && state.currentEffectId !== effectId)
@@ -372,7 +374,7 @@ export async function requestCreationWorkspace(
       `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
     );
   if (!state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
       nextEffectId: effectId,
@@ -421,7 +423,7 @@ export async function requestCreationBranch(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `branch:${input.project}:${input.branch}`;
   if (state.completedEffectIds.includes(effectId)) return state;
   if (state.currentEffectId && state.currentEffectId !== effectId)
@@ -429,7 +431,7 @@ export async function requestCreationBranch(
       `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
     );
   if (!state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
       nextEffectId: effectId,
@@ -476,7 +478,7 @@ export async function requestCreationCredential(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `credential:${input.principal}:${input.scope}`;
   if (state.completedEffectIds.includes(effectId)) return state;
   if (state.currentEffectId && state.currentEffectId !== effectId)
@@ -484,7 +486,7 @@ export async function requestCreationCredential(
       `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
     );
   if (!state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
       nextEffectId: effectId,
@@ -530,7 +532,7 @@ export async function requestCreationSandbox(
   options: CreationIntentOptions = {},
 ): Promise<DurableCreationState> {
   const kernel = options.kernel ?? sessionKernel(input.sessionId);
-  let state = ensureCreationPlanned(input.sessionId, input.identity, kernel);
+  let state = await ensureCreationPlanned(input.sessionId, input.identity, kernel);
   const effectId = `sandbox:${input.provider}:${input.sessionId}`;
   if (state.completedEffectIds.includes(effectId)) return state;
   if (state.currentEffectId && state.currentEffectId !== effectId)
@@ -538,7 +540,7 @@ export async function requestCreationSandbox(
       `Creation effect ${state.currentEffectId} must settle before ${effectId}`,
     );
   if (!state.currentEffectId) {
-    const emitted = kernel.applyCreationEvent({
+    const emitted = await kernel.applyCreationEvent({
       identity: input.identity,
       event: "preparation_started",
       nextEffectId: effectId,

--- a/packages/core/opensession-server/src/server/session-kernel/delivery-map.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/delivery-map.ts
@@ -1,9 +1,9 @@
 import type { DeliverySlot } from "./store";
-import { sessionDelivery } from "./kernel";
+import { sessionDelivery, sessionKernelStore } from "./kernel";
 import { immutableCopy } from "./immutable-copy";
 
 /** Map-compatible projection backed by the actor's durable delivery aggregate. */
-export class DeliveryOwnedMap<V> implements Map<string, V> {
+export class DeliveryOwnedMap<V> {
   readonly [Symbol.toStringTag] = "DeliveryOwnedMap";
   constructor(private readonly slot: DeliverySlot) {}
 
@@ -11,16 +11,16 @@ export class DeliveryOwnedMap<V> implements Map<string, V> {
     return this.entriesArray().length;
   }
 
-  clear(): void {
-    sessionDelivery({ op: "clear_slot", slot: this.slot });
+  async clear(): Promise<void> {
+    await sessionDelivery({ op: "clear_slot", slot: this.slot });
   }
 
-  delete(sessionId: string): boolean {
+  async delete(sessionId: string): Promise<boolean> {
     return sessionDelivery({ op: "delete", sessionId, slot: this.slot });
   }
 
   get(sessionId: string): V | undefined {
-    const state = sessionDelivery({ op: "snapshot", sessionId });
+    const state = sessionKernelStore().deliverySnapshot(sessionId);
     const value =
       this.slot === "queued"
         ? state.queued
@@ -36,8 +36,8 @@ export class DeliveryOwnedMap<V> implements Map<string, V> {
     return this.get(sessionId) !== undefined;
   }
 
-  set(sessionId: string, value: V): this {
-    sessionDelivery({
+  async set(sessionId: string, value: V): Promise<this> {
+    await sessionDelivery({
       op: "set",
       sessionId,
       slot: this.slot,
@@ -47,7 +47,7 @@ export class DeliveryOwnedMap<V> implements Map<string, V> {
   }
 
   private entriesArray(): Array<[string, V]> {
-    return sessionDelivery({ op: "entries", slot: this.slot }).map(
+    return sessionKernelStore().deliveryEntries(this.slot).map(
       ([sessionId, value]) => [sessionId, immutableCopy(value as V)],
     );
   }
@@ -56,17 +56,13 @@ export class DeliveryOwnedMap<V> implements Map<string, V> {
     return this.entriesArray()[Symbol.iterator]();
   }
   keys(): MapIterator<string> {
-    return this.entriesArray()
-      .map(([key]) => key)
-      [Symbol.iterator]();
+    return this.entriesArray().map(([key]) => key)[Symbol.iterator]();
   }
   values(): MapIterator<V> {
-    return this.entriesArray()
-      .map(([, value]) => value)
-      [Symbol.iterator]();
+    return this.entriesArray().map(([, value]) => value)[Symbol.iterator]();
   }
   forEach(
-    callbackfn: (value: V, key: string, map: Map<string, V>) => void,
+    callbackfn: (value: V, key: string, map: DeliveryOwnedMap<V>) => void,
     thisArg?: unknown,
   ): void {
     for (const [key, value] of this.entriesArray())

--- a/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
@@ -1,4 +1,8 @@
-import type { DeliverySlot, DurableDeliveryState } from "./store";
+import type {
+  DeliverySlot,
+  DurableDeliveryState,
+  DurableSteerTarget,
+} from "./store";
 import type { DurableRunTarget } from "./turn-protocol";
 
 export function deliveryInterruptForAnchor(
@@ -56,9 +60,25 @@ export type DeliveryActorRequest =
   | { op: "enqueue"; sessionId: string; item: unknown; front?: boolean }
   | { op: "delete"; sessionId: string; slot: DeliverySlot }
   | { op: "clear_slot"; slot: DeliverySlot }
-  | { op: "prepare_steer"; sessionId: string; itemId: string; item?: unknown }
-  | { op: "accept_steer"; sessionId: string; itemId: string }
-  | { op: "reject_steer"; sessionId: string; itemId: string }
+  | {
+      op: "prepare_steer";
+      sessionId: string;
+      itemId: string;
+      target: DurableSteerTarget;
+      item?: unknown;
+    }
+  | {
+      op: "accept_steer";
+      sessionId: string;
+      itemId: string;
+      target: DurableSteerTarget;
+    }
+  | {
+      op: "reject_steer";
+      sessionId: string;
+      itemId: string;
+      target: DurableSteerTarget;
+    }
   | { op: "settle_pending_steers" }
   | { op: "requeue_steers"; sessionId: string; items: unknown[] }
   | {

--- a/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/delivery-protocol.ts
@@ -53,6 +53,7 @@ export type DeliveryActorRequest =
     }
   | { op: "entries"; slot: DeliverySlot }
   | { op: "set"; sessionId: string; slot: DeliverySlot; value: unknown }
+  | { op: "enqueue"; sessionId: string; item: unknown; front?: boolean }
   | { op: "delete"; sessionId: string; slot: DeliverySlot }
   | { op: "clear_slot"; slot: DeliverySlot }
   | { op: "prepare_steer"; sessionId: string; itemId: string; item?: unknown }
@@ -136,6 +137,7 @@ export type DeliveryActorResult<T extends DeliveryActorRequest> =
                   ? unknown | undefined
                   : T extends {
                         op:
+                          | "enqueue"
                           | "delete"
                           | "ack_dispatch"
                           | "fail_dispatch"

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 	store.close();
 });
 
-test("tracked schema version matches the store reader", () => {
+test("tracked schema version matches the store reader", async () => {
 	expect(
 		Number(
 			readFileSync(join(import.meta.dir, "schema-version"), "utf8").trim(),
@@ -44,7 +44,7 @@ test("tracked schema version matches the store reader", () => {
 	expect(SESSION_KERNEL_ACTOR_VERSION).toBe(SESSION_KERNEL_SCHEMA_VERSION);
 });
 
-test("refuses an unsafe schema downgrade", () => {
+test("refuses an unsafe schema downgrade", async () => {
 	const dir = mkdtempSync(join(tmpdir(), "session-kernel-newer-schema-"));
 	const path = join(dir, "kernel.sqlite");
 	const newer = new Database(path);
@@ -57,7 +57,7 @@ test("refuses an unsafe schema downgrade", () => {
 	}
 });
 
-test("read-only mirrors observe later WAL commits and cannot mutate", () => {
+test("read-only mirrors observe later WAL commits and cannot mutate", async () => {
 	const dir = mkdtempSync(join(tmpdir(), "session-kernel-read-mirror-"));
 	const path = join(dir, "kernel.sqlite");
 	const writer = new SessionKernelStore(path);
@@ -78,7 +78,7 @@ test("read-only mirrors observe later WAL commits and cannot mutate", () => {
 	}
 });
 
-test("durable cancel and interrupt receipts restore their original command target", () => {
+test("durable cancel and interrupt receipts restore their original command target", async () => {
   expect(targetForTurnCancel({
     cancelId: "stop:request-one",
     phase: "settled",
@@ -118,7 +118,7 @@ test("durable cancel and interrupt receipts restore their original command targe
   });
 });
 
-test("boot maintenance compacts change history in bounded batches", () => {
+test("boot maintenance compacts change history in bounded batches", async () => {
 	const dir = mkdtempSync(join(tmpdir(), "session-kernel-maintenance-"));
 	const path = join(dir, "kernel.sqlite");
 	const initial = new SessionKernelStore(path);
@@ -155,7 +155,7 @@ test("boot maintenance compacts change history in bounded batches", () => {
 	}
 });
 
-test("schema 6 upgrades create autonomous creation, delivery and ask state", () => {
+test("schema 6 upgrades create autonomous creation, delivery and ask state", async () => {
 	const dir = mkdtempSync(join(tmpdir(), "session-kernel-schema-"));
 	const path = join(dir, "kernel.sqlite");
 	const legacy = new Database(path);
@@ -187,7 +187,7 @@ test("schema 6 upgrades create autonomous creation, delivery and ask state", () 
 });
 
 describe("SessionKernel", () => {
-	test("fails closed non-idempotent projection work after actor restart", () => {
+	test("fails closed non-idempotent projection work after actor restart", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-projection-crash-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -214,7 +214,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("re-admits only destination-idempotent gateway work after restart", () => {
+	test("re-admits only destination-idempotent gateway work after restart", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-gateway-replay-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -271,7 +271,7 @@ describe("SessionKernel", () => {
 		})).toThrow(`Session ${sessionId} was deleted`);
 	});
 
-	test("deduplicates deletion before and after its permanent tombstone", () => {
+	test("deduplicates deletion before and after its permanent tombstone", async () => {
 		const input = {
 			sessionId: "delete-once",
 			requestId: "delete:delete-once",
@@ -288,7 +288,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("replays typed submit-prompt results under one immutable identity", () => {
+	test("replays typed submit-prompt results under one immutable identity", async () => {
 		const input = {
 			sessionId: "typed-submit",
 			requestId: "delivery-one",
@@ -317,7 +317,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("adopts a queued submit after a crash before command completion", () => {
+	test("adopts a queued submit after a crash before command completion", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-submit-replay-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -362,7 +362,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("turns pre-execution pending admission into a durable retry receipt", () => {
+	test("turns pre-execution pending admission into a durable retry receipt", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-pending-restart-"));
 		const path = join(dir, "kernel.sqlite");
 		const firstStore = new SessionKernelStore(path);
@@ -392,7 +392,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("backfills pre-policy processing receipts as replay-safe", () => {
+	test("backfills pre-policy processing receipts as replay-safe", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-policy-migration-"));
 		const path = join(dir, "kernel.sqlite");
 		const db = new Database(path);
@@ -423,7 +423,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("promotes replay policy without changing request identity", () => {
+	test("promotes replay policy without changing request identity", async () => {
 		store.acceptCommand({
 			sessionId: "promote",
 			requestId: "same",
@@ -440,7 +440,7 @@ describe("SessionKernel", () => {
 		expect(promoted.replaySafe).toBe(true);
 	});
 
-	test("fails closed on interrupted work that was not declared replay-safe", () => {
+	test("fails closed on interrupted work that was not declared replay-safe", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-indeterminate-"));
 		const path = join(dir, "kernel.sqlite");
 		const firstStore = new SessionKernelStore(path);
@@ -487,7 +487,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("keeps deletion tombstones permanent", () => {
+	test("keeps deletion tombstones permanent", async () => {
 		store.tombstoneSession("deleted-forever");
 		expect(
 			store.isTombstoned(
@@ -497,7 +497,7 @@ describe("SessionKernel", () => {
 		).toBe(true);
 	});
 
-	test("persists run state and monotonic change sequence", () => {
+	test("persists run state and monotonic change sequence", async () => {
 		const kernel = sessionKernel("s1");
 		expect(kernel.runState().state).toBe("idle");
 		expect(store.setRunState({ sessionId: "a", state: "starting", event: "prompt" }).changeSeq,).toBe(1);
@@ -516,7 +516,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("reduces and fences run events in one actor-store transaction", () => {
+	test("reduces and fences run events in one actor-store transaction", async () => {
 		expect(store.applyRunEvent({ sessionId: "fsm", event: "prompt" })).toMatchObject({
 			accepted: true,
 			from: "idle",
@@ -542,7 +542,7 @@ describe("SessionKernel", () => {
 		expect(store.changesSince("fsm", 0)).toHaveLength(2);
 	});
 
-	test("owns creation transitions and rejects stale effect results", () => {
+	test("owns creation transitions and rejects stale effect results", async () => {
 		store.applyCreationEvent({
 			sessionId: "create-opening-requires-effect",
 			identity: "request-direct",
@@ -769,7 +769,7 @@ describe("SessionKernel", () => {
 		).toBe(true);
 		const { settleRecoveredCreationOpening } = await import("../run-session");
 		expect(
-			settleRecoveredCreationOpening(sessionId, promptEntryId),
+			await settleRecoveredCreationOpening(sessionId, promptEntryId),
 		).toBe(true);
 		const settled = store.creationState(sessionId);
 		expect(settled?.state).toBe("ready");
@@ -820,7 +820,7 @@ describe("SessionKernel", () => {
 		});
 		const { settleRecoveredCreationOpening } = await import("../run-session");
 		expect(
-			settleRecoveredCreationOpening(
+			await settleRecoveredCreationOpening(
 				sessionId,
 				promptEntryId,
 				undefined,
@@ -833,7 +833,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("clears an accepted creation effect so replay is a stale no-op", () => {
+	test("clears an accepted creation effect so replay is a stale no-op", async () => {
 		const sessionId = "create-result-replay";
 		const identity = "request-result-replay";
 		expect(store.applyCreationEvent({ sessionId, identity, event: "plan" }).accepted).toBe(true);
@@ -899,7 +899,7 @@ describe("SessionKernel", () => {
 		expect(store.pendingOutbox()).toHaveLength(0);
 	});
 
-	test("persists completed creation effect receipts across actor-store restart", () => {
+	test("persists completed creation effect receipts across actor-store restart", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-create-receipt-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -945,7 +945,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("persists opening recovery input with its effect and clears it terminally", () => {
+	test("persists opening recovery input with its effect and clears it terminally", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-opening-plan-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -1011,7 +1011,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("settles a cancelled opening effect and fences its late success", () => {
+	test("settles a cancelled opening effect and fences its late success", async () => {
 		const sessionId = "create-opening-cancelled";
 		const identity = "request-opening-cancelled";
 		const effectId = "opening:entry-cancelled";
@@ -1062,7 +1062,7 @@ describe("SessionKernel", () => {
 		})).toMatchObject({ accepted: false, reason: "stale_effect" });
 	});
 
-	test("rejects creation effect capacity before accepting more work", () => {
+	test("rejects creation effect capacity before accepting more work", async () => {
 		const sessionId = "create-receipt-capacity";
 		const identity = "request-receipt-capacity";
 		store.applyCreationEvent({ sessionId, identity, event: "plan" });
@@ -1120,7 +1120,7 @@ describe("SessionKernel", () => {
 		expect(store.pendingOutbox(Date.now(), 10_000)).toHaveLength(outboxBefore);
 	});
 
-	test("rolls creation state back when its durable effect cannot commit", () => {
+	test("rolls creation state back when its durable effect cannot commit", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-create-crash-"));
 		const path = join(dir, "kernel.sqlite");
 		const crashStore = new SessionKernelStore(path);
@@ -1167,7 +1167,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("claims and restores a delivery batch atomically", () => {
+	test("claims and restores a delivery batch atomically", async () => {
 		store.setDeliverySlot("delivery", "queued", [
 			{ id: "one", content: "first" },
 			{ id: "two", content: "second" },
@@ -1197,7 +1197,7 @@ describe("SessionKernel", () => {
 		expect(store.deliverySnapshot("delivery").dispatch).toBeUndefined();
 	});
 
-	test("retires a terminal creation dispatch before a later prompt drains", () => {
+	test("retires a terminal creation dispatch before a later prompt drains", async () => {
 		const sessionId = "failed-opening-follow-up";
 		const identity = "failed-opening-request";
 		const promptEntryId = "failed-opening-prompt";
@@ -1275,7 +1275,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("selects and claims the next queue batch in one actor transaction", () => {
+	test("selects and claims the next queue batch in one actor transaction", async () => {
 		store.setDeliverySlot("next-delivery", "queued", [
 			{ id: "held", content: "wait", hold: true },
 			{
@@ -1335,7 +1335,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("rolls an unabortable steered receipt back to its durable slot", () => {
+	test("rolls an unabortable steered receipt back to its durable slot", async () => {
 		store.setDeliverySlot("steered-interrupt", "steered", [
 			{ id: "before", content: "before" },
 			{ id: "target", content: "accepted but unread" },
@@ -1367,7 +1367,7 @@ describe("SessionKernel", () => {
 		).toBeUndefined();
 	});
 
-	test("does not transfer an interrupt to an earlier retry group", () => {
+	test("does not transfer an interrupt to an earlier retry group", async () => {
 		store.setDeliverySlot("interrupt-behind-retry", "queued", [
 			{ id: "retry", retryDispatchId: "older-entry", content: "retry first" },
 			{ id: "anchor", content: "interrupt target", hold: true },
@@ -1409,7 +1409,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("does not apply a solo interrupt after its target is removed", () => {
+	test("does not apply a solo interrupt after its target is removed", async () => {
 		store.setDeliverySlot("stale-solo-interrupt", "queued", [
 			{ id: "removed", content: "interrupt target", hold: true },
 			{ id: "other", content: "still held", hold: true },
@@ -1495,7 +1495,7 @@ describe("SessionKernel", () => {
     });
   });
 
-  test("durably projects one exact terminal outcome through the actor outbox", () => {
+  test("durably projects one exact terminal outcome through the actor outbox", async () => {
     const dir = mkdtempSync(join(tmpdir(), "session-kernel-outcome-"));
     const path = join(dir, "kernel.sqlite");
     const first = new SessionKernelStore(path);
@@ -1798,7 +1798,7 @@ describe("SessionKernel", () => {
     }
   });
 
-  test("durably prepares, retries, and generation-fences explicit turn cancellation", () => {
+  test("durably prepares, retries, and generation-fences explicit turn cancellation", async () => {
     const dir = mkdtempSync(join(tmpdir(), "session-kernel-cancel-"));
     const path = join(dir, "kernel.sqlite");
     const first = new SessionKernelStore(path);
@@ -1950,7 +1950,7 @@ describe("SessionKernel", () => {
     }
   });
 
-	test("recovers prepared and claimed interrupts across crashes", () => {
+	test("recovers prepared and claimed interrupts across crashes", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-interrupt-"));
 		const path = join(dir, "kernel.sqlite");
 		const first = new SessionKernelStore(path);
@@ -2049,7 +2049,7 @@ describe("SessionKernel", () => {
 		}
 	});
 
-	test("reuses a failed multi-item dispatch identity", () => {
+	test("reuses a failed multi-item dispatch identity", async () => {
 		store.setDeliverySlot("failed-multi-dispatch", "queued", [
 			{ id: "one", content: "first" },
 			{ id: "two", content: "second" },
@@ -2139,7 +2139,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("recovers an ambiguous prepared steer without duplicate queue delivery", () => {
+	test("recovers an ambiguous prepared steer without duplicate queue delivery", async () => {
 		store.setDeliverySlot("steer-recovery", "queued", [
 			{ id: "steer-one", content: "fold me in" },
 		]);
@@ -2167,7 +2167,7 @@ describe("SessionKernel", () => {
 		});
 	});
 
-	test("batches compatibility effects in one store transaction", () => {
+	test("batches compatibility effects in one store transaction", async () => {
 		expect(store.enqueueOutboxMany("compatibility", [
 			{ kind: "one", payload: { n: 1 }, effectKey: "a" },
 			{ kind: "two", payload: { n: 2 }, effectKey: "b" },
@@ -2175,17 +2175,17 @@ describe("SessionKernel", () => {
 		expect(store.pendingOutbox().map((effect) => effect.effectKey)).toEqual(["a", "b"]);
 	});
 
-	test("actor-owned delivery maps isolate nested mutable values", () => {
+	test("actor-owned delivery maps isolate nested mutable values", async () => {
 		const map = new DeliveryOwnedMap<Array<{ nested: { values: string[] } }>>("queued");
 		const source = [{ nested: { values: ["a"] } }];
-		map.set("nested-session", source);
+		await map.set("nested-session", source);
 		source[0].nested.values.push("source");
 		const read = map.get("nested-session")!;
 		read[0].nested.values.push("reader");
 		expect(map.get("nested-session")?.[0].nested.values).toEqual(["a"]);
 	});
 
-	test("read projections do not activate dormant sessions", () => {
+	test("read projections do not activate dormant sessions", async () => {
 		const projection = new DeliveryOwnedMap<string>("queued");
 		expect(projection.get("dormant")).toBeUndefined();
 		expect(activeSessionKernels()).toHaveLength(0);
@@ -2265,7 +2265,7 @@ describe("SessionKernel durable runtime", () => {
 		}
 	});
 
-	test("retires a timer without replay after actor completion survives a crash", () => {
+	test("retires a timer without replay after actor completion survives a crash", async () => {
 		store.scheduleTimer({
 			sessionId: "timer-complete-crash",
 			timerId: "wake",
@@ -2285,7 +2285,7 @@ describe("SessionKernel durable runtime", () => {
 		expect(store.timer(timer.sessionId, timer.timerId)).toBeUndefined();
 	});
 
-	test("replays a timer when the actor did not commit handler completion", () => {
+	test("replays a timer when the actor did not commit handler completion", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "session-kernel-timer-replay-"));
 		const path = join(dir, "kernel.sqlite");
 		let durableStore = new SessionKernelStore(path);
@@ -2308,7 +2308,7 @@ describe("SessionKernel durable runtime", () => {
 		}
 	});
 
-	test("accounts timer runtime failures once per observed attempt", () => {
+	test("accounts timer runtime failures once per observed attempt", async () => {
 		store.scheduleTimer({
 			sessionId: "timer-runtime-failure",
 			timerId: "wake",
@@ -2332,7 +2332,7 @@ describe("SessionKernel durable runtime", () => {
 		expect(store.timer(timer.sessionId, timer.timerId)?.attempts).toBe(1);
 	});
 
-	test("stale timer settlement cannot mutate a replacement generation", () => {
+	test("stale timer settlement cannot mutate a replacement generation", async () => {
 		const sessionId = "timer-stale-settlement";
 		store.scheduleTimer({
 			sessionId,
@@ -2383,7 +2383,7 @@ describe("SessionKernel durable runtime", () => {
 		} finally { unregister(); }
 	});
 
-	test("stale timer failure cannot back off a replacement generation", () => {
+	test("stale timer failure cannot back off a replacement generation", async () => {
 		store.scheduleTimer({ sessionId: "stale-failure", timerId: "same", kind: "test", dueAt: 1, payload: 1 });
 		const stale = store.timer("stale-failure", "same")!;
 		store.scheduleTimer({ sessionId: "stale-failure", timerId: "same", kind: "test", dueAt: 1, payload: 2 });
@@ -2417,7 +2417,7 @@ describe("SessionKernel durable runtime", () => {
 		}
 	});
 
-	test("backs off failed timers instead of refiring every runtime tick", () => {
+	test("backs off failed timers instead of refiring every runtime tick", async () => {
 		sessionKernel("timer-backoff").scheduleTimer({
 			timerId: "wake",
 			kind: "missing",
@@ -2432,7 +2432,7 @@ describe("SessionKernel durable runtime", () => {
 		});
 	});
 
-	test("dead-letters poison timers after bounded attempts", () => {
+	test("dead-letters poison timers after bounded attempts", async () => {
 		sessionKernel("timer-poison").scheduleTimer({
 			timerId: "wake",
 			kind: "broken",
@@ -2479,7 +2479,7 @@ describe("SessionKernel durable runtime", () => {
 		}
 	});
 
-	test("dead-letters a poison outbox effect after its bounded attempts", () => {
+	test("dead-letters a poison outbox effect after its bounded attempts", async () => {
 		const id = store.enqueueOutbox("poison", "notify", null, "one");
 		for (let attempt = 0; attempt < 20; attempt++)
 			store.noteOutboxFailure(id, "still broken", 20);
@@ -2543,7 +2543,7 @@ describe("SessionKernel durable runtime", () => {
 		}
 	});
 
-	test("re-admits only pre-execution branch compatibility false positives", () => {
+	test("re-admits only pre-execution branch compatibility false positives", async () => {
 		const sharedPayload = {
 			creationIdentity: "creation-one",
 			creationGeneration: 1,
@@ -2665,7 +2665,7 @@ describe("SessionKernel durable runtime", () => {
 			if (calls === 1) throw new Error("temporary");
 		});
 		try {
-			sessionKernel("outbox-session").enqueueEffect(
+			await sessionKernel("outbox-session").enqueueEffect(
 				"human_ask_deliver",
 				{ askId: "retry", skipUi: false },
 			);

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -473,10 +473,10 @@ describe("SessionKernel", () => {
 		const { transitionRunState } = await import("../run-state");
 		const id = `fence-${crypto.randomUUID()}`;
 		try {
-			transitionRunState(id, "prompt");
-			transitionRunState(id, "run_registered", { run_key: "run-new" });
+			await transitionRunState(id, "prompt");
+			await transitionRunState(id, "run_registered", { run_key: "run-new" });
 			const generation = sessionKernel(id).runState().generation;
-			transitionRunState(id, "run_registered", { run_key: "run-old" });
+			await transitionRunState(id, "run_registered", { run_key: "run-old" });
 			expect(sessionKernel(id).runState()).toMatchObject({
 				state: "running",
 				currentRunId: "run-new",
@@ -496,6 +496,15 @@ describe("SessionKernel", () => {
 			),
 		).toBe(true);
 	});
+
+  test("rejects a run event after a writable preflight races deletion", () => {
+    const sessionId = "deleted-before-run-event";
+    expect(store.isTombstoned(sessionId)).toBe(false);
+    store.tombstoneSession(sessionId);
+    expect(() => store.applyRunEvent({ sessionId, event: "prompt" }))
+      .toThrow(`Session ${sessionId} was deleted`);
+    expect(store.runState(sessionId).state).toBe("idle");
+  });
 
 	test("persists run state and monotonic change sequence", async () => {
 		const kernel = sessionKernel("s1");
@@ -1454,7 +1463,7 @@ describe("SessionKernel", () => {
     ]);
     const { isUserStopped, liftUserStop } = await import("../queue-state");
     expect(isUserStopped("cancel-starting")).toBe(true);
-    liftUserStop("cancel-starting");
+    await liftUserStop("cancel-starting");
     expect(store.runState("cancel-starting").state).toBe("idle");
     expect(isUserStopped("cancel-starting")).toBe(true);
     expect(store.applyRunEvent({

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.test.ts
@@ -2149,11 +2149,19 @@ describe("SessionKernel", () => {
 	});
 
 	test("recovers an ambiguous prepared steer without duplicate queue delivery", async () => {
+		store.setRunState({
+			sessionId: "steer-recovery",
+			state: "running",
+			event: "run_registered",
+			currentRunId: "run-one",
+			generation: 1,
+		});
+		const target = { token: "token-one", runId: "run-one", generation: 1 };
 		store.setDeliverySlot("steer-recovery", "queued", [
 			{ id: "steer-one", content: "fold me in" },
 		]);
 		expect(
-			store.prepareSteerDelivery("steer-recovery", "steer-one"),
+			store.prepareSteerDelivery("steer-recovery", "steer-one", target),
 		).toMatchObject({ id: "steer-one" });
 		expect(store.deliverySnapshot("steer-recovery")).toMatchObject({
 			queued: [],
@@ -2173,6 +2181,41 @@ describe("SessionKernel", () => {
 		expect(store.deliverySnapshot("steer-recovery")).toMatchObject({
 			queued: [{ id: "steer-one", content: "fold me in" }],
 			steered: [],
+		});
+	});
+
+	test("does not accept a prepared steer after run ownership changes", () => {
+		const sessionId = "steer-owner-swap";
+		const oldTarget = { token: "token-old", runId: "run-old", generation: 1 };
+		store.setRunState({
+			sessionId,
+			state: "running",
+			event: "run_registered",
+			currentRunId: oldTarget.runId,
+			generation: oldTarget.generation,
+		});
+		store.setDeliverySlot(sessionId, "queued", [{ id: "steer-one" }]);
+		expect(store.prepareSteerDelivery(sessionId, "steer-one", oldTarget))
+			.toMatchObject({ id: "steer-one" });
+		store.setRunState({
+			sessionId,
+			state: "running",
+			event: "run_registered",
+			currentRunId: "run-new",
+			generation: 2,
+		});
+
+		expect(store.acceptSteerDelivery(sessionId, "steer-one", oldTarget)).toBe(false);
+		expect(store.deliverySnapshot(sessionId)).toMatchObject({
+			queued: [],
+			steered: [],
+			pendingSteers: [{ target: oldTarget }],
+		});
+		expect(store.rejectSteerDelivery(sessionId, "steer-one", oldTarget)).toBe(true);
+		expect(store.deliverySnapshot(sessionId)).toMatchObject({
+			queued: [{ id: "steer-one" }],
+			steered: [],
+			pendingSteers: [],
 		});
 	});
 

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -68,7 +68,6 @@ type GlobalKernelState = {
 	store?: SessionKernelStoreApi;
 	actor?: SessionKernelActorClient;
 	kernels?: Map<string, SessionKernel>;
-	deliveryProjection?: Map<string, DurableDeliveryState>;
 };
 
 const globalState = globalThis as typeof globalThis & {
@@ -92,17 +91,17 @@ export function sessionAgentOperation(request: AgentOperationRequest): AgentOper
   return compatibilityStoreForTest("core").decideAgentOperation(decoded);
 }
 
-export function registerAgentHostPlan(
+export async function registerAgentHostPlan(
   request: AgentHostPlanRegistration,
-): AgentHostPlanRegistrationResult {
-  if (state.actor) return state.actor.decideAgentHostSupervision(request);
+): Promise<AgentHostPlanRegistrationResult> {
+  if (state.actor) return state.actor.decideAgentHostSupervisionAsync(request);
   return compatibilityStoreForTest("core").registerAgentHostPlan(request);
 }
 
-export function claimAgentHostSupervision(
+export async function claimAgentHostSupervision(
   request: AgentHostSupervisionClaim,
-): AgentHostSupervisionResult {
-  if (state.actor) return state.actor.decideAgentHostSupervision(request);
+): Promise<AgentHostSupervisionResult> {
+  if (state.actor) return state.actor.decideAgentHostSupervisionAsync(request);
   return compatibilityStoreForTest("core").claimAgentHostSupervision(request);
 }
 
@@ -230,11 +229,6 @@ export async function sessionGatewayCommandAsync<T extends GatewayCommandRequest
 export async function sessionDelivery<T extends DeliveryActorRequest>(
   request: T,
 ): Promise<DeliveryActorResult<T>> {
-  const projection = (state.deliveryProjection ??= new Map());
-  if (request.op === "snapshot") {
-    const cached = projection.get(request.sessionId);
-    if (cached) return cached as DeliveryActorResult<T>;
-  }
   const actor = state.actor;
   let result: unknown;
   if (actor) result = await actor.decideDeliveryAsync(request);
@@ -256,6 +250,8 @@ export async function sessionDelivery<T extends DeliveryActorRequest>(
       request.slot,
       request.value,
     );
+  else if (request.op === "enqueue")
+    result = store.enqueueDelivery(request.sessionId, request.item, request.front);
   else if (request.op === "delete")
     result = store.deleteDeliverySlot(request.sessionId, request.slot);
   else if (request.op === "clear_slot")
@@ -295,13 +291,6 @@ export async function sessionDelivery<T extends DeliveryActorRequest>(
         request.promptEntryId,
       );
   }
-  if (request.op === "snapshot") {
-    projection.set(request.sessionId, result as DurableDeliveryState);
-  } else if ("sessionId" in request) {
-    projection.delete(request.sessionId);
-  } else if (request.op === "clear_slot" || request.op === "settle_pending_steers") {
-    projection.clear();
-  }
   return result as DeliveryActorResult<T>;
 }
 
@@ -329,10 +318,7 @@ export async function sessionDeliveryAsync<T extends DeliveryActorRequest>(
 export async function sessionDeliveryProjection(
   sessionId: string,
 ): Promise<DurableDeliveryState> {
-  const projection = (state.deliveryProjection ??= new Map());
-  const cached = projection.get(sessionId);
-  if (cached) return cached;
-  return await sessionDelivery({ op: "snapshot", sessionId });
+  return sessionDelivery({ op: "snapshot", sessionId });
 }
 
 export function sessionKernelActorActive(): boolean {
@@ -362,7 +348,6 @@ export function __setSessionKernelStoreForTest(
 	state.store = store;
 	state.actor = undefined;
 	state.kernels?.clear();
-	state.deliveryProjection?.clear();
 	return previous instanceof SessionKernelStore ? previous : undefined;
 }
 
@@ -373,7 +358,6 @@ export function installSessionKernelActor(
 	state.actor = actor;
   state.store = actor?.store;
 	state.kernels?.clear();
-	state.deliveryProjection?.clear();
 	return previous;
 }
 
@@ -390,22 +374,28 @@ export class SessionKernel {
 		return this.lastUsedAt;
 	}
 
-	private assertWritable(operation?: string): void {
+	private async assertWritable(operation?: string): Promise<void> {
+    const tombstoned = state.actor
+      ? await state.actor.callAsync<boolean>(
+          { t: "store", method: "isTombstoned", args: [this.sessionId] },
+          "isTombstoned",
+        )
+      : sessionKernelStore().isTombstoned(this.sessionId);
 		if (
-			sessionKernelStore().isTombstoned(this.sessionId) &&
+			tombstoned &&
 			operation !== "session_delete" &&
 			operation !== "transcript_delete"
 		)
 			throw new Error(`Session ${this.sessionId} was deleted`);
 	}
 
-  applyCreationEvent(
+  async applyCreationEvent(
     input: Omit<CreationEventDecision, "sessionId">,
-  ): CreationEventDecisionResult {
-    this.assertWritable(`creation_state:${input.event}`);
+  ): Promise<CreationEventDecisionResult> {
+    await this.assertWritable(`creation_state:${input.event}`);
     this.touch();
     const result = state.actor
-      ? state.actor.decideCreationEvent({
+      ? await state.actor.decideCreationEventAsync({
           sessionId: this.sessionId,
           ...input,
         })
@@ -431,15 +421,17 @@ export class SessionKernel {
     return sessionKernelStore().creationState(this.sessionId);
   }
 
-  applyRunEvent(
+  async applyRunEvent(
     input: Omit<RunEventDecision, "sessionId">,
-  ): RunEventDecisionResult {
-		this.assertWritable(`run_state:${input.event}`);
+  ): Promise<RunEventDecisionResult> {
+		await this.assertWritable(`run_state:${input.event}`);
 		this.touch();
-    return sessionKernelStore().applyRunEvent({
-      sessionId: this.sessionId,
-      ...input,
-    });
+    return state.actor
+      ? state.actor.decideRunEventAsync({ sessionId: this.sessionId, ...input })
+      : compatibilityStoreForTest("core").applyRunEvent({
+          sessionId: this.sessionId,
+          ...input,
+        });
 	}
 
 	runState(): DurableRunState {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -133,7 +133,7 @@ export async function sessionTurn<T extends TurnActorRequest>(
   request: T,
 ): Promise<TurnActorResult<T>> {
   const actor = state.actor;
-  if (actor) return actor.decideTurn(request);
+  if (actor) return actor.decideTurnAsync(request);
   const store = compatibilityStoreForTest("turn");
   if (request.op === "snapshot")
     return store.turnSnapshot(request.sessionId) as TurnActorResult<T>;
@@ -474,12 +474,12 @@ export class SessionKernel {
 			| "deadLetteredAt"
 			| "createdAt"
 		>,
-	): void {
-    sessionTimer({ op: "schedule", sessionId: this.sessionId, ...timer });
+	): Promise<void> {
+    return sessionTimer({ op: "schedule", sessionId: this.sessionId, ...timer });
 	}
 
-	cancelTimer(timerId: string): void {
-    sessionTimer({ op: "cancel", sessionId: this.sessionId, timerId });
+	cancelTimer(timerId: string): Promise<void> {
+    return sessionTimer({ op: "cancel", sessionId: this.sessionId, timerId }).then(() => {});
 	}
 
 	enqueueEffect<K extends SessionActorEffectKind>(
@@ -497,12 +497,12 @@ export class SessionKernel {
     });
 	}
 
-	clear(): void {
-    sessionCore({ op: "clear", sessionId: this.sessionId });
+	clear(): Promise<void> {
+    return sessionCore({ op: "clear", sessionId: this.sessionId }).then(() => {});
 	}
 
-	tombstone(): void {
-    sessionCore({ op: "tombstone", sessionId: this.sessionId });
+	tombstone(): Promise<void> {
+    return sessionCore({ op: "tombstone", sessionId: this.sessionId }).then(() => {});
 	}
 
 	private touch(): void {
@@ -547,9 +547,9 @@ export function passivateIdleSessionKernels(
 	return count;
 }
 
-export function clearSessionKernel(sessionId: string): void {
+export async function clearSessionKernel(sessionId: string): Promise<void> {
 	const kernel = kernels().get(sessionId) ?? sessionKernel(sessionId);
-	kernel.clear();
+	await kernel.clear();
 	kernels().delete(sessionId);
 }
 
@@ -633,8 +633,8 @@ export async function maintainSessionKernel(): Promise<boolean> {
 	return sessionKernelStore().maintain();
 }
 
-export function tombstoneSessionKernel(sessionId: string): void {
+export async function tombstoneSessionKernel(sessionId: string): Promise<void> {
 	const kernel = state.kernels?.get(sessionId) ?? new SessionKernel(sessionId);
-	kernel.tombstone();
+	await kernel.tombstone();
 	state.kernels?.delete(sessionId);
 }

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -303,27 +303,6 @@ export async function sessionDelivery<T extends DeliveryActorRequest>(
   return result as DeliveryActorResult<T>;
 }
 
-export async function sessionDeliveryAsync<T extends DeliveryActorRequest>(
-  request: T,
-): Promise<DeliveryActorResult<T>> {
-  if (state.actor) {
-    const result = await state.actor.decideDeliveryAsync(request);
-    if (
-      request.op !== "snapshot" &&
-      request.op !== "entries" &&
-      "sessionId" in request
-    )
-      state.deliveryProjection?.delete(request.sessionId);
-    else if (
-      request.op === "clear_slot" ||
-      request.op === "settle_pending_steers"
-    )
-      state.deliveryProjection?.clear();
-    return result;
-  }
-  return sessionDelivery(request);
-}
-
 export async function sessionDeliveryProjection(
   sessionId: string,
 ): Promise<DurableDeliveryState> {

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -106,10 +106,10 @@ export function claimAgentHostSupervision(
   return compatibilityStoreForTest("core").claimAgentHostSupervision(request);
 }
 
-export function sessionAsk<T extends AskActorRequest>(
+export async function sessionAsk<T extends AskActorRequest>(
   request: T,
-): AskActorResult<T> {
-  if (state.actor) return state.actor.decideAsk(request);
+): Promise<AskActorResult<T>> {
+  if (state.actor) return state.actor.decideAskAsync(request);
   const store = compatibilityStoreForTest("ask");
   let result: unknown;
   if (request.op === "snapshot") result = store.askSnapshot(request.sessionId);
@@ -129,9 +129,9 @@ export function sessionAsk<T extends AskActorRequest>(
   return result as AskActorResult<T>;
 }
 
-export function sessionTurn<T extends TurnActorRequest>(
+export async function sessionTurn<T extends TurnActorRequest>(
   request: T,
-): TurnActorResult<T> {
+): Promise<TurnActorResult<T>> {
   const actor = state.actor;
   if (actor) return actor.decideTurn(request);
   const store = compatibilityStoreForTest("turn");
@@ -156,10 +156,10 @@ export function sessionTurn<T extends TurnActorRequest>(
   return store.settleTurnOutcomeProjection(request) as TurnActorResult<T>;
 }
 
-export function sessionTimer<T extends TimerActorRequest>(
+export async function sessionTimer<T extends TimerActorRequest>(
   request: T,
-): TimerActorResult<T> {
-  if (state.actor) return state.actor.decideTimer(request);
+): Promise<TimerActorResult<T>> {
+  if (state.actor) return state.actor.decideTimerAsync(request);
   const store = compatibilityStoreForTest("turn");
   if (request.op === "schedule")
     return store.scheduleTimer(request) as TimerActorResult<T>;
@@ -174,10 +174,10 @@ export function sessionTimer<T extends TimerActorRequest>(
   return store.recordTimerRuntimeFailure(request) as TimerActorResult<T>;
 }
 
-export function sessionCore<T extends CoreActorRequest>(
+export async function sessionCore<T extends CoreActorRequest>(
   request: T,
-): CoreActorResult<T> {
-  if (state.actor) return state.actor.decideCore(request);
+): Promise<CoreActorResult<T>> {
+  if (state.actor) return state.actor.decideCoreAsync(request);
   const store = compatibilityStoreForTest("core");
   if (request.op === "enqueue_effect")
     return store.enqueueOutbox(
@@ -208,10 +208,10 @@ export async function sessionCoreAsync<T extends CoreActorRequest>(
   return sessionCore(request);
 }
 
-export function sessionGatewayCommand<T extends GatewayCommandRequest>(
+export async function sessionGatewayCommand<T extends GatewayCommandRequest>(
   request: T,
-): GatewayCommandResult<T> {
-  if (state.actor) return state.actor.decideGateway(request);
+): Promise<GatewayCommandResult<T>> {
+  if (state.actor) return state.actor.decideGatewayAsync(request);
   const store = compatibilityStoreForTest("gateway command");
   if (request.op === "request")
     return store.requestGatewayCommand(request) as GatewayCommandResult<T>;
@@ -227,9 +227,9 @@ export async function sessionGatewayCommandAsync<T extends GatewayCommandRequest
   return sessionGatewayCommand(request);
 }
 
-export function sessionDelivery<T extends DeliveryActorRequest>(
+export async function sessionDelivery<T extends DeliveryActorRequest>(
   request: T,
-): DeliveryActorResult<T> {
+): Promise<DeliveryActorResult<T>> {
   const projection = (state.deliveryProjection ??= new Map());
   if (request.op === "snapshot") {
     const cached = projection.get(request.sessionId);
@@ -237,7 +237,7 @@ export function sessionDelivery<T extends DeliveryActorRequest>(
   }
   const actor = state.actor;
   let result: unknown;
-  if (actor) result = actor.decideDelivery(request);
+  if (actor) result = await actor.decideDeliveryAsync(request);
   else {
     const store = compatibilityStoreForTest("delivery");
     if (request.op === "snapshot")
@@ -326,11 +326,13 @@ export async function sessionDeliveryAsync<T extends DeliveryActorRequest>(
   return sessionDelivery(request);
 }
 
-export function sessionDeliveryProjection(sessionId: string): DurableDeliveryState {
+export async function sessionDeliveryProjection(
+  sessionId: string,
+): Promise<DurableDeliveryState> {
   const projection = (state.deliveryProjection ??= new Map());
   const cached = projection.get(sessionId);
   if (cached) return cached;
-  return sessionDelivery({ op: "snapshot", sessionId });
+  return await sessionDelivery({ op: "snapshot", sessionId });
 }
 
 export function sessionKernelActorActive(): boolean {
@@ -484,7 +486,7 @@ export class SessionKernel {
 		kind: K,
 		payload: SessionActorEffectFor<K>["payload"],
 		effectKey: string = crypto.randomUUID(),
-	): number {
+	): Promise<number> {
 		this.touch();
     return sessionCore({
       op: "enqueue_effect",

--- a/packages/core/opensession-server/src/server/session-kernel/kernel.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/kernel.ts
@@ -260,12 +260,21 @@ export async function sessionDelivery<T extends DeliveryActorRequest>(
     result = store.prepareSteerDelivery(
       request.sessionId,
       request.itemId,
+      request.target,
       request.item,
     );
   else if (request.op === "accept_steer")
-    result = store.acceptSteerDelivery(request.sessionId, request.itemId);
+    result = store.acceptSteerDelivery(
+      request.sessionId,
+      request.itemId,
+      request.target,
+    );
   else if (request.op === "reject_steer")
-    result = store.rejectSteerDelivery(request.sessionId, request.itemId);
+    result = store.rejectSteerDelivery(
+      request.sessionId,
+      request.itemId,
+      request.target,
+    );
   else if (request.op === "settle_pending_steers")
     result = store.settlePendingSteers();
   else if (request.op === "requeue_steers")

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -217,6 +217,10 @@ describe("single session ownership", () => {
     const queuedSteer = read("queued-steer.ts");
     expect(queuedSteer).toContain("await deps.prepare(");
     expect(queuedSteer).toContain("steerAgentRunToken");
+    expect(queuedSteer).toContain("interruptAndSteerAgentRunToken");
+    const runSession = read("run-session.ts");
+    expect(runSession).toContain("await prepareAndInterruptQueuedPrompt({");
+    expect(runSession).not.toContain("!interruptAndSteerAgentRun(");
 	});
 
 	test("sandbox prompts are visible before remote startup can fail", () => {
@@ -253,6 +257,15 @@ describe("single session ownership", () => {
 		const entry = read("../../opensession.ts");
 		expect(entry.indexOf("await startSessionKernelActor()")).toBeLessThan(
 			entry.indexOf("initHumanAsks()"),
+		);
+		expect(entry).toContain("await restorePendingAsks()");
+		expect(entry).toContain("await hydratePersistedQueueState()");
+		expect(entry).toContain("await restorePromptQueues(new Set(resumedIds))");
+		const queueRestore = entry.indexOf(
+			"await restorePromptQueues(new Set(resumedIds))",
+		);
+		expect(queueRestore).toBeLessThan(
+			entry.indexOf("reconcileSessionKernelOwnership(", queueRestore),
 		);
 		const actor = read("session-kernel/actor-worker.ts");
 		expect(actor).toContain("const host = new SessionKernelStoreHost()");

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -720,6 +720,46 @@ describe("single session ownership", () => {
     expect(settleProjection).toBeGreaterThan(applyProjection);
     expect(run).toContain("projectionId: `outcome:${startToken}`");
     expect(create).toContain("projectionId: `outcome:${startToken}`");
+
+    const terminalOutcome = run.indexOf(
+      "await recordRunOutcome(session.id, runFailure",
+    );
+    expect(terminalOutcome).toBeGreaterThan(0);
+    expect(run.indexOf("await clearSteerReceipts", terminalOutcome))
+      .toBeGreaterThan(terminalOutcome);
+    expect(run.indexOf('type: "stream_done"', terminalOutcome))
+      .toBeGreaterThan(terminalOutcome);
+
+    const openingOutcome = create.indexOf(
+      "await recordRunOutcome(bksId, runFailure",
+    );
+    expect(openingOutcome).toBeGreaterThan(0);
+    expect(create.indexOf("await settleCreation", openingOutcome))
+      .toBeGreaterThan(openingOutcome);
+    const setupOutcome = create.lastIndexOf("await recordRunOutcome(");
+    expect(create.indexOf('type: "stream_done"', setupOutcome))
+      .toBeGreaterThan(setupOutcome);
+    expect(create.indexOf("await settleCreationFailed(", setupOutcome))
+      .toBeGreaterThan(setupOutcome);
+
+    const boot = read("../../opensession.ts");
+    const recoveredOutcome = boot.indexOf("await recordRunOutcome(");
+    expect(boot.indexOf("await settleRecoveredCreationOpening(", recoveredOutcome))
+      .toBeGreaterThan(recoveredOutcome);
+
+    const github = read("../agents/github/run.ts");
+    const githubOutcome = github.indexOf("await recordRunOutcome(");
+    expect(github.indexOf("journalClearIfLineage(", githubOutcome))
+      .toBeGreaterThan(githubOutcome);
+
+    const journal = read("run-journal.ts");
+    expect(journal).toContain(
+      'await transition(record.osSessionId, "run_registered"',
+    );
+    expect(journal).toContain(
+      'await transition(r.osSessionId, "boot_journal_found"',
+    );
+    expect(journal).not.toContain("void transitionRunState(");
 	});
 
 	test("WebSocket session mutations enter the mailbox before dispatch", () => {

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -65,7 +65,8 @@ describe("single session ownership", () => {
 		expect(kernel).toContain("compatibilityStoreForTest");
 		expect(kernel).toContain('process.env.NODE_ENV !== "test"');
 		expect(kernel).toContain("requires the authoritative actor");
-		expect(kernel).toContain("projection.delete(request.sessionId)");
+		expect(kernel).toContain("actor.decideAskAsync(request)");
+		expect(kernel).toContain("actor.decideDeliveryAsync(request)");
 		expect(kernel).not.toContain(
 			'actor.decideDelivery({ op: "snapshot", sessionId: request.sessionId })',
 		);
@@ -619,7 +620,7 @@ describe("single session ownership", () => {
 			'throw new Error("Opening run ended without a terminal event")',
 		);
 		expect(create).toContain("openingJournal?.terminalFailure");
-		expect(create).toContain("startToken = markSessionStarting(");
+		expect(create).toContain("startToken = await markSessionStarting(");
 		expect(create).toContain("hostId: startToken");
 		expect(create).toContain("isAgentSessionCancelled(bksId, startToken)");
 		// Sandbox launches bind the physical host to the admitted token so
@@ -633,7 +634,7 @@ describe("single session ownership", () => {
 		const runSession = read("run-session.ts");
 		const cancelPrepared = runSession.indexOf('op: "prepare_cancel"');
 		const settleGuarded = runSession.indexOf(
-			"try {\n    settleCreationOpeningForStop(sessionId);",
+			"try {\n    await settleCreationOpeningForStop(sessionId);",
 			cancelPrepared,
 		);
 		const bookkeeping = runSession.indexOf("} finally {", settleGuarded);

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -212,7 +212,11 @@ describe("single session ownership", () => {
 		const steerItem = control.indexOf("const steerItem = durableQueueItem(id");
 		expect(steerEligibility).toBeGreaterThan(-1);
 		expect(steerItem).toBeGreaterThan(steerEligibility);
-		expect(control.indexOf("prepareQueuedSteer(id", steerItem)).toBeGreaterThan(steerItem);
+		expect(control.indexOf("await prepareAndSteerQueuedPrompt({", steerItem))
+      .toBeGreaterThan(steerItem);
+    const queuedSteer = read("queued-steer.ts");
+    expect(queuedSteer).toContain("await deps.prepare(");
+    expect(queuedSteer).toContain("steerAgentRunToken");
 	});
 
 	test("sandbox prompts are visible before remote startup can fail", () => {

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -56,10 +56,10 @@ async function timerRuntimeFailure(
 	return new SessionTimerExecutionError(error, deadLetteredNow);
 }
 
-function failDeadCreationEffect(
+async function failDeadCreationEffect(
 	item: DurableOutboxItem,
 	error: string,
-): void {
+): Promise<void> {
 	if (!item.kind.startsWith("creation_")) return;
 	const payload = item.payload as
 		| { creationIdentity?: unknown; creationGeneration?: unknown }
@@ -70,7 +70,7 @@ function failDeadCreationEffect(
 		!Number.isSafeInteger(payload.creationGeneration)
 	)
 		return;
-	const result = sessionKernel(item.sessionId).applyCreationEvent({
+	const result = await sessionKernel(item.sessionId).applyCreationEvent({
 		identity: payload.creationIdentity,
 		event: "failed",
 		effectId: item.effectKey,
@@ -154,7 +154,7 @@ export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 		} catch (settlementError) {
 			if (settlementError instanceof SessionTimerExecutionError)
 				throw settlementError;
-			throw timerRuntimeFailure(timer, settlementError);
+			throw await timerRuntimeFailure(timer, settlementError);
 		}
 	}
 	try {
@@ -271,7 +271,7 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 								error instanceof CreationEffectIndeterminateError ? 1 : 20,
 						});
 						if (settled.deadLetteredNow) {
-							failDeadCreationEffect(item, message);
+							await failDeadCreationEffect(item, message);
 							audit({
 								msg: "session_kernel_dead_lettered",
 								kind: "outbox",
@@ -357,9 +357,9 @@ export function stopSessionKernelRuntime(): void {
 }
 
 /** Settle durable ownership left behind without a recoverable journal. */
-export function reconcileSessionKernelOwnership(
+export async function reconcileSessionKernelOwnership(
 	ownedSessionIds: ReadonlySet<string>,
-): string[] {
+): Promise<string[]> {
 	const unsettled = new Set([
 		"preparing",
 		"starting",
@@ -376,7 +376,7 @@ export function reconcileSessionKernelOwnership(
 			sessionKernelStore().quarantinedSession(state.sessionId)
 		)
 			continue;
-		sessionKernel(state.sessionId).applyRunEvent({
+		await sessionKernel(state.sessionId).applyRunEvent({
 			event: "boot_owner_missing",
 			detail: { previousState: state.state },
 		});

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -34,13 +34,13 @@ class SessionTimerExecutionError extends Error {
 	}
 }
 
-function timerRuntimeFailure(
+async function timerRuntimeFailure(
 	timer: DurableTimer,
 	error: unknown,
-): SessionTimerExecutionError {
+): Promise<SessionTimerExecutionError> {
 	let deadLetteredNow = false;
 	try {
-		deadLetteredNow = sessionTimer({
+		deadLetteredNow = (await sessionTimer({
 			op: "record_runtime_failure",
 			sessionId: timer.sessionId,
 			timerId: timer.timerId,
@@ -48,7 +48,7 @@ function timerRuntimeFailure(
 			error: error instanceof Error ? error.message : String(error),
 			maxAttempts: 20,
 			observedAttempts: timer.attempts,
-		}).deadLetteredNow;
+		})).deadLetteredNow;
 	} catch {
 		// The actor is the only timer writer. If it is unavailable, preserve the
 		// original failure and let the next actor-owned runtime pass retry.
@@ -127,14 +127,14 @@ export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 	if (!handler) return false;
 	let decision: "execute" | "completed" | "missing";
 	try {
-		decision = sessionTimer({
+		decision = await sessionTimer({
 			op: "begin",
 			sessionId: timer.sessionId,
 			timerId: timer.timerId,
 			token: timer.token,
 		});
 	} catch (error) {
-		throw timerRuntimeFailure(timer, error);
+		throw await timerRuntimeFailure(timer, error);
 	}
 	if (decision === "missing") return false;
 	if (decision === "completed") return true;
@@ -142,7 +142,7 @@ export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 		await handler(timer);
 	} catch (error) {
 		try {
-			const settled = sessionTimer({
+			const settled = await sessionTimer({
 				op: "fail",
 				sessionId: timer.sessionId,
 				timerId: timer.timerId,
@@ -158,14 +158,14 @@ export async function fireSessionTimer(timer: DurableTimer): Promise<boolean> {
 		}
 	}
 	try {
-		sessionTimer({
+		await sessionTimer({
 			op: "complete",
 			sessionId: timer.sessionId,
 			timerId: timer.timerId,
 			token: timer.token,
 		});
 	} catch (error) {
-		throw timerRuntimeFailure(timer, error);
+		throw await timerRuntimeFailure(timer, error);
 	}
 	return true;
 }

--- a/packages/core/opensession-server/src/server/session-kernel/scheduled-prompts.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/scheduled-prompts.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 describe("scheduled prompt kernel timers", () => {
-	test("creation and deletion update the durable timer", () => {
+	test("creation and deletion update the durable timer", async () => {
 		const created = createScheduledPrompt({
 			sessionId: "s1",
 			prompt: "continue",
@@ -44,7 +44,7 @@ describe("scheduled prompt kernel timers", () => {
 		if ("error" in created) throw new Error(created.error);
 		expect(store.timer("s1", created.id)?.kind).toBe("scheduled_prompt");
 		expect(listScheduledPrompts("s1")).toHaveLength(1);
-		expect(deleteScheduledPrompt(created.id)).toBe(true);
+		expect(await deleteScheduledPrompt(created.id)).toBe(true);
 		expect(store.timer("s1", created.id)).toBeUndefined();
 	});
 

--- a/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-host.test.ts
@@ -392,9 +392,17 @@ describe("per-session session kernel storage", () => {
       state: "idle",
       event: "seed",
     }]);
+    host.call("setRunState", [{
+      sessionId: "pending-session",
+      state: "running",
+      event: "run_registered",
+      currentRunId: "run-one",
+      generation: 1,
+    }]);
     host.call("prepareSteerDelivery", [
       "pending-session",
       "steer-one",
+      { token: "token-one", runId: "run-one", generation: 1 },
       { id: "steer-one", content: "recover me" },
     ]);
     Object.defineProperty(host.storeForSession("empty-session"), "settlePendingSteers", {

--- a/packages/core/opensession-server/src/server/session-kernel/store-routing.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store-routing.ts
@@ -104,7 +104,7 @@ const OUTBOX_ID_METHODS = new Set([
   "retryDeadOutbox",
 ]);
 
-const READ_METHODS = new Set([
+export const READ_METHODS = new Set([
   "command",
   "quarantinedSession",
   "creationState",
@@ -112,10 +112,20 @@ const READ_METHODS = new Set([
   "changesSince",
   "isTombstoned",
   "askSnapshot",
+  "askEntries",
   "turnSnapshot",
   "deliverySnapshot",
+  "deliveryEntries",
+  "runStates",
+  "quarantinedSessions",
+  "dueTimers",
+  "pendingOutbox",
+  "stats",
+  "deadLetters",
   "timer",
   "outboxSessionId",
+  "askMigrationComplete",
+  "deliveryMigrationComplete",
 ]);
 
 /** The single routing registry for the compatibility store surface. */

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -2874,6 +2874,8 @@ export class SessionKernelStore {
 		const since = new Date(now).toISOString();
 		let result!: RunEventDecisionResult;
 		const tx = this.db.transaction(() => {
+      if (this.isTombstoned(input.sessionId))
+        throw new Error(`Session ${input.sessionId} was deleted`);
 			const prior = this.runState(input.sessionId);
 			const from = prior.state as RunState;
       if (
@@ -3663,6 +3665,20 @@ export class SessionKernelStore {
         state.steered = Array.isArray(value) ? value : [];
       else state.dispatch = value;
     });
+  }
+
+  enqueueDelivery(sessionId: string, item: unknown, front = false): boolean {
+    return this.mutateDelivery(sessionId, "delivery_queued_enqueue", (state) => {
+      const queue = state.queued as Array<{ id?: string }>;
+      const id = item && typeof item === "object"
+        ? (item as { id?: unknown }).id
+        : undefined;
+      if (typeof id === "string" && queue.some((queued) => queued.id === id))
+        return false;
+      if (front) queue.unshift(item as { id?: string });
+      else queue.push(item as { id?: string });
+      return true;
+    }).result as boolean;
   }
 
   deleteDeliverySlot(sessionId: string, slot: DeliverySlot): boolean {

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -109,6 +109,12 @@ export interface DurableTimer {
 	createdAt: number;
 }
 
+export type DurableSteerTarget = {
+  token: string;
+  runId: string;
+  generation: number;
+};
+
 export type DurableDeliveryState = {
   revision: number;
   queued: unknown[];
@@ -123,7 +129,12 @@ export type DurableDeliveryState = {
     source?: { slot: "steered"; index: number };
   };
   steered: unknown[];
-  pendingSteers: Array<{ item: unknown; index: number; preparedAt: number }>;
+  pendingSteers: Array<{
+    item: unknown;
+    index: number;
+    preparedAt: number;
+    target?: DurableSteerTarget;
+  }>;
   updatedAt: number;
 };
 
@@ -3347,7 +3358,7 @@ export class SessionKernelStore {
       interrupt: parsed(row.interrupt as string | null),
       steered: parsed<unknown[]>(String(row.steered)) ?? [],
       pendingSteers:
-        parsed<Array<{ item: unknown; index: number; preparedAt: number }>>(
+        parsed<DurableDeliveryState["pendingSteers"]>(
           String(row.pending_steers),
         ) ?? [],
       updatedAt: Number(row.updated_at),
@@ -3704,9 +3715,15 @@ export class SessionKernelStore {
   prepareSteerDelivery(
     sessionId: string,
     itemId: string,
+    target: DurableSteerTarget,
     directItem?: unknown,
   ): unknown | undefined {
     return this.mutateDelivery(sessionId, "delivery_steer_prepared", (state) => {
+      const run = this.runState(sessionId);
+      if (
+        run.currentRunId !== target.runId ||
+        run.generation !== target.generation
+      ) return undefined;
       const queue = state.queued as Array<{ id?: string }>;
       const index = queue.findIndex((item) => item.id === itemId);
       if (index < 0 && directItem === undefined) return undefined;
@@ -3721,48 +3738,62 @@ export class SessionKernelStore {
         item,
         index: index >= 0 ? index : 0,
         preparedAt: Date.now(),
+        target,
       });
       return item;
     }).result;
   }
 
-  acceptSteerDelivery(sessionId: string, itemId: string): boolean {
-    const current = this.deliveryRow(sessionId).pendingSteers.find(
-      (pending) => (pending.item as { id?: string }).id === itemId,
-    );
-    if (!current) return false;
-    this.mutateDelivery(sessionId, "delivery_steer_accepted", (state) => {
+  acceptSteerDelivery(
+    sessionId: string,
+    itemId: string,
+    target: DurableSteerTarget,
+  ): boolean {
+    return this.mutateDelivery(sessionId, "delivery_steer_accepted", (state) => {
+      const run = this.runState(sessionId);
+      if (
+        run.currentRunId !== target.runId ||
+        run.generation !== target.generation
+      ) return false;
       const index = state.pendingSteers.findIndex(
-        (pending) => (pending.item as { id?: string }).id === itemId,
+        (pending) =>
+          (pending.item as { id?: string }).id === itemId &&
+          pending.target?.token === target.token &&
+          pending.target.runId === target.runId &&
+          pending.target.generation === target.generation,
       );
-      if (index < 0) throw new Error("Pending steer changed before acceptance");
+      if (index < 0) return false;
       const [pending] = state.pendingSteers.splice(index, 1);
       state.steered.push({
         ...(pending.item as Record<string, unknown>),
         steeredAt: Date.now(),
       });
-    });
-    return true;
+      return true;
+    }).result as boolean;
   }
 
-  rejectSteerDelivery(sessionId: string, itemId: string): boolean {
-    const current = this.deliveryRow(sessionId).pendingSteers.find(
-      (pending) => (pending.item as { id?: string }).id === itemId,
-    );
-    if (!current) return false;
-    this.mutateDelivery(sessionId, "delivery_steer_rejected", (state) => {
+  rejectSteerDelivery(
+    sessionId: string,
+    itemId: string,
+    target: DurableSteerTarget,
+  ): boolean {
+    return this.mutateDelivery(sessionId, "delivery_steer_rejected", (state) => {
       const index = state.pendingSteers.findIndex(
-        (pending) => (pending.item as { id?: string }).id === itemId,
+        (pending) =>
+          (pending.item as { id?: string }).id === itemId &&
+          pending.target?.token === target.token &&
+          pending.target.runId === target.runId &&
+          pending.target.generation === target.generation,
       );
-      if (index < 0) throw new Error("Pending steer changed before rejection");
+      if (index < 0) return false;
       const [pending] = state.pendingSteers.splice(index, 1);
       state.queued.splice(
         Math.min(pending.index, state.queued.length),
         0,
         pending.item,
       );
-    });
-    return true;
+      return true;
+    }).result as boolean;
   }
 
   requeueSteerDeliveries(sessionId: string, items: unknown[]): number {

--- a/packages/core/opensession-server/src/server/session-model-migration.test.ts
+++ b/packages/core/opensession-server/src/server/session-model-migration.test.ts
@@ -7,8 +7,8 @@ import { __setSessionsDirForTest } from "./paths";
 const scratch = mkdtempSync(join(tmpdir(), "migrate-engine-test-"));
 const prevDir = __setSessionsDirForTest(scratch);
 
-// The module reads the live sessions-dir binding on every call, so a normal
-// import is isolated by this test file's process without a cache-busting URL.
+// Import AFTER repointing the sessions dir isn't required (the module reads the
+// live binding per call), but cache-bust anyway for isolation.
 const { migrateSessionEngine, isAutomationOwnedSession, sessionHasJournaledRun } =
   await import("./session-model-migration");
 
@@ -47,9 +47,9 @@ afterAll(() => {
   rmSync(scratch, { recursive: true, force: true });
 });
 
-describe("migrateSessionEngine", () => {
-  test("flips the model and records modelHistory", () => {
-    const res = migrateSessionEngine(
+describe("migrateSessionEngine", async () => {
+  test("flips the model and records modelHistory", async () => {
+    const res = await migrateSessionEngine(
       "bks-mig-ok",
       "pi/anthropic/claude-haiku-4-5",
       "tester"
@@ -69,43 +69,43 @@ describe("migrateSessionEngine", () => {
       by: "tester",
     });
     // Idempotent: same target again is ok, no duplicate history entry.
-    const again = migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-haiku-4-5");
+    const again = await migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-haiku-4-5");
     expect(again.ok).toBe(true);
     expect(
       JSON.parse(readFileSync(join(scratch, "bks-mig-ok.json"), "utf-8")).modelHistory
     ).toHaveLength(1);
   });
 
-  test("rejects targets that name a model rather than an engine", () => {
+  test("rejects targets that name a model rather than an engine", async () => {
     // A bare native slug dispatches to whatever the default engine is — it is
     // not an engine choice, so it can't be a migration target.
     for (const target of ["claude-sonnet-5", "gpt-5.6-sol", "nonsense"]) {
-      const res = migrateSessionEngine("bks-mig-ok", target);
+      const res = await migrateSessionEngine("bks-mig-ok", target);
       expect(res.ok).toBe(false);
       if (!res.ok) expect(res.error).toContain("not an engine model id");
     }
   });
 
-  test("accepts any enabled engine, not just pi", () => {
+  test("accepts any enabled engine, not just pi", async () => {
     // pi ids need no extra switch here: the pi runner reports its own config
     // gate at run time.
-    const pi = migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-opus-5");
+    const pi = await migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-opus-5");
     expect(pi.ok).toBe(true);
     if (pi.ok) expect(pi.to).toBe("pi/anthropic/claude-opus-5");
 
     // A legacy direct-engine id normalizes onto pi (the engines are
     // removed), so the flip lands the session on a runnable engine rather
     // than failing or bricking it.
-    const legacy = migrateSessionEngine("bks-mig-ok", "claude/anthropic/claude-opus-5");
+    const legacy = await migrateSessionEngine("bks-mig-ok", "claude/anthropic/claude-opus-5");
     expect(legacy.ok).toBe(true);
     if (legacy.ok) expect(legacy.to).toBe("pi/anthropic/claude-opus-5");
     // Leave the session where the other tests expect it.
-    migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-haiku-4-5");
+    await migrateSessionEngine("bks-mig-ok", "pi/anthropic/claude-haiku-4-5");
   });
 
-  test("allows automation-owned sessions to migrate to Pi", () => {
+  test("allows automation-owned sessions to migrate to Pi", async () => {
     for (const id of ["bks-mig-automation", "bks-mig-automation2"]) {
-      const pi = migrateSessionEngine(id, "pi/anthropic/claude-haiku-4-5");
+      const pi = await migrateSessionEngine(id, "pi/anthropic/claude-haiku-4-5");
       expect(pi.ok).toBe(true);
       if (pi.ok) expect(pi.to).toBe("pi/anthropic/claude-haiku-4-5");
     }
@@ -113,9 +113,9 @@ describe("migrateSessionEngine", () => {
     expect(isAutomationOwnedSession({ createdBy: "Alex" })).toBe(false);
   });
 
-  test("can preserve last activity during a fleet migration", () => {
+  test("can preserve last activity during a fleet migration", async () => {
     writeSession("bks-mig-preserve");
-    const res = migrateSessionEngine(
+    const res = await migrateSessionEngine(
       "bks-mig-preserve",
       "pi/anthropic/claude-haiku-4-5",
       "fleet",
@@ -129,15 +129,15 @@ describe("migrateSessionEngine", () => {
     expect(data.modelHistory.at(-1)).toMatchObject({ by: "fleet" });
   });
 
-  test("rejects sessions with an in-flight journaled run", () => {
+  test("rejects sessions with an in-flight journaled run", async () => {
     expect(sessionHasJournaledRun("bks-mig-busy")).toBe(true);
-    const res = migrateSessionEngine("bks-mig-busy", "pi/anthropic/claude-haiku-4-5");
+    const res = await migrateSessionEngine("bks-mig-busy", "pi/anthropic/claude-haiku-4-5");
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toContain("in-flight");
   });
 
-  test("rejects unknown sessions", () => {
-    const res = migrateSessionEngine("bks-nope", "pi/anthropic/claude-haiku-4-5");
+  test("rejects unknown sessions", async () => {
+    const res = await migrateSessionEngine("bks-nope", "pi/anthropic/claude-haiku-4-5");
     expect(res.ok).toBe(false);
   });
 });

--- a/packages/core/opensession-server/src/server/session-model-migration.ts
+++ b/packages/core/opensession-server/src/server/session-model-migration.ts
@@ -84,12 +84,12 @@ export function sessionHasJournaledRun(
  * migrates via the transcript handoff. Pure session-file operation. See the
  * module doc for what it deliberately does not do.
  */
-export function migrateSessionEngine(
+export async function migrateSessionEngine(
   sessionId: string,
   targetModel: string,
   by = "engine-migration",
   options: { preserveActivity?: boolean } = {}
-): MigrateEngineResult {
+): Promise<MigrateEngineResult> {
   const path = `${OPENSESSION_SESSIONS_DIR}/${sessionId}.json`;
   const data = readJson<NativeSessionFile>(path);
   if (!data?.id) {
@@ -131,7 +131,7 @@ export function migrateSessionEngine(
   }
 
   const from = data.model;
-  executeSessionProjection(sessionId, "model_migration", () =>
+  await executeSessionProjection(sessionId, "model_migration", () =>
     writeJsonAtomic(path, {
       ...data,
       model: resolved.id,

--- a/packages/core/opensession-server/src/server/session-projection-executor.ts
+++ b/packages/core/opensession-server/src/server/session-projection-executor.ts
@@ -3,90 +3,113 @@ import {
   type GatewayCommandOperation,
 } from "./session-kernel";
 
+const projectionState = globalThis as typeof globalThis & {
+  __sessionProjectionTails?: Map<string, Promise<void>>;
+};
+
+function serializeSessionProjection<T>(
+  sessionId: string,
+  project: () => Promise<T>,
+): Promise<T> {
+  const tails = (projectionState.__sessionProjectionTails ??= new Map());
+  const prior = tails.get(sessionId) ?? Promise.resolve();
+  const result = prior.then(project);
+  const tail = result.then(() => undefined, () => undefined);
+  tails.set(sessionId, tail);
+  void tail.finally(() => {
+    if (tails.get(sessionId) === tail) tails.delete(sessionId);
+  });
+  return result;
+}
+
 /**
- * Execute one destination mutation after a short actor admission. The mutation
- * runs on the gateway thread, never in the actor Worker. The actor remains free
- * to reduce Stop, steer, and other commands while this continuation is active.
+ * Execute one destination mutation after actor admission. The physical mutation
+ * runs on the gateway thread, never in the actor Worker, while admission and
+ * exact completion remain durable and ordered with other session projections.
  */
-export async function executeDestinationIdempotentSessionProjection<T>(
+export function executeDestinationIdempotentSessionProjection<T>(
   sessionId: string,
   requestId: string,
   operation: "transcript_destination_append",
   identity: unknown,
   mutate: () => T | Promise<T>,
 ): Promise<T> {
-  const plan = await sessionGatewayCommand({
-    op: "request",
-    sessionId,
-    requestId,
-    operation,
-    identity,
-  });
-  if (plan.status === "completed") return plan.result as T;
-  if (plan.status === "in_progress")
-    throw new Error(`Destination command ${requestId} is already in progress`);
-  let physicalFinished = false;
-  try {
-    const result = await mutate();
-    physicalFinished = true;
-    return await sessionGatewayCommand({
-      op: "complete",
+  return serializeSessionProjection(sessionId, async () => {
+    const plan = await sessionGatewayCommand({
+      op: "request",
       sessionId,
       requestId,
       operation,
-      result,
-    }) as T;
-  } catch (error) {
-    if (!physicalFinished) {
-      await sessionGatewayCommand({
-        op: "fail",
+      identity,
+    });
+    if (plan.status === "completed") return plan.result as T;
+    if (plan.status === "in_progress")
+      throw new Error(`Destination command ${requestId} is already in progress`);
+    let physicalFinished = false;
+    try {
+      const result = await mutate();
+      physicalFinished = true;
+      return await sessionGatewayCommand({
+        op: "complete",
         sessionId,
         requestId,
         operation,
-        error: error instanceof Error ? error.message : String(error),
-        retryable: true,
-      });
+        result,
+      }) as T;
+    } catch (error) {
+      if (!physicalFinished) {
+        await sessionGatewayCommand({
+          op: "fail",
+          sessionId,
+          requestId,
+          operation,
+          error: error instanceof Error ? error.message : String(error),
+          retryable: true,
+        });
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }
 
-export async function executeSessionProjection<T>(
+export function executeSessionProjection<T>(
   sessionId: string,
   operation: GatewayCommandOperation,
   mutate: () => T | Promise<T>,
 ): Promise<T> {
-  const requestId = `${operation}:${crypto.randomUUID()}`;
-  const plan = await sessionGatewayCommand({
-    op: "request",
-    sessionId,
-    requestId,
-    operation,
-  });
-  if (plan.status !== "execute")
-    throw new Error(`Unexpected duplicate ${operation} command`);
-  let physicalFinished = false;
-  try {
-    const result = await mutate();
-    physicalFinished = true;
-    return await sessionGatewayCommand({
-      op: "complete",
+  return serializeSessionProjection(sessionId, async () => {
+    const requestId = `${operation}:${crypto.randomUUID()}`;
+    const plan = await sessionGatewayCommand({
+      op: "request",
       sessionId,
       requestId,
       operation,
-      result,
-    }) as T;
-  } catch (error) {
-    if (!physicalFinished) {
-      await sessionGatewayCommand({
-        op: "fail",
+    });
+    if (plan.status !== "execute")
+      throw new Error(`Unexpected duplicate ${operation} command`);
+    let physicalFinished = false;
+    try {
+      const result = await mutate();
+      physicalFinished = true;
+      return await sessionGatewayCommand({
+        op: "complete",
         sessionId,
         requestId,
         operation,
-        error: error instanceof Error ? error.message : String(error),
-        retryable: false,
-      });
+        result,
+      }) as T;
+    } catch (error) {
+      if (!physicalFinished) {
+        await sessionGatewayCommand({
+          op: "fail",
+          sessionId,
+          requestId,
+          operation,
+          error: error instanceof Error ? error.message : String(error),
+          retryable: false,
+        });
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }

--- a/packages/core/opensession-server/src/server/session-projection-executor.ts
+++ b/packages/core/opensession-server/src/server/session-projection-executor.ts
@@ -4,19 +4,18 @@ import {
 } from "./session-kernel";
 
 /**
- * Execute one synchronous destination mutation after a short actor admission.
- * The mutation runs on the gateway thread, never in the actor Worker. The actor
- * remains free to reduce Stop, steer, and other commands while this continuation
- * is active.
+ * Execute one destination mutation after a short actor admission. The mutation
+ * runs on the gateway thread, never in the actor Worker. The actor remains free
+ * to reduce Stop, steer, and other commands while this continuation is active.
  */
-export function executeDestinationIdempotentSessionProjection<T>(
+export async function executeDestinationIdempotentSessionProjection<T>(
   sessionId: string,
   requestId: string,
   operation: "transcript_destination_append",
   identity: unknown,
-  mutate: () => T,
-): T {
-  const plan = sessionGatewayCommand({
+  mutate: () => T | Promise<T>,
+): Promise<T> {
+  const plan = await sessionGatewayCommand({
     op: "request",
     sessionId,
     requestId,
@@ -28,9 +27,9 @@ export function executeDestinationIdempotentSessionProjection<T>(
     throw new Error(`Destination command ${requestId} is already in progress`);
   let physicalFinished = false;
   try {
-    const result = mutate();
+    const result = await mutate();
     physicalFinished = true;
-    return sessionGatewayCommand({
+    return await sessionGatewayCommand({
       op: "complete",
       sessionId,
       requestId,
@@ -39,7 +38,7 @@ export function executeDestinationIdempotentSessionProjection<T>(
     }) as T;
   } catch (error) {
     if (!physicalFinished) {
-      sessionGatewayCommand({
+      await sessionGatewayCommand({
         op: "fail",
         sessionId,
         requestId,
@@ -52,13 +51,13 @@ export function executeDestinationIdempotentSessionProjection<T>(
   }
 }
 
-export function executeSessionProjection<T>(
+export async function executeSessionProjection<T>(
   sessionId: string,
   operation: GatewayCommandOperation,
-  mutate: () => T,
-): T {
+  mutate: () => T | Promise<T>,
+): Promise<T> {
   const requestId = `${operation}:${crypto.randomUUID()}`;
-  const plan = sessionGatewayCommand({
+  const plan = await sessionGatewayCommand({
     op: "request",
     sessionId,
     requestId,
@@ -68,9 +67,9 @@ export function executeSessionProjection<T>(
     throw new Error(`Unexpected duplicate ${operation} command`);
   let physicalFinished = false;
   try {
-    const result = mutate();
+    const result = await mutate();
     physicalFinished = true;
-    return sessionGatewayCommand({
+    return await sessionGatewayCommand({
       op: "complete",
       sessionId,
       requestId,
@@ -78,15 +77,16 @@ export function executeSessionProjection<T>(
       result,
     }) as T;
   } catch (error) {
-    if (!physicalFinished)
-      sessionGatewayCommand({
-      op: "fail",
-      sessionId,
-      requestId,
-      operation,
-      error: error instanceof Error ? error.message : String(error),
-      retryable: false,
-    });
+    if (!physicalFinished) {
+      await sessionGatewayCommand({
+        op: "fail",
+        sessionId,
+        requestId,
+        operation,
+        error: error instanceof Error ? error.message : String(error),
+        retryable: false,
+      });
+    }
     throw error;
   }
 }

--- a/packages/core/opensession-server/src/server/session-social-card.test.ts
+++ b/packages/core/opensession-server/src/server/session-social-card.test.ts
@@ -104,12 +104,12 @@ describe("session social card", () => {
 		expect(data).not.toHaveProperty("accent");
 	});
 
-	test("stacks walkthrough, featured, then person-attached screenshots", () => {
+	test("stacks walkthrough, featured, then person-attached screenshots", async () => {
 		const opening = testImage("opening.png");
 		const featured = testImage("featured.png");
 		const walkthrough = testImage("walkthrough.png");
 		const sessionId = "sess-social-shot-priority";
-		transcriptStore().appendTranscriptEvents(sessionId, [
+		await transcriptStore().appendTranscriptEvents(sessionId, [
 			{
 				id: "opening",
 				type: "user",
@@ -146,7 +146,7 @@ describe("session social card", () => {
 		).toEqual([walkthrough, featured, opening]);
 
 		const personOnlyId = "sess-social-person-shot";
-		transcriptStore().appendTranscriptEvents(personOnlyId, [
+		await transcriptStore().appendTranscriptEvents(personOnlyId, [
 			{
 				id: "person-shot",
 				type: "user",
@@ -169,10 +169,10 @@ describe("session social card", () => {
 		).toEqual([opening]);
 	});
 
-	test("restores transcript-owned chat screenshots from bounded rows", () => {
+	test("restores transcript-owned chat screenshots from bounded rows", async () => {
 		const sessionId = "sess-social-data-shot";
 		const dataUrl = `data:image/png;base64,${imageBytes.toString("base64")}`;
-		transcriptStore().appendTranscriptEvents(sessionId, [
+		await transcriptStore().appendTranscriptEvents(sessionId, [
 			{
 				id: "data-shot",
 				type: "user",
@@ -405,7 +405,7 @@ describe("session social card", () => {
 	});
 
 	test("serves a signed Slack-style session id", async () => {
-		transcriptStore().appendTranscriptEvents(signedRouteSessionId, [
+		await transcriptStore().appendTranscriptEvents(signedRouteSessionId, [
 			{
 				id: "signed-shot",
 				type: "user",

--- a/packages/core/opensession-server/src/server/session-unarchive.test.ts
+++ b/packages/core/opensession-server/src/server/session-unarchive.test.ts
@@ -16,7 +16,7 @@ function recorder(registryIds: string[] = []) {
 		setArchived(id, value) {
 			archived.push([id, value]);
 		},
-		clearSessionFileArchive(id) {
+		async clearSessionFileArchive(id) {
 			files.push(id);
 			return true;
 		},

--- a/packages/core/opensession-server/src/server/sessions.ts
+++ b/packages/core/opensession-server/src/server/sessions.ts
@@ -367,22 +367,21 @@ function v2StoreTranscript(
   // read as growth next time instead of being silently covered.
   const totalSize = v2MirrorFiles(session).reduce((sum, f) => sum + f.size, 0);
   const legacy = session.transcriptPath ? parseTranscript(session.transcriptPath) : [];
-  try {
-    store.importLegacyTranscript(
-      sessionId,
-      legacy,
-      store.getImportInfo(sessionId)?.src || "merged",
-      totalSize
-    );
-    // The full re-import restored every entry the store had missed — release
-    // the failure-side marker (no-op for ids that never carried it).
+  void store.importLegacyTranscript(
+    sessionId,
+    legacy,
+    store.getImportInfo(sessionId)?.src || "merged",
+    totalSize
+  ).then(() => {
+    // The full re-import restored every entry the store had missed. Release
+    // the failure marker only after actor completion.
     clearTranscriptStoreDegraded(sessionId);
-  } catch (e) {
+  }).catch((error) => {
     console.warn(
       `[sessions] transcript v2 drift re-import failed for ${sessionId}:`,
-      e instanceof Error ? e.message : e
+      error instanceof Error ? error.message : error
     );
-  }
+  });
   return legacy;
 }
 
@@ -1371,8 +1370,8 @@ function removeSessionArtifacts(session: UnifiedSession): void {
     void removeSessionScratch(id);
 }
 
-export function deleteSession(session: UnifiedSession): void {
-  executeSessionProjection(session.id, "session_delete", () => {
+export async function deleteSession(session: UnifiedSession): Promise<void> {
+  await executeSessionProjection(session.id, "session_delete", () => {
     removeSessionArtifacts(session);
   });
 }

--- a/packages/core/opensession-server/src/server/testing/fake-engine.ts
+++ b/packages/core/opensession-server/src/server/testing/fake-engine.ts
@@ -174,7 +174,7 @@ export function makeFakeEngine(
       recordEngineSessionOwner(engineSessionId, unifiedId);
     const runKey = bks ? opts.startToken || `fake-${bks}` : null;
     if (runKey) {
-      journalSet({
+      await journalSet({
         runKey,
         osSessionId: bks,
         claudeSessionId: engineSessionId,

--- a/packages/core/opensession-server/src/server/testing/fake-engine.ts
+++ b/packages/core/opensession-server/src/server/testing/fake-engine.ts
@@ -215,7 +215,7 @@ export function makeFakeEngine(
       for (const text of turn.text ?? []) {
         yield { type: "text_chunk", text };
         if (options.persistTranscript)
-          appendTranscriptEntries(engineSessionId, [
+          await appendTranscriptEntries(engineSessionId, [
             transcriptLineAssistantText(
               text,
               `fake-text-${++fakeEntrySeq}`,
@@ -238,7 +238,7 @@ export function makeFakeEngine(
           toolUseId,
         };
         if (options.persistTranscript)
-          appendTranscriptEntries(engineSessionId, [
+          await appendTranscriptEntries(engineSessionId, [
             transcriptLineToolUse(toolUseId, tool.name, tool.input ?? {}),
             transcriptLineToolResult(toolUseId, tool.result ?? "(ok)"),
           ]);

--- a/packages/core/opensession-server/src/server/testing/snapshot-harness.ts
+++ b/packages/core/opensession-server/src/server/testing/snapshot-harness.ts
@@ -140,7 +140,7 @@ export interface SnapshotHarness {
   writeEngineTranscript(
     engineSessionId: string,
     lines: Record<string, unknown>[],
-  ): string;
+  ): Promise<string>;
   /** Seed a memory scope for the duration of `fn` (its own store dir). */
   withMemory(
     scopes: Record<string, Array<{ id: string; text: string; by: string }>>,
@@ -251,7 +251,7 @@ export async function loadSnapshotHarness(): Promise<SnapshotHarness> {
     patchSession(id, extra) {
       writeSession(id, { ...readSession(id), ...extra });
     },
-    writeEngineTranscript(engineSessionId, lines) {
+    async writeEngineTranscript(engineSessionId, lines) {
       const files = require("fs").readdirSync(d.sessions) as string[];
       const owner = files
         .filter((file) => file.endsWith(".json"))
@@ -263,7 +263,7 @@ export async function loadSnapshotHarness(): Promise<SnapshotHarness> {
         );
       if (!owner?.id) throw new Error(`No session owns engine id ${engineSessionId}`);
       const { parseJsonlLines } = require("../jsonl-parser") as typeof import("../jsonl-parser");
-      transcriptStore.transcriptStore().importLegacyTranscript(
+      await transcriptStore.transcriptStore().importLegacyTranscript(
         owner.id,
         parseJsonlLines(lines.map((line) => JSON.stringify(line))),
         "merged",

--- a/packages/core/opensession-server/src/server/transcript-backfill.ts
+++ b/packages/core/opensession-server/src/server/transcript-backfill.ts
@@ -140,7 +140,7 @@ export async function runTranscriptBackfill(
 				// WP-A touchpoint: chunked import (≤500 rows/tx, design §1);
 				// importLegacyTranscript marks the session imported with the
 				// src + mirror watermark internally.
-				store.importLegacyTranscript(session.id, entries, "merged", watermark);
+				await store.importLegacyTranscript(session.id, entries, "merged", watermark);
 			}
 			summary.imported++;
 			summary.entries += entries.length;

--- a/packages/core/opensession-server/src/server/transcript-destination.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-destination.test.ts
@@ -313,27 +313,27 @@ describe("destination-idempotent transcript append receipts", () => {
     }
   });
 
-  test("destination continuation does not hold the session actor mailbox", () => {
+  test("destination continuation does not hold the session actor mailbox", async () => {
     const { dir, store } = fixture();
     const kernel = new SessionKernelStore(
       join(dir, "responsive-kernel.sqlite"),
     );
     const previous = __setSessionKernelStoreForTest(kernel);
     try {
-      const result = executeDestinationIdempotentSessionProjection(
+      const result = await executeDestinationIdempotentSessionProjection(
         "os-responsive",
         "transcript-destination:responsive",
         "transcript_destination_append",
         { digest: "one" },
-        () => {
-          const admission = sessionGatewayCommand({
+        async () => {
+          const admission = await sessionGatewayCommand({
             op: "request",
             sessionId: "os-responsive",
             requestId: "transcript_append:responsive-sibling",
             operation: "transcript_append",
           });
           expect(admission).toEqual({ status: "execute" });
-          sessionGatewayCommand({
+          await sessionGatewayCommand({
             op: "complete",
             sessionId: "os-responsive",
             requestId: "transcript_append:responsive-sibling",

--- a/packages/core/opensession-server/src/server/transcript-destination.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-destination.test.ts
@@ -85,7 +85,9 @@ describe("destination-idempotent transcript append receipts", () => {
     const { dir, path, store } = fixture();
     let hooks = 0;
     let bus = 0;
-    setAppendHook(() => hooks++);
+    setAppendHook(() => {
+      hooks++;
+    });
     const unsubscribe = subscribeTranscript("os-destination", () => bus++);
     try {
       const first = store.commitTranscriptDestinationAppend(request());

--- a/packages/core/opensession-server/src/server/transcript-destination.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-destination.test.ts
@@ -359,7 +359,9 @@ describe("destination-idempotent transcript append receipts", () => {
     const transcriptAnchor = emptyAnchor();
     let hooks = 0;
     let bus = 0;
-    setAppendHook(() => hooks++);
+    setAppendHook(() => {
+      hooks++;
+    });
     const unsubscribe = subscribeTranscript("os-destination", () => bus++);
     const input = request({
       transcriptAnchor,

--- a/packages/core/opensession-server/src/server/transcript-early-persist.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-early-persist.test.ts
@@ -15,12 +15,12 @@ import { TranscriptStore } from "./transcript-store";
 import { transcriptLineUser } from "./transcript-persistence";
 import { parseJsonlLines } from "./jsonl-parser";
 
-function withStore(run: (store: TranscriptStore) => void) {
+async function withStore(run: (store: TranscriptStore) => Promise<void>) {
   const dir = mkdtempSync(join(tmpdir(), "transcript-early-persist-"));
   try {
     const store = new TranscriptStore(join(dir, "transcripts.db"));
     try {
-      run(store);
+      await run(store);
     } finally {
       store.close();
     }
@@ -49,18 +49,18 @@ describe("intake-time user-line persist", () => {
     expect(workspaceSetup).toBeGreaterThan(promptWrite);
   });
 
-  test("intake write + runner write with the same uuid = one upserted row", () => {
-    withStore((store) => {
+  test("intake write + runner write with the same uuid = one upserted row", async () => {
+    await withStore(async (store) => {
       const uuid = "prompt-uuid-1";
       // Intake: raw user content, persisted before any engine exists.
-      const first = store.appendTranscriptEvents(
+      const first = await store.appendTranscriptEvents(
         SESSION,
         userEntries("fix the mask selection", uuid)
       );
       expect(first).toMatchObject({ inserted: 1, updated: 0 });
 
       // Runner start: same uuid, content now carries the context decoration.
-      const second = store.appendTranscriptEvents(
+      const second = await store.appendTranscriptEvents(
         SESSION,
         userEntries(
           "<opensession:context>\nhandoff\n</backstage:context>\n\nfix the mask selection",
@@ -77,19 +77,19 @@ describe("intake-time user-line persist", () => {
     });
   });
 
-  test("a re-run with a DIFFERENT uuid would duplicate — the contract promptEntryId exists to prevent", () => {
-    withStore((store) => {
-      store.appendTranscriptEvents(SESSION, userEntries("do the thing", "uuid-a"));
-      store.appendTranscriptEvents(SESSION, userEntries("do the thing", "uuid-b"));
+  test("a re-run with a DIFFERENT uuid would duplicate — the contract promptEntryId exists to prevent", async () => {
+    await withStore(async (store) => {
+      await store.appendTranscriptEvents(SESSION, userEntries("do the thing", "uuid-a"));
+      await store.appendTranscriptEvents(SESSION, userEntries("do the thing", "uuid-b"));
       const users = store.readTail(SESSION).entries.filter((e) => e.type === "user");
       expect(users).toHaveLength(2);
     });
   });
 
-  test("a session first touched by an intake write is marked live-only, not import-blocked", () => {
-    withStore((store) => {
+  test("a session first touched by an intake write is marked live-only, not import-blocked", async () => {
+    await withStore(async (store) => {
       expect(store.needsImport(SESSION)).toBe(true);
-      store.appendTranscriptEvents(SESSION, userEntries("first ever message", "u1"));
+      await store.appendTranscriptEvents(SESSION, userEntries("first ever message", "u1"));
       expect(store.needsImport(SESSION)).toBe(false);
       expect(store.readTail(SESSION).entries).toHaveLength(1);
     });

--- a/packages/core/opensession-server/src/server/transcript-orphan-sweep.ts
+++ b/packages/core/opensession-server/src/server/transcript-orphan-sweep.ts
@@ -233,7 +233,7 @@ export async function sweepOrphanTranscripts(
 
 	for (const candidate of candidates) {
 		try {
-			if (!summary.dryRun) store.deleteSessionTranscript(candidate.sessionId);
+			if (!summary.dryRun) await store.deleteSessionTranscript(candidate.sessionId);
 			summary.removed++;
 			summary.removedEvents += candidate.events;
 			removedIds.push(candidate.sessionId);

--- a/packages/core/opensession-server/src/server/transcript-persistence.ts
+++ b/packages/core/opensession-server/src/server/transcript-persistence.ts
@@ -111,7 +111,7 @@ function warnFailureOnce(id: string, message: string, error: unknown): void {
   console.warn(`${message} (further warnings suppressed for this session)`, error);
 }
 
-function appendLines(engineSessionId: string, lines: JsonlLine[]): void {
+async function appendLines(engineSessionId: string, lines: JsonlLine[]): Promise<void> {
   const sessionId = sessionForEngineId(engineSessionId);
   if (!sessionId) {
     markTranscriptStoreDegraded(engineSessionId);
@@ -123,7 +123,7 @@ function appendLines(engineSessionId: string, lines: JsonlLine[]): void {
   }
   try {
     const entries = parseJsonlLines(lines.map((line) => JSON.stringify(line)));
-    if (entries.length) transcriptStore().appendTranscriptEvents(sessionId, entries);
+    if (entries.length) await transcriptStore().appendTranscriptEvents(sessionId, entries);
   } catch (error) {
     markTranscriptStoreDegraded(sessionId);
     warnFailureOnce(sessionId, `[transcript] append failed for ${sessionId}`, error);
@@ -142,7 +142,11 @@ export function storeAppendUserLineEarly(
   }
   try {
     const entries = parseJsonlLines([JSON.stringify(line)]);
-    if (entries.length) transcriptStore().appendTranscriptEvents(sessionId, entries);
+    if (entries.length) {
+      void transcriptStore().appendTranscriptEvents(sessionId, entries).catch((error) => {
+        warnFailureOnce(sessionId, `[transcript] early user-line persist failed for ${sessionId}`, error);
+      });
+    }
   } catch (error) {
     warnFailureOnce(sessionId, `[transcript] early user-line persist failed for ${sessionId}`, error);
   }
@@ -410,40 +414,40 @@ export function transcriptLineForEntry(e: TranscriptEntry): JsonlLine | null {
 }
 
 
-export function appendTranscriptEntries(
+export async function appendTranscriptEntries(
   engineSessionId: string,
   lines: JsonlLine[],
-): void {
-  if (lines.length) appendLines(engineSessionId, lines);
+): Promise<void> {
+  if (lines.length) await appendLines(engineSessionId, lines);
 }
 
-export function applyForwardedTranscriptStrict(
+export async function applyForwardedTranscriptStrict(
   sessionId: string,
   engineSessionId: string,
   lines: JsonlLine[],
-): void {
+): Promise<void> {
   if (!sessionId || !lines.length)
     throw new Error("Invalid forwarded transcript projection");
   if (engineSessionId && engineSessionId !== sessionId)
     recordEngineSessionOwner(engineSessionId, sessionId);
   const entries = parseJsonlLines(lines.map((line) => JSON.stringify(line)));
-  if (entries.length) transcriptStore().appendTranscriptEvents(sessionId, entries);
+  if (entries.length) await transcriptStore().appendTranscriptEvents(sessionId, entries);
 }
 
-export function applyForwardedTranscript(
+export async function applyForwardedTranscript(
   sessionId: string,
   engineSessionId: string,
   lines: JsonlLine[],
-): void {
+): Promise<void> {
   if (!sessionId || !lines.length) return;
   try {
     if (!engineSessionId || engineSessionId === sessionId) {
       const entries = parseJsonlLines(lines.map((line) => JSON.stringify(line)));
-      if (entries.length) transcriptStore().appendTranscriptEvents(sessionId, entries);
+      if (entries.length) await transcriptStore().appendTranscriptEvents(sessionId, entries);
       return;
     }
     recordEngineSessionOwner(engineSessionId, sessionId);
-    appendTranscriptEntries(engineSessionId, lines);
+    await appendTranscriptEntries(engineSessionId, lines);
   } catch (error) {
     warnFailureOnce(sessionId, `[transcript] forwarded append failed for ${sessionId}`, error);
   }

--- a/packages/core/opensession-server/src/server/transcript-store.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-store.test.ts
@@ -525,16 +525,17 @@ describe("bus + append hook", () => {
     }
   });
 
-  test("append hook fires post-commit; a throwing hook never breaks appends", async () => {
+  test("append hook fires post-commit; a rejected hook never breaks appends", async () => {
     const sid = "bks-hook";
     const seen: [string, number][] = [];
-    setAppendHook((sessionId, entries) => {
+    setAppendHook(async (sessionId, entries) => {
       seen.push([sessionId, entries.length]);
       throw new Error("hook boom");
     });
     try {
       const res = await store.appendTranscriptEvents(sid, [entry("hk1", "user msg", { type: "user" })]);
       expect(res!.inserted).toBe(1);
+      await Promise.resolve();
       expect(seen).toEqual([[sid, 1]]);
     } finally {
       setAppendHook(null);

--- a/packages/core/opensession-server/src/server/transcript-store.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-store.test.ts
@@ -53,9 +53,9 @@ const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 describe("append + read roundtrip", () => {
   const sid = "bks-roundtrip";
 
-  test("appends assign dense 1-based seqs and read back in order", () => {
+  test("appends assign dense 1-based seqs and read back in order", async () => {
     const entries = [1, 2, 3, 4, 5].map((i) => entry(`e${i}`, `msg ${i}`));
-    const res = store.appendTranscriptEvents(sid, entries);
+    const res = await store.appendTranscriptEvents(sid, entries);
     expect(res).toEqual({ firstSeq: 1, lastSeq: 5, inserted: 5, updated: 0 });
     expect(store.getLastSeq(sid)).toBe(5);
 
@@ -68,14 +68,14 @@ describe("append + read roundtrip", () => {
     expect(tail.lastSeq).toBe(5);
   });
 
-  test("readTail limit returns the LAST n entries", () => {
+  test("readTail limit returns the LAST n entries", async () => {
     const tail = store.readTail(sid, 3);
     expect(tail.entries.map((e) => e.seq)).toEqual([3, 4, 5]);
     expect(tail.firstSeq).toBe(3);
     expect(tail.lastSeq).toBe(5);
   });
 
-  test("empty session reads as empty page, lastSeq 0", () => {
+  test("empty session reads as empty page, lastSeq 0", async () => {
     const t = store.readTail("bks-nonexistent");
     expect(t.entries).toEqual([]);
     expect(t.firstSeq).toBe(0);
@@ -83,15 +83,15 @@ describe("append + read roundtrip", () => {
     expect(store.getLastSeq("bks-nonexistent")).toBe(0);
   });
 
-  test("entries without an id are skipped, not thrown", () => {
+  test("entries without an id are skipped, not thrown", async () => {
     const bad = { type: "system", content: "no id", timestamp: "" } as unknown as TranscriptEntry;
-    expect(store.appendTranscriptEvents("bks-badid", [bad])).toBeNull();
+    expect(await store.appendTranscriptEvents("bks-badid", [bad])).toBeNull();
     expect(store.getLastSeq("bks-badid")).toBe(0);
   });
 });
 
 describe("stored media sanitation", () => {
-  test("removes implicit attachments from old grep result rows on every read path", () => {
+  test("removes implicit attachments from old grep result rows on every read path", async () => {
     const sid = "bks-grep-media";
     const result = entry(
       "grep-result",
@@ -101,7 +101,7 @@ describe("stored media sanitation", () => {
         videos: ["https://example.com/demo.mp4"],
       },
     );
-    store.appendTranscriptEvents(sid, [result]);
+    await store.appendTranscriptEvents(sid, [result]);
 
     expect(store.readTail(sid).entries[0].videos).toBeUndefined();
     expect(store.readSince(sid, 0).entries[0].videos).toBeUndefined();
@@ -112,17 +112,17 @@ describe("stored media sanitation", () => {
 describe("uuid dedup + upsert", () => {
   const sid = "bks-dedup";
 
-  test("re-append of the same entry mints no new seq", () => {
-    store.appendTranscriptEvents(sid, [entry("a", "one"), entry("b", "two")]);
+  test("re-append of the same entry mints no new seq", async () => {
+    await store.appendTranscriptEvents(sid, [entry("a", "one"), entry("b", "two")]);
     expect(store.getLastSeq(sid)).toBe(2);
 
-    const res = store.appendTranscriptEvents(sid, [entry("a", "one")]);
+    const res = await store.appendTranscriptEvents(sid, [entry("a", "one")]);
     expect(res).toEqual({ firstSeq: 1, lastSeq: 1, inserted: 0, updated: 1 });
     expect(store.getLastSeq(sid)).toBe(2);
   });
 
-  test("upsert updates data in place and keeps the original seq", () => {
-    const res = store.appendTranscriptEvents(sid, [
+  test("upsert updates data in place and keeps the original seq", async () => {
+    const res = await store.appendTranscriptEvents(sid, [
       entry("a", "one REWRITTEN by stream"),
     ]);
     expect(res!.updated).toBe(1);
@@ -134,8 +134,8 @@ describe("uuid dedup + upsert", () => {
     expect(tail.entries[1].content).toBe("two");
   });
 
-  test("mixed batch: upsert keeps seq, new row gets next seq", () => {
-    const res = store.appendTranscriptEvents(sid, [
+  test("mixed batch: upsert keeps seq, new row gets next seq", async () => {
+    const res = await store.appendTranscriptEvents(sid, [
       entry("b", "two v2"),
       entry("c", "three"),
     ]);
@@ -153,14 +153,14 @@ describe("big-entry bounding", () => {
   const bigContent = "x".repeat(100_000);
   const dataUrl = "data:image/png;base64," + "A".repeat(80_000);
 
-  test("oversized entry is stripped in data, full in blob", () => {
+  test("oversized entry is stripped in data, full in blob", async () => {
     const big = entry("big-1", bigContent, {
       type: "tool_use",
       toolName: "Bash",
       toolInput: { command: "echo hi", giant: "y".repeat(50_000) },
       images: [dataUrl, "https://cdn.tella.tv/pic.png"],
     });
-    const res = store.appendTranscriptEvents(sid, [big]);
+    const res = await store.appendTranscriptEvents(sid, [big]);
     expect(res!.inserted).toBe(1);
 
     // Raw row is hard-bounded and carries a full_ref.
@@ -201,8 +201,8 @@ describe("big-entry bounding", () => {
     expect(full.contentClamped).toBeUndefined();
   });
 
-  test("small entry: no blob, getFullEntry serves from the row", () => {
-    store.appendTranscriptEvents(sid, [entry("small-1", "tiny")]);
+  test("small entry: no blob, getFullEntry serves from the row", async () => {
+    await store.appendTranscriptEvents(sid, [entry("small-1", "tiny")]);
     const raw = new Database(dbPath, { readonly: true });
     try {
       const row = raw
@@ -218,8 +218,8 @@ describe("big-entry bounding", () => {
     expect(store.getFullEntry(sid, "does-not-exist")).toBeNull();
   });
 
-  test("upsert that shrinks below the bound drops the stale blob", () => {
-    store.appendTranscriptEvents(sid, [entry("big-1", "now small", { type: "tool_use", toolName: "Bash" })]);
+  test("upsert that shrinks below the bound drops the stale blob", async () => {
+    await store.appendTranscriptEvents(sid, [entry("big-1", "now small", { type: "tool_use", toolName: "Bash" })]);
     const raw = new Database(dbPath, { readonly: true });
     try {
       const blob = raw
@@ -241,8 +241,8 @@ describe("big-entry bounding", () => {
 describe("paging: readSince / readBefore", () => {
   const sid = "bks-paging";
 
-  test("setup + readSince returns strictly-after entries ascending", () => {
-    store.appendTranscriptEvents(
+  test("setup + readSince returns strictly-after entries ascending", async () => {
+    await store.appendTranscriptEvents(
       sid,
       [1, 2, 3, 4, 5, 6].map((i) => entry(`p${i}`, `p ${i}`))
     );
@@ -253,7 +253,7 @@ describe("paging: readSince / readBefore", () => {
     expect(store.readSince(sid, 6, 10).entries).toEqual([]);
   });
 
-  test("readBefore returns the LAST n entries below the cursor, ascending", () => {
+  test("readBefore returns the LAST n entries below the cursor, ascending", async () => {
     const before = store.readBefore(sid, 5, 2);
     expect(before.entries.map((e) => e.seq)).toEqual([3, 4]);
     expect(before.firstSeq).toBe(3);
@@ -266,9 +266,9 @@ describe("paging: readSince / readBefore", () => {
 });
 
 describe("message-aware tail windows", () => {
-  test("extends past the entry floor until it reaches conversation", () => {
+  test("extends past the entry floor until it reaches conversation", async () => {
     const sid = "bks-tail-window-messages";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("tw-u", "question", { type: "user" }),
       entry("tw-a", "answer"),
       ...Array.from({ length: 10 }, (_, i) =>
@@ -288,9 +288,9 @@ describe("message-aware tail windows", () => {
     expect(page.entries.at(-1)).toMatchObject({ id: "tw-tool-9", seq: 12 });
   });
 
-  test("assistant rows alone do not satisfy a required user boundary", () => {
+  test("assistant rows alone do not satisfy a required user boundary", async () => {
     const sid = "bks-tail-window-user";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("tu-u", "question", { type: "user" }),
       entry("tu-a0", "starting"),
       entry("tu-a1", "still working"),
@@ -311,9 +311,9 @@ describe("message-aware tail windows", () => {
     expect(page.entries[0]).toMatchObject({ id: "tu-u", type: "user" });
   });
 
-  test("the estimated byte ceiling bounds extension past the entry floor", () => {
+  test("the estimated byte ceiling bounds extension past the entry floor", async () => {
     const sid = "bks-tail-window-bytes";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("tb-u", "old question", { type: "user" }),
       entry("tb-a", "old answer"),
       ...Array.from({ length: 8 }, (_, i) =>
@@ -338,9 +338,9 @@ describe("message-aware tail windows", () => {
     ]);
   });
 
-  test("the row ceiling bounds a message-poor tail", () => {
+  test("the row ceiling bounds a message-poor tail", async () => {
     const sid = "bks-tail-window-rows";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("tr-u", "old question", { type: "user" }),
       ...Array.from({ length: 10 }, (_, i) =>
         entry(`tr-tool-${i}`, `step ${i}`, { type: "tool_use" })
@@ -360,9 +360,9 @@ describe("message-aware tail windows", () => {
     expect(page.lastSeq).toBe(11);
   });
 
-  test("measures stored rows in UTF-8 bytes", () => {
+  test("measures stored rows in UTF-8 bytes", async () => {
     const sid = "bks-tail-window-utf8";
-    store.appendTranscriptEvents(sid, [entry("utf8", "😀".repeat(20))]);
+    await store.appendTranscriptEvents(sid, [entry("utf8", "😀".repeat(20))]);
     let measured = 0;
 
     store.readTailWindow(sid, {
@@ -392,10 +392,10 @@ describe("message-aware tail windows", () => {
 });
 
 describe("import-first gate + legacy import", () => {
-  test("import then live-append: history seqs precede live seqs", () => {
+  test("import then live-append: history seqs precede live seqs", async () => {
     const sid = "bks-import-order";
     const history = [1, 2, 3].map((i) => entry(`h${i}`, `hist ${i}`));
-    const res = store.importLegacyTranscript(sid, history, "mirror", 4096);
+    const res = await store.importLegacyTranscript(sid, history, "mirror", 4096);
     expect(res).toEqual({ inserted: 3, updated: 0 });
     expect(store.hasImported(sid)).toBe(true);
     expect(store.needsImport(sid)).toBe(false);
@@ -405,7 +405,7 @@ describe("import-first gate + legacy import", () => {
       watermark: 4096,
     });
 
-    store.appendTranscriptEvents(sid, [entry("live1", "live 1")]);
+    await store.appendTranscriptEvents(sid, [entry("live1", "live 1")]);
     expect(store.readTail(sid).entries.map((e) => [e.seq, e.id])).toEqual([
       [1, "h1"],
       [2, "h2"],
@@ -414,9 +414,9 @@ describe("import-first gate + legacy import", () => {
     ]);
   });
 
-  test("re-import is idempotent (uuid upserts, seqs kept)", () => {
+  test("re-import is idempotent (uuid upserts, seqs kept)", async () => {
     const sid = "bks-import-order";
-    const res = store.importLegacyTranscript(
+    const res = await store.importLegacyTranscript(
       sid,
       [entry("h2", "hist 2 edited"), entry("h5", "hist 5 new")],
       "merged",
@@ -430,22 +430,22 @@ describe("import-first gate + legacy import", () => {
     expect(store.getImportInfo(sid)!.watermark).toBe(8192);
   });
 
-  test("chunked import handles > 500 rows in one call", () => {
+  test("chunked import handles > 500 rows in one call", async () => {
     const sid = "bks-import-chunks";
     const many = Array.from({ length: 1203 }, (_, i) => entry(`m${i}`, `m ${i}`));
-    const res = store.importLegacyTranscript(sid, many, "mirror", null);
+    const res = await store.importLegacyTranscript(sid, many, "mirror", null);
     expect(res.inserted).toBe(1203);
     expect(store.getLastSeq(sid)).toBe(1203);
   });
 
-  test("appendTranscriptEvents runs ensureImported before assigning live seqs", () => {
+  test("appendTranscriptEvents runs ensureImported before assigning live seqs", async () => {
     const sid = "bks-gate";
     let calls = 0;
     const ensureImported = (s: string) => {
       calls++;
-      store.importLegacyTranscript(s, [entry("g1", "old 1"), entry("g2", "old 2")], "mirror", 100);
+      (store as any).importLegacyTranscriptOwned(s, [entry("g1", "old 1"), entry("g2", "old 2")], "mirror", 100);
     };
-    store.appendTranscriptEvents(sid, [entry("g-live", "live")], { ensureImported });
+    await store.appendTranscriptEvents(sid, [entry("g-live", "live")], { ensureImported });
     expect(calls).toBe(1);
     expect(store.readTail(sid).entries.map((e) => [e.seq, e.id])).toEqual([
       [1, "g1"],
@@ -453,26 +453,26 @@ describe("import-first gate + legacy import", () => {
       [3, "g-live"],
     ]);
     // Gate is one-time: hook is not called again.
-    store.appendTranscriptEvents(sid, [entry("g-live2", "live 2")], { ensureImported });
+    await store.appendTranscriptEvents(sid, [entry("g-live2", "live 2")], { ensureImported });
     expect(calls).toBe(1);
   });
 
-  test("fresh session with no hook gets marked live-only", () => {
+  test("fresh session with no hook gets marked live-only", async () => {
     const sid = "bks-liveonly";
-    store.appendTranscriptEvents(sid, [entry("l1", "hello")]);
+    await store.appendTranscriptEvents(sid, [entry("l1", "hello")]);
     expect(store.hasImported(sid)).toBe(true);
     expect(store.getImportInfo(sid)!.src).toBe("live-only");
   });
 
-  test("a throwing ensureImported aborts the append (import-first invariant)", () => {
+  test("a throwing ensureImported aborts the append (import-first invariant)", async () => {
     const sid = "bks-gate-throw";
-    expect(() =>
+    await expect(
       store.appendTranscriptEvents(sid, [entry("t1", "live")], {
         ensureImported: () => {
           throw new Error("legacy parse exploded");
         },
-      })
-    ).toThrow("legacy parse exploded");
+      }),
+    ).rejects.toThrow("legacy parse exploded");
     expect(store.getLastSeq(sid)).toBe(0);
     expect(store.needsImport(sid)).toBe(true);
   });
@@ -489,13 +489,12 @@ describe("bus + append hook", () => {
     });
     const unsub2 = subscribeTranscript(sid, (ev) => got.push(ev));
     try {
-      const res = store.appendTranscriptEvents(sid, [
+      const res = await store.appendTranscriptEvents(sid, [
         entry("bus1", "hello"),
         entry("bus2", "world"),
       ]);
       expect(res!.lastSeq).toBe(2);
-      expect(got).toEqual([]); // fan-out is async (microtask), never in-tx
-      await tick();
+      // The async projection boundary yields after post-commit fan-out.
       expect(got.length).toBe(1);
       expect(got[0].firstSeq).toBe(1);
       expect(got[0].lastSeq).toBe(2);
@@ -515,7 +514,7 @@ describe("bus + append hook", () => {
     const got: TranscriptBusEvent[] = [];
     const unsub = subscribeTranscript(sid, (ev) => got.push(ev));
     try {
-      store.appendTranscriptEvents(sid, [entry("bus1", "hello v2")]);
+      await store.appendTranscriptEvents(sid, [entry("bus1", "hello v2")]);
       await tick();
       expect(got.length).toBe(1);
       expect(got[0].firstSeq).toBe(1);
@@ -526,7 +525,7 @@ describe("bus + append hook", () => {
     }
   });
 
-  test("append hook fires post-commit; a throwing hook never breaks appends", () => {
+  test("append hook fires post-commit; a throwing hook never breaks appends", async () => {
     const sid = "bks-hook";
     const seen: [string, number][] = [];
     setAppendHook((sessionId, entries) => {
@@ -534,7 +533,7 @@ describe("bus + append hook", () => {
       throw new Error("hook boom");
     });
     try {
-      const res = store.appendTranscriptEvents(sid, [entry("hk1", "user msg", { type: "user" })]);
+      const res = await store.appendTranscriptEvents(sid, [entry("hk1", "user msg", { type: "user" })]);
       expect(res!.inserted).toBe(1);
       expect(seen).toEqual([[sid, 1]]);
     } finally {
@@ -544,15 +543,15 @@ describe("bus + append hook", () => {
 });
 
 describe("deleteSessionTranscript", () => {
-  test("removes events, blobs and session row; import gate re-arms", () => {
+  test("removes events, blobs and session row; import gate re-arms", async () => {
     const sid = "bks-delete";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("d1", "x".repeat(100_000)), // forces a blob
       entry("d2", "small"),
     ]);
     expect(store.getLastSeq(sid)).toBe(2);
 
-    store.deleteSessionTranscript(sid);
+    await store.deleteSessionTranscript(sid);
     expect(store.getLastSeq(sid)).toBe(0);
     expect(store.readTail(sid).entries).toEqual([]);
     expect(store.getFullEntry(sid, "d1")).toBeNull();
@@ -571,15 +570,15 @@ describe("deleteSessionTranscript", () => {
     }
 
     // A later append starts a fresh dense sequence.
-    store.appendTranscriptEvents(sid, [entry("d3", "fresh start")]);
+    await store.appendTranscriptEvents(sid, [entry("d3", "fresh start")]);
     expect(store.readTail(sid).entries.map((e) => e.seq)).toEqual([1]);
   });
 });
 
 describe("transcript outline and random-access ranges", () => {
-  test("indexes display roles without shipping content", () => {
+  test("indexes display roles without shipping content", async () => {
     const sid = "bks-outline";
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("context", "private context", {
         type: "system",
         contextInjection: { source: "repos" },
@@ -622,20 +621,20 @@ describe("transcript outline and random-access ranges", () => {
     expect(outline.lastSeq).toBe(6);
   });
 
-  test("updates an old outline row in place when its role changes", () => {
+  test("updates an old outline row in place when its role changes", async () => {
     const sid = "bks-outline-upsert";
-    store.appendTranscriptEvents(sid, [entry("same", "draft")]);
+    await store.appendTranscriptEvents(sid, [entry("same", "draft")]);
     const before = store.readTranscriptIndex(sid).entries[0];
-    store.appendTranscriptEvents(sid, [entry("same", "now a person", { type: "user" })]);
+    await store.appendTranscriptEvents(sid, [entry("same", "now a person", { type: "user" })]);
     const after = store.readTranscriptIndex(sid).entries[0];
     expect(after.seq).toBe(before.seq);
     expect(after.changeSeq).toBeGreaterThan(before.changeSeq);
     expect(after.role).toBe("user");
   });
 
-  test("hydrates an inclusive span in bounded chunks", () => {
+  test("hydrates an inclusive span in bounded chunks", async () => {
     const sid = "bks-range";
-    store.appendTranscriptEvents(
+    await store.appendTranscriptEvents(
       sid,
       Array.from({ length: 5 }, (_, index) => entry(`range-${index + 1}`, `row ${index + 1}`)),
     );
@@ -649,9 +648,9 @@ describe("transcript outline and random-access ranges", () => {
     expect(second.complete).toBe(true);
   });
 
-  test("paginates a range larger than the wire cap", () => {
+  test("paginates a range larger than the wire cap", async () => {
     const sid = "bks-range-large";
-    store.appendTranscriptEvents(
+    await store.appendTranscriptEvents(
       sid,
       Array.from({ length: 501 }, (_, index) =>
         entry(`large-range-${index + 1}`, `row ${index + 1}`),
@@ -668,7 +667,7 @@ describe("transcript outline and random-access ranges", () => {
 
   test("backfills existing canonical rows in bounded async batches", async () => {
     const sid = "bks-outline-backfill";
-    store.appendTranscriptEvents(
+    await store.appendTranscriptEvents(
       sid,
       Array.from({ length: 250 }, (_, index) =>
         entry(`backfill-${index}`, "hello", { type: "user" }),
@@ -695,7 +694,7 @@ describe("transcript outline and random-access ranges", () => {
     const sid = "bks-outline-full-blob";
     const content =
       "[GitHub] <!--os:review-handoff-->\nReview PR #42\n" + "x".repeat(100_000);
-    store.appendTranscriptEvents(sid, [
+    await store.appendTranscriptEvents(sid, [
       entry("large-handoff", content, { type: "user" }),
     ]);
     const written = store.readTranscriptIndex(sid).entries[0];

--- a/packages/core/opensession-server/src/server/transcript-store.ts
+++ b/packages/core/opensession-server/src/server/transcript-store.ts
@@ -256,7 +256,7 @@ export interface TailWindowOpts {
 export type TranscriptAppendHook = (
   sessionId: string,
   entries: SeqEntry[]
-) => void;
+) => void | Promise<void>;
 
 const g = globalThis as unknown as {
   __osTranscriptStore?: TranscriptStore;
@@ -676,9 +676,11 @@ export class TranscriptStore {
     const hook = g.__osTranscriptAppendHook;
     if (hook) {
       try {
-        hook(sessionId, outcome.affected);
-      } catch (e) {
-        console.warn("[transcript-store] append hook threw:", e);
+        void Promise.resolve(hook(sessionId, outcome.affected)).catch((error) => {
+          console.warn("[transcript-store] append hook threw:", error);
+        });
+      } catch (error) {
+        console.warn("[transcript-store] append hook threw:", error);
       }
     }
     return result;
@@ -930,7 +932,14 @@ export class TranscriptStore {
     const hook = g.__osTranscriptAppendHook;
     if (hook) {
       try {
-        hook(request.sessionId, outcome.affected);
+        void Promise.resolve(hook(request.sessionId, outcome.affected)).catch(
+          (error) => {
+            console.warn(
+              "[transcript-store] destination append hook threw:",
+              error,
+            );
+          },
+        );
       } catch (error) {
         console.warn(
           "[transcript-store] destination append hook threw:",

--- a/packages/core/opensession-server/src/server/transcript-store.ts
+++ b/packages/core/opensession-server/src/server/transcript-store.ts
@@ -609,11 +609,11 @@ export class TranscriptStore {
    * publishes the affected entries on the bus and invokes the append hook —
    * neither can throw into this path.
    */
-  appendTranscriptEvents(
+  async appendTranscriptEvents(
     sessionId: string,
     entries: TranscriptEntry[],
     opts?: AppendOpts
-  ): AppendResult | null {
+  ): Promise<AppendResult | null> {
     return executeSessionProjection(sessionId, "transcript_append", () =>
       this.appendTranscriptEventsOwned(sessionId, entries, opts)
     );
@@ -940,12 +940,12 @@ export class TranscriptStore {
    * drift detection). Idempotent: re-import upserts by uuid and keeps seqs.
    * Publishes one post-import wake so an already-active watcher reconciles.
    */
-  importLegacyTranscript(
+  async importLegacyTranscript(
     sessionId: string,
     entries: TranscriptEntry[],
     src: TranscriptImportSrc | string,
     watermark: number | null
-  ): { inserted: number; updated: number } {
+  ): Promise<{ inserted: number; updated: number }> {
     return executeSessionProjection(sessionId, "transcript_import", () =>
       this.importLegacyTranscriptOwned(sessionId, entries, src, watermark)
     );
@@ -981,10 +981,10 @@ export class TranscriptStore {
 
   /** Replace a file-backed transcript authoritatively while preserving the
    * monotonic change cursor. Used for truncation/atomic replacement only. */
-  replaceTranscriptEvents(
+  async replaceTranscriptEvents(
     sessionId: string,
     entries: TranscriptEntry[]
-  ): { inserted: number; updated: number } {
+  ): Promise<{ inserted: number; updated: number }> {
     return executeSessionProjection(sessionId, "transcript_replace", () =>
       this.replaceTranscriptEventsOwned(sessionId, entries)
     );
@@ -1304,8 +1304,8 @@ export class TranscriptStore {
   // ── Delete / maintenance ──────────────────────────────────────────────────
 
   /** Remove every trace of a session (events + blobs + session row). */
-  deleteSessionTranscript(sessionId: string): void {
-    executeSessionProjection(sessionId, "transcript_delete", () => {
+  async deleteSessionTranscript(sessionId: string): Promise<void> {
+    await executeSessionProjection(sessionId, "transcript_delete", () => {
       this.txDelete.immediate(sessionId);
       this.importedCache.delete(sessionId);
     });

--- a/packages/core/opensession-server/src/server/transcript-store.ts
+++ b/packages/core/opensession-server/src/server/transcript-store.ts
@@ -295,7 +295,7 @@ export function transcriptStore(): TranscriptStore {
     isTestRunner() && !sessionsDirRedirected()
       ? scratchTranscriptDbPath()
       : transcriptDbPath();
-  return (g.__osTranscriptStore = new TranscriptStore(path));
+  return (g.__osTranscriptStore = new TranscriptStore(path, { actorOwned: true }));
 }
 
 function isTestRunner(): boolean {
@@ -406,7 +406,10 @@ export class TranscriptStore {
     immediate: (request: ValidatedDestinationAppend) => DestinationWriteOutcome;
   };
 
-  constructor(public readonly dbPath: string) {
+  constructor(
+    public readonly dbPath: string,
+    private readonly options: { actorOwned?: boolean } = {},
+  ) {
     if (dbPath !== ":memory:") {
       const dir = dirname(dbPath);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
@@ -609,11 +612,18 @@ export class TranscriptStore {
    * publishes the affected entries on the bus and invokes the append hook —
    * neither can throw into this path.
    */
-  async appendTranscriptEvents(
+  appendTranscriptEvents(
     sessionId: string,
     entries: TranscriptEntry[],
     opts?: AppendOpts
   ): Promise<AppendResult | null> {
+    if (!this.options.actorOwned) {
+      try {
+        return Promise.resolve(this.appendTranscriptEventsOwned(sessionId, entries, opts));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     return executeSessionProjection(sessionId, "transcript_append", () =>
       this.appendTranscriptEventsOwned(sessionId, entries, opts)
     );
@@ -680,12 +690,12 @@ export class TranscriptStore {
    * after a gateway crash the actor re-admits the operation and this store
    * returns the already-committed destination result without another write.
    */
-  appendTranscriptDestination(
+  async appendTranscriptDestination(
     input: DestinationTranscriptAppendRequest,
-  ): DestinationTranscriptAppendResult {
+  ): Promise<DestinationTranscriptAppendResult> {
     const request = validateDestinationAppend(input, false);
     try {
-      return executeDestinationIdempotentSessionProjection(
+      return await executeDestinationIdempotentSessionProjection(
         request.sessionId,
         `transcript-destination:${request.appendId}`,
         "transcript_destination_append",
@@ -940,12 +950,21 @@ export class TranscriptStore {
    * drift detection). Idempotent: re-import upserts by uuid and keeps seqs.
    * Publishes one post-import wake so an already-active watcher reconciles.
    */
-  async importLegacyTranscript(
+  importLegacyTranscript(
     sessionId: string,
     entries: TranscriptEntry[],
     src: TranscriptImportSrc | string,
     watermark: number | null
   ): Promise<{ inserted: number; updated: number }> {
+    if (!this.options.actorOwned) {
+      try {
+        return Promise.resolve(
+          this.importLegacyTranscriptOwned(sessionId, entries, src, watermark),
+        );
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     return executeSessionProjection(sessionId, "transcript_import", () =>
       this.importLegacyTranscriptOwned(sessionId, entries, src, watermark)
     );
@@ -981,10 +1000,17 @@ export class TranscriptStore {
 
   /** Replace a file-backed transcript authoritatively while preserving the
    * monotonic change cursor. Used for truncation/atomic replacement only. */
-  async replaceTranscriptEvents(
+  replaceTranscriptEvents(
     sessionId: string,
     entries: TranscriptEntry[]
   ): Promise<{ inserted: number; updated: number }> {
+    if (!this.options.actorOwned) {
+      try {
+        return Promise.resolve(this.replaceTranscriptEventsOwned(sessionId, entries));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     return executeSessionProjection(sessionId, "transcript_replace", () =>
       this.replaceTranscriptEventsOwned(sessionId, entries)
     );
@@ -1304,11 +1330,20 @@ export class TranscriptStore {
   // ── Delete / maintenance ──────────────────────────────────────────────────
 
   /** Remove every trace of a session (events + blobs + session row). */
-  async deleteSessionTranscript(sessionId: string): Promise<void> {
-    await executeSessionProjection(sessionId, "transcript_delete", () => {
+  deleteSessionTranscript(sessionId: string): Promise<void> {
+    const remove = () => {
       this.txDelete.immediate(sessionId);
       this.importedCache.delete(sessionId);
-    });
+    };
+    if (!this.options.actorOwned) {
+      try {
+        remove();
+        return Promise.resolve();
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+    return executeSessionProjection(sessionId, "transcript_delete", remove);
   }
 
   /**

--- a/packages/core/opensession-server/src/server/workflow-execute.ts
+++ b/packages/core/opensession-server/src/server/workflow-execute.ts
@@ -132,7 +132,7 @@ export async function runAgentCollect(
 			if (next === "aborted") {
 				if (engineSessionId) {
 					try {
-						cancelAgentRun(engineSessionId);
+						await cancelAgentRun(engineSessionId);
 					} catch {}
 				}
 				void it.return?.(undefined)?.catch?.(() => {});

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -93,15 +93,12 @@ function lastRestartBy(): string {
  * one AND the sinceOffset resume (these are cheap and idempotent; the client
  * replaces rather than merges them).
  */
-function sendWatchExtras(
+async function sendWatchExtras(
 	ws: any,
 	sessionId: string,
 	session: NonNullable<Awaited<ReturnType<typeof findSessionAsync>>>,
-): void {
-	const pendingAsk = sessionProjectionOr(
-		() => pendingAskAwaitingAnswer(sessionId),
-		undefined,
-	);
+): Promise<void> {
+	const pendingAsk = pendingAskAwaitingAnswer(sessionId);
 	if (pendingAsk) {
 		ws.send(
 			JSON.stringify({
@@ -117,10 +114,7 @@ function sendWatchExtras(
 
 	// Older in-memory rows may lack ids; assign and persist them before
 	// sending so edit/delete/steer actions can address the same row.
-	const queueState = sessionProjectionOr(
-		() => queueDisplayState(sessionId),
-		undefined,
-	);
+	const queueState = await queueDisplayState(sessionId);
 	if (queueState) {
 		const { queued: queuedPrompts, steered: steeredPrompts } = queueState;
 		if (queuedPrompts.length > 0 || steeredPrompts.length > 0) persistQueues();
@@ -133,7 +127,6 @@ function sendWatchExtras(
 			}),
 		);
 	}
-
 	ws.send(
 		JSON.stringify({
 			type: "session_status",
@@ -597,12 +590,12 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
         : undefined;
       const persistedCancel =
         msg.type === "cancel"
-          ? sessionTurn({ op: "snapshot", sessionId: commandSessionId }).cancel
+          ? (await sessionTurn({ op: "snapshot", sessionId: commandSessionId })).cancel
           : undefined;
       const persistedInterrupt =
         msg.type === "interrupt_prompt"
           ? deliveryInterruptForAnchor(
-              sessionDelivery({
+              await sessionDelivery({
                 op: "snapshot",
                 sessionId: commandSessionId,
               }),
@@ -649,7 +642,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
       let gatewayCommandExecuting = false;
       let gatewayPhysicalFinished = false;
 				try {
-          const plan = sessionGatewayCommand({
+          const plan = await sessionGatewayCommand({
             op: "request",
             sessionId: commandSessionId,
             requestId,
@@ -716,7 +709,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					if (dispatchError) throw dispatchError;
 					const result = kernelDispatchResults.get(kernelToken);
             gatewayPhysicalFinished = true;
-            sessionGatewayCommand({
+            await sessionGatewayCommand({
               op: "complete",
               sessionId: commandSessionId,
               requestId,
@@ -747,7 +740,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 						error instanceof Error ? error.message : String(error);
 					const retryable = isRetryableSessionCommandError(error);
           if (gatewayCommandExecuting && !gatewayPhysicalFinished)
-            sessionGatewayCommand({
+            await sessionGatewayCommand({
               op: "fail",
               sessionId: commandSessionId,
               requestId,
@@ -886,7 +879,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					);
 				}
 				if (v2Served) {
-					sendWatchExtras(ws, sessionId, session);
+					await sendWatchExtras(ws, sessionId, session);
 					break;
 				}
 
@@ -914,7 +907,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					sinceOffset <= statSync(session.transcriptPath).size
 				) {
 					startWatching(session.transcriptPath, ws, sinceOffset, sessionId);
-					sendWatchExtras(ws, sessionId, session);
+					await sendWatchExtras(ws, sessionId, session);
 					break;
 				}
 
@@ -966,7 +959,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					startWatching(session.transcriptPath, ws, endOffset, sessionId);
 				}
 
-				sendWatchExtras(ws, sessionId, session);
+				await sendWatchExtras(ws, sessionId, session);
 				break;
 			}
 
@@ -1323,7 +1316,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 						!hasFiles &&
 						!hasContext &&
 						steerItem.id &&
-						prepareQueuedSteer(sessionId, steerItem.id, steerItem)
+						await prepareQueuedSteer(sessionId, steerItem.id, steerItem)
 					) {
 						if (
 							steerAgentRun(
@@ -1333,10 +1326,10 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 								steerItem.id,
 							)
 						) {
-							if (!acceptQueuedSteer(sessionId, steerItem.id))
+							if (!await acceptQueuedSteer(sessionId, steerItem.id))
 								throw new Error("Pending steer changed before runner acceptance");
 						} else {
-							rejectQueuedSteer(sessionId, steerItem.id);
+							await rejectQueuedSteer(sessionId, steerItem.id);
 							watchExternalRunAndDrain(sessionId);
 						}
 						break;
@@ -1423,13 +1416,13 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 
 			case "delete_queued_prompt": {
 				const { sessionId, queueId, queueIndex } = msg;
-				deleteQueuedPrompt(sessionId, queueId, queueIndex);
+				await deleteQueuedPrompt(sessionId, queueId, queueIndex);
 				break;
 			}
 
 			case "take_queued_prompt": {
 				const { sessionId, queueId } = msg;
-				const item = takeQueuedPrompt(
+				const item = await takeQueuedPrompt(
 					sessionId,
 					queueId,
 					ws.data.authUser || ws.data.user || undefined,
@@ -1459,7 +1452,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					queueId,
 				);
 				const item = retracted
-					? takeSteeredPrompt(sessionId, queueId, actor) ?? receipt
+					? await takeSteeredPrompt(sessionId, queueId, actor) ?? receipt
 					: undefined;
 				const response = {
 					type: "queued_prompt_taken",
@@ -1480,7 +1473,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				const images = Array.isArray(msg.images)
 					? (asDataUrlList(msg.images) ?? [])
 					: undefined;
-				updateQueuedPrompt(
+				await updateQueuedPrompt(
 					sessionId,
 					queueId,
 					queueIndex,
@@ -1523,7 +1516,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 			case "reorder_queued_prompt": {
 				const { sessionId, order } = msg;
 				if (Array.isArray(order) && order.every((x) => typeof x === "string")) {
-					reorderQueuedPrompt(sessionId, order);
+					await reorderQueuedPrompt(sessionId, order);
 				}
 				break;
 			}
@@ -1545,7 +1538,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
             expectedRunId &&
             expectedGeneration !== undefined
           ) {
-            ({ requeued } = requestTurnCancel(sessionId, session, {
+            ({ requeued } = await requestTurnCancel(sessionId, session, {
               cancelId: `stop:${msg.requestId}`,
               expectedRunId,
               expectedGeneration,

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -98,7 +98,7 @@ async function sendWatchExtras(
 	sessionId: string,
 	session: NonNullable<Awaited<ReturnType<typeof findSessionAsync>>>,
 ): Promise<void> {
-	const pendingAsk = pendingAskAwaitingAnswer(sessionId);
+	const pendingAsk = await pendingAskAwaitingAnswer(sessionId);
 	if (pendingAsk) {
 		ws.send(
 			JSON.stringify({
@@ -1271,7 +1271,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				// An explicit send is the user's next action after a Stop, so it lifts the
 				// stop latch here rather than inside the run the latch prevents. Without
 				// this the message below queues durably and the drain parks it forever.
-				liftUserStop(sessionId);
+				await liftUserStop(sessionId);
 
 				// Busy sends queue by default, so the user can still delete/edit or
 				// manually steer the message. Settings can opt the composer into
@@ -1285,7 +1285,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 					)
 				) {
 					if (msg.busyMode === "queue") {
-						enqueuePrompt(sessionId, {
+						await enqueuePrompt(sessionId, {
 							id: msg.requestId,
 							content,
 							user,
@@ -1334,7 +1334,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 						}
 						break;
 					}
-					enqueuePrompt(sessionId, {
+					await enqueuePrompt(sessionId, {
 						id: msg.requestId,
 						content,
 						user,
@@ -1350,7 +1350,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				// a per-session single-flight lock, so the first queued message owns
 				// the wake and later messages remain FIFO behind it.
 				if (session.sandbox?.sandboxId && session.sandbox.provider !== "local") {
-					enqueuePrompt(sessionId, {
+					await enqueuePrompt(sessionId, {
 						id: msg.requestId,
 						content, user, images: imageUrls, files: msg.files, contextSessions,
 					});
@@ -1363,7 +1363,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				// Every accepted prompt enters the durable queue first. drainQueue moves
 				// it into a dispatch record that survives a restart until the engine has
 				// written its own active-run journal.
-				enqueuePrompt(sessionId, {
+				await enqueuePrompt(sessionId, {
 					id: msg.requestId,
 					content,
 					user,
@@ -1389,8 +1389,8 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				unarchiveForHumanTurn(session);
 				maybePersistEffort(session, msg.effort);
 				maybePersistFastMode(session, msg.fastMode);
-				liftUserStop(sessionId);
-				enqueuePrompt(sessionId, {
+				await liftUserStop(sessionId);
+				await enqueuePrompt(sessionId, {
 					id: msg.requestId,
 					content,
 					user,
@@ -1404,7 +1404,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 						session.id,
 					)
 				) {
-					if (!abortTurnAndDrain(sessionId, session, undefined, msg.requestId))
+					if (!await abortTurnAndDrain(sessionId, session, undefined, msg.requestId))
 						watchExternalRunAndDrain(sessionId);
 				} else {
 					void drainQueue(sessionId).catch((error) =>
@@ -1485,7 +1485,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 
 			case "steer_queued_prompt": {
 				const { sessionId, queueId, queueIndex } = msg;
-				if (!steerQueuedPrompt(sessionId, queueId, queueIndex)) {
+				if (!await steerQueuedPrompt(sessionId, queueId, queueIndex)) {
 					ws.send(
 						JSON.stringify({
 							type: "notice",
@@ -1500,7 +1500,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 
 			case "interrupt_queued_prompt": {
 				const { sessionId, queueId, queueIndex } = msg;
-				if (!interruptQueuedPrompt(sessionId, queueId, queueIndex)) {
+				if (!await interruptQueuedPrompt(sessionId, queueId, queueIndex)) {
 					ws.send(
 						JSON.stringify({
 							type: "notice",
@@ -1578,9 +1578,9 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 
 			case "answer_question": {
 				const { sessionId, questionId, answers } = msg;
-				const pending = pendingAskAwaitingAnswer(sessionId);
+				const pending = await pendingAskAwaitingAnswer(sessionId);
 				if (pending && pending.questionId === questionId) {
-					pending.resolve(
+					await pending.resolve(
 						answers && typeof answers === "object" ? answers : null,
 					);
 				}

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -8,7 +8,7 @@
 import type { WebSocketHandler } from "bun";
 import type { WSClientData } from "./ws-hub";
 
-import { currentAgentRunToken, interruptAndSteerAgentRun, isAgentSessionBusy, retractAgentSteer, steerAgentRun } from "./agent-runner";
+import { currentAgentRunToken, interruptAndSteerAgentRun, isAgentSessionBusy, retractAgentSteer } from "./agent-runner";
 
 import { audit } from "./audit";
 import { pendingAskAwaitingAnswer } from "./asks";
@@ -19,7 +19,8 @@ import { INIT_WIRE_CLAMP_BYTES, entriesForWire, parseTranscriptAsync, parseTrans
 import { providerFor } from "./models";
 
 import { appendTranscriptEntries, clearTranscriptStoreDegraded, transcriptLineRunnerNotice } from "./transcript-persistence";
-import { deleteQueuedPrompt, editableSteerReceipt, liftUserStop, persistQueues, promptQueues, queueDisplayState, durableQueueItem, queueItem, acceptQueuedSteer, prepareQueuedSteer, rejectQueuedSteer, reorderQueuedPrompt, steeredReceipts, stoppedSessions, takeQueuedPrompt, takeSteeredPrompt, updateQueuedPrompt } from "./queue-state";
+import { deleteQueuedPrompt, editableSteerReceipt, liftUserStop, persistQueues, promptQueues, queueDisplayState, durableQueueItem, queueItem, reorderQueuedPrompt, steeredReceipts, stoppedSessions, takeQueuedPrompt, takeSteeredPrompt, updateQueuedPrompt } from "./queue-state";
+import { prepareAndSteerQueuedPrompt } from "./queued-steer";
 
 import { abortTurnAndDrain, drainQueue, enqueuePrompt, interruptQueuedPrompt, requestTurnCancel, runSessionPrompt, runSessionPromptAndDrain, steerQueuedPrompt, watchExternalRunAndDrain, } from "./run-session";
 import { sandboxWsClose, sandboxWsMessage, sandboxWsOpen } from "./run-ws";
@@ -1315,24 +1316,19 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 						msg.busyMode === "steer" &&
 						!hasFiles &&
 						!hasContext &&
-						steerItem.id &&
-						await prepareQueuedSteer(sessionId, steerItem.id, steerItem)
+						steerItem.id
 					) {
-						if (
-							steerAgentRun(
-								[session.claudeSessionId, session.codexThreadId, session.id],
-								attributed,
-								images,
-								steerItem.id,
-							)
-						) {
-							if (!await acceptQueuedSteer(sessionId, steerItem.id))
-								throw new Error("Pending steer changed before runner acceptance");
-						} else {
-							await rejectQueuedSteer(sessionId, steerItem.id);
-							watchExternalRunAndDrain(sessionId);
+						const steerResult = await prepareAndSteerQueuedPrompt({
+							sessionId,
+							itemId: steerItem.id,
+							item: steerItem,
+							text: attributed,
+							images,
+						});
+						if (steerResult !== "not_prepared") {
+							if (steerResult === "rejected") watchExternalRunAndDrain(sessionId);
+							break;
 						}
-						break;
 					}
 					await enqueuePrompt(sessionId, {
 						id: msg.requestId,

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -247,16 +247,16 @@ async function sendTranscriptIndex(
  *  only transcriptPath would leave pi sessions permanently
  *  grown-beyond-watermark). Also the drift RE-import: idempotent upserts, and
  *  a completed import releases the failure-side store-degraded marker. */
-function v2ImportSession(
+async function v2ImportSession(
 	session: NonNullable<Awaited<ReturnType<typeof findSessionAsync>>>,
-): void {
+): Promise<void> {
 	// Deliberately id-less ref: guarantees the legacy merge — an id-carrying
 	// ref would route mergedSessionTranscript back into the v2 store path,
 	// which on a drift re-import is exactly what we're refreshing.
 	const entries = mergedSessionTranscript({
 		transcriptPath: session.transcriptPath ?? null,
 	});
-	v2FinishImport(session, entries);
+	await v2FinishImport(session, entries);
 }
 
 /** v2ImportSession for the background queue: the merge parse yields to the
@@ -269,19 +269,19 @@ async function v2ImportSessionAsync(
 	const entries = await mergedSessionTranscriptAsync({
 		transcriptPath: session.transcriptPath ?? null,
 	});
-	v2FinishImport(session, entries);
+	await v2FinishImport(session, entries);
 }
 
-function v2FinishImport(
+async function v2FinishImport(
 	session: NonNullable<Awaited<ReturnType<typeof findSessionAsync>>>,
 	entries: ReturnType<typeof mergedSessionTranscript>,
-): void {
+): Promise<void> {
 	let watermark: number | null = null;
 	try {
 		const files = v2MirrorFiles(session);
 		if (files.length) watermark = files.reduce((sum, f) => sum + f.size, 0);
 	} catch {}
-	transcriptStore().importLegacyTranscript(
+	await transcriptStore().importLegacyTranscript(
 		session.id,
 		entries,
 		entries.length ? "merged" : "live-only",
@@ -318,12 +318,12 @@ function v2QueueBackgroundImport(sessionId: string, reimport = false): void {
  * eligible / import deferred / flag off — fall through to the untouched
  * legacy path.
  */
-function serveTranscriptV2(
+async function serveTranscriptV2(
 	ws: any,
 	sessionId: string,
 	session: NonNullable<Awaited<ReturnType<typeof findSessionAsync>>>,
 	msg: any,
-): boolean {
+): Promise<boolean> {
 	if (msg.supportsSeq !== true) return false;
 	// Plain loop runs don't thread a unified session id to the runner (§3), so
 	// their store rows would be forever partial — refuse v2, keep legacy.
@@ -363,7 +363,7 @@ function serveTranscriptV2(
 				v2QueueBackgroundImport(sessionId);
 				return false;
 			}
-			v2ImportSession(session);
+			await v2ImportSession(session);
 		} else if (v2TranscriptHasDrift(store, sessionId, session)) {
 			// Imported but stale (§8): the mirror grew in a way the store can't
 			// explain — external CLI/tmux runs while we were idle, unmapped oc
@@ -871,7 +871,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
 				// client got no init and no error).
 				let v2Served = false;
 				try {
-					v2Served = serveTranscriptV2(ws, sessionId, session, msg);
+					v2Served = await serveTranscriptV2(ws, sessionId, session, msg);
 				} catch (e) {
 					console.error(
 						`[ws] transcript v2 serve threw for ${sessionId} — falling back to legacy watch:`,
@@ -1557,7 +1557,7 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
             // Projection remains idempotent by its stable request-derived id.
             if (session.claudeSessionId) {
               try {
-                appendTranscriptEntries(session.claudeSessionId, [
+                await appendTranscriptEntries(session.claudeSessionId, [
                   transcriptLineRunnerNotice(
                     `Stopped by ${data.user || "someone"}.`,
                     `stop-${msg.requestId}`,

--- a/packages/core/opensession-server/src/server/zz-fake-run.test.ts
+++ b/packages/core/opensession-server/src/server/zz-fake-run.test.ts
@@ -196,7 +196,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 	// that centralization only runSessionPromptInner wrote it, and a resumed
 	// run's death left the conversation ending mid-turn with no explanation
 	// (bks-019fb757, 2026-07-31).
-	test("failed opening run: the failure lands in the transcript before an engine session exists", () => {
+	test("failed opening run: the failure lands in the transcript before an engine session exists", async () => {
 		if (!redirected) return;
 		// The store is a globalThis singleton — if an earlier suite file opened
 		// it against the real sessions dir, skip rather than write to it.
@@ -207,7 +207,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		writeSessionFile(sid);
 		sessionCache.invalidateSessionsCache();
 
-		sessionCache.recordRunOutcome(sid, "boom: unrecoverable test failure");
+		await sessionCache.recordRunOutcome(sid, "boom: unrecoverable test failure");
 
 		const chip = store
 			.readTail(sid, 50)
@@ -215,7 +215,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		expect(chip?.content).toBe("Run failed: boom: unrecoverable test failure");
 	});
 
-	test("usage-limit stop is worded as a stop, and a runner-written notice wins", () => {
+	test("usage-limit stop is worded as a stop, and a runner-written notice wins", async () => {
 		if (!redirected) return;
 		const store = transcriptStoreMod.transcriptStore();
 		if (!store.dbPath.startsWith(tmp)) return;
@@ -226,13 +226,13 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		sessionCache.invalidateSessionsCache();
 		ocTranscript.recordEngineSessionOwner(engineId, sid);
 
-		sessionCache.recordRunOutcome(sid, "Usage limit reached on every account", {
+		await sessionCache.recordRunOutcome(sid, "Usage limit reached on every account", {
 			engineSessionId: engineId,
 			noticeLabel: "Run stopped",
 		});
 		// noticePersisted: the runner already wrote its own friendlier line, so
 		// this must not add a second one.
-		sessionCache.recordRunOutcome(sid, "timed out after 60m", {
+		await sessionCache.recordRunOutcome(sid, "timed out after 60m", {
 			engineSessionId: engineId,
 			noticePersisted: true,
 		});
@@ -246,7 +246,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		);
 	});
 
-	test("a recovered Pi run falls back to the Pi transcript for its failure chip", () => {
+	test("a recovered Pi run falls back to the Pi transcript for its failure chip", async () => {
 		if (!redirected) return;
 		const store = transcriptStoreMod.transcriptStore();
 		if (!store.dbPath.startsWith(tmp)) return;
@@ -263,7 +263,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 
 		// Boot recovery failures do not always carry a terminal event session id.
 		// recordRunOutcome must resolve the active engine slot from the session.
-		sessionCache.recordRunOutcome(
+		await sessionCache.recordRunOutcome(
 			sid,
 			"Restart recovery stopped unexpectedly. Send the prompt again to continue.",
 		);

--- a/packages/core/opensession-server/src/server/zz-fake-run.test.ts
+++ b/packages/core/opensession-server/src/server/zz-fake-run.test.ts
@@ -475,13 +475,13 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		// latch park the queue (ws-handlers "cancel"). This actor state is
 		// load-bearing: advancing it to `starting` during intake makes the drain
 		// mistake the new message for an already-owned run and park forever.
-		runState.transitionRunState(sid, "prompt", { run_key: "stopped-run" });
-		runState.transitionRunState(sid, "run_registered", {
+		await runState.transitionRunState(sid, "prompt", { run_key: "stopped-run" });
+		await runState.transitionRunState(sid, "run_registered", {
 			run_key: "stopped-run",
 		});
-		runState.transitionRunState(sid, "cancel", { run_key: "stopped-run" });
+		await runState.transitionRunState(sid, "cancel", { run_key: "stopped-run" });
 		queueState.stoppedSessions.add(sid);
-		runSession.enqueuePrompt(
+		await runSession.enqueuePrompt(
 			sid,
 			queueState.queueItem({ content: "parked", user: "Test" }),
 		);
@@ -492,8 +492,8 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 		// The next explicit send lifts it at intake, the way every human send
 		// path does. Without that lift the message below is queued forever:
 		// only runSessionPrompt clears the latch, and the drain is what calls it.
-		queueState.liftUserStop(sid);
-		runSession.enqueuePrompt(
+		await queueState.liftUserStop(sid);
+		await runSession.enqueuePrompt(
 			sid,
 			queueState.queueItem({ content: "second try", user: "Test" }),
 		);

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -39,21 +39,21 @@ afterEach(() => {
 });
 
 describe("run journal", () => {
-	it("keeps interrupted and reattaching sessions busy until recovery settles", () => {
+	it("keeps interrupted and reattaching sessions busy until recovery settles", async () => {
 		const sessionId = `recovery-${crypto.randomUUID()}`;
 		try {
-			transitionRunState(sessionId, "boot_journal_found", undefined, () => {});
+			await transitionRunState(sessionId, "boot_journal_found", undefined, () => {});
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
-			transitionRunState(sessionId, "reattach_start", undefined, () => {});
+			await transitionRunState(sessionId, "reattach_start", undefined, () => {});
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
-			transitionRunState(sessionId, "run_failed", undefined, () => {});
+			await transitionRunState(sessionId, "run_failed", undefined, () => {});
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(false);
 		} finally {
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("settles an exhausted recovery with a visible terminal error", () => {
+	it("settles an exhausted recovery with a visible terminal error", async () => {
 		const sessionId = `exhausted-${crypto.randomUUID()}`;
 		const runKey = `run-${crypto.randomUUID()}`;
 		const startedAt = new Date().toISOString();
@@ -69,12 +69,12 @@ describe("run journal", () => {
 		});
 		// Simulate the fresh process: journalSet marked the old process running,
 		// while restart recovery rebuilds state from the journal on boot.
-		clearRunState(sessionId);
+		await clearRunState(sessionId);
 		expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
 		let terminal: StreamEvent | undefined;
 		const errorLog = spyOn(console, "error").mockImplementation(() => {});
 		try {
-			const handled = agent.resumeInterruptedRuns((_id, event) => {
+			const handled = await agent.resumeInterruptedRuns((_id, event) => {
 				terminal = event;
 				throw new Error("observer failed");
 			});
@@ -88,11 +88,11 @@ describe("run journal", () => {
 			expect(mod.activeRunRecords()).toEqual([]);
 		} finally {
 			errorLog.mockRestore();
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("leaves a detached GitHub review journal for its posting workflow", () => {
+	it("leaves a detached GitHub review journal for its posting workflow", async () => {
 		const sessionId = `github-review-${crypto.randomUUID()}`;
 		const runKey = `rh-${crypto.randomUUID()}`;
 		try {
@@ -105,19 +105,19 @@ describe("run journal", () => {
 				kind: "github-review",
 				startedAt: new Date().toISOString(),
 			});
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 
-			expect(agent.resumeInterruptedRuns()).toContain(sessionId);
+			expect(await agent.resumeInterruptedRuns()).toContain(sessionId);
 			expect(
 				mod.activeRunRecords().some((run) => run.runKey === runKey),
 			).toBe(true);
 		} finally {
 			mod.journalClear(runKey);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("keeps an unclaimed journal owner fenced until recovery proves it absent", () => {
+	it("keeps an unclaimed journal owner fenced until recovery proves it absent", async () => {
 		const sessionId = `queued-recovery-${crypto.randomUUID()}`;
 		const runKey = `run-${crypto.randomUUID()}`;
 		try {
@@ -130,17 +130,17 @@ describe("run journal", () => {
 			});
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
 
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
 
       expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
       expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(true);
 		} finally {
       mod.journalClear(runKey);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-  it("preserves a stopped journal owned by a durable cancel effect", () => {
+  it("preserves a stopped journal owned by a durable cancel effect", async () => {
     const sessionId = `durable-stop-recovery-${crypto.randomUUID()}`;
     const runKey = `rh-${crypto.randomUUID()}`;
     const store = sessionKernelStore();
@@ -172,7 +172,7 @@ describe("run journal", () => {
       });
       // A boot after actor settlement still restores the exact cancellation
       // latch before the detached control reconnects.
-      expect(agent.reissueDurableRecoveryCancel(recovery)).toBe(false);
+      expect(await agent.reissueDurableRecoveryCancel(recovery)).toBe(false);
       expect(agent.isAgentSessionCancelled(sessionId, runKey)).toBe(true);
       mod.journalSet(recovery);
       mod.journalRecordAbnormalCompletion(recovery);
@@ -185,7 +185,7 @@ describe("run journal", () => {
     }
   });
 
-  it("retires abnormal ownership when actor settlement wins the reverse race", () => {
+  it("retires abnormal ownership when actor settlement wins the reverse race", async () => {
     const sessionId = `cancel-abnormal-reverse-${crypto.randomUUID()}`;
     const runKey = `rh-${crypto.randomUUID()}`;
     const store = sessionKernelStore();
@@ -230,7 +230,7 @@ describe("run journal", () => {
     }
   });
 
-  it("retires confirmed interrupt abnormal ownership in both race orders", () => {
+  it("retires confirmed interrupt abnormal ownership in both race orders", async () => {
     const store = sessionKernelStore();
     for (const sourceFirst of [true, false]) {
       const sessionId = `interrupt-abnormal-${sourceFirst}-${crypto.randomUUID()}`;
@@ -306,52 +306,52 @@ describe("run journal", () => {
 			model: "claude-fable-5",
 			startedAt: new Date().toISOString(),
 		});
-		clearRunState(sessionId);
+		await clearRunState(sessionId);
 
 		try {
-			agent.resumeInterruptedRuns();
+			await agent.resumeInterruptedRuns();
 			while (fake.calls.length === 0) await Bun.sleep(5);
 
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
 			expect(getRunState(sessionId)).toBe("stopped");
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
 
 			release();
 			while (agent.isAgentSessionBusy(sessionId)) await Bun.sleep(5);
 
-			agent.markSessionStarting(sessionId);
+			await agent.markSessionStarting(sessionId);
 			expect(getRunState(sessionId)).toBe("starting");
 			agent.unmarkSessionStarting(sessionId);
-			transitionRunState(sessionId, "start_aborted", undefined, () => {});
+			await transitionRunState(sessionId, "start_aborted", undefined, () => {});
 		} finally {
 			release();
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-  it("settles a pre-journal terminal against its reserved dispatch token", () => {
+  it("settles a pre-journal terminal against its reserved dispatch token", async () => {
     const sessionId = `pre-journal-terminal-${crypto.randomUUID()}`;
-    const token = agent.markSessionStarting(sessionId);
+    const token = await agent.markSessionStarting(sessionId);
     try {
       expect(sessionKernelStore().runState(sessionId)).toMatchObject({
         state: "starting",
         currentRunId: token,
       });
-      transitionRunState(sessionId, "run_failed", {
+      await transitionRunState(sessionId, "run_failed", {
         run_key: token,
         source: "pre_journal_failure",
       });
       expect(getRunState(sessionId)).toBe("failed");
     } finally {
       agent.unmarkSessionStarting(sessionId, token);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
-  it("keeps process and actor ownership on the first concurrent preparation", () => {
+  it("keeps process and actor ownership on the first concurrent preparation", async () => {
     const sessionId = `preparation-winner-${crypto.randomUUID()}`;
-    const firstToken = agent.markSessionStarting(sessionId);
-    const secondToken = agent.markSessionStarting(sessionId);
+    const firstToken = await agent.markSessionStarting(sessionId);
+    const secondToken = await agent.markSessionStarting(sessionId);
     const store = sessionKernelStore();
     try {
       expect(secondToken).not.toBe(firstToken);
@@ -380,11 +380,11 @@ describe("run journal", () => {
     }
   });
 
-  it("uses one stable physical token without admitting a concurrent duplicate", () => {
+  it("uses one stable physical token without admitting a concurrent duplicate", async () => {
     const sessionId = `stable-preparation-${crypto.randomUUID()}`;
     const stableToken = `rh-opening-${crypto.randomUUID()}`;
-    const admitted = agent.markSessionStarting(sessionId, stableToken);
-    const rejected = agent.markSessionStarting(sessionId, stableToken);
+    const admitted = await agent.markSessionStarting(sessionId, stableToken);
+    const rejected = await agent.markSessionStarting(sessionId, stableToken);
     try {
       expect(admitted).toBe(stableToken);
       expect(rejected).not.toBe(stableToken);
@@ -396,15 +396,15 @@ describe("run journal", () => {
     } finally {
       agent.unmarkSessionStarting(sessionId, rejected);
       agent.unmarkSessionStarting(sessionId, stableToken);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
-  it("does not let a stale gateway projection replace the actor's start owner", () => {
+  it("does not let a stale gateway projection replace the actor's start owner", async () => {
     const sessionId = `actor-preparation-winner-${crypto.randomUUID()}`;
-    const firstToken = agent.markSessionStarting(sessionId);
+    const firstToken = await agent.markSessionStarting(sessionId);
     agent.unmarkSessionStarting(sessionId, firstToken);
-    const rejectedToken = agent.markSessionStarting(sessionId);
+    const rejectedToken = await agent.markSessionStarting(sessionId);
     try {
       expect(agent.isAgentSessionCancelled(sessionId, rejectedToken)).toBe(true);
       expect(agent.currentAgentRunToken(sessionId)).toBeUndefined();
@@ -414,7 +414,7 @@ describe("run journal", () => {
       });
     } finally {
       agent.unmarkSessionStarting(sessionId, rejectedToken);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
@@ -422,8 +422,8 @@ describe("run journal", () => {
     const sessionId = `preparation-engine-winner-${crypto.randomUUID()}`;
     const fake = makeFakeEngine([{ kind: "clean" }]);
     agent.__setEngineForTest(fake.engine);
-    const firstToken = agent.markSessionStarting(sessionId);
-    const rejectedToken = agent.markSessionStarting(sessionId);
+    const firstToken = await agent.markSessionStarting(sessionId);
+    const rejectedToken = await agent.markSessionStarting(sessionId);
     const run = (startToken: string) => agent.runAgent({
       prompt: "continue",
       cwd: "/tmp",
@@ -443,7 +443,7 @@ describe("run journal", () => {
     } finally {
       agent.unmarkSessionStarting(sessionId, rejectedToken);
       agent.unmarkSessionStarting(sessionId, firstToken);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
@@ -462,9 +462,9 @@ describe("run journal", () => {
 		});
 
 		try {
-			const stoppedToken = agent.markSessionStarting(sessionId);
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
-			const replacementToken = agent.markSessionStarting(sessionId);
+			const stoppedToken = await agent.markSessionStarting(sessionId);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
+			const replacementToken = await agent.markSessionStarting(sessionId);
 			for await (const _event of run(stoppedToken)) {}
 			expect(fake.calls).toHaveLength(0);
 			agent.unmarkSessionStarting(sessionId, stoppedToken);
@@ -475,7 +475,7 @@ describe("run journal", () => {
 			agent.unmarkSessionStarting(sessionId, replacementToken);
 		} finally {
 			agent.unmarkSessionStarting(sessionId);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
@@ -493,17 +493,17 @@ describe("run journal", () => {
 			startToken,
 		});
 
-		const firstToken = agent.markSessionStarting(sessionId);
-		const secondToken = agent.markSessionStarting(sessionId);
+		const firstToken = await agent.markSessionStarting(sessionId);
+		const secondToken = await agent.markSessionStarting(sessionId);
 		try {
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
 			for await (const _event of run(firstToken)) {}
 			for await (const _event of run(secondToken)) {}
 			expect(fake.calls).toHaveLength(0);
 		} finally {
 			agent.unmarkSessionStarting(sessionId, firstToken);
 			agent.unmarkSessionStarting(sessionId, secondToken);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
@@ -520,18 +520,18 @@ describe("run journal", () => {
       journal: { osSessionId: sessionId, kind: "prompt" },
       startToken,
     });
-    const firstToken = agent.markSessionStarting(sessionId);
+    const firstToken = await agent.markSessionStarting(sessionId);
     for await (const _event of run(firstToken)) {}
     agent.unmarkSessionStarting(sessionId, firstToken);
-    const successorToken = agent.markSessionStarting(sessionId);
+    const successorToken = await agent.markSessionStarting(sessionId);
     try {
-      expect(agent.cancelAgentRunToken(firstToken)).toBe(false);
+      expect(await agent.cancelAgentRunToken(firstToken)).toBe(false);
       expect(agent.isAgentSessionCancelled(sessionId, successorToken)).toBe(false);
       for await (const _event of run(successorToken)) {}
       expect(fake.calls).toHaveLength(2);
     } finally {
       agent.unmarkSessionStarting(sessionId, successorToken);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
@@ -543,7 +543,7 @@ describe("run journal", () => {
     });
     const fake = makeFakeEngine([{ kind: "clean", gate }]);
     agent.__setEngineForTest(fake.engine);
-    const token = agent.markSessionStarting(sessionId);
+    const token = await agent.markSessionStarting(sessionId);
     const running = (async () => {
       try {
         for await (const _event of agent.runAgent({
@@ -570,7 +570,7 @@ describe("run journal", () => {
       release();
       await running;
       agent.unmarkSessionStarting(sessionId, token);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
@@ -591,11 +591,11 @@ describe("run journal", () => {
       expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(true);
     } finally {
       mod.journalClear(runKey);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
-	it("bridges pending preparations left by the pre-token hot-reload global", () => {
+	it("bridges pending preparations left by the pre-token hot-reload global", async () => {
 		const sessionId = `legacy-preparing-${crypto.randomUUID()}`;
 		const g = globalThis as any;
 		const previousPending = g.__pendingSessionStarts;
@@ -604,16 +604,16 @@ describe("run journal", () => {
 			g.__pendingSessionStarts = new Set([sessionId]);
 			g.__cancelledSessionRuns = new Set();
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
 			expect(g.__cancelledSessionRuns.has(sessionId)).toBe(true);
 		} finally {
 			g.__pendingSessionStarts = previousPending;
 			g.__cancelledSessionRuns = previousCancelled;
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("does not clear a replacement journal that reuses a cancelled recovery run key", () => {
+	it("does not clear a replacement journal that reuses a cancelled recovery run key", async () => {
 		const sessionId = `replacement-${crypto.randomUUID()}`;
 		const runKey = `engine-${crypto.randomUUID()}`;
 		const oldStartedAt = new Date(Date.now() - 1000).toISOString();
@@ -634,11 +634,11 @@ describe("run journal", () => {
 			);
 		} finally {
 			mod.journalClear(runKey);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("resets the consecutive recovery fuse after resumed work progresses", () => {
+	it("resets the consecutive recovery fuse after resumed work progresses", async () => {
 		const sessionId = `attached-${crypto.randomUUID()}`;
 		const runKey = `engine-${crypto.randomUUID()}`;
 		const startedAt = new Date().toISOString();
@@ -670,11 +670,11 @@ describe("run journal", () => {
 			expect(nextBoot.resumeAttempts).toBe(1);
 		} finally {
 			mod.journalClear(runKey);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("does not reset the recovery fuse on a replacement lineage", () => {
+	it("does not reset the recovery fuse on a replacement lineage", async () => {
 		const sessionId = `attached-replacement-${crypto.randomUUID()}`;
 		const runKey = `engine-${crypto.randomUUID()}`;
 		try {
@@ -698,11 +698,11 @@ describe("run journal", () => {
 			expect(mod.activeRunRecords()[0]).toMatchObject({ cwd: "/replacement", resumeAttempts: 2 });
 		} finally {
 			mod.journalClear(runKey);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("copies account and reviewer policy into every journal shape", () => {
+	it("copies account and reviewer policy into every journal shape", async () => {
 		const record = mod.buildRunJournalRecord(
 			{
 				accountId: "account-1",
@@ -762,7 +762,7 @@ describe("run journal", () => {
 		try {
 			while (fake.calls.length < 1) await Bun.sleep(5);
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
-			expect(agent.cancelAgentRun(sessionId)).toBe(true);
+			expect(await agent.cancelAgentRun(sessionId)).toBe(true);
 		} finally {
 			release();
 			await running;
@@ -791,14 +791,14 @@ describe("run journal", () => {
 			startToken,
 		});
 
-		const winnerToken = agent.markSessionStarting(sessionId);
+		const winnerToken = await agent.markSessionStarting(sessionId);
 		const winner = (async () => {
 			for await (const _event of run(winnerToken)) {}
 			agent.unmarkSessionStarting(sessionId, winnerToken);
 		})();
 		try {
 			while (fake.calls.length < 1) await Bun.sleep(5);
-			const loserToken = agent.markSessionStarting(sessionId);
+			const loserToken = await agent.markSessionStarting(sessionId);
 			for await (const _event of run(loserToken)) {}
 			agent.unmarkSessionStarting(sessionId, loserToken);
 			expect(getRunState(sessionId)).toBe("running");
@@ -810,11 +810,11 @@ describe("run journal", () => {
 			release();
 			await winner;
 			agent.unmarkSessionStarting(sessionId);
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
-	it("does not notify for a rejected record when the same session will recover", () => {
+	it("does not notify for a rejected record when the same session will recover", async () => {
 		const sessionId = `mixed-recovery-${crypto.randomUUID()}`;
 		const startedAt = new Date().toISOString();
 		const valid: mod.ActiveRunRecord = {
@@ -839,7 +839,7 @@ describe("run journal", () => {
 		});
 	});
 
-	it("deduplicates and recovers every valid run while rejecting recursive records", () => {
+	it("deduplicates and recovers every valid run while rejecting recursive records", async () => {
 		const now = Date.now();
 		const records: mod.ActiveRunRecord[] = Array.from({ length: 40 }, (_, i) => ({
 			runKey: `run-${i}`,
@@ -863,7 +863,7 @@ describe("run journal", () => {
 		expect(result.quarantined.some((r) => r.run.runKey === "recursive" && r.reason === "recursive_recovery_kind")).toBe(true);
 	});
 
-	it("recovers the oldest unique runs first so repeated restarts cannot starve them", () => {
+	it("recovers the oldest unique runs first so repeated restarts cannot starve them", async () => {
 		const now = Date.now();
 		const result = agent.sanitizeInterruptedRuns(
 			[
@@ -889,7 +889,7 @@ describe("run journal", () => {
 		]);
 	});
 
-	it("accepts interleaved fallback recovery markers with a bounded durable counter", () => {
+	it("accepts interleaved fallback recovery markers with a bounded durable counter", async () => {
 		const now = Date.now();
 		const run: mod.ActiveRunRecord = {
 			runKey: "interleaved",
@@ -905,7 +905,7 @@ describe("run journal", () => {
 		expect(result.quarantined).toEqual([]);
 	});
 
-	it("rejects expired lineage and exhausted durable resume attempts", () => {
+	it("rejects expired lineage and exhausted durable resume attempts", async () => {
 		const now = Date.now();
 		const base: mod.ActiveRunRecord = {
 			runKey: "base",
@@ -925,7 +925,7 @@ describe("run journal", () => {
 		]);
 	});
 
-	it("keeps recovery kinds and prompts bounded across repeated restarts", () => {
+	it("keeps recovery kinds and prompts bounded across repeated restarts", async () => {
 		expect(agent.recoveryKind("prompt", "resume")).toBe("prompt-resume");
 		expect(agent.recoveryKind("prompt-resume", "resume")).toBe("prompt-resume");
 		expect(agent.recoveryKind("prompt-resume-rerun", "rerun")).toBe("prompt-rerun");
@@ -1031,7 +1031,7 @@ describe("run journal", () => {
 		expect(mod.takeInterruptedRuns()).toEqual([]);
 	});
 
-	it("leaves filtered recovery journals unclaimed for a later boot", () => {
+	it("leaves filtered recovery journals unclaimed for a later boot", async () => {
 		mod.journalSet({
 			runKey: "quarantined-run",
 			osSessionId: "quarantined-session",
@@ -1046,7 +1046,7 @@ describe("run journal", () => {
 		expect(preserved.claimedAt).toBeUndefined();
 	});
 
-	it("defers actor-owned opening journals to the durable effect executor", () => {
+	it("defers actor-owned opening journals to the durable effect executor", async () => {
 		mod.journalSet({
 			runKey: "opening-run",
 			osSessionId: "opening-session",
@@ -1057,7 +1057,7 @@ describe("run journal", () => {
 			startedAt: new Date().toISOString(),
 		});
 		expect(
-			agent.resumeInterruptedRuns(
+			await agent.resumeInterruptedRuns(
 				undefined,
 				undefined,
 				undefined,
@@ -1072,7 +1072,7 @@ describe("run journal", () => {
 		]);
 	});
 
-	it("adopts a durable abnormal-completion receipt without relaunching", () => {
+	it("adopts a durable abnormal-completion receipt without relaunching", async () => {
 		const runKey = "abnormal-opening";
 		const record: mod.ActiveRunRecord = {
 			runKey,
@@ -1090,7 +1090,7 @@ describe("run journal", () => {
 		);
 		let terminal: StreamEvent | undefined;
 		expect(
-			agent.resumeInterruptedRuns((_sessionId, event) => {
+			await agent.resumeInterruptedRuns((_sessionId, event) => {
 				terminal = event;
 			}),
 		).toEqual(["abnormal-session"]);
@@ -1119,7 +1119,7 @@ describe("run journal", () => {
 		]);
 	});
 
-	it("quarantines ambiguous Runner admission out of boot recovery", () => {
+	it("quarantines ambiguous Runner admission out of boot recovery", async () => {
 		const run: mod.ActiveRunRecord = {
 			runKey: "ambiguous-runner-opening",
 			osSessionId: "ambiguous-runner-session",
@@ -1148,7 +1148,7 @@ describe("run journal", () => {
 		]);
 	});
 
-	it("preserves first-journaled time while incrementing recovery attempts", () => {
+	it("preserves first-journaled time while incrementing recovery attempts", async () => {
 		const first = new Date(Date.now() - 10_000).toISOString();
 		mod.journalSet({ runKey: "lineage", cwd: "/tmp", startedAt: first });
 		const prepared = mod.journalStartRecovery(mod.activeRunRecords()[0]);
@@ -1178,8 +1178,8 @@ describe("run journal", () => {
 		const terminal = new Promise<{ id?: string; event?: StreamEvent }>((resolve) => {
 			resolveTerminal = resolve;
 		});
-		const observed = new Promise<{ id: string; event: unknown }>((resolve) => {
-			const resumed = agent.resumeInterruptedRuns(
+		const observed = new Promise<{ id: string; event: unknown }>(async (resolve) => {
+			const resumed = await agent.resumeInterruptedRuns(
 				(id, event) => resolveTerminal({ id, event }),
 				undefined,
 				undefined,
@@ -1217,7 +1217,7 @@ describe("run journal", () => {
 		});
 	});
 
-	it("recognizes malformed recovered tool-output envelopes without matching real answers", () => {
+	it("recognizes malformed recovered tool-output envelopes without matching real answers", async () => {
 		expect(
 			agent.recoveredResultNeedsContinuation({
 				type: "done",
@@ -1269,7 +1269,7 @@ describe("run journal", () => {
 		).toBe(true);
 	});
 
-	it("flags fabricated tool transcripts in assistant text (both observed costumes)", () => {
+	it("flags fabricated tool transcripts in assistant text (both observed costumes)", async () => {
 		// Costume 1 (2026-07-29 morning): Meridian's result-delivery envelope
 		// authored by the model, MCP tool name included.
 		expect(
@@ -1337,7 +1337,7 @@ describe("restart recovery queue", () => {
 			{ length: 5 },
 			(_, i) => `starved-${i}-${crypto.randomUUID()}`,
 		);
-		sessions.forEach((sessionId, i) => {
+		await Promise.all(sessions.map(async (sessionId, i) => {
 			mod.journalSet({
 				runKey: `run-${sessionId}`,
 				osSessionId: sessionId,
@@ -1347,11 +1347,11 @@ describe("restart recovery queue", () => {
 				model: "claude-fable-5",
 				startedAt: new Date(Date.now() - i * 1000).toISOString(),
 			});
-			clearRunState(sessionId);
-		});
+			await clearRunState(sessionId);
+		}));
 		const terminals: StreamEvent[] = [];
 		try {
-			agent.resumeInterruptedRuns((_id, event) => {
+			await agent.resumeInterruptedRuns((_id, event) => {
 				if (event) terminals.push(event);
 			});
 			// Each fake emits `init` before its gate. That proves the replacement
@@ -1364,7 +1364,7 @@ describe("restart recovery queue", () => {
 			for (const open of gates) open();
 			for (const sessionId of sessions) {
 				while (agent.isAgentSessionBusy(sessionId)) await Bun.sleep(5);
-				clearRunState(sessionId);
+				await clearRunState(sessionId);
 			}
 		}
 	});
@@ -1393,7 +1393,7 @@ describe("restart recovery reattach", () => {
 			startedAt: new Date().toISOString(),
 		};
 		try {
-			agent.resumeInterruptedRuns(
+			await agent.resumeInterruptedRuns(
 				() => {},
 				undefined,
 				undefined,
@@ -1406,7 +1406,7 @@ describe("restart recovery reattach", () => {
 			expect(fake.calls).toHaveLength(0);
 			expect(agent.isAgentSessionBusy(sessionId)).toBe(true);
 		} finally {
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
@@ -1429,7 +1429,7 @@ describe("restart recovery reattach", () => {
     };
     const terminal = Promise.withResolvers<StreamEvent>();
     try {
-      agent.resumeInterruptedRuns(
+      await agent.resumeInterruptedRuns(
         (_id, event) => event && terminal.resolve(event),
         undefined,
         undefined,
@@ -1445,7 +1445,7 @@ describe("restart recovery reattach", () => {
       expect(fake.calls[0].opts.startToken).toBe(hostId);
     } finally {
       mod.journalClear(hostId);
-      clearRunState(sessionId);
+      await clearRunState(sessionId);
     }
   });
 
@@ -1489,7 +1489,7 @@ describe("restart recovery reattach", () => {
         cancelId: `stop:${hostId}`,
         outcome: "confirmed",
       });
-      agent.resumeInterruptedRuns(
+      await agent.resumeInterruptedRuns(
         () => {},
         undefined,
         undefined,
@@ -1549,7 +1549,7 @@ describe("restart recovery reattach", () => {
 		});
 
 		try {
-			const resumed = agent.resumeInterruptedRuns(
+			const resumed = await agent.resumeInterruptedRuns(
 				(_id, event) => event && resolveTerminal(event),
 				undefined,
 				undefined,
@@ -1569,7 +1569,7 @@ describe("restart recovery reattach", () => {
 			expect(fake.calls).toHaveLength(0);
 			expect(mod.activeRunRecords()).toEqual([]);
 		} finally {
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 
@@ -1590,19 +1590,19 @@ describe("restart recovery reattach", () => {
 			startedAt,
 		};
 		mod.journalSet(run);
-		clearRunState(sessionId);
+		await clearRunState(sessionId);
 		const streamEnded = Promise.withResolvers<void>();
 		agent.__setLocalHostResumeForTest(async () =>
 			(async function* () {
 				mod.journalClear(hostId);
-				transitionRunState(sessionId, "turn_end", { run_key: hostId });
+				await transitionRunState(sessionId, "turn_end", { run_key: hostId });
 				streamEnded.resolve();
 			})(),
 		);
 		const terminals: StreamEvent[] = [];
 
 		try {
-			expect(agent.resumeInterruptedRuns((_id, event) => {
+			expect(await agent.resumeInterruptedRuns((_id, event) => {
 				if (event) terminals.push(event);
 			})).toEqual([sessionId]);
 			await streamEnded.promise;
@@ -1610,7 +1610,7 @@ describe("restart recovery reattach", () => {
 			expect(terminals).toEqual([]);
 			expect(mod.activeRunRecords()).toEqual([]);
 		} finally {
-			clearRunState(sessionId);
+			await clearRunState(sessionId);
 		}
 	});
 

--- a/packages/core/opensession-server/src/server/zz-run-journal.test.ts
+++ b/packages/core/opensession-server/src/server/zz-run-journal.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import * as mod from "./run-journal";
@@ -39,6 +39,75 @@ afterEach(() => {
 });
 
 describe("run journal", () => {
+	it("awaits run registration before journal admission completes", async () => {
+		const gate = Promise.withResolvers<void>();
+		const started = Promise.withResolvers<void>();
+		const events: string[] = [];
+		const registration = mod.journalSet(
+			{
+				runKey: "awaited-registration",
+				osSessionId: "awaited-registration-session",
+				cwd: "/tmp",
+				startedAt: new Date().toISOString(),
+			},
+			async (_sessionId, event) => {
+				events.push(event);
+				started.resolve();
+				await gate.promise;
+			},
+		);
+		let completed = false;
+		void registration.then(() => {
+			completed = true;
+		});
+		await started.promise;
+		expect(completed).toBe(false);
+		expect(events).toEqual(["run_registered"]);
+		gate.resolve();
+		await registration;
+		expect(completed).toBe(true);
+	});
+
+	it("does not hand out boot records before transition settlement", async () => {
+		const record: mod.ActiveRunRecord = {
+			runKey: "awaited-boot-transition",
+			osSessionId: "awaited-boot-session",
+			cwd: "/tmp",
+			startedAt: new Date().toISOString(),
+		};
+		writeFileSync(
+			join(dir, "active-runs.json"),
+			JSON.stringify({ [record.runKey]: record }),
+		);
+		const gate = Promise.withResolvers<void>();
+		const taking = mod.takeInterruptedRuns([], () => true, async () => {
+			await gate.promise;
+		});
+		let completed = false;
+		void taking.then(() => {
+			completed = true;
+		});
+		await Promise.resolve();
+		expect(completed).toBe(false);
+		gate.resolve();
+		expect(await taking).toEqual([record]);
+
+		const rejected: mod.ActiveRunRecord = {
+			...record,
+			runKey: "rejected-boot-transition",
+			osSessionId: "rejected-boot-session",
+		};
+		writeFileSync(
+			join(dir, "active-runs.json"),
+			JSON.stringify({ [rejected.runKey]: rejected }),
+		);
+		await expect(mod.takeInterruptedRuns([], () => true, async () => {
+			throw new Error("boot transition rejected");
+		})).rejects.toThrow("boot transition rejected");
+		expect(mod.activeRunRecords()).toContainEqual(
+			expect.objectContaining({ runKey: rejected.runKey }),
+		);
+	});
 	it("keeps interrupted and reattaching sessions busy until recovery settles", async () => {
 		const sessionId = `recovery-${crypto.randomUUID()}`;
 		try {
@@ -57,7 +126,7 @@ describe("run journal", () => {
 		const sessionId = `exhausted-${crypto.randomUUID()}`;
 		const runKey = `run-${crypto.randomUUID()}`;
 		const startedAt = new Date().toISOString();
-		mod.journalSet({
+		await mod.journalSet({
 			runKey,
 			osSessionId: sessionId,
 			claudeSessionId: `engine-${crypto.randomUUID()}`,
@@ -96,7 +165,7 @@ describe("run journal", () => {
 		const sessionId = `github-review-${crypto.randomUUID()}`;
 		const runKey = `rh-${crypto.randomUUID()}`;
 		try {
-			mod.journalSet({
+			await mod.journalSet({
 				runKey,
 				hostId: runKey,
 				osSessionId: sessionId,
@@ -121,7 +190,7 @@ describe("run journal", () => {
 		const sessionId = `queued-recovery-${crypto.randomUUID()}`;
 		const runKey = `run-${crypto.randomUUID()}`;
 		try {
-			mod.journalSet({
+			await mod.journalSet({
 				runKey,
 				osSessionId: sessionId,
 				claudeSessionId: `engine-${crypto.randomUUID()}`,
@@ -174,8 +243,8 @@ describe("run journal", () => {
       // latch before the detached control reconnects.
       expect(await agent.reissueDurableRecoveryCancel(recovery)).toBe(false);
       expect(agent.isAgentSessionCancelled(sessionId, runKey)).toBe(true);
-      mod.journalSet(recovery);
-      mod.journalRecordAbnormalCompletion(recovery);
+      await mod.journalSet(recovery);
+      await mod.journalRecordAbnormalCompletion(recovery);
       expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
         false,
       );
@@ -214,8 +283,8 @@ describe("run journal", () => {
         cancelId: `stop:${runKey}`,
         runGeneration: generation,
       })).toBe("execute");
-      mod.journalSet(record);
-      mod.journalRecordAbnormalCompletion(record);
+      await mod.journalSet(record);
+      await mod.journalRecordAbnormalCompletion(record);
       expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(true);
       store.settleTurnCancel({
         sessionId,
@@ -261,8 +330,8 @@ describe("run journal", () => {
             interruptId,
             runGeneration: prepared.runGeneration,
           })).toBe("execute");
-          mod.journalSet(record);
-          mod.journalRecordAbnormalCompletion(record);
+          await mod.journalSet(record);
+          await mod.journalRecordAbnormalCompletion(record);
           expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
             true,
           );
@@ -277,8 +346,8 @@ describe("run journal", () => {
             mod.journalRetireCancelledAbnormalAfterSettlement(sessionId, runKey),
           ).toBe(true);
         } else {
-          mod.journalSet(record);
-          mod.journalRecordAbnormalCompletion(record);
+          await mod.journalSet(record);
+          await mod.journalRecordAbnormalCompletion(record);
         }
         expect(mod.activeRunRecords().some((run) => run.runKey === runKey)).toBe(
           false,
@@ -298,7 +367,7 @@ describe("run journal", () => {
 		});
 		const fake = makeFakeEngine([{ kind: "clean", gate }]);
 		agent.__setEngineForTest(fake.engine);
-		mod.journalSet({
+		await mod.journalSet({
 			runKey: `run-${crypto.randomUUID()}`,
 			osSessionId: sessionId,
 			prompt: "continue",
@@ -578,7 +647,7 @@ describe("run journal", () => {
     const sessionId = `detached-cancel-${crypto.randomUUID()}`;
     const runKey = `rh-${crypto.randomUUID()}`;
     try {
-      mod.journalSet({
+      await mod.journalSet({
         runKey,
         hostId: runKey,
         osSessionId: sessionId,
@@ -618,10 +687,10 @@ describe("run journal", () => {
 		const runKey = `engine-${crypto.randomUUID()}`;
 		const oldStartedAt = new Date(Date.now() - 1000).toISOString();
 		try {
-			mod.journalSet({ runKey, osSessionId: sessionId, cwd: "/old", startedAt: oldStartedAt });
+			await mod.journalSet({ runKey, osSessionId: sessionId, cwd: "/old", startedAt: oldStartedAt });
 			const old = mod.activeRunRecords().find((run) => run.runKey === runKey)!;
 			mod.journalClear(runKey);
-			mod.journalSet({
+			await mod.journalSet({
 				runKey,
 				osSessionId: sessionId,
 				cwd: "/replacement",
@@ -643,7 +712,7 @@ describe("run journal", () => {
 		const runKey = `engine-${crypto.randomUUID()}`;
 		const startedAt = new Date().toISOString();
 		try {
-			mod.journalSet({ runKey, osSessionId: sessionId, cwd: "/tmp", startedAt });
+			await mod.journalSet({ runKey, osSessionId: sessionId, cwd: "/tmp", startedAt });
 			const started = mod.journalStartRecovery(mod.activeRunRecords()[0]);
 			expect(started.resumeAttempts).toBe(1);
 			expect(started.lastResumeAt).toBeTruthy();
@@ -657,7 +726,7 @@ describe("run journal", () => {
 
 			// A later model fallback re-journals opts captured before the reset.
 			// The live journal's healthy state must win over those stale fields.
-			mod.journalSet({
+			await mod.journalSet({
 				...started,
 				resumeAttempts: 1,
 				lastResumeAt: new Date().toISOString(),
@@ -678,7 +747,7 @@ describe("run journal", () => {
 		const sessionId = `attached-replacement-${crypto.randomUUID()}`;
 		const runKey = `engine-${crypto.randomUUID()}`;
 		try {
-			mod.journalSet({
+			await mod.journalSet({
 				runKey,
 				osSessionId: sessionId,
 				cwd: "/old",
@@ -686,7 +755,7 @@ describe("run journal", () => {
 			});
 			const old = mod.journalStartRecovery(mod.activeRunRecords()[0]);
 			mod.journalClear(runKey);
-			mod.journalSet({
+			await mod.journalSet({
 				runKey,
 				osSessionId: sessionId,
 				cwd: "/replacement",
@@ -995,7 +1064,7 @@ describe("run journal", () => {
 	});
 
 	it("preserves human-confirmed tool policy across restart drains", async () => {
-		mod.journalSet({
+		await mod.journalSet({
 			runKey: "run-1",
 			osSessionId: "bks-1",
 			claudeSessionId: "engine-1",
@@ -1011,7 +1080,7 @@ describe("run journal", () => {
 			startedAt: "2026-07-02T00:00:00.000Z",
 		});
 
-		const [run] = mod.takeInterruptedRuns();
+		const [run] = await mod.takeInterruptedRuns();
 		expect(run.confirmTools).toEqual({
 			mcp__stripe__create_refund: "Create a refund",
 		});
@@ -1028,11 +1097,11 @@ describe("run journal", () => {
 		expect(claimed.runKey).toBe("run-1");
 		expect(claimed.claimedAt).toBeTruthy();
 		// The same process never takes an already-claimed run twice.
-		expect(mod.takeInterruptedRuns()).toEqual([]);
+		expect(await mod.takeInterruptedRuns()).toEqual([]);
 	});
 
 	it("leaves filtered recovery journals unclaimed for a later boot", async () => {
-		mod.journalSet({
+		await mod.journalSet({
 			runKey: "quarantined-run",
 			osSessionId: "quarantined-session",
 			prompt: "preserve me",
@@ -1040,14 +1109,14 @@ describe("run journal", () => {
 			startedAt: new Date().toISOString(),
 		});
 
-		expect(mod.takeInterruptedRuns([], () => false)).toEqual([]);
+		expect(await mod.takeInterruptedRuns([], () => false)).toEqual([]);
 		const [preserved] = mod.activeRunRecords();
 		expect(preserved.runKey).toBe("quarantined-run");
 		expect(preserved.claimedAt).toBeUndefined();
 	});
 
 	it("defers actor-owned opening journals to the durable effect executor", async () => {
-		mod.journalSet({
+		await mod.journalSet({
 			runKey: "opening-run",
 			osSessionId: "opening-session",
 			promptEntryId: "opening-prompt",
@@ -1083,8 +1152,8 @@ describe("run journal", () => {
 			mcpServers: [],
 			startedAt: new Date().toISOString(),
 		};
-		mod.journalSet(record);
-		mod.journalRecordAbnormalCompletion(
+		await mod.journalSet(record);
+		await mod.journalRecordAbnormalCompletion(
 			record,
 			"Opening backend ended without a terminal event",
 		);
@@ -1103,7 +1172,7 @@ describe("run journal", () => {
 
 	it("moves rejected recovery records into an inspectable quarantine", async () => {
 		for (let i = 0; i < 5; i++) {
-			mod.journalSet({ runKey: `batch-${i}`, cwd: "/tmp", mcpServers: [], startedAt: new Date().toISOString() });
+			await mod.journalSet({ runKey: `batch-${i}`, cwd: "/tmp", mcpServers: [], startedAt: new Date().toISOString() });
 		}
 		mod.journalQuarantine([
 			{ run: mod.activeRunRecords().find((run) => run.runKey === "batch-1")!, reason: "recovery_expired", notify: true },
@@ -1132,7 +1201,7 @@ describe("run journal", () => {
 			launchPhase: "launching",
 			startedAt: new Date().toISOString(),
 		};
-		mod.journalSet(run);
+		await mod.journalSet(run);
 		mod.journalQuarantine([
 			{ run, reason: "ambiguous_runner_launch", notify: false },
 		]);
@@ -1150,12 +1219,12 @@ describe("run journal", () => {
 
 	it("preserves first-journaled time while incrementing recovery attempts", async () => {
 		const first = new Date(Date.now() - 10_000).toISOString();
-		mod.journalSet({ runKey: "lineage", cwd: "/tmp", startedAt: first });
+		await mod.journalSet({ runKey: "lineage", cwd: "/tmp", startedAt: first });
 		const prepared = mod.journalStartRecovery(mod.activeRunRecords()[0]);
 		expect(prepared.firstJournaledAt).toBe(first);
 		expect(prepared.resumeAttempts).toBe(1);
 		expect(prepared.lastResumeAt).toBeTruthy();
-		mod.journalSet({ ...prepared, startedAt: new Date().toISOString() });
+		await mod.journalSet({ ...prepared, startedAt: new Date().toISOString() });
 		expect(mod.activeRunRecords()[0].firstJournaledAt).toBe(first);
 		expect(mod.activeRunRecords()[0].resumeAttempts).toBe(1);
 	});
@@ -1163,7 +1232,7 @@ describe("run journal", () => {
 	it("emits recovered run stream events during restart resume", async () => {
 		agent.__setEngineForTest(makeFakeEngine([{ kind: "usage_exhausted" }]).engine);
 		process.env.OPENSESSION_FORCE_LIMIT = "1";
-		mod.journalSet({
+		await mod.journalSet({
 			runKey: "run-2",
             kind: "prompt",
 			osSessionId: "bks-2",
@@ -1338,7 +1407,7 @@ describe("restart recovery queue", () => {
 			(_, i) => `starved-${i}-${crypto.randomUUID()}`,
 		);
 		await Promise.all(sessions.map(async (sessionId, i) => {
-			mod.journalSet({
+			await mod.journalSet({
 				runKey: `run-${sessionId}`,
 				osSessionId: sessionId,
 				claudeSessionId: `engine-${sessionId}`,
@@ -1589,7 +1658,7 @@ describe("restart recovery reattach", () => {
 			firstJournaledAt: startedAt,
 			startedAt,
 		};
-		mod.journalSet(run);
+		await mod.journalSet(run);
 		await clearRunState(sessionId);
 		const streamEnded = Promise.withResolvers<void>();
 		agent.__setLocalHostResumeForTest(async () =>

--- a/packages/core/opensession-server/src/server/zz-snapshot-runs.test.ts
+++ b/packages/core/opensession-server/src/server/zz-snapshot-runs.test.ts
@@ -61,7 +61,7 @@ describe("transcript snapshots", () => {
       workspaceId: "ws-snap-attached",
       piSessionId: "ses_snap_attached",
     });
-    h.writeEngineTranscript("ses_snap_attached", [
+    await h.writeEngineTranscript("ses_snap_attached", [
         {
           type: "user",
           uuid: "attached-1",

--- a/packages/core/opensession-server/src/session-kernel-transport-worker.ts
+++ b/packages/core/opensession-server/src/session-kernel-transport-worker.ts
@@ -11,6 +11,8 @@ import {
   type KernelActorSyncRequest,
   type KernelActorTransportEnvelope,
 } from "./server/session-kernel/actor-protocol";
+import { isReadReducer } from "./server/session-kernel/actor-routing";
+import { READ_METHODS } from "./server/session-kernel/store-routing";
 import {
   readSessionKernelCredential,
   sessionKernelServiceUrl,
@@ -156,15 +158,18 @@ self.onmessage = (
             } satisfies KernelActorAsyncResponse);
             return;
           }
+          const retryableRead = request.t === "reduce"
+            ? isReadReducer(request.command)
+            : READ_METHODS.has(request.method);
           if (
-            request.t === "store" &&
+            retryableRead &&
             response.status === 2 &&
             typeof response.length === "number" &&
             response.length > outputBytes &&
             response.length <= ASYNC_MAX_OUTPUT_BYTES
           ) {
-            // Exactly-sized retry for large read-only snapshots. Reductions
-            // are never retried, so this cannot replay a committed mutation.
+            // Exactly-sized retry for provable reads. A mutation may already
+            // have committed before its encoded response overflowed.
             outputBytes = response.length;
             continue;
           }


### PR DESCRIPTION
## Summary
- transport worker completes rpcId store/reduce envelopes over the posted-message path (exactly-sized retries preserve large snapshots)
- actor client gains callAsync plus async variants of all eight decide operations
- sessionAsk/Turn/Timer/Core/GatewayCommand/Delivery become async; all result-dependent callers await
- AskOwnedMap/DeliveryOwnedMap writes are Promise-based and awaited through ask/queue flows; reads stay served from the existing gateway-local caches

## Why
The synchronous Atomics.wait bridge blocks the gateway event loop per call; queued UI requests serialized behind slow actor lanes caused the timer-poison self-restarts. This stage removes blocking from every facade path while keeping single-writer actor semantics unchanged.

Stage 2 (follow-up) deletes SharedArrayBuffer, Atomics.wait, the sync buffers, and the breaker once remaining store-method sites convert.

## Verification
- 85 focused kernel/actor/system tests pass
- typecheck clean for all touched files (two pre-existing pi-runner.test.ts errors on main are in an untouched file)
- module side-effect scan pass

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0143b-707f-7000-b364-96c999a5f1fc)