### PR TITLE
Fix rootless gateway control socket

### DIFF
--- a/packages/core/opensession-server/src/server/gateway-supervisor.test.ts
+++ b/packages/core/opensession-server/src/server/gateway-supervisor.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   discoverRuntimePeerGenerations,
+  gatewayControlSocket,
   GatewaySupervisor,
   inheritedGatewaySocketFd,
   type ManagedGateway,
@@ -52,6 +53,21 @@ function controlledGateway(pid: number, releaseRoot: string, standby = false) {
 }
 
 describe("gateway supervisor", () => {
+  test("keeps user services inside their systemd runtime directory", () => {
+    expect(gatewayControlSocket({ XDG_RUNTIME_DIR: "/run/user/1001" })).toBe(
+      "/run/user/1001/opensession-gateway/control.sock",
+    );
+    expect(gatewayControlSocket({})).toBe(
+      "/run/opensession-gateway/control.sock",
+    );
+    expect(
+      gatewayControlSocket({
+        XDG_RUNTIME_DIR: "/run/user/1001",
+        OPENSESSION_GATEWAY_CONTROL_SOCKET: "/custom/control.sock",
+      }),
+    ).toBe("/custom/control.sock");
+  });
+
   test("accepts only systemd descriptors addressed to this supervisor", () => {
     expect(
       inheritedGatewaySocketFd({ LISTEN_PID: "42", LISTEN_FDS: "1" }, 42),

--- a/packages/core/opensession-server/src/server/gateway-supervisor.ts
+++ b/packages/core/opensession-server/src/server/gateway-supervisor.ts
@@ -19,9 +19,18 @@ import {
 import { createStableFrontendResponder } from "./stable-frontend";
 import { publishGatewayBackendPort } from "./gateway-routing";
 
-export const GATEWAY_CONTROL_SOCKET =
-  process.env.OPENSESSION_GATEWAY_CONTROL_SOCKET ||
-  "/run/opensession-gateway/control.sock";
+export function gatewayControlSocket(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return (
+    env.OPENSESSION_GATEWAY_CONTROL_SOCKET ||
+    (env.XDG_RUNTIME_DIR
+      ? join(env.XDG_RUNTIME_DIR, "opensession-gateway/control.sock")
+      : "/run/opensession-gateway/control.sock")
+  );
+}
+
+export const GATEWAY_CONTROL_SOCKET = gatewayControlSocket();
 
 const PUBLIC_HOST = process.env.HOST || "127.0.0.1";
 const PUBLIC_PORT = Number(process.env.PORT || 3850);


### PR DESCRIPTION
## Summary
- place the source gateway supervisor control socket under `XDG_RUNTIME_DIR` for rootless systemd user services
- keep the existing `/run/opensession-gateway` path for system services and preserve explicit overrides
- cover all three path-resolution cases

## Root cause
The rootless unit creates `RuntimeDirectory=opensession-gateway` under `/run/user/<uid>`, but the source gateway supervisor always listened on `/run/opensession-gateway/control.sock`. On a clean Ubuntu install that parent directory does not exist, so the supervisor crash-loops with `ENOENT` while ingress remains up with no backend.

This is deterministic on current `origin/main`, not a readiness flake. A fresh Ubuntu 24.04 systemd container reproduced the installer exit after both readiness windows. With this change, the same clean install exits 0, `/api/health` responds, all three user services are active, and the control socket is owned by the installing user under `/run/user/<uid>/opensession-gateway`.

## Verification
- `bun test scripts/lib/service.test.ts packages/core/opensession-server/src/server/gateway-supervisor.test.ts`
- `bun scripts/check-module-side-effects.ts`
- `bun run check`
- clean Ubuntu 24.04 `install.sh --yes --no-engine` before and after the fix

Started by Johnny Lin in [this OS session](https://os.tella.dev/session/bks-08123b0a-b295-7b5f-883f-4d015709b6f8)
