### PR TITLE
Require verified Tella editor fixture leases

### DIFF
--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -649,9 +649,9 @@ Restart one supervised Portal using its registered command and port. Repository-
 
 ### `set_editor_preview_path`
 
-`mcp__opensession-portals__set_editor_preview_path` · input: `path` (string, required), `exclusiveKey` (string, required), `durationSeconds` (number, required), `clipCount` (integer, required), `transcriptWordCount` (integer, required), `leaseMinutes` (integer)
+`mcp__opensession-portals__set_editor_preview_path` · input: `path` (string, required), `videoId` (string, required), `fixtureLeaseId` (string, required), `fixtureExpiresAt` (string, required)
 
-Set and exclusively reserve the staging route for an editor feature. Call this only after verifying the staging record is at least 60 seconds long, has multiple clips, and has a ready non-empty transcript.
+Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.
 
 ### `set_portal_path`
 

--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -649,9 +649,9 @@ Restart one supervised Portal using its registered command and port. Repository-
 
 ### `set_editor_preview_path`
 
-`mcp__opensession-portals__set_editor_preview_path` · input: `path` (string, required), `videoId` (string, required), `fixtureLeaseId` (string, required), `fixtureExpiresAt` (string, required)
+`mcp__opensession-portals__set_editor_preview_path` · input: `fixtureLeaseId` (string, required)
 
-Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.
+Verify a Tella editor fixture lease server-side, then set and exclusively reserve its authoritative editor route. Invented, expired, mismatched, or inaccessible fixtures are rejected.
 
 ### `set_portal_path`
 

--- a/packages/core/opensession-server/src/server/interactive-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.test.ts
@@ -7,7 +7,10 @@ import {
   registerRunToken,
   unregisterRunToken,
 } from "./run-rpc";
-import { runSessionPreviewAction } from "./interactive-mcp";
+import {
+  editorFixtureGrantUser,
+  runSessionPreviewAction,
+} from "./interactive-mcp";
 
 function session(
   id: string,
@@ -177,5 +180,15 @@ describe("interactive opensession-preview MCP lifecycle", () => {
       runSessionPreviewAction("os-preview", "start", injected),
     ).rejects.toThrow("daytona sandbox is not available");
     expect(calls).toEqual([]);
+  });
+});
+
+describe("editor fixture grant identity", () => {
+  test("uses the persisted creator before the legacy starter", () => {
+    expect(
+      editorFixtureGrantUser({ createdBy: "Kent", startedBy: "Michael" }),
+    ).toBe("Kent");
+    expect(editorFixtureGrantUser({ startedBy: "Michael" })).toBe("Michael");
+    expect(editorFixtureGrantUser(undefined)).toBeUndefined();
   });
 });

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -308,6 +308,7 @@ export function interactiveMcpServers(
                 key: options.exclusiveKey,
                 sessionId,
                 path: path || "/",
+                sourceLeaseId: options.sourceLeaseId,
                 ttlMinutes: options.leaseMinutes,
               });
               if (!claim.ok)

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -37,6 +37,7 @@ import { createAssetsMcpServer } from "../agents/slack/assets-tools";
 import { createWorkflowsMcpServer } from "../agents/slack/workflow-tools";
 import { createSelfDeployMcpServer } from "./self-deploy";
 import { createWebMcpServer } from "./web-mcp";
+import { callMcpTool } from "./mcp-client";
 import { papercutsEnabledForRepo } from "./papercuts";
 import { defaultRepo, productName } from "./config";
 import { githubCredentialForRun } from "./github-auth";
@@ -146,6 +147,17 @@ function papercutsServerFor(
       },
     }),
   };
