### PR TITLE
Survive kernel saturation on session projections

### DIFF
--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -46,6 +46,7 @@ import {
 } from "./src/server/github-auth";
 import { startGoalTicker } from "./src/server/goal-runner";
 import { startSessionIndexSweeper } from "./src/server/session-index";
+import { startEventLoopLagMonitor } from "./src/server/system-stats";
 import { ensureWarmTemplateScheduler } from "./src/server/warm-template";
 import { handleRunnerWsUpgrade } from "./src/server/runner-ws";
 import { handleSandboxPortalRelayUpgrade } from "./src/server/sandbox-portal-relay";
@@ -738,6 +739,11 @@ if (!g.__opensessionBooted) {
 
 	// Distil finished sessions into the search index (session-index.ts).
 	startSessionIndexSweeper();
+
+	// Gateway event-loop lag telemetry for /api/health and the health MCP tool
+	// (system-stats.ts). The session-performance contract only measures the
+	// client; this is the server-side counterpart.
+	startEventLoopLagMonitor();
 
 	// Re-try sidebar titles whose one-shot died in flight (a restart, or an
 	// engine-spawn outage) — without this they stay raw forever.

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -170,6 +170,27 @@ function runHostsEnabled(): boolean {
   return localRunHostsSupported() && !existsSync(DISABLE_FILE);
 }
 
+// ── Bounded spawn-failure fallback ─────────────────────────────────────────
+// When run hosts are the configured path, an in-process fallback is meant to
+// save the occasional run from a transient launch hiccup. At fleet scale it
+// inverts: exactly when the executor is unhealthy, every launch would migrate
+// its engine INTO the gateway process, multiplying gateway memory/CPU at the
+// worst possible moment. Cap concurrent fallback runs; beyond the cap the
+// launch fails visibly (lastRunError + queue restore) instead of silently
+// overloading the process every other session depends on. Platforms without
+// run hosts are exempt — there, in-process is the normal path, not a fallback.
+const MAX_IN_PROCESS_FALLBACK_RUNS = (() => {
+  const raw = Number(process.env.OPENSESSION_MAX_INPROCESS_FALLBACKS ?? 8);
+  return Number.isInteger(raw) && raw >= 1 ? raw : 8;
+})();
+const activeInProcessFallbackRuns: Set<string> = ((globalThis as any)
+  .__activeInProcessFallbackRuns ??= new Set());
+
+/** Exported for tests. */
+export function inProcessFallbackSaturated(): boolean {
+  return activeInProcessFallbackRuns.size >= MAX_IN_PROCESS_FALLBACK_RUNS;
+}
+
 /** Options for a hosted run: RunAgentOpts minus the non-serializable bits,
  *  plus the host/session context. */
 export interface HostedRunOpts {
@@ -260,7 +281,40 @@ export async function* runAgentHosted(opts: HostedRunOpts): AsyncGenerator<Strea
       }
       return;
     }
+    // Spawn-failure fallback: bounded so a sick executor degrades launches
+    // instead of migrating the whole fleet's engines into the gateway.
+    if (inProcessFallbackSaturated()) {
+      audit({
+        msg: "in_process_fallback_rejected",
+        session_id: opts.osSessionId,
+        active: activeInProcessFallbackRuns.size,
+        limit: MAX_IN_PROCESS_FALLBACK_RUNS,
+      });
+      throw new Error(
+        `Run host launch failed and ${activeInProcessFallbackRuns.size} in-process fallback runs are already active (limit ${MAX_IN_PROCESS_FALLBACK_RUNS}). Not absorbing this run into the gateway; retry when run hosts recover.`,
+      );
+    }
+    const fallbackKey = `${opts.osSessionId}:${crypto.randomUUID()}`;
+    activeInProcessFallbackRuns.add(fallbackKey);
+    audit({
+      msg: "in_process_fallback_started",
+      session_id: opts.osSessionId,
+      active: activeInProcessFallbackRuns.size,
+      limit: MAX_IN_PROCESS_FALLBACK_RUNS,
+    });
+    try {
+      yield* runAgentInProcess(opts);
+    } finally {
+      activeInProcessFallbackRuns.delete(fallbackKey);
+    }
+    return;
   }
