### PR TITLE
Rename native Plain queue to Support

### DIFF
--- a/packages/clients/ios/OS1/SidebarFeeds.swift
+++ b/packages/clients/ios/OS1/SidebarFeeds.swift
@@ -22,6 +22,8 @@ enum SidebarFeeds {
     /// sources the account can show is a different question, and the server
     /// answers it (`/api/feeds`, see `sources(known:hidden:)`).
     static let plain = "plain"
+    /// Product-facing name for the support queue. `plain` remains its wire id.
+    static let supportTitle = "Support"
 
     /// A source this instance offers, as `/api/feeds` describes it. A tolerant
     /// subset of the server's `FeedDescriptor`: the rest of that shape names

--- a/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
+++ b/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
@@ -788,7 +788,7 @@ struct AppearanceSettingsView: View {
                 } header: {
                     Text("Support tickets")
                 } footer: {
-                    Text("Choose where the Plain queue lives. This setting follows your account across the web and native apps.")
+                    Text("Choose where the Support queue lives. This setting follows your account across the web and native apps.")
                 }
             }
 

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -3198,7 +3198,7 @@ struct SessionsListView: View {
                     #else
                     RepoTile(name: "plain", size: plainRowTileSize)
                     #endif
-                    Text("Plain")
+                    Text(SidebarFeeds.supportTitle)
                         #if os(iOS)
                         .font(.callout.weight(.medium))
                         .foregroundStyle(OS1VisualStyle.textDim)
@@ -3221,8 +3221,8 @@ struct SessionsListView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(
                 urgentPlainTicketCount > 0
-                    ? "Open Plain, \(supportQueue.threads.count) tickets, \(urgentPlainTicketCount) urgent"
-                    : "Open Plain, \(supportQueue.threads.count) tickets"
+                    ? "Open \(SidebarFeeds.supportTitle), \(supportQueue.threads.count) tickets, \(urgentPlainTicketCount) urgent"
+                    : "Open \(SidebarFeeds.supportTitle), \(supportQueue.threads.count) tickets"
             )
             // The long press the web sidebar answers with a right-click on the
             // same band. One item, like that menu: this row leads somewhere

--- a/packages/clients/ios/OS1Tests/SidebarFeedsTests.swift
+++ b/packages/clients/ios/OS1Tests/SidebarFeedsTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import OS1
 
 final class SidebarFeedsTests: XCTestCase {
+    func testPlainFeedUsesTheSupportProductName() {
+        XCTAssertEqual(SidebarFeeds.supportTitle, "Support")
+    }
+
     func testHidingKeepsSourcesThisBuildDoesNotRender() {
         // The list is the account's, and the browser has bands the phone has
         // never heard of. Rewriting it must not quietly restore them.


### PR DESCRIPTION
## Summary
- rename the native sidebar queue from Plain to Support
- update its accessibility label and Appearance description
- keep `plain` as the provider and preference wire id

## Tests
- OS1 and OS1Mac build
- SidebarFeedsTests, 10 passed
- iOS simulator screenshot verified the Support row

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-f280c9c2-8222-73ff-9a2f-e5db545f85a5)