### PR TITLE
Add unarchive action to session toolbar

### DIFF
--- a/packages/core/opensession-server/src/frontend/App.tsx
+++ b/packages/core/opensession-server/src/frontend/App.tsx
@@ -4884,6 +4884,7 @@ if (siblingCreateRef.current === optimisticId)
 					// this can't double-record.
 					rememberArchived([viewerSession.id]);
 				}}
+				onUnarchive={unarchiveSession}
 				send={socket.send}
 				setTyping={socket.setTyping}
 				addHandler={socket.addHandler}

--- a/packages/core/opensession-server/src/frontend/components/SessionSidebarAction.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionSidebarAction.test.tsx
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import type { ReactElement } from "react";
+import { Button } from "../ui/button";
+import { Menu } from "../ui/menu";
+import { IconUnarchive } from "./icons";
+import { SessionSidebarAction } from "./SessionSidebarAction";
+import { KeepInSidebarIcon } from "./sidebar/KeepInSidebarMark";
+
+test("archived sessions render Unarchive in the desktop toolbar", () => {
+  let unarchived = 0;
+  const action = SessionSidebarAction({
+    archived: true,
+    canKeepInSidebar: false,
+    inMenu: false,
+    onKeepInSidebar: () => {},
+    onUnarchive: () => unarchived++,
+  }) as ReactElement<{
+    title: string;
+    icon: ReactElement;
+    onClick: () => void;
+    children: string;
+  }>;
+
+  expect(action.type).toBe(Button);
+  expect(action.props.title).toBe("Unarchive");
+  expect(action.props.children).toBe("Unarchive");
+  expect(action.props.icon.type).toBe(IconUnarchive);
+  action.props.onClick();
+  expect(unarchived).toBe(1);
+});
+
+test("non-archived sessions keep Add to sidebar in the phone menu", () => {
+  let kept = 0;
+  const action = SessionSidebarAction({
+    archived: false,
+    canKeepInSidebar: true,
+    inMenu: true,
+    onKeepInSidebar: () => kept++,
+    onUnarchive: () => {},
+  }) as ReactElement<{
+    title: string;
+    onClick: () => void;
+    children: [ReactElement, ReactElement<{ children: string }>];
+  }>;
+
+  expect(action.type).toBe(Menu.Item);
+  expect(action.props.title).toBe("Add to sidebar");
+  expect(action.props.children[0].type).toBe(KeepInSidebarIcon);
+  expect(action.props.children[1].props.children).toBe("Add to sidebar");
+  action.props.onClick();
+  expect(kept).toBe(1);
+});

