### PR TITLE
Keep pending prompt on one visual surface

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -194,6 +194,7 @@ import {
 	markPendingBusy,
 	markPendingStarted,
 	type OptimisticPendingPrompt,
+	optimisticOutboxFallbacks,
 	reconcilePending,
 } from "../lib/pending-reconcile";
 import {
@@ -4622,11 +4623,13 @@ export function SessionViewer({
 			.filter((item) => item.state === "failed")
 			.map((item) => `outbox-${item.clientId}`),
 	);
+	const reconciliationNow = Date.now();
+	const deliveryEchoes = [...queued, ...steered];
 	const pendingReconciliation = reconcilePending(
 		pending,
 		entries,
-		[...queued, ...steered],
-		Date.now(),
+		deliveryEchoes,
+		reconciliationNow,
 	);
 	const visiblePending = pending.filter(
 		(item) =>
@@ -4634,10 +4637,34 @@ export function SessionViewer({
 			!pendingReconciliation.landed.has(item.id) &&
 			!pendingReconciliation.expired.has(item.id),
 	);
-	const pendingQueue = visiblePending.filter((p) => p.busyMode || settingUpWorkspace);
-	const pendingBubbles = visiblePending.filter(
-		(p) => !p.busyMode && !settingUpWorkspace,
+	// React pending state, transcript frames, queue echoes and the REST outbox
+	// settle on independent clocks. If the local row drops first, keep a pristine
+	// idle outbox item on the same optimistic surface instead of flashing its
+	// transport-only "Waiting to send" state between two copies of the bubble.
+	const fallbackCandidates = optimisticOutboxFallbacks(
+		outboxItems,
+		new Set(pending.map((item) => item.id)),
+		landedOutboxIds,
 	);
+	const fallbackReconciliation = reconcilePending(
+		fallbackCandidates,
+		entries,
+		deliveryEchoes,
+		reconciliationNow,
+	);
+	const fallbackPending = fallbackCandidates.filter(
+		(item) =>
+			!fallbackReconciliation.landed.has(item.id) &&
+			!fallbackReconciliation.expired.has(item.id),
+	);
+	const pendingQueue = [
+		...visiblePending.filter((p) => p.busyMode || settingUpWorkspace),
+		...(settingUpWorkspace ? fallbackPending : []),
+	];
+	const pendingBubbles = [
+		...visiblePending.filter((p) => !p.busyMode && !settingUpWorkspace),
+		...(settingUpWorkspace ? [] : fallbackPending),
+	];
 	const optimisticTranscriptEntries: TranscriptEntry[] =
 		pendingBubbles.length === 0
 			? EMPTY_TRANSCRIPT_ENTRIES
@@ -4648,17 +4675,14 @@ export function SessionViewer({
 					timestamp: new Date(pending.sentAt).toISOString(),
 					...(pending.images?.length ? { images: pending.images } : {}),
 				}));
-	// The durable row covers a prompt the store still holds: one this tab never
-	// showed a bubble for (another tab's send, or a reload), or one whose bubble
-	// is still up. A prompt already confirmed by the server is dropped from the
-	// row instead of rendering twice. Dropped, not discarded: the store is
-	// localStorage-backed and cross-tab, so a discard is durable and a wrong
-	// match would lose the message, while a wrong hide only costs a row until
-	// delivery removes the item itself.
+	// Retried, failed and authoritatively busy prompts keep the explicit outbox
+	// surface. A pristine idle item is already represented by the fallback above.
+	const fallbackIds = new Set(fallbackCandidates.map((item) => item.id));
 	const durableOutbox = outboxItems.filter(
 		(item) =>
 			item.state === "failed" ||
-			(!pending.some((entry) => entry.id === `outbox-${item.clientId}`) &&
+			(!fallbackIds.has(`outbox-${item.clientId}`) &&
+				!pending.some((entry) => entry.id === `outbox-${item.clientId}`) &&
 				!landedOutboxIds.has(`outbox-${item.clientId}`)),
 	);
 	const hasLiveConversation =

--- a/packages/core/opensession-server/src/frontend/lib/pending-reconcile.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/pending-reconcile.test.ts
@@ -3,9 +3,11 @@ import {
 	markPendingBusy,
 	markPendingStarted,
 	type OptimisticPendingPrompt,
+	optimisticOutboxFallbacks,
 	PENDING_GIVE_UP_MS,
 	reconcilePending,
 } from "./pending-reconcile";
+import type { PromptOutboxItem } from "./prompt-outbox";
 
 const SENT = 1_000_000;
 const bubble = (id: string, content: string, user?: string) => ({
@@ -18,6 +20,63 @@ const entry = (content: string, at = SENT) => ({
 	type: "user",
 	content,
 	timestamp: new Date(at).toISOString(),
+});
+
+const outboxItem = (
+	overrides: Partial<PromptOutboxItem> = {},
+): PromptOutboxItem => ({
+	clientId: "a",
+	sessionId: "session",
+	content: "ship it",
+	state: "pending",
+	attempts: 0,
+	createdAt: SENT,
+	nextAttemptAt: SENT,
+	...overrides,
+});
+
+describe("optimisticOutboxFallbacks", () => {
+	test("keeps a pristine idle outbox handoff on the transcript surface", () => {
+		expect(optimisticOutboxFallbacks([outboxItem()], new Set(), new Set())).toEqual([
+			{
+				id: "outbox-a",
+				content: "ship it",
+				user: undefined,
+				sentAt: SENT,
+			},
+		]);
+	});
+
+	test("does not duplicate a local pending row or a landed delivery", () => {
+		expect(
+			optimisticOutboxFallbacks(
+				[outboxItem()],
+				new Set(["outbox-a"]),
+				new Set(),
+			),
+		).toEqual([]);
+		expect(
+			optimisticOutboxFallbacks(
+				[outboxItem()],
+				new Set(),
+				new Set(["outbox-a"]),
+			),
+		).toEqual([]);
+	});
+
+	test("leaves real queue placement and retry feedback in the outbox", () => {
+		expect(
+			optimisticOutboxFallbacks(
+				[
+					outboxItem({ busyMode: "queue" }),
+					outboxItem({ clientId: "b", attempts: 1 }),
+					outboxItem({ clientId: "c", state: "failed" }),
+				],
+				new Set(),
+				new Set(),
+			),
+		).toEqual([]);
+	});
 });
 
 describe("markPendingStarted", () => {

--- a/packages/core/opensession-server/src/frontend/lib/pending-reconcile.ts
+++ b/packages/core/opensession-server/src/frontend/lib/pending-reconcile.ts
@@ -1,3 +1,5 @@
+import type { PromptOutboxItem } from "./prompt-outbox";
+
 /**
  * Which optimistic "just sent" bubbles the server has accounted for.
  *
@@ -28,6 +30,36 @@ export interface PendingPrompt {
 export interface OptimisticPendingPrompt extends PendingPrompt {
 	images?: string[];
 	busyMode?: "queue" | "steer";
+}
+
+/**
+ * A pristine idle outbox item is the same optimistic message even when React's
+ * local pending row has already reconciled or has not committed yet. Project it
+ * onto the transcript instead of exposing the outbox's transport status.
+ */
+export function optimisticOutboxFallbacks(
+	items: readonly PromptOutboxItem[],
+	pendingIds: ReadonlySet<string>,
+	landedIds: ReadonlySet<string>,
+): OptimisticPendingPrompt[] {
+	return items
+		.filter((item) => {
+			const id = `outbox-${item.clientId}`;
+			return (
+				item.state !== "failed" &&
+				item.attempts === 0 &&
+				!item.busyMode &&
+				!pendingIds.has(id) &&
+				!landedIds.has(id)
+			);
+		})
+		.map((item) => ({
+			id: `outbox-${item.clientId}`,
+			content: item.content,
+			user: item.user,
+			sentAt: item.createdAt,
+			...(item.images?.length ? { images: item.images } : {}),
+		}));
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep pristine idle outbox items on the optimistic transcript surface during React/outbox handoff gaps
- reserve explicit waiting UI for retries, failures, and authoritatively queued messages
- cover pending, landed, queued, retry, and failure projections

## Root cause
The first fix stopped transient actor queue echoes from claiming the optimistic row. A second independent handoff remained: React pending state, transcript frames, and the localStorage REST outbox settle on separate tasks. When the pending row retired before the outbox request did, the same pristine message briefly fell through to the transport-only “Waiting to send” row, then returned when admission completed.

## Verification
- `bun test packages/core/opensession-server/src/frontend/lib/pending-reconcile.test.ts packages/core/opensession-server/src/frontend/lib/prompt-outbox.test.ts packages/core/opensession-server/src/frontend/components/session-viewer`
- `bun scripts/check-react-compiler.ts`
- `bunx oxlint packages/core/opensession-server/src/frontend/lib/pending-reconcile.ts packages/core/opensession-server/src/frontend/lib/pending-reconcile.test.ts packages/core/opensession-server/src/frontend/components/SessionViewer.tsx`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a03ffb-1945-7cd0-b872-d40ea5a855d5)
