### PR TITLE
Expose isolatedWorktree on the sessions MCP surface

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/sessions-tools.test.ts
+++ b/packages/core/opensession-server/src/agents/slack/sessions-tools.test.ts
@@ -361,6 +361,30 @@ describe("spawnTaskImpl", () => {
     );
     expect(inferred.ok).toBe(true);
   });
+
+  it("accepts isolatedWorktree: a branchless code task gets its own worktree instead of sharing the parent's", async () => {
+    const h = makeHarness();
+    const parent = `bks-test-parent-${++uniq}`;
+    h.files.set(parent, { id: parent });
+    h.sessions.set(parent, {
+      id: parent,
+      mode: "code",
+      worktreeDir: "/home/ubuntu/projects/opensession",
+      repo: "opensession",
+    });
+
+    const res = await spawnTaskImpl(
+      { prompt: "Fan out: fix module B.", isolatedWorktree: true },
+      ctx(parent),
+      h.deps,
+    );
+    expect(res.ok).toBe(true);
+    // Forwarded so the wiring mints a per-branch worktree (branch generated
+    // from the prompt by the durable create plan) while keeping child linkage.
+    expect(h.created[0].isolatedWorktree).toBe(true);
+    expect(h.created[0].branch).toBeUndefined();
+    expect(h.created[0].parentSessionId).toBe(parent);
+  });
 });
 
 describe("session creator metadata", () => {
@@ -490,6 +514,48 @@ describe("session creator metadata", () => {
       ).content[0].text;
       expect(h.created[0].branch).toBeUndefined();
       expect(output).toContain("code session");
+    } finally {
+      await client.close();
+      await server.instance.close();
+    }
+  });
+
+  it("exposes isolatedWorktree on create_session and forwards it to createSession", async () => {
+    const h = makeHarness();
+    registerSessionControl(h.deps.control);
+    const server = createSessionsMcpServer(ctx("bks-parent"));
+    const client = new Client({
+      name: "sessions-tools-test",
+      version: "1.0.0",
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.instance.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const listedTools = await client.listTools();
+      const createTool = listedTools.tools.find(
+        (tool) => tool.name === "create_session",
+      );
+      // The server capability exists (SessionControlCreateInput); the MCP
+      // adapter must expose it or matching-repo children always share the
+      // parent worktree from the agent's perspective.
+      expect(createTool?.inputSchema.properties).toHaveProperty(
+        "isolatedWorktree",
+      );
+
+      await client.callTool({
+        name: "create_session",
+        arguments: {
+          prompt: "Fan out: fix the lint errors in module A.",
+          mode: "code",
+          isolatedWorktree: true,
+        },
+      });
+      // Forwarded to SessionControl.createSession, with child linkage intact.
+      expect(h.created[0].isolatedWorktree).toBe(true);
+      expect(h.created[0].parentSessionId).toBe("bks-parent");
+      expect(h.created[0].reportBack).toBe(true);
     } finally {
       await client.close();
       await server.instance.close();

--- a/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/sessions-tools.ts
@@ -443,6 +443,8 @@ export interface SpawnTaskArgs {
   branch?: string;
   model?: string;
   mode?: "ask" | "code" | "scratch";
+  /** Give the child its own worktree/branch instead of sharing the parent's. */
+  isolatedWorktree?: boolean;
   /** true = config default provider; or an explicit configured provider id. */
   sandbox?:
     | boolean
@@ -499,7 +501,7 @@ export async function spawnTaskImpl(
   // Code mode needs somewhere to work: an explicit branch, or a parent code
   // session whose worktree the child will share (createSession's same-
   // workspace = same-worktree rule; only when the repo matches).
-  if (mode === "code" && !args.branch?.trim()) {
+  if (mode === "code" && !args.branch?.trim() && !args.isolatedWorktree) {
     let sharable = false;
     if (caller) {
       try {
@@ -532,6 +534,7 @@ export async function spawnTaskImpl(
     mode,
     branch: args.branch,
     model: args.model,
+    isolatedWorktree: args.isolatedWorktree,
     parentSessionId: caller,
     reportBack: Boolean(caller),
     user: ctx.createdBy,
@@ -1057,7 +1060,7 @@ export function createSessionsMcpServer(
       ),
       tool(
         "create_session",
-        `Spin up a visible ${productName()} session and start it on a prompt. Use this as the sub-session primitive: workers can delegate focused tasks and report back to this parent session. mode 'ask' (default) runs read-only on the selected repo checkout; mode 'code' can edit files / open PRs (never merges). A worker targeting one of the parent's repos shares that exact primary or attached worktree, so reviewers see current/uncommitted work; pass repo explicitly for attached-repo tasks. \`branch\` is only used when there is nothing to share — a standalone worker, or a worker targeting a repo the parent does not carry — and is generated from the prompt when omitted. Repo defaults to the parent session's repo (${defaultRepo().id} when standalone); pass another registered repo id to override. For workers that only need filesystem/code access, pass mcpServers: [] to avoid unrelated MCP startup cost/failures. When called from a session, the worker defaults to the same workspace and is instructed to report back here; set standalone true or reportBack false to opt out. When a HUMAN asks for "a new session" ("create a new session for X", "spin one up on Y"), this tool is what they mean — a detached session that appears in their sidebar and outlives the current run — never an in-process subagent or task agent; reply with the new session's URL.`,
+        `Spin up a visible ${productName()} session and start it on a prompt. Use this as the sub-session primitive: workers can delegate focused tasks and report back to this parent session. mode 'ask' (default) runs read-only on the selected repo checkout; mode 'code' can edit files / open PRs (never merges). A worker targeting one of the parent's repos shares that exact primary or attached worktree, so reviewers see current/uncommitted work; pass repo explicitly for attached-repo tasks. Pass isolatedWorktree true to instead give the worker its own worktree and branch (child/report-back linkage is kept) — use it when fanning work out across separate workspaces. \`branch\` is only used when there is nothing to share — a standalone worker, or a worker targeting a repo the parent does not carry — and is generated from the prompt when omitted. Repo defaults to the parent session's repo (${defaultRepo().id} when standalone); pass another registered repo id to override. For workers that only need filesystem/code access, pass mcpServers: [] to avoid unrelated MCP startup cost/failures. When called from a session, the worker defaults to the same workspace and is instructed to report back here; set standalone true or reportBack false to opt out. When a HUMAN asks for "a new session" ("create a new session for X", "spin one up on Y"), this tool is what they mean — a detached session that appears in their sidebar and outlives the current run — never an in-process subagent or task agent; reply with the new session's URL.`,
         {
           prompt: z
             .string()
@@ -1110,6 +1113,12 @@ export function createSessionsMcpServer(
             .describe(
               "Create an unrelated standalone session instead of a child of the current session.",
             ),
+          isolatedWorktree: z
+            .boolean()
+            .optional()
+            .describe(
+              "Code mode: give the worker its own worktree and branch instead of sharing the parent workspace's worktree, while keeping child/report-back linkage. Use when fanning work out across separate workspaces so each child produces its own diff. Branch is generated from the prompt when omitted.",
+            ),
           sandbox: z
             .union([
               z.boolean(),
@@ -1157,6 +1166,7 @@ export function createSessionsMcpServer(
             parentSessionId?: string;
             reportBack?: boolean;
             standalone?: boolean;
+            isolatedWorktree?: boolean;
             sandbox?:
               | boolean
               | "docker"
@@ -1200,6 +1210,7 @@ export function createSessionsMcpServer(
               branch,
               model: args.model,
               mcpServers: args.mcpServers,
+              isolatedWorktree: args.isolatedWorktree,
               parentSessionId,
               reportBack: shouldReportBack,
               user: ctx.createdBy,
@@ -1271,7 +1282,7 @@ export function createSessionsMcpServer(
     tools.push(
       tool(
         "spawn_task",
-        "Delegate a self-contained task to a child session and return IMMEDIATELY with {taskId, url} — the lightweight alternative to create_session + send_to_session choreography when you just want work done and a handle to poll. The child is created through the same code path as create_session (it shares this session's worktree in code mode when repos match, inherits your user, is linked as a child, and is told to report back here); poll it with task_status and stop it with cancel_task. Mode defaults to 'code' (pass a branch unless the child can share this session's code worktree); use 'ask' for read-only investigation. Loop guard: spawned children may delegate one further level, then spawn_task refuses (depth ≥ 2)." +
+        "Delegate a self-contained task to a child session and return IMMEDIATELY with {taskId, url} — the lightweight alternative to create_session + send_to_session choreography when you just want work done and a handle to poll. The child is created through the same code path as create_session (it shares this session's worktree in code mode when repos match, inherits your user, is linked as a child, and is told to report back here); poll it with task_status and stop it with cancel_task. Mode defaults to 'code' (pass a branch, or isolatedWorktree true for a generated one, unless the child can share this session's code worktree); use 'ask' for read-only investigation. Loop guard: spawned children may delegate one further level, then spawn_task refuses (depth ≥ 2)." +
           (ctx.automationSelf
             ? " Children may edit code and open PRs but NEVER merge — a human reviews every PR."
             : " Not available from automation sessions."),
@@ -1290,6 +1301,12 @@ export function createSessionsMcpServer(
             .optional()
             .describe(
               "Branch for code mode when the child can't share this session's worktree (standalone or different repo).",
+            ),
+          isolatedWorktree: z
+            .boolean()
+            .optional()
+            .describe(
+              "Code mode: give the child its own worktree and branch instead of sharing this session's worktree, keeping child/report-back linkage. Branch is generated from the prompt when omitted.",
             ),
           model: z
             .string()


### PR DESCRIPTION
## Root cause

`SessionControl.createSession` has supported `isolatedWorktree` (mint a per-branch worktree even when the child could share the parent's) since the server capability landed in session-control / session-control-wiring, but the public `opensession-sessions` MCP adapter (`src/agents/slack/sessions-tools.ts`) never exposed it: the `create_session` Zod schema, handler argument type, and forwarded `createSession` input all omitted the field. As a result, an agent fanning work out to matching-repo child sessions could not get separate workspaces — every child shared the parent worktree and produced one mingled diff. `spawn_task` had the same omission, plus a branchless code-mode guard that would have refused the isolated case.

## Fix

- Expose `isolatedWorktree?: boolean` on `create_session` and `spawn_task` (schema + handler types), forward it to `SessionControl.createSession`.
- Let `isolatedWorktree: true` satisfy `spawn_task`'s branchless code-mode guard — the durable create plan generates a branch from the prompt, exactly as the wiring already does for non-shared creates.
- Document in both tool descriptions that `true` keeps child/report-back linkage while creating the child's own worktree and branch.

## Tests

Two regression tests, written first and failing at exactly the omission before the fix:

- `exposes isolatedWorktree on create_session and forwards it to createSession` — asserts the field is in the MCP tool's input schema and reaches `createSession` with parent linkage and report-back intact.
- `accepts isolatedWorktree: a branchless code task gets its own worktree instead of sharing the parent's` — spawn_task no longer refuses a branchless isolated code task and forwards the flag with `branch` left undefined for plan generation.

`bun test src/agents/slack/sessions-tools.test.ts`: 30 pass, 0 fail. `bunx tsc --noEmit` clean.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/bks-dacf12b6-511c-71fe-a5c8-8782199fdcd3)