### PR TITLE
Keep transcript feed frames in delivery order

### DIFF
--- a/packages/core/opensession-server/src/server/session-feed.test.ts
+++ b/packages/core/opensession-server/src/server/session-feed.test.ts
@@ -6,6 +6,7 @@ import {
 	sessionFeedSnapshot,
 } from "./session-feed";
 import { onSessionStateChange } from "./session-state-events";
+import { publishTranscript, subscribeTranscript } from "./transcript-bus";
 
 type FeedAppend = Extract<
 	Extract<ProtocolServerMessage, { type: "session_feed" }>["event"],
@@ -46,6 +47,52 @@ describe("session feed", () => {
 		});
 	});
 
+	test("sequences committed frames when their async fan-out delivers", async () => {
+		const sessionId = `feed-${crypto.randomUUID()}`;
+		let committedSeq: number | undefined;
+		const unsubscribe = subscribeTranscript(sessionId, (event) => {
+			committedSeq = event.feed?.feedSeq;
+		});
+		try {
+			publishTranscript(sessionId, {
+				entries: [
+					{
+						id: "call-1",
+						type: "tool_use",
+						content: "Using Read",
+						timestamp: new Date().toISOString(),
+						toolName: "Read",
+						toolUseId: "call-1",
+						toolInput: { path: "README.md" },
+						seq: 1,
+						changeSeq: 1,
+					},
+				],
+				firstSeq: 1,
+				lastSeq: 1,
+			});
+
+			// A runner can emit the next live frame before transcript fan-out's
+			// microtask. Its synchronous delivery must receive the earlier feed
+			// sequence too, or the client advances past and drops the durable call.
+			const live = appendSessionFeed(sessionId, {
+				type: "stream_tool_result",
+				sessionId,
+				entry: {
+					id: "tr-call-1",
+					type: "tool_result",
+					content: "ok",
+					timestamp: new Date().toISOString(),
+					toolUseId: "call-1",
+				},
+			});
+			await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+			expect(committedSeq).toBe(live.feedSeq + 1);
+		} finally {
+			unsubscribe();
+		}
+	});
 
 	test("orders active frames and resumes a true gap", () => {
 		const sessionId = `feed-${crypto.randomUUID()}`;

--- a/packages/core/opensession-server/src/server/transcript-bus.ts
+++ b/packages/core/opensession-server/src/server/transcript-bus.ts
@@ -10,10 +10,10 @@
  * Contract:
  *  - `subscribeTranscript(sessionId, fn)` returns an unsubscribe function.
  *    Call it exactly once from every teardown path (double-unsub is a no-op).
- *  - `publishTranscript(sessionId, payload)` fans out via queueMicrotask —
- *    one microtask per subscriber, each wrapped in try/catch, so a throwing
- *    subscriber can neither break sibling subscribers nor throw back into
- *    the store's append path.
+ *  - `publishTranscript(sessionId, payload)` assigns and fans out the feed
+ *    frame in one microtask. This keeps feed sequence aligned with delivery:
+ *    a synchronous stream event sent before that microtask must sort before
+ *    the committed frame too. Subscriber errors stay isolated.
  *  - Zero runtime imports from engine/run-rpc/session modules (the only
  *    import below is type-only and erased at compile time) — this module is
  *    safe to import from tests and from anywhere in the server graph.
@@ -77,39 +77,41 @@ export function subscribeTranscript(
 
 /**
  * Fan a committed batch out to this session's subscribers. Fire-and-forget:
- * delivery happens on the microtask queue (never synchronously inside the
- * caller's transaction scope) and subscriber errors are isolated.
+ * feed sequencing and delivery happen together on the microtask queue (never
+ * synchronously inside the caller's transaction scope), and subscriber errors
+ * are isolated.
  */
 export function publishTranscript(
   sessionId: string,
   event: TranscriptBusEvent
 ): void {
-  const lastChangeSeq = event.entries.reduce(
-    (last, entry) => Math.max(last, entry.changeSeq),
-    0
-  );
-  const feed = appendSessionFeed(sessionId, {
-    type: "transcript_append",
-    sessionId,
-    entries: event.entries,
-    firstSeq: event.firstSeq,
-    lastSeq: event.lastSeq,
-    ...(lastChangeSeq ? { lastChangeSeq } : {}),
-    v2: true,
-  });
-  const subs = bus().get(sessionId);
-  if (!subs || subs.size === 0) return;
-  // Snapshot so a subscriber unsubscribing (or subscribing) during fan-out
-  // doesn't mutate the set we're iterating.
-  for (const fn of [...subs]) {
-    queueMicrotask(() => {
+  const subscribers = [...(bus().get(sessionId) ?? [])];
+  queueMicrotask(() => {
+    const lastChangeSeq = event.entries.reduce(
+      (last, entry) => Math.max(last, entry.changeSeq),
+      0
+    );
+    // Assign the feed sequence at delivery time. Appending it before this
+    // microtask let a later stream_tool_* frame send synchronously with a
+    // higher sequence first; clients then rejected this durable append as
+    // stale, leaving live tool rows missing until refresh.
+    const feed = appendSessionFeed(sessionId, {
+      type: "transcript_append",
+      sessionId,
+      entries: event.entries,
+      firstSeq: event.firstSeq,
+      lastSeq: event.lastSeq,
+      ...(lastChangeSeq ? { lastChangeSeq } : {}),
+      v2: true,
+    });
+    for (const fn of subscribers) {
       try {
         fn({ ...event, feed });
       } catch (e) {
         console.warn("[transcript-bus] subscriber threw:", e);
       }
-    });
-  }
+    }
+  });
 }
 
 /** Live subscriber count for one session (diagnostics / serve decisions). */


### PR DESCRIPTION
## Summary
- assign committed transcript feed sequence numbers when async fan-out actually delivers
- prevent later live tool frames from advancing clients past durable tool calls
- cover the race with a regression test

## Tests
- `bun test packages/core/opensession-server/src/server/session-feed.test.ts packages/core/opensession-server/src/server/transcript-watch.test.ts packages/core/opensession-server/src/server/transcript-store.test.ts`
- `bun run typecheck` *(blocked by pre-existing errors in the shared uncommitted `scripts/frontend-dev.ts`)*

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a04016-a69e-726a-859a-7b89c23a5b3d)