### PR TITLE
Workflow engine: deadline-aware agents and restart-safe pauses

### DIFF
--- a/.agents/skills/workflow-authoring/SKILL.md
+++ b/.agents/skills/workflow-authoring/SKILL.md
@@ -65,6 +65,8 @@ Options:
 
 A successful unstructured call resolves to final text. A schema call resolves to the parsed value. An errored call resolves to `null`, so filter nulls before synthesis. Unsupported effort levels are ignored rather than failing the call.
 
+Agents are deadline-aware. An agent explores until a soft deadline, then its session is resumed once with a "stop and answer now" instruction funded by the rest of its budget, so a long call returns a real verdict instead of dying mid-thought. Write prompts whose output contract still makes sense for a partial answer. Only the hard deadline fails the call, and that row keeps the tail of the partial reply and the tool-call count for the run's own diagnostics.
+
 Agents are read-only by default. Use `write` only when a lightweight branch-producing agent is sufficient. A successful write call returns an object containing `text`, `structured`, `seq`, `branch`, `worktreeDir`, `changed`, `files`, `insertions`, and `deletions`. Use a durable child session when work needs an inspectable transcript, steering, a worktree, or a pull request.
 
 ### `merge(writeResults)`

--- a/packages/core/opensession-server/src/server/workflow-execute.test.ts
+++ b/packages/core/opensession-server/src/server/workflow-execute.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { RunAgentOpts } from "./agent-runner";
 import type { StreamEvent } from "./run-events";
 import {
+  _setAgentDeadlinesForTests,
   _setRunAgentForTests,
   extractLastFencedJson,
   runAgentCollect,
@@ -13,6 +14,7 @@ import { WORKFLOW_LIMITS, type WorkflowExecCtx } from "./workflow-types";
 
 afterEach(() => {
   _setRunAgentForTests(null);
+  _setAgentDeadlinesForTests(null);
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -661,5 +663,82 @@ describe("workflowExecutor", () => {
     ]);
     expect(a.text).toBe("result-A");
     expect(b.text).toBe("result-B");
+  });
+});
+
+// ── Deadlines ────────────────────────────────────────────────────────────────
+
+describe("workflowExecutor deadlines", () => {
+  test("soft deadline asks the agent to wrap up and returns that verdict", async () => {
+    const calls: RunAgentOpts[] = [];
+    _setAgentDeadlinesForTests({ softMs: 20, hardMs: 5_000 });
+    _setRunAgentForTests(async function* (opts: RunAgentOpts) {
+      calls.push(opts);
+      yield { type: "init", sessionId: "oc-1" } as StreamEvent;
+      if (calls.length === 1) {
+        yield { type: "tool_use", name: "Read" } as StreamEvent;
+        yield { type: "text_chunk", text: "still exploring" } as StreamEvent;
+        await new Promise(() => {}); // hang until the soft deadline aborts us
+      }
+      yield { type: "text_chunk", text: "VERDICT: ship it" } as StreamEvent;
+      yield { type: "done" } as StreamEvent;
+    });
+
+    const out = await workflowExecutor.execute(
+      { prompt: "review this", opts: {}, seq: 0 },
+      makeCtx(),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.text).toBe("VERDICT: ship it");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].prompt).toContain("STOP.");
+    // Resumed, so the task and everything it read are still in context.
+    expect(calls[1].sessionId).toBe("oc-1");
+    // The exploring turn's spend is carried into the final row.
+    expect(out.toolCalls).toBe(1);
+    expect(out.timeoutDiagnostics).toBeUndefined();
+  });
+
+  test("hard deadline keeps the partial reply as diagnostics", async () => {
+    const calls: RunAgentOpts[] = [];
+    _setAgentDeadlinesForTests({ softMs: 20, hardMs: 150 });
+    _setRunAgentForTests(async function* (opts: RunAgentOpts) {
+      calls.push(opts);
+      yield { type: "init", sessionId: "oc-1" } as StreamEvent;
+      yield { type: "tool_use", name: "Read" } as StreamEvent;
+      yield { type: "text_chunk", text: "half an answer" } as StreamEvent;
+      await new Promise(() => {}); // never finishes, wrap-up turn included
+    });
+
+    const out = await workflowExecutor.execute(
+      { prompt: "review this", opts: {}, seq: 0 },
+      makeCtx(),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain("timed out");
+    expect(out.timeoutDiagnostics?.warned).toBe(true);
+    expect(out.timeoutDiagnostics?.partialText).toContain("half an answer");
+    expect(out.timeoutDiagnostics?.toolCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a plain workflow cancel is not reported as a timeout", async () => {
+    _setAgentDeadlinesForTests({ softMs: 5_000, hardMs: 10_000 });
+    const controller = new AbortController();
+    _setRunAgentForTests(async function* () {
+      yield { type: "init", sessionId: "oc-1" } as StreamEvent;
+      controller.abort();
+      await new Promise(() => {});
+    });
+
+    const out = await workflowExecutor.execute(
+      { prompt: "review this", opts: {}, seq: 0 },
+      makeCtx({ signal: controller.signal }),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("workflow cancelled");
+    expect(out.timeoutDiagnostics).toBeUndefined();
   });
 });

--- a/packages/core/opensession-server/src/server/workflow-execute.ts
+++ b/packages/core/opensession-server/src/server/workflow-execute.ts
@@ -97,6 +97,26 @@ export function _setWorktreeOpsForTests(ops: WorkflowWorktreeOps | null): void {
   worktreeOps = ops ?? realWorktreeOps;
 }
 
+// ── deadline seam (tests shrink the 15-minute budget) ───────────────────────
+
+let deadlineOverride: { hardMs: number; softMs: number } | null = null;
+
+/** Test seam: shrink the per-agent deadlines (null restores the real ones). */
+export function _setAgentDeadlinesForTests(
+  deadlines: { hardMs: number; softMs: number } | null,
+): void {
+  deadlineOverride = deadlines;
+}
+
+function agentDeadlines(): { hardMs: number; softMs: number } {
+  if (deadlineOverride) return deadlineOverride;
+  const hardMs = WORKFLOW_LIMITS.agentTimeoutMs;
+  return {
+    hardMs,
+    softMs: Math.round(hardMs * WORKFLOW_LIMITS.agentWrapUpAtFraction),
+  };
+}
+
 // ── runAgentCollect ──────────────────────────────────────────────────────────
 
 export interface RunAgentCollectResult {
@@ -477,6 +497,15 @@ const WRITE_PREAMBLE =
   "sibling worktrees in parallel. Your final message is a short report of what " +
   "you changed — no greeting, preamble or sign-off.";
 
+/** Sent when the soft deadline stops an exploring turn. It resumes the agent's
+ *  own session, so the task and everything it has read are still in context. */
+const WRAP_UP_PROMPT =
+  "STOP. You are out of time on this task. Do not read, search, or call any " +
+  "more tools. Reply now with your final answer in exactly the format the task " +
+  "asked for, based only on what you already know. If you are not fully " +
+  "confident, still give your best current verdict and say briefly what is " +
+  "unresolved — a partial answer now is worth far more than none.";
+
 function capResult(text: string): string {
   return text.length > WORKFLOW_LIMITS.maxResultChars
     ? text.slice(0, WORKFLOW_LIMITS.maxResultChars)
@@ -572,16 +601,31 @@ export const workflowExecutor: WorkflowExecutor = {
     const effort = agentEffort(model, req.opts.effort);
     const write = req.opts.write === true;
 
-    // Per-agent timeout + the workflow's cancel signal fold into one signal.
+    // Deadline shape: the agent explores until the SOFT deadline, then gets one
+    // short wrap-up turn ("stop and answer now") funded by the rest of the
+    // budget. Only the HARD deadline fails the call. `inner` carries the
+    // exploring turn, `wrapUp` the final one, and the workflow's own cancel
+    // aborts both.
+    const { hardMs: hardDeadlineMs, softMs: softDeadlineMs } = agentDeadlines();
     const inner = new AbortController();
+    const wrapUp = new AbortController();
+    let softExpired = false;
     let timedOut = false;
-    const onCancel = () => inner.abort();
-    if (ctx.signal.aborted) inner.abort();
-    else ctx.signal.addEventListener("abort", onCancel, { once: true });
-    const timer = setTimeout(() => {
-      timedOut = true;
+    let warned = false;
+    const onCancel = () => {
       inner.abort();
-    }, WORKFLOW_LIMITS.agentTimeoutMs);
+      wrapUp.abort();
+    };
+    if (ctx.signal.aborted) onCancel();
+    else ctx.signal.addEventListener("abort", onCancel, { once: true });
+    const softTimer = setTimeout(() => {
+      softExpired = true;
+      inner.abort();
+    }, softDeadlineMs);
+    const hardTimer = setTimeout(() => {
+      timedOut = true;
+      onCancel();
+    }, hardDeadlineMs);
 
     // Set once a write agent's worktree exists — the finally block cleans it
     // up when the agent produced no commit of its own.
@@ -623,7 +667,10 @@ export const workflowExecutor: WorkflowExecutor = {
 
       const cancelError = () =>
         timedOut
-          ? `agent timed out after ${Math.round(WORKFLOW_LIMITS.agentTimeoutMs / 60_000)}m`
+          ? `agent timed out after ${Math.round(hardDeadlineMs / 60_000)}m` +
+            (warned
+              ? " (it was asked to wrap up and still did not finish)"
+              : "")
           : "workflow cancelled";
 
       let engineSessionId: string | undefined;
@@ -631,7 +678,74 @@ export const workflowExecutor: WorkflowExecutor = {
         engineSessionId = id;
         ctx.onEngineSession?.(id);
       };
-      const runner = runAgentImpl ?? detachedWorkflowRunner(ctx, inner.signal);
+      // One runner per turn: the detached host binds to the signal it was built
+      // with, so the wrap-up turn needs its own or it dies on the already-
+      // aborted exploring signal.
+      const runnerFor = (signal: AbortSignal): RunAgentFn =>
+        runAgentImpl ?? detachedWorkflowRunner(ctx, signal);
+
+      /**
+       * Run one agent turn under the deadline policy. When the soft deadline
+       * stops an exploring turn, resume the SAME engine session once with a
+       * terse "answer now" instruction and return that reply instead. Spend from
+       * both turns is summed so per-agent accounting stays whole.
+       */
+      const collect = async (
+        opts: RunAgentOpts,
+        wrapUpSuffix = "",
+      ): Promise<RunAgentCollectResult> => {
+        const first = await runAgentCollect(
+          opts,
+          inner.signal,
+          onEngineSession,
+          runnerFor(inner.signal),
+        );
+        const resumeId = first.engineSessionId || engineSessionId;
+        const softStopped =
+          first.error === "cancelled" &&
+          softExpired &&
+          !timedOut &&
+          !ctx.signal.aborted;
+        // Without a session to resume, a wrap-up turn would start cold with no
+        // task context — worth nothing, so keep the partial result instead.
+        if (!softStopped || !resumeId) return first;
+        warned = true;
+        const wrap = await runAgentCollect(
+          {
+            ...opts,
+            prompt: WRAP_UP_PROMPT + wrapUpSuffix,
+            sessionId: resumeId,
+          },
+          wrapUp.signal,
+          onEngineSession,
+          runnerFor(wrapUp.signal),
+        );
+        return {
+          ...wrap,
+          text: wrap.text || first.text,
+          model: wrap.model || first.model,
+          tokens: addTokens(first.tokens, wrap.tokens),
+          toolCalls: first.toolCalls + wrap.toolCalls,
+          engineSessionId: wrap.engineSessionId || resumeId,
+        };
+      };
+
+      /** What a timed-out agent had already produced. Without this a 15-minute
+       *  agent that died one sentence short reports nothing at all. */
+      const timeoutDiagnostics = (
+        res: RunAgentCollectResult,
+        totalToolCalls = res.toolCalls,
+      ): Pick<WorkflowAgentOutcome, "timeoutDiagnostics"> => {
+        if (!timedOut) return {};
+        const tail = res.text.trim().slice(-WORKFLOW_LIMITS.timeoutTailChars);
+        return {
+          timeoutDiagnostics: {
+            ...(tail ? { partialText: tail } : {}),
+            toolCalls: totalToolCalls,
+            warned,
+          },
+        };
+      };
 
       /** Everything a write agent adds on top of a finished run: commit its
        *  work, diffstat it, and drop the worktree when it changed nothing. */
@@ -679,12 +793,7 @@ export const workflowExecutor: WorkflowExecutor = {
       };
 
       if (req.opts.schema === undefined) {
-        const res = await runAgentCollect(
-          { ...baseOpts, prompt },
-          inner.signal,
-          onEngineSession,
-          runner,
-        );
+        const res = await collect({ ...baseOpts, prompt });
         if (res.error) {
           return await withWriteResult({
             ok: false,
@@ -693,6 +802,7 @@ export const workflowExecutor: WorkflowExecutor = {
             model: res.model || model,
             tokens: res.tokens,
             toolCalls: res.toolCalls,
+            ...timeoutDiagnostics(res),
           });
         }
         return await withWriteResult({
@@ -707,9 +817,10 @@ export const workflowExecutor: WorkflowExecutor = {
 
       // Schema mode: demand a fenced json block, validate, retry by
       // resuming the same engine session with the validation errors.
-      prompt +=
+      const schemaReminder =
         "\n\nReply with ONLY a fenced ```json block matching this JSON Schema:\n" +
         JSON.stringify(req.opts.schema);
+      prompt += schemaReminder;
       let tokens: { input: number; output: number } | undefined;
       let toolCalls = 0;
       let lastModel: string | undefined;
@@ -731,11 +842,9 @@ export const workflowExecutor: WorkflowExecutor = {
               "Reply again with ONLY a fenced ```json block matching the schema — no other " +
               "text. In case earlier context was lost, the original task follows.\n\n" +
               prompt;
-        const res = await runAgentCollect(
+        const res = await collect(
           { ...baseOpts, prompt: attemptPrompt, sessionId: engineSessionId },
-          inner.signal,
-          onEngineSession,
-          runner,
+          schemaReminder,
         );
         engineSessionId = res.engineSessionId || engineSessionId;
         tokens = addTokens(tokens, res.tokens);
@@ -749,6 +858,7 @@ export const workflowExecutor: WorkflowExecutor = {
             model: lastModel || model,
             tokens,
             toolCalls,
+            ...timeoutDiagnostics(res, toolCalls),
           });
         }
         const raw = extractLastFencedJson(res.text) ?? res.text.trim();
@@ -782,7 +892,8 @@ export const workflowExecutor: WorkflowExecutor = {
         toolCalls,
       });
     } finally {
-      clearTimeout(timer);
+      clearTimeout(softTimer);
+      clearTimeout(hardTimer);
       ctx.signal.removeEventListener("abort", onCancel);
       // A write agent with nothing to show for itself (no changes, an error,
       // a cancel, or a throw on the way) leaves no worktree or branch behind.

--- a/packages/core/opensession-server/src/server/workflow-store.test.ts
+++ b/packages/core/opensession-server/src/server/workflow-store.test.ts
@@ -31,7 +31,11 @@ import {
   unregisterLiveWorkflow,
   updateWorkflowRun,
 } from "./workflow-store";
-import { WORKFLOW_LIMITS, type WorkflowJournalEntry } from "./workflow-types";
+import {
+  WORKFLOW_LIMITS,
+  WORKFLOW_RESTART_PAUSE_REASON,
+  type WorkflowJournalEntry,
+} from "./workflow-types";
 import { hasSessionRunningHold } from "./session-state-events";
 
 const savedEnv = process.env.OPENSESSION_WORKFLOWS_DIR;
@@ -245,5 +249,36 @@ describe("workflow store", () => {
     expect(recoverableWorkflowRunIds()).toContain(dead.runId);
     expect(getWorkflowRun(live.runId)?.status).toBe("running");
     expect(getWorkflowRun(finished.runId)?.status).toBe("done");
+  });
+
+  test("markInterruptedWorkflows resumes a restart pause but not a human pause", () => {
+    const humanPaused = makeRun({ recovery: { autoResume: true } });
+    updateWorkflowRun(humanPaused.runId, (s) => {
+      s.status = "paused";
+      s.pauseReason = "paused by the operator";
+    });
+    unregisterLiveWorkflow(humanPaused.runId);
+
+    const restartPaused = makeRun({ recovery: { autoResume: true } });
+    updateWorkflowRun(restartPaused.runId, (s) => {
+      s.status = "paused";
+      s.pauseReason = WORKFLOW_RESTART_PAUSE_REASON;
+    });
+    unregisterLiveWorkflow(restartPaused.runId);
+
+    markInterruptedWorkflows();
+
+    // A human halted this one on purpose: a restart must not undo that.
+    const human = getWorkflowRun(humanPaused.runId)!;
+    expect(human.status).toBe("paused");
+    expect(human.pauseReason).toBe("paused by the operator");
+    expect(human.interruptedByRestart).toBeUndefined();
+    expect(recoverableWorkflowRunIds()).not.toContain(humanPaused.runId);
+
+    // We paused this one to shut down, so it is ours to pick back up.
+    const restart = getWorkflowRun(restartPaused.runId)!;
+    expect(restart.status).toBe("interrupted");
+    expect(restart.interruptedByRestart).toBe(true);
+    expect(recoverableWorkflowRunIds()).toContain(restartPaused.runId);
   });
 });

--- a/packages/core/opensession-server/src/server/workflow-store.ts
+++ b/packages/core/opensession-server/src/server/workflow-store.ts
@@ -32,6 +32,7 @@ import {
 } from "./session-state-events";
 import {
   WORKFLOW_LIMITS,
+  WORKFLOW_RESTART_PAUSE_REASON,
   type WorkflowJournalRecord,
   type WorkflowRecoverySnapshot,
   type WorkflowRunSnapshot,
@@ -354,7 +355,7 @@ export function controlLiveWorkflowAgent(
 export function pauseWorkflowsForShutdown(): number {
   let paused = 0;
   for (const live of liveWorkflows.values()) {
-    if (live.controls.pause("server restart")) paused++;
+    if (live.controls.pause(WORKFLOW_RESTART_PAUSE_REASON)) paused++;
   }
   return paused;
 }
@@ -379,12 +380,18 @@ export function markInterruptedWorkflows(): void {
   for (const runId of runIdsOnDisk()) {
     if (liveWorkflows.has(runId)) continue;
     const snapshot = readRunJson(runId);
-    if (
-      !snapshot ||
-      (snapshot.status !== "running" && snapshot.status !== "paused")
-    )
-      continue;
+    if (!snapshot) continue;
+    // Only runs the service itself stopped are interrupted. A "running" run died
+    // with the previous process; a "paused" run counts only when we paused it for
+    // shutdown. A pause a human asked for must survive the restart untouched, or
+    // recoverableWorkflowRunIds() would auto-resume work they deliberately halted.
+    const stoppedByService =
+      snapshot.status === "running" ||
+      (snapshot.status === "paused" &&
+        snapshot.pauseReason === WORKFLOW_RESTART_PAUSE_REASON);
+    if (!stoppedByService) continue;
     snapshot.status = "interrupted";
+    snapshot.interruptedByRestart = true;
     snapshot.endedAt = new Date().toISOString();
     for (const agent of snapshot.agents) {
       if (agent.status === "pending" || agent.status === "running") {

--- a/packages/core/opensession-server/src/shared/workflow-types.ts
+++ b/packages/core/opensession-server/src/shared/workflow-types.ts
@@ -419,6 +419,13 @@ export type WorkflowRunStatus =
   /** Marked on boot for runs that were live when the process died. */
   | "interrupted";
 
+/**
+ * Pause reason recorded when the service pauses live runs during its own
+ * shutdown. Only runs paused for this reason are eligible for automatic resume
+ * on the next boot: a pause a human asked for must survive a restart.
+ */
+export const WORKFLOW_RESTART_PAUSE_REASON = "server restart";
+
 export interface WorkflowRecoverySnapshot {
   /** Only active runs carrying this descriptor are replayed after restart. */
   autoResume: boolean;
@@ -477,6 +484,12 @@ export interface WorkflowRunSnapshot {
   /** New run that replayed this interrupted run after a process restart. */
   recoveredAsRunId?: string;
   recoveryError?: string;
+  /**
+   * True when this run was marked `interrupted` because the service stopped
+   * under it, rather than because a human paused it. Human pauses are never
+   * marked interrupted, so this stays unset for them.
+   */
+  interruptedByRestart?: boolean;
   pausedAt?: string;
   pauseReason?: string;
   totalPausedMs?: number;

--- a/packages/core/opensession-server/src/shared/workflow-types.ts
+++ b/packages/core/opensession-server/src/shared/workflow-types.ts
@@ -40,6 +40,12 @@ export const WORKFLOW_LIMITS = {
   /** Per-agent wall clock before the run is failed. An agent may use the
    * workflow's full active-time budget instead of being cut off early. */
   agentTimeoutMs: 60 * 60_000,
+  /** Fraction of agentTimeoutMs an agent may spend exploring before it is told
+   *  to stop and hand back its verdict. The remainder funds that wrap-up turn,
+   *  so a long agent returns a usable answer instead of dying mid-thought. */
+  agentWrapUpAtFraction: 0.8,
+  /** Cap on the partial reply retained as diagnostics when an agent times out. */
+  timeoutTailChars: 2_000,
   /** Whole-workflow active wall clock before the worker is terminated. Time
    * spent paused does not consume this allowance. */
   workflowTimeoutMs: 60 * 60_000,
@@ -280,6 +286,16 @@ export interface WorkflowAgentOutcome {
   engineSessionId?: string;
   /** Where it ran (the session's worktree, or a write agent's own one). */
   cwd?: string;
+  /** Present only when the agent hit its hard wall clock. Keeps what it had
+   *  already produced so a timeout is inspectable instead of an opaque null. */
+  timeoutDiagnostics?: {
+    /** Tail of the reply streamed before the deadline (timeoutTailChars). */
+    partialText?: string;
+    /** Tool calls the agent made across the whole attempt. */
+    toolCalls: number;
+    /** True when it got the wrap-up turn and still ran out of time. */
+    warned: boolean;
+  };
   // ── write agents ──
   /** Set exactly when a branch was retained, whether the turn succeeded or
    *  failed. Read this (never `ok`) to decide whether there is anything to


### PR DESCRIPTION
Two of the seven workflow-engine smoothness items from the parent session, each
with tests. The other five are **not** in this PR — see "Not implemented" below
so nothing is silently dropped.

## 1. Deadline-aware agent timeouts

A workflow agent got one wall-clock budget and was killed the instant it
expired. The run returned `agent timed out after <n>m` and threw away every byte
the agent had already streamed, so a long review that died a sentence short of
its verdict handed the script `null`.

The budget is now split. The agent explores until a soft deadline
(`agentWrapUpAtFraction`, 80% by default), then its engine session is **resumed
once** with a terse "stop, answer now" instruction funded by the remainder.
Resuming rather than starting cold is the point: the task and everything the
agent read are still in context, so the wrap-up reply is a real verdict.

Only the hard deadline fails the call, and that outcome now carries
`timeoutDiagnostics` — the tail of the partial reply, the tool-call count, and
whether the agent had already been warned.

Notes:
- Both turns' tokens and tool calls are summed into the single agent row, so
  per-agent accounting still matches what the run actually spent.
- Replay is unaffected: the journal hash is computed by the runner from the
  script's own prompt and opts, never from the internal wrap-up prompt.
- The detached host binds to the signal it was constructed with, so the wrap-up
  turn builds its own runner; reusing the exploring turn's signal would have
  killed it instantly.
- `_setAgentDeadlinesForTests` is a new test seam — the deadline path had no
  coverage at all before this.

## 2. Restart-safe pauses

`markInterruptedWorkflows()` marked every `running` **and** `paused` run as
`interrupted` on boot. `recoverableWorkflowRunIds()` then auto-resumed any
interrupted run carrying `recovery.autoResume`, so a run an operator had
deliberately paused restarted on its own after the next deploy.

The shutdown pause is now recorded under a shared
`WORKFLOW_RESTART_PAUSE_REASON`, and a paused run is only marked interrupted
when that is the reason it stopped. Runs that died while `running` still count
as service-interrupted. Snapshots carry `interruptedByRestart` so callers can
tell the two apart.

## Not implemented in this PR

Reported explicitly rather than dropped. I ran out of session budget before
these could be done to a standard I would merge:

3. **Child branch head SHA + final report on session status/wait** — not started.
4. **`run_workflow` repo-relative script path** — not started.
5. **Explicit replay/journal key for agent calls** — not started. The change
   belongs in `hashAgentCall(prompt, opts)` in `workflow-runner.ts`, which today
   hashes `prompt + stableStringify(opts)`; an opt-in key should be namespaced
   the way `hashMcpCall` already is so it cannot collide with a prompt-byte hash.
6. **Per-agent token accounting consistency** — partially advanced: the wrap-up
   turn sums both turns' usage into one row (item 1), but the aggregate-vs-row
   reconciliation for resumed/replayed agents was not audited.
7. **Coalescing duplicate completion notices across superseded lineage runs** —
   not started.

The parent's script-level mitigations (null-review retry, immutable child SHA in
review prompts, deadline budgeting) are **superseded in part** by item 1: the
engine now performs the wrap-up retry itself, so a script-level "retry at lower
effort with a tight prompt" is no longer the only defence against a null review.
The parent's local `.frontend-refactor-workflow.js` is untracked and not present
in this worktree, so nothing there was edited.

## Verification

`bun run check` passes (exit 0) on the final commit — format, typecheck, lint,
isolated unit tests, strict transcript snapshots. 101 tests pass across
`workflow-execute.test.ts`, `workflow-store.test.ts`, `workflow-runner.test.ts`,
including 3 new deadline tests and 1 new restart-pause test.

Rebased onto `e007f2946` ("Allow workflow agents to run for an hour"), which
landed mid-work and raised `agentTimeoutMs` to 60 minutes; the conflict was
resolved to keep that value, so the wrap-up turn is funded by the last 12
minutes of the hour.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a04919-7ba6-73e2-84ec-50ff5a4ca088)
