### PR TITLE
Scale session concurrency with resource-aware admission

### DIFF
--- a/docs/executor-architecture.md
+++ b/docs/executor-architecture.md
@@ -51,6 +51,37 @@ raw `systemd-run` or arbitrary `systemctl` arguments. If the executor restarts
 while a launch is in progress, the next request reconciles the existing unit and
 host socket instead of starting a second run.
 
+## Capacity controls
+
+Before persisting a detached launch, the gateway checks the active and pending
+host count, Linux `MemAvailable`, and CPU PSI `some avg10`. A launch waits with
+bounded backoff when a present signal is over its limit. Missing `/proc` signals
+fail open so non-Linux development remains usable. After the admission timeout,
+the turn fails visibly instead of falling back into the gateway process and
+consuming the same scarce resources.
+
+Gateway settings can be placed in `~/.opensession.env`:
+
+| Setting                                         | Default | Purpose                                  |
+| ----------------------------------------------- | ------: | ---------------------------------------- |
+| `OPENSESSION_RUN_HOST_MAX_ACTIVE`               |     128 | Active plus admitted detached hosts      |
+| `OPENSESSION_RUN_HOST_MIN_AVAILABLE_MB`         |    4096 | Memory headroom retained for the machine |
+| `OPENSESSION_RUN_HOST_RESERVED_MB`              |    1024 | Memory reserved for each pending launch  |
+| `OPENSESSION_RUN_HOST_MAX_CPU_PRESSURE`         |      85 | Maximum CPU PSI `some avg10` percentage  |
+| `OPENSESSION_RUN_HOST_ADMISSION_TIMEOUT_S`      |     900 | Maximum capacity wait before refusal     |
+| `OPENSESSION_ONESHOT_CONCURRENCY`               |       4 | Concurrent gateway one-shot jobs         |
+| `OPENSESSION_OPENING_TURN_CONCURRENCY`          |       8 | Concurrent session opening turns         |
+| `OPENSESSION_KERNEL_TIMER_CONCURRENCY`          |       8 | Concurrent durable timer effects         |
+| `OPENSESSION_KERNEL_OUTBOX_CONCURRENCY`         |       8 | Concurrent general outbox effects        |
+| `OPENSESSION_KERNEL_OPENING_OUTBOX_CONCURRENCY` |     100 | Concurrent opening-turn effects          |
+
+The independently supervised executor does not read `~/.opensession.env`. Set
+`OPENSESSION_EXECUTOR_LAUNCH_CONCURRENCY` (default 8) with an `Environment=`
+systemd drop-in on `opensession-executor.service`.
+
+All overrides are bounded integers. Invalid or out-of-range values log an error
+and retain the built-in default.
+
 ## Failure behavior
 
 | Failure | Behavior |

--- a/packages/core/opensession-server/src/executor/coordinator.ts
+++ b/packages/core/opensession-server/src/executor/coordinator.ts
@@ -18,6 +18,7 @@ import {
   runHostsDir,
 } from "../runner-host/protocol";
 import { writeJsonAtomic } from "../server/shared/atomic-write";
