### PR TITLE
Make webhook test identity deterministic

### DIFF
--- a/packages/core/opensession-server/src/server/pr-webhook.test.ts
+++ b/packages/core/opensession-server/src/server/pr-webhook.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   reviewerRemovalClearsSessionRequest,
   sandboxEnvironmentInvalidationNeeded,
 } from "./pr-webhook";
+import { __setIdentitiesForTest } from "./shared/user-mappings";
 
 describe("review request webhook sync", () => {
+  let restoreIdentities: (() => void) | undefined;
+
+  beforeAll(() => {
+    restoreIdentities = __setIdentitiesForTest([
+      {
+        name: "Kent de Bruin",
+        email: "kent@example.test",
+        aliases: ["kent"],
+        github: "kentdebruin",
+      },
+    ]);
+  });
+  afterAll(() => restoreIdentities?.());
+
   test("clears a mirrored person request when GitHub removes it", () => {
     expect(
       reviewerRemovalClearsSessionRequest(


### PR DESCRIPTION
## Summary
- pin the webhook review-sync tests to a fixture identity roster
- restore the host roster after the test suite
- keep production identity resolution and fail-closed checks unchanged

## Root cause
With `OPENSESSION_CONFIG` pointing to a missing file, `configuredIdentity()` returns an empty team. The existing test expected `"Kent"` to resolve to `kentdebruin`, so `githubLoginFor("Kent")` returned `null` and the assertion at `pr-webhook.test.ts:37` failed. The fixture now makes that mapping explicit and independent of the machine running the test.

## Verification
- reproduced on current `origin/main` with `OPENSESSION_CONFIG` pointing to a missing file
- reran the focused test with the same empty configuration
- `bun run check`

Started by Johnny Lin in [this OS session](https://os.tella.dev/session/bks-08123b0a-b295-7b5f-883f-4d015709b6f8)
