### PR TITLE
Add an offline repair for stranded automation quarantines

### DIFF
--- a/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Two things are proved here:
+ *
+ * 1. The deadlock is real. A session quarantined by the wedge detector with
+ *    `run_state:running` reports `repairable: false` and `releaseQuarantine`
+ *    refuses it, so no explicit operator release can recover these sessions.
+ * 2. The offline repair fixes the CAUSE and lets the UNMODIFIED release
+ *    succeed, while every session that cannot produce durable terminal proof
+ *    keeps its fence.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionKernelStore } from "./store";
+import {
+  ORPHANED_RUN_QUARANTINE_REASON,
+  inspectAutomationQuarantine,
+  repairSettledAutomationQuarantines,
+  settledAutomationQuarantineEvidence,
+  type AutomationLedgerStatus,
+} from "./automation-quarantine-repair";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+/** A stranded automation session, exactly as the wedge detector leaves it. */
+function fixture(
+  sessions: Array<{
+    sessionId: string;
+    state?: string;
+    reason?: string;
+    commandKind?: string;
+  }>,
+): string {
+  const root = mkdtempSync(join(tmpdir(), "automation-quarantine-repair-"));
+  roots.push(root);
+  const centralPath = join(root, "session-kernel.sqlite");
+  const store = new SessionKernelStore(centralPath);
+  for (const session of sessions) {
+    store.setRunState({
+      sessionId: session.sessionId,
+      state: session.state ?? "running",
+      event: "run_registered",
+      currentRunId: `rh-${session.sessionId}`,
+    });
+    store.quarantineSession(
+      session.sessionId,
+      session.reason ?? ORPHANED_RUN_QUARANTINE_REASON,
+      session.commandKind ?? `run_state:${session.state ?? "running"}`,
+    );
+  }
+  store.close();
+  return centralPath;
+}
+
+const ledger =
+  (entries: Record<string, AutomationLedgerStatus>) => (sessionId: string) =>
+    entries[sessionId];
+const noJournal = () => false;
+
+describe("the stranded state is genuinely unrecoverable online", () => {
+  test("a run_state fence reports repairable:false and refuses release", () => {
+    const centralPath = fixture([{ sessionId: "stranded" }]);
+    const store = new SessionKernelStore(centralPath);
+    try {
+      // What GET /api/system/session-kernel/dead-letters surfaces.
+      expect(store.quarantinedSession("stranded")?.repairable).toBe(false);
+      // And the reducer refuses, so an explicit operator release is a no-op.
+      expect(store.releaseQuarantine("stranded")).toBe(false);
+      expect(store.quarantinedSession("stranded")).toBeTruthy();
+    } finally {
+      store.close();
+    }
+  });
+
+  test("the unsettled run state is what blocks the release", () => {
+    const centralPath = fixture([{ sessionId: "stranded" }]);
+    const store = new SessionKernelStore(centralPath);
+    try {
+      expect(
+        store.quarantineRepairEvidence("stranded", "run_state:running"),
+      ).toBe(false);
+      // Settling the FSM is the whole difference: no fence logic changes.
+      store.setRunState({
+        sessionId: "stranded",
+        state: "idle",
+        event: "turn_end",
+      });
+      expect(
+        store.quarantineRepairEvidence("stranded", "run_state:running"),
+      ).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("durable terminal evidence", () => {
+  const base = {
+    quarantine: {
+      reason: ORPHANED_RUN_QUARANTINE_REASON,
+      commandKind: "run_state:running",
+    },
+    runState: "running",
+    ledgerStatus: "ok" as AutomationLedgerStatus,
+    journalBusy: false,
+  };
+
+  test("accepts a completed automation run with no owner", () => {
+    expect(settledAutomationQuarantineEvidence(base)).toEqual({
+      repairable: true,
+      settleAs: "idle",
+      event: "turn_end",
+    });
+  });
+
+  test("settles a failed automation run as failed", () => {
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, ledgerStatus: "error" }),
+    ).toEqual({ repairable: true, settleAs: "failed", event: "run_failed" });
+  });
+
+  test("refuses without a terminal ledger verdict", () => {
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, ledgerStatus: "running" })
+        .repairable,
+    ).toBe(false);
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, ledgerStatus: undefined })
+        .repairable,
+    ).toBe(false);
+  });
+
+  test("refuses while the run journal still owns the session", () => {
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, journalBusy: true })
+        .repairable,
+    ).toBe(false);
+  });
+
+  test("refuses any quarantine that is not the ownership wedge", () => {
+    expect(
+      settledAutomationQuarantineEvidence({
+        ...base,
+        quarantine: {
+          reason: "Outbox 7 crossed session ownership",
+          commandKind: "core:ack_outbox",
+        },
+      }).repairable,
+    ).toBe(false);
+    expect(
+      settledAutomationQuarantineEvidence({
+        ...base,
+        quarantine: {
+          reason: ORPHANED_RUN_QUARANTINE_REASON,
+          commandKind: "gateway:complete",
+        },
+      }).repairable,
+    ).toBe(false);
+  });
+
+  test("only applies edges the run-state machine actually defines", () => {
+    // `idle` has no turn_end edge: settling it would be a double teardown.
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, runState: "idle" })
+        .repairable,
+    ).toBe(false);
+    // A human-blocked ask is not an owner-less run and has its own edge rules.
+    expect(
+      settledAutomationQuarantineEvidence({ ...base, runState: "ask_blocked" }),
+    ).toEqual({ repairable: true, settleAs: "idle", event: "turn_end" });
+  });
+});
+
+describe("offline repair", () => {
+  test("settles and releases a completed automation session", () => {
+    const centralPath = fixture([{ sessionId: "auto-done" }]);
+    const result = repairSettledAutomationQuarantines({
+      centralPath,
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    });
+
+    expect(result.repaired).toEqual([
+      {
+        sessionId: "auto-done",
+        ledgerStatus: "ok",
+        from: "running",
+        to: "idle",
+        released: true,
+      },
+    ]);
+    const store = new SessionKernelStore(centralPath);
+    try {
+      expect(store.quarantinedSession("auto-done")).toBeUndefined();
+      expect(store.runState("auto-done").state).toBe("idle");
+      // A settled run must not keep claiming a physical owner.
+      expect(store.runState("auto-done").currentRunId).toBeUndefined();
+    } finally {
+      store.close();
+    }
+  });
+
+  test("a dry run changes nothing", () => {
+    const centralPath = fixture([{ sessionId: "auto-done" }]);
+    const result = repairSettledAutomationQuarantines({
+      centralPath,
+      dryRun: true,
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    });
+
+    expect(result.repaired[0]).toMatchObject({ to: "idle", released: false });
+    const store = new SessionKernelStore(centralPath);
+    try {
+      expect(store.quarantinedSession("auto-done")).toBeTruthy();
+      expect(store.runState("auto-done").state).toBe("running");
+    } finally {
+      store.close();
+    }
+  });
+
+  test("leaves every unproven quarantine fenced", () => {
+    const centralPath = fixture([
+      { sessionId: "auto-done" },
+      { sessionId: "auto-still-running" },
+      { sessionId: "auto-owned" },
+      { sessionId: "not-an-automation" },
+      {
+        sessionId: "other-fence",
+        reason: "actor restarted before acknowledgement",
+        commandKind: "gateway:complete",
+      },
+    ]);
+    const result = repairSettledAutomationQuarantines({
+      centralPath,
+      ledgerStatus: ledger({
+        "auto-done": "ok",
+        "auto-still-running": "running",
+        "auto-owned": "ok",
+        "other-fence": "ok",
+      }),
+      journalBusy: (id) => id === "auto-owned",
+    });
+
+    expect(result.scanned).toBe(5);
+    expect(result.repaired.map((r) => r.sessionId)).toEqual(["auto-done"]);
+    expect(result.skipped.map((s) => s.sessionId).sort()).toEqual([
+      "auto-owned",
+      "auto-still-running",
+      "not-an-automation",
+      "other-fence",
+    ]);
+    const store = new SessionKernelStore(centralPath);
+    try {
+      for (const id of [
+        "auto-still-running",
+        "auto-owned",
+        "not-an-automation",
+        "other-fence",
+      ]) {
+        expect(store.quarantinedSession(id)).toBeTruthy();
+        expect(store.runState(id).state).toBe("running");
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  test("is idempotent", () => {
+    const centralPath = fixture([{ sessionId: "auto-done" }]);
+    const inputs = {
+      centralPath,
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    };
+    repairSettledAutomationQuarantines(inputs);
+    const second = repairSettledAutomationQuarantines(inputs);
+
+    expect(second.scanned).toBe(0);
+    expect(second.repaired).toEqual([]);
+  });
+
+  test("inspection reports the verdict without mutating anything", () => {
+    const centralPath = fixture([{ sessionId: "auto-done" }]);
+    const verdict = inspectAutomationQuarantine(centralPath, "auto-done", {
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    });
+
+    expect(verdict).toMatchObject({ quarantined: true, repairable: true });
+    const store = new SessionKernelStore(centralPath);
+    try {
+      expect(store.quarantinedSession("auto-done")).toBeTruthy();
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.test.ts
@@ -11,8 +11,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { SessionKernelStore } from "./store";
+import { SessionKernelStoreHost } from "./store-host";
 import {
   ORPHANED_RUN_QUARANTINE_REASON,
   inspectAutomationQuarantine,
@@ -55,6 +56,49 @@ function fixture(
   }
   store.close();
   return centralPath;
+}
+
+/**
+ * The same stranded session, placed in an actor-isolated store — which is how
+ * live sessions are placed. Its quarantine row and run state live in that
+ * session's own database, and the catalog holds only a sparse projection, so a
+ * reader that opens the central store directly sees neither.
+ *
+ * The fence is applied THROUGH the host, after isolation, because that is the
+ * production path: the wedge detector quarantines via the actor, and
+ * `SessionKernelStoreHost.quarantineSession` publishes the catalog projection
+ * as it writes the isolated row. Seeding the fence into the central store
+ * before migrating instead produces a shape the live instance never has.
+ */
+function isolatedFixture(sessionId: string): {
+  centralPath: string;
+  isolatedRoot: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "automation-quarantine-isolated-"));
+  roots.push(root);
+  const centralPath = join(root, "session-kernel.sqlite");
+  const isolatedRoot = join(root, "session-kernel-sessions");
+  const central = new SessionKernelStore(centralPath);
+  central.setRunState({
+    sessionId,
+    state: "running",
+    event: "run_registered",
+    currentRunId: `rh-${sessionId}`,
+  });
+  central.close();
+  const host = new SessionKernelStoreHost(centralPath, isolatedRoot);
+  try {
+    expect(host.migrateLegacySessions(10)).toBeGreaterThan(0);
+    expect(host.isIsolated(sessionId)).toBe(true);
+    host.call("quarantineSession", [
+      sessionId,
+      ORPHANED_RUN_QUARANTINE_REASON,
+      "run_state:running",
+    ]);
+  } finally {
+    host.close();
+  }
+  return { centralPath, isolatedRoot };
 }
 
 const ledger =
@@ -299,5 +343,110 @@ describe("offline repair", () => {
     } finally {
       store.close();
     }
+  });
+
+  test("inspection sees an actor-isolated quarantine", () => {
+    const { centralPath } = isolatedFixture("auto-done");
+
+    // Opening the central store directly is the bug: for an isolated session
+    // the quarantine row lives in that session's own database, so a direct
+    // central read reports a live fence as "not quarantined" and an operator
+    // concludes there is nothing to repair.
+    const direct = new SessionKernelStore(centralPath);
+    try {
+      expect(direct.quarantinedSession("auto-done")).toBeUndefined();
+    } finally {
+      direct.close();
+    }
+
+    const verdict = inspectAutomationQuarantine(centralPath, "auto-done", {
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    });
+
+    expect(verdict).toMatchObject({ quarantined: true, repairable: true });
+  });
+
+  test("inspection reads an isolated session's own run state", () => {
+    const { centralPath } = isolatedFixture("auto-still-running");
+
+    // The evidence reducer refuses without a terminal ledger verdict. Reaching
+    // that refusal at all proves the quarantine and run state were both read
+    // from the isolated store rather than missed entirely.
+    const verdict = inspectAutomationQuarantine(
+      centralPath,
+      "auto-still-running",
+      {
+        ledgerStatus: ledger({ "auto-still-running": "running" }),
+        journalBusy: noJournal,
+      },
+    );
+
+    expect(verdict).toMatchObject({
+      quarantined: true,
+      repairable: false,
+      reason: "automation ledger is still running",
+    });
+  });
+
+  test("inspection accepts an explicit isolated root", () => {
+    const { centralPath, isolatedRoot } = isolatedFixture("auto-done");
+
+    const verdict = inspectAutomationQuarantine(
+      centralPath,
+      "auto-done",
+      { ledgerStatus: ledger({ "auto-done": "ok" }), journalBusy: noJournal },
+      isolatedRoot,
+    );
+
+    expect(verdict).toMatchObject({ quarantined: true, repairable: true });
+  });
+
+  test("inspection still refuses an unknown session", () => {
+    const { centralPath } = isolatedFixture("auto-done");
+
+    // Fail closed: routing through the host must not turn "no such fence" into
+    // a repairable verdict.
+    expect(
+      inspectAutomationQuarantine(centralPath, "never-quarantined", {
+        ledgerStatus: ledger({ "never-quarantined": "ok" }),
+        journalBusy: noJournal,
+      }),
+    ).toMatchObject({
+      quarantined: false,
+      repairable: false,
+      reason: "session is not quarantined",
+    });
+  });
+
+  test("the repair job settles and releases an isolated session", () => {
+    const { centralPath, isolatedRoot } = isolatedFixture("auto-done");
+
+    // The scan reads the merged catalog through the host, so unlike inspection
+    // it was never blind. Pin it end to end anyway: this is the shape every
+    // live stranded session actually has, and a regression in the catalog
+    // routing would silently strand all of them.
+    const result = repairSettledAutomationQuarantines({
+      centralPath,
+      isolatedRoot,
+      ledgerStatus: ledger({ "auto-done": "ok" }),
+      journalBusy: noJournal,
+    });
+
+    expect(result.repaired).toEqual([
+      {
+        sessionId: "auto-done",
+        ledgerStatus: "ok",
+        from: "running",
+        to: "idle",
+        released: true,
+      },
+    ]);
+    expect(
+      inspectAutomationQuarantine(centralPath, "auto-done", {
+        ledgerStatus: ledger({ "auto-done": "ok" }),
+        journalBusy: noJournal,
+      }),
+    ).toMatchObject({ quarantined: false });
   });
 });

--- a/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.ts
@@ -18,11 +18,7 @@
  * code path changes, and generic `run_state` quarantine keeps its full
  * strength for every session that cannot produce the proof below.
  */
-import {
-  SessionKernelStore,
-  type DurableSessionQuarantine,
-  type DurableRunState,
-} from "./store";
+import { type DurableSessionQuarantine, type DurableRunState } from "./store";
 import { SessionKernelStoreHost } from "./store-host";
 import { nextRunState, type RunState } from "./run-state-machine";
 
@@ -190,31 +186,45 @@ export function repairSettledAutomationQuarantines(
   return result;
 }
 
-/** Read-only helper for operators inspecting a single session's evidence. */
+/**
+ * Read-only helper for operators inspecting a single session's evidence.
+ *
+ * Routes through the store host, exactly as the repair does. Opening the
+ * central database directly reads the wrong store for an actor-isolated
+ * session: its quarantine row and run state live in that session's own
+ * database, and the catalog holds only a sparse projection. A direct central
+ * read therefore reports a live fence as "session is not quarantined", and
+ * even when the catalog does carry the row it cannot recompute `repairable`
+ * from the isolated store's own evidence the way the host does.
+ */
 export function inspectAutomationQuarantine(
   centralPath: string,
   sessionId: string,
   inputs: AutomationQuarantineRepairInputs,
+  isolatedRoot?: string,
 ): AutomationQuarantineVerdict & { quarantined: boolean } {
-  const store = new SessionKernelStore(centralPath);
+  const host = new SessionKernelStoreHost(centralPath, isolatedRoot);
   try {
-    const quarantine = store.quarantinedSession(sessionId);
+    const quarantine = host.call("quarantinedSession", [sessionId]) as
+      | DurableSessionQuarantine
+      | undefined;
     if (!quarantine)
       return {
         quarantined: false,
         repairable: false,
         reason: "session is not quarantined",
       };
+    const runState = host.call("runState", [sessionId]) as DurableRunState;
     return {
       quarantined: true,
       ...settledAutomationQuarantineEvidence({
         quarantine,
-        runState: store.runState(sessionId).state,
+        runState: runState.state,
         ledgerStatus: inputs.ledgerStatus(sessionId),
         journalBusy: inputs.journalBusy(sessionId),
       }),
     };
   } finally {
-    store.close();
+    host.close();
   }
 }

--- a/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair.ts
@@ -1,0 +1,220 @@
+/**
+ * Offline repair for automation sessions stranded by the missing settlement
+ * that `settleAutomationRunState` now prevents.
+ *
+ * Those sessions are deadlocked by design, and the deadlock is correct:
+ *
+ * - The wedge detector quarantined them with `run_state:<state>` because the
+ *   FSM claimed a run with no live owner.
+ * - `quarantineRepairEvidence` refuses to release while the FSM is in an
+ *   unsettled state, so the fence reports `repairable: false`.
+ * - The actor fences every session mutation except `quarantineSession` and
+ *   `releaseQuarantine`, so nothing online can settle the FSM either.
+ *
+ * The fix is to repair the CAUSE rather than weaken the fence: settle the run
+ * state offline, after which the existing `releaseQuarantine` passes on its own
+ * unmodified merits. Every other evidence check — ambiguous commands, claimed
+ * timers, pending effects — still runs and still fails closed. No production
+ * code path changes, and generic `run_state` quarantine keeps its full
+ * strength for every session that cannot produce the proof below.
+ */
+import {
+  SessionKernelStore,
+  type DurableSessionQuarantine,
+  type DurableRunState,
+} from "./store";
+import { SessionKernelStoreHost } from "./store-host";
+import { nextRunState, type RunState } from "./run-state-machine";
+
+/** The exact wedge-detector reason. Any other quarantine is out of scope. */
+export const ORPHANED_RUN_QUARANTINE_REASON =
+  "The active run no longer has a live execution owner or recovery claim";
+
+export type AutomationLedgerStatus = "running" | "ok" | "error";
+
+export interface AutomationQuarantineEvidence {
+  quarantine: Pick<DurableSessionQuarantine, "reason" | "commandKind">;
+  runState: string;
+  /** The automation ledger's own verdict for this session's run. */
+  ledgerStatus?: AutomationLedgerStatus;
+  /** Whether any run-journal record still names this session. */
+  journalBusy: boolean;
+}
+
+export type AutomationQuarantineVerdict =
+  | { repairable: true; settleAs: RunState; event: "turn_end" | "run_failed" }
+  | { repairable: false; reason: string };
+
+/**
+ * Durable proof that an automation run is terminal and unowned.
+ *
+ * Every clause is a fail-closed conjunct. In particular the ledger must have
+ * already recorded a terminal verdict for THIS session: that is the durable
+ * receipt that `runAutomation` drained its engine stream and reached its
+ * completion tail, which is exactly the state the missing settlement stranded.
+ * A ledger still reading `running` proves nothing and is left alone.
+ */
+export function settledAutomationQuarantineEvidence(
+  input: AutomationQuarantineEvidence,
+): AutomationQuarantineVerdict {
+  if (input.quarantine.reason !== ORPHANED_RUN_QUARANTINE_REASON)
+    return { repairable: false, reason: "quarantine reason is not the wedge" };
+  if (!input.quarantine.commandKind.startsWith("run_state:"))
+    return { repairable: false, reason: "quarantine is not a run-state fence" };
+  if (!input.ledgerStatus)
+    return { repairable: false, reason: "no automation ledger entry" };
+  if (input.ledgerStatus === "running")
+    return { repairable: false, reason: "automation ledger is still running" };
+  // A journal record is a live owner or a recovery claim. Either way the run
+  // may still execute, and settling it would let a successor overlap it.
+  if (input.journalBusy)
+    return { repairable: false, reason: "run journal still owns this session" };
+  const event = input.ledgerStatus === "error" ? "run_failed" : "turn_end";
+  // Only a legal FSM edge. This never invents a state the machine would refuse;
+  // it applies the settlement the completed run should have applied itself.
+  const settleAs = nextRunState(input.runState as RunState, event);
+  if (!settleAs)
+    return {
+      repairable: false,
+      reason: `no ${event} edge from ${input.runState}`,
+    };
+  return { repairable: true, settleAs, event };
+}
+
+export interface AutomationQuarantineRepair {
+  sessionId: string;
+  ledgerStatus: "ok" | "error";
+  from: string;
+  to: string;
+  released: boolean;
+}
+
+export interface AutomationQuarantineRepairResult {
+  dryRun: boolean;
+  scanned: number;
+  repaired: AutomationQuarantineRepair[];
+  skipped: Array<{ sessionId: string; reason: string }>;
+}
+
+export interface AutomationQuarantineRepairInputs {
+  /** Terminal ledger verdict per automation session id. */
+  ledgerStatus: (sessionId: string) => AutomationLedgerStatus | undefined;
+  /** Whether the run journal still names this session. */
+  journalBusy: (sessionId: string) => boolean;
+}
+
+/**
+ * Settle and release every automation session that can prove the state above.
+ *
+ * Runs against a stopped instance (the caller asserts that), so it may open the
+ * kernel store host directly. It walks the quarantine catalog only — never the
+ * placement table and never every actor database — so it stays inside the
+ * ownership invariants even though it is an offline job.
+ */
+export function repairSettledAutomationQuarantines(
+  options: {
+    centralPath: string;
+    isolatedRoot?: string;
+    dryRun?: boolean;
+    pageSize?: number;
+  } & AutomationQuarantineRepairInputs,
+): AutomationQuarantineRepairResult {
+  const host = new SessionKernelStoreHost(
+    options.centralPath,
+    options.isolatedRoot,
+  );
+  const result: AutomationQuarantineRepairResult = {
+    dryRun: options.dryRun === true,
+    scanned: 0,
+    repaired: [],
+    skipped: [],
+  };
+  const pageSize = options.pageSize ?? 100;
+  try {
+    const quarantines: DurableSessionQuarantine[] = [];
+    for (let offset = 0; ; offset += pageSize) {
+      const page = host.call("quarantinedSessions", [
+        pageSize,
+        offset,
+      ]) as DurableSessionQuarantine[];
+      quarantines.push(...page);
+      if (page.length < pageSize) break;
+    }
+    for (const quarantine of quarantines) {
+      result.scanned += 1;
+      const sessionId = quarantine.sessionId;
+      const runState = host.call("runState", [sessionId]) as DurableRunState;
+      const verdict = settledAutomationQuarantineEvidence({
+        quarantine,
+        runState: runState.state,
+        ledgerStatus: options.ledgerStatus(sessionId),
+        journalBusy: options.journalBusy(sessionId),
+      });
+      if (!verdict.repairable) {
+        result.skipped.push({ sessionId, reason: verdict.reason });
+        continue;
+      }
+      const ledgerStatus = options.ledgerStatus(sessionId) as "ok" | "error";
+      if (options.dryRun) {
+        result.repaired.push({
+          sessionId,
+          ledgerStatus,
+          from: runState.state,
+          to: verdict.settleAs,
+          released: false,
+        });
+        continue;
+      }
+      host.call("setRunState", [
+        {
+          sessionId,
+          state: verdict.settleAs,
+          event: verdict.event,
+          detail: { source: "offline_automation_quarantine_repair" },
+        },
+      ]);
+      // The unmodified release. It re-derives its own evidence, so a session
+      // carrying anything else unproven still refuses here.
+      const released = host.call("releaseQuarantine", [sessionId]) as boolean;
+      result.repaired.push({
+        sessionId,
+        ledgerStatus,
+        from: runState.state,
+        to: verdict.settleAs,
+        released,
+      });
+    }
+  } finally {
+    host.close();
+  }
+  return result;
+}
+
+/** Read-only helper for operators inspecting a single session's evidence. */
+export function inspectAutomationQuarantine(
+  centralPath: string,
+  sessionId: string,
+  inputs: AutomationQuarantineRepairInputs,
+): AutomationQuarantineVerdict & { quarantined: boolean } {
+  const store = new SessionKernelStore(centralPath);
+  try {
+    const quarantine = store.quarantinedSession(sessionId);
+    if (!quarantine)
+      return {
+        quarantined: false,
+        repairable: false,
+        reason: "session is not quarantined",
+      };
+    return {
+      quarantined: true,
+      ...settledAutomationQuarantineEvidence({
+        quarantine,
+        runState: store.runState(sessionId).state,
+        ledgerStatus: inputs.ledgerStatus(sessionId),
+        journalBusy: inputs.journalBusy(sessionId),
+      }),
+    };
+  } finally {
+    store.close();
+  }
+}

--- a/scripts/repair-automation-quarantines.test.ts
+++ b/scripts/repair-automation-quarantines.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  automationLedgerVerdicts,
+  journaledSessionIds,
+} from "./repair-automation-quarantines";
+
+describe("automation ledger verdicts", () => {
+  test("indexes each run's terminal status by session id", () => {
+    const verdicts = automationLedgerVerdicts([
+      {
+        runs: [
+          { at: "1", sessionId: "os-a", trigger: "cron", status: "ok" },
+          { at: "2", sessionId: "os-b", trigger: "cron", status: "error" },
+        ],
+      },
+      {
+        runs: [
+          { at: "3", sessionId: "os-c", trigger: "manual", status: "running" },
+        ],
+      },
+    ]);
+
+    expect(verdicts.get("os-a")).toBe("ok");
+    expect(verdicts.get("os-b")).toBe("error");
+    expect(verdicts.get("os-c")).toBe("running");
+    expect(verdicts.get("os-unknown")).toBeUndefined();
+  });
+
+  test("a still-running duplicate wins, so the repair stays fail-closed", () => {
+    const verdicts = automationLedgerVerdicts([
+      {
+        runs: [
+          { at: "1", sessionId: "os-dup", trigger: "cron", status: "running" },
+          { at: "2", sessionId: "os-dup", trigger: "cron", status: "ok" },
+        ],
+      },
+    ]);
+
+    expect(verdicts.get("os-dup")).toBe("running");
+  });
+
+  test("tolerates automations with no run ledger", () => {
+    expect(automationLedgerVerdicts([{}, { runs: [] }]).size).toBe(0);
+  });
+});
+
+describe("journaled session ids", () => {
+  test("collects every alias a record can be owned under", () => {
+    const owned = journaledSessionIds([
+      {
+        runKey: "rh-1",
+        osSessionId: "os-a",
+        claudeSessionId: "engine-a",
+        cwd: "/tmp",
+      },
+      { runKey: "rh-2", cwd: "/tmp" },
+    ] as any);
+
+    expect([...owned].sort()).toEqual(["engine-a", "os-a", "rh-1", "rh-2"]);
+  });
+
+  test("an empty journal owns nothing", () => {
+    expect(journaledSessionIds([]).size).toBe(0);
+  });
+});

--- a/scripts/repair-automation-quarantines.ts
+++ b/scripts/repair-automation-quarantines.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+/**
+ * Offline operator job: recover automation sessions stranded by the missing
+ * run-state settlement that `settleAutomationRunState` now prevents.
+ *
+ * These sessions cannot be recovered online. The wedge detector fenced them
+ * with `run_state:<state>`, and `quarantineRepairEvidence` refuses to release
+ * while the run state is unsettled, so the fence reports `repairable: false`
+ * and an explicit release is a no-op. The actor also fences every session
+ * mutation except quarantine/release, so nothing online can settle the state
+ * either. This job repairs the cause offline; the release reducer then passes
+ * on its own unmodified merits.
+ *
+ * Run with the instance stopped:
+ *   sudo systemctl stop opensession opensession-executor opensession-session-kernel
+ *   bun scripts/repair-automation-quarantines.ts --dry-run
+ *   bun scripts/repair-automation-quarantines.ts
+ *   sudo systemctl start opensession
+ */
+import { dirname } from "node:path";
+import { assertServicesStopped } from "./migrate-actor-transcripts";
+import {
+  listAutomations,
+  type AutomationRun,
+} from "../packages/core/opensession-server/src/server/automations";
+import { activeRunRecords } from "../packages/core/opensession-server/src/server/run-journal";
+import { sessionKernelDbPath } from "../packages/core/opensession-server/src/server/session-kernel/store";
+import {
+  repairSettledAutomationQuarantines,
+  type AutomationLedgerStatus,
+} from "../packages/core/opensession-server/src/server/session-kernel/automation-quarantine-repair";
+
+/**
+ * The automation ledger's terminal verdict per session. This is the durable
+ * receipt that `runAutomation` drained its stream and reached its completion
+ * tail — the exact state the missing settlement stranded.
+ */
+export function automationLedgerVerdicts(
+  automations: Array<{ runs?: AutomationRun[] }> = listAutomations(),
+): Map<string, AutomationLedgerStatus> {
+  const verdicts = new Map<string, AutomationLedgerStatus>();
+  for (const automation of automations) {
+    for (const run of automation.runs || []) {
+      if (!run.sessionId) continue;
+      // A session can only have one ledger entry; if a duplicate ever appears,
+      // the least settled verdict wins so the repair stays fail-closed.
+      const prior = verdicts.get(run.sessionId);
+      if (prior === "running") continue;
+      verdicts.set(run.sessionId, run.status);
+    }
+  }
+  return verdicts;
+}
+
+/** Every session id any journal record still names, by any of its aliases. */
+export function journaledSessionIds(records = activeRunRecords()): Set<string> {
+  const owned = new Set<string>();
+  for (const record of records)
+    for (const id of [
+      record.osSessionId,
+      record.claudeSessionId,
+      record.runKey,
+    ])
+      if (id) owned.add(id);
+  return owned;
+}
+
+function value(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function main(): void {
+  assertServicesStopped();
+  const centralPath = value("--central") ?? sessionKernelDbPath();
+  const isolatedRoot =
+    value("--isolated-root") ??
+    `${dirname(centralPath)}/session-kernel-sessions`;
+  const dryRun =
+    process.argv.includes("--dry-run") || process.argv.includes("--audit");
+  const startedAt = performance.now();
+
+  const verdicts = automationLedgerVerdicts();
+  const journaled = journaledSessionIds();
+  const result = repairSettledAutomationQuarantines({
+    centralPath,
+    isolatedRoot,
+    dryRun,
+    ledgerStatus: (sessionId) => verdicts.get(sessionId),
+    journalBusy: (sessionId) => journaled.has(sessionId),
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        ...result,
+        centralPath,
+        automationSessionsWithLedgerVerdict: verdicts.size,
+        journaledSessions: journaled.size,
+        elapsedMs: Math.round(performance.now() - startedAt),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
Follow-up to #256. That PR stops new automation sessions from being stranded; this one recovers the ones already stranded. Split out because it touches no production code path — it is an offline operator job plus a pure evidence reducer.

## Why an explicit release does not work

I originally reported that already-quarantined sessions could be recovered with an explicit `{type: "quarantine", action: "release", sessionId}`. That was wrong, and the tests here prove it:

- The wedge detector fences these with `commandKind: "run_state:running"`.
- `SessionKernelStore.quarantineRepairEvidence` returns `false` whenever the run state is one of `preparing/starting/running/ask_blocked/interrupted/reattaching` and there is no recoverable gateway/delivery settlement. A `run_state:*` fence has neither, so it short-circuits to `false`.
- So `quarantinedSession().repairable` is `false` — which is what `GET /api/system/session-kernel/dead-letters` reports — and `releaseQuarantine` returns without deleting the row.
- `actor-worker.ts` fences every session mutation except `quarantineSession` and `releaseQuarantine`, so nothing online can settle the run state either.

That is a genuine deadlock, and it is correct behaviour: the fence exists precisely because an unsettled run state with no owner is unverified. `the stranded state is genuinely unrecoverable online` in the new test file pins both halves.

## Approach: repair the cause, not the fence

Rather than adding a bypass to `quarantineRepairEvidence`, the job settles the run state offline. After that the **unmodified** `releaseQuarantine` passes on its own merits, with every other evidence check still running — ambiguous commands, claimed timers, pending effects all still fail closed. Generic `run_state` quarantine keeps its full strength for every session that cannot produce the proof below.

No production code path changes.

## The durable proof required

Every clause is a fail-closed conjunct (`settledAutomationQuarantineEvidence`):

1. Quarantine reason is exactly the ownership wedge string, and `commandKind` starts with `run_state:`.
2. The automation ledger holds a **terminal** verdict (`ok`/`error`) for that exact session id. This is the durable receipt that `runAutomation` drained its engine stream and reached its completion tail — the precise state the missing settlement stranded. A ledger still reading `running` proves nothing and is refused.
3. No run-journal record names the session under any alias (`osSessionId`, `claudeSessionId`, `runKey`). A journal record is a live owner or a recovery claim; either way the run may still execute.
4. The settlement is a legal `nextRunState` edge. `turn_end` for `ok`, `run_failed` for `error`. This never invents a state the machine would refuse — it applies the settlement the completed run should have applied itself.

## Ownership invariants

The job walks the quarantine catalog only. It never enumerates placements and never opens every actor database. It asserts `opensession`, `opensession-executor` and `opensession-session-kernel` all report explicit `inactive` before touching state, reusing `assertServicesStopped` from `scripts/migrate-actor-transcripts.ts`.

## Usage

```
sudo systemctl stop opensession opensession-executor opensession-session-kernel
bun scripts/repair-automation-quarantines.ts --dry-run
bun scripts/repair-automation-quarantines.ts
sudo systemctl start opensession
```

## Tests

18 across two files. Beyond the two deadlock-proof tests above:

- accepts a completed run; settles a failed run as `failed`
- refuses without a terminal ledger verdict (both `running` and absent)
- refuses while the run journal still owns the session
- refuses any quarantine that is not the ownership wedge (outbox fence, gateway fence)
- only applies edges the run-state machine defines (`idle` + `turn_end` is refused as a double teardown)
- settles and releases end to end, asserting `currentRunId` is cleared
- dry run changes nothing; the job is idempotent; inspection does not mutate
- mixed fixture: one repairable session among four unproven ones, asserting the other four keep both their fence and their run state
- ledger indexing prefers a still-running duplicate, so the repair stays fail-closed

`bun run check` passes.

Started by Johnny Lin in [this OS session](https://os.tella.dev/session/bks-1d5e3c79-0034-7753-9646-f09f5e29f060)