+}
+
+export function editorFixtureGrantUser(
+  session:
+    | {
+        createdBy?: string | null;
+        startedBy?: string | null;
+      }
+    | undefined,
+): string | undefined {
+  return session?.createdBy || session?.startedBy || undefined;
 }
 
 export function interactiveMcpServers(
@@ -287,6 +299,21 @@ export function interactiveMcpServers(
             hasSandbox: () =>
               Boolean(findSession(sessionId)?.sandbox?.sandboxId),
             runner: () => findSession(sessionId),
+            verifyEditorFixture: (leaseId) => {
+              const session = findSession(sessionId);
+              const grantUser = editorFixtureGrantUser(session);
+              if (!grantUser)
+                throw new Error(
+                  "This session has no creator identity for Tella verification.",
+                );
+              return callMcpTool(
+                "tella-stage",
+                "verify_editor_fixture",
+                { leaseKey: sessionId, leaseId },
+                grantUser,
+                { requireUserGrant: true },
+              );
+            },
             setDefaultPath: async (path, options) => {
               const session = findSession(sessionId);
               if (!session) throw new Error("Session not found.");

--- a/packages/core/opensession-server/src/server/mcp-catalog.ts
+++ b/packages/core/opensession-server/src/server/mcp-catalog.ts
@@ -305,6 +305,9 @@ export const MCP_SERVER_CATALOG: McpServerCatalogEntry[] = [
       createPortalsMcpServer({
         sessionId: SESSION_ID,
         worktreeDir: () => undefined,
+        verifyEditorFixture: async () => {
+          throw new Error("catalog-only fixture verifier");
+        },
         setDefaultPath: async () => ({}),
         sandbox: async () => null,
         hasSandbox: () => false,

--- a/packages/core/opensession-server/src/server/mcp-client.test.ts
+++ b/packages/core/opensession-server/src/server/mcp-client.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { selectMcpAuthorization } from "./mcp-client";
+
+describe("server-side MCP authorization", () => {
+  test("requires the named user's personal grant without fallback", () => {
+    expect(
+      selectMcpAuthorization({
+        personal: "Bearer personal",
+        standard: "Bearer shared",
+        staticAuthorization: "Bearer static",
+        requireUserGrant: true,
+      }),
+    ).toBe("Bearer personal");
+
+    expect(() =>
+      selectMcpAuthorization({
+        standard: "Bearer shared",
+        staticAuthorization: "Bearer static",
+        requireUserGrant: true,
+      }),
+    ).toThrow("personal OAuth grant is required");
+  });
+
+  test("keeps normal server-side calls on the standard fallback chain", () => {
+    expect(
+      selectMcpAuthorization({
+        standard: "Bearer shared",
+        staticAuthorization: "Bearer static",
+        requireUserGrant: false,
+      }),
+    ).toBe("Bearer shared");
+  });
+});

--- a/packages/core/opensession-server/src/server/mcp-client.ts
+++ b/packages/core/opensession-server/src/server/mcp-client.ts
@@ -14,9 +14,27 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { readMcpConfig } from "./connections";
-import { mcpAuthHeader } from "./mcp-oauth";
+import { mcpAuthHeader, mcpUserGrantHeader } from "./mcp-oauth";
 
 export class McpToolError extends Error {}
+
+export interface McpToolCallOptions {
+  /** Require this user's own OAuth grant. Never fall back to shared or static credentials. */
+  requireUserGrant?: boolean;
+}
+
+export function selectMcpAuthorization(input: {
+  personal?: string;
+  standard?: string;
+  staticAuthorization?: string;
+  requireUserGrant: boolean;
+}): string | undefined {
+  if (!input.requireUserGrant)
+    return input.standard ?? input.staticAuthorization;
+  if (!input.personal)
+    throw new McpToolError("A personal OAuth grant is required");
+  return input.personal;
+}
 
 /** List a server's tool catalog (name + description) — powers the New
  *  project flow's tool picker. */
@@ -61,13 +79,22 @@ export async function callMcpTool<T = unknown>(
   tool: string,
   args: Record<string, unknown>,
   user?: string,
+  options: McpToolCallOptions = {},
 ): Promise<T> {
   const cfg = readMcpConfig().mcpServers[serverName] as
     | { url?: string; headers?: Record<string, string> }
     | undefined;
   if (!cfg?.url) throw new McpToolError(`No HTTP MCP server "${serverName}"`);
-  const oauth = mcpAuthHeader(serverName, user);
-  const auth = oauth || cfg.headers?.Authorization;
+  const auth = selectMcpAuthorization({
+    personal: options.requireUserGrant
+      ? mcpUserGrantHeader(serverName, user)
+      : undefined,
+    standard: options.requireUserGrant
+      ? undefined
+      : mcpAuthHeader(serverName, user),
+    staticAuthorization: cfg.headers?.Authorization,
+    requireUserGrant: options.requireUserGrant === true,
+  });
   const transport = new StreamableHTTPClientTransport(new URL(cfg.url), {
     requestInit: {
       headers: {

--- a/packages/core/opensession-server/src/server/portals-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createMcpRuntime, type McpRuntime } from "./mcp-runtime";
-import { createPortalsMcpServer } from "./portals-mcp";
+import { createPortalsMcpServer, type PortalsMcpContext } from "./portals-mcp";
 
 const open: McpRuntime[] = [];
 
@@ -8,7 +8,25 @@ afterEach(async () => {
   for (const runtime of open.splice(0)) await runtime.close();
 });
 
-async function harness() {
+type VerifiedFixture = Awaited<
+  ReturnType<PortalsMcpContext["verifyEditorFixture"]>
+>;
+
+function fixture(overrides: Partial<VerifiedFixture> = {}): VerifiedFixture {
+  return {
+    leaseId: "epfl_fixturelease",
+    videoId: "vid_fixture",
+    editorPath: "/video/vid_fixture/edit?status=Subtitles",
+    expiresAt: new Date(Date.now() + 120.5 * 60_000).toISOString(),
+    editorAccessVerified: true,
+    ...overrides,
+  };
+}
+
+async function harness(
+  verifyEditorFixture: PortalsMcpContext["verifyEditorFixture"] = async () =>
+    fixture(),
+) {
   const calls: Array<{
     path: string | null;
     options?: {
@@ -17,9 +35,14 @@ async function harness() {
       leaseMinutes?: number;
     };
   }> = [];
+  const verificationCalls: string[] = [];
   const server = createPortalsMcpServer({
     sessionId: "session-a",
     worktreeDir: () => "/tmp",
+    verifyEditorFixture: async (leaseId) => {
+      verificationCalls.push(leaseId);
+      return verifyEditorFixture(leaseId);
+    },
     setDefaultPath: async (path, options) => {
       calls.push({ path, options });
       return options?.exclusiveKey ? { leaseId: "lease-a" } : {};
@@ -34,26 +57,19 @@ async function harness() {
     inProcessMcp: { "opensession-portals": server },
   });
   open.push(runtime);
-  return { calls, runtime };
+  return { calls, runtime, verificationCalls };
 }
 
 describe("Portals MCP staging routes", () => {
-  test("normalizes and reserves a server-proven Tella fixture", async () => {
-    const { calls, runtime } = await harness();
-    const fixtureExpiresAt = new Date(
-      Date.now() + 120.5 * 60_000,
-    ).toISOString();
+  test("uses Tella's authoritative fixture fields", async () => {
+    const { calls, runtime, verificationCalls } = await harness();
     const response = await runtime.callExact(
       "opensession-portals_set_editor_preview_path",
-      {
-        path: " /video/vid_fixture/edit?status=Subtitles ",
-        videoId: "vid_fixture",
-        fixtureLeaseId: "epfl_fixturelease",
-        fixtureExpiresAt,
-      },
+      { fixtureLeaseId: "epfl_fixturelease" },
       { toolCallId: "reserve" },
     );
 
+    expect(verificationCalls).toEqual(["epfl_fixturelease"]);
     expect(calls).toEqual([
       {
         path: "/video/vid_fixture/edit?status=Subtitles",
@@ -66,57 +82,68 @@ describe("Portals MCP staging routes", () => {
     ]);
     expect(response.content[0]).toMatchObject({
       type: "text",
-      text: expect.stringContaining("epfl_fixturelease"),
+      text: expect.stringContaining("Verified and reserved"),
     });
   });
 
-  test("rejects self-reported or invented fixture evidence", async () => {
-    const { calls, runtime } = await harness();
-    await expect(
-      runtime.callExact(
-        "opensession-portals_set_editor_preview_path",
-        {
-          path: "/video/vid_fixture/edit",
-          videoId: "vid_fixture",
-          fixtureLeaseId: "local-fixture",
-          fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
-        },
-        { toolCallId: "invented" },
-      ),
-    ).rejects.toThrow();
-    expect(calls).toEqual([]);
-  });
-
-  test("rejects a reservation key for another video", async () => {
-    const { calls, runtime } = await harness();
+  test("rejects an invented lease that Tella does not recognize", async () => {
+    const { calls, runtime } = await harness(async () => {
+      throw new Error("The editor preview fixture lease is not active");
+    });
     const response = await runtime.callExact(
       "opensession-portals_set_editor_preview_path",
-      {
-        path: "/video/vid_route/edit",
-        videoId: "vid_other",
-        fixtureLeaseId: "epfl_fixturelease",
-        fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
-      },
-      { toolCallId: "mismatch" },
+      { fixtureLeaseId: "epfl_invented" },
+      { toolCallId: "invented" },
     );
 
     expect(calls).toEqual([]);
     expect(response.content[0]).toMatchObject({
       type: "text",
-      text: expect.stringContaining("must match the video ID"),
+      text: expect.stringContaining("not active"),
     });
   });
 
-  test("rejects expired Tella fixture leases", async () => {
-    const { calls, runtime } = await harness();
+  test("rejects a different lease returned by Tella", async () => {
+    const { calls, runtime } = await harness(async () =>
+      fixture({ leaseId: "epfl_otherlease" }),
+    );
     const response = await runtime.callExact(
       "opensession-portals_set_editor_preview_path",
-      {
-        path: "/video/vid_fixture/edit",
-        videoId: "vid_fixture",
-        fixtureLeaseId: "epfl_fixturelease",
-        fixtureExpiresAt: new Date(Date.now() - 60_000).toISOString(),
-      },
+      { fixtureLeaseId: "epfl_fixturelease" },
+      { toolCallId: "lease-mismatch" },
+    );
+
+    expect(calls).toEqual([]);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("different fixture lease"),
+    });
+  });
+
+  test("rejects a Tella route for another video", async () => {
+    const { calls, runtime } = await harness(async () =>
+      fixture({ editorPath: "/video/vid_other/edit" }),
+    );
+    const response = await runtime.callExact(
+      "opensession-portals_set_editor_preview_path",
+      { fixtureLeaseId: "epfl_fixturelease" },
+      { toolCallId: "video-mismatch" },
+    );
+
+    expect(calls).toEqual([]);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("does not match"),
+    });
+  });
+
+  test("rejects an expired Tella lease", async () => {
+    const { calls, runtime } = await harness(async () =>
+      fixture({ expiresAt: new Date(Date.now() - 60_000).toISOString() }),
+    );
+    const response = await runtime.callExact(
+      "opensession-portals_set_editor_preview_path",
+      { fixtureLeaseId: "epfl_fixturelease" },
       { toolCallId: "expired" },
     );
 
@@ -127,7 +154,7 @@ describe("Portals MCP staging routes", () => {
     });
   });
 
-  test("rejects malformed routes before persistence", async () => {
+  test("rejects malformed ordinary routes before persistence", async () => {
     const { calls, runtime } = await harness();
     const response = await runtime.callExact(
       "opensession-portals_set_portal_path",
@@ -143,13 +170,14 @@ describe("Portals MCP staging routes", () => {
   });
 
   test("keeps ordinary web routes outside the exclusive editor flow", async () => {
-    const { calls, runtime } = await harness();
+    const { calls, runtime, verificationCalls } = await harness();
     const response = await runtime.callExact(
       "opensession-portals_set_portal_path",
       { path: "/settings/tags" },
       { toolCallId: "ordinary" },
     );
 
+    expect(verificationCalls).toEqual([]);
     expect(calls).toEqual([{ path: "/settings/tags", options: undefined }]);
     expect(response.content[0]).toMatchObject({
       type: "text",

--- a/packages/core/opensession-server/src/server/portals-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.test.ts
@@ -11,7 +11,11 @@ afterEach(async () => {
 async function harness() {
   const calls: Array<{
     path: string | null;
-    options?: { exclusiveKey?: string; leaseMinutes?: number };
+    options?: {
+      exclusiveKey?: string;
+      sourceLeaseId?: string;
+      leaseMinutes?: number;
+    };
   }> = [];
   const server = createPortalsMcpServer({
     sessionId: "session-a",
@@ -34,17 +38,18 @@ async function harness() {
 }
 
 describe("Portals MCP staging routes", () => {
-  test("normalizes and reserves a proven editor staging record", async () => {
+  test("normalizes and reserves a server-proven Tella fixture", async () => {
     const { calls, runtime } = await harness();
+    const fixtureExpiresAt = new Date(
+      Date.now() + 120.5 * 60_000,
+    ).toISOString();
     const response = await runtime.callExact(
       "opensession-portals_set_editor_preview_path",
       {
         path: " /video/vid_fixture/edit?status=Subtitles ",
-        exclusiveKey: "video:vid_fixture",
-        durationSeconds: 90,
-        clipCount: 3,
-        transcriptWordCount: 240,
-        leaseMinutes: 120,
+        videoId: "vid_fixture",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt,
       },
       { toolCallId: "reserve" },
     );
@@ -54,29 +59,29 @@ describe("Portals MCP staging routes", () => {
         path: "/video/vid_fixture/edit?status=Subtitles",
         options: {
           exclusiveKey: "video:vid_fixture",
+          sourceLeaseId: "epfl_fixturelease",
           leaseMinutes: 120,
         },
       },
     ]);
     expect(response.content[0]).toMatchObject({
       type: "text",
-      text: expect.stringContaining("90s, 3 clips, 240 transcript words"),
+      text: expect.stringContaining("epfl_fixturelease"),
     });
   });
 
-  test("rejects editor records without the required content", async () => {
+  test("rejects self-reported or invented fixture evidence", async () => {
     const { calls, runtime } = await harness();
     await expect(
       runtime.callExact(
         "opensession-portals_set_editor_preview_path",
         {
           path: "/video/vid_fixture/edit",
-          exclusiveKey: "video:vid_fixture",
-          durationSeconds: 20,
-          clipCount: 1,
-          transcriptWordCount: 0,
+          videoId: "vid_fixture",
+          fixtureLeaseId: "local-fixture",
+          fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
         },
-        { toolCallId: "too-small" },
+        { toolCallId: "invented" },
       ),
     ).rejects.toThrow();
     expect(calls).toEqual([]);
@@ -88,10 +93,9 @@ describe("Portals MCP staging routes", () => {
       "opensession-portals_set_editor_preview_path",
       {
         path: "/video/vid_route/edit",
-        exclusiveKey: "video:vid_other",
-        durationSeconds: 90,
-        clipCount: 2,
-        transcriptWordCount: 100,
+        videoId: "vid_other",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
       },
       { toolCallId: "mismatch" },
     );
@@ -103,11 +107,31 @@ describe("Portals MCP staging routes", () => {
     });
   });
 
+  test("rejects expired Tella fixture leases", async () => {
+    const { calls, runtime } = await harness();
+    const response = await runtime.callExact(
+      "opensession-portals_set_editor_preview_path",
+      {
+        path: "/video/vid_fixture/edit",
+        videoId: "vid_fixture",
+        fixtureLeaseId: "epfl_fixturelease",
+        fixtureExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+      { toolCallId: "expired" },
+    );
+
+    expect(calls).toEqual([]);
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("between 10 minutes and 7 days"),
+    });
+  });
+
   test("rejects malformed routes before persistence", async () => {
     const { calls, runtime } = await harness();
     const response = await runtime.callExact(
       "opensession-portals_set_portal_path",
-      { path: "https://example.com/video", exclusiveKey: "video:fixture" },
+      { path: "https://example.com/video" },
       { toolCallId: "invalid" },
     );
 

--- a/packages/core/opensession-server/src/server/portals-mcp.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.ts
@@ -39,7 +39,11 @@ export interface PortalsMcpContext {
   worktreeDir: () => string | undefined;
   setDefaultPath: (
     path: string | null,
-    options?: { exclusiveKey?: string; leaseMinutes?: number },
+    options?: {
+      exclusiveKey?: string;
+      sourceLeaseId?: string;
+      leaseMinutes?: number;
+    },
   ) => Promise<{ leaseId?: string }>;
   /** An explicit computation action may wake the Sandbox. Passive listing may not. */
   sandbox: (options?: { wake?: boolean }) => Promise<Sandbox | null>;
@@ -383,34 +387,23 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
       ),
       tool(
         "set_editor_preview_path",
-        "Set and exclusively reserve the staging route for an editor feature. Call this only after verifying the staging record is at least 60 seconds long, has multiple clips, and has a ready non-empty transcript.",
+        "Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.",
         {
           path: z.string(),
-          exclusiveKey: z.string().regex(/^video:[A-Za-z0-9_-]+$/),
-          durationSeconds: z.number().min(60),
-          clipCount: z.number().int().min(2),
-          transcriptWordCount: z.number().int().min(1),
-          leaseMinutes: z
-            .number()
-            .int()
-            .min(10)
-            .max(30 * 24 * 60)
-            .optional(),
+          videoId: z.string().regex(/^vid_[A-Za-z0-9]+$/),
+          fixtureLeaseId: z.string().regex(/^epfl_[A-Za-z0-9]+$/),
+          fixtureExpiresAt: z.string().datetime(),
         },
         async ({
           path,
-          exclusiveKey,
-          durationSeconds,
-          clipCount,
-          transcriptWordCount,
-          leaseMinutes,
+          videoId,
+          fixtureLeaseId,
+          fixtureExpiresAt,
         }: {
           path: string;
-          exclusiveKey: string;
-          durationSeconds: number;
-          clipCount: number;
-          transcriptWordCount: number;
-          leaseMinutes?: number;
+          videoId: string;
+          fixtureLeaseId: string;
+          fixtureExpiresAt: string;
         }) => {
           const dir = workspace(ctx);
           if (dir instanceof Error) return result(dir.message);
@@ -418,21 +411,28 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
             const normalized = normalizePortalPath(path);
             if (!normalized)
               throw new Error("An editor staging route cannot be empty.");
-            const videoId = exclusiveKey.slice("video:".length);
             const pathname = new URL(normalized, "https://preview.invalid")
               .pathname;
             if (!pathname.split("/").includes(videoId))
               throw new Error(
-                "The exclusive video key must match the video ID in the route.",
+                "The leased video ID must match the video ID in the route.",
+              );
+            const remainingMinutes = Math.floor(
+              (Date.parse(fixtureExpiresAt) - Date.now()) / 60_000,
+            );
+            if (remainingMinutes < 10 || remainingMinutes > 7 * 24 * 60)
+              throw new Error(
+                "The editor fixture lease must have between 10 minutes and 7 days remaining.",
               );
             const reservation = await ctx.setDefaultPath(normalized, {
-              exclusiveKey,
-              leaseMinutes,
+              exclusiveKey: `video:${videoId}`,
+              sourceLeaseId: fixtureLeaseId,
+              leaseMinutes: remainingMinutes,
             });
             if (!reservation.leaseId)
               throw new Error("The staging record could not be reserved.");
             return result(
-              `Reserved ${normalized} for this session (${Math.round(durationSeconds)}s, ${clipCount} clips, ${transcriptWordCount} transcript words).`,
+              `Reserved Tella fixture ${fixtureLeaseId} at ${normalized} for this session.`,
             );
           } catch (error) {
             return result(

--- a/packages/core/opensession-server/src/server/portals-mcp.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.ts
@@ -34,9 +34,20 @@ import type { Sandbox } from "./sandbox/provider";
 import { createWorkloadIdentityEnv } from "./workload-identity";
 import { getRepo } from "./worktree";
 
+const verifiedEditorFixtureSchema = z.object({
+  leaseId: z.string().regex(/^epfl_[A-Za-z0-9]+$/),
+  videoId: z.string().regex(/^vid_[A-Za-z0-9]+$/),
+  editorPath: z.string(),
+  expiresAt: z.string().datetime(),
+  editorAccessVerified: z.literal(true),
+});
+
+type VerifiedEditorFixture = z.infer<typeof verifiedEditorFixtureSchema>;
+
 export interface PortalsMcpContext {
   sessionId: string;
   worktreeDir: () => string | undefined;
+  verifyEditorFixture: (leaseId: string) => Promise<VerifiedEditorFixture>;
   setDefaultPath: (
     path: string | null,
     options?: {
@@ -387,52 +398,44 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
       ),
       tool(
         "set_editor_preview_path",
-        "Set and exclusively reserve the route returned by Tella's stage-only lease_editor_fixture tool. Self-reported fixture evidence and local video IDs are not accepted.",
+        "Verify a Tella editor fixture lease server-side, then set and exclusively reserve its authoritative editor route. Invented, expired, mismatched, or inaccessible fixtures are rejected.",
         {
-          path: z.string(),
-          videoId: z.string().regex(/^vid_[A-Za-z0-9]+$/),
           fixtureLeaseId: z.string().regex(/^epfl_[A-Za-z0-9]+$/),
-          fixtureExpiresAt: z.string().datetime(),
         },
-        async ({
-          path,
-          videoId,
-          fixtureLeaseId,
-          fixtureExpiresAt,
-        }: {
-          path: string;
-          videoId: string;
-          fixtureLeaseId: string;
-          fixtureExpiresAt: string;
-        }) => {
+        async ({ fixtureLeaseId }: { fixtureLeaseId: string }) => {
           const dir = workspace(ctx);
           if (dir instanceof Error) return result(dir.message);
           try {
-            const normalized = normalizePortalPath(path);
+            const fixture = verifiedEditorFixtureSchema.parse(
+              await ctx.verifyEditorFixture(fixtureLeaseId),
+            );
+            if (fixture.leaseId !== fixtureLeaseId)
+              throw new Error("Tella returned a different fixture lease.");
+            const normalized = normalizePortalPath(fixture.editorPath);
             if (!normalized)
-              throw new Error("An editor staging route cannot be empty.");
+              throw new Error("Tella returned an empty editor staging route.");
             const pathname = new URL(normalized, "https://preview.invalid")
               .pathname;
-            if (!pathname.split("/").includes(videoId))
+            if (!pathname.split("/").includes(fixture.videoId))
               throw new Error(
-                "The leased video ID must match the video ID in the route.",
+                "Tella's leased video ID does not match its editor route.",
               );
             const remainingMinutes = Math.floor(
-              (Date.parse(fixtureExpiresAt) - Date.now()) / 60_000,
+              (Date.parse(fixture.expiresAt) - Date.now()) / 60_000,
             );
             if (remainingMinutes < 10 || remainingMinutes > 7 * 24 * 60)
               throw new Error(
-                "The editor fixture lease must have between 10 minutes and 7 days remaining.",
+                "Tella's editor fixture lease must have between 10 minutes and 7 days remaining.",
               );
             const reservation = await ctx.setDefaultPath(normalized, {
-              exclusiveKey: `video:${videoId}`,
-              sourceLeaseId: fixtureLeaseId,
+              exclusiveKey: `video:${fixture.videoId}`,
+              sourceLeaseId: fixture.leaseId,
               leaseMinutes: remainingMinutes,
             });
             if (!reservation.leaseId)
               throw new Error("The staging record could not be reserved.");
             return result(
-              `Reserved Tella fixture ${fixtureLeaseId} at ${normalized} for this session.`,
+              `Verified and reserved Tella fixture ${fixture.leaseId} at ${normalized} for this session.`,
             );
           } catch (error) {
             return result(

--- a/packages/core/opensession-server/src/server/preview-path-leases.test.ts
+++ b/packages/core/opensession-server/src/server/preview-path-leases.test.ts
@@ -28,6 +28,7 @@ describe("preview path leases", () => {
         key: "video:vid_fixture",
         sessionId: "session-a",
         path: "/video/vid_fixture/edit",
+        sourceLeaseId: "epfl_fixture",
       },
       { file, now: 1_000 },
     );
@@ -40,7 +41,7 @@ describe("preview path leases", () => {
       { file, now: 2_000 },
     );
 
-    expect(first.ok).toBe(true);
+    expect(first.ok && first.lease.sourceLeaseId).toBe("epfl_fixture");
     expect(conflict).toEqual({ ok: false, reason: "in_use" });
   });
 

--- a/packages/core/opensession-server/src/server/preview-path-leases.ts
+++ b/packages/core/opensession-server/src/server/preview-path-leases.ts
@@ -11,6 +11,7 @@ interface PreviewPathLease {
   key: string;
   sessionId: string;
   path: string;
+  sourceLeaseId?: string;
   acquiredAt: string;
   expiresAt: string;
 }
@@ -45,6 +46,7 @@ function parseLease(value: unknown): PreviewPathLease {
     typeof value.sessionId !== "string" ||
     !("path" in value) ||
     typeof value.path !== "string" ||
+    ("sourceLeaseId" in value && typeof value.sourceLeaseId !== "string") ||
     !("acquiredAt" in value) ||
     typeof value.acquiredAt !== "string" ||
     !("expiresAt" in value) ||
@@ -56,6 +58,10 @@ function parseLease(value: unknown): PreviewPathLease {
     key: value.key,
     sessionId: value.sessionId,
     path: value.path,
+    sourceLeaseId:
+      "sourceLeaseId" in value && typeof value.sourceLeaseId === "string"
+        ? value.sourceLeaseId
+        : undefined,
     acquiredAt: value.acquiredAt,
     expiresAt: value.expiresAt,
   };
@@ -106,6 +112,7 @@ export function claimPreviewPathLease(
     key: string;
     sessionId: string;
     path: string;
+    sourceLeaseId?: string;
     ttlMinutes?: number;
   },
   options: LeaseStoreOptions = {},
@@ -133,6 +140,7 @@ export function claimPreviewPathLease(
     key,
     sessionId: input.sessionId,
     path: input.path,
+    sourceLeaseId: input.sourceLeaseId,
     acquiredAt: existing?.acquiredAt ?? new Date(now).toISOString(),
     expiresAt: new Date(now + ttlMs(input.ttlMinutes)).toISOString(),
   };

--- a/packages/core/opensession-server/src/server/run-instructions.test.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.test.ts
@@ -50,9 +50,8 @@ describe("buildRunInstructions", () => {
     );
     expect(prompt).toContain("`tella-stage` `lease_editor_fixture`");
     expect(prompt).toContain("this Open Session id as `leaseKey`");
-    expect(prompt).toContain(
-      "Never construct a video id or report fixture evidence yourself",
-    );
+    expect(prompt).toContain("Pass only its `leaseId`");
+    expect(prompt).toContain("verifies the lease directly with Tella");
     expect(prompt.length).toBeLessThan(1_200);
   });
 });

--- a/packages/core/opensession-server/src/server/run-instructions.test.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.test.ts
@@ -48,13 +48,11 @@ describe("buildRunInstructions", () => {
     expect(prompt).toContain(
       "For PRs outside the current primary repository, write `<repo>#<number>`, never bare `#<number>`.",
     );
+    expect(prompt).toContain("`tella-stage` `lease_editor_fixture`");
+    expect(prompt).toContain("this Open Session id as `leaseKey`");
     expect(prompt).toContain(
-      "For editors, call `opensession-portals` `set_editor_preview_path`",
+      "Never construct a video id or report fixture evidence yourself",
     );
-    expect(prompt).toContain(
-      "at least 60 seconds, 2+ clips, and a ready non-empty transcript",
-    );
-    expect(prompt).toContain("to prevent reuse by another active session");
     expect(prompt.length).toBeLessThan(1_200);
   });
 });

--- a/packages/core/opensession-server/src/server/run-instructions.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.ts
@@ -169,13 +169,13 @@ export function buildRunInstructions(input: {
   }
   if (!input.isAsk && inproc["opensession-portals"]) {
     parts.push(
-      "## Preview links\nBefore finishing a user-facing web change, set its exact " +
-        "root-relative route, query included. For editors, call `opensession-portals` " +
-        "`set_editor_preview_path` with a dedicated or fresh staging record: at least 60 " +
-        "seconds, 2+ clips, and a ready non-empty transcript. Pass a stable `exclusiveKey` " +
-        "such as `video:<id>` to prevent reuse by another active session. Never use a local " +
-        "fixture. For other web changes, call `set_portal_path` without a name. Open the " +
-        "resulting staging URL and verify it shows the changed feature.",
+      "## Preview links\nFor user-facing web changes, set the exact root-relative route, " +
+        "query included. For editors, call `tella-stage` `lease_editor_fixture` with " +
+        "fixture `multi_clip_transcript_v1` and this Open Session id as `leaseKey`. Pass its " +
+        "`editorPath`, `videoId`, `leaseId`, and `expiresAt` to `opensession-portals` " +
+        "`set_editor_preview_path`. Never construct a video id or report fixture evidence " +
+        "yourself. Otherwise call `set_portal_path` without a name. Open the staging URL and " +
+        "verify the changed feature.",
     );
   }
 

--- a/packages/core/opensession-server/src/server/run-instructions.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.ts
@@ -171,9 +171,9 @@ export function buildRunInstructions(input: {
     parts.push(
       "## Preview links\nFor user-facing web changes, set the exact root-relative route, " +
         "query included. For editors, call `tella-stage` `lease_editor_fixture` with " +
-        "fixture `multi_clip_transcript_v1` and this Open Session id as `leaseKey`. Pass its " +
-        "`editorPath`, `videoId`, `leaseId`, and `expiresAt` to `opensession-portals` " +
-        "`set_editor_preview_path`. Never construct a video id or report fixture evidence " +
+        "fixture `multi_clip_transcript_v1` and this Open Session id as `leaseKey`. Pass only " +
+        "its `leaseId` to `opensession-portals` `set_editor_preview_path`; Open Session " +
+        "verifies the lease directly with Tella. Never construct a video id or report evidence " +
         "yourself. Otherwise call `set_portal_path` without a name. Open the staging URL and " +
         "verify the changed feature.",
     );


### PR DESCRIPTION
## Summary
- replace self-reported editor fixture evidence with a server-side `tella-stage` verification call
- require the session creator's personal Tella OAuth grant, with no shared or static fallback
- derive the video, editor path, expiry, and reservation key from Tella's authoritative lease
- reject invented, expired, mismatched, inaccessible, and malformed fixture responses

Depends on tella-fusion#6104.
Supersedes #263, which was based on an older main commit.

## Verification
- `bun run check`
- focused Portal, MCP auth, interactive identity, lease, instruction, and catalog tests

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a057a7-74e5-7b22-86d1-fcc0e4448bc8)
