### PR TITLE
Settle automation sessions when their run host retires

### DIFF
--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -177,6 +177,55 @@ describe("automation run settlement", () => {
     expect(inLoopSettle).toBeLessThan(streamDrained);
   });
 
+  test("a stream with no terminal event records error, not ok", () => {
+    // Parity with session-create.ts, which throws "Opening run ended without a
+    // terminal event" for exactly this shape, and with every journal wrapper,
+    // which records journalRecordAbnormalCompletion instead of clearing so
+    // boot recovery reports a failure. runAutomation used to fall through with
+    // an empty errorMsg: outputs delivered for a turn that produced nothing,
+    // ledger `ok`, session still unsettled — the same split-brain this module
+    // exists to remove.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const drained = source.indexOf("errorMsg = declaredRunFailure(textTail)");
+    const abnormal = source.indexOf(
+      "if (!errorMsg && !sawTerminalEvent)",
+      drained,
+    );
+    expect(abnormal).toBeGreaterThan(drained);
+    expect(source).toContain('errorMsg = "Run ended without a terminal event"');
+    // The ledger verdict and the output delivery both read errorMsg, so the
+    // correction has to land before either of them.
+    for (const consumer of [
+      "await deliverAutomationOutputs({",
+      "settleRun(automation.id, bksId,",
+      "recordAutomationIntentTerminal(bksId,",
+    ]) {
+      expect(source.indexOf(consumer, drained)).toBeGreaterThan(abnormal);
+    }
+  });
+
+  test("an abnormal completion still keeps the session's safety fence", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    // The ledger now records an error for this shape, but the run state must
+    // NOT be settled from here: nothing proved what the turn did, the journal
+    // still carries its terminalFailure, and boot recovery owns settling it.
+    await settleAutomationRunState(
+      id,
+      "Run ended without a terminal event",
+      false,
+      runKeyFor(id),
+      silent,
+    );
+
+    expect(getRunState(id)).toBe("running");
+    expect(isRunStateUnsettled(getRunState(id))).toBe(true);
+  });
+
   test("a usage-exhausted done becomes a failure before the run settles", () => {
     // Dying on usage limits with no account left reports as a `done` carrying
     // `usageLimitExhausted`, not an `error`. An automation with

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -29,6 +29,25 @@ const created: string[] = [];
 /** The physical run id whichever backend journals for this turn. */
 const runKeyFor = (id: string) => `rh-${id}`;
 
+/** Terminal outcome projections the settlement issued. Production routes these
+ *  to recordRunOutcome, which writes runErrors and the session file's
+ *  lastRunError — the only sources the session APIs read. */
+const projected: Array<{
+  sessionId: string;
+  errorMessage: string | null;
+  runId?: string;
+}> = [];
+const deps = {
+  emit: silent,
+  project: async (
+    sessionId: string,
+    errorMessage: string | null,
+    opts?: { runId?: string },
+  ) => {
+    projected.push({ sessionId, errorMessage, runId: opts?.runId });
+  },
+};
+
 /** Put the session where a journaled detached automation host leaves it. */
 async function hostedAutomationRunning(id: string): Promise<void> {
   created.push(id);
@@ -42,6 +61,7 @@ async function hostedAutomationRunning(id: string): Promise<void> {
 }
 
 afterEach(async () => {
+  projected.length = 0;
   for (const id of created.splice(0)) await clearRunState(id);
 });
 
@@ -55,7 +75,7 @@ describe("automation run settlement", () => {
     // quarantine precondition ("no live execution owner or recovery claim").
     expect(runStateRequiresLiveOwner(getRunState(id))).toBe(true);
 
-    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
+    await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
 
     expect(getRunState(id)).toBe("idle");
     expect(isRunStateUnsettled(getRunState(id))).toBe(false);
@@ -71,7 +91,7 @@ describe("automation run settlement", () => {
       "RUN STATUS: failed",
       true,
       runKeyFor(id),
-      silent,
+      deps,
     );
 
     expect(getRunState(id)).toBe("failed");
@@ -84,7 +104,7 @@ describe("automation run settlement", () => {
 
     // Nothing proved what this run did, so it must stay owned and pausable.
     // Settling here would retire a fence that exists for unverified effects.
-    await settleAutomationRunState(id, null, false, runKeyFor(id), silent);
+    await settleAutomationRunState(id, null, false, runKeyFor(id), deps);
 
     expect(getRunState(id)).toBe("running");
     expect(isRunStateUnsettled(getRunState(id))).toBe(true);
@@ -107,27 +127,31 @@ describe("automation run settlement", () => {
     );
     expect(getRunState(id)).toBe("running");
 
-    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
+    await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
 
     // The actor's stale-run fence rejected it, so the successor keeps its turn.
     expect(getRunState(id)).toBe("running");
 
     // The successor's own settlement still works.
-    await settleAutomationRunState(id, null, true, "rh-successor", silent);
+    await settleAutomationRunState(id, null, true, "rh-successor", deps);
     expect(getRunState(id)).toBe("idle");
   });
 
   test("settling an already-settled session emits no double teardown", async () => {
     const id = sid();
     await hostedAutomationRunning(id);
-    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
+    await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
 
     const events: Record<string, unknown>[] = [];
-    await settleAutomationRunState(id, null, true, runKeyFor(id), (event) =>
-      events.push(event),
-    );
+    projected.length = 0;
+    await settleAutomationRunState(id, null, true, runKeyFor(id), {
+      ...deps,
+      emit: (event) => events.push(event),
+    });
 
     expect(events).toEqual([]);
+    // A no-op settlement must not re-project either.
+    expect(projected).toEqual([]);
     expect(getRunState(id)).toBe("idle");
   });
 
@@ -219,7 +243,7 @@ describe("automation run settlement", () => {
       "Run ended without a terminal event",
       false,
       runKeyFor(id),
-      silent,
+      deps,
     );
 
     expect(getRunState(id)).toBe("running");
@@ -273,11 +297,110 @@ describe("automation run settlement", () => {
       "Usage limit reached on every account",
       true,
       runKeyFor(id),
-      silent,
+      deps,
     );
 
     expect(getRunState(id)).toBe("failed");
     expect(isRunStateUnsettled(getRunState(id))).toBe(false);
+  });
+
+  test("a terminal failure is projected, not only moved in the FSM", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    await settleAutomationRunState(
+      id,
+      "Usage limit reached on every account",
+      true,
+      runKeyFor(id),
+      deps,
+    );
+
+    // The session APIs read lastRunError from runErrors and the session file,
+    // both written by recordRunOutcome. Reaching `failed` without that
+    // projection leaves a run that cannot explain itself to any consumer.
+    expect(projected).toEqual([
+      {
+        sessionId: id,
+        errorMessage: "Usage limit reached on every account",
+        runId: runKeyFor(id),
+      },
+    ]);
+  });
+
+  test("a clean turn projects a null outcome, clearing any earlier failure", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
+
+    expect(getRunState(id)).toBe("idle");
+    expect(projected).toEqual([
+      { sessionId: id, errorMessage: null, runId: runKeyFor(id) },
+    ]);
+  });
+
+  test("a stale settlement projects nothing onto the successor", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+    await transitionRunState(id, "cancel", { run_key: runKeyFor(id) }, silent);
+    await transitionRunState(id, "prompt", { run_key: "rh-successor" }, silent);
+    await transitionRunState(
+      id,
+      "run_registered",
+      { run_key: "rh-successor" },
+      silent,
+    );
+
+    await settleAutomationRunState(
+      id,
+      "late failure",
+      true,
+      runKeyFor(id),
+      deps,
+    );
+
+    // The actor rejected the transition, so the outcome must not be stamped
+    // onto whoever owns the session now.
+    expect(getRunState(id)).toBe("running");
+    expect(projected).toEqual([]);
+  });
+
+  test("a definitively failed launch settles from the outer catch", () => {
+    // spawnHostRun journals `run_registered` (session -> `running`) BEFORE
+    // launching. On a definitively failed launch its catch proves absence,
+    // clears that journal, and rethrows — leaving the session `running` with
+    // no journal record and no engine, which the watchdog quarantines. An
+    // ambiguous launch keeps its journal, so the two negative checks below
+    // leave it fenced.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const catchStart = source.indexOf("} catch (e: any) {");
+    expect(catchStart).toBeGreaterThan(0);
+    const guard = source.indexOf(
+      "!hasActiveRunFor(bksId, automationRunKey)",
+      catchStart,
+    );
+    const liveness = source.indexOf(
+      "!isAgentLiveEngineBusy(bksId, automationRunKey)",
+      catchStart,
+    );
+    const settle = source.indexOf(
+      "await settleAutomationRunState(",
+      catchStart,
+    );
+    expect(guard).toBeGreaterThan(catchStart);
+    expect(liveness).toBeGreaterThan(guard);
+    expect(settle).toBeGreaterThan(liveness);
+    // The run key has to outlive the try block for the catch to fence on it.
+    const keyDecl = source.indexOf(
+      "const automationRunKey = `rh-${randomUUIDv7()}`",
+    );
+    const tryStart = source.indexOf("  try {", keyDecl);
+    expect(keyDecl).toBeGreaterThan(0);
+    expect(keyDecl).toBeLessThan(tryStart);
   });
 
   test("nothing that can reject runs between the terminal event and settlement", () => {
@@ -324,9 +447,10 @@ describe("automation run settlement", () => {
     // Sandboxed runs journal spec.hostId; both gateway paths journal startToken.
     expect(source).toContain("hostId: automationRunKey");
     expect(source.match(/startToken: automationRunKey/g)).toHaveLength(2);
-    // Both settlement call sites (in-loop and the post-loop safety net) fence.
+    // All three settlement call sites fence: in-loop, the post-loop safety
+    // net, and the outer catch's definitive-launch-failure branch.
     const settlements = source.match(/await settleAutomationRunState\(/g);
-    expect(settlements).toHaveLength(2);
-    expect(source.match(/^\s*automationRunKey,\n\s*\);$/gm)).toHaveLength(2);
+    expect(settlements).toHaveLength(3);
+    expect(source.match(/^\s*automationRunKey,\n\s*\);$/gm)).toHaveLength(3);
   });
 });

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -177,6 +177,60 @@ describe("automation run settlement", () => {
     expect(inLoopSettle).toBeLessThan(streamDrained);
   });
 
+  test("a usage-exhausted done becomes a failure before the run settles", () => {
+    // Dying on usage limits with no account left reports as a `done` carrying
+    // `usageLimitExhausted`, not an `error`. An automation with
+    // `fallbackModel: "none"` gets that event unfiltered, because
+    // runAgentInner yields runOnModel directly instead of routing it into the
+    // fallback walk. Both other consumers of the hosted path convert the shape
+    // into a failure; without the same conversion the ledger records `ok`,
+    // outputs are delivered for a turn that never ran, and the session settles
+    // `turn_end` instead of `failed`.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const loopStart = source.indexOf("for await (const event of events) {");
+    const doneBranch = source.indexOf(
+      'if (event.type === "done") {',
+      loopStart,
+    );
+    const conversion = source.indexOf(
+      "if (event.usageLimitExhausted)",
+      doneBranch,
+    );
+    const inLoopSettle = source.indexOf(
+      "await settleAutomationRunState(",
+      loopStart,
+    );
+    expect(doneBranch).toBeGreaterThan(loopStart);
+    expect(conversion).toBeGreaterThan(doneBranch);
+    // The conversion has to precede the settlement, or the run state is
+    // decided before the failure is known.
+    expect(conversion).toBeLessThan(inLoopSettle);
+    expect(source).toContain(
+      'errorMsg = event.result || "Usage limit reached on every account"',
+    );
+  });
+
+  test("an exhausted run settles as failed, matching the ledger", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    // What the loop now passes for a usage-exhausted `done`: the same
+    // non-null message the ledger records as `error`.
+    await settleAutomationRunState(
+      id,
+      "Usage limit reached on every account",
+      true,
+      runKeyFor(id),
+      silent,
+    );
+
+    expect(getRunState(id)).toBe("failed");
+    expect(isRunStateUnsettled(getRunState(id))).toBe(false);
+  });
+
   test("nothing that can reject runs between the terminal event and settlement", () => {
     // The outer catch settles the LEDGER but cannot settle the session: the
     // run-state variables are scoped to the try. So every fallible step of the

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -26,6 +26,8 @@ import { runStateRequiresLiveOwner } from "./session-cache";
 const silent = () => {};
 const sid = () => `automation-settlement-${crypto.randomUUID()}`;
 const created: string[] = [];
+/** The physical run id whichever backend journals for this turn. */
+const runKeyFor = (id: string) => `rh-${id}`;
 
 /** Put the session where a journaled detached automation host leaves it. */
 async function hostedAutomationRunning(id: string): Promise<void> {
@@ -33,7 +35,7 @@ async function hostedAutomationRunning(id: string): Promise<void> {
   await transitionRunState(
     id,
     "run_registered",
-    { run_key: `rh-${id}`, kind: "automation" },
+    { run_key: runKeyFor(id), kind: "automation" },
     silent,
   );
   expect(getRunState(id)).toBe("running");
@@ -53,7 +55,7 @@ describe("automation run settlement", () => {
     // quarantine precondition ("no live execution owner or recovery claim").
     expect(runStateRequiresLiveOwner(getRunState(id))).toBe(true);
 
-    await settleAutomationRunState(id, null, true, silent);
+    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
 
     expect(getRunState(id)).toBe("idle");
     expect(isRunStateUnsettled(getRunState(id))).toBe(false);
@@ -64,7 +66,13 @@ describe("automation run settlement", () => {
     const id = sid();
     await hostedAutomationRunning(id);
 
-    await settleAutomationRunState(id, "RUN STATUS: failed", true, silent);
+    await settleAutomationRunState(
+      id,
+      "RUN STATUS: failed",
+      true,
+      runKeyFor(id),
+      silent,
+    );
 
     expect(getRunState(id)).toBe("failed");
     expect(isRunStateUnsettled(getRunState(id))).toBe(false);
@@ -76,19 +84,46 @@ describe("automation run settlement", () => {
 
     // Nothing proved what this run did, so it must stay owned and pausable.
     // Settling here would retire a fence that exists for unverified effects.
-    await settleAutomationRunState(id, null, false, silent);
+    await settleAutomationRunState(id, null, false, runKeyFor(id), silent);
 
     expect(getRunState(id)).toBe("running");
     expect(isRunStateUnsettled(getRunState(id))).toBe(true);
   });
 
+  test("a late settlement cannot retire a successor's run", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    // Stop retires this automation's run, then a new prompt claims the
+    // session. The automation's hosted generator is still draining and its
+    // settlement lands only now — against a run it does not own.
+    await transitionRunState(id, "cancel", { run_key: runKeyFor(id) }, silent);
+    await transitionRunState(id, "prompt", { run_key: "rh-successor" }, silent);
+    await transitionRunState(
+      id,
+      "run_registered",
+      { run_key: "rh-successor" },
+      silent,
+    );
+    expect(getRunState(id)).toBe("running");
+
+    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
+
+    // The actor's stale-run fence rejected it, so the successor keeps its turn.
+    expect(getRunState(id)).toBe("running");
+
+    // The successor's own settlement still works.
+    await settleAutomationRunState(id, null, true, "rh-successor", silent);
+    expect(getRunState(id)).toBe("idle");
+  });
+
   test("settling an already-settled session emits no double teardown", async () => {
     const id = sid();
     await hostedAutomationRunning(id);
-    await settleAutomationRunState(id, null, true, silent);
+    await settleAutomationRunState(id, null, true, runKeyFor(id), silent);
 
     const events: Record<string, unknown>[] = [];
-    await settleAutomationRunState(id, null, true, (event) =>
+    await settleAutomationRunState(id, null, true, runKeyFor(id), (event) =>
       events.push(event),
     );
 
@@ -102,9 +137,7 @@ describe("automation run settlement", () => {
       "utf8",
     );
     const terminalFlag = source.indexOf("sawTerminalEvent = true");
-    const settleSession = source.indexOf(
-      "await settleAutomationRunState(bksId,",
-    );
+    const settleSession = source.indexOf("await settleAutomationRunState(");
     const settleLedger = source.indexOf(
       "settleRun(automation.id, bksId,",
       settleSession,
@@ -130,7 +163,7 @@ describe("automation run settlement", () => {
     );
     expect(streamDrained).toBeGreaterThan(0);
     const settleSession = source.indexOf(
-      "await settleAutomationRunState(bksId,",
+      "await settleAutomationRunState(",
       streamDrained,
     );
     expect(settleSession).toBeGreaterThan(streamDrained);
@@ -143,5 +176,20 @@ describe("automation run settlement", () => {
         settleSession,
       );
     }
+  });
+
+  test("every automation backend journals the run id the settlement fences on", () => {
+    // The fence only holds if the id passed to settlement is the same one the
+    // backend journals as `run_registered` — that is what becomes the actor's
+    // `currentRunId`. All three dispatch paths must carry it.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    expect(source).toContain("const automationRunKey = `rh-${randomUUIDv7()}`");
+    // Sandboxed runs journal spec.hostId; both gateway paths journal startToken.
+    expect(source).toContain("hostId: automationRunKey");
+    expect(source.match(/startToken: automationRunKey/g)).toHaveLength(2);
+    expect(source).toContain("automationRunKey,\n    );");
   });
 });

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -147,6 +147,36 @@ describe("automation run settlement", () => {
     expect(settleLedger).toBeGreaterThan(settleSession);
   });
 
+  test("settlement happens inside the loop, before the journal wrapper clears", () => {
+    // Requesting the generator's NEXT item is what resumes the journal
+    // wrapper, and every wrapper clears this run's recovery journal in its
+    // `finally` on normal source completion. Settling only after the loop
+    // leaves a window where the session is `running` with no journal record
+    // left to recover it. So the settlement must sit inside the loop body,
+    // between the terminal-event capture and the loop's closing brace.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const loopStart = source.indexOf("for await (const event of events) {");
+    const streamDrained = source.indexOf(
+      "errorMsg = declaredRunFailure(textTail)",
+    );
+    const terminalCapture = source.indexOf(
+      'if (event.type === "error") {',
+      loopStart,
+    );
+    const inLoopSettle = source.indexOf(
+      "await settleAutomationRunState(",
+      loopStart,
+    );
+    expect(loopStart).toBeGreaterThan(0);
+    expect(terminalCapture).toBeGreaterThan(loopStart);
+    expect(inLoopSettle).toBeGreaterThan(terminalCapture);
+    // Still inside the loop: it precedes the post-loop drain line.
+    expect(inLoopSettle).toBeLessThan(streamDrained);
+  });
+
   test("nothing that can reject runs between the terminal event and settlement", () => {
     // The outer catch settles the LEDGER but cannot settle the session: the
     // run-state variables are scoped to the try. So every fallible step of the
@@ -181,7 +211,8 @@ describe("automation run settlement", () => {
   test("every automation backend journals the run id the settlement fences on", () => {
     // The fence only holds if the id passed to settlement is the same one the
     // backend journals as `run_registered` — that is what becomes the actor's
-    // `currentRunId`. All three dispatch paths must carry it.
+    // `currentRunId`. All three dispatch paths must carry it, and every
+    // settlement call site must pass it.
     const source = readFileSync(
       resolve(import.meta.dir, "automations.ts"),
       "utf8",
@@ -190,6 +221,9 @@ describe("automation run settlement", () => {
     // Sandboxed runs journal spec.hostId; both gateway paths journal startToken.
     expect(source).toContain("hostId: automationRunKey");
     expect(source.match(/startToken: automationRunKey/g)).toHaveLength(2);
-    expect(source).toContain("automationRunKey,\n    );");
+    // Both settlement call sites (in-loop and the post-loop safety net) fence.
+    const settlements = source.match(/await settleAutomationRunState\(/g);
+    expect(settlements).toHaveLength(2);
+    expect(source.match(/^\s*automationRunKey,\n\s*\);$/gm)).toHaveLength(2);
   });
 });

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -113,4 +113,35 @@ describe("automation run settlement", () => {
     expect(settleSession).toBeGreaterThan(terminalFlag);
     expect(settleLedger).toBeGreaterThan(settleSession);
   });
+
+  test("nothing that can reject runs between the terminal event and settlement", () => {
+    // The outer catch settles the LEDGER but cannot settle the session: the
+    // run-state variables are scoped to the try. So every fallible step of the
+    // completion tail — session persistence, output delivery, the ledger — has
+    // to come after settlement, or a rejection reinstates the owner-less
+    // running session this module exists to prevent.
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    // Anchor past the event loop: `persistSession` is also called on `init`.
+    const streamDrained = source.indexOf(
+      "errorMsg = declaredRunFailure(textTail)",
+    );
+    expect(streamDrained).toBeGreaterThan(0);
+    const settleSession = source.indexOf(
+      "await settleAutomationRunState(bksId,",
+      streamDrained,
+    );
+    expect(settleSession).toBeGreaterThan(streamDrained);
+    for (const fallible of [
+      "await persistSession(engineSessionId);",
+      "await deliverAutomationOutputs({",
+      "settleRun(automation.id, bksId,",
+    ]) {
+      expect(source.indexOf(fallible, streamDrained)).toBeGreaterThan(
+        settleSession,
+      );
+    }
+  });
 });

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -22,6 +22,7 @@ import {
   transitionRunState,
 } from "./run-state";
 import { runStateRequiresLiveOwner } from "./session-cache";
+import { sessionKernel } from "./session-kernel";
 
 const silent = () => {};
 const sid = () => `automation-settlement-${crypto.randomUUID()}`;
@@ -36,15 +37,23 @@ const projected: Array<{
   sessionId: string;
   errorMessage: string | null;
   runId?: string;
+  runGeneration?: number;
+  projectionId?: string;
 }> = [];
 const deps = {
   emit: silent,
   project: async (
     sessionId: string,
     errorMessage: string | null,
-    opts?: { runId?: string },
+    opts?: { runId?: string; runGeneration?: number; projectionId?: string },
   ) => {
-    projected.push({ sessionId, errorMessage, runId: opts?.runId });
+    projected.push({
+      sessionId,
+      errorMessage,
+      runId: opts?.runId,
+      runGeneration: opts?.runGeneration,
+      projectionId: opts?.projectionId,
+    });
   },
 };
 
@@ -319,13 +328,28 @@ describe("automation run settlement", () => {
     // The session APIs read lastRunError from runErrors and the session file,
     // both written by recordRunOutcome. Reaching `failed` without that
     // projection leaves a run that cannot explain itself to any consumer.
-    expect(projected).toEqual([
-      {
-        sessionId: id,
-        errorMessage: "Usage limit reached on every account",
-        runId: runKeyFor(id),
-      },
-    ]);
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toMatchObject({
+      sessionId: id,
+      errorMessage: "Usage limit reached on every account",
+      runId: runKeyFor(id),
+      // Durable identity: these three route the outcome through the actor's
+      // turn-outcome executor instead of a best-effort direct write.
+      projectionId: `outcome:${runKeyFor(id)}`,
+    });
+    expect(typeof projected[0]!.runGeneration).toBe("number");
+  });
+
+  test("the projected generation is the one this run owned", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+    const owned = sessionKernel(id).runStateProjection().generation;
+
+    await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
+
+    // Captured before the transition. Reading it afterwards would race a
+    // successor claiming the session, and the executor fences on this value.
+    expect(projected[0]!.runGeneration).toBe(owned);
   });
 
   test("a clean turn projects a null outcome, clearing any earlier failure", async () => {
@@ -335,9 +359,13 @@ describe("automation run settlement", () => {
     await settleAutomationRunState(id, null, true, runKeyFor(id), deps);
 
     expect(getRunState(id)).toBe("idle");
-    expect(projected).toEqual([
-      { sessionId: id, errorMessage: null, runId: runKeyFor(id) },
-    ]);
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toMatchObject({
+      sessionId: id,
+      errorMessage: null,
+      runId: runKeyFor(id),
+      projectionId: `outcome:${runKeyFor(id)}`,
+    });
   });
 
   test("a stale settlement projects nothing onto the successor", async () => {

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression cover for the automation lifecycle split-brain:
+ * `automation last ok` while the session stays `running` and unrecoverable.
+ *
+ * Automation turns execute in a detached run host. The host journals
+ * `run_registered` (session FSM → `running`) and, when it ends, only clears its
+ * journal — settling the VISIBLE run is the consumer's job, exactly as
+ * run-session.ts, session-create.ts and the GitHub agent already do. When
+ * runAutomation skipped that step, a perfectly successful run left the session
+ * `running` with no live execution owner, so the ownership watchdog paused it
+ * for safety while the automation ledger recorded `last ok`, and send/cancel
+ * were refused as quarantined.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { settleAutomationRunState } from "./automations";
+import {
+  clearRunState,
+  getRunState,
+  isRunStateUnsettled,
+  transitionRunState,
+} from "./run-state";
+import { runStateRequiresLiveOwner } from "./session-cache";
+
+const silent = () => {};
+const sid = () => `automation-settlement-${crypto.randomUUID()}`;
+const created: string[] = [];
+
+/** Put the session where a journaled detached automation host leaves it. */
+async function hostedAutomationRunning(id: string): Promise<void> {
+  created.push(id);
+  await transitionRunState(
+    id,
+    "run_registered",
+    { run_key: `rh-${id}`, kind: "automation" },
+    silent,
+  );
+  expect(getRunState(id)).toBe("running");
+}
+
+afterEach(async () => {
+  for (const id of created.splice(0)) await clearRunState(id);
+});
+
+describe("automation run settlement", () => {
+  test("a completed automation turn leaves no owner-less running session", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    // The exact reported state: the host has retired, nothing owns the run,
+    // and the FSM still claims `running` — the ownership watchdog's
+    // quarantine precondition ("no live execution owner or recovery claim").
+    expect(runStateRequiresLiveOwner(getRunState(id))).toBe(true);
+
+    await settleAutomationRunState(id, null, true, silent);
+
+    expect(getRunState(id)).toBe("idle");
+    expect(isRunStateUnsettled(getRunState(id))).toBe(false);
+    expect(runStateRequiresLiveOwner(getRunState(id))).toBe(false);
+  });
+
+  test("a declared or streamed failure settles as failed, not running", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    await settleAutomationRunState(id, "RUN STATUS: failed", true, silent);
+
+    expect(getRunState(id)).toBe("failed");
+    expect(isRunStateUnsettled(getRunState(id))).toBe(false);
+  });
+
+  test("a stream that ended without a terminal event keeps the safety fence", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+
+    // Nothing proved what this run did, so it must stay owned and pausable.
+    // Settling here would retire a fence that exists for unverified effects.
+    await settleAutomationRunState(id, null, false, silent);
+
+    expect(getRunState(id)).toBe("running");
+    expect(isRunStateUnsettled(getRunState(id))).toBe(true);
+  });
+
+  test("settling an already-settled session emits no double teardown", async () => {
+    const id = sid();
+    await hostedAutomationRunning(id);
+    await settleAutomationRunState(id, null, true, silent);
+
+    const events: Record<string, unknown>[] = [];
+    await settleAutomationRunState(id, null, true, (event) =>
+      events.push(event),
+    );
+
+    expect(events).toEqual([]);
+    expect(getRunState(id)).toBe("idle");
+  });
+
+  test("runAutomation settles the session before claiming the ledger outcome", () => {
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const terminalFlag = source.indexOf("sawTerminalEvent = true");
+    const settleSession = source.indexOf(
+      "await settleAutomationRunState(bksId,",
+    );
+    const settleLedger = source.indexOf(
+      "settleRun(automation.id, bksId,",
+      settleSession,
+    );
+    expect(terminalFlag).toBeGreaterThan(0);
+    expect(settleSession).toBeGreaterThan(terminalFlag);
+    expect(settleLedger).toBeGreaterThan(settleSession);
+  });
+});

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -31,6 +31,11 @@ import { getAccountById } from "./claude-accounts";
 import { getCodexAccountById } from "./codex-accounts";
 import { runAgent } from "./agent-runner";
 import { activeRunRecords } from "./run-journal";
+import {
+  getRunState,
+  isRunStateUnsettled,
+  transitionRunState,
+} from "./run-state";
 import { runAgentHosted } from "./host-client";
 import {
   providerFor,
@@ -1082,6 +1087,39 @@ function recordRunStart(id: string, run: AutomationRun): void {
   });
 }
 
+/**
+ * Settle the SESSION's run state when an automation's engine stream ends.
+ *
+ * Automation turns execute in a detached run host (runAgentHosted, the only
+ * path since every model routes to pi). The host journals `run_registered`,
+ * which moves the session FSM to `running`, but its own teardown only clears
+ * the journal — retiring the VISIBLE run is the consumer's job, exactly as
+ * run-session.ts, session-create.ts and the GitHub agent already do. Without
+ * this, a successful automation left the session `running` with no live
+ * execution owner: the ownership watchdog paused it for safety while the
+ * ledger below recorded `last ok`, and send/cancel were refused as
+ * quarantined.
+ *
+ * Only a terminal engine event settles. A stream that ended without one has
+ * not proven what the run did, so it keeps the real safety fence rather than
+ * being waved through as finished.
+ */
+export async function settleAutomationRunState(
+  sessionId: string,
+  errorMessage: string | null,
+  sawTerminalEvent: boolean,
+  emit?: Parameters<typeof transitionRunState>[3],
+): Promise<void> {
+  if (!sawTerminalEvent) return;
+  if (!isRunStateUnsettled(getRunState(sessionId))) return;
+  await transitionRunState(
+    sessionId,
+    errorMessage ? "run_failed" : "turn_end",
+    { source: "automation_terminal" },
+    emit,
+  );
+}
+
 /** Settle the ledger entry for `sessionId` (matched by id, not position, so
  *  overlapping runs settle independently). */
 function settleRun(
@@ -1681,6 +1719,9 @@ export async function runAutomation(
 
     let engineSessionId = "";
     let errorMsg = "";
+    // Whether the engine reported a terminal outcome. Only that proves the
+    // turn is over and lets settleAutomationRunState retire the session.
+    let sawTerminalEvent = false;
     // Tail of the assistant's text: an automation whose prompt declares
     // failure (`RUN STATUS: failed — …` / `SCAN STATUS: failed — …` as the
     // final line) settles the ledger as error instead of "the turn finished
@@ -1806,6 +1847,7 @@ export async function runAutomation(
         }
       }
       if (event.type === "done") {
+        sawTerminalEvent = true;
         engineSessionId = event.sessionId || engineSessionId;
         if (event.provider) effectiveProvider = event.provider;
         if (event.model) effectiveModel = event.model;
@@ -1814,12 +1856,17 @@ export async function runAutomation(
         textTail = (textTail + event.text).slice(-16384);
       }
       if (event.type === "error") {
+        sawTerminalEvent = true;
         errorMsg = event.content || "Unknown error";
       }
     }
     if (!errorMsg) errorMsg = declaredRunFailure(textTail) || "";
 
     await persistSession(engineSessionId);
+
+    // Before the ledger claims an outcome: a session the ledger calls done
+    // must not still read as an owner-less running turn.
+    await settleAutomationRunState(bksId, errorMsg || null, sawTerminalEvent);
 
     if (!errorMsg) {
       await deliverAutomationOutputs({

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -1870,6 +1870,17 @@ export async function runAutomation(
         engineSessionId = event.sessionId || engineSessionId;
         if (event.provider) effectiveProvider = event.provider;
         if (event.model) effectiveModel = event.model;
+        // Dying on usage limits with no account left to rotate to reports as
+        // a `done` whose result is the limit notice, not an `error` — but it
+        // still needs a human. An automation with `fallbackModel: "none"`
+        // reaches the caller unfiltered, because runAgentInner yields
+        // runOnModel directly on that path instead of routing the event into
+        // its fallback walk. run-session.ts and session-create.ts both
+        // convert this shape into a failure; without the same conversion the
+        // ledger would record `ok`, outputs would be delivered for a turn
+        // that never ran, and the session would settle `turn_end`.
+        if (event.usageLimitExhausted)
+          errorMsg = event.result || "Usage limit reached on every account";
       }
       if (event.type === "text_chunk" && event.text) {
         textTail = (textTail + event.text).slice(-16384);

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -29,12 +29,12 @@ import {
 } from "./runner-shared";
 import { getAccountById } from "./claude-accounts";
 import { getCodexAccountById } from "./codex-accounts";
-import { runAgent } from "./agent-runner";
-import { activeRunRecords } from "./run-journal";
+import { isAgentLiveEngineBusy, runAgent } from "./agent-runner";
+import { activeRunRecords, hasActiveRunFor } from "./run-journal";
 import {
+  decideRunStateTransition,
   getRunState,
   isRunStateUnsettled,
-  transitionRunState,
 } from "./run-state";
 import { runAgentHosted } from "./host-client";
 import {
@@ -53,7 +53,7 @@ import {
   worktreeHeadBranch,
 } from "./worktree";
 import { engineSessionPatch } from "./sessions";
-import { updateSessionFile } from "./session-cache";
+import { recordRunOutcome, updateSessionFile } from "./session-cache";
 import { resolvePlainWorkspace } from "./workspace-resolve";
 import { getWorkspace } from "./workspaces";
 import type { NativeSessionFile } from "./types";
@@ -1100,20 +1100,37 @@ function recordRunStart(id: string, run: AutomationRun): void {
  * ledger below recorded `last ok`, and send/cancel were refused as
  * quarantined.
  *
- * Only a terminal engine event settles. A stream that ended without one has
- * not proven what the run did, so it keeps the real safety fence rather than
- * being waved through as finished.
+ * `terminalProven` is the caller's evidence that this run is over: a terminal
+ * engine event on the streaming path, or a definitively failed launch with no
+ * journal record and no live engine left on the throw path. Without such
+ * evidence nothing settles, so a run whose fate is unknown keeps the real
+ * safety fence rather than being waved through as finished.
+ *
+ * Settling the FSM alone is not enough. The session APIs read `lastRunError`
+ * from `runErrors` and the session file, both written by `recordRunOutcome`,
+ * so a run that reaches `failed` without that projection cannot explain itself
+ * to any consumer. Project through the same choke point the other callers use.
  */
+type AutomationOutcomeProjector = (
+  sessionId: string,
+  errorMessage: string | null,
+  opts?: { runId?: string },
+) => Promise<void>;
+
 export async function settleAutomationRunState(
   sessionId: string,
   errorMessage: string | null,
-  sawTerminalEvent: boolean,
+  terminalProven: boolean,
   runKey?: string,
-  emit?: Parameters<typeof transitionRunState>[3],
+  deps?: {
+    emit?: Parameters<typeof decideRunStateTransition>[3];
+    /** Test seam. Production always projects through recordRunOutcome. */
+    project?: AutomationOutcomeProjector;
+  },
 ): Promise<void> {
-  if (!sawTerminalEvent) return;
+  if (!terminalProven) return;
   if (!isRunStateUnsettled(getRunState(sessionId))) return;
-  await transitionRunState(
+  const decision = await decideRunStateTransition(
     sessionId,
     errorMessage ? "run_failed" : "turn_end",
     {
@@ -1125,8 +1142,14 @@ export async function settleAutomationRunState(
       // retire the SUCCESSOR's turn.
       ...(runKey ? { run_key: runKey } : {}),
     },
-    emit,
+    deps?.emit,
   );
+  // A rejected decision means this run no longer owns the session. Projecting
+  // anyway would stamp our outcome onto whoever does.
+  if (!decision.accepted) return;
+  await (deps?.project ?? recordRunOutcome)(sessionId, errorMessage, {
+    ...(runKey ? { runId: runKey } : {}),
+  });
 }
 
 /** Settle the ledger entry for `sessionId` (matched by id, not position, so
@@ -1450,6 +1473,12 @@ export async function runAutomation(
   const stamp = startedAt.toISOString().slice(0, 16).replace("T", " ");
   automationPreparations.add(bksId);
   let sandboxRpcToken: string | undefined;
+  // One physical run id for whichever backend runs this turn. Every backend
+  // journals `run_registered` under it, so it becomes the session's
+  // `currentRunId` and lets the terminal settlement be fenced to this exact
+  // run rather than to whatever owns the session when it lands. Declared out
+  // here so the outer catch can settle a launch that threw before dispatch.
+  const automationRunKey = `rh-${randomUUIDv7()}`;
 
   try {
     const runtimeSandboxValidation = validateSandboxAutomation(automation);
@@ -1754,11 +1783,6 @@ export async function runAutomation(
         `[automations] "${automation.name}" completing accepted setup during shutdown`,
       );
     let events: AsyncGenerator<StreamEvent>;
-    // One physical run id for whichever backend runs this turn. Every backend
-    // journals `run_registered` under it, so it becomes the session's
-    // `currentRunId` and lets the terminal settlement below be fenced to this
-    // exact run rather than to whatever owns the session when it lands.
-    const automationRunKey = `rh-${randomUUIDv7()}`;
     if (sandbox) {
       sandboxRpcToken = crypto.randomUUID();
       registerRunToken(sandboxRpcToken, { sessionId: bksId });
@@ -1973,8 +1997,31 @@ export async function runAutomation(
       error: e.message || String(e),
       durationMs: Date.now() - startedAt.getTime(),
     });
-    // A thrown consumer after physical adoption is ambiguous. Keep the intent;
-    // boot reconciles its active journal or terminal receipt before replay.
+    // A throw is usually ambiguous — the host may still be executing, so the
+    // journal stays and boot recovery owns settling it. One shape is not
+    // ambiguous: spawnHostRun journals `run_registered` (session -> `running`)
+    // BEFORE launching, and on a definitively failed launch its catch proves
+    // absence, clears that journal, and rethrows. That leaves the session
+    // `running` with no journal record and no engine — an owner-less run the
+    // watchdog will quarantine, and the same stranding this change exists to
+    // prevent, reached without any terminal event.
+    //
+    // Require both negatives before settling: no journal record naming this
+    // session or run key, and no live engine. An ambiguous launch keeps its
+    // journal (host-client only clears when the error is not `ambiguousLaunch`),
+    // so it fails these checks and stays fenced.
+    if (
+      !hasActiveRunFor(bksId, automationRunKey) &&
+      !isAgentLiveEngineBusy(bksId, automationRunKey)
+    )
+      await settleAutomationRunState(
+        bksId,
+        e.message || String(e),
+        true,
+        automationRunKey,
+      );
+    // Keep the intent; boot reconciles its active journal or terminal receipt
+    // before replay.
   } finally {
     automationPreparations.delete(bksId);
     activeAutomationIntentSessions.delete(bksId);

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -1912,6 +1912,21 @@ export async function runAutomation(
       }
     }
     if (!errorMsg) errorMsg = declaredRunFailure(textTail) || "";
+    // A stream that ended without any terminal event never proved the turn
+    // finished. session-create.ts throws "Opening run ended without a terminal
+    // event" for exactly this shape, and every journal wrapper records
+    // journalRecordAbnormalCompletion instead of clearing, so boot recovery
+    // reports it as a failure. runAutomation used to fall through with an
+    // empty errorMsg: it delivered outputs for a turn that produced nothing
+    // and recorded `ok` while the session stayed unsettled — the same
+    // ledger-ok/session-running split-brain this change exists to remove.
+    //
+    // The run state deliberately stays fenced (settleAutomationRunState
+    // refuses without a terminal event): the journal still carries this run's
+    // terminalFailure, and boot recovery owns settling it. Only the LEDGER
+    // verdict is corrected here, so the two sides agree.
+    if (!errorMsg && !sawTerminalEvent)
+      errorMsg = "Run ended without a terminal event";
 
     // Safety net for a stream that reported its terminal outcome in a shape
     // the loop could not settle on. Already-settled sessions return early, so

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -1108,6 +1108,7 @@ export async function settleAutomationRunState(
   sessionId: string,
   errorMessage: string | null,
   sawTerminalEvent: boolean,
+  runKey?: string,
   emit?: Parameters<typeof transitionRunState>[3],
 ): Promise<void> {
   if (!sawTerminalEvent) return;
@@ -1115,7 +1116,15 @@ export async function settleAutomationRunState(
   await transitionRunState(
     sessionId,
     errorMessage ? "run_failed" : "turn_end",
-    { source: "automation_terminal" },
+    {
+      source: "automation_terminal",
+      // Fence the settlement to this automation's own physical run. The
+      // hosted generator can still be draining when a Stop retires this run
+      // and a new prompt claims the session; without the key the actor skips
+      // its stale-run check in applyRunEvent and this late settlement would
+      // retire the SUCCESSOR's turn.
+      ...(runKey ? { run_key: runKey } : {}),
+    },
     emit,
   );
 }
@@ -1742,11 +1751,16 @@ export async function runAutomation(
         `[automations] "${automation.name}" completing accepted setup during shutdown`,
       );
     let events: AsyncGenerator<StreamEvent>;
+    // One physical run id for whichever backend runs this turn. Every backend
+    // journals `run_registered` under it, so it becomes the session's
+    // `currentRunId` and lets the terminal settlement below be fenced to this
+    // exact run rather than to whatever owns the session when it lands.
+    const automationRunKey = `rh-${randomUUIDv7()}`;
     if (sandbox) {
       sandboxRpcToken = crypto.randomUUID();
       registerRunToken(sandboxRpcToken, { sessionId: bksId });
       const spec: RunHostSpec = {
-        hostId: `rh-${randomUUIDv7()}`,
+        hostId: automationRunKey,
         osSessionId: bksId,
         prompt,
         cwd,
@@ -1803,6 +1817,7 @@ export async function runAutomation(
           ? runAgentHosted({
               ...common,
               osSessionId: bksId,
+              startToken: automationRunKey,
               proxyMcpServers: Object.keys(inProcessMcp),
               fallbackInProcessMcp: () => inProcessMcp,
               journalKind: "automation",
@@ -1810,6 +1825,7 @@ export async function runAutomation(
             })
           : runAgent({
               ...common,
+              startToken: automationRunKey,
               inProcessMcp,
               journal: { osSessionId: bksId, kind: "automation" },
             });
@@ -1871,7 +1887,12 @@ export async function runAutomation(
     // session this function exists to prevent. The engine session id is
     // already persisted from the `init` event, so nothing below is a
     // precondition for reading this session back.
-    await settleAutomationRunState(bksId, errorMsg || null, sawTerminalEvent);
+    await settleAutomationRunState(
+      bksId,
+      errorMsg || null,
+      sawTerminalEvent,
+      automationRunKey,
+    );
 
     await persistSession(engineSessionId);
 

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -1731,6 +1731,9 @@ export async function runAutomation(
     // Whether the engine reported a terminal outcome. Only that proves the
     // turn is over and lets settleAutomationRunState retire the session.
     let sawTerminalEvent = false;
+    // Settlement happens once, inside the event loop. The flag keeps the
+    // post-loop safety net from re-entering it.
+    let settledRunState = false;
     // Tail of the assistant's text: an automation whose prompt declares
     // failure (`RUN STATUS: failed — …` / `SCAN STATUS: failed — …` as the
     // final line) settles the ledger as error instead of "the turn finished
@@ -1875,24 +1878,43 @@ export async function runAutomation(
         sawTerminalEvent = true;
         errorMsg = event.content || "Unknown error";
       }
+      // Settle HERE, inside the loop, not after it. Asking the generator for
+      // its next item is what resumes the journal wrapper, and every wrapper
+      // (hostedEventsWithJournal and both sandbox wrappers) clears this run's
+      // recovery journal in its `finally` on normal source completion. A
+      // session-kernel restart in the window between that clear and a
+      // post-loop settlement would leave the session `running` with no journal
+      // record left to recover it — the exact stranding this change exists to
+      // prevent. Settling first means the journal still names this run for as
+      // long as the session is unsettled.
+      //
+      // The declared-failure tail is read here too: text chunks precede the
+      // terminal event, so it carries the same verdict the ledger will record.
+      if (sawTerminalEvent && !settledRunState) {
+        settledRunState = true;
+        await settleAutomationRunState(
+          bksId,
+          errorMsg || declaredRunFailure(textTail) || null,
+          true,
+          automationRunKey,
+        );
+      }
     }
     if (!errorMsg) errorMsg = declaredRunFailure(textTail) || "";
 
-    // First, before anything that can reject. The engine reported a terminal
-    // outcome and the host has already retired its journal, so the session is
-    // owner-less from here on. Everything below — session persistence, output
-    // delivery, the ledger — can fail into the outer catch, which settles the
-    // ledger but cannot settle the session (its state is scoped to this try).
-    // Settling after any of them would leave exactly the owner-less running
-    // session this function exists to prevent. The engine session id is
-    // already persisted from the `init` event, so nothing below is a
-    // precondition for reading this session back.
-    await settleAutomationRunState(
-      bksId,
-      errorMsg || null,
-      sawTerminalEvent,
-      automationRunKey,
-    );
+    // Safety net for a stream that reported its terminal outcome in a shape
+    // the loop could not settle on. Already-settled sessions return early, so
+    // this is a no-op on the normal path. It stays ahead of everything that
+    // can reject — session persistence, output delivery, the ledger — because
+    // the outer catch settles the LEDGER but cannot settle the session: the
+    // run-state locals are scoped to this try.
+    if (!settledRunState)
+      await settleAutomationRunState(
+        bksId,
+        errorMsg || null,
+        sawTerminalEvent,
+        automationRunKey,
+      );
 
     await persistSession(engineSessionId);
 

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -1862,11 +1862,18 @@ export async function runAutomation(
     }
     if (!errorMsg) errorMsg = declaredRunFailure(textTail) || "";
 
-    await persistSession(engineSessionId);
-
-    // Before the ledger claims an outcome: a session the ledger calls done
-    // must not still read as an owner-less running turn.
+    // First, before anything that can reject. The engine reported a terminal
+    // outcome and the host has already retired its journal, so the session is
+    // owner-less from here on. Everything below — session persistence, output
+    // delivery, the ledger — can fail into the outer catch, which settles the
+    // ledger but cannot settle the session (its state is scoped to this try).
+    // Settling after any of them would leave exactly the owner-less running
+    // session this function exists to prevent. The engine session id is
+    // already persisted from the `init` event, so nothing below is a
+    // precondition for reading this session back.
     await settleAutomationRunState(bksId, errorMsg || null, sawTerminalEvent);
+
+    await persistSession(engineSessionId);
 
     if (!errorMsg) {
       await deliverAutomationOutputs({

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -54,6 +54,7 @@ import {
 } from "./worktree";
 import { engineSessionPatch } from "./sessions";
 import { recordRunOutcome, updateSessionFile } from "./session-cache";
+import { sessionKernel } from "./session-kernel";
 import { resolvePlainWorkspace } from "./workspace-resolve";
 import { getWorkspace } from "./workspaces";
 import type { NativeSessionFile } from "./types";
@@ -1109,12 +1110,20 @@ function recordRunStart(id: string, run: AutomationRun): void {
  * Settling the FSM alone is not enough. The session APIs read `lastRunError`
  * from `runErrors` and the session file, both written by `recordRunOutcome`,
  * so a run that reaches `failed` without that projection cannot explain itself
- * to any consumer. Project through the same choke point the other callers use.
+ * to any consumer. Project through the same choke point the other callers use,
+ * with the same durable identity they pass: this run's id, the generation it
+ * owned, and a stable projection id. Those three route the outcome through the
+ * actor's turn-outcome executor, which makes the projection idempotent and
+ * fenced to this exact run rather than a best-effort direct write.
  */
 type AutomationOutcomeProjector = (
   sessionId: string,
   errorMessage: string | null,
-  opts?: { runId?: string },
+  opts?: {
+    runId?: string;
+    runGeneration?: number;
+    projectionId?: string;
+  },
 ) => Promise<void>;
 
 export async function settleAutomationRunState(
@@ -1130,6 +1139,12 @@ export async function settleAutomationRunState(
 ): Promise<void> {
   if (!terminalProven) return;
   if (!isRunStateUnsettled(getRunState(sessionId))) return;
+  // Capture the generation BEFORE settling. It is the generation this run
+  // owned, which is what the outcome executor fences against; reading it after
+  // the transition would race a successor that claims the session in between.
+  const runGeneration = runKey
+    ? sessionKernel(sessionId).runStateProjection().generation
+    : undefined;
   const decision = await decideRunStateTransition(
     sessionId,
     errorMessage ? "run_failed" : "turn_end",
@@ -1148,7 +1163,15 @@ export async function settleAutomationRunState(
   // anyway would stamp our outcome onto whoever does.
   if (!decision.accepted) return;
   await (deps?.project ?? recordRunOutcome)(sessionId, errorMessage, {
-    ...(runKey ? { runId: runKey } : {}),
+    ...(runKey
+      ? {
+          runId: runKey,
+          runGeneration,
+          // Stable and derived from the run id, so a retry of the same run
+          // reuses the projection rather than issuing a second one.
+          projectionId: `outcome:${runKey}`,
+        }
+      : {}),
   });
 }
 


### PR DESCRIPTION
## The bug

Three successive runs of `auto-01a05a31-7005-73ee-a035-aeef59b92f54` emitted a final assistant report and recorded `last ok` in the automation registry, yet each session stayed `running` in the task/session APIs and the UI showed "Paused for safety — Open Session paused because it couldn't verify the last action." Send and cancel were refused with `Session <id> is quarantined: The active run no longer has a live execution owner or recovery claim`.

The cleanest reproduction, `os-01a05ae3-3983-735b-a48e-3ee9310d5a9d`, only ran find/grep/read, reported no tool failures, and had a clean worktree — so denied shell calls and the dirty `bun.lock` in the other sessions were coincidental, not causal.

## Root cause

A missing settlement step in `runAutomation`, not a regression of `60b6935dd`.

Automation turns execute in a detached run host (`runAgentHosted` — the only path now that every model routes to pi). The lifecycle is split across two owners:

1. `journalSet` journals the host and fires `run_registered`, moving the session FSM to `running`.
2. When the stream ends, `hostedEventsWithJournal`'s `finally` only calls `journalClear`. It deliberately does not settle the FSM — retiring the *visible* run is the consumer's job.

Every other consumer of the hosted path does that job: `run-session.ts`, `session-create.ts` and `src/agents/github/run.ts` each call `recordRunOutcome`, which transitions `turn_end`/`run_failed`. `automations.ts` called neither `recordRunOutcome` nor `transitionRunState` anywhere — it settled only its own ledger via `settleRun`.

So after a successful automation:

- automation ledger → `last ok` (`settleRun`)
- session FSM → still `running`, journal empty, no live engine
- `isRunStateUnsettled("running")` → session projects `isRunning: true` forever
- `checkRunStateWedge` sees `runStateRequiresLiveOwner("running") && !ownerBusy` for 3 minutes and calls `quarantineSessionForSafety(..., "The active run no longer has a live execution owner or recovery claim", "run_state:running")`
- `run_state:*` is not in `automaticallyRecoverableSessionSafety`, so the fence never auto-released, and send/cancel stayed refused

That is the exact reported split-brain. The in-process `runAgent` path settles itself in its own `finally`, which is why this only bites the hosted path; automations became hosted-only when `providerFor` collapsed to `pi` in `e32266756`.

## The fix

Add the one missing consumer-side step, mirroring what the other three callers already do:

- `settleAutomationRunState(sessionId, errorMessage, sawTerminalEvent, runKey)` transitions `turn_end`/`run_failed` when the FSM is still unsettled.
- `runAutomation` calls it **inside** the event loop, immediately after the terminal event is captured. Requesting the generator's next item is what resumes the journal wrapper, and all three wrappers (`hostedEventsWithJournal` and both sandbox wrappers) clear this run's recovery journal in their `finally` on normal source completion. Settling only after the loop left a window where the session read `running` with no journal record left to recover it. Settling first means the journal still names this run for as long as the session is unsettled.
- A post-loop call remains as a safety net for a stream that reported its outcome in a shape the loop could not settle on. A `settledRunState` flag makes it a no-op on the normal path, and it still precedes every fallible step of the completion tail (`persistSession`, `deliverAutomationOutputs`, `settleRun`) because the outer `catch` settles the ledger but structurally cannot settle the session — the run-state locals are scoped to the `try`.

The settlement is fenced to this automation's own physical run. `runAutomation` mints one `automationRunKey` per turn and passes it to whichever backend runs it — `spec.hostId` for sandboxed runs, `startToken` for `runAgentHosted` and `runAgent` — so every backend journals `run_registered` under the same id and it becomes the session's `currentRunId`. Without that key, `applyRunEvent` skips its stale-run check, and a Stop plus a new prompt during the hosted drain would let this late settlement retire the *successor's* turn.

A usage-exhausted turn is treated as a failure. Dying on usage limits with no account left reports as a `done` carrying `usageLimitExhausted`, not an `error`, and an automation with `fallbackModel: "none"` receives that shape unfiltered because `runAgentInner` yields `runOnModel` directly on that path instead of routing the event into its fallback walk. `run-session.ts` and `session-create.ts` both convert it; `runAutomation` did not, so the ledger recorded `ok`, outputs were delivered for a turn that never ran, and the session settled `turn_end`. The conversion sits in the `done` branch, ahead of the settlement that reads `errorMsg`.

A stream that ends with no terminal event at all is recorded as a failure. `session-create.ts` throws "Opening run ended without a terminal event" for that shape, and every journal wrapper records `journalRecordAbnormalCompletion` rather than clearing, so boot recovery surfaces it. `runAutomation` fell through with an empty `errorMsg`, delivering outputs for a turn that produced nothing and recording `ok` while the session stayed unsettled. Only the ledger verdict is corrected: the run state stays fenced, because nothing proved what the turn did and boot recovery owns settling it.

A full parity audit of `runAutomation`'s terminal handling against both reference callers is posted as a PR comment.

Real safety quarantine is preserved deliberately:

- Only a terminal engine event (`done`/`error`) settles. A stream that ended without one has not proven what the run did, so it keeps its fence.
- The `catch` path stays fenced for every ambiguous throw — the host may still be alive there, and boot recovery reconciles it. The one exception is a *definitively* failed host launch: `spawnHostRun` journals `run_registered` (session -> `running`) before launching, and on a proven-absent launch failure its catch clears that journal and rethrows, leaving an owner-less `running` session with no journal and no engine. That case settles from the outer catch, gated on both `!hasActiveRunFor` and `!isAgentLiveEngineBusy`. An ambiguous launch keeps its journal, so it fails those checks and stays fenced.
- The guard is `isRunStateUnsettled`, so this never emits a double teardown.

Terminal outcomes are projected, not only moved in the FSM. The session APIs read `lastRunError` from `runErrors` and the session file, both written by `recordRunOutcome`, so a run reaching `failed` without that projection cannot explain itself to any consumer. The settlement uses `decideRunStateTransition` and projects **only** on an accepted decision: a rejected one means this run no longer owns the session, and projecting anyway would stamp a dead automation's error onto a live successor's turn.

The projection carries the same durable identity the other two callers pass: this run's id, the generation it owned, and a stable `outcome:${runKey}` projection id. All three together are what routes the outcome through the actor's turn-outcome executor rather than the direct best-effort write, making it idempotent and fenced to this exact run. The generation is captured **before** the transition, since reading it afterwards would race a successor claiming the session.

## Tests

New `src/server/automation-run-settlement.test.ts`, which fails on `main` and passes here:

- a completed automation turn leaves no owner-less running session (asserts the quarantine precondition `runStateRequiresLiveOwner` before, and `idle` after)
- a declared or streamed failure settles as `failed`, not `running`
- a stream that ended without a terminal event keeps the safety fence
- a late settlement cannot retire a successor's run (cancel + new prompt during the hosted drain; mutation-checked against removing the `run_key` fence)
- settling an already-settled session emits no double teardown
- a usage-exhausted `done` becomes a failure before the run settles (mutation-checked against deleting the conversion)
- an exhausted run settles as `failed`, matching what the ledger records
- a stream with no terminal event records `error`, not `ok` (mutation-checked)
- an abnormal completion still keeps the session's safety fence
- a source invariant that `runAutomation` settles the session before claiming the ledger outcome
- a source invariant that settlement happens inside the loop, before the journal wrapper clears (mutation-checked against deleting the in-loop call)
- a source invariant that nothing which can reject runs between the terminal event and settlement
- a terminal failure is projected, not only moved in the FSM (mutation-checked against deleting the projection)
- a clean turn projects a null outcome, clearing any earlier failure
- a stale settlement projects nothing onto the successor
- the projected generation is the one this run owned (mutation-checked against dropping the durable identity)
- a source invariant that a definitively failed launch settles from the outer catch (mutation-checked)
- a source invariant that every automation backend journals the run id all three settlement call sites fence on

`bun run check` passes in full.

## Production remediation

This fixes new runs only. The sessions already stranded are **not** recoverable by an explicit safety release — an earlier version of this description claimed they were, and that was wrong.

`SessionKernelStore.quarantineRepairEvidence` returns `false` whenever the run state is `preparing/starting/running/ask_blocked/interrupted/reattaching` and there is no recoverable gateway or delivery settlement. A `run_state:*` fence has neither, so it short-circuits: `repairable` is `false` (which is what `GET /api/system/session-kernel/dead-letters` reports) and `releaseQuarantine` returns without deleting the row. `actor-worker.ts` also fences every session mutation except `quarantineSession` and `releaseQuarantine`, so nothing online can settle the run state either.

Recovery for those sessions is opensession#257, an offline operator job that repairs the cause (settles the run state) so the **unmodified** release passes on its own merits, gated on durable proof that the run is terminal and unowned.

Not merged and not deployed.

Started by Johnny Lin in [this OS session](https://os.tella.dev/session/bks-1d5e3c79-0034-7753-9646-f09f5e29f060)






