### PR TITLE
Serialize prompt delivery across browser tabs

### DIFF
--- a/packages/core/opensession-server/src/frontend/lib/prompt-outbox.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/prompt-outbox.test.ts
@@ -9,6 +9,17 @@ function memoryStorage() {
 	};
 }
 
+function serialLocks() {
+	const tails = new Map<string, Promise<void>>();
+	return {
+		request<T>(name: string, callback: () => Promise<T>): Promise<T> {
+			const turn = (tails.get(name) ?? Promise.resolve()).then(callback);
+			tails.set(name, turn.then(() => undefined, () => undefined));
+			return turn;
+		},
+	};
+}
+
 test("persists before returning and delivers each session in order", async () => {
 	const storage = memoryStorage();
 	const delivered: string[] = [];
@@ -69,6 +80,52 @@ test("keeps the item state as the only in-tab send lock", async () => {
 	expect(delivered).toEqual(["first", "second"]);
 	expect(outbox.list()).toEqual([]);
 	outbox.dispose();
+});
+
+test("serializes one durable prompt across browser tabs", async () => {
+	const storage = memoryStorage();
+	const locks = serialLocks();
+	let deliveries = 0;
+	let deliveryStarted!: () => void;
+	const started = new Promise<void>((resolve) => {
+		deliveryStarted = resolve;
+	});
+	let releaseDelivery!: () => void;
+	const held = new Promise<void>((resolve) => {
+		releaseDelivery = resolve;
+	});
+	const deliver = async () => {
+		deliveries += 1;
+		deliveryStarted();
+		await held;
+		return { status: "started" as const, message: "ok" };
+	};
+	const firstTab = new PromptOutbox({
+		storage,
+		locks,
+		scope: "cross-tab",
+		deliver,
+	});
+	firstTab.enqueue({ sessionId: "s1", content: "once" });
+	const secondTab = new PromptOutbox({
+		storage,
+		locks,
+		scope: "cross-tab",
+		deliver,
+	});
+	const secondFlush = secondTab.flush();
+
+	await started;
+	expect(deliveries).toBe(1);
+	releaseDelivery();
+	await secondFlush;
+	await firstTab.flush();
+
+	expect(deliveries).toBe(1);
+	expect(firstTab.list()).toEqual([]);
+	expect(secondTab.list()).toEqual([]);
+	firstTab.dispose();
+	secondTab.dispose();
 });
 
 test("reports a handled command before retiring its durable row", async () => {

--- a/packages/core/opensession-server/src/frontend/lib/prompt-outbox.ts
+++ b/packages/core/opensession-server/src/frontend/lib/prompt-outbox.ts
@@ -35,6 +35,9 @@ export type PromptOutboxInput = Omit<
 type StoredOutbox = { version: 1; items: PromptOutboxItem[] };
 type DeliveryObserver = (item: PromptOutboxItem, result: PromptDelivery) => void;
 type Listener = () => void;
+interface OutboxLockManager {
+	request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+}
 
 export const PROMPT_OUTBOX_MAX_ITEMS = 100;
 export const PROMPT_OUTBOX_RETRY_BASE_MS = 1_000;
@@ -85,6 +88,7 @@ export class PromptOutbox {
 			storage?: Pick<Storage, "getItem" | "setItem">;
 			scope?: string;
 			now?: () => number;
+			locks?: OutboxLockManager;
 			deliver?: (sessionId: string, body: Omit<PromptOutboxItem, "sessionId" | "state" | "attempts" | "createdAt" | "nextAttemptAt" | "error">) => Promise<PromptDelivery>;
 		} = {},
 	) {
@@ -179,6 +183,27 @@ export class PromptOutbox {
 	}
 
 	private async flushSession(sessionId: string): Promise<void> {
+		const locks =
+			this.opts.locks ??
+			(typeof navigator !== "undefined" ? navigator.locks : undefined);
+		if (!locks) {
+			await this.flushSessionOwned(sessionId);
+			return;
+		}
+		// localStorage shares the durable queue across tabs, but its in-memory
+		// `sending` guard does not. Without an origin-wide lock every open tab
+		// submits the same client id, and the actor correctly rejects all but the
+		// winner as "already in progress". Those retry writes are what made one
+		// optimistic message flash through "Waiting to send". Re-read storage only
+		// after ownership transfers: the prior tab usually removed the item while
+		// this caller waited, so there is then nothing left to deliver.
+		await locks.request(`${this.key}:deliver:${sessionId}`, async () => {
+			this.reload(false);
+			await this.flushSessionOwned(sessionId);
+		});
+	}
+
+	private async flushSessionOwned(sessionId: string): Promise<void> {
 		while (true) {
 			const item = this.items.find((candidate) => candidate.sessionId === sessionId && candidate.state === "pending" && candidate.nextAttemptAt <= this.now());
 			if (!item) return;


### PR DESCRIPTION
## Summary
- serialize durable prompt delivery per session across same-origin browser tabs with the Web Locks API
- re-read shared localStorage after a tab acquires delivery ownership so a prior winner's completed item is not submitted again
- retain the existing in-process fallback where Web Locks are unavailable

## Root cause
The repeated UI churn was backed by real retry traffic, not another projection-only race. A send at 22:17:19 produced many simultaneous `Prompt delivery is already in progress` responses. The outbox is shared through localStorage, but its `sending` guard was only in memory, so every open tab submitted the same client id. The SessionKernel correctly let one request execute and rejected the duplicates; losing tabs then wrote retry state into the shared outbox, making the sender flash through “Waiting to send” before the winning request completed.

## Verification
- `bun test packages/core/opensession-server/src/frontend/lib/prompt-outbox.test.ts packages/core/opensession-server/src/frontend/lib/pending-reconcile.test.ts`
- `bun scripts/check-react-compiler.ts`
- `bunx oxlint packages/core/opensession-server/src/frontend/lib/prompt-outbox.ts packages/core/opensession-server/src/frontend/lib/prompt-outbox.test.ts`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a03ffb-1945-7cd0-b872-d40ea5a855d5)
