### PR TITLE
Add first-party Apple mobile MCP integration

### DIFF
--- a/.agents/skills/apple-mobile/SKILL.md
+++ b/.agents/skills/apple-mobile/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: apple-mobile
+description: Build SwiftPM/xtool iOS apps and prepare explicitly approved ad-hoc or TestFlight releases through the apple-build and apple-release MCP servers.
+---
+
+# Apple mobile workflow
+
+Use `apple_mobile_doctor` and `apple_mobile_inspect_project` before any build.
+
+## Safety rules
+
+- Never paste or print an App Store Connect private key, Apple password, certificate private key, or provisioning secret.
+- Treat xtool as a development-build backend only. Do not claim its current development profiles are ad-hoc or App Store profiles.
+- Never release from a dirty worktree or an unapproved branch.
+- Never call `apple_release_execute` in the same response that creates a plan. Show the plan, artifact/commit, version/build, destination, and effects; wait for explicit human approval.
+- The execute confirmation must be the full commit SHA from the reviewed plan.
+- TestFlight upload is not App Review submission or public release. This integration deliberately exposes neither action.
+- Do not revoke certificates.
+
+## Development
+
+1. Run `apple_mobile_doctor`.
+2. Run `apple_mobile_inspect_project`.
+3. Run `apple_mobile_test` where the package has host-portable tests.
+4. Use `apple_mobile_build_unsigned` for a non-signing build.
+5. Inspect generated IPAs with `apple_mobile_inspect_ipa`.
+
+## Ad-hoc or TestFlight
+
+1. Run `apple_release_doctor` and inspect the project.
+2. Create a plan using `apple_release_plan_adhoc`, `apple_release_plan_testflight`, or `apple_release_plan_upload`.
+3. Present the plan and stop for approval.
+4. After explicit approval, call `apple_release_execute` with the plan ID and full planned commit SHA.
+5. Report the output artifact SHA-256 or upload result. Do not imply Apple processing has completed unless separately verified.
+
+## Repository contract
+
+Each app must commit `.opensession/apple-mobile.json`. Paths are relative to the project and must remain under an administrator-configured allowed root. Distribution operations require the `xcode` backend; xtool is intentionally rejected for distribution.

--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,16 @@
       "name": "@tellahq/opensession-protocol",
       "version": "0.1.0",
     },
