### PR TITLE
Show persistent native run activity feedback

### DIFF
--- a/packages/clients/ios/OS1/Views/TranscriptRow.swift
+++ b/packages/clients/ios/OS1/Views/TranscriptRow.swift
@@ -848,50 +848,79 @@ struct StreamingBubble: View {
     }
 }
 
-/// The live run, at the end of the transcript: an amber pulse and the
-/// ticking clock, sitting directly under the last message so it reads as
-/// something that message is still doing. It used to ride the composer, which
-/// put the state on the field you type in rather than on the work.
+/// The live run, at the end of the transcript. Copy acknowledges a quiet or
+/// unusually long request without claiming which model or tool phase is active.
 struct RunStatusFooter: View {
     let since: Date?
 
     var body: some View {
-        HStack(spacing: 6) {
-            // Amber is the in-progress colour everywhere else in the app —
-            // the sessions list's in-progress lane, the tab strip's running
-            // pill — so the transcript says "running" in the same voice.
-            PulsingDot(color: OS1VisualStyle.yellowInk, size: 6)
-            RunElapsedLabel(since: since)
-                .font(.caption2.weight(.medium))
-                .foregroundStyle(OS1VisualStyle.yellowInk)
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let status = RunActivityStatus(elapsed: elapsed(at: context.date))
+            HStack(spacing: 6) {
+                // `PulsingDot` stops animating when Reduce Motion is enabled.
+                PulsingDot(color: OS1VisualStyle.yellowInk, size: 6)
+                Text(status.label)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(OS1VisualStyle.textDim)
+                if let elapsed = status.elapsed {
+                    Text("· \(elapsed)")
+                        .font(.caption2)
+                        .foregroundStyle(OS1VisualStyle.textFaint)
+                        .monospacedDigit()
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            // The clock is visual context only. VoiceOver hears the status when
+            // it focuses the footer, never a new elapsed value every second.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(status.label)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Working")
+    }
+
+    private func elapsed(at date: Date) -> TimeInterval {
+        guard let since else { return 0 }
+        return date.timeIntervalSince(since)
     }
 }
 
-/// Ticking elapsed-run clock ("8.3s", "2m 14s", "1h 5m") — the web viewer's
-/// BusyElapsed format. Falls back to "Running" with no anchor.
+struct RunActivityStatus: Equatable {
+    let label: String
+    let elapsed: String?
+
+    init(elapsed: TimeInterval) {
+        let seconds = max(0, elapsed)
+        if seconds < 10 {
+            label = "Working"
+            self.elapsed = nil
+        } else {
+            label = seconds < 45 ? "Still working" : "Taking longer than usual"
+            self.elapsed = Self.format(seconds)
+        }
+    }
+
+    static func format(_ elapsed: TimeInterval) -> String {
+        let seconds = max(0, Int(elapsed.rounded()))
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        if minutes < 60 { return "\(minutes)m" }
+        let hours = minutes / 60
+        return minutes % 60 == 0 ? "\(hours)h" : "\(hours)h \(minutes % 60)m"
+    }
+}
+
+/// Compact elapsed-run clock used outside the transcript footer.
 struct RunElapsedLabel: View {
     let since: Date?
 
     var body: some View {
         if let since {
-            TimelineView(.periodic(from: .now, by: 0.1)) { context in
-                Text(label(elapsed: context.date.timeIntervalSince(since)))
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                Text(RunActivityStatus.format(context.date.timeIntervalSince(since)))
                     .monospacedDigit()
             }
         } else {
             Text("Running")
         }
-    }
-
-    private func label(elapsed: TimeInterval) -> String {
-        let s = max(0, elapsed)
-        if s < 60 { return String(format: "%.1fs", s) }
-        let total = Int(s)
-        if total < 3600 { return "\(total / 60)m \(total % 60)s" }
-        return "\(total / 3600)h \((total % 3600) / 60)m"
     }
 }

--- a/packages/clients/ios/OS1/Views/TranscriptRow.swift
+++ b/packages/clients/ios/OS1/Views/TranscriptRow.swift
@@ -948,7 +948,7 @@ struct RunActivityStatus: Equatable {
     }
 
     static func format(_ elapsed: TimeInterval) -> String {
-        let seconds = max(0, Int(elapsed.rounded()))
+        let seconds = Int(max(0, elapsed))
         if seconds < 60 { return "\(seconds)s" }
         let minutes = seconds / 60
         if minutes < 60 { return "\(minutes)m" }

--- a/packages/clients/ios/OS1/Views/TranscriptRow.swift
+++ b/packages/clients/ios/OS1/Views/TranscriptRow.swift
@@ -896,50 +896,79 @@ struct StreamingBubble: View {
     }
 }
 
-/// The live run, at the end of the transcript: an amber pulse and the
-/// ticking clock, sitting directly under the last message so it reads as
-/// something that message is still doing. It used to ride the composer, which
-/// put the state on the field you type in rather than on the work.
+/// The live run, at the end of the transcript. Copy acknowledges a quiet or
+/// unusually long request without claiming which model or tool phase is active.
 struct RunStatusFooter: View {
     let since: Date?
 
     var body: some View {
-        HStack(spacing: 6) {
-            // Amber is the in-progress colour everywhere else in the app —
-            // the sessions list's in-progress lane, the tab strip's running
-            // pill — so the transcript says "running" in the same voice.
-            PulsingDot(color: OS1VisualStyle.yellowInk, size: 6)
-            RunElapsedLabel(since: since)
-                .font(.caption2.weight(.medium))
-                .foregroundStyle(OS1VisualStyle.yellowInk)
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let status = RunActivityStatus(elapsed: elapsed(at: context.date))
+            HStack(spacing: 6) {
+                // `PulsingDot` stops animating when Reduce Motion is enabled.
+                PulsingDot(color: OS1VisualStyle.yellowInk, size: 6)
+                Text(status.label)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(OS1VisualStyle.textDim)
+                if let elapsed = status.elapsed {
+                    Text("· \(elapsed)")
+                        .font(.caption2)
+                        .foregroundStyle(OS1VisualStyle.textFaint)
+                        .monospacedDigit()
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            // The clock is visual context only. VoiceOver hears the status when
+            // it focuses the footer, never a new elapsed value every second.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(status.label)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Working")
+    }
+
+    private func elapsed(at date: Date) -> TimeInterval {
+        guard let since else { return 0 }
+        return date.timeIntervalSince(since)
     }
 }
 
-/// Ticking elapsed-run clock ("8.3s", "2m 14s", "1h 5m") — the web viewer's
-/// BusyElapsed format. Falls back to "Running" with no anchor.
+struct RunActivityStatus: Equatable {
+    let label: String
+    let elapsed: String?
+
+    init(elapsed: TimeInterval) {
+        let seconds = max(0, elapsed)
+        if seconds < 10 {
+            label = "Working"
+            self.elapsed = nil
+        } else {
+            label = seconds < 45 ? "Still working" : "Taking longer than usual"
+            self.elapsed = Self.format(seconds)
+        }
+    }
+
+    static func format(_ elapsed: TimeInterval) -> String {
+        let seconds = max(0, Int(elapsed.rounded()))
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        if minutes < 60 { return "\(minutes)m" }
+        let hours = minutes / 60
+        return minutes % 60 == 0 ? "\(hours)h" : "\(hours)h \(minutes % 60)m"
+    }
+}
+
+/// Compact elapsed-run clock used outside the transcript footer.
 struct RunElapsedLabel: View {
     let since: Date?
 
     var body: some View {
         if let since {
-            TimelineView(.periodic(from: .now, by: 0.1)) { context in
-                Text(label(elapsed: context.date.timeIntervalSince(since)))
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                Text(RunActivityStatus.format(context.date.timeIntervalSince(since)))
                     .monospacedDigit()
             }
         } else {
             Text("Running")
         }
-    }
-
-    private func label(elapsed: TimeInterval) -> String {
-        let s = max(0, elapsed)
-        if s < 60 { return String(format: "%.1fs", s) }
-        let total = Int(s)
-        if total < 3600 { return "\(total / 60)m \(total % 60)s" }
-        return "\(total / 3600)h \((total % 3600) / 60)m"
     }
 }

--- a/packages/clients/ios/OS1Tests/RunActivityStatusTests.swift
+++ b/packages/clients/ios/OS1Tests/RunActivityStatusTests.swift
@@ -8,7 +8,12 @@ final class RunActivityStatusTests: XCTestCase {
 
     func testAcknowledgesWorkAfterTenSeconds() {
         assertStatus(10, label: "Still working", elapsed: "10s")
-        assertStatus(44, label: "Still working", elapsed: "44s")
+        assertStatus(44.999, label: "Still working", elapsed: "44s")
+    }
+
+    func testElapsedTimeDoesNotCrossUnitBoundariesEarly() {
+        XCTAssertEqual(RunActivityStatus.format(59.999), "59s")
+        XCTAssertEqual(RunActivityStatus.format(60), "1m")
     }
 
     func testSetsExpectationsForAnExtendedRun() {

--- a/packages/clients/ios/OS1Tests/RunActivityStatusTests.swift
+++ b/packages/clients/ios/OS1Tests/RunActivityStatusTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import OS1
+
+final class RunActivityStatusTests: XCTestCase {
+    func testStartsWithWorkingWithoutElapsedTime() {
+        assertStatus(9.999, label: "Working", elapsed: nil)
+    }
+
+    func testAcknowledgesWorkAfterTenSeconds() {
+        assertStatus(10, label: "Still working", elapsed: "10s")
+        assertStatus(44, label: "Still working", elapsed: "44s")
+    }
+
+    func testSetsExpectationsForAnExtendedRun() {
+        assertStatus(45, label: "Taking longer than usual", elapsed: "45s")
+        assertStatus(90, label: "Taking longer than usual", elapsed: "1m")
+    }
+
+    func testFormatsLongRunsCompactlyAndClampsClockSkew() {
+        XCTAssertEqual(RunActivityStatus.format(3_900), "1h 5m")
+        assertStatus(-1, label: "Working", elapsed: nil)
+    }
+
+    private func assertStatus(
+        _ seconds: TimeInterval,
+        label: String,
+        elapsed: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let status = RunActivityStatus(elapsed: seconds)
+        XCTAssertEqual(status.label, label, file: file, line: line)
+        XCTAssertEqual(status.elapsed, elapsed, file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary
- progress copy moves from Working to Still working at 10s and Taking longer than usual at 45s
- use a 1 Hz timeline with compact, accessibility-hidden elapsed time
- add threshold and duration formatting tests

## Verification
- OS1 iOS Simulator build passed
- OS1Mac build passed
- OS1Mac test bundle built; execution was blocked by the build node testmanagerd helper being unavailable
- captured the extended-run state on iPhone 17 Pro simulator

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-be6f7d27-64be-75fa-b733-f175d5dfbd78)