+import { envCapacity } from "../server/shared/env-capacity";
 import {
   hostUnitActive,
   launchHostUnitDirect,
@@ -27,6 +28,16 @@ import {
 import { timingSafeEqual } from "crypto";
 
 const HOST_ID_RE = /^rh-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Bounds concurrent launch requests crossing the control socket, not active
+// hosts. Executor service process: it does not load ~/.opensession.env, so an
+// override only takes effect through a systemd drop-in on
+// opensession-executor.service.
+const LAUNCH_INFLIGHT_LIMIT = envCapacity(
+  "OPENSESSION_EXECUTOR_LAUNCH_CONCURRENCY",
+  8,
+  1,
+  64,
+);
 const HASH_RE = /^[0-9a-f]{64}$/i;
 
 interface LaunchRecord {
@@ -263,7 +274,7 @@ export class ExecutorCoordinator {
       }
       return active.promise;
     }
-    if (this.inflight.size >= 8) {
+    if (this.inflight.size >= LAUNCH_INFLIGHT_LIMIT) {
       throw new CoordinatorError(
         "executor_busy",
         "executor launch capacity is full; retry shortly",

--- a/packages/core/opensession-server/src/server/host-admission.test.ts
+++ b/packages/core/opensession-server/src/server/host-admission.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decideRunHostAdmission,
+  readCpuSomeAvg10,
+  readMemAvailableMb,
+  RunHostAdmissionError,
+  waitForRunHostAdmission,
+  type HostAdmissionLimits,
+  type HostCapacitySnapshot,
+} from "./host-admission";
+
+const limits: HostAdmissionLimits = {
+  maxActiveHosts: 4,
+  minAvailableMb: 1_000,
+  reservedPerHostMb: 500,
+  maxCpuPressure: 85,
+  admissionTimeoutMs: 10_000,
+};
+
+const roomy: HostCapacitySnapshot = {
+  memAvailableMb: 8_000,
+  cpuSomeAvg10: 5,
+  activeHosts: 1,
+  pendingHosts: 0,
+};
+
+describe("decideRunHostAdmission", () => {
+  test("admits with headroom", () => {
+    expect(decideRunHostAdmission(roomy, limits)).toEqual({ admit: true });
+  });
+
+  test("refuses at the active host cap", () => {
+    const decision = decideRunHostAdmission(
+      { ...roomy, activeHosts: 4 },
+      limits,
+    );
+    expect(decision.admit).toBe(false);
+    if (!decision.admit) expect(decision.reason).toContain("4/4");
+  });
+
+  test("refuses when reserving the host would break the memory floor", () => {
+    // 1400 - 500 reserved = 900 < 1000 floor.
+    const decision = decideRunHostAdmission(
+      { ...roomy, memAvailableMb: 1_400 },
+      limits,
+    );
+    expect(decision.admit).toBe(false);
+    // Exactly at the floor admits.
+    expect(
+      decideRunHostAdmission({ ...roomy, memAvailableMb: 1_500 }, limits),
+    ).toEqual({ admit: true });
+  });
+
+  test("reserves memory and host slots for pending launches", () => {
+    expect(
+      decideRunHostAdmission(
+        { ...roomy, activeHosts: 2, pendingHosts: 2 },
+        limits,
+      ).admit,
+    ).toBe(false);
+    expect(
+      decideRunHostAdmission(
+        { ...roomy, memAvailableMb: 2_400, pendingHosts: 2 },
+        limits,
+      ).admit,
+    ).toBe(false);
+  });
+
+  test("refuses under CPU pressure", () => {
+    const decision = decideRunHostAdmission(
+      { ...roomy, cpuSomeAvg10: 92.5 },
+      limits,
+    );
+    expect(decision.admit).toBe(false);
+  });
+
+  test("missing signals fail open", () => {
+    expect(
+      decideRunHostAdmission(
+        {
+          memAvailableMb: null,
+          cpuSomeAvg10: null,
+          activeHosts: 0,
+          pendingHosts: 0,
+        },
+        limits,
+      ),
+    ).toEqual({ admit: true });
+  });
+});
+
+describe("proc parsing", () => {
+  test("parses MemAvailable in MiB", () => {
+    const read = () =>
+      "MemTotal:       128000000 kB\nMemAvailable:   116736000 kB\n";
+    expect(readMemAvailableMb(read)).toBe(114_000);
+    expect(readMemAvailableMb(() => "")).toBeNull();
+  });
+
+  test("parses CPU PSI some avg10", () => {
+    const read = () =>
+      "some avg10=12.34 avg60=5.00 avg300=1.00 total=1\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n";
+    expect(readCpuSomeAvg10(read)).toBe(12.34);
+    expect(readCpuSomeAvg10(() => "")).toBeNull();
+  });
+});
+
+describe("waitForRunHostAdmission", () => {
+  test("admits immediately without sleeping when capacity exists", async () => {
+    let slept = 0;
+    const result = await waitForRunHostAdmission({
+      sessionId: "s1",
+      activeHosts: () => 1,
+      limits,
+      snapshot: (activeHosts) => ({ ...roomy, activeHosts }),
+      sleep: async () => {
+        slept += 1;
+      },
+    });
+    expect(result).toBe("admitted");
+    expect(slept).toBe(0);
+  });
+
+  test("waits with backoff until capacity appears", async () => {
+    const sleeps: number[] = [];
+    let mem = 1_000;
+    const result = await waitForRunHostAdmission({
+      sessionId: "s2",
+      activeHosts: () => 1,
+      limits,
+      snapshot: (activeHosts, pendingHosts) => ({
+        ...roomy,
+        memAvailableMb: mem,
+        activeHosts,
+        pendingHosts,
+      }),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        if (sleeps.length === 3) mem = 8_000;
+      },
+      now: () => 0,
+    });
+    expect(result).toBe("admitted");
+    expect(sleeps).toEqual([1_000, 2_000, 4_000]);
+  });
+
+  test("reserves admission before another caller can pass", async () => {
+    const oneHostLimit = { ...limits, maxActiveHosts: 1 };
+    let pendingHosts = 0;
+    const first = await waitForRunHostAdmission({
+      sessionId: "first",
+      activeHosts: () => 0,
+      pendingHosts: () => pendingHosts,
+      onAdmit: () => {
+        pendingHosts += 1;
+      },
+      limits: oneHostLimit,
+      snapshot: (activeHosts, pending) => ({
+        ...roomy,
+        activeHosts,
+        pendingHosts: pending,
+      }),
+    });
+    expect(first).toBe("admitted");
+    expect(pendingHosts).toBe(1);
+
+    let slept = false;
+    const second = await waitForRunHostAdmission({
+      sessionId: "second",
+      activeHosts: () => 0,
+      pendingHosts: () => pendingHosts,
+      onAdmit: () => {
+        pendingHosts += 1;
+      },
+      limits: oneHostLimit,
+      snapshot: (activeHosts, pending) => ({
+        ...roomy,
+        activeHosts,
+        pendingHosts: pending,
+      }),
+      sleep: async () => {
+        slept = true;
+        pendingHosts -= 1;
+      },
+      now: () => 0,
+    });
+    expect(second).toBe("admitted");
+    expect(slept).toBe(true);
+    expect(pendingHosts).toBe(1);
+  });
+
+  test("cancellation wins over waiting", async () => {
+    let cancelled = false;
+    const result = await waitForRunHostAdmission({
+      sessionId: "s3",
+      activeHosts: () => 4,
+      shouldCancel: () => cancelled,
+      limits,
+      snapshot: (activeHosts) => ({ ...roomy, activeHosts }),
+      sleep: async () => {
+        cancelled = true;
+      },
+      now: () => 0,
+    });
+    expect(result).toBe("cancelled");
+  });
+
+  test("fails closed with a distinct error after the timeout", async () => {
+    let clock = 0;
+    await expect(
+      waitForRunHostAdmission({
+        sessionId: "s4",
+        activeHosts: () => 4,
+        limits,
+        snapshot: (activeHosts) => ({ ...roomy, activeHosts }),
+        sleep: async (ms) => {
+          clock += ms;
+        },
+        now: () => clock,
+      }),
+    ).rejects.toBeInstanceOf(RunHostAdmissionError);
+  });
+});

--- a/packages/core/opensession-server/src/server/host-admission.ts
+++ b/packages/core/opensession-server/src/server/host-admission.ts
@@ -1,0 +1,235 @@
+/**
+ * Resource-aware admission for detached run-host launches.
+ *
+ * Every accepted prompt used to launch its engine process unconditionally,
+ * so the first hard wall under load was the machine itself: nothing stopped
+ * the Nth engine from exhausting memory and taking the gateway and kernel
+ * down with the agents. Before each launch the gateway now checks live
+ * capacity — MemAvailable, CPU pressure (PSI), and the active host count —
+ * and waits with bounded backoff instead of starting into an overload.
+ *
+ * Waiting is deliberately in-memory: the prompt's queue claim and run journal
+ * are already durable, so a crash while waiting re-admits the same turn.
+ * Missing signals fail open (a machine without /proc must not stop launches);
+ * present signals fail the launch closed only after the configured patience
+ * runs out, with a distinct error type so callers do not "fall back" to an
+ * in-process run that would consume the same scarce memory.
+ *
+ * Gateway process: knobs read ~/.opensession.env (or a drop-in on
+ * opensession.service).
+ */
+import { readFileSync } from "fs";
+import { audit } from "./audit";
+import { envCapacity } from "./shared/env-capacity";
+
+export type HostAdmissionLimits = {
+  /** Hard cap on concurrently active detached hosts. */
+  maxActiveHosts: number;
+  /** MemAvailable floor that must remain after reserving the new host. */
+  minAvailableMb: number;
+  /** Expected worst-typical footprint reserved for the host being admitted. */
+  reservedPerHostMb: number;
+  /** Maximum acceptable CPU PSI some avg10 percentage. */
+  maxCpuPressure: number;
+  /** How long a launch may wait for capacity before failing closed. */
+  admissionTimeoutMs: number;
+};
+
+export function hostAdmissionLimits(): HostAdmissionLimits {
+  return {
+    maxActiveHosts: envCapacity(
+      "OPENSESSION_RUN_HOST_MAX_ACTIVE",
+      128,
+      1,
+      4_096,
+    ),
+    minAvailableMb: envCapacity(
+      "OPENSESSION_RUN_HOST_MIN_AVAILABLE_MB",
+      4_096,
+      256,
+      1_048_576,
+    ),
+    reservedPerHostMb: envCapacity(
+      "OPENSESSION_RUN_HOST_RESERVED_MB",
+      1_024,
+      0,
+      65_536,
+    ),
+    maxCpuPressure: envCapacity(
+      "OPENSESSION_RUN_HOST_MAX_CPU_PRESSURE",
+      85,
+      1,
+      100,
+    ),
+    admissionTimeoutMs:
+      envCapacity("OPENSESSION_RUN_HOST_ADMISSION_TIMEOUT_S", 900, 10, 86_400) *
+      1_000,
+  };
+}
+
+export type HostCapacitySnapshot = {
+  /** MemAvailable in MiB, or null when the signal is unavailable. */
+  memAvailableMb: number | null;
+  /** CPU PSI `some avg10` percentage, or null when unavailable. */
+  cpuSomeAvg10: number | null;
+  /** Currently active detached hosts on this gateway. */
+  activeHosts: number;
+  /** Launches admitted but not yet reflected in MemAvailable. */
+  pendingHosts: number;
+};
+
+export function readMemAvailableMb(
+  read: (path: string) => string = readProcFile,
+): number | null {
+  const match = /MemAvailable:\s+(\d+)\s*kB/.exec(read("/proc/meminfo"));
+  return match ? Math.floor(Number(match[1]) / 1_024) : null;
+}
+
+export function readCpuSomeAvg10(
+  read: (path: string) => string = readProcFile,
+): number | null {
+  const match = /some avg10=([\d.]+)/.exec(read("/proc/pressure/cpu"));
+  return match ? Number(match[1]) : null;
+}
+
+function readProcFile(path: string): string {
+  try {
+    // Failures (macOS, containers without PSI) simply disable that signal.
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export type AdmissionDecision =
+  | { admit: true }
+  | { admit: false; reason: string };
+
+/** Pure decision: admit unless a *present* signal says the machine is full. */
+export function decideRunHostAdmission(
+  snapshot: HostCapacitySnapshot,
+  limits: HostAdmissionLimits,
+): AdmissionDecision {
+  const admittedHosts = snapshot.activeHosts + snapshot.pendingHosts;
+  if (admittedHosts >= limits.maxActiveHosts)
+    return {
+      admit: false,
+      reason: `active and pending run hosts at cap (${admittedHosts}/${limits.maxActiveHosts})`,
+    };
+  const reservedMb = limits.reservedPerHostMb * (snapshot.pendingHosts + 1);
+  if (
+    snapshot.memAvailableMb !== null &&
+    snapshot.memAvailableMb - reservedMb < limits.minAvailableMb
+  )
+    return {
+      admit: false,
+      reason: `MemAvailable ${snapshot.memAvailableMb}MiB would drop below the ${limits.minAvailableMb}MiB floor after reserving ${reservedMb}MiB`,
+    };
+  if (
+    snapshot.cpuSomeAvg10 !== null &&
+    snapshot.cpuSomeAvg10 > limits.maxCpuPressure
+  )
+    return {
+      admit: false,
+      reason: `CPU pressure some avg10 ${snapshot.cpuSomeAvg10}% exceeds ${limits.maxCpuPressure}%`,
+    };
+  return { admit: true };
+}
+
+/** Launch was refused because capacity never appeared within the timeout.
+ * Callers must fail the turn visibly, not fall back to an in-process run. */
+export class RunHostAdmissionError extends Error {
+  constructor(reason: string) {
+    super(`Run host launch refused: ${reason}`);
+    this.name = "RunHostAdmissionError";
+  }
+}
+
+export type WaitForAdmissionOptions = {
+  sessionId: string;
+  activeHosts: () => number;
+  pendingHosts?: () => number;
+  /** Reserve capacity synchronously with a successful decision. */
+  onAdmit?: () => void;
+  shouldCancel?: () => boolean;
+  limits?: HostAdmissionLimits;
+  snapshot?: (
+    activeHosts: number,
+    pendingHosts: number,
+  ) => HostCapacitySnapshot;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+};
+
+function defaultSnapshot(
+  activeHosts: number,
+  pendingHosts: number,
+): HostCapacitySnapshot {
+  return {
+    memAvailableMb: readMemAvailableMb(),
+    cpuSomeAvg10: readCpuSomeAvg10(),
+    activeHosts,
+    pendingHosts,
+  };
+}
+
+/**
+ * Wait until the machine can take one more run host. Returns "admitted" or
+ * "cancelled"; throws RunHostAdmissionError when the timeout elapses while
+ * the machine is still full.
+ */
+export async function waitForRunHostAdmission(
+  options: WaitForAdmissionOptions,
+): Promise<"admitted" | "cancelled"> {
+  const limits = options.limits ?? hostAdmissionLimits();
+  const snapshot = options.snapshot ?? defaultSnapshot;
+  const sleep = options.sleep ?? ((ms: number) => Bun.sleep(ms));
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  let waited = false;
+  let backoffMs = 1_000;
+  let lastReason = "";
+  for (;;) {
+    if (options.shouldCancel?.()) return "cancelled";
+    const decision = decideRunHostAdmission(
+      snapshot(options.activeHosts(), options.pendingHosts?.() ?? 0),
+      limits,
+    );
+    if (decision.admit) {
+      if (waited)
+        audit({
+          msg: "run_host_admission_resumed",
+          session_id: options.sessionId,
+          waited_ms: now() - startedAt,
+        });
+      // No await separates the final capacity check from this reservation.
+      // Concurrent callers therefore see it in their own pendingHosts count.
+      options.onAdmit?.();
+      return "admitted";
+    }
+    if (!waited || decision.reason !== lastReason) {
+      audit({
+        msg: "run_host_admission_wait",
+        session_id: options.sessionId,
+        reason: decision.reason,
+      });
+      console.warn(
+        `[host-admission] deferring run host launch for ${options.sessionId}: ${decision.reason}`,
+      );
+    }
+    waited = true;
+    lastReason = decision.reason;
+    if (now() - startedAt >= limits.admissionTimeoutMs) {
+      audit({
+        msg: "run_host_admission_refused",
+        session_id: options.sessionId,
+        reason: decision.reason,
+        waited_ms: now() - startedAt,
+      });
+      throw new RunHostAdmissionError(decision.reason);
+    }
+    const remainingMs = limits.admissionTimeoutMs - (now() - startedAt);
+    await sleep(Math.min(backoffMs, remainingMs));
+    backoffMs = Math.min(30_000, backoffMs * 2);
+  }
+}

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -28,6 +28,7 @@
 
 import type { McpScope } from "./runner-shared";
 import { audit } from "./audit";
+import { waitForRunHostAdmission } from "./host-admission";
 import {
   isRetryableSessionCommandError,
   sessionKernel,
@@ -63,6 +64,7 @@ import {
   addHostRunKey,
   unregisterHostRun,
   hostRunBusy,
+  hostRunCount,
   type HostRunControl,
 } from "./host-registry";
 import { registerRunToken, unregisterRunToken } from "./run-rpc";
@@ -149,9 +151,20 @@ const DISABLE_FILE = `${OPENSESSION_SESSIONS_DIR}/disable-run-hosts`;
 // registration takes over once launch completes.
 const activeHostedRunKeys: Set<string> = ((globalThis as any)
   .__activeHostedRunKeys ??= new Set());
+const pendingRunHostAdmissions: Set<symbol> = ((globalThis as any)
+  .__pendingRunHostAdmissions ??= new Set());
 registerActiveRunProbe(
   (runKey) => activeHostedRunKeys.has(runKey) || hostRunBusy(runKey),
 );
+
+function activeRunHostCount(): number {
+  // HostHandle registration includes spawned and reattached runs. Add only keys
+  // still in the pre-handle launch window, avoiding double-counting the rest.
+  const launchesWithoutHandle = [...activeHostedRunKeys].filter(
+    (runKey) => !hostRunBusy(runKey),
+  ).length;
+  return hostRunCount() + launchesWithoutHandle;
+}
 
 export function localRunHostsSupported(
   platform = process.platform,
@@ -259,10 +272,35 @@ export interface HostedRunOpts {
 export async function* runAgentHosted(opts: HostedRunOpts): AsyncGenerator<StreamEvent> {
   if (opts.shouldCancel?.()) return;
   if (runHostsEnabled()) {
+    // Machine-capacity admission before the engine process exists. Waits with
+    // backoff while the host is full (the queue claim and journal are already
+    // durable, so a crash mid-wait re-admits the turn) and fails closed after
+    // the configured patience: an in-process fallback would consume the same
+    // scarce memory, so RunHostAdmissionError deliberately propagates.
+    const admission = Symbol(opts.osSessionId);
+    if (
+      (await waitForRunHostAdmission({
+        sessionId: opts.osSessionId,
+        activeHosts: activeRunHostCount,
+        pendingHosts: () => pendingRunHostAdmissions.size,
+        onAdmit: () => pendingRunHostAdmissions.add(admission),
+        shouldCancel: opts.shouldCancel,
+      })) === "cancelled"
+    )
+      return;
+    if (opts.shouldCancel?.()) {
+      pendingRunHostAdmissions.delete(admission);
+      return;
+    }
     let spawned: { handle: HostHandle; spec: RunHostSpec } | null = null;
     try {
-      spawned = await spawnHostRun(opts);
+      // spawnHostRun reserves activeHostedRunKeys synchronously before its first
+      // await. Transfer the admission reservation without opening a race.
+      const launch = spawnHostRun(opts);
+      pendingRunHostAdmissions.delete(admission);
+      spawned = await launch;
     } catch (e) {
+      pendingRunHostAdmissions.delete(admission);
       if (e instanceof ExecutorProtocolError && e.ambiguousLaunch) throw e;
       console.error("[host-client] spawn failed — falling back to in-process run:", e);
     }

--- a/packages/core/opensession-server/src/server/one-shot.ts
+++ b/packages/core/opensession-server/src/server/one-shot.ts
@@ -20,13 +20,16 @@ import {
   type SessionEffort,
 } from "./models";
 import { isShuttingDown } from "./shutdown-state";
+import { envCapacity } from "./shared/env-capacity";
 
 const DEFAULT_ONESHOT_MODEL = "pi/anthropic/claude-haiku-4-5";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const ONESHOT_CWD = `${PI_STATE_DIR}/oneshot`;
-const ONESHOT_CONCURRENCY = Math.max(
+const ONESHOT_CONCURRENCY = envCapacity(
+  "OPENSESSION_ONESHOT_CONCURRENCY",
+  4,
   1,
-  Number(process.env.OPENSESSION_ONESHOT_CONCURRENCY || 4),
+  64,
 );
 
 type OneShotPool = {

--- a/packages/core/opensession-server/src/server/session-create.ts
+++ b/packages/core/opensession-server/src/server/session-create.ts
@@ -79,6 +79,7 @@ import {
 import { ownedWorktree } from "./session-workspace";
 import { engineSessionPatch } from "./sessions";
 import { commitAuthorFor, userMatchesAny } from "./shared/user-mappings";
+import { envCapacity } from "./shared/env-capacity";
 import { sanitizeBranchSlug } from "./suggest-branch";
 import { type NativeSessionFile, type SessionUsage, type UnifiedSession, } from "./types";
 import { storeAppendUserLineEarly, transcriptLineUser } from "./transcript-persistence";
@@ -414,7 +415,15 @@ const activeOpeningCreates = new Map<
 	}
 >();
 
-const OPENING_TURN_CONCURRENCY = 8;
+// Bounds concurrent opening turns (worktree materialization, deps install,
+// repo attach and the opening engine turn). Gateway process: configurable via
+// ~/.opensession.env or a systemd drop-in.
+const OPENING_TURN_CONCURRENCY = envCapacity(
+	"OPENSESSION_OPENING_TURN_CONCURRENCY",
+	8,
+	1,
+	64,
+);
 type OpeningTurnGate = {
 	active: number;
 	waiters: Array<(release: () => void) => void>;

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
@@ -485,6 +485,41 @@ describe("session kernel actor service", () => {
     expect(unauthorized.status).toBe(401);
   });
 
+  test("reports per-lane occupancy and cumulative counters on /ready", async () => {
+    // Complete at least one turn so counters have advanced.
+    await rpc({
+      t: "call",
+      rpcId: crypto.randomUUID(),
+      outputBytes: 256 * 1024,
+      request: { t: "store", method: "stats", args: [] },
+    });
+    const ready = (await (await fetch(`${service.url}/ready`)).json()) as {
+      workers: { capacity: number };
+      lanes: Array<Record<string, unknown>>;
+    };
+    // Catalog lane (index 0) plus every session lane.
+    expect(ready.lanes.length).toBe(ready.workers.capacity + 1);
+    for (const lane of ready.lanes) {
+      expect(lane).toMatchObject({ ready: true, restarting: false });
+      expect(typeof lane.index).toBe("number");
+      expect(typeof lane.queued).toBe("number");
+      expect(typeof lane.executing).toBe("number");
+      expect(typeof lane.turnsCompleted).toBe("number");
+      expect(typeof lane.queueWaitMsTotal).toBe("number");
+      expect(typeof lane.busyMsTotal).toBe("number");
+      expect(typeof lane.timeouts).toBe("number");
+      expect(typeof lane.restarts).toBe("number");
+      expect(typeof lane.rejectedFull).toBe("number");
+    }
+    // The handshake and at least one call ran somewhere: total completed turns
+    // across lanes must have advanced.
+    const completed = ready.lanes.reduce(
+      (total, lane) => total + Number(lane.turnsCompleted),
+      0,
+    );
+    expect(completed).toBeGreaterThan(0);
+  });
+
   test("refuses to send the actor credential off host", () => {
     const previous = process.env.OPENSESSION_SESSION_KERNEL_URL;
     process.env.OPENSESSION_SESSION_KERNEL_URL = "https://example.com/rpc";

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
@@ -19,6 +19,7 @@ import {
 } from "./actor-routing";
 import { READ_METHODS } from "./store-routing";
 import { workerEntry } from "../../runner-host/exe";
+import { chooseSessionLane, type LaneLoad } from "./lane-placement";
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 3849;
@@ -260,6 +261,11 @@ export async function startSessionKernelService(
   );
   const sessionSlots = slots.slice(1);
   const sessionMailboxes = new Map<string, SessionMailbox>();
+  // Sticky lane pins (session id -> lane), bounded and LRU-evicted only when
+  // the pinned session's mailbox is idle. Sized well above the open-store
+  // bound per lane so an active working set never cycles pins.
+  const MAX_LANE_PINS = 8_192;
+  const lanePins = new Map<string, WorkerSlot>();
   let queuedSessionTurns = 0;
   let queuedGlobalTurns = 0;
   let admittedTransportRequests = 0;
@@ -565,15 +571,42 @@ export async function startSessionKernelService(
   }
 
   function assignedSessionSlot(sessionId: string): WorkerSlot {
-    // Stable affinity keeps one logical actor's in-memory SQLite/cache state on
-    // one lane until that lane restarts. The durable database remains the
-    // authority and is rehydrated after restart or LRU passivation.
-    let hash = 2_166_136_261;
-    for (let index = 0; index < sessionId.length; index += 1) {
-      hash ^= sessionId.charCodeAt(index);
-      hash = Math.imul(hash, 16_777_619);
+    // Sticky affinity keeps one logical actor's in-memory SQLite/cache state on
+    // one lane. The durable database remains the authority and is rehydrated
+    // after restart or LRU passivation. Placement is two-choice: the session's
+    // two rendezvous candidates are fixed by its id, and the quieter one is
+    // pinned when the session first becomes active. A pin never moves while
+    // the session's mailbox is live; it can only be dropped between turns by
+    // the bounded pin cache, after which the next activation re-chooses.
+    const pinned = lanePins.get(sessionId);
+    if (pinned) {
+      lanePins.delete(sessionId);
+      lanePins.set(sessionId, pinned);
+      return pinned;
     }
-    return sessionSlots[(hash >>> 0) % sessionSlots.length]!;
+    const loads: LaneLoad[] = sessionSlots.map((slot) => ({
+      // A restarting lane retries quickly; weigh it as a full queue rather
+      // than excluding it so both candidates stay usable.
+      queued: slot.queue.length + (slot.ready ? 0 : laneQueueLimit),
+      executing: slot.pending.size,
+    }));
+    const chosen = sessionSlots[chooseSessionLane(sessionId, loads)]!;
+    while (lanePins.size >= MAX_LANE_PINS) {
+      // Evict the least recently used pin whose mailbox is idle. An active
+      // mailbox is never unpinned; if every pin is active, exceed the bound
+      // rather than move live work.
+      let evicted = false;
+      for (const key of lanePins.keys()) {
+        if (!sessionMailboxes.has(key)) {
+          lanePins.delete(key);
+          evicted = true;
+          break;
+        }
+      }
+      if (!evicted) break;
+    }
+    lanePins.set(sessionId, chosen);
+    return chosen;
   }
 
   function pumpSessionMailbox(sessionId: string, mailbox: SessionMailbox): void {

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.ts
@@ -52,14 +52,28 @@ type Pending = {
   request: KernelActorTransportEnvelope["request"];
   readOnly: boolean;
   criticalSessionId?: string;
+  /** When the turn started executing on the worker (lane busy-time metric). */
+  startedAt: number;
 };
 
 type SlotTurn = {
   request: KernelActorTransportEnvelope["request"];
   allowUnready: boolean;
   priority: boolean;
+  enqueuedAt: number;
   resolve: (response: KernelActorResponse) => void;
   reject: (error: Error) => void;
+};
+
+/** Cumulative per-lane counters. Monotonic for the service lifetime — they
+ * deliberately survive lane restarts so operators can see instability. */
+type LaneMetrics = {
+  turnsCompleted: number;
+  queueWaitMsTotal: number;
+  busyMsTotal: number;
+  timeouts: number;
+  restarts: number;
+  rejectedFull: number;
 };
 
 type WorkerSlot = {
@@ -71,6 +85,7 @@ type WorkerSlot = {
   ready: boolean;
   restarting: boolean;
   priorityBurst: number;
+  metrics: LaneMetrics;
 };
 
 type QueuedSessionTurn = {
@@ -233,6 +248,14 @@ export async function startSessionKernelService(
       ready: false,
       restarting: false,
       priorityBurst: 0,
+      metrics: {
+        turnsCompleted: 0,
+        queueWaitMsTotal: 0,
+        busyMsTotal: 0,
+        timeouts: 0,
+        restarts: 0,
+        rejectedFull: 0,
+      },
     }),
   );
   const sessionSlots = slots.slice(1);
@@ -362,6 +385,7 @@ export async function startSessionKernelService(
     if (safeCatalogReadRestart)
       console.warn("Restarting session kernel catalog lane after read failure", error);
     slot.restarting = true;
+    slot.metrics.restarts += 1;
     stopSlot(slot, error, true);
     void (async () => {
       const critical = active.filter((entry) => entry.criticalSessionId);
@@ -414,7 +438,10 @@ export async function startSessionKernelService(
     const originalRpcId = turn.request.rpcId;
     const rpcId = crypto.randomUUID();
     const generation = slot.generation;
+    const startedAt = Date.now();
+    slot.metrics.queueWaitMsTotal += Math.max(0, startedAt - turn.enqueuedAt);
     const timer = setTimeout(() => {
+      slot.metrics.timeouts += 1;
       const error = new Error(`Session actor lane ${slot.index} response timed out`);
       restartSessionSlot(slot, error, generation);
     }, responseTimeoutMs);
@@ -425,6 +452,7 @@ export async function startSessionKernelService(
       request: turn.request,
       readOnly: isReadOnlyRequest(turn.request),
       criticalSessionId: criticalSessionId(turn.request),
+      startedAt,
     });
     try {
       slot.worker.postMessage({ ...turn.request, rpcId });
@@ -460,9 +488,12 @@ export async function startSessionKernelService(
         RESERVED_LANE_PRIORITY_TURNS,
         Math.max(0, laneQueueLimit - 1),
       ))
-    ) return Promise.reject(new RetryableActorHostError("Session actor lane is full"));
+    ) {
+      slot.metrics.rejectedFull += 1;
+      return Promise.reject(new RetryableActorHostError("Session actor lane is full"));
+    }
     return new Promise((resolve, reject) => {
-      const turn = { request, allowUnready, priority, resolve, reject };
+      const turn = { request, allowUnready, priority, enqueuedAt: Date.now(), resolve, reject };
       if (urgent) slot.queue.unshift(turn);
       else slot.queue.push(turn);
       pumpSlot(slot);
@@ -484,6 +515,8 @@ export async function startSessionKernelService(
         if (!entry) return;
         slot.pending.delete(response.rpcId);
         clearTimeout(entry.timer);
+        slot.metrics.turnsCompleted += 1;
+        slot.metrics.busyMsTotal += Math.max(0, Date.now() - entry.startedAt);
         const restored = { ...response, rpcId: entry.originalRpcId };
         entry.resolve(restored);
         if (actorFatal(response))
@@ -743,6 +776,18 @@ export async function startSessionKernelService(
               ready: sessionSlots.filter((slot) => slot.ready).length,
               capacity: sessionSlots.length,
             },
+            // Per-lane occupancy and cumulative counters. Index 0 is the
+            // catalog lane; the rest are session execution lanes. Counters are
+            // monotonic for the service lifetime so operators can compute
+            // rates and spot lane skew, timeout storms, and restart churn.
+            lanes: slots.map((slot) => ({
+              index: slot.index,
+              ready: slot.ready,
+              restarting: slot.restarting,
+              queued: slot.queue.length,
+              executing: slot.pending.size,
+              ...slot.metrics,
+            })),
           },
           { status: ready ? 200 : 503 },
         );

--- a/packages/core/opensession-server/src/server/session-kernel/lane-placement.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/lane-placement.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { chooseSessionLane, laneHash, type LaneLoad } from "./lane-placement";
+
+const idle = (count: number): LaneLoad[] =>
+  Array.from({ length: count }, () => ({ queued: 0, executing: 0 }));
+
+describe("chooseSessionLane", () => {
+  test("is deterministic for equal loads and matches the primary hash", () => {
+    const lanes = idle(8);
+    for (const sessionId of ["a", "session-123", "bks_0192", "🚀"]) {
+      const primary = laneHash(sessionId, 0) % lanes.length;
+      expect(chooseSessionLane(sessionId, lanes)).toBe(primary);
+      // Deterministic: same inputs, same lane.
+      expect(chooseSessionLane(sessionId, lanes)).toBe(primary);
+    }
+  });
+
+  test("single lane always places on lane 0", () => {
+    expect(chooseSessionLane("anything", idle(1))).toBe(0);
+  });
+
+  test("prefers the less loaded of its two candidates", () => {
+    const lanes = idle(8);
+    // Find a session whose two candidates differ.
+    let sessionId = "";
+    let first = 0;
+    let second = 0;
+    for (let n = 0; n < 10_000; n += 1) {
+      const candidate = `session-${n}`;
+      const a = laneHash(candidate, 0) % lanes.length;
+      const b = laneHash(candidate, 0x9e37_79b9) % lanes.length;
+      if (a !== b) {
+        sessionId = candidate;
+        first = a;
+        second = b;
+        break;
+      }
+    }
+    expect(sessionId).not.toBe("");
+    // Equal load keeps the primary candidate.
+    expect(chooseSessionLane(sessionId, lanes)).toBe(first);
+    // Loaded primary moves the placement to the second candidate.
+    lanes[first] = { queued: 3, executing: 1 };
+    expect(chooseSessionLane(sessionId, lanes)).toBe(second);
+    // But an equally loaded second candidate keeps the primary (ties stick).
+    lanes[second] = { queued: 4, executing: 0 };
+    expect(chooseSessionLane(sessionId, lanes)).toBe(first);
+  });
+
+  test("never places outside the lane range and spreads sessions", () => {
+    const lanes = idle(5);
+    const seen = new Set<number>();
+    for (let n = 0; n < 500; n += 1) {
+      const lane = chooseSessionLane(`spread-${n}`, lanes);
+      expect(lane).toBeGreaterThanOrEqual(0);
+      expect(lane).toBeLessThan(lanes.length);
+      seen.add(lane);
+    }
+    expect(seen.size).toBe(lanes.length);
+  });
+
+  test("rejects an empty lane set", () => {
+    expect(() => chooseSessionLane("x", [])).toThrow();
+  });
+});

--- a/packages/core/opensession-server/src/server/session-kernel/lane-placement.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/lane-placement.ts
@@ -1,0 +1,51 @@
+/**
+ * Sticky two-choice lane placement for session actors.
+ *
+ * A session picks its execution lane once, when it activates (its service
+ * mailbox is created), and keeps that lane until the mailbox drains. Stable
+ * affinity keeps one logical actor's process-local reducer caches on one lane
+ * while it is active; the durable database remains the authority and is
+ * rehydrated after restart or LRU passivation, so a later activation may pick
+ * a different lane safely.
+ *
+ * Placement uses two rendezvous candidates from independent hashes and takes
+ * the one with the lower live load. Ties keep the primary candidate, so a
+ * quiet service places exactly like the previous pure-hash affinity. An
+ * active mailbox is never moved: only activation chooses.
+ */
+
+/** FNV-1a over the session id, with an optional seed for a second candidate. */
+export function laneHash(sessionId: string, seed = 0): number {
+  let hash = (2_166_136_261 ^ seed) >>> 0;
+  for (let index = 0; index < sessionId.length; index += 1) {
+    hash ^= sessionId.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+export type LaneLoad = {
+  /** Turns waiting in the lane queue. */
+  queued: number;
+  /** Turns currently executing on the lane worker. */
+  executing: number;
+};
+
+const SECOND_CANDIDATE_SEED = 0x9e37_79b9;
+
+/**
+ * Choose the lane index for a session activating now. Deterministic given the
+ * same loads; equal-load ties resolve to the primary hash candidate.
+ */
+export function chooseSessionLane(
+  sessionId: string,
+  lanes: readonly LaneLoad[],
+): number {
+  if (lanes.length === 0) throw new Error("No session lanes to place on");
+  const first = laneHash(sessionId, 0) % lanes.length;
+  if (lanes.length === 1) return first;
+  const second = laneHash(sessionId, SECOND_CANDIDATE_SEED) % lanes.length;
+  if (second === first) return first;
+  const load = (index: number) => lanes[index]!.queued + lanes[index]!.executing;
+  return load(second) < load(first) ? second : first;
+}

--- a/packages/core/opensession-server/src/server/session-kernel/runtime.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/runtime.ts
@@ -23,6 +23,28 @@ import {
 } from "./creation-effect-executors";
 import { audit } from "../audit";
 import { SessionKernelQuarantinedError } from "./actor-client";
+import { envCapacity } from "../shared/env-capacity";
+
+// Runtime effect execution happens in the gateway process (physical work),
+// so these knobs are read from the gateway environment.
+const TIMER_CONCURRENCY = envCapacity(
+	"OPENSESSION_KERNEL_TIMER_CONCURRENCY",
+	8,
+	1,
+	64,
+);
+const OUTBOX_CONCURRENCY = envCapacity(
+	"OPENSESSION_KERNEL_OUTBOX_CONCURRENCY",
+	8,
+	1,
+	64,
+);
+const OPENING_OUTBOX_CONCURRENCY = envCapacity(
+	"OPENSESSION_KERNEL_OPENING_OUTBOX_CONCURRENCY",
+	100,
+	1,
+	512,
+);
 
 type TimerHandler = (timer: DurableTimer) => void | Promise<void>;
 
@@ -195,12 +217,17 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 			// Admit enough opening effects to project their session files immediately.
 			// session-create.ts applies the smaller eight-turn engine gate only after
 			// projection, so slow agent turns cannot hide later accepted sessions.
-			const openings = await sessionKernelRuntimeWork([], [openingKind], Date.now(), 100);
+			const openings = await sessionKernelRuntimeWork(
+				[],
+				[openingKind],
+				Date.now(),
+				OPENING_OUTBOX_CONCURRENCY,
+			);
 			work.outbox.push(...openings.outbox);
 		}
 		const activeTimers = (runtime.activeTimers ??= new Set());
 		for (const timer of work.timers) {
-			if (activeTimers.size >= 8) break;
+			if (activeTimers.size >= TIMER_CONCURRENCY) break;
 			const key = `${timer.sessionId}:${timer.timerId}:${timer.token}`;
 			if (activeTimers.has(key)) continue;
 			activeTimers.add(key);
@@ -233,7 +260,10 @@ export async function drainSessionKernelRuntime(): Promise<void> {
 				item.kind === "creation_opening_turn"
 					? activeOpeningOutbox
 					: activeOutbox;
-			const admissionLimit = item.kind === openingKind ? 100 : 8;
+			const admissionLimit =
+				item.kind === openingKind
+					? OPENING_OUTBOX_CONCURRENCY
+					: OUTBOX_CONCURRENCY;
 			if (active.size >= admissionLimit || active.has(item.id)) continue;
 			active.add(item.id);
 			void executeSessionEffect(item)

--- a/packages/core/opensession-server/src/server/shared/env-capacity.test.ts
+++ b/packages/core/opensession-server/src/server/shared/env-capacity.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { envCapacity } from "./env-capacity";
+
+const NAME = "OPENSESSION_TEST_CAPACITY_KNOB";
+
+afterEach(() => {
+  delete process.env[NAME];
+});
+
+describe("envCapacity", () => {
+  test("returns the fallback when unset or blank", () => {
+    expect(envCapacity(NAME, 8, 1, 64)).toBe(8);
+    process.env[NAME] = "  ";
+    expect(envCapacity(NAME, 8, 1, 64)).toBe(8);
+  });
+
+  test("accepts a bounded integer", () => {
+    process.env[NAME] = "16";
+    expect(envCapacity(NAME, 8, 1, 64)).toBe(16);
+    process.env[NAME] = "1";
+    expect(envCapacity(NAME, 8, 1, 64)).toBe(1);
+    process.env[NAME] = "64";
+    expect(envCapacity(NAME, 8, 1, 64)).toBe(64);
+  });
+
+  test("keeps the fallback for out-of-range or malformed values", () => {
+    for (const raw of ["0", "65", "-3", "2.5", "abc", "8x", "Infinity", "NaN"]) {
+      process.env[NAME] = raw;
+      expect(envCapacity(NAME, 8, 1, 64)).toBe(8);
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/shared/env-capacity.ts
+++ b/packages/core/opensession-server/src/server/shared/env-capacity.ts
@@ -1,0 +1,30 @@
+/**
+ * Bounded integer capacity overrides from the environment.
+ *
+ * Capacity knobs are read once at module load: they size long-lived pools and
+ * gates, so a live process never resizes them mid-flight. An invalid value
+ * keeps the built-in default instead of throwing — a typo in a drop-in must
+ * not prevent boot.
+ *
+ * Mind which process reads a knob: the gateway loads ~/.opensession.env, but
+ * the session-kernel and executor services deliberately do not. Their knobs
+ * only take effect through a dedicated systemd drop-in (`Environment=`) on
+ * that service, never through the application environment file.
+ */
+export function envCapacity(
+  name: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    console.error(
+      `[capacity] Ignoring ${name}=${raw}; expected an integer between ${min} and ${max}`,
+    );
+    return fallback;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- make fixed gateway, executor, timer, outbox, and opening-turn capacity gates independently configurable with bounded integer overrides
- expose per-lane occupancy, queue latency, busy time, timeout, restart, and completion counters on the session-kernel readiness endpoint
- place session actors with sticky two-choice rendezvous hashing so affinity is stable while new sessions avoid overloaded lanes
- gate detached run-host launches on active and pending host count, `MemAvailable`, and CPU PSI, with race-safe reservations, bounded waiting, visible refusal, and operator documentation

## Testing

- `bun run typecheck`
- `bun test packages/core/opensession-server/src/server/host-admission.test.ts packages/core/opensession-server/src/server/host-client.test.ts packages/core/opensession-server/src/server/shared/env-capacity.test.ts`
- `bun test packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts packages/core/opensession-server/src/server/session-kernel/lane-placement.test.ts packages/core/opensession-server/src/executor/coordinator.test.ts packages/core/opensession-server/src/server/one-shot.test.ts packages/core/opensession-server/src/server/session-create-plan.test.ts`
- `bun scripts/check-module-side-effects.ts`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a03fca-05e1-7251-9833-2c9134ce8d6f)