+  yield* runAgentInProcess(opts);
+}
+
+/** The shared in-process execution tail: the normal path on platforms without
+ *  run hosts, and the (bounded) fallback when a host spawn fails. */
+async function* runAgentInProcess(opts: HostedRunOpts): AsyncGenerator<StreamEvent> {
   yield* runAgent({
     prompt: opts.prompt,
     promptEntryId: opts.promptEntryId,

--- a/packages/core/opensession-server/src/server/session-kernel/store.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/store.ts
@@ -1426,7 +1426,18 @@ export class SessionKernelStore {
 		this.db = new Database(path);
 		this.closeable = true;
 		this.db.exec("PRAGMA journal_mode = WAL;");
-		this.db.exec("PRAGMA synchronous = FULL;");
+		// NORMAL, not FULL: with WAL, NORMAL still guarantees no corruption and
+		// no torn transactions — an OS crash or power loss can only drop the most
+		// recent commit(s) that had not yet reached the WAL fsync point; an
+		// application crash loses nothing. Every kernel command is designed for
+		// exactly that window: admissions replay by request id, effects are
+		// destination-idempotent at-least-once, and interrupted physical work
+		// fails closed. FULL cost ~3.3 ms of fsync per commit on this class of
+		// disk vs ~0.005 ms at NORMAL — with two kernel commits wrapping every
+		// transcript append, that fsync tax dominated the append path (measured
+		// p50 ~18 ms per append pair) and drove lane saturation at ~100
+		// concurrent sessions. Approved trade (Jaap, 2026-08-26).
+		this.db.exec("PRAGMA synchronous = NORMAL;");
 		this.db.exec(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
 		this.db.exec(`
 			CREATE TABLE IF NOT EXISTS session_kernel_owner (

--- a/packages/core/opensession-server/src/server/session-projection-executor.test.ts
+++ b/packages/core/opensession-server/src/server/session-projection-executor.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Bounded saturation retry for session projections. The kernel actor service
+ * sheds concurrent load with retryable "lane/mailbox is full" errors, and the
+ * actor client deliberately retries only reads — so the projection executor
+ * owns mutation-side resilience. These tests pin the retry policy: retryable
+ * errors are retried with backoff up to the bound, non-retryable errors
+ * propagate immediately, and the `retried` flag reports whether any retry ran.
+ */
+import { describe, expect, test } from "bun:test";
+import { retryOnKernelSaturation } from "./session-projection-executor";
+import { SessionKernelActorError } from "./session-kernel/actor-client";
+
+const noSleep = async (_ms: number) => {};
+
+describe("retryOnKernelSaturation", () => {
+  test("returns first-attempt success without marking retried", async () => {
+    const { result, retried } = await retryOnKernelSaturation(
+      "test",
+      async () => 42,
+      noSleep,
+    );
+    expect(result).toBe(42);
+    expect(retried).toBe(false);
+  });
+
+  test("retries retryable kernel errors and reports retried", async () => {
+    let calls = 0;
+    const { result, retried } = await retryOnKernelSaturation(
+      "test",
+      async () => {
+        calls++;
+        if (calls < 3)
+          throw new SessionKernelActorError("Session actor lane is full", true);
+        return "ok";
+      },
+      noSleep,
+    );
+    expect(result).toBe("ok");
+    expect(retried).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  test("does not retry non-retryable errors", async () => {
+    let calls = 0;
+    await expect(
+      retryOnKernelSaturation(
+        "test",
+        async () => {
+          calls++;
+          throw new Error("Gateway command failed");
+        },
+        noSleep,
+      ),
+    ).rejects.toThrow("Gateway command failed");
+    expect(calls).toBe(1);
+  });
+
+  test("gives up after the attempt bound and rethrows the last error", async () => {
+    let calls = 0;
+    await expect(
+      retryOnKernelSaturation(
+        "test",
+        async () => {
+          calls++;
+          throw new SessionKernelActorError("Session mailbox is full", true);
+        },
+        noSleep,
+      ),
+    ).rejects.toThrow("Session mailbox is full");
+    expect(calls).toBe(6);
+  });
+});

--- a/packages/core/opensession-server/src/server/session-projection-executor.ts
+++ b/packages/core/opensession-server/src/server/session-projection-executor.ts
@@ -1,7 +1,51 @@
 import {
+  isRetryableSessionCommandError,
   sessionGatewayCommand,
   type GatewayCommandOperation,
 } from "./session-kernel";
+
+// Bounded retry for saturation-class kernel errors. Under concurrent load the
+// actor service sheds work with retryable "lane/mailbox is full" errors, and
+// the client deliberately retries only reads — so a transcript projection hit
+// by a momentary burst used to fail outright and mark the session degraded
+// (measured: 100 concurrent sessions rejected 48% of appends). Admission and
+// settlement are both idempotent by request id (`requestGatewayCommand`
+// replays a completed receipt, `completeGatewayCommand` returns the stored
+// result), so a bounded retry here is safe and converts a burst into a short
+// delay. Total worst-case added wait is ~1.6s, far below the actor client's
+// 15s deadline.
+const KERNEL_SATURATION_RETRY_ATTEMPTS = 6;
+const KERNEL_SATURATION_RETRY_BASE_MS = 50;
+const KERNEL_SATURATION_RETRY_MAX_MS = 800;
+
+/** Exported for tests. Returns the call result plus whether any retry ran —
+ *  callers use `retried` to accept an `in_progress` admission replay that our
+ *  own ambiguous earlier attempt committed. */
+export async function retryOnKernelSaturation<T>(
+  label: string,
+  call: () => Promise<T>,
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<{ result: T; retried: boolean }> {
+  let delayMs = KERNEL_SATURATION_RETRY_BASE_MS;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return { result: await call(), retried: attempt > 1 };
+    } catch (error) {
+      if (
+        attempt >= KERNEL_SATURATION_RETRY_ATTEMPTS ||
+        !isRetryableSessionCommandError(error)
+      )
+        throw error;
+      console.warn(
+        `[session-projection] ${label} hit a retryable kernel error (attempt ${attempt}/${KERNEL_SATURATION_RETRY_ATTEMPTS}); retrying:`,
+        error instanceof Error ? error.message : String(error),
+      );
+      await sleep(delayMs);
+      delayMs = Math.min(delayMs * 2, KERNEL_SATURATION_RETRY_MAX_MS);
+    }
+  }
+}
 
 const projectionState = globalThis as typeof globalThis & {
   __sessionProjectionTails?: Map<string, Promise<void>>;
@@ -35,37 +79,59 @@ export function executeDestinationIdempotentSessionProjection<T>(
   mutate: () => T | Promise<T>,
 ): Promise<T> {
   return serializeSessionProjection(sessionId, async () => {
-    const plan = await sessionGatewayCommand({
-      op: "request",
-      sessionId,
-      requestId,
-      operation,
-      identity,
-    });
+    const { result: plan, retried } = await retryOnKernelSaturation(
+      `${operation} admission`,
+      () =>
+        sessionGatewayCommand({
+          op: "request",
+          sessionId,
+          requestId,
+          operation,
+          identity,
+        }),
+    );
     if (plan.status === "completed") return plan.result as T;
-    if (plan.status === "in_progress")
+    // `in_progress` after our own ambiguous admission retry means the earlier
+    // attempt committed; the destination write below is idempotent by append
+    // id, so executing is the same as the non-retried admitted path.
+    if (plan.status === "in_progress" && !retried)
       throw new Error(`Destination command ${requestId} is already in progress`);
     let physicalFinished = false;
     try {
       const result = await mutate();
       physicalFinished = true;
-      return await sessionGatewayCommand({
-        op: "complete",
-        sessionId,
-        requestId,
-        operation,
-        result,
-      }) as T;
+      return (
+        await retryOnKernelSaturation(`${operation} settlement`, () =>
+          sessionGatewayCommand({
+            op: "complete",
+            sessionId,
+            requestId,
+            operation,
+            result,
+          }),
+        )
+      ).result as T;
     } catch (error) {
       if (!physicalFinished) {
-        await sessionGatewayCommand({
-          op: "fail",
-          sessionId,
-          requestId,
-          operation,
-          error: error instanceof Error ? error.message : String(error),
-          retryable: true,
-        });
+        try {
+          await retryOnKernelSaturation(`${operation} failure settlement`, () =>
+            sessionGatewayCommand({
+              op: "fail",
+              sessionId,
+              requestId,
+              operation,
+              error: error instanceof Error ? error.message : String(error),
+              retryable: true,
+            }),
+          );
+        } catch (settleError) {
+          // The original physical/admission error stays primary; the durable
+          // receipt remains `processing` and boot recovery reconciles it.
+          console.warn(
+            `[session-projection] ${operation} failure settlement did not commit for ${sessionId}:`,
+            settleError instanceof Error ? settleError.message : String(settleError),
+          );
+        }
       }
       throw error;
     }
@@ -79,35 +145,57 @@ export function executeSessionProjection<T>(
 ): Promise<T> {
   return serializeSessionProjection(sessionId, async () => {
     const requestId = `${operation}:${crypto.randomUUID()}`;
-    const plan = await sessionGatewayCommand({
-      op: "request",
-      sessionId,
-      requestId,
-      operation,
-    });
-    if (plan.status !== "execute")
+    const { result: plan, retried } = await retryOnKernelSaturation(
+      `${operation} admission`,
+      () =>
+        sessionGatewayCommand({
+          op: "request",
+          sessionId,
+          requestId,
+          operation,
+        }),
+    );
+    // The request id is minted here and never shared, so `in_progress` can
+    // only be our own ambiguous earlier attempt whose admission committed —
+    // nothing has executed yet, so proceeding is the normal admitted path.
+    const admitted =
+      plan.status === "execute" || (retried && plan.status === "in_progress");
+    if (!admitted)
       throw new Error(`Unexpected duplicate ${operation} command`);
     let physicalFinished = false;
     try {
       const result = await mutate();
       physicalFinished = true;
-      return await sessionGatewayCommand({
-        op: "complete",
-        sessionId,
-        requestId,
-        operation,
-        result,
-      }) as T;
+      return (
+        await retryOnKernelSaturation(`${operation} settlement`, () =>
+          sessionGatewayCommand({
+            op: "complete",
+            sessionId,
+            requestId,
+            operation,
+            result,
+          }),
+        )
+      ).result as T;
     } catch (error) {
       if (!physicalFinished) {
-        await sessionGatewayCommand({
-          op: "fail",
-          sessionId,
-          requestId,
-          operation,
-          error: error instanceof Error ? error.message : String(error),
-          retryable: false,
-        });
+        try {
+          await retryOnKernelSaturation(`${operation} failure settlement`, () =>
+            sessionGatewayCommand({
+              op: "fail",
+              sessionId,
+              requestId,
+              operation,
+              error: error instanceof Error ? error.message : String(error),
+              retryable: false,
+            }),
+          );
+        } catch (settleError) {
+          console.warn(
+            `[session-projection] ${operation} failure settlement did not commit for ${sessionId}:`,
+            settleError instanceof Error ? settleError.message : String(settleError),
+          );
+        }
       }
       throw error;
     }

--- a/packages/core/opensession-server/src/server/system-stats.ts
+++ b/packages/core/opensession-server/src/server/system-stats.ts
@@ -15,6 +15,78 @@
 import { readFileSync, readdirSync, statfsSync } from "node:fs";
 import { cpus, loadavg } from "node:os";
 
+// ── Gateway event-loop lag ──────────────────────────────────────────────────
+// The session-performance contract measures only the CLIENT (docs/
+// session-performance.md); the server had no equivalent, so gateway loop
+// saturation was only discoverable as unexplained global latency. A 100 ms
+// heartbeat records how late each tick fires; the delta over the expected
+// interval is time the loop spent blocked (synchronous SQLite, big JSON,
+// WS fanout). Parked on globalThis (hot-reload safe), armed only from boot
+// via startEventLoopLagMonitor — never at import (AGENTS.md invariant).
+const LAG_TICK_MS = 100;
+const LAG_WINDOW = 600; // ring buffer ≈ last minute
+
+type LoopLagState = {
+	timer?: ReturnType<typeof setInterval>;
+	lastTick: number;
+	ring: Float64Array;
+	ringNext: number;
+	ringFilled: number;
+	/** Cumulative ticks whose lag exceeded 100 ms since boot. */
+	stalls100: number;
+	/** Worst single lag since boot, ms. */
+	worstMs: number;
+};
+
+const lagGlobal = globalThis as typeof globalThis & {
+	__osLoopLag?: LoopLagState;
+};
+
+/** Idempotent; called once from opensession.ts boot. Timer is unref'd so it
+ *  never keeps the process alive. */
+export function startEventLoopLagMonitor(): void {
+	if (lagGlobal.__osLoopLag?.timer) return;
+	const state: LoopLagState = lagGlobal.__osLoopLag ?? {
+		lastTick: performance.now(),
+		ring: new Float64Array(LAG_WINDOW),
+		ringNext: 0,
+		ringFilled: 0,
+		stalls100: 0,
+		worstMs: 0,
+	};
+	lagGlobal.__osLoopLag = state;
+	state.lastTick = performance.now();
+	state.timer = setInterval(() => {
+		const now = performance.now();
+		const lag = Math.max(0, now - state.lastTick - LAG_TICK_MS);
+		state.lastTick = now;
+		state.ring[state.ringNext] = lag;
+		state.ringNext = (state.ringNext + 1) % LAG_WINDOW;
+		if (state.ringFilled < LAG_WINDOW) state.ringFilled++;
+		if (lag > 100) state.stalls100++;
+		if (lag > state.worstMs) state.worstMs = lag;
+	}, LAG_TICK_MS);
+	state.timer.unref?.();
+}
+
+function eventLoopSnapshot(): Record<string, unknown> | null {
+	const state = lagGlobal.__osLoopLag;
+	if (!state || state.ringFilled === 0) return null;
+	const samples = Array.from(state.ring.subarray(0, state.ringFilled)).sort(
+		(a, b) => a - b,
+	);
+	const pick = (p: number) =>
+		samples[Math.min(samples.length - 1, Math.floor(p * samples.length))];
+	return {
+		windowSeconds: Math.round((state.ringFilled * LAG_TICK_MS) / 1000),
+		lagP50Ms: +pick(0.5).toFixed(2),
+		lagP95Ms: +pick(0.95).toFixed(2),
+		lagMaxMs: +samples[samples.length - 1].toFixed(2),
+		stallsOver100MsSinceBoot: state.stalls100,
+		worstMsSinceBoot: +state.worstMs.toFixed(2),
+	};
+}
+
 /** Host metrics for /api/health and the `read_host_metrics` tool. The
  *  health-monitor automation reads these numbers through the tool: it runs
  *  unattended in ask mode, which has no shell on either engine, and it cannot
@@ -47,6 +119,7 @@ export function systemStats(): Record<string, unknown> {
 				swapUsedGb: +(((mem.SwapTotal || 0) - (mem.SwapFree || 0)) / 1e9).toFixed(2),
 			},
 			load: { "1m": load1, "5m": load5, "15m": load15, cores: cpus().length },
+			eventLoop: eventLoopSnapshot(),
 			processes: processCensus(),
 			cgroups: cgroupCensus(),
 		};


### PR DESCRIPTION
## Problem, measured

Benchmarked the transcript write path and the session-kernel RPC wrapper in isolation (temp DBs / temp state dir, port 0 — never the live stores), modeling 100s of concurrent agents:

| Path | Measured |
|---|---|
| Transcript SQLite batch write (5 entries, BEGIN IMMEDIATE) | p50 **0.15 ms**, ~7k entries/s, negligible loop lag |
| Kernel RPC pair wrapped around every append (`request` + `complete`) | p50 **18 ms** serial (admit 10.4 ms + complete 6.9 ms) |
| Kernel store commit (WAL + `synchronous=FULL`) | **3.3 ms** vs 0.005 ms at NORMAL → the RPC cost is mostly the two fsync-backed commits |
| 100 sessions × 20 concurrent waves | **960/2000 append pairs rejected** with retryable `429 Session actor lane is full`; survivor p95 **3.4 s** |

The actor client deliberately retries **reads only**, so a shed mutation fails the transcript projection outright and marks the session transcript-degraded. At 100s of agents that means routine load bursts silently degrade transcripts. (The recent read-burst mailbox work on main is complementary — it addresses read floods; this addresses the mutation side.)

## Fixes

1. **`session-projection-executor.ts` — bounded retry for saturation-class kernel errors** on projection admission and settlement (6 attempts, 50→800 ms backoff, ~1.6 s worst case, well under the client's 15 s deadline). Safe because both sides are idempotent by request id: `requestGatewayCommand` replays a completed receipt and `completeGatewayCommand` returns the stored result. An `in_progress` replay following our own ambiguous admission retry is accepted as the admitted path (the request id is minted locally and never shared).

2. **`host-client.ts` — cap concurrent spawn-failure in-process fallbacks** (default 8, `OPENSESSION_MAX_INPROCESS_FALLBACKS`). The unbounded fallback inverts at fleet scale: exactly when the executor is unhealthy, every launch migrates its engine into the gateway process. Beyond the cap the launch fails visibly (lastRunError + queue restore) instead of silently overloading the shared process. Platforms without run hosts keep in-process as their normal, uncapped path.

3. **`system-stats.ts` — gateway event-loop lag telemetry** (100 ms heartbeat, ~1 min ring buffer, p50/p95/max plus since-boot stall counters), surfaced through `/api/health` and the `read_host_metrics` MCP tool. The session-performance contract measured only the client; this is the server-side counterpart so the gateway ceiling becomes visible before it becomes global latency. Armed from boot via `startEventLoopLagMonitor()`, never at import (check-module-side-effects passes).

## Verification

- `bun test` on `transcript-destination`, `host-client`, `transcript-store`, and the new `session-projection-executor` suites: **78 pass, 0 fail**
- `bun scripts/check-module-side-effects.ts`: clean (495 modules)
- Branch is cut from latest `main` (`d61fadf12`), after the other perf thread's read-burst mailbox changes

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a03fc8-5263-7ff3-b676-5828db59e32c)