--- a/packages/core/opensession-server/src/frontend/components/SessionSidebarAction.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionSidebarAction.tsx
@@ -1,0 +1,52 @@
+import { Button } from "../ui/button";
+import { Menu, MENU_ICON } from "../ui/menu";
+import { IconUnarchive } from "./icons";
+import { KeepInSidebarIcon } from "./sidebar/KeepInSidebarMark";
+
+type SessionSidebarActionProps = {
+  archived: boolean;
+  canKeepInSidebar: boolean;
+  inMenu: boolean;
+  onKeepInSidebar: () => void;
+  onUnarchive?: () => void;
+};
+
+export function SessionSidebarAction({
+  archived,
+  canKeepInSidebar,
+  inMenu,
+  onKeepInSidebar,
+  onUnarchive,
+}: SessionSidebarActionProps) {
+  const action =
+    archived && onUnarchive
+      ? { label: "Unarchive", Icon: IconUnarchive, onClick: onUnarchive }
+      : canKeepInSidebar
+        ? {
+            label: "Add to sidebar",
+            Icon: KeepInSidebarIcon,
+            onClick: onKeepInSidebar,
+          }
+        : null;
+  if (!action) return null;
+  const { Icon, label, onClick } = action;
+
+  return inMenu ? (
+    <Menu.Item onClick={onClick} title={label}>
+      <Icon className={MENU_ICON} />
+      <span className="grow">{label}</span>
+    </Menu.Item>
+  ) : (
+    <Button
+      size="md"
+      variant="default"
+      className="mr-1.5 text-fg"
+      icon={<Icon />}
+      iconTone="full"
+      onClick={onClick}
+      title={label}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -300,7 +300,7 @@ import {
 	IconArrowUpRight,
 	IconStack,
 } from "./icons";
-import { KeepInSidebarIcon } from "./sidebar/KeepInSidebarMark";
+import { SessionSidebarAction } from "./SessionSidebarAction";
 import { SessionRelations, type RelatedSession } from "./SessionRelations";
 import {
 	SOURCE_CHIP,
@@ -524,6 +524,8 @@ interface Props {
 	/** Claim this workspace into your own per-user sidebar lanes ("mine"), or
 	    release it (null) — the ⋯ menu's twin of the sidebar row's action. */
 	onSetStatus?: (sessions: UnifiedSession[], status: Lane | null) => void;
+	/** Restore the currently viewed archived session to the normal sidebar. */
+	onUnarchive?: (session: UnifiedSession) => void;
 	/** Every session — the pool the workspace-context picker and the PR panel
 	    draw their sibling sessions from. */
 	allSessions?: UnifiedSession[];
@@ -779,6 +781,7 @@ export function SessionViewer({
 	onDeleteWorkspace,
 	workspaceSessions,
 	onSetStatus,
+	onUnarchive,
 	allSessions,
 	onNewSession,
 	onNewWorkspace,
@@ -5850,26 +5853,15 @@ export function SessionViewer({
 			</Modal.Root>
 			{!hideHeader && (() => {
 				const workspaceScopedMenu = Boolean(session.workspaceId);
-				const keepInSidebarAction = (inMenu: boolean) =>
-					canKeepInSidebar &&
-					(inMenu ? (
-						<Menu.Item onClick={keepInSidebar} title="Add to sidebar">
-							<KeepInSidebarIcon className={MENU_ICON} />
-							<span className="grow">Add to sidebar</span>
-						</Menu.Item>
-					) : (
-						<Button
-							size="md"
-							variant="default"
-							className="mr-1.5 text-fg"
-							icon={<KeepInSidebarIcon />}
-							iconTone="full"
-							onClick={keepInSidebar}
-							title="Add to sidebar"
-						>
-							Add to sidebar
-						</Button>
-					));
+				const keepInSidebarAction = (inMenu: boolean) => (
+					<SessionSidebarAction
+						archived={Boolean(session.archived)}
+						canKeepInSidebar={canKeepInSidebar}
+						inMenu={inMenu}
+						onKeepInSidebar={keepInSidebar}
+						onUnarchive={onUnarchive ? () => onUnarchive(session) : undefined}
+					/>
+				);
 				// Share rides inline on a wide header but tucks into the ⋯ overflow
 				// menu when it gets narrow. Both spellings use the link glyph, since
 				// the action copies a link rather than opening a share sheet. Inline
@@ -6332,7 +6324,9 @@ export function SessionViewer({
 									? workspaceLifecycleActions
 									: (
 										<>
-											{(!isPhone || session.archived) && archiveAction}
+											{((!isPhone && !session.archived) ||
+												(session.archived && !onUnarchive)) &&
+												archiveAction}
 											{deleteAction}
 										</>
 									)}


### PR DESCRIPTION
## Summary
- show **Unarchive** in the archived session toolbar where **Add to sidebar** appears for non-archived sessions
- route the action through App's existing optimistic unarchive flow
- preserve Add to sidebar behavior and avoid a duplicate archived-session overflow action
- cover archived desktop and non-archived phone action rendering

## Checks
- `bun test packages/core/opensession-server/src/frontend/components/SessionSidebarAction.test.tsx`
- `bun run lint`
- `bun run typecheck`
- light-mode capture harness exercised at 1440×900 and 390×844

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a048e4-c4b8-72c3-b19d-fec2c28e4282)