### PR TITLE
Require Tella-issued editor fixture leases

### DIFF
--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -649,9 +649,9 @@ Restart one supervised Portal using its registered command and port. Repository-
 
 ### `set_editor_preview_path`
 
-`mcp__opensession-portals__set_editor_preview_path` · input: `path` (string, required), `exclusiveKey` (string, required), `durationSeconds` (number, required), `clipCount` (integer, required), `transcriptWordCount` (integer, required), `leaseMinutes` (integer)
+`mcp__opensession-portals__set_editor_preview_path` · input: `path` (string, required), `videoId` (string, required), `fixtureLeaseId` (string, required), `fixtureExpiresAt` (string, required)
 
-Set and exclusively reserve the staging route for an editor feature. Call this only after verifying the staging record is at least 60 seconds long, has multiple clips, and has a ready non-empty transcript.
+Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.
 
 ### `set_portal_path`
 

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -308,6 +308,7 @@ export function interactiveMcpServers(
                 key: options.exclusiveKey,
                 sessionId,
                 path: path || "/",
+                sourceLeaseId: options.sourceLeaseId,
                 ttlMinutes: options.leaseMinutes,
               });
               if (!claim.ok)

--- a/packages/core/opensession-server/src/server/portals-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.test.ts
@@ -11,7 +11,11 @@ afterEach(async () => {
 async function harness() {
   const calls: Array<{
     path: string | null;
-    options?: { exclusiveKey?: string; leaseMinutes?: number };
+    options?: {
+      exclusiveKey?: string;
+      sourceLeaseId?: string;
+      leaseMinutes?: number;
+    };
   }> = [];
   const server = createPortalsMcpServer({
     sessionId: "session-a",
@@ -34,17 +38,18 @@ async function harness() {
 }
 
 describe("Portals MCP staging routes", () => {
-  test("normalizes and reserves a proven editor staging record", async () => {
+  test("normalizes and reserves a server-proven Tella fixture", async () => {
     const { calls, runtime } = await harness();
+    const fixtureExpiresAt = new Date(
+      Date.now() + 120.5 * 60_000,
+    ).toISOString();
     const response = await runtime.callExact(
       "opensession-portals_set_editor_preview_path",
       {
         path: " /video/vid_fixture/edit?status=Subtitles ",
-        exclusiveKey: "video:vid_fixture",
-        durationSeconds: 90,
-        clipCount: 3,
-        transcriptWordCount: 240,
-        leaseMinutes: 120,
+        videoId: "vid_fixture",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt,
       },
       { toolCallId: "reserve" },
     );
@@ -54,29 +59,29 @@ describe("Portals MCP staging routes", () => {
         path: "/video/vid_fixture/edit?status=Subtitles",
         options: {
           exclusiveKey: "video:vid_fixture",
+          sourceLeaseId: "epfl_fixturelease",
           leaseMinutes: 120,
         },
       },
     ]);
     expect(response.content[0]).toMatchObject({
       type: "text",
-      text: expect.stringContaining("90s, 3 clips, 240 transcript words"),
+      text: expect.stringContaining("epfl_fixturelease"),
     });
   });
 
-  test("rejects editor records without the required content", async () => {
+  test("rejects self-reported or invented fixture evidence", async () => {
     const { calls, runtime } = await harness();
     await expect(
       runtime.callExact(
         "opensession-portals_set_editor_preview_path",
         {
           path: "/video/vid_fixture/edit",
-          exclusiveKey: "video:vid_fixture",
-          durationSeconds: 20,
-          clipCount: 1,
-          transcriptWordCount: 0,
+          videoId: "vid_fixture",
+          fixtureLeaseId: "local-fixture",
+          fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
         },
-        { toolCallId: "too-small" },
+        { toolCallId: "invented" },
       ),
     ).rejects.toThrow();
     expect(calls).toEqual([]);
@@ -88,10 +93,9 @@ describe("Portals MCP staging routes", () => {
       "opensession-portals_set_editor_preview_path",
       {
         path: "/video/vid_route/edit",
-        exclusiveKey: "video:vid_other",
-        durationSeconds: 90,
-        clipCount: 2,
-        transcriptWordCount: 100,
+        videoId: "vid_other",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
       },
       { toolCallId: "mismatch" },
     );
@@ -103,11 +107,31 @@ describe("Portals MCP staging routes", () => {
     });
   });
 
+  test("rejects expired Tella fixture leases", async () => {
+    const { calls, runtime } = await harness();
+    const response = await runtime.callExact(
+      "opensession-portals_set_editor_preview_path",
+      {
+        path: "/video/vid_fixture/edit",
+        videoId: "vid_fixture",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+      { toolCallId: "expired" },
+    );
+
+    expect(calls).toEqual([]);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("between 10 minutes and 7 days"),
+    });
+  });
+
   test("rejects malformed routes before persistence", async () => {
     const { calls, runtime } = await harness();
     const response = await runtime.callExact(
       "opensession-portals_set_portal_path",
-      { path: "https://example.com/video", exclusiveKey: "video:fixture" },
+      { path: "https://example.com/video" },
       { toolCallId: "invalid" },
     );
 

--- a/packages/core/opensession-server/src/server/portals-mcp.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.ts
@@ -39,7 +39,11 @@ export interface PortalsMcpContext {
   worktreeDir: () => string | undefined;
   setDefaultPath: (
     path: string | null,
-    options?: { exclusiveKey?: string; leaseMinutes?: number },
+    options?: {
+      exclusiveKey?: string;
+      sourceLeaseId?: string;
+      leaseMinutes?: number;
+    },
   ) => Promise<{ leaseId?: string }>;
   /** An explicit computation action may wake the Sandbox. Passive listing may not. */
   sandbox: (options?: { wake?: boolean }) => Promise<Sandbox | null>;
@@ -383,34 +387,23 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
       ),
       tool(
         "set_editor_preview_path",
-        "Set and exclusively reserve the staging route for an editor feature. Call this only after verifying the staging record is at least 60 seconds long, has multiple clips, and has a ready non-empty transcript.",
+        "Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.",
         {
           path: z.string(),
-          exclusiveKey: z.string().regex(/^video:[A-Za-z0-9_-]+$/),
-          durationSeconds: z.number().min(60),
-          clipCount: z.number().int().min(2),
-          transcriptWordCount: z.number().int().min(1),
-          leaseMinutes: z
-            .number()
-            .int()
-            .min(10)
-            .max(30 * 24 * 60)
-            .optional(),
+          videoId: z.string().regex(/^vid_[A-Za-z0-9]+$/),
+          fixtureLeaseId: z.string().regex(/^epfl_[A-Za-z0-9]+$/),
+          fixtureExpiresAt: z.string().datetime(),
         },
         async ({
           path,
-          exclusiveKey,
-          durationSeconds,
-          clipCount,
-          transcriptWordCount,
-          leaseMinutes,
+          videoId,
+          fixtureLeaseId,
+          fixtureExpiresAt,
         }: {
           path: string;
-          exclusiveKey: string;
-          durationSeconds: number;
-          clipCount: number;
-          transcriptWordCount: number;
-          leaseMinutes?: number;
+          videoId: string;
+          fixtureLeaseId: string;
+          fixtureExpiresAt: string;
         }) => {
           const dir = workspace(ctx);
           if (dir instanceof Error) return result(dir.message);
@@ -418,21 +411,28 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
             const normalized = normalizePortalPath(path);
             if (!normalized)
               throw new Error("An editor staging route cannot be empty.");
-            const videoId = exclusiveKey.slice("video:".length);
             const pathname = new URL(normalized, "https://preview.invalid")
               .pathname;
             if (!pathname.split("/").includes(videoId))
               throw new Error(
-                "The exclusive video key must match the video ID in the route.",
+                "The leased video ID must match the video ID in the route.",
+              );
+            const remainingMinutes = Math.floor(
+              (Date.parse(fixtureExpiresAt) - Date.now()) / 60_000,
+            );
+            if (remainingMinutes < 10 || remainingMinutes > 7 * 24 * 60)
+              throw new Error(
+                "The editor fixture lease must have between 10 minutes and 7 days remaining.",
               );
             const reservation = await ctx.setDefaultPath(normalized, {
-              exclusiveKey,
-              leaseMinutes,
+              exclusiveKey: `video:${videoId}`,
+              sourceLeaseId: fixtureLeaseId,
+              leaseMinutes: remainingMinutes,
             });
             if (!reservation.leaseId)
               throw new Error("The staging record could not be reserved.");
             return result(
-              `Reserved ${normalized} for this session (${Math.round(durationSeconds)}s, ${clipCount} clips, ${transcriptWordCount} transcript words).`,
+              `Reserved Tella fixture ${fixtureLeaseId} at ${normalized} for this session.`,
             );
           } catch (error) {
             return result(

--- a/packages/core/opensession-server/src/server/preview-path-leases.test.ts
+++ b/packages/core/opensession-server/src/server/preview-path-leases.test.ts
@@ -28,6 +28,7 @@ describe("preview path leases", () => {
         key: "video:vid_fixture",
         sessionId: "session-a",
         path: "/video/vid_fixture/edit",
+        sourceLeaseId: "epfl_fixture",
       },
       { file, now: 1_000 },
     );
@@ -40,7 +41,7 @@ describe("preview path leases", () => {
       { file, now: 2_000 },
     );
 
-    expect(first.ok).toBe(true);
+    expect(first.ok && first.lease.sourceLeaseId).toBe("epfl_fixture");
     expect(conflict).toEqual({ ok: false, reason: "in_use" });
   });
 

--- a/packages/core/opensession-server/src/server/preview-path-leases.ts
+++ b/packages/core/opensession-server/src/server/preview-path-leases.ts
@@ -11,6 +11,7 @@ interface PreviewPathLease {
   key: string;
   sessionId: string;
   path: string;
+  sourceLeaseId?: string;
   acquiredAt: string;
   expiresAt: string;
 }
@@ -45,6 +46,7 @@ function parseLease(value: unknown): PreviewPathLease {
     typeof value.sessionId !== "string" ||
     !("path" in value) ||
     typeof value.path !== "string" ||
+    ("sourceLeaseId" in value && typeof value.sourceLeaseId !== "string") ||
     !("acquiredAt" in value) ||
     typeof value.acquiredAt !== "string" ||
     !("expiresAt" in value) ||
@@ -56,6 +58,10 @@ function parseLease(value: unknown): PreviewPathLease {
     key: value.key,
     sessionId: value.sessionId,
     path: value.path,
+    sourceLeaseId:
+      "sourceLeaseId" in value && typeof value.sourceLeaseId === "string"
+        ? value.sourceLeaseId
+        : undefined,
     acquiredAt: value.acquiredAt,
     expiresAt: value.expiresAt,
   };
@@ -106,6 +112,7 @@ export function claimPreviewPathLease(
     key: string;
     sessionId: string;
     path: string;
+    sourceLeaseId?: string;
     ttlMinutes?: number;
   },
   options: LeaseStoreOptions = {},
@@ -133,6 +140,7 @@ export function claimPreviewPathLease(
     key,
     sessionId: input.sessionId,
     path: input.path,
+    sourceLeaseId: input.sourceLeaseId,
     acquiredAt: existing?.acquiredAt ?? new Date(now).toISOString(),
     expiresAt: new Date(now + ttlMs(input.ttlMinutes)).toISOString(),
   };

--- a/packages/core/opensession-server/src/server/run-instructions.test.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.test.ts
@@ -24,13 +24,11 @@ describe("buildRunInstructions", () => {
     expect(prompt).toContain(
       "For PRs outside the current primary repository, write `<repo>#<number>`, never bare `#<number>`.",
     );
+    expect(prompt).toContain("`tella-stage` `lease_editor_fixture`");
+    expect(prompt).toContain("this Open Session id as `leaseKey`");
     expect(prompt).toContain(
-      "For editors, call `opensession-portals` `set_editor_preview_path`",
+      "Never construct a video id or report fixture evidence yourself",
     );
-    expect(prompt).toContain(
-      "at least 60 seconds, 2+ clips, and a ready non-empty transcript",
-    );
-    expect(prompt).toContain("to prevent reuse by another active session");
     expect(prompt.length).toBeLessThan(1_200);
   });
 });

--- a/packages/core/opensession-server/src/server/run-instructions.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.ts
@@ -169,13 +169,13 @@ export function buildRunInstructions(input: {
   }
   if (!input.isAsk && inproc["opensession-portals"]) {
     parts.push(
-      "## Preview links\nBefore finishing a user-facing web change, set its exact " +
-        "root-relative route, query included. For editors, call `opensession-portals` " +
-        "`set_editor_preview_path` with a dedicated or fresh staging record: at least 60 " +
-        "seconds, 2+ clips, and a ready non-empty transcript. Pass a stable `exclusiveKey` " +
-        "such as `video:<id>` to prevent reuse by another active session. Never use a local " +
-        "fixture. For other web changes, call `set_portal_path` without a name. Open the " +
-        "resulting staging URL and verify it shows the changed feature.",
+      "## Preview links\nFor user-facing web changes, set the exact root-relative route, " +
+        "query included. For editors, call `tella-stage` `lease_editor_fixture` with " +
+        "fixture `multi_clip_transcript_v1` and this Open Session id as `leaseKey`. Pass its " +
+        "`editorPath`, `videoId`, `leaseId`, and `expiresAt` to `opensession-portals` " +
+        "`set_editor_preview_path`. Never construct a video id or report fixture evidence " +
+        "yourself. Otherwise call `set_portal_path` without a name. Open the staging URL and " +
+        "verify the changed feature.",
     );
   }
 


### PR DESCRIPTION
## Summary
- replace self-reported editor fixture evidence with Tella-issued lease fields
- bind the leased video ID to the preview route and local exclusive reservation
- reject invented, expired, mismatched, and local fixture values
- instruct editor sessions to lease through the configured `tella-stage` MCP server

Depends on tella-fusion#6104.

## Verification
- `bun run check`
- 18 focused Portal, lease, instruction, and catalog tests

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a057a7-74e5-7b22-86d1-fcc0e4448bc8)