+    "packages/integrations/apple-mobile": {
+      "name": "@tellahq/opensession-apple-mobile",
+      "version": "0.1.0",
+      "bin": {
+        "opensession-apple-mobile-mcp": "src/server.ts",
+      },
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+      },
+    },
   },
   "patchedDependencies": {
     "@pierre/trees@1.0.0-beta.4": "patches/@pierre%2Ftrees@1.0.0-beta.4.patch",
@@ -774,6 +784,8 @@
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.8", "", {}, "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA=="],
 
     "@team-plain/typescript-sdk": ["@team-plain/typescript-sdk@5.12.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "ajv": "^8.12.0", "ajv-formats": "^2.1.1", "graphql": "^16.6.0", "lodash.get": "^4.4.2", "zod": "3.22.4" } }, "sha512-EgCzFDsRkFcexuOWJMFh99w86E86U5/1VN26Q6Dogtmi2ln5wFHeoJ8/0PQQmDj9GWRI/y63ltlE6I4KN0fvLA=="],
+
+    "@tellahq/opensession-apple-mobile": ["@tellahq/opensession-apple-mobile@workspace:packages/integrations/apple-mobile"],
 
     "@tellahq/opensession-protocol": ["@tellahq/opensession-protocol@workspace:packages/core/protocol"],
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -176,6 +176,7 @@ that touches them.
 | [linear.md](linear.md)                                       | Linear OAuth app, webhooks, the Linear agent                                                                                      |
 | [plain.md](plain.md)                                         | Plain support tickets, the triage automation                                                                                      |
 | [integrations-misc.md](integrations-misc.md)                 | Stripe, WorkOS, Grafana/Sentry/Tinybird, web push, voice                                                                          |
+| [apple-mobile.md](apple-mobile.md)                           | SwiftPM/xtool development builds and user-restricted Xcode release tools                                                          |
 | [engines.md](engines.md)                                     | the Pi engine, account pools, provider keys, run isolation                                                                        |
 | [../self-hosting-sandboxes.md](../self-hosting-sandboxes.md) | certified Docker, Daytona, Box, and Modal sandboxes; implemented E2B and Lambda adapters remain unavailable pending certification |
 | [../runners.md](../runners.md)                               | attaching a Mac/Linux/Windows box as a Runner                                                                                     |

--- a/docs/setup/apple-mobile.md
+++ b/docs/setup/apple-mobile.md
@@ -1,0 +1,97 @@
+# Apple mobile
+
+Open Session ships an opt-in Apple mobile MCP integration for SwiftPM and iOS projects. It has separate build and release servers so normal development never receives Apple credentials.
+
+## Capabilities and limits
+
+The build server can inspect a configured project, run `swift test`, create unsigned Xcode simulator builds, and create xtool development builds. xtool distribution is development-only. Do not treat an xtool IPA or development profile as ad-hoc, TestFlight, or App Store distribution.
+
+Release planning and execution require Xcode on macOS. The integration can create ad-hoc exports and upload to TestFlight. It cannot submit an app for App Review or release an app publicly. It never revokes certificates.
+
+xtool can download and use Apple SDK material on Linux. Apple licenses may restrict where and how that SDK may be used. Open Session does not bundle an Apple SDK or grant a license to one. Have your organization review Apple's terms before enabling xtool on Linux.
+
+## Add the connections
+
+In **Settings → Connections**, add two stdio MCP servers. `opensession` must be on the service user's `PATH`.
+
+### Build tools
+
+- Name: `apple-build`
+- Command: `opensession`
+- Arguments: `apple-mobile-mcp --mode build`
+- Environment:
+
+  ```text
+  APPLE_MOBILE_ALLOWED_ROOTS=/Users/YOU/dev:/Users/YOU/.opensession/worktrees
+  ```
+
+This server is credential-free. It may be available to normal interactive coding sessions. Building a repository can execute repository-controlled SwiftPM plugins and build scripts, so keep the allowed roots narrow.
+
+### Release tools
+
+- Name: `apple-release`
+- Command: `opensession`
+- Arguments: `apple-mobile-mcp --mode release`
+- Environment:
+
+  ```text
+  APPLE_MOBILE_ALLOWED_ROOTS=/Users/YOU/dev:/Users/YOU/.opensession/worktrees
+  APPLE_ASC_KEY_ID=YOUR_KEY_ID
+  APPLE_ASC_ISSUER_ID=YOUR_ISSUER_ID
+  APPLE_ASC_PRIVATE_KEY_PATH=/protected/apple/AuthKey_YOUR_KEY_ID.p8
+  APPLE_DEVELOPER_TEAM_ID=YOUR_TEAM_ID
+  ```
+
+Set **Allowed users** to the people permitted to release. Never leave `apple-release` unrestricted. Open Session's `allowedUsers` gate keeps the server out of other users' sessions and unattended automations. The package does not set or bypass that operator-owned gate.
+
+Store the private key outside every allowed project root and worktree with mode `0600`. Put credentials in protected Open Session configuration, not a repository, project config, or chat.
+
+## Configure an app
+
+Commit `.opensession/apple-mobile.json` in the app repository. Paths are project-relative and symlinks may not escape the project.
+
+### xtool development
+
+The project also needs `Package.swift` and `xtool.yml`.
+
+```json
+{
+  "version": 1,
+  "backend": "xtool",
+  "bundleId": "com.example.App",
+  "xtool": { "configuration": "debug" },
+  "release": { "requireClean": true, "allowedBranches": ["main"] }
+}
+```
+
+### Xcode release
+
+```json
+{
+  "version": 1,
+  "backend": "xcode",
+  "bundleId": "com.example.App",
+  "teamId": "TEAMID",
+  "xcode": {
+    "container": "workspace",
+    "path": "App.xcworkspace",
+    "scheme": "App",
+    "configuration": "Release"
+  },
+  "release": {
+    "requireClean": true,
+    "allowedBranches": ["main"],
+    "artifactDirectory": ".build/apple-mobile"
+  }
+}
+```
+
+Add the artifact directory to `.gitignore`.
+
+## Release approval
+
+Release plans expire after one hour. A plan is authenticated and bound to the clean git commit, branch, project config, and, for an existing IPA upload, the artifact SHA-256. Execution requires the exact full commit SHA shown in the plan.
+
+The shipped skill requires a separate user turn between planning and execution. Review the commit, version, build number, destination, and effects before approving. TestFlight upload only hands the build to Apple for processing. It does not submit for review or make the app public.
+
+Existing IPA upload uses `xcrun altool` on macOS. Linux and Windows uploads are unsupported. Release execution always requires macOS and Xcode.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "workspaces": [
     "packages/clients/website",
     "packages/core/opensession-server",
-    "packages/core/protocol"
+    "packages/core/protocol",
+    "packages/integrations/apple-mobile"
   ],
   "scripts": {
     "app:dev": "bun scripts/app-dev.ts",

--- a/packages/core/opensession-server/src/frontend/components/Connections.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Connections.tsx
@@ -102,6 +102,8 @@ const MCP_BLURBS: Record<string, string> = {
   ahrefs: "SEO, keywords & backlink data",
   github: "Repos, issues & pull requests",
   circle: "Community & support workspace",
+  "apple-build": "Credential-free Swift and unsigned iOS builds",
+  "apple-release": "Restricted ad-hoc and TestFlight release tools",
   vercel: "Projects, deployments & logs",
   vero: "Broadcasts and customer journeys",
 };

--- a/packages/core/opensession-server/src/frontend/components/settings/LibraryPanel.tsx
+++ b/packages/core/opensession-server/src/frontend/components/settings/LibraryPanel.tsx
@@ -64,6 +64,7 @@ const TYPE_ORDER: LibraryEntryType[] = [
   "tool",
   "automation",
   "integration",
+  "connection",
   "package",
 ];
 
@@ -71,6 +72,7 @@ const TYPE_LABELS: Record<LibraryEntryType, string> = {
   tool: "Tools",
   automation: "Automations",
   integration: "Integrations",
+  connection: "Connections",
   package: "Packages",
 };
 
@@ -78,6 +80,7 @@ const TYPE_BLURB: Record<LibraryEntryType, string> = {
   tool: "Tools appear in your sidebar.",
   automation: "A prompt and a trigger: a schedule, an event, or a webhook.",
   integration: "Outside systems this instance can listen to and act in.",
+  connection: "First-party MCP servers maintained with Open Session.",
   // Listed once installed rather than browsed: installing a package mounts an
   // MCP server and adds text an agent reads, so the review that gates it
   // lives in the terminal. `opensession plugins add <owner/repo>`.
@@ -89,6 +92,7 @@ const FILTERS: { key: "all" | LibraryEntryType; label: string }[] = [
   { key: "tool", label: "Tools" },
   { key: "automation", label: "Automations" },
   { key: "integration", label: "Integrations" },
+  { key: "connection", label: "Connections" },
   { key: "package", label: "Packages" },
 ];
 
@@ -148,6 +152,7 @@ const TYPE_GLYPHS: Record<LibraryEntryType, Glyph> = {
   tool: { icon: IconStack, tone: "sky" },
   automation: { icon: IconBolt, tone: "orange" },
   integration: { icon: IconPlug, tone: "green" },
+  connection: { icon: IconPlug, tone: "sky" },
   package: { icon: IconStack, tone: "indigo" },
 };
 
@@ -214,6 +219,12 @@ function EntryIcon({
 const installLinkClass =
   "inline-flex min-h-[26px] shrink-0 items-center rounded-control border border-line bg-button px-2.5 text-xs font-medium text-dim no-underline smooth-shadow-xs transition-colors hover:border-line-strong hover:text-fg";
 
+function entryHref(entry: LibraryEntry): string {
+  return /^https?:\/\//.test(entry.href)
+    ? entry.href
+    : `${BASE_PATH}${entry.href}`;
+}
+
 function EntryControl({
   entry,
   toolVisible,
@@ -240,7 +251,7 @@ function EntryControl({
     );
 
   return (
-    <a className={installLinkClass} href={`${BASE_PATH}${entry.href}`}>
+    <a className={installLinkClass} href={entryHref(entry)}>
       {entry.install === "guided"
         ? "Set up"
         : entry.install === "draft"
@@ -462,7 +473,7 @@ export function LibraryPanel() {
             {installed.map((entry) => (
               <a
                 key={entry.id}
-                href={`${BASE_PATH}${entry.href}`}
+                href={entryHref(entry)}
                 title={entry.name}
                 aria-label={entry.name}
                 // The tile's own corner, so the focus ring traces the mark

--- a/packages/core/opensession-server/src/frontend/lib/api/library.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/library.ts
@@ -6,6 +6,7 @@ export type LibraryEntryType =
   | "tool"
   | "automation"
   | "integration"
+  | "connection"
   | "package";
 export type LibraryInstallKind = "one-click" | "draft" | "guided" | "client";
 

--- a/packages/core/opensession-server/src/server/connections-security.test.ts
+++ b/packages/core/opensession-server/src/server/connections-security.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { requiresAllowedUsers } from "./connections";
+
+describe("first-party MCP connection policy", () => {
+  test("requires the credentialed Apple release server to be user-scoped", () => {
+    expect(requiresAllowedUsers("apple-release")).toBe(true);
+    expect(requiresAllowedUsers("APPLE-RELEASE")).toBe(true);
+  });
+
+  test("keeps credential-free build tools available for ordinary setup", () => {
+    expect(requiresAllowedUsers("apple-build")).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/connections.ts
+++ b/packages/core/opensession-server/src/server/connections.ts
@@ -176,12 +176,24 @@ function cleanAllowedUsers(users?: string[]): string[] | undefined {
   return out.length ? out : undefined;
 }
 
+/** Credentialed first-party release tools must never become fleet-wide. */
+export function requiresAllowedUsers(name: string): boolean {
+  return name.toLowerCase() === "apple-release";
+}
+
 export function addMcpServer(
   input: AddMcpInput,
 ): { ok: true } | { error: string } {
   const name = (input.name || "").trim();
   if (!/^[a-z0-9][a-z0-9_-]{0,40}$/i.test(name)) {
     return { error: "Name must be alphanumeric (dashes/underscores allowed)" };
+  }
+
+  const allowedUsers = cleanAllowedUsers(input.allowedUsers);
+  if (requiresAllowedUsers(name) && !allowedUsers) {
+    return {
+      error: 'Server "apple-release" requires at least one allowed user',
+    };
   }
 
   const config = readMcpConfig();
@@ -211,7 +223,6 @@ export function addMcpServer(
     if (Object.keys(env).length > 0) entry.env = env;
   }
 
-  const allowedUsers = cleanAllowedUsers(input.allowedUsers);
   if (allowedUsers) entry.allowedUsers = allowedUsers;
 
   config.mcpServers[name] = entry;
@@ -240,12 +251,17 @@ export function addMcpServerEntry(
   if (!/^[a-z0-9][a-z0-9_-]{0,40}$/i.test(clean)) {
     return { error: "Name must be alphanumeric (dashes/underscores allowed)" };
   }
+  const allowedUsers = cleanAllowedUsers(opts.allowedUsers);
+  if (requiresAllowedUsers(clean) && !allowedUsers) {
+    return {
+      error: 'Server "apple-release" requires at least one allowed user',
+    };
+  }
   const config = readMcpConfig();
   if (config.mcpServers[clean]) {
     return { error: `Server "${clean}" already exists, remove it first` };
   }
   const { allowedUsers: _ignored, ...rest } = entry;
-  const allowedUsers = cleanAllowedUsers(opts.allowedUsers);
   config.mcpServers[clean] = allowedUsers ? { ...rest, allowedUsers } : rest;
   writeMcpConfig(config);
   return { ok: true };
@@ -264,6 +280,11 @@ export function setMcpAllowedUsers(
   const entry = config.mcpServers[name];
   if (!entry) return { error: `Server "${name}" not found` };
   const cleaned = cleanAllowedUsers(allowedUsers);
+  if (requiresAllowedUsers(name) && !cleaned) {
+    return {
+      error: 'Server "apple-release" requires at least one allowed user',
+    };
+  }
   if (cleaned) entry.allowedUsers = cleaned;
   else delete entry.allowedUsers;
   writeMcpConfig(config);

--- a/packages/core/opensession-server/src/server/library.ts
+++ b/packages/core/opensession-server/src/server/library.ts
@@ -18,23 +18,24 @@
  *   automation    recipes/automations/*.json          a config seed
  *                 AUTOMATION_TEMPLATES                a pre-filled create form
  *   integration   integrations/registry.ts            credentials + a restart
+ *   connection    curated first-party MCP servers     guided setup
  *   package       ~/.opensession-plugins.json         `opensession plugins add`
  *
- * The entries are DERIVED, never copied: adding a recipe file or a registry
- * entry puts it in the library with no edit here. That is the property worth
- * protecting — a catalog maintained by hand drifts from the thing it lists
- * within a month, and this repo already has one instance of that drift
+ * Most entries are derived: adding a recipe file or integration registry
+ * entry puts it in the library with no edit here. Core tools and curated
+ * first-party connections are the two hand-maintained exceptions because
+ * neither has another registry to derive from. Keeping that exception narrow
+ * matters: a catalog maintained by hand drifts from the thing it lists, and
+ * this repo already has one instance of that drift
  * (recipes/ and automation-templates.ts describe overlapping jobs in two
  * formats; the library shows both and marks how each installs, which is the
  * honest presentation until they are merged).
  *
  * What is NOT here yet, and why:
  *
- * - **Connections (MCP servers).** The biggest gap — the Connections UI has no
- *   catalog at all, just a blank form — but a catalog entry for a server is
- *   only useful if its command/URL is verified to work, so the curated list
- *   has to be assembled deliberately rather than guessed. The install path
- *   (`addMcpServer`) is already tested and needs no restart.
+ * - **Third-party connections.** Connections still has no general catalog.
+ *   Curated first-party servers can be listed here once their command, setup,
+ *   and permission boundary are maintained in this repository.
  * - **Skills.** `.agents/skills/` and `skills-lock.json` are instance-local
  *   and gitignored, so there is nothing in the repository to catalogue. The
  *   lock file's `{source, sourceType, skillPath, computedHash}` shape is the
@@ -64,11 +65,13 @@ import { listAutomations } from "./automations";
 import { INTEGRATIONS } from "./integrations/registry";
 import { isEnabled } from "./integrations/load";
 import { listInstalledPackages } from "./plugins";
+import { readMcpConfig } from "./connections";
 
 export type LibraryEntryType =
   | "tool"
   | "automation"
   | "integration"
+  | "connection"
   | "package";
 
 /**
@@ -283,6 +286,29 @@ function integrationDescription(id: string): string {
  * this a library rather than four settings pages with a search box, so the
  * card names the package rather than listing its pieces separately.
  */
+function connectionEntries(): LibraryEntry[] {
+  const servers = readMcpConfig().mcpServers;
+  return [
+    {
+      id: "connection:apple-mobile",
+      type: "connection" as const,
+      slug: "apple-mobile",
+      name: "Apple mobile",
+      description:
+        "Build Swift apps and prepare approved ad-hoc or TestFlight releases.",
+      category: "Developer tools",
+      install: "guided" as const,
+      installed: Boolean(
+        servers["apple-build"] &&
+        Array.isArray(servers["apple-release"]?.allowedUsers) &&
+        servers["apple-release"].allowedUsers.length,
+      ),
+      href: "https://github.com/tellahq/opensession/blob/main/docs/setup/apple-mobile.md",
+      source: "builtin" as const,
+    },
+  ];
+}
+
 function packageEntries(): LibraryEntry[] {
   try {
     return listInstalledPackages().map((pkg) => ({
@@ -309,6 +335,7 @@ export function listLibrary(): LibraryEntry[] {
     ...toolEntries(),
     ...automationEntries(installedNames),
     ...integrationEntries(),
+    ...connectionEntries(),
     ...packageEntries(),
   ];
 }

--- a/packages/integrations/apple-mobile/README.md
+++ b/packages/integrations/apple-mobile/README.md
@@ -1,0 +1,10 @@
+# Open Session Apple mobile
+
+First-party MCP servers for SwiftPM/xtool development builds and commit-bound Xcode ad-hoc or TestFlight releases.
+
+This package is private to the Open Session workspace. Run it through the stable `opensession apple-mobile-mcp` entry point rather than installing a scratch-local binary.
+
+- `--mode build` exposes credential-free inspection, tests, unsigned builds, and IPA inspection.
+- `--mode release` exposes release planning and execution. Configure this server with App Store Connect credentials and a non-empty Open Session `allowedUsers` list.
+
+See [the setup guide](../../../docs/setup/apple-mobile.md) for connection configuration, project examples, security boundaries, and platform limitations.

--- a/packages/integrations/apple-mobile/examples/SwiftUIApp/.opensession/apple-mobile.json
+++ b/packages/integrations/apple-mobile/examples/SwiftUIApp/.opensession/apple-mobile.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "backend": "xtool",
+  "bundleId": "com.example.MySwiftUIApp",
+  "teamId": "YOUR_TEAM_ID",
+  "xtool": {
+    "configuration": "debug"
+  },
+  "release": {
+    "requireClean": true,
+    "allowedBranches": ["main"],
+    "artifactDirectory": ".build/apple-mobile"
+  }
+}

--- a/packages/integrations/apple-mobile/examples/apple-mobile.xcode.json
+++ b/packages/integrations/apple-mobile/examples/apple-mobile.xcode.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "backend": "xcode",
+  "bundleId": "com.example.MySwiftUIApp",
+  "teamId": "YOUR_TEAM_ID",
+  "xcode": {
+    "container": "workspace",
+    "path": "MySwiftUIApp.xcworkspace",
+    "scheme": "MySwiftUIApp",
+    "configuration": "Release"
+  },
+  "release": {
+    "requireClean": true,
+    "allowedBranches": ["main"],
+    "artifactDirectory": ".build/apple-mobile"
+  }
+}

--- a/packages/integrations/apple-mobile/package.json
+++ b/packages/integrations/apple-mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tellahq/opensession-apple-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "opensession-apple-mobile-mcp": "src/server.ts"
+  },
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0"
+  }
+}

--- a/packages/integrations/apple-mobile/src/build.ts
+++ b/packages/integrations/apple-mobile/src/build.ts
@@ -1,0 +1,181 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, relative } from "node:path";
+import { loadConfig } from "./config";
+import { findExecutable, runChecked, runCommand } from "./exec";
+import { resolveProjectDir, resolveProjectPath } from "./security";
+
+async function probe(name: string, args: string[]) {
+  const path = findExecutable(name);
+  if (!path) return { path: null, usable: false, detail: "not installed" };
+  try {
+    const result = await runCommand(
+      { executable: name, args, cwd: process.cwd() },
+      { timeoutMs: 10_000 },
+    );
+    const detail = (result.stdout || result.stderr)
+      .trim()
+      .split("\n")
+      .slice(0, 3)
+      .join(" | ");
+    return { path, usable: result.exitCode === 0, detail };
+  } catch (error) {
+    return {
+      path,
+      usable: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function doctor(projectDirInput?: string) {
+  const platform = `${process.platform}/${process.arch}`;
+  const tools = {
+    swift: await probe("swift", ["--version"]),
+    xtool: await probe("xtool", ["--version"]),
+    xcodebuild: await probe("xcodebuild", ["-version"]),
+    xcrun: await probe("xcrun", ["--version"]),
+    unzip: await probe("unzip", ["-v"]),
+    python3: await probe("python3", ["--version"]),
+    git: await probe("git", ["--version"]),
+  };
+  let project: unknown;
+  if (projectDirInput) {
+    const projectDir = resolveProjectDir(projectDirInput);
+    try {
+      project = (await loadConfig(projectDir)).config;
+    } catch (error) {
+      project = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  return {
+    platform,
+    mode: process.env.APPLE_MOBILE_MCP_MODE ?? "build",
+    tools,
+    allowedRoots:
+      process.env.APPLE_MOBILE_ALLOWED_ROOTS?.split(":") ?? "defaults",
+    appleCredentialsConfigured: {
+      keyId: Boolean(process.env.APPLE_ASC_KEY_ID),
+      issuerId: Boolean(process.env.APPLE_ASC_ISSUER_ID),
+      privateKeyPath: Boolean(process.env.APPLE_ASC_PRIVATE_KEY_PATH),
+    },
+    project,
+    notes: [
+      "xtool builds are development/experimental; this integration never uses xtool for App Store distribution.",
+      "Xcode is required for archive, ad-hoc, and TestFlight release operations.",
+    ],
+  };
+}
+
+export async function runSwiftTests(projectDirInput: string) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  if (!existsSync(join(projectDir, "Package.swift")))
+    throw new Error("Package.swift is required");
+  return runChecked(
+    { executable: "swift", args: ["test"], cwd: projectDir },
+    { timeoutMs: 30 * 60_000 },
+  );
+}
+
+export async function buildUnsigned(
+  projectDirInput: string,
+  configuration?: "debug" | "release",
+  ipa = false,
+) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const { config } = await loadConfig(projectDir);
+  const selected = configuration ?? config.xtool?.configuration ?? "debug";
+
+  if (config.backend === "xtool") {
+    const args = ["dev", "build", "--configuration", selected];
+    if (ipa) args.push("--ipa");
+    const result = await runChecked(
+      { executable: "xtool", args, cwd: projectDir },
+      { timeoutMs: 45 * 60_000 },
+    );
+    const match = result.stdout.match(/Wrote to (.+)$/m);
+    return {
+      backend: "xtool",
+      configuration: selected,
+      artifact: match?.[1]?.trim() ?? null,
+      result,
+    };
+  }
+
+  const xcode = config.xcode!;
+  const containerPath = resolveProjectPath(projectDir, xcode.path);
+  const args = [
+    xcode.container === "workspace" ? "-workspace" : "-project",
+    containerPath,
+    "-scheme",
+    xcode.scheme,
+    "-configuration",
+    xcode.configuration ?? selected[0]!.toUpperCase() + selected.slice(1),
+    "-sdk",
+    "iphonesimulator",
+    "CODE_SIGNING_ALLOWED=NO",
+    "build",
+  ];
+  const result = await runChecked(
+    { executable: "xcodebuild", args, cwd: projectDir },
+    { timeoutMs: 45 * 60_000 },
+  );
+  return { backend: "xcode", configuration: selected, artifact: null, result };
+}
+
+export async function inspectIpa(
+  projectDirInput: string,
+  artifactPath: string,
+) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const ipa = resolveProjectPath(projectDir, artifactPath);
+  if (!ipa.endsWith(".ipa"))
+    throw new Error("artifactPath must reference an .ipa");
+  if (!findExecutable("unzip") || !findExecutable("python3"))
+    throw new Error("unzip and python3 are required");
+
+  const temporary = mkdtempSync(join(tmpdir(), "apple-mobile-ipa-"));
+  try {
+    await runChecked({
+      executable: "unzip",
+      args: ["-qq", ipa, "-d", temporary],
+      cwd: projectDir,
+    });
+    const glob = new Bun.Glob("Payload/*.app/Info.plist");
+    const matches = Array.from(
+      glob.scanSync({ cwd: temporary, absolute: true }),
+    );
+    if (matches.length !== 1)
+      throw new Error(`Expected one app Info.plist, found ${matches.length}`);
+    const script = [
+      "import json, plistlib, sys",
+      "with open(sys.argv[1], 'rb') as f: p=plistlib.load(f)",
+      "keys=['CFBundleIdentifier','CFBundleDisplayName','CFBundleShortVersionString','CFBundleVersion','MinimumOSVersion']",
+      "print(json.dumps({k:p.get(k) for k in keys}, sort_keys=True))",
+    ].join("; ");
+    const parsed = await runChecked({
+      executable: "python3",
+      args: ["-c", script, matches[0]!],
+      cwd: projectDir,
+    });
+    const metadata = JSON.parse(parsed.stdout);
+    const sha256 = new Bun.CryptoHasher("sha256")
+      .update(await Bun.file(ipa).arrayBuffer())
+      .digest("hex");
+    return {
+      artifact: relative(projectDir, ipa),
+      file: basename(ipa),
+      size: Bun.file(ipa).size,
+      sha256,
+      metadata,
+    };
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+export function ensureDirectory(path: string) {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+}

--- a/packages/integrations/apple-mobile/src/config.ts
+++ b/packages/integrations/apple-mobile/src/config.ts
@@ -1,0 +1,133 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { AppleMobileConfig } from "./types";
+import { resolveProjectPath } from "./security";
+
+export const CONFIG_PATH = ".opensession/apple-mobile.json";
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim())
+    throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+export async function loadConfig(projectDir: string): Promise<{
+  config: AppleMobileConfig;
+  path: string;
+  hash: string;
+}> {
+  const path = resolve(projectDir, CONFIG_PATH);
+  if (!existsSync(path)) throw new Error(`Missing ${CONFIG_PATH}`);
+  const text = await Bun.file(path).text();
+  let raw: Record<string, unknown>;
+  try {
+    raw = object(JSON.parse(text), CONFIG_PATH);
+  } catch (error) {
+    throw new Error(
+      `Invalid ${CONFIG_PATH}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (raw.version !== 1) throw new Error(`${CONFIG_PATH}: version must be 1`);
+  if (raw.backend !== "xtool" && raw.backend !== "xcode") {
+    throw new Error(`${CONFIG_PATH}: backend must be xtool or xcode`);
+  }
+  const bundleId = optionalString(raw.bundleId, "bundleId");
+  if (!bundleId || !/^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/.test(bundleId)) {
+    throw new Error(`${CONFIG_PATH}: bundleId is invalid`);
+  }
+
+  const config: AppleMobileConfig = {
+    version: 1,
+    backend: raw.backend,
+    bundleId,
+    teamId: optionalString(raw.teamId, "teamId"),
+  };
+
+  if (raw.xtool !== undefined) {
+    const xtool = object(raw.xtool, "xtool");
+    const configuration = xtool.configuration;
+    if (
+      configuration !== undefined &&
+      configuration !== "debug" &&
+      configuration !== "release"
+    ) {
+      throw new Error("xtool.configuration must be debug or release");
+    }
+    config.xtool = {
+      configuration: configuration as "debug" | "release" | undefined,
+    };
+  }
+
+  if (raw.xcode !== undefined) {
+    const xcode = object(raw.xcode, "xcode");
+    if (xcode.container !== "workspace" && xcode.container !== "project") {
+      throw new Error("xcode.container must be workspace or project");
+    }
+    const xcodePath = optionalString(xcode.path, "xcode.path");
+    const scheme = optionalString(xcode.scheme, "xcode.scheme");
+    if (!xcodePath || !scheme)
+      throw new Error("xcode.path and xcode.scheme are required");
+    resolveProjectPath(projectDir, xcodePath);
+    config.xcode = {
+      container: xcode.container,
+      path: xcodePath,
+      scheme,
+      configuration: optionalString(xcode.configuration, "xcode.configuration"),
+    };
+  }
+
+  if (raw.release !== undefined) {
+    const release = object(raw.release, "release");
+    const allowedBranches = release.allowedBranches;
+    if (
+      allowedBranches !== undefined &&
+      (!Array.isArray(allowedBranches) ||
+        allowedBranches.some((x) => typeof x !== "string" || !x))
+    ) {
+      throw new Error(
+        "release.allowedBranches must be an array of non-empty strings",
+      );
+    }
+    if (
+      release.requireClean !== undefined &&
+      typeof release.requireClean !== "boolean"
+    ) {
+      throw new Error("release.requireClean must be boolean");
+    }
+    const artifactDirectory = optionalString(
+      release.artifactDirectory,
+      "release.artifactDirectory",
+    );
+    if (artifactDirectory)
+      resolveProjectPath(projectDir, artifactDirectory, { mustExist: false });
+    config.release = {
+      requireClean: release.requireClean as boolean | undefined,
+      allowedBranches: allowedBranches as string[] | undefined,
+      artifactDirectory,
+    };
+  }
+
+  if (config.backend === "xcode" && !config.xcode) {
+    throw new Error(
+      `${CONFIG_PATH}: xcode configuration is required for the xcode backend`,
+    );
+  }
+  if (
+    config.backend === "xtool" &&
+    !existsSync(resolve(projectDir, "xtool.yml"))
+  ) {
+    throw new Error(`${CONFIG_PATH}: xtool backend requires xtool.yml`);
+  }
+
+  const hash = new Bun.CryptoHasher("sha256").update(text).digest("hex");
+  return { config, path, hash };
+}

--- a/packages/integrations/apple-mobile/src/exec.ts
+++ b/packages/integrations/apple-mobile/src/exec.ts
@@ -1,0 +1,75 @@
+import { accessSync, constants } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+import type { CommandResult, CommandSpec } from "./types";
+import { redact } from "./security";
+
+const OUTPUT_LIMIT = 200_000;
+
+export function findExecutable(name: string): string | undefined {
+  if (isAbsolute(name)) {
+    try {
+      accessSync(name, constants.X_OK);
+      return name;
+    } catch {
+      return undefined;
+    }
+  }
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    const candidate = join(dir, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  return undefined;
+}
+
+export async function runCommand(
+  spec: CommandSpec,
+  options: { timeoutMs?: number; extraEnv?: Record<string, string> } = {},
+): Promise<CommandResult> {
+  const executable = findExecutable(spec.executable);
+  if (!executable) throw new Error(`Executable not found: ${spec.executable}`);
+  const started = Date.now();
+  const proc = Bun.spawn([executable, ...spec.args], {
+    cwd: spec.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      TMPDIR: process.env.TMPDIR ?? "/tmp",
+      LANG: process.env.LANG ?? "en_US.UTF-8",
+      ...options.extraEnv,
+    },
+  });
+  const timeout = setTimeout(
+    () => proc.kill("SIGTERM"),
+    options.timeoutMs ?? 20 * 60_000,
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).finally(() => clearTimeout(timeout));
+  return {
+    command: redact([spec.executable, ...spec.args].join(" ")),
+    exitCode,
+    stdout: redact(stdout.slice(-OUTPUT_LIMIT)),
+    stderr: redact(stderr.slice(-OUTPUT_LIMIT)),
+    durationMs: Date.now() - started,
+  };
+}
+
+export async function runChecked(
+  spec: CommandSpec,
+  options: { timeoutMs?: number; extraEnv?: Record<string, string> } = {},
+): Promise<CommandResult> {
+  const result = await runCommand(spec, options);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${result.command} failed (${result.exitCode})\n${result.stderr || result.stdout}`,
+    );
+  }
+  return result;
+}

--- a/packages/integrations/apple-mobile/src/plans.ts
+++ b/packages/integrations/apple-mobile/src/plans.ts
@@ -1,0 +1,342 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { timingSafeEqual } from "node:crypto";
+import { basename, dirname, join, relative } from "node:path";
+import { homedir } from "node:os";
+import { loadConfig } from "./config";
+import {
+  resolvePrivateKeyPath,
+  resolveProjectDir,
+  resolveProjectPath,
+} from "./security";
+import { enforceReleasePolicy } from "./project";
+import type {
+  AppleMobileConfig,
+  CommandSpec,
+  ReleaseAction,
+  ReleasePlan,
+} from "./types";
+
+const PLAN_TTL_MS = 60 * 60_000;
+export const CREDENTIAL_REFS = {
+  keyId: "<APPLE_ASC_KEY_ID>",
+  issuerId: "<APPLE_ASC_ISSUER_ID>",
+  keyPath: "<APPLE_ASC_PRIVATE_KEY_PATH>",
+} as const;
+
+export function credentials(required: boolean) {
+  const keyId = process.env.APPLE_ASC_KEY_ID;
+  const issuerId = process.env.APPLE_ASC_ISSUER_ID;
+  const keyPath = process.env.APPLE_ASC_PRIVATE_KEY_PATH;
+  if (required && (!keyId || !issuerId || !keyPath)) {
+    throw new Error(
+      "APPLE_ASC_KEY_ID, APPLE_ASC_ISSUER_ID, and APPLE_ASC_PRIVATE_KEY_PATH are required",
+    );
+  }
+  const resolvedKeyPath = keyPath ? resolvePrivateKeyPath(keyPath) : undefined;
+  return { keyId, issuerId, keyPath: resolvedKeyPath };
+}
+
+function artifactRoot(projectDir: string, config: AppleMobileConfig): string {
+  return resolveProjectPath(
+    projectDir,
+    config.release?.artifactDirectory ?? ".build/apple-mobile",
+    { mustExist: false },
+  );
+}
+
+function xcodeArchiveCommand(
+  projectDir: string,
+  config: AppleMobileConfig,
+  archivePath: string,
+  marketingVersion?: string,
+  buildNumber?: string,
+): CommandSpec {
+  if (config.backend !== "xcode" || !config.xcode) {
+    throw new Error(
+      "Distribution releases require the xcode backend; xtool currently supports development signing only",
+    );
+  }
+  credentials(true);
+  const xcode = config.xcode;
+  const args = [
+    xcode.container === "workspace" ? "-workspace" : "-project",
+    resolveProjectPath(projectDir, xcode.path),
+    "-scheme",
+    xcode.scheme,
+    "-configuration",
+    xcode.configuration ?? "Release",
+    "-destination",
+    "generic/platform=iOS",
+    "-archivePath",
+    archivePath,
+    "-allowProvisioningUpdates",
+    "-authenticationKeyPath",
+    CREDENTIAL_REFS.keyPath,
+    "-authenticationKeyID",
+    CREDENTIAL_REFS.keyId,
+    "-authenticationKeyIssuerID",
+    CREDENTIAL_REFS.issuerId,
+  ];
+  const teamId = config.teamId ?? process.env.APPLE_DEVELOPER_TEAM_ID;
+  if (teamId) args.push(`DEVELOPMENT_TEAM=${teamId}`);
+  if (marketingVersion) args.push(`MARKETING_VERSION=${marketingVersion}`);
+  if (buildNumber) args.push(`CURRENT_PROJECT_VERSION=${buildNumber}`);
+  args.push("archive");
+  return { executable: "xcodebuild", args, cwd: projectDir };
+}
+
+function xcodeExportCommand(
+  projectDir: string,
+  archivePath: string,
+  outputPath: string,
+  plistPath: string,
+): CommandSpec {
+  credentials(true);
+  return {
+    executable: "xcodebuild",
+    args: [
+      "-exportArchive",
+      "-archivePath",
+      archivePath,
+      "-exportPath",
+      outputPath,
+      "-exportOptionsPlist",
+      plistPath,
+      "-allowProvisioningUpdates",
+      "-authenticationKeyPath",
+      CREDENTIAL_REFS.keyPath,
+      "-authenticationKeyID",
+      CREDENTIAL_REFS.keyId,
+      "-authenticationKeyIssuerID",
+      CREDENTIAL_REFS.issuerId,
+    ],
+    cwd: projectDir,
+  };
+}
+
+function uploadCommand(
+  projectDir: string,
+  ipaPlaceholder: string,
+): CommandSpec {
+  credentials(true);
+  return {
+    executable: "xcrun",
+    args: [
+      "altool",
+      "--upload-app",
+      "--type",
+      "ios",
+      "--file",
+      ipaPlaceholder,
+      "--apiKey",
+      CREDENTIAL_REFS.keyId,
+      "--apiIssuer",
+      CREDENTIAL_REFS.issuerId,
+    ],
+    cwd: projectDir,
+  };
+}
+
+function plansDir(projectDir: string, config: AppleMobileConfig): string {
+  return join(artifactRoot(projectDir, config), "plans");
+}
+
+function signingKeyPath(): string {
+  const root =
+    process.env.OPENSESSION_STATE_DIR || join(homedir(), ".opensession");
+  return join(root, "apple-mobile-plan-key");
+}
+
+function signingKey(): Uint8Array {
+  const path = signingKeyPath();
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    try {
+      writeFileSync(path, crypto.getRandomValues(new Uint8Array(32)), {
+        mode: 0o600,
+        flag: "wx",
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+  const key = readFileSync(path);
+  if (key.byteLength !== 32) throw new Error("Invalid Apple mobile plan key");
+  return key;
+}
+
+function signature(plan: ReleasePlan): string {
+  return new Bun.CryptoHasher("sha256", signingKey())
+    .update(JSON.stringify(plan))
+    .digest("hex");
+}
+
+function validSignature(plan: ReleasePlan, actual: unknown): boolean {
+  if (typeof actual !== "string" || !/^[0-9a-f]{64}$/.test(actual))
+    return false;
+  return timingSafeEqual(
+    Buffer.from(signature(plan), "hex"),
+    Buffer.from(actual, "hex"),
+  );
+}
+
+export function planPath(
+  projectDir: string,
+  config: AppleMobileConfig,
+  planId: string,
+): string {
+  if (!/^[0-9a-f-]{36}$/.test(planId)) throw new Error("Invalid planId");
+  return join(plansDir(projectDir, config), `${planId}.json`);
+}
+
+async function persist(plan: ReleasePlan, config: AppleMobileConfig) {
+  const path = planPath(plan.projectDir, config, plan.id);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  await Bun.write(
+    path,
+    JSON.stringify({ plan, signature: signature(plan) }, null, 2) + "\n",
+  );
+  chmodSync(path, 0o600);
+  return { plan, planFile: relative(plan.projectDir, path) };
+}
+
+export async function createBuildPlan(
+  projectDirInput: string,
+  action: Exclude<ReleaseAction, "upload">,
+  options: { marketingVersion?: string; buildNumber?: string } = {},
+) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const { config, hash, git } = await enforceReleasePolicy(projectDir);
+  credentials(true);
+  const id = crypto.randomUUID();
+  const outputDirectory = join(artifactRoot(projectDir, config), id);
+  const archivePath = join(
+    outputDirectory,
+    `${config.xcode?.scheme ?? "App"}.xcarchive`,
+  );
+  const exportPath = join(outputDirectory, "export");
+  const plistPath = join(outputDirectory, "ExportOptions.plist");
+  const commands = [
+    xcodeArchiveCommand(
+      projectDir,
+      config,
+      archivePath,
+      options.marketingVersion,
+      options.buildNumber,
+    ),
+    xcodeExportCommand(projectDir, archivePath, exportPath, plistPath),
+  ];
+  if (action === "testflight")
+    commands.push(uploadCommand(projectDir, "<exported-ipa>"));
+  const now = Date.now();
+  const plan: ReleasePlan = {
+    schemaVersion: 1,
+    id,
+    action,
+    projectDir,
+    commit: git.commit,
+    branch: git.branch,
+    configHash: hash,
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + PLAN_TTL_MS).toISOString(),
+    marketingVersion: options.marketingVersion,
+    buildNumber: options.buildNumber,
+    outputDirectory,
+    commands,
+  };
+  return persist(plan, config);
+}
+
+export async function createUploadPlan(
+  projectDirInput: string,
+  artifactPath: string,
+) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const { config, hash, git } = await enforceReleasePolicy(projectDir);
+  credentials(true);
+  const artifact = resolveProjectPath(projectDir, artifactPath);
+  if (!artifact.endsWith(".ipa"))
+    throw new Error("Only .ipa uploads are supported");
+  const sha256 = new Bun.CryptoHasher("sha256")
+    .update(await Bun.file(artifact).arrayBuffer())
+    .digest("hex");
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const plan: ReleasePlan = {
+    schemaVersion: 1,
+    id,
+    action: "upload",
+    projectDir,
+    commit: git.commit,
+    branch: git.branch,
+    configHash: hash,
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + PLAN_TTL_MS).toISOString(),
+    sourceArtifact: artifact,
+    sourceArtifactSha256: sha256,
+    outputDirectory: dirname(artifact),
+    commands: [uploadCommand(projectDir, artifact)],
+  };
+  return persist(plan, config);
+}
+
+export async function loadPlan(
+  projectDirInput: string,
+  planId: string,
+): Promise<{ plan: ReleasePlan; config: AppleMobileConfig }> {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const loaded = await loadConfig(projectDir);
+  const path = planPath(projectDir, loaded.config, planId);
+  const stored = JSON.parse(await Bun.file(path).text()) as {
+    plan: ReleasePlan;
+    signature: unknown;
+  };
+  const plan = stored.plan;
+  if (!plan || !validSignature(plan, stored.signature)) {
+    throw new Error("Release plan signature is invalid");
+  }
+  if (
+    plan.schemaVersion !== 1 ||
+    plan.id !== planId ||
+    plan.projectDir !== projectDir
+  )
+    throw new Error("Invalid release plan");
+  if (Date.parse(plan.expiresAt) < Date.now())
+    throw new Error("Release plan has expired");
+  const current = await enforceReleasePolicy(projectDir);
+  if (current.git.commit !== plan.commit)
+    throw new Error("Commit changed after planning");
+  if (current.git.branch !== plan.branch)
+    throw new Error("Branch changed after planning");
+  if (current.hash !== plan.configHash)
+    throw new Error("Configuration changed after planning");
+  if (plan.sourceArtifact && plan.sourceArtifactSha256) {
+    const hash = new Bun.CryptoHasher("sha256")
+      .update(await Bun.file(plan.sourceArtifact).arrayBuffer())
+      .digest("hex");
+    if (hash !== plan.sourceArtifactSha256)
+      throw new Error("IPA changed after planning");
+  }
+  return { plan, config: loaded.config };
+}
+
+export function exportOptions(
+  config: AppleMobileConfig,
+  action: ReleaseAction,
+): Record<string, unknown> {
+  const method = action === "adhoc" ? "release-testing" : "app-store-connect";
+  return {
+    method,
+    destination: "export",
+    signingStyle: "automatic",
+    teamID: config.teamId ?? process.env.APPLE_DEVELOPER_TEAM_ID,
+    manageAppVersionAndBuildNumber: false,
+    uploadSymbols: true,
+  };
+}

--- a/packages/integrations/apple-mobile/src/project.ts
+++ b/packages/integrations/apple-mobile/src/project.ts
@@ -1,0 +1,75 @@
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { loadConfig } from "./config";
+import { findExecutable, runChecked } from "./exec";
+import { resolveProjectDir } from "./security";
+
+export async function gitSnapshot(projectDir: string): Promise<{
+  commit: string;
+  branch: string;
+  clean: boolean;
+  changes: string[];
+}> {
+  if (!findExecutable("git"))
+    throw new Error("git is required for release plans");
+  const cwd = resolveProjectDir(projectDir);
+  const commit = (
+    await runChecked({ executable: "git", args: ["rev-parse", "HEAD"], cwd })
+  ).stdout.trim();
+  const branch = (
+    await runChecked({
+      executable: "git",
+      args: ["branch", "--show-current"],
+      cwd,
+    })
+  ).stdout.trim();
+  const status = (
+    await runChecked({
+      executable: "git",
+      args: ["status", "--porcelain"],
+      cwd,
+    })
+  ).stdout;
+  const changes = status
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return { commit, branch, clean: changes.length === 0, changes };
+}
+
+export async function inspectProject(projectDirInput: string) {
+  const projectDir = resolveProjectDir(projectDirInput);
+  const loaded = await loadConfig(projectDir);
+  let git: Awaited<ReturnType<typeof gitSnapshot>> | undefined;
+  try {
+    git = await gitSnapshot(projectDir);
+  } catch {}
+  return {
+    projectDir,
+    configPath: relative(projectDir, loaded.path),
+    configHash: loaded.hash,
+    config: loaded.config,
+    git,
+    files: {
+      packageSwift: existsSync(join(projectDir, "Package.swift")),
+      xtoolYml: existsSync(join(projectDir, "xtool.yml")),
+    },
+  };
+}
+
+export async function enforceReleasePolicy(projectDir: string) {
+  const loaded = await loadConfig(projectDir);
+  const git = await gitSnapshot(projectDir);
+  if ((loaded.config.release?.requireClean ?? true) && !git.clean) {
+    throw new Error(
+      `Release requires a clean worktree; changes: ${git.changes.join(", ")}`,
+    );
+  }
+  const allowed = loaded.config.release?.allowedBranches ?? ["main"];
+  if (!allowed.includes(git.branch)) {
+    throw new Error(
+      `Branch ${git.branch || "<detached>"} is not release-enabled (${allowed.join(", ")})`,
+    );
+  }
+  return { ...loaded, git };
+}

--- a/packages/integrations/apple-mobile/src/release.ts
+++ b/packages/integrations/apple-mobile/src/release.ts
@@ -1,0 +1,146 @@
+import { chmodSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { ensureDirectory } from "./build";
+import { findExecutable, runChecked } from "./exec";
+import { CREDENTIAL_REFS, credentials, exportOptions, loadPlan } from "./plans";
+import type { CommandResult, CommandSpec, ReleasePlan } from "./types";
+
+async function writePlist(
+  path: string,
+  value: Record<string, unknown>,
+  cwd: string,
+) {
+  const json = JSON.stringify(value);
+  const script =
+    "import json,plistlib,sys; plistlib.dump(json.loads(sys.argv[2]),open(sys.argv[1],'wb'),fmt=plistlib.FMT_XML)";
+  await runChecked({
+    executable: "python3",
+    args: ["-c", script, path, json],
+    cwd,
+  });
+  chmodSync(path, 0o600);
+}
+
+function privateKeyEnv(): Record<string, string> {
+  const path = credentials(true).keyPath!;
+  return { API_PRIVATE_KEYS_DIR: dirname(path) };
+}
+
+function withCredentials(command: CommandSpec): CommandSpec {
+  const auth = credentials(true);
+  const values: Record<string, string> = {
+    [CREDENTIAL_REFS.keyId]: auth.keyId!,
+    [CREDENTIAL_REFS.issuerId]: auth.issuerId!,
+    [CREDENTIAL_REFS.keyPath]: auth.keyPath!,
+  };
+  return {
+    ...command,
+    args: command.args.map((arg) => values[arg] ?? arg),
+  };
+}
+
+function findExportedIpa(exportPath: string): string {
+  const ipas = readdirSync(exportPath, { recursive: true })
+    .map(String)
+    .filter((entry) => entry.endsWith(".ipa"))
+    .map((entry) => join(exportPath, entry));
+  if (ipas.length !== 1)
+    throw new Error(`Expected one exported IPA, found ${ipas.length}`);
+  return ipas[0]!;
+}
+
+export async function executePlan(
+  projectDir: string,
+  planId: string,
+  confirmation: string,
+) {
+  const { plan, config } = await loadPlan(projectDir, planId);
+  if (confirmation !== plan.commit) {
+    throw new Error("confirmation must exactly match the planned commit SHA");
+  }
+  if (process.platform !== "darwin" || !findExecutable("xcodebuild")) {
+    throw new Error("Release execution requires Xcode on macOS");
+  }
+  if (
+    (plan.action === "testflight" || plan.action === "upload") &&
+    !findExecutable("xcrun")
+  ) {
+    throw new Error(
+      "TestFlight upload requires Xcode command-line tools on macOS",
+    );
+  }
+  ensureDirectory(plan.outputDirectory);
+  const results: CommandResult[] = [];
+  let artifact = plan.sourceArtifact;
+
+  if (plan.action === "upload") {
+    results.push(
+      await runChecked(withCredentials(plan.commands[0]!), {
+        timeoutMs: 45 * 60_000,
+        extraEnv: privateKeyEnv(),
+      }),
+    );
+  } else {
+    const exportPath = join(plan.outputDirectory, "export");
+    const plistPath = join(plan.outputDirectory, "ExportOptions.plist");
+    ensureDirectory(exportPath);
+    await writePlist(
+      plistPath,
+      exportOptions(config, plan.action),
+      plan.projectDir,
+    );
+    results.push(
+      await runChecked(withCredentials(plan.commands[0]!), {
+        timeoutMs: 60 * 60_000,
+      }),
+    );
+    results.push(
+      await runChecked(withCredentials(plan.commands[1]!), {
+        timeoutMs: 45 * 60_000,
+      }),
+    );
+    artifact = findExportedIpa(exportPath);
+    if (plan.action === "testflight") {
+      const upload = structuredClone(plan.commands[2]!);
+      upload.args = upload.args.map((arg) =>
+        arg === "<exported-ipa>" ? artifact! : arg,
+      );
+      results.push(
+        await runChecked(withCredentials(upload), {
+          timeoutMs: 45 * 60_000,
+          extraEnv: privateKeyEnv(),
+        }),
+      );
+    }
+  }
+
+  const sha256 = artifact
+    ? new Bun.CryptoHasher("sha256")
+        .update(await Bun.file(artifact).arrayBuffer())
+        .digest("hex")
+    : undefined;
+  return {
+    planId: plan.id,
+    action: plan.action,
+    commit: plan.commit,
+    artifact: artifact ? relative(plan.projectDir, artifact) : undefined,
+    sha256,
+    results,
+  };
+}
+
+export function safePlanView(plan: ReleasePlan) {
+  return {
+    ...plan,
+    commands: plan.commands.map((command) => ({
+      ...command,
+      args: command.args.map((arg) => {
+        if (arg === process.env.APPLE_ASC_PRIVATE_KEY_PATH)
+          return "<private-key-path>";
+        if (arg === process.env.APPLE_ASC_KEY_ID) return "<key-id>";
+        if (arg === process.env.APPLE_ASC_ISSUER_ID) return "<issuer-id>";
+        return arg;
+      }),
+    })),
+  };
+}

--- a/packages/integrations/apple-mobile/src/security.ts
+++ b/packages/integrations/apple-mobile/src/security.ts
@@ -1,0 +1,108 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+function defaultRoots(): string[] {
+  const home = homedir();
+  return [
+    resolve(home, "dev"),
+    resolve(home, ".opensession/worktrees"),
+    resolve(home, ".opensession-worktrees"),
+    resolve(home, ".opensession-scratch"),
+    resolve(home, ".opensession-session-scratch"),
+  ];
+}
+
+export function allowedRoots(): string[] {
+  const configured = process.env.APPLE_MOBILE_ALLOWED_ROOTS;
+  const roots = configured
+    ? configured
+        .split(":")
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : defaultRoots();
+  return roots.map((root) =>
+    existsSync(root) ? realpathSync(root) : resolve(root),
+  );
+}
+
+export function isWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return (
+    rel === "" ||
+    (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel))
+  );
+}
+
+export function resolveProjectDir(input: string): string {
+  if (!input || typeof input !== "string")
+    throw new Error("projectDir is required");
+  const candidate = realpathSync(resolve(input));
+  if (!allowedRoots().some((root) => isWithin(root, candidate))) {
+    throw new Error(
+      `Project is outside APPLE_MOBILE_ALLOWED_ROOTS: ${candidate}`,
+    );
+  }
+  return candidate;
+}
+
+export function resolveProjectPath(
+  projectDir: string,
+  input: string,
+  options: { mustExist?: boolean } = {},
+): string {
+  if (!input || isAbsolute(input))
+    throw new Error("Paths must be non-empty and project-relative");
+  const unresolved = resolve(projectDir, input);
+  if (!isWithin(projectDir, unresolved))
+    throw new Error(`Path escapes project: ${input}`);
+
+  if (options.mustExist !== false) {
+    const candidate = realpathSync(unresolved);
+    if (!isWithin(projectDir, candidate))
+      throw new Error(`Symlink escapes project: ${input}`);
+    return candidate;
+  }
+
+  let parent = dirname(unresolved);
+  while (!existsSync(parent)) {
+    const next = dirname(parent);
+    if (next === parent) break;
+    parent = next;
+  }
+  const realParent = realpathSync(parent);
+  if (!isWithin(projectDir, realParent))
+    throw new Error(`Output parent escapes project: ${input}`);
+  return unresolved;
+}
+
+export function resolvePrivateKeyPath(input: string): string {
+  if (!input) throw new Error("APPLE_ASC_PRIVATE_KEY_PATH is required");
+  const path = realpathSync(resolve(input));
+  const stat = statSync(path);
+  if (!stat.isFile())
+    throw new Error("APPLE_ASC_PRIVATE_KEY_PATH must be a file");
+  if ((stat.mode & 0o077) !== 0) {
+    throw new Error(
+      "APPLE_ASC_PRIVATE_KEY_PATH must not be accessible by group or others",
+    );
+  }
+  if (allowedRoots().some((root) => isWithin(root, path))) {
+    throw new Error(
+      "APPLE_ASC_PRIVATE_KEY_PATH must be outside APPLE_MOBILE_ALLOWED_ROOTS",
+    );
+  }
+  return path;
+}
+
+export function redact(value: string): string {
+  const secrets = [
+    process.env.APPLE_ASC_PRIVATE_KEY_PATH,
+    process.env.APPLE_ASC_KEY_ID,
+    process.env.APPLE_ASC_ISSUER_ID,
+  ].filter((entry): entry is string => Boolean(entry));
+  return secrets.reduce(
+    (text, secret) => text.split(secret).join("<redacted>"),
+    value,
+  );
+}

--- a/packages/integrations/apple-mobile/src/server.ts
+++ b/packages/integrations/apple-mobile/src/server.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env bun
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import { buildUnsigned, doctor, inspectIpa, runSwiftTests } from "./build";
+import { inspectProject } from "./project";
+import { createBuildPlan, createUploadPlan } from "./plans";
+import { executePlan, safePlanView } from "./release";
+
+function modeFrom(args: string[]): "build" | "release" {
+  const index = args.indexOf("--mode");
+  const mode = index >= 0 ? args[index + 1] : "build";
+  if (mode !== "build" && mode !== "release") {
+    throw new Error("--mode must be build or release");
+  }
+  return mode;
+}
+
+type Args = Record<string, unknown>;
+const string = (
+  args: Args,
+  key: string,
+  required = true,
+): string | undefined => {
+  const value = args[key];
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== "string" || !value)
+    throw new Error(`${key} must be a non-empty string`);
+  return value;
+};
+const boolean = (args: Args, key: string, fallback = false): boolean => {
+  const value = args[key];
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") throw new Error(`${key} must be boolean`);
+  return value;
+};
+
+const projectProperty = {
+  projectDir: {
+    type: "string",
+    description: "Absolute path to an allowed OpenSession app worktree",
+  },
+};
+const buildTools: Tool[] = [
+  {
+    name: "apple_mobile_doctor",
+    description:
+      "Inspect host Apple/Swift/xtool capabilities without changing anything.",
+    inputSchema: {
+      type: "object",
+      properties: { projectDir: { type: "string" } },
+    },
+  },
+  {
+    name: "apple_mobile_inspect_project",
+    description:
+      "Validate .opensession/apple-mobile.json and inspect the project/revision.",
+    inputSchema: {
+      type: "object",
+      properties: projectProperty,
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "apple_mobile_test",
+    description:
+      "Run swift test in a configured Swift package. No signing or upload.",
+    inputSchema: {
+      type: "object",
+      properties: projectProperty,
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "apple_mobile_build_unsigned",
+    description:
+      "Build with xtool or Xcode without signing. xtool can optionally emit an IPA.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        configuration: { type: "string", enum: ["debug", "release"] },
+        ipa: { type: "boolean" },
+      },
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "apple_mobile_inspect_ipa",
+    description:
+      "Read version/bundle metadata and SHA-256 from an IPA inside the project.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        artifactPath: {
+          type: "string",
+          description: "Project-relative IPA path",
+        },
+      },
+      required: ["projectDir", "artifactPath"],
+    },
+  },
+];
+const releaseTools: Tool[] = [
+  {
+    name: "apple_release_doctor",
+    description:
+      "Inspect release prerequisites and credential presence without revealing credentials.",
+    inputSchema: {
+      type: "object",
+      properties: { projectDir: { type: "string" } },
+    },
+  },
+  {
+    name: "apple_release_plan_adhoc",
+    description:
+      "Create a one-hour, commit-bound plan for an Xcode ad-hoc export. Does not build or sign.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        marketingVersion: { type: "string" },
+        buildNumber: { type: "string" },
+      },
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "apple_release_plan_testflight",
+    description:
+      "Create a one-hour, commit-bound plan for Xcode archive/export/TestFlight upload. Does not upload.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        marketingVersion: { type: "string" },
+        buildNumber: { type: "string" },
+      },
+      required: ["projectDir"],
+    },
+  },
+  {
+    name: "apple_release_plan_upload",
+    description:
+      "Create a one-hour plan bound to the commit and SHA-256 of an existing IPA. Execution requires Xcode command-line tools on macOS.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        artifactPath: { type: "string" },
+      },
+      required: ["projectDir", "artifactPath"],
+    },
+  },
+  {
+    name: "apple_release_execute",
+    description:
+      "Execute a previously reviewed plan. confirmation must exactly equal its full commit SHA.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...projectProperty,
+        planId: { type: "string" },
+        confirmation: {
+          type: "string",
+          description: "Full planned git commit SHA",
+        },
+      },
+      required: ["projectDir", "planId", "confirmation"],
+    },
+  },
+];
+
+async function call(name: string, args: Args): Promise<unknown> {
+  switch (name) {
+    case "apple_mobile_doctor":
+    case "apple_release_doctor":
+      return doctor(string(args, "projectDir", false));
+    case "apple_mobile_inspect_project":
+      return inspectProject(string(args, "projectDir")!);
+    case "apple_mobile_test":
+      return runSwiftTests(string(args, "projectDir")!);
+    case "apple_mobile_build_unsigned":
+      return buildUnsigned(
+        string(args, "projectDir")!,
+        string(args, "configuration", false) as "debug" | "release" | undefined,
+        boolean(args, "ipa"),
+      );
+    case "apple_mobile_inspect_ipa":
+      return inspectIpa(
+        string(args, "projectDir")!,
+        string(args, "artifactPath")!,
+      );
+    case "apple_release_plan_adhoc": {
+      const result = await createBuildPlan(
+        string(args, "projectDir")!,
+        "adhoc",
+        {
+          marketingVersion: string(args, "marketingVersion", false),
+          buildNumber: string(args, "buildNumber", false),
+        },
+      );
+      return { ...result, plan: safePlanView(result.plan) };
+    }
+    case "apple_release_plan_testflight": {
+      const result = await createBuildPlan(
+        string(args, "projectDir")!,
+        "testflight",
+        {
+          marketingVersion: string(args, "marketingVersion", false),
+          buildNumber: string(args, "buildNumber", false),
+        },
+      );
+      return { ...result, plan: safePlanView(result.plan) };
+    }
+    case "apple_release_plan_upload": {
+      const result = await createUploadPlan(
+        string(args, "projectDir")!,
+        string(args, "artifactPath")!,
+      );
+      return { ...result, plan: safePlanView(result.plan) };
+    }
+    case "apple_release_execute":
+      return executePlan(
+        string(args, "projectDir")!,
+        string(args, "planId")!,
+        string(args, "confirmation")!,
+      );
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+export async function startAppleMobileServer(args = process.argv.slice(2)) {
+  const mode = modeFrom(args);
+  process.env.APPLE_MOBILE_MCP_MODE = mode;
+  const server = new Server(
+    { name: `opensession-apple-${mode}`, version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: mode === "build" ? buildTools : releaseTools,
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    try {
+      const result = await call(
+        request.params.name,
+        (request.params.arguments ?? {}) as Args,
+      );
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: error instanceof Error ? error.message : String(error),
+          },
+        ],
+      };
+    }
+  });
+  await server.connect(new StdioServerTransport());
+}
+
+if (import.meta.main) await startAppleMobileServer();

--- a/packages/integrations/apple-mobile/src/types.ts
+++ b/packages/integrations/apple-mobile/src/types.ts
@@ -1,0 +1,58 @@
+export type BuildBackend = "xtool" | "xcode";
+
+export interface XcodeProjectConfig {
+  container: "workspace" | "project";
+  path: string;
+  scheme: string;
+  configuration?: string;
+}
+
+export interface AppleMobileConfig {
+  version: 1;
+  backend: BuildBackend;
+  bundleId: string;
+  teamId?: string;
+  xtool?: {
+    configuration?: "debug" | "release";
+  };
+  xcode?: XcodeProjectConfig;
+  release?: {
+    requireClean?: boolean;
+    allowedBranches?: string[];
+    artifactDirectory?: string;
+  };
+}
+
+export type ReleaseAction = "adhoc" | "testflight" | "upload";
+
+export interface CommandSpec {
+  executable: string;
+  args: string[];
+  cwd: string;
+}
+
+export interface ReleasePlan {
+  schemaVersion: 1;
+  id: string;
+  action: ReleaseAction;
+  projectDir: string;
+  commit: string;
+  branch: string;
+  configHash: string;
+  createdAt: string;
+  expiresAt: string;
+  marketingVersion?: string;
+  buildNumber?: string;
+  sourceArtifact?: string;
+  sourceArtifactSha256?: string;
+  outputDirectory: string;
+  commands: CommandSpec[];
+}
+
+export interface CommandResult {
+  command: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}

--- a/packages/integrations/apple-mobile/tests/integration.test.ts
+++ b/packages/integrations/apple-mobile/tests/integration.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../src/config";
+import { createBuildPlan, loadPlan } from "../src/plans";
+import { resolveProjectDir, resolveProjectPath } from "../src/security";
+import { runChecked } from "../src/exec";
+
+let root: string;
+let project: string;
+let key: string;
+const previous = { ...process.env };
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "apple-mobile-test-"));
+  project = join(root, "app");
+  mkdirSync(join(project, ".opensession"), { recursive: true });
+  mkdirSync(join(project, "App.xcworkspace"));
+  key = join(root, "AuthKey_TEST.p8");
+  await Bun.write(key, "test-key");
+  chmodSync(key, 0o600);
+  process.env.APPLE_MOBILE_ALLOWED_ROOTS = project;
+  process.env.OPENSESSION_STATE_DIR = join(root, "state");
+  process.env.APPLE_ASC_KEY_ID = "TESTKEY";
+  process.env.APPLE_ASC_ISSUER_ID = "00000000-0000-0000-0000-000000000000";
+  process.env.APPLE_ASC_PRIVATE_KEY_PATH = key;
+  await Bun.write(
+    join(project, ".opensession/apple-mobile.json"),
+    JSON.stringify({
+      version: 1,
+      backend: "xcode",
+      bundleId: "com.example.App",
+      teamId: "TEAM123",
+      xcode: { container: "workspace", path: "App.xcworkspace", scheme: "App" },
+      release: {
+        requireClean: true,
+        allowedBranches: ["main"],
+        artifactDirectory: ".build/apple-mobile",
+      },
+    }),
+  );
+  await Bun.write(join(project, ".gitignore"), ".build\n");
+  await runChecked({
+    executable: "git",
+    args: ["init", "-b", "main"],
+    cwd: project,
+  });
+  await runChecked({
+    executable: "git",
+    args: ["config", "user.email", "test@example.invalid"],
+    cwd: project,
+  });
+  await runChecked({
+    executable: "git",
+    args: ["config", "user.name", "Test"],
+    cwd: project,
+  });
+  await runChecked({ executable: "git", args: ["add", "."], cwd: project });
+  await runChecked({
+    executable: "git",
+    args: ["commit", "-m", "fixture"],
+    cwd: project,
+  });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  process.env = { ...previous };
+});
+
+describe("configuration and path boundary", () => {
+  test("loads a valid Xcode app config", async () => {
+    const loaded = await loadConfig(resolveProjectDir(project));
+    expect(loaded.config.bundleId).toBe("com.example.App");
+    expect(loaded.hash).toHaveLength(64);
+  });
+
+  test("rejects paths outside the project", () => {
+    expect(() => resolveProjectPath(project, "../AuthKey_TEST.p8")).toThrow(
+      "escapes project",
+    );
+  });
+
+  test("rejects projects outside configured roots", () => {
+    process.env.APPLE_MOBILE_ALLOWED_ROOTS = join(root, "other");
+    expect(() => resolveProjectDir(project)).toThrow(
+      "outside APPLE_MOBILE_ALLOWED_ROOTS",
+    );
+  });
+});
+
+describe("release plans", () => {
+  test("binds a TestFlight plan to commit and config", async () => {
+    const result = await createBuildPlan(project, "testflight", {
+      marketingVersion: "1.2.3",
+      buildNumber: "42",
+    });
+    expect(result.plan.action).toBe("testflight");
+    expect(result.plan.commit).toHaveLength(40);
+    expect(result.plan.commands).toHaveLength(3);
+    expect(result.plan.commands[0]!.args).toContain("MARKETING_VERSION=1.2.3");
+    const loaded = await loadPlan(project, result.plan.id);
+    expect(loaded.plan.id).toBe(result.plan.id);
+  });
+
+  test("rejects a release key stored in an allowed worktree", async () => {
+    process.env.APPLE_ASC_PRIVATE_KEY_PATH = join(
+      project,
+      ".build/AuthKey_TEST.p8",
+    );
+    mkdirSync(join(project, ".build"));
+    await Bun.write(process.env.APPLE_ASC_PRIVATE_KEY_PATH, "test-key");
+    chmodSync(process.env.APPLE_ASC_PRIVATE_KEY_PATH, 0o600);
+    expect(createBuildPlan(project, "adhoc")).rejects.toThrow(
+      "must be outside APPLE_MOBILE_ALLOWED_ROOTS",
+    );
+  });
+
+  test("rejects a tampered plan even when the commit is unchanged", async () => {
+    const result = await createBuildPlan(project, "adhoc");
+    const planFile = join(project, result.planFile);
+    const stored = JSON.parse(await Bun.file(planFile).text());
+    stored.plan.commands[0].executable = "malicious-command";
+    await Bun.write(planFile, JSON.stringify(stored));
+    expect(loadPlan(project, result.plan.id)).rejects.toThrow(
+      "signature is invalid",
+    );
+  });
+
+  test("invalidates a plan when configuration changes", async () => {
+    const result = await createBuildPlan(project, "adhoc");
+    const configPath = join(project, ".opensession/apple-mobile.json");
+    const config = JSON.parse(await Bun.file(configPath).text());
+    config.bundleId = "com.example.Changed";
+    await Bun.write(configPath, JSON.stringify(config));
+    expect(loadPlan(project, result.plan.id)).rejects.toThrow();
+  });
+});

--- a/packages/integrations/apple-mobile/tests/mcp.test.ts
+++ b/packages/integrations/apple-mobile/tests/mcp.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const clients: Client[] = [];
+const transports: StdioClientTransport[] = [];
+
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.close()));
+  await Promise.all(transports.splice(0).map((transport) => transport.close()));
+});
+
+async function tools(mode: "build" | "release") {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [
+      new URL("../../../../scripts/cli.ts", import.meta.url).pathname,
+      "apple-mobile-mcp",
+      "--mode",
+      mode,
+    ],
+  });
+  const client = new Client({ name: "test", version: "1.0.0" });
+  transports.push(transport);
+  clients.push(client);
+  await client.connect(transport);
+  return client.listTools();
+}
+
+describe("MCP surfaces", () => {
+  test("build mode exposes no release mutators", async () => {
+    const result = await tools("build");
+    const names = result.tools.map((tool) => tool.name);
+    expect(names).toContain("apple_mobile_build_unsigned");
+    expect(names.some((name) => name.startsWith("apple_release"))).toBe(false);
+  });
+
+  test("release mode exposes planning and execution separately", async () => {
+    const result = await tools("release");
+    const names = result.tools.map((tool) => tool.name);
+    expect(names).toContain("apple_release_plan_testflight");
+    expect(names).toContain("apple_release_execute");
+    expect(names.some((name) => name.startsWith("apple_mobile_build"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/integrations/apple-mobile/tsconfig.json
+++ b/packages/integrations/apple-mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src", "tests"]
+}

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -494,6 +494,15 @@ async function main(): Promise<number> {
         return await runnersRemove(positional[1] ?? "");
       return await runnersList();
 
+    // First-party stdio MCP entry point. Keeping it behind the installed
+    // command gives Connections a stable target across release worktrees.
+    case "apple-mobile-mcp": {
+      const { startAppleMobileServer } =
+        await import("../packages/integrations/apple-mobile/src/server");
+      await startAppleMobileServer(argv.slice(1));
+      await new Promise<never>(() => {});
+    }
+
     // Internal git credential-helper entrypoint. It stays out of --help, but is
     // routed through the installed command so compiled releases need no Bun or
     // source-tree sidecar.


### PR DESCRIPTION
## Summary

- add the maintained `@tellahq/opensession-apple-mobile` workspace package and stable `opensession apple-mobile-mcp` stdio entry point
- keep credential-free build tools separate from user-restricted release tools, including enforced `allowedUsers` protection for `apple-release`, project-root boundaries, protected credential paths, and authenticated commit-bound release plans
- ship the Apple mobile skill, setup guide, examples, Connections labels, and a Library catalog entry
- document xtool's development-only distribution, Apple SDK licensing concerns on Linux, the macOS/Xcode release requirement, and the absence of App Review or public-release actions

## Verification

- `bun test packages/integrations/apple-mobile packages/core/opensession-server/src/server/connections-security.test.ts packages/core/opensession-server/src/server/plugins.test.ts packages/core/opensession-server/src/server/routes/connections.test.ts` (50 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun scripts/check-module-side-effects.ts`

Created by [this Assistant session](http://100.81.254.102:3850/session/bks-0fd11e2a-f3d3-7625-b346-ea5af3926480)
