### PR TITLE
Extract SessionViewer runtime controllers

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.socket.test.ts
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.socket.test.ts
@@ -64,6 +64,23 @@ test("SessionViewer receives its socket capabilities from context", async () => 
   expect(app).toMatch(/renderSessionPane\(\s*currentSession,\s*mainSocket,/);
 });
 
+test("SessionViewer delegates its session subscription once", async () => {
+  const [viewer, subscription] = await Promise.all([
+    source("./SessionViewer.tsx"),
+    source("../hooks/useSessionViewerSubscription.ts"),
+  ]);
+
+  expect(viewer.match(/useSessionViewerSubscription\(/g)).toHaveLength(1);
+  expect(viewer).not.toContain('case "transcript_init"');
+  expect(viewer).not.toContain('type: "watch"');
+  expect(subscription).toContain('case "transcript_init"');
+  expect(subscription).toContain('case "transcript_append"');
+  const register = subscription.indexOf("const unsubscribe = addHandler(");
+  const watch = subscription.indexOf('type: "watch"');
+  expect(register).toBeGreaterThanOrEqual(0);
+  expect(watch).toBeGreaterThan(register);
+});
+
 test("SessionViewer descendants no longer receive socket props", async () => {
   const [viewer, sidePanelHost, terminal] = await Promise.all([
     source("./SessionViewer.tsx"),

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -14,9 +14,6 @@ import { AnimatePresence, motion } from "motion/react";
 import { duration, ease } from "../ui/motion";
 import { EmptyState, InlineAlert, TranscriptSkeleton } from "../ui/state";
 import { LiveTurnStore } from "../lib/live-turn-store";
-import { getLiveTypingPref } from "../lib/live-typing-pref";
-import { randomUUID } from "../lib/random-uuid";
-import { isTimelineOnlyRunnerNotice } from "../lib/runner-events";
 import { TranscriptViewStore } from "../lib/transcript-view-store";
 import {
   measureSessionPerf,
@@ -45,10 +42,7 @@ import {
   mergeTranscriptEntries,
   orderTranscriptEntries,
 } from "../lib/transcript-state";
-import {
-  HISTORY_PAGE_ENTRIES,
-  shouldContinueHistoryReveal,
-} from "../lib/transcript-history";
+import { HISTORY_PAGE_ENTRIES } from "../lib/transcript-history";
 import { MessageRail } from "./MessageRail";
 import { collectSentMessages } from "../lib/sent-messages";
 import { canonicalToolName, type LiveSubagent } from "./ToolCallBlock";
@@ -128,12 +122,12 @@ import { useBackSwipe } from "../hooks/useBackSwipe";
 import { useNavigation } from "../hooks/useNavigation";
 import { useSessionSocket } from "../hooks/useSessionSocket";
 import { useSessionRuntime } from "../hooks/useSessionRuntime";
+import { useSessionViewerSubscription } from "../hooks/useSessionViewerSubscription";
 import {
   dedupeViewers,
   facepileAvatarStyle,
   otherViewers,
 } from "../lib/presence";
-import { otherTypingUsers } from "../lib/typing";
 import { personKey, prReviewCompletion } from "../lib/review-queue";
 import { Composer } from "./Composer";
 import { TypingIndicator } from "./TypingIndicator";
@@ -173,8 +167,8 @@ import {
 import {
   markPendingBusy,
   markPendingStarted,
-  type OptimisticPendingPrompt,
   reconcilePending,
+  type OptimisticPendingPrompt,
 } from "../lib/pending-reconcile";
 import { promptOutbox, type PromptOutboxItem } from "../lib/prompt-outbox";
 import { withPreviewPath } from "../lib/preview-url";
@@ -195,7 +189,6 @@ import {
   metadataModelLabel,
   modelIsCodex,
   prettyModel,
-  switchDividerText,
 } from "./session-viewer/model-labels";
 import { withModelSwitches } from "./session-viewer/model-switches";
 import {
@@ -2447,494 +2440,61 @@ export function SessionViewer({
   // digest of each. One-shot: cleared once a send consumes them.
   const [contextSessions, setContextSessions] = useState<string[]>([]);
 
-  // Subscribe to WebSocket messages
-  const subscribeToSession = useEffectEvent(() => {
-    if (!connected) return;
-
-    // Resume rather than re-snapshot when this exact session's transcript is
-    // still mounted (a reconnect blip, not a session switch) and we hold a
-    // cursor from a previous frame. Seq mode (transcript v2) resumes with
-    // sinceSeq; legacy with the byte cursor. supportsSeq advertises the
-    // capability — old servers ignore it and behave exactly as before.
-    const cursor = transcriptCursorRef.current;
-    const seqState = transcriptSeqRef.current;
-    const ready = transcriptReadySessionRef.current === session.id;
-    const resume =
-      ready && seqState?.sessionId === session.id
-        ? {
-            sinceSeq: seqState.lastSeq,
-            sinceChangeSeq: seqState.lastChangeSeq,
-          }
-        : ready && cursor?.sessionId === session.id
-          ? { sinceOffset: cursor.offset, sinceRev: cursor.rev }
-          : {};
-    const unsubscribe = addHandler((msg) => {
-      // Session-scoped messages carry the session id — drop anything meant
-      // for a different session. Without this, a socket race (or a lingering
-      // creator-side direct send from a session you navigated away from) bleeds
-      // another session's stream into this view. Messages without a
-      // sessionId (direct replies like slash-command notices) pass through.
-      if ("sessionId" in msg && msg.sessionId && msg.sessionId !== session.id) {
-        return;
-      }
-      switch (msg.type) {
-        case "workflow_update": {
-          // Dynamic workflows: upsert the live run snapshot (already
-          // session-filtered by the sessionId gate above).
-          const run = msg.run;
-          setWorkflowRuns((prev) =>
-            prev.some((r) => r.runId === run.runId)
-              ? prev.map((r) => (r.runId === run.runId ? run : r))
-              : [run, ...prev],
-          );
-          break;
-        }
-        case "transcript_init": {
-          // Weave persisted model switches into the conversation as dividers.
-          const merged = withModelSwitches(msg.entries, session.modelHistory);
-          transcriptReadySessionRef.current = session.id;
-          // Mode detection (transcript v2): an init carrying seq fields
-          // switches this session into seq mode; one without switches it
-          // back to legacy (e.g. the flag was turned off — the resume
-          // falls back to a full legacy snapshot). Init frames are
-          // authoritative for the mode.
-          const v2 = msg.v2 === true && typeof msg.lastSeq === "number";
-          const existingIndex = existingIndexForInit(v2);
-          setIndexMode(v2);
-          if (v2) {
-            transcriptSeqRef.current = {
-              sessionId: session.id,
-              lastSeq: msg.lastSeq!,
-              firstSeq:
-                typeof msg.firstSeq === "number" && msg.firstSeq > 0
-                  ? msg.firstSeq
-                  : null,
-              lastChangeSeq:
-                typeof msg.lastChangeSeq === "number"
-                  ? msg.lastChangeSeq
-                  : msg.lastSeq!,
-            };
-            // Seq mode ignores offset/rev cursors entirely.
-            transcriptCursorRef.current = null;
-          } else {
-            transcriptSeqRef.current = null;
-            if (typeof msg.endOffset === "number" && msg.rev) {
-              transcriptCursorRef.current = {
-                sessionId: session.id,
-                rev: msg.rev,
-                offset: msg.endOffset,
-              };
-            } else {
-              transcriptCursorRef.current = null;
-            }
-          }
-          if (v2) acceptInitTail(msg.entries, existingIndex);
-          if (v2 && existingIndex)
-            transcriptViewStore.merge(merged, true, true);
-          else transcriptViewStore.replace(merged, true, v2);
-          setHistoryTruncated(!!msg.truncated);
-          backgroundHistoryRef.current = false;
-          historyRevealRef.current = null;
-          loadingHistoryRef.current = false;
-          setLoadingHistory(false);
-          setLoading(false);
-          // A whole-history walk ends here when the server answers with the
-          // whole transcript — the legacy path's only way to serve a backlog,
-          // and the seq path's fallback when a store read fails. A TRUNCATED
-          // init is a re-snapshot of the tail instead (a reconnect landing
-          // mid-walk), so cancel that quietly rather than parking the reader
-          // at the top of a tail they didn't ask for.
-          if (historyWalkRef.current?.sessionId === session.id) {
-            if (msg.truncated) {
-              historyWalkRef.current = null;
-              setLoadingAllHistory(false);
-            } else {
-              finishHistoryWalk();
-            }
-          }
-          shellTiming.record();
-          // Pagination cursor for "load earlier" (the byte offset the shipped
-          // tail begins at). Each history page arrives as transcript_history
-          // below. Seq mode pages with
-          // beforeSeq instead, so the byte cursor stays untouched there.
-          if (!v2 && typeof msg.startOffset === "number") {
-            historyStartRef.current = msg.startOffset;
-          }
-          break;
-        }
-        case "transcript_index": {
-          replaceIndex(msg, messagesRef.current, followingLive.current);
-          setHistoryTruncated(false);
-          backgroundHistoryRef.current = false;
-          historyRevealRef.current = null;
-          loadingHistoryRef.current = false;
-          setLoadingHistory(false);
-          break;
-        }
-        case "transcript_range": {
-          acceptRange(msg);
-          break;
-        }
-        case "transcript_history": {
-          // Older entries from a "load earlier" page: merge by id and re-sort
-          // by time — mergeEntries
-          // appends, which is wrong for content older than what's shown.
-          transcriptViewStore.prepend(msg.entries, msg.v2 === true);
-          setHistoryTruncated(!!msg.truncated);
-          const seqState = transcriptSeqRef.current;
-          const inSeqMode = seqState?.sessionId === session.id;
-          if (
-            inSeqMode &&
-            msg.v2 === true &&
-            typeof msg.firstSeq === "number" &&
-            msg.firstSeq > 0
-          ) {
-            // Older-page cursor: earliest seq loaded so far (min).
-            seqState.firstSeq =
-              seqState.firstSeq === null
-                ? msg.firstSeq
-                : Math.min(seqState.firstSeq, msg.firstSeq);
-          } else if (!inSeqMode && typeof msg.startOffset === "number") {
-            historyStartRef.current =
-              historyStartRef.current === null
-                ? msg.startOffset
-                : Math.min(historyStartRef.current, msg.startOffset);
-          }
-          // Whole-history walk: this page's cursor is now in place, so ask
-          // for the next one straight from here — leaving loadingHistory
-          // true across the gap. Stop on a whole transcript, an empty page,
-          // a cursor that stopped receding, or the ceiling.
-          const jump = historyWalkRef.current;
-          if (jump && jump.sessionId === session.id) {
-            jump.loaded += msg.entries.length;
-            const cursor = inSeqMode
-              ? seqState.firstSeq
-              : historyStartRef.current;
-            if (
-              msg.truncated &&
-              msg.entries.length > 0 &&
-              cursor !== null &&
-              cursor !== jump.cursor &&
-              jump.loaded < JUMP_MAX_ENTRIES
-            ) {
-              jump.cursor = cursor;
-              requestHistoryPage(true);
-              break;
-            }
-            finishHistoryWalk();
-          }
-          const reveal = historyRevealRef.current;
-          if (reveal && reveal.sessionId === session.id && inSeqMode) {
-            reveal.loaded += msg.entries.length;
-            const cursor = seqState.firstSeq;
-            if (
-              shouldContinueHistoryReveal({
-                entries: msg.entries,
-                truncated: !!msg.truncated,
-                loaded: reveal.loaded,
-                cursor,
-                previousCursor: reveal.cursor,
-              })
-            ) {
-              reveal.cursor = cursor;
-              requestHistoryPage();
-              break;
-            }
-            historyRevealRef.current = null;
-          }
-          if (backgroundHistoryRef.current) scrollToLatest("auto");
-          backgroundHistoryRef.current = false;
-          loadingHistoryRef.current = false;
-          setLoadingHistory(false);
-          break;
-        }
-        case "transcript_append": {
-          const seqState = transcriptSeqRef.current;
-          const inSeqMode = seqState?.sessionId === session.id;
-          if (inSeqMode) {
-            // Seq mode: track the resume cursor as a max — upsert
-            // republishes reuse the entry's ORIGINAL seq, so a frame's
-            // lastSeq can sit below what we already hold. Offset/rev
-            // fields (if any) are ignored while in this mode.
-            if (
-              msg.v2 === true &&
-              typeof msg.lastSeq === "number" &&
-              msg.lastSeq > 0
-            ) {
-              seqState.lastSeq = Math.max(seqState.lastSeq, msg.lastSeq);
-            }
-            if (typeof msg.lastChangeSeq === "number") {
-              seqState.lastChangeSeq = Math.max(
-                seqState.lastChangeSeq,
-                msg.lastChangeSeq,
-              );
-            }
-          } else if (typeof msg.endOffset === "number" && msg.rev) {
-            transcriptCursorRef.current = {
-              sessionId: session.id,
-              rev: msg.rev,
-              offset: msg.endOffset,
-            };
-          }
-          transcriptViewStore.merge(msg.entries, inSeqMode, true);
-          if (inSeqMode) projectAppend(msg.entries, msg.firstSeq);
-          // The live stream and the transcript tail both carry assistant text.
-          // stream_text accumulates whole blocks until stream_done (end of the
-          // run), so a mid-run text block would otherwise show twice: as the
-          // persisted entry above later tool steps AND in the streaming bubble
-          // at the bottom. Once a block lands as an entry, drop it from the
-          // stream buffer.
-          const landed = msg.entries.filter(
-            (e) => e.type === "assistant" && e.content,
-          );
-          if (landed.length) {
-            liveTurnStore.land(
-              landed.map((e) => ({ id: e.id, content: e.content })),
-            );
-          }
-          break;
-        }
-        case "presence":
-          if (msg.sessionId === session.id) setViewers(msg.viewers);
-          break;
-        case "typing":
-          if (msg.sessionId === session.id)
-            setTypingUsers(otherTypingUsers(msg.users, getCurrentUser()));
-          break;
-        case "queue_update":
-          if (msg.sessionId === session.id) {
-            // Don't let a broadcast rewrite the list mid-drag (see
-            // draggingQueueRef) — the drop will send our order and the
-            // server's echo reconciles it right after.
-            dispatchSessionRuntime({
-              type: "frame",
-              frame: msg,
-              acceptQueueUpdate: !draggingQueueRef.current,
-            });
-          }
-          break;
-        case "queued_prompt_taken": {
-          if (msg.sessionId !== session.id) break;
-          if (!msg.item) {
-            dispatchSessionRuntime({ type: "frame", frame: msg });
-            toast(msg.message || "That queued message could not be edited");
-            break;
-          }
-          const item = msg.item as QueueReceipt;
-          const existing = loadDraft(draftKey);
-          setImages((current) => [...current, ...(item.images ?? [])]);
-          const restoredFiles = Array.isArray(item.files)
-            ? item.files.flatMap((file) => {
-                if (!file || typeof file !== "object") return [];
-                const value = file as Record<string, unknown>;
-                if (typeof value.name !== "string") return [];
-                return [
-                  {
-                    name: value.name,
-                    type:
-                      typeof value.type === "string"
-                        ? value.type
-                        : "application/octet-stream",
-                    ...(typeof value.path === "string"
-                      ? { path: value.path }
-                      : {}),
-                    ...(typeof value.dataUrl === "string"
-                      ? { dataUrl: value.dataUrl }
-                      : {}),
-                  },
-                ];
-              })
-            : [];
-          setFiles((current) => [...current, ...restoredFiles]);
-          setContextSessions((current) => [
-            ...new Set([...current, ...(item.contextSessions ?? [])]),
-          ]);
-          setComposerPrefill((current) => ({
-            seq: (current?.seq ?? 0) + 1,
-            text: item.content,
-            replace: !existing.text.trim(),
-          }));
-          break;
-        }
-        case "ask_question":
-        case "ask_resolved":
-          if (msg.sessionId === session.id)
-            dispatchSessionRuntime({ type: "frame", frame: msg });
-          break;
-        case "reply_suggestions":
-          // Null retires the row (the turn they answered has been answered).
-          if (msg.sessionId === session.id)
-            setReplySuggestions(msg.suggestions ?? []);
-          break;
-        case "slack_composer":
-          if (msg.sessionId === session.id) {
-            setSlackComposer(msg.request);
-            setSlackComposerStatus("idle");
-            setSlackComposerReconnect(false);
-            if (msg.request) setSlackComposerSent(null);
-          }
-          break;
-        case "slack_composer_resolved":
-          if (msg.sessionId === session.id) {
-            setSlackComposer((current) =>
-              current?.id === msg.requestId ? null : current,
-            );
-            if (msg.status === "sent" && msg.channel) {
-              setSlackComposerSent({
-                channelName: msg.channel.name,
-                permalink: msg.permalink,
-                receiptKey: msg.requestId,
-                channelId: msg.channel.id,
-                ts: msg.ts,
-              });
-            }
-          }
-          break;
-        case "session_status": {
-          const running = !!msg.isRunning && !msg.safety;
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          if (!running) {
-            // Every isRunning:false broadcast follows its run's stream_done,
-            // so a live turn never gets cut here. This clears the stale case:
-            // a socket that died mid-stream (server restart) reconnects, the
-            // re-watch hello reports the turn already over, and the spinner
-            // from the dead stream would otherwise stay up forever.
-            liveTurnStore.finish();
-          }
-          onRunningChange?.(session.id, running);
-          break;
-        }
-        case "git_pushed":
-          if (msg.sessionId === session.id) setGitRefreshTick((t) => t + 1);
-          break;
-        case "pr_updated":
-          // Include PR-backed workspace branches: legacy review sessions keep a
-          // synthetic checkout branch that differs from the real PR head.
-          if (sessionPrTargetsRef.current.has(`${msg.repo}\0${msg.branch}`))
-            setGitRefreshTick((t) => t + 1);
-          break;
-        case "workspace_status":
-          if (msg.sessionId === session.id) setWorkspacePreparing(!msg.ready);
-          break;
-        case "stream_start":
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          // A new turn is never the stopped one: clear the pending stop so
-          // its label can't bleed into the run that follows it.
-          setStopRequestedAt(null);
-          liveTurnStore.start(msg.by);
-          // A new turn answers the last one's chips. The server clears its
-          // copy on the same event; this is what stops the row lingering
-          // for the seconds before that broadcast lands.
-          setReplySuggestions(EMPTY_SUGGESTIONS);
-          break;
-        case "stream_text": {
-          if (isTimelineOnlyRunnerNotice(msg.text)) break;
-          // Live typing is per viewer (Settings > Preferences), default off.
-          // Dropping the frame is the whole implementation: the durable
-          // entry for the block still lands over the transcript feed, which
-          // is what filled the transcript before streaming existed. Read per
-          // frame rather than captured, so a toggle takes on the running turn.
-          if (!getLiveTypingPref()) break;
-          liveTurnStore.append(msg.text, msg.blockId);
-          break;
-        }
-        case "stream_tool_use":
-        case "stream_tool_result":
-          transcriptViewStore.merge([msg.entry]);
-          break;
-        case "stream_done": {
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          liveTurnStore.finish();
-          break;
-        }
-        case "model_changed":
-          if (msg.sessionId !== session.id) break;
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          if (msg.by && msg.by !== getCurrentUser()) {
-            setEntries((prev) => [
-              ...prev,
-              {
-                id: `model-switch-live-${Date.now()}`,
-                type: "system",
-                content: switchDividerText(msg.model, msg.from, msg.by),
-                timestamp: new Date().toISOString(),
-              },
-            ]);
-          }
-          break;
-        case "subscription_changed":
-          // Keep every viewer's Subscription submenu in sync; the /sub
-          // notice in the transcript carries the human-readable detail.
-          if (msg.sessionId !== session.id) break;
-          setAccountId(msg.accountId || "");
-          break;
-        case "usage_update":
-          if (msg.sessionId !== session.id) break;
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          break;
-        case "cache_warning":
-          if (msg.sessionId !== session.id) break;
-          toast("Prompt cache missed");
-          break;
-        case "notice":
-          setEntries((prev) => [
-            ...prev,
-            {
-              id: randomUUID(),
-              type: "system",
-              content: msg.message,
-              timestamp: new Date().toISOString(),
-            },
-          ]);
-          break;
-        case "error":
-          dispatchSessionRuntime({ type: "frame", frame: msg });
-          liveTurnStore.finish();
-          // Show the failure where the reply would have been — otherwise a
-          // failed run looks like a send that silently went nowhere.
-          if (msg.message) {
-            setEntries((prev) => [
-              ...prev,
-              {
-                id: randomUUID(),
-                type: "system",
-                content: `⚠ Run failed: ${msg.message}`,
-                timestamp: new Date().toISOString(),
-              },
-            ]);
-          }
-          break;
-      }
-    });
-    // Register first: `watch` synchronously receives a presence snapshot. On a
-    // reconnect, sending before this handler exists can drop the empty snapshot
-    // and leave a departed viewer's face rendered indefinitely.
-    send({
-      type: "watch",
-      sessionId: session.id,
-      user: getCurrentUser(),
-      supportsSeq: true,
-      supportsChangeSeq: true,
-      supportsTranscriptIndex: true,
-      ...resume,
-    });
-    return () => {
-      unsubscribe();
-      // Tell the server we stopped watching, so it can drop the transcript
-      // stream and our presence entry (otherwise we linger as a ghost viewer).
-      // send() is a no-op unless the socket is OPEN, so a dropped connection
-      // (the usual reason this effect re-runs) never throws here.
-      send({ type: "unwatch", sessionId: session.id });
-    };
-    // `ran` in deps: new sessions start with no engine conversation and no
-    // transcript file — re-watch once the first run makes one so the live
-    // tail attaches. It stands in for `transcriptPath`, which said the same
-    // thing a moment later but is detail-only now: reading it here would
-    // re-watch every session ONCE MORE the instant its detail hydrated.
-  });
-  useEffect(
-    () => subscribeToSession(),
-    [session.id, connected, session.ran, liveTurnStore],
+  useSessionViewerSubscription(
+    connected,
+    transcriptCursorRef,
+    transcriptSeqRef,
+    transcriptReadySessionRef,
+    session,
+    addHandler,
+    setWorkflowRuns,
+    existingIndexForInit,
+    setIndexMode,
+    acceptInitTail,
+    transcriptViewStore,
+    setHistoryTruncated,
+    backgroundHistoryRef,
+    historyRevealRef,
+    loadingHistoryRef,
+    setLoadingHistory,
+    setLoading,
+    historyWalkRef,
+    setLoadingAllHistory,
+    finishHistoryWalk,
+    shellTiming,
+    historyStartRef,
+    replaceIndex,
+    messagesRef,
+    followingLive,
+    acceptRange,
+    JUMP_MAX_ENTRIES,
+    requestHistoryPage,
+    scrollToLatest,
+    projectAppend,
+    liveTurnStore,
+    setViewers,
+    setTypingUsers,
+    dispatchSessionRuntime,
+    draggingQueueRef,
+    draftKey,
+    setImages,
+    setFiles,
+    setContextSessions,
+    setComposerPrefill,
+    setReplySuggestions,
+    EMPTY_SUGGESTIONS,
+    setSlackComposer,
+    setSlackComposerStatus,
+    setSlackComposerReconnect,
+    setSlackComposerSent,
+    onRunningChange,
+    setGitRefreshTick,
+    sessionPrTargetsRef,
+    setWorkspacePreparing,
+    setStopRequestedAt,
+    setEntries,
+    setAccountId,
+    send,
   );
 
   // Drop optimistic bubbles once their real turn shows up. Each pending message

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -148,6 +148,7 @@ import {
 import { BrandMark } from "./BrandMark";
 import { SessionHeader } from "./session/SessionHeader";
 import { SidePanelHost } from "./session/SidePanelHost";
+import { SessionPreviewSurface } from "./session/SessionPreviewSurface";
 import { TranscriptView } from "./session/TranscriptView";
 import { splitAttachments, type FileAttachment } from "../lib/images";
 import { cropImageRegionFile } from "../lib/image-region-comment";
@@ -231,8 +232,6 @@ import { AssetOverlay } from "./AssetView";
 import { SessionReportsPanel, useSessionReports } from "./SessionReportsPanel";
 import type { WorkflowRunSnapshot } from "../../server/workflow-types";
 import { ArchivedSessionItems } from "./ArchivedSessionItems";
-import { PreviewPane } from "./PreviewPane";
-import { PortalPane } from "./PortalPane";
 import { PortalsPage } from "./PortalsPanel";
 import { portalTargetFor } from "../lib/portals";
 import { StagingLink } from "./StagingLink";
@@ -266,7 +265,6 @@ import {
   IconGlobe,
   IconRobot,
   IconMessage,
-  IconArrowUpRight,
 } from "./icons";
 import { KeepInSidebarIcon } from "./sidebar/KeepInSidebarMark";
 import { Button } from "../ui/button";
@@ -6176,114 +6174,27 @@ export function SessionViewer({
           )}
         >
           {showPortal && portalTarget ? (
-            <div className={VIEWER_REVIEW_MAIN}>
-              <PortalPane target={portalTarget} />
-            </div>
+            <SessionPreviewSurface
+              surface={{ kind: "portal", target: portalTarget }}
+            />
           ) : showPreviewTab ? (
-            <div className={VIEWER_REVIEW_MAIN}>
-              <PreviewPane
-                session={session}
-                status={previewStatus}
-                onClose={() => onClosePreviewTab?.()}
-              />
-            </div>
+            <SessionPreviewSurface
+              surface={{
+                kind: "preview",
+                session,
+                status: previewStatus,
+                onClose: () => onClosePreviewTab?.(),
+              }}
+            />
           ) : showStaging && stagingUrl ? (
-            staging?.embeddable ? (
-              // This deploy opts into being framed by this app (its CSP
-              // frame-ancestors names our origin), so we embed it inline.
-              // When the deploy's session cookie is scoped to a parent
-              // domain this app also sits under (SameSite=None; Secure), it
-              // rides into the frame on every device, iOS included, so a
-              // logged-in reviewer sees the deploy directly. A
-              // logged-OUT one gets a blank frame (staging redirects to
-              // WorkOS AuthKit, which refuses framing), so the header keeps a
-              // first-party "Open" break-out to log in, then come back.
-              <div className={VIEWER_REVIEW_MAIN}>
-                <div className="flex h-full flex-col">
-                  <div className="flex items-center gap-2 border-b border-divider bg-panel px-3 py-1.5 text-xs text-dim">
-                    <IconGlobe size={14} />
-                    <span className="truncate">
-                      Preview environment
-                      {staging.status !== "Ready"
-                        ? ` · ${staging.status.toLowerCase()}…`
-                        : ""}
-                    </span>
-                    <div className="ml-auto flex items-center gap-3">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          shareLink(stagingUrl, { toast: "Link copied" })
-                        }
-                        className="inline-flex items-center gap-1 transition-colors hover:text-fg"
-                      >
-                        <IconCopy size={13} />
-                        Copy link
-                      </button>
-                      <a
-                        href={stagingUrl}
-                        target="_blank"
-                        rel="noopener"
-                        title="Open first-party in a new tab. Needed if the frame is blank because you aren't logged in to the preview environment yet."
-                        className="inline-flex items-center gap-1 transition-colors hover:text-fg"
-                      >
-                        Open
-                        <IconArrowUpRight size={13} />
-                      </a>
-                    </div>
-                  </div>
-                  <iframe
-                    key={stagingUrl}
-                    src={stagingUrl}
-                    title="Preview environment"
-                    className="min-h-0 flex-1 border-0 bg-surface"
-                    allow="camera; microphone; display-capture; fullscreen; autoplay; clipboard-write"
-                  />
-                </div>
-              </div>
-            ) : (
-              // Deploy hasn't opted into being framed (older preview, or the
-              // fusion CSP change hasn't reached it yet) — open it
-              // first-party in a new tab rather than show a blocked frame.
-              <div className={VIEWER_REVIEW_MAIN}>
-                <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
-                  <IconGlobe size={40} className="text-dim" />
-                  <div className="flex flex-col items-center gap-1">
-                    <div className="text-base font-medium text-fg">
-                      Preview environment
-                    </div>
-                    <div className="text-xs text-dim">
-                      {staging?.status === "Ready"
-                        ? "Test this PR on real infra"
-                        : `Deploy is ${(staging?.status ?? "building").toLowerCase()}…`}
-                    </div>
-                  </div>
-                  <a
-                    href={stagingUrl}
-                    target="_blank"
-                    rel="noopener"
-                    className="inline-flex items-center gap-2 rounded-md border border-line bg-surface px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-panel"
-                  >
-                    <IconGlobe size={16} />
-                    Open staging
-                    <IconArrowUpRight size={16} />
-                  </a>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      shareLink(stagingUrl, { toast: "Link copied" })
-                    }
-                    className="inline-flex items-center gap-1.5 text-xs text-dim transition-colors hover:text-fg"
-                  >
-                    <IconCopy size={14} />
-                    Copy link
-                  </button>
-                  <div className="max-w-xs text-xs leading-relaxed text-dim">
-                    Opens in a new tab. This deploy isn&apos;t set up to embed
-                    here yet.
-                  </div>
-                </div>
-              </div>
-            )
+            <SessionPreviewSurface
+              surface={{
+                kind: "staging",
+                deployment: staging,
+                url: stagingUrl,
+                shareLink,
+              }}
+            />
           ) : showAssets ? (
             // The session's scratch assets, full-width (same component
             // the Info panel's Assets button opens). AssetsPanel is

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -68,8 +68,6 @@ import { UserAvatar } from "./UserAvatar";
 import {
   deleteSessionApi,
   archiveSessionApi,
-  fetchModels,
-  fetchProviderAccounts,
   fetchFileMentions,
   fetchMentionSuggestions,
   fetchSkillMentions,
@@ -84,8 +82,6 @@ import {
   portalActionApi,
   startPortalRecipeApi,
   type WorkspaceMediaItem,
-  type ModelOption,
-  type ProviderAccountOption,
   type SessionSubagentSnapshot,
   type PreviewPortalRecipe,
   type PreviewStatus,
@@ -122,6 +118,7 @@ import { useBackSwipe } from "../hooks/useBackSwipe";
 import { useNavigation } from "../hooks/useNavigation";
 import { useSessionSocket } from "../hooks/useSessionSocket";
 import { useSessionRuntime } from "../hooks/useSessionRuntime";
+import { useSessionModelWorkflowController } from "../hooks/useSessionModelWorkflowController";
 import { useSessionViewerSubscription } from "../hooks/useSessionViewerSubscription";
 import {
   dedupeViewers,
@@ -1971,112 +1968,25 @@ export function SessionViewer({
     };
   }, [session.id]);
 
-  // Per-session model (switchable from the composer; "" = default)
-  const [models, setModels] = useState<ModelOption[]>([]);
-  const [defaultModel, setDefaultModel] = useState("");
-  // Pinnable Claude/Codex accounts + this session's pin ("" = auto pool).
-  const [accounts, setAccounts] = useState<ProviderAccountOption[]>([]);
-  const [accountId, setAccountId] = useState(session.accountId || "");
-  // Live token/cost accounting is seeded from the session and updated per run
-  // through the `usage_update` broadcast in useSessionRuntime.
-  // Reasoning effort — a composer control mirroring the new-session palette.
-  // Persisted on the session server-side and enforced per run (Claude effort /
-  // Codex modelReasoningEffort), so seed from the session's stored value.
-  const [effort, setEffort] = useState(session.effort || "high");
-  const [fastMode, setFastMode] = useState(session.fastMode || false);
-  // Optimistic goal: reflects a just-set/cleared goal instantly (the /goal
-  // command persists server-side but doesn't broadcast a live session update).
-  // `undefined` = defer to session.goal; a string/null = the pending override.
-  const [goalOverride, setGoalOverride] = useState<string | null | undefined>(
-    undefined,
-  );
-  // Drop the override once the server-side session catches up (or we switch).
-  useEffect(() => setGoalOverride(undefined), [session.id, session.goal]);
-  const currentGoal =
-    goalOverride !== undefined ? goalOverride : (session.goal ?? null);
-  useEffect(() => {
-    fetchModels(session.workspaceId || undefined)
-      .then((m) => {
-        setModels(m.models);
-        setDefaultModel(m.default);
-      })
-      .catch(() => {});
-    fetchProviderAccounts()
-      .then(setAccounts)
-      .catch(() => {});
-  }, [session.workspaceId]);
-  useEffect(() => {
-    dispatchSessionRuntime({
-      type: "sync_model",
-      model: session.model || "",
-    });
-  }, [dispatchSessionRuntime, session.id, session.model]);
-  useEffect(() => {
-    setAccountId(session.accountId || "");
-  }, [session.id, session.accountId]);
-  useEffect(() => {
-    setEffort(session.effort || "high");
-  }, [session.id, session.effort]);
-  useEffect(() => {
-    setFastMode(session.fastMode || false);
-  }, [session.id, session.fastMode]);
-  useEffect(() => {
-    dispatchSessionRuntime({ type: "sync_usage", usage: session.usage });
-  }, [dispatchSessionRuntime, session.id, session.usage]);
-
-  // Dynamic workflow runs (opensession-workflows MCP): seeded by a fetch on
-  // open/session switch, then kept live by workflow_update broadcasts. Powers
-  // the Agents tab — hidden entirely while empty.
-  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRunSnapshot[]>([]);
-  // True once the seed fetch for the current session has settled — the
-  // runs-vanished fallback below must not flip tabs off an empty [] mid-fetch.
-  const [workflowsLoaded, setWorkflowsLoaded] = useState(false);
-  useEffect(() => {
-    let stale = false;
-    setWorkflowRuns([]);
-    setWorkflowsLoaded(false);
-    fetch(
-      `${BASE_PATH}/api/sessions/${encodeURIComponent(session.id)}/workflows`,
-    )
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        if (stale) return;
-        if (Array.isArray(d?.runs)) {
-          const fetched = d.runs as WorkflowRunSnapshot[];
-          // WS upserts may have landed while the fetch was in flight — those
-          // snapshots are newer than the seed, so keep them and only add
-          // fetched runs we don't have yet (the panel re-sorts by startedAt).
-          setWorkflowRuns((prev) => {
-            const have = new Set(prev.map((r) => r.runId));
-            const added = fetched.filter((r) => !have.has(r.runId));
-            return added.length ? [...prev, ...added] : prev;
-          });
-        }
-        setWorkflowsLoaded(true);
-      })
-      .catch(() => {
-        if (!stale) setWorkflowsLoaded(true);
-      });
-    return () => {
-      stale = true;
-    };
-  }, [session.id]);
-  function workflowAction(
-    runId: string,
-    action: "cancel" | "pause" | "resume" | "skip" | "retry",
-    seq?: number,
-  ) {
-    // Fire-and-forget: workflow_update echoes every state transition. Resume
-    // after a process restart may create a new run, which arrives as another
-    // workflow_update on the same session.
-    const suffix =
-      action === "skip" || action === "retry"
-        ? `/agents/${seq}/${action}`
-        : `/${action}`;
-    fetch(`${BASE_PATH}/api/workflows/${encodeURIComponent(runId)}${suffix}`, {
-      method: "POST",
-    }).catch(() => {});
-  }
+  // What a send runs with (model, account, effort, fast mode, goal) plus the
+  // dynamic workflow runs the Agents tab lists. The memos over these stay
+  // below, so their dependency arrays are unchanged.
+  const {
+    model: {
+      models,
+      defaultModel,
+      accounts,
+      accountId,
+      setAccountId,
+      effort,
+      setEffort,
+      fastMode,
+      setFastMode,
+      setGoalOverride,
+      currentGoal,
+    },
+    workflows: { workflowRuns, setWorkflowRuns, workflowAction },
+  } = useSessionModelWorkflowController({ session, dispatchSessionRuntime });
 
   // Sub-agents the session spawned directly (pi task-tool children /
   // SDK Task agents) — shown in the Agents tab next to workflow runs. Seeded
@@ -2371,7 +2281,7 @@ export function SessionViewer({
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [focused, models, defaultModel, model, effort]);
+  }, [focused, models, defaultModel, model, effort, setEffort]);
 
   // ⌃⇧↑/⌃⇧↓ page the transcript up/down — keyboard scrolling that works while
   // the composer is focused. A programmatic scroll carries no reader gesture,

--- a/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-settle.test.ts
+++ b/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-settle.test.ts
@@ -1,11 +1,15 @@
 import { expect, test } from "bun:test";
 import { readFollowingLive } from "./transcript-anchor";
 
-const [viewer, transcriptView, transcriptHook] = await Promise.all([
-  Bun.file(new URL("../SessionViewer.tsx", import.meta.url)).text(),
-  Bun.file(new URL("../session/TranscriptView.tsx", import.meta.url)).text(),
-  Bun.file(new URL("../../hooks/useTranscript.ts", import.meta.url)).text(),
-]);
+const [viewer, subscriptionHook, transcriptView, transcriptHook] =
+  await Promise.all([
+    Bun.file(new URL("../SessionViewer.tsx", import.meta.url)).text(),
+    Bun.file(
+      new URL("../../hooks/useSessionViewerSubscription.ts", import.meta.url),
+    ).text(),
+    Bun.file(new URL("../session/TranscriptView.tsx", import.meta.url)).text(),
+    Bun.file(new URL("../../hooks/useTranscript.ts", import.meta.url)).text(),
+  ]);
 
 test("fresh transcript ranges reaffirm a cached reader's live edge", () => {
   expect(transcriptHook).toContain("settledIndexRef.current = index");
@@ -49,7 +53,7 @@ test("setup and loading surfaces leave before transcript rows mount", () => {
 test("indexed transcripts settle positively but cannot stay hidden forever", () => {
   expect(transcriptHook).toContain("if (!outlineReady) return");
   expect(viewer).toContain("onSettled: () => setOpenSettlePending(false)");
-  expect(viewer).toContain("setIndexMode(v2)");
+  expect(subscriptionHook).toContain("setIndexMode(v2)");
   expect(transcriptHook).toContain("setOutlineReady(!v2)");
   expect(transcriptHook).toContain("setOutlineReady(true)");
   expect(viewer).toContain("const LEGACY_OPEN_SETTLE_MAX_MS = 350");

--- a/packages/core/opensession-server/src/frontend/components/session/SessionPreviewSurface.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/session/SessionPreviewSurface.test.tsx
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SessionPreviewSurface } from "./SessionPreviewSurface";
+
+const STAGING_URL = "https://preview.example.test/path?record=1";
+const shareLink = () => {};
+
+test("an embeddable staging deployment keeps its framed preview controls", () => {
+  const html = renderToStaticMarkup(
+    <SessionPreviewSurface
+      surface={{
+        kind: "staging",
+        deployment: { status: "Building", embeddable: true },
+        url: STAGING_URL,
+        shareLink,
+      }}
+    />,
+  );
+
+  expect(html).toContain("Preview environment · building…");
+  expect(html).toContain(`<iframe src="${STAGING_URL.replace("&", "&amp;")}"`);
+  expect(html).toContain(
+    'allow="camera; microphone; display-capture; fullscreen; autoplay; clipboard-write"',
+  );
+  expect(html).toContain("Copy link");
+  expect(html).toContain(">Open<");
+});
+
+test("a non-embeddable deployment keeps the first-party fallback", () => {
+  const html = renderToStaticMarkup(
+    <SessionPreviewSurface
+      surface={{
+        kind: "staging",
+        deployment: { status: "Ready" },
+        url: STAGING_URL,
+        shareLink,
+      }}
+    />,
+  );
+
+  expect(html).not.toContain("<iframe");
+  expect(html).toContain("Test this PR on real infra");
+  expect(html).toContain("Open staging");
+  expect(html).toContain("Copy link");
+  expect(html).toContain(`href="${STAGING_URL.replace("&", "&amp;")}"`);
+});
+
+test("SessionViewer keeps preview selection and state ownership", async () => {
+  const viewer = await Bun.file(
+    new URL("../SessionViewer.tsx", import.meta.url),
+  ).text();
+  const branch = viewer.slice(
+    viewer.indexOf("{showPortal && portalTarget ? ("),
+    viewer.indexOf(") : showAssets ? ("),
+  );
+  const portal = branch.indexOf('kind: "portal"');
+  const preview = branch.indexOf('kind: "preview"');
+  const staging = branch.indexOf('kind: "staging"');
+
+  expect(branch).toContain("<SessionPreviewSurface");
+  expect(portal).toBeGreaterThan(-1);
+  expect(preview).toBeGreaterThan(portal);
+  expect(staging).toBeGreaterThan(preview);
+  expect(branch).toContain("deployment: staging");
+  expect(branch).toContain("url: stagingUrl");
+  expect(branch).toContain("shareLink,");
+});

--- a/packages/core/opensession-server/src/frontend/components/session/SessionPreviewSurface.tsx
+++ b/packages/core/opensession-server/src/frontend/components/session/SessionPreviewSurface.tsx
@@ -1,0 +1,175 @@
+import type { ComponentProps } from "react";
+import type { PreviewStatus } from "../../lib/api";
+import { VIEWER_REVIEW_MAIN } from "../../lib/session-viewer-classes";
+import type { UnifiedSession } from "../../lib/types";
+import { IconArrowUpRight, IconCopy, IconGlobe } from "../icons";
+import { PortalPane } from "../PortalPane";
+import { PreviewPane } from "../PreviewPane";
+
+interface StagingDeployment {
+  status: string;
+  embeddable?: boolean;
+}
+
+interface SessionStagingPaneProps {
+  deployment: StagingDeployment | null;
+  url: string;
+  shareLink: (
+    link: string,
+    options?: { toast?: string | boolean; title?: string },
+  ) => void;
+}
+
+type PreviewSurface =
+  | {
+      kind: "portal";
+      target: ComponentProps<typeof PortalPane>["target"];
+    }
+  | {
+      kind: "preview";
+      session: UnifiedSession;
+      status: PreviewStatus | null;
+      onClose: () => void;
+    }
+  | {
+      kind: "staging";
+      deployment: StagingDeployment | null;
+      url: string;
+      shareLink: SessionStagingPaneProps["shareLink"];
+    };
+
+/** The active workspace preview tab. */
+export function SessionPreviewSurface({
+  surface,
+}: {
+  surface: PreviewSurface;
+}) {
+  switch (surface.kind) {
+    case "portal":
+      return (
+        <div className={VIEWER_REVIEW_MAIN}>
+          <PortalPane target={surface.target} />
+        </div>
+      );
+    case "preview":
+      return (
+        <div className={VIEWER_REVIEW_MAIN}>
+          <PreviewPane
+            session={surface.session}
+            status={surface.status}
+            onClose={surface.onClose}
+          />
+        </div>
+      );
+    case "staging":
+      return (
+        <SessionStagingPane
+          deployment={surface.deployment}
+          url={surface.url}
+          shareLink={surface.shareLink}
+        />
+      );
+  }
+}
+
+/** The embedded or first-party fallback view for a PR preview deployment. */
+function SessionStagingPane({
+  deployment,
+  url,
+  shareLink,
+}: SessionStagingPaneProps) {
+  if (deployment?.embeddable) {
+    // This deploy opts into being framed by this app (its CSP frame-ancestors
+    // names our origin), so we embed it inline. When the deploy's session
+    // cookie is scoped to a parent domain this app also sits under
+    // (SameSite=None; Secure), it rides into the frame on every device, iOS
+    // included, so a logged-in reviewer sees the deploy directly. A logged-OUT
+    // one gets a blank frame (staging redirects to WorkOS AuthKit, which refuses
+    // framing), so the header keeps a first-party "Open" break-out to log in,
+    // then come back.
+    return (
+      <div className={VIEWER_REVIEW_MAIN}>
+        <div className="flex h-full flex-col">
+          <div className="flex items-center gap-2 border-b border-divider bg-panel px-3 py-1.5 text-xs text-dim">
+            <IconGlobe size={14} />
+            <span className="truncate">
+              Preview environment
+              {deployment.status !== "Ready"
+                ? ` · ${deployment.status.toLowerCase()}…`
+                : ""}
+            </span>
+            <div className="ml-auto flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => shareLink(url, { toast: "Link copied" })}
+                className="inline-flex items-center gap-1 transition-colors hover:text-fg"
+              >
+                <IconCopy size={13} />
+                Copy link
+              </button>
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener"
+                title="Open first-party in a new tab. Needed if the frame is blank because you aren't logged in to the preview environment yet."
+                className="inline-flex items-center gap-1 transition-colors hover:text-fg"
+              >
+                Open
+                <IconArrowUpRight size={13} />
+              </a>
+            </div>
+          </div>
+          <iframe
+            key={url}
+            src={url}
+            title="Preview environment"
+            className="min-h-0 flex-1 border-0 bg-surface"
+            allow="camera; microphone; display-capture; fullscreen; autoplay; clipboard-write"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Deploy hasn't opted into being framed (older preview, or the fusion CSP
+  // change hasn't reached it yet), so open it first-party in a new tab rather
+  // than show a blocked frame.
+  return (
+    <div className={VIEWER_REVIEW_MAIN}>
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+        <IconGlobe size={40} className="text-dim" />
+        <div className="flex flex-col items-center gap-1">
+          <div className="text-base font-medium text-fg">
+            Preview environment
+          </div>
+          <div className="text-xs text-dim">
+            {deployment?.status === "Ready"
+              ? "Test this PR on real infra"
+              : `Deploy is ${(deployment?.status ?? "building").toLowerCase()}…`}
+          </div>
+        </div>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener"
+          className="inline-flex items-center gap-2 rounded-md border border-line bg-surface px-4 py-2 text-sm font-medium text-fg transition-colors hover:bg-panel"
+        >
+          <IconGlobe size={16} />
+          Open staging
+          <IconArrowUpRight size={16} />
+        </a>
+        <button
+          type="button"
+          onClick={() => shareLink(url, { toast: "Link copied" })}
+          className="inline-flex items-center gap-1.5 text-xs text-dim transition-colors hover:text-fg"
+        >
+          <IconCopy size={14} />
+          Copy link
+        </button>
+        <div className="max-w-xs text-xs leading-relaxed text-dim">
+          Opens in a new tab. This deploy isn&apos;t set up to embed here yet.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionModelWorkflowController.test.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionModelWorkflowController.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+const viewerSource = await Bun.file(
+  new URL("../components/SessionViewer.tsx", import.meta.url),
+).text();
+const hookSource = await Bun.file(
+  new URL("useSessionModelWorkflowController.ts", import.meta.url),
+).text();
+
+function expectInOrder(source: string, needles: string[]) {
+  let offset = 0;
+  for (const needle of needles) {
+    const index = source.indexOf(needle, offset);
+    expect(index).toBeGreaterThanOrEqual(offset);
+    offset = index + needle.length;
+  }
+}
+
+describe("session model and workflow ownership", () => {
+  test("SessionViewer delegates the send settings once", () => {
+    expect(
+      viewerSource.match(/useSessionModelWorkflowController\(\{/g),
+    ).toHaveLength(1);
+    expect(viewerSource).not.toContain("const [models, setModels]");
+    expect(viewerSource).not.toContain("const [defaultModel, setDefaultModel]");
+    expect(viewerSource).not.toContain("const [accounts, setAccounts]");
+    expect(viewerSource).not.toContain("const [effort, setEffort]");
+    expect(viewerSource).not.toContain("const [fastMode, setFastMode]");
+    expect(viewerSource).not.toContain("const [goalOverride, setGoalOverride]");
+    expect(viewerSource).not.toContain("const [workflowRuns, setWorkflowRuns]");
+    expect(viewerSource).not.toContain("function workflowAction(");
+    expect(viewerSource).not.toContain("fetchModels(");
+    expect(viewerSource).not.toContain("fetchProviderAccounts(");
+  });
+
+  test("the controller owns the seed fetches and the workflow endpoint", () => {
+    expect(hookSource).toContain("fetchModels(session.workspaceId");
+    expect(hookSource).toContain("fetchProviderAccounts()");
+    expect(hookSource).toContain("/workflows`");
+    expect(hookSource).toContain("api/workflows/${encodeURIComponent(runId)}");
+  });
+
+  test("keeps the sync effects and the workflow seed in source order", () => {
+    expectInOrder(hookSource, [
+      "useEffect(() => setGoalOverride(undefined), [session.id, session.goal]);",
+      "fetchModels(session.workspaceId",
+      'type: "sync_model"',
+      "setAccountId(session.accountId",
+      "setEffort(session.effort",
+      "setFastMode(session.fastMode",
+      'type: "sync_usage"',
+      "setWorkflowsLoaded(false);",
+      "function workflowAction(",
+    ]);
+  });
+
+  test("returns grouped slices rather than a flat bag", () => {
+    expect(hookSource).toContain("    model: {");
+    expect(hookSource).toContain(
+      "    workflows: { workflowRuns, setWorkflowRuns, workflowAction },",
+    );
+    expect(viewerSource).toContain(
+      "    workflows: { workflowRuns, setWorkflowRuns, workflowAction },",
+    );
+  });
+
+  test("the sub-agent list and the busy flag stay in the viewer", () => {
+    expect(hookSource).not.toContain("fetchSessionSubagents");
+    expect(hookSource).not.toContain("const isBusy");
+    expect(viewerSource).toContain("fetchSessionSubagents(session.id)");
+    expect(viewerSource).toContain(
+      "const isBusy = !safety && (isRunningLive || isStreaming);",
+    );
+  });
+});

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionModelWorkflowController.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionModelWorkflowController.ts
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import type { Dispatch } from "react";
+import { BASE_PATH } from "../lib/base";
+import {
+  fetchModels,
+  fetchProviderAccounts,
+  type ModelOption,
+  type ProviderAccountOption,
+} from "../lib/api";
+import type { SessionRuntimeAction } from "../lib/session-runtime";
+import type { UnifiedSession } from "../lib/types";
+import type { WorkflowRunSnapshot } from "../../server/workflow-types";
+
+export interface SessionModelWorkflowControllerOptions {
+  session: UnifiedSession;
+  dispatchSessionRuntime: Dispatch<SessionRuntimeAction>;
+}
+
+/**
+ * What a send will run with — model, pinned account, effort, fast mode and the
+ * optimistic goal — plus the dynamic workflow runs the Agents tab lists.
+ *
+ * Split out of SessionViewer verbatim, in the order the hooks ran there, so
+ * hook order is unchanged and the memos over these values stay in the
+ * component. The result is grouped rather than flat so each caller reads which
+ * slice it depends on.
+ */
+export function useSessionModelWorkflowController({
+  session,
+  dispatchSessionRuntime,
+}: SessionModelWorkflowControllerOptions) {
+  // Per-session model (switchable from the composer; "" = default)
+  const [models, setModels] = useState<ModelOption[]>([]);
+  const [defaultModel, setDefaultModel] = useState("");
+  // Pinnable Claude/Codex accounts + this session's pin ("" = auto pool).
+  const [accounts, setAccounts] = useState<ProviderAccountOption[]>([]);
+  const [accountId, setAccountId] = useState(session.accountId || "");
+  // Live token/cost accounting is seeded from the session and updated per run
+  // through the `usage_update` broadcast in useSessionRuntime.
+  // Reasoning effort — a composer control mirroring the new-session palette.
+  // Persisted on the session server-side and enforced per run (Claude effort /
+  // Codex modelReasoningEffort), so seed from the session's stored value.
+  const [effort, setEffort] = useState(session.effort || "high");
+  const [fastMode, setFastMode] = useState(session.fastMode || false);
+  // Optimistic goal: reflects a just-set/cleared goal instantly (the /goal
+  // command persists server-side but doesn't broadcast a live session update).
+  // `undefined` = defer to session.goal; a string/null = the pending override.
+  const [goalOverride, setGoalOverride] = useState<string | null | undefined>(
+    undefined,
+  );
+  // Drop the override once the server-side session catches up (or we switch).
+  useEffect(() => setGoalOverride(undefined), [session.id, session.goal]);
+  const currentGoal =
+    goalOverride !== undefined ? goalOverride : (session.goal ?? null);
+  useEffect(() => {
+    fetchModels(session.workspaceId || undefined)
+      .then((m) => {
+        setModels(m.models);
+        setDefaultModel(m.default);
+      })
+      .catch(() => {});
+    fetchProviderAccounts()
+      .then(setAccounts)
+      .catch(() => {});
+  }, [session.workspaceId]);
+  useEffect(() => {
+    dispatchSessionRuntime({
+      type: "sync_model",
+      model: session.model || "",
+    });
+  }, [dispatchSessionRuntime, session.id, session.model]);
+  useEffect(() => {
+    setAccountId(session.accountId || "");
+  }, [session.id, session.accountId]);
+  useEffect(() => {
+    setEffort(session.effort || "high");
+  }, [session.id, session.effort]);
+  useEffect(() => {
+    setFastMode(session.fastMode || false);
+  }, [session.id, session.fastMode]);
+  useEffect(() => {
+    dispatchSessionRuntime({ type: "sync_usage", usage: session.usage });
+  }, [dispatchSessionRuntime, session.id, session.usage]);
+
+  // Dynamic workflow runs (opensession-workflows MCP): seeded by a fetch on
+  // open/session switch, then kept live by workflow_update broadcasts. Powers
+  // the Agents tab — hidden entirely while empty.
+  const [workflowRuns, setWorkflowRuns] = useState<WorkflowRunSnapshot[]>([]);
+  // True once the seed fetch for the current session has settled — the
+  // runs-vanished fallback must not flip tabs off an empty [] mid-fetch.
+  const [workflowsLoaded, setWorkflowsLoaded] = useState(false);
+  useEffect(() => {
+    let stale = false;
+    setWorkflowRuns([]);
+    setWorkflowsLoaded(false);
+    fetch(
+      `${BASE_PATH}/api/sessions/${encodeURIComponent(session.id)}/workflows`,
+    )
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (stale) return;
+        if (Array.isArray(d?.runs)) {
+          const fetched = d.runs as WorkflowRunSnapshot[];
+          // WS upserts may have landed while the fetch was in flight — those
+          // snapshots are newer than the seed, so keep them and only add
+          // fetched runs we don't have yet (the panel re-sorts by startedAt).
+          setWorkflowRuns((prev) => {
+            const have = new Set(prev.map((r) => r.runId));
+            const added = fetched.filter((r) => !have.has(r.runId));
+            return added.length ? [...prev, ...added] : prev;
+          });
+        }
+        setWorkflowsLoaded(true);
+      })
+      .catch(() => {
+        if (!stale) setWorkflowsLoaded(true);
+      });
+    return () => {
+      stale = true;
+    };
+  }, [session.id]);
+  function workflowAction(
+    runId: string,
+    action: "cancel" | "pause" | "resume" | "skip" | "retry",
+    seq?: number,
+  ) {
+    // Fire-and-forget: workflow_update echoes every state transition. Resume
+    // after a process restart may create a new run, which arrives as another
+    // workflow_update on the same session.
+    const suffix =
+      action === "skip" || action === "retry"
+        ? `/agents/${seq}/${action}`
+        : `/${action}`;
+    fetch(`${BASE_PATH}/api/workflows/${encodeURIComponent(runId)}${suffix}`, {
+      method: "POST",
+    }).catch(() => {});
+  }
+
+  return {
+    model: {
+      models,
+      defaultModel,
+      accounts,
+      accountId,
+      setAccountId,
+      effort,
+      setEffort,
+      fastMode,
+      setFastMode,
+      setGoalOverride,
+      currentGoal,
+    },
+    workflows: { workflowRuns, setWorkflowRuns, workflowAction },
+  };
+}

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionViewerSubscription.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionViewerSubscription.ts
@@ -1,0 +1,624 @@
+import type { WorkflowRunSnapshot } from "../../server/workflow-types";
+import {
+  useEffect,
+  useEffectEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { withModelSwitches } from "../components/session-viewer/model-switches";
+import { switchDividerText } from "../components/session-viewer/model-labels";
+import type { SlackSent } from "../components/ShippedChangeComposer";
+import { getCurrentUser } from "../components/UserPicker";
+import type { FileAttachment } from "../lib/images";
+import { loadDraft } from "../lib/drafts";
+import { getLiveTypingPref } from "../lib/live-typing-pref";
+import { randomUUID } from "../lib/random-uuid";
+import { isTimelineOnlyRunnerNotice } from "../lib/runner-events";
+import type { QueueReceipt } from "../lib/session-queue";
+import type { SessionRuntimeAction } from "../lib/session-runtime";
+import { shouldContinueHistoryReveal } from "../lib/transcript-history";
+import type { TranscriptViewStore } from "../lib/transcript-view-store";
+import type {
+  TranscriptEntry,
+  UnifiedSession,
+  WSServerMessage,
+} from "../lib/types";
+import { otherTypingUsers } from "../lib/typing";
+import type { LiveTurnStore } from "../lib/live-turn-store";
+import { toast } from "../ui/toast";
+import type { ReplySuggestion } from "../lib/reply-suggestions";
+import type {
+  SessionSocketAddHandler,
+  SessionSocketSend,
+} from "./useSessionSocket";
+import type { TranscriptController } from "./useTranscript";
+
+type Setter<T> = Dispatch<SetStateAction<T>>;
+type TranscriptCursor = {
+  sessionId: string;
+  rev: string;
+  offset: number;
+};
+type TranscriptSequence = {
+  sessionId: string;
+  lastSeq: number;
+  firstSeq: number | null;
+  lastChangeSeq: number;
+};
+type HistoryWalk = {
+  sessionId: string;
+  loaded: number;
+  cursor: number | null;
+};
+type ComposerPrefill = {
+  seq: number;
+  text: string;
+  replace?: boolean;
+};
+type SlackComposerRequest = Extract<
+  WSServerMessage,
+  { type: "slack_composer" }
+>["request"];
+type SetEntries = (
+  update:
+    | TranscriptEntry[]
+    | ((previous: TranscriptEntry[]) => TranscriptEntry[]),
+) => void;
+
+// Hidden for at least this long, returning to the tab is a "reopen" — jump to
+// the live edge even if nothing new arrived. Shorter absences (glancing at a
+// notification) keep the reader's place unless the transcript grew meanwhile.
+const HIDDEN_REOPEN_MS = 30_000;
+// After becoming visible again, keep watching this long for growth that lands
+// late: on the iOS PWA the WebSocket only reconnects after visibility, so what
+// streamed while backgrounded arrives moments after the visibilitychange.
+const RESUME_GROWTH_WINDOW_MS = 8_000;
+
+export function useSessionViewerSubscription(
+  connected: boolean,
+  transcriptCursorRef: RefObject<TranscriptCursor | null>,
+  transcriptSeqRef: RefObject<TranscriptSequence | null>,
+  transcriptReadySessionRef: RefObject<string | null>,
+  session: UnifiedSession,
+  addHandler: SessionSocketAddHandler,
+  setWorkflowRuns: Setter<WorkflowRunSnapshot[]>,
+  existingIndexForInit: TranscriptController["existingIndexForInit"],
+  setIndexMode: TranscriptController["setIndexMode"],
+  acceptInitTail: TranscriptController["acceptInitTail"],
+  transcriptViewStore: TranscriptViewStore,
+  setHistoryTruncated: Setter<boolean>,
+  backgroundHistoryRef: RefObject<boolean>,
+  historyRevealRef: RefObject<HistoryWalk | null>,
+  loadingHistoryRef: RefObject<boolean>,
+  setLoadingHistory: Setter<boolean>,
+  setLoading: Setter<boolean>,
+  historyWalkRef: RefObject<HistoryWalk | null>,
+  setLoadingAllHistory: Setter<boolean>,
+  finishHistoryWalk: () => void,
+  shellTiming: { record: () => void },
+  historyStartRef: RefObject<number | null>,
+  replaceIndex: TranscriptController["replaceIndex"],
+  messagesRef: RefObject<HTMLDivElement | null>,
+  followingLive: RefObject<boolean>,
+  acceptRange: TranscriptController["acceptRange"],
+  jumpMaxEntries: number,
+  requestHistoryPage: (whole?: boolean) => void,
+  scrollToLatest: (behavior?: ScrollBehavior) => void,
+  projectAppend: TranscriptController["projectAppend"],
+  liveTurnStore: LiveTurnStore,
+  setViewers: Setter<string[]>,
+  setTypingUsers: Setter<string[]>,
+  dispatchSessionRuntime: Dispatch<SessionRuntimeAction>,
+  draggingQueueRef: RefObject<boolean>,
+  draftKey: string,
+  setImages: Setter<string[]>,
+  setFiles: Setter<FileAttachment[]>,
+  setContextSessions: Setter<string[]>,
+  setComposerPrefill: Setter<ComposerPrefill | null>,
+  setReplySuggestions: Setter<ReplySuggestion[]>,
+  emptySuggestions: ReplySuggestion[],
+  setSlackComposer: Setter<SlackComposerRequest>,
+  setSlackComposerStatus: Setter<"idle" | "sharing">,
+  setSlackComposerReconnect: Setter<boolean>,
+  setSlackComposerSent: Setter<SlackSent | null>,
+  onRunningChange: ((id: string, isRunning: boolean) => void) | undefined,
+  setGitRefreshTick: Setter<number>,
+  sessionPrTargetsRef: RefObject<Set<string>>,
+  setWorkspacePreparing: Setter<boolean>,
+  setStopRequestedAt: Setter<number | null>,
+  setEntries: SetEntries,
+  setAccountId: Setter<string>,
+  send: SessionSocketSend,
+) {
+  // Subscribe to WebSocket messages
+  const subscribeToSession = useEffectEvent(() => {
+    if (!connected) return;
+
+    // Resume rather than re-snapshot when this exact session's transcript is
+    // still mounted (a reconnect blip, not a session switch) and we hold a
+    // cursor from a previous frame. Seq mode (transcript v2) resumes with
+    // sinceSeq; legacy with the byte cursor. supportsSeq advertises the
+    // capability — old servers ignore it and behave exactly as before.
+    const cursor = transcriptCursorRef.current;
+    const seqState = transcriptSeqRef.current;
+    const ready = transcriptReadySessionRef.current === session.id;
+    const resume =
+      ready && seqState?.sessionId === session.id
+        ? {
+            sinceSeq: seqState.lastSeq,
+            sinceChangeSeq: seqState.lastChangeSeq,
+          }
+        : ready && cursor?.sessionId === session.id
+          ? { sinceOffset: cursor.offset, sinceRev: cursor.rev }
+          : {};
+    const unsubscribe = addHandler((msg) => {
+      // Session-scoped messages carry the session id — drop anything meant
+      // for a different session. Without this, a socket race (or a lingering
+      // creator-side direct send from a session you navigated away from) bleeds
+      // another session's stream into this view. Messages without a
+      // sessionId (direct replies like slash-command notices) pass through.
+      if ("sessionId" in msg && msg.sessionId && msg.sessionId !== session.id) {
+        return;
+      }
+      switch (msg.type) {
+        case "workflow_update": {
+          // Dynamic workflows: upsert the live run snapshot (already
+          // session-filtered by the sessionId gate above).
+          const run = msg.run;
+          setWorkflowRuns((prev) =>
+            prev.some((r) => r.runId === run.runId)
+              ? prev.map((r) => (r.runId === run.runId ? run : r))
+              : [run, ...prev],
+          );
+          break;
+        }
+        case "transcript_init": {
+          // Weave persisted model switches into the conversation as dividers.
+          const merged = withModelSwitches(msg.entries, session.modelHistory);
+          transcriptReadySessionRef.current = session.id;
+          // Mode detection (transcript v2): an init carrying seq fields
+          // switches this session into seq mode; one without switches it
+          // back to legacy (e.g. the flag was turned off — the resume
+          // falls back to a full legacy snapshot). Init frames are
+          // authoritative for the mode.
+          const v2 = msg.v2 === true && typeof msg.lastSeq === "number";
+          const existingIndex = existingIndexForInit(v2);
+          setIndexMode(v2);
+          if (v2) {
+            transcriptSeqRef.current = {
+              sessionId: session.id,
+              lastSeq: msg.lastSeq!,
+              firstSeq:
+                typeof msg.firstSeq === "number" && msg.firstSeq > 0
+                  ? msg.firstSeq
+                  : null,
+              lastChangeSeq:
+                typeof msg.lastChangeSeq === "number"
+                  ? msg.lastChangeSeq
+                  : msg.lastSeq!,
+            };
+            // Seq mode ignores offset/rev cursors entirely.
+            transcriptCursorRef.current = null;
+          } else {
+            transcriptSeqRef.current = null;
+            if (typeof msg.endOffset === "number" && msg.rev) {
+              transcriptCursorRef.current = {
+                sessionId: session.id,
+                rev: msg.rev,
+                offset: msg.endOffset,
+              };
+            } else {
+              transcriptCursorRef.current = null;
+            }
+          }
+          if (v2) acceptInitTail(msg.entries, existingIndex);
+          if (v2 && existingIndex)
+            transcriptViewStore.merge(merged, true, true);
+          else transcriptViewStore.replace(merged, true, v2);
+          setHistoryTruncated(!!msg.truncated);
+          backgroundHistoryRef.current = false;
+          historyRevealRef.current = null;
+          loadingHistoryRef.current = false;
+          setLoadingHistory(false);
+          setLoading(false);
+          // A whole-history walk ends here when the server answers with the
+          // whole transcript — the legacy path's only way to serve a backlog,
+          // and the seq path's fallback when a store read fails. A TRUNCATED
+          // init is a re-snapshot of the tail instead (a reconnect landing
+          // mid-walk), so cancel that quietly rather than parking the reader
+          // at the top of a tail they didn't ask for.
+          if (historyWalkRef.current?.sessionId === session.id) {
+            if (msg.truncated) {
+              historyWalkRef.current = null;
+              setLoadingAllHistory(false);
+            } else {
+              finishHistoryWalk();
+            }
+          }
+          shellTiming.record();
+          // Pagination cursor for "load earlier" (the byte offset the shipped
+          // tail begins at). Each history page arrives as transcript_history
+          // below. Seq mode pages with
+          // beforeSeq instead, so the byte cursor stays untouched there.
+          if (!v2 && typeof msg.startOffset === "number") {
+            historyStartRef.current = msg.startOffset;
+          }
+          break;
+        }
+        case "transcript_index": {
+          replaceIndex(msg, messagesRef.current, followingLive.current);
+          setHistoryTruncated(false);
+          backgroundHistoryRef.current = false;
+          historyRevealRef.current = null;
+          loadingHistoryRef.current = false;
+          setLoadingHistory(false);
+          break;
+        }
+        case "transcript_range": {
+          acceptRange(msg);
+          break;
+        }
+        case "transcript_history": {
+          // Older entries from a "load earlier" page: merge by id and re-sort
+          // by time — mergeEntries
+          // appends, which is wrong for content older than what's shown.
+          transcriptViewStore.prepend(msg.entries, msg.v2 === true);
+          setHistoryTruncated(!!msg.truncated);
+          const seqState = transcriptSeqRef.current;
+          const inSeqMode = seqState?.sessionId === session.id;
+          if (
+            inSeqMode &&
+            msg.v2 === true &&
+            typeof msg.firstSeq === "number" &&
+            msg.firstSeq > 0
+          ) {
+            // Older-page cursor: earliest seq loaded so far (min).
+            seqState.firstSeq =
+              seqState.firstSeq === null
+                ? msg.firstSeq
+                : Math.min(seqState.firstSeq, msg.firstSeq);
+          } else if (!inSeqMode && typeof msg.startOffset === "number") {
+            historyStartRef.current =
+              historyStartRef.current === null
+                ? msg.startOffset
+                : Math.min(historyStartRef.current, msg.startOffset);
+          }
+          // Whole-history walk: this page's cursor is now in place, so ask
+          // for the next one straight from here — leaving loadingHistory
+          // true across the gap. Stop on a whole transcript, an empty page,
+          // a cursor that stopped receding, or the ceiling.
+          const jump = historyWalkRef.current;
+          if (jump && jump.sessionId === session.id) {
+            jump.loaded += msg.entries.length;
+            const cursor = inSeqMode
+              ? seqState.firstSeq
+              : historyStartRef.current;
+            if (
+              msg.truncated &&
+              msg.entries.length > 0 &&
+              cursor !== null &&
+              cursor !== jump.cursor &&
+              jump.loaded < jumpMaxEntries
+            ) {
+              jump.cursor = cursor;
+              requestHistoryPage(true);
+              break;
+            }
+            finishHistoryWalk();
+          }
+          const reveal = historyRevealRef.current;
+          if (reveal && reveal.sessionId === session.id && inSeqMode) {
+            reveal.loaded += msg.entries.length;
+            const cursor = seqState.firstSeq;
+            if (
+              shouldContinueHistoryReveal({
+                entries: msg.entries,
+                truncated: !!msg.truncated,
+                loaded: reveal.loaded,
+                cursor,
+                previousCursor: reveal.cursor,
+              })
+            ) {
+              reveal.cursor = cursor;
+              requestHistoryPage();
+              break;
+            }
+            historyRevealRef.current = null;
+          }
+          if (backgroundHistoryRef.current) scrollToLatest("auto");
+          backgroundHistoryRef.current = false;
+          loadingHistoryRef.current = false;
+          setLoadingHistory(false);
+          break;
+        }
+        case "transcript_append": {
+          const seqState = transcriptSeqRef.current;
+          const inSeqMode = seqState?.sessionId === session.id;
+          if (inSeqMode) {
+            // Seq mode: track the resume cursor as a max — upsert
+            // republishes reuse the entry's ORIGINAL seq, so a frame's
+            // lastSeq can sit below what we already hold. Offset/rev
+            // fields (if any) are ignored while in this mode.
+            if (
+              msg.v2 === true &&
+              typeof msg.lastSeq === "number" &&
+              msg.lastSeq > 0
+            ) {
+              seqState.lastSeq = Math.max(seqState.lastSeq, msg.lastSeq);
+            }
+            if (typeof msg.lastChangeSeq === "number") {
+              seqState.lastChangeSeq = Math.max(
+                seqState.lastChangeSeq,
+                msg.lastChangeSeq,
+              );
+            }
+          } else if (typeof msg.endOffset === "number" && msg.rev) {
+            transcriptCursorRef.current = {
+              sessionId: session.id,
+              rev: msg.rev,
+              offset: msg.endOffset,
+            };
+          }
+          transcriptViewStore.merge(msg.entries, inSeqMode, true);
+          if (inSeqMode) projectAppend(msg.entries, msg.firstSeq);
+          // The live stream and the transcript tail both carry assistant text.
+          // stream_text accumulates whole blocks until stream_done (end of the
+          // run), so a mid-run text block would otherwise show twice: as the
+          // persisted entry above later tool steps AND in the streaming bubble
+          // at the bottom. Once a block lands as an entry, drop it from the
+          // stream buffer.
+          const landed = msg.entries.filter(
+            (e) => e.type === "assistant" && e.content,
+          );
+          if (landed.length) {
+            liveTurnStore.land(
+              landed.map((e) => ({ id: e.id, content: e.content })),
+            );
+          }
+          break;
+        }
+        case "presence":
+          if (msg.sessionId === session.id) setViewers(msg.viewers);
+          break;
+        case "typing":
+          if (msg.sessionId === session.id)
+            setTypingUsers(otherTypingUsers(msg.users, getCurrentUser()));
+          break;
+        case "queue_update":
+          if (msg.sessionId === session.id) {
+            // Don't let a broadcast rewrite the list mid-drag (see
+            // draggingQueueRef) — the drop will send our order and the
+            // server's echo reconciles it right after.
+            dispatchSessionRuntime({
+              type: "frame",
+              frame: msg,
+              acceptQueueUpdate: !draggingQueueRef.current,
+            });
+          }
+          break;
+        case "queued_prompt_taken": {
+          if (msg.sessionId !== session.id) break;
+          if (!msg.item) {
+            dispatchSessionRuntime({ type: "frame", frame: msg });
+            toast(msg.message || "That queued message could not be edited");
+            break;
+          }
+          const item = msg.item as QueueReceipt;
+          const existing = loadDraft(draftKey);
+          setImages((current) => [...current, ...(item.images ?? [])]);
+          const restoredFiles = Array.isArray(item.files)
+            ? item.files.flatMap((file) => {
+                if (!file || typeof file !== "object") return [];
+                const value = file as Record<string, unknown>;
+                if (typeof value.name !== "string") return [];
+                return [
+                  {
+                    name: value.name,
+                    type:
+                      typeof value.type === "string"
+                        ? value.type
+                        : "application/octet-stream",
+                    ...(typeof value.path === "string"
+                      ? { path: value.path }
+                      : {}),
+                    ...(typeof value.dataUrl === "string"
+                      ? { dataUrl: value.dataUrl }
+                      : {}),
+                  },
+                ];
+              })
+            : [];
+          setFiles((current) => [...current, ...restoredFiles]);
+          setContextSessions((current) => [
+            ...new Set([...current, ...(item.contextSessions ?? [])]),
+          ]);
+          setComposerPrefill((current) => ({
+            seq: (current?.seq ?? 0) + 1,
+            text: item.content,
+            replace: !existing.text.trim(),
+          }));
+          break;
+        }
+        case "ask_question":
+        case "ask_resolved":
+          if (msg.sessionId === session.id)
+            dispatchSessionRuntime({ type: "frame", frame: msg });
+          break;
+        case "reply_suggestions":
+          // Null retires the row (the turn they answered has been answered).
+          if (msg.sessionId === session.id)
+            setReplySuggestions(msg.suggestions ?? []);
+          break;
+        case "slack_composer":
+          if (msg.sessionId === session.id) {
+            setSlackComposer(msg.request);
+            setSlackComposerStatus("idle");
+            setSlackComposerReconnect(false);
+            if (msg.request) setSlackComposerSent(null);
+          }
+          break;
+        case "slack_composer_resolved":
+          if (msg.sessionId === session.id) {
+            setSlackComposer((current) =>
+              current?.id === msg.requestId ? null : current,
+            );
+            if (msg.status === "sent" && msg.channel) {
+              setSlackComposerSent({
+                channelName: msg.channel.name,
+                permalink: msg.permalink,
+                receiptKey: msg.requestId,
+                channelId: msg.channel.id,
+                ts: msg.ts,
+              });
+            }
+          }
+          break;
+        case "session_status": {
+          const running = !!msg.isRunning && !msg.safety;
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          if (!running) {
+            // Every isRunning:false broadcast follows its run's stream_done,
+            // so a live turn never gets cut here. This clears the stale case:
+            // a socket that died mid-stream (server restart) reconnects, the
+            // re-watch hello reports the turn already over, and the spinner
+            // from the dead stream would otherwise stay up forever.
+            liveTurnStore.finish();
+          }
+          onRunningChange?.(session.id, running);
+          break;
+        }
+        case "git_pushed":
+          if (msg.sessionId === session.id) setGitRefreshTick((t) => t + 1);
+          break;
+        case "pr_updated":
+          // Include PR-backed workspace branches: legacy review sessions keep a
+          // synthetic checkout branch that differs from the real PR head.
+          if (sessionPrTargetsRef.current.has(`${msg.repo}\0${msg.branch}`))
+            setGitRefreshTick((t) => t + 1);
+          break;
+        case "workspace_status":
+          if (msg.sessionId === session.id) setWorkspacePreparing(!msg.ready);
+          break;
+        case "stream_start":
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          // A new turn is never the stopped one: clear the pending stop so
+          // its label can't bleed into the run that follows it.
+          setStopRequestedAt(null);
+          liveTurnStore.start(msg.by);
+          // A new turn answers the last one's chips. The server clears its
+          // copy on the same event; this is what stops the row lingering
+          // for the seconds before that broadcast lands.
+          setReplySuggestions(emptySuggestions);
+          break;
+        case "stream_text": {
+          if (isTimelineOnlyRunnerNotice(msg.text)) break;
+          // Live typing is per viewer (Settings > Preferences), default off.
+          // Dropping the frame is the whole implementation: the durable
+          // entry for the block still lands over the transcript feed, which
+          // is what filled the transcript before streaming existed. Read per
+          // frame rather than captured, so a toggle takes on the running turn.
+          if (!getLiveTypingPref()) break;
+          liveTurnStore.append(msg.text, msg.blockId);
+          break;
+        }
+        case "stream_tool_use":
+        case "stream_tool_result":
+          transcriptViewStore.merge([msg.entry]);
+          break;
+        case "stream_done": {
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          liveTurnStore.finish();
+          break;
+        }
+        case "model_changed":
+          if (msg.sessionId !== session.id) break;
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          if (msg.by && msg.by !== getCurrentUser()) {
+            setEntries((prev) => [
+              ...prev,
+              {
+                id: `model-switch-live-${Date.now()}`,
+                type: "system",
+                content: switchDividerText(msg.model, msg.from, msg.by),
+                timestamp: new Date().toISOString(),
+              },
+            ]);
+          }
+          break;
+        case "subscription_changed":
+          // Keep every viewer's Subscription submenu in sync; the /sub
+          // notice in the transcript carries the human-readable detail.
+          if (msg.sessionId !== session.id) break;
+          setAccountId(msg.accountId || "");
+          break;
+        case "usage_update":
+          if (msg.sessionId !== session.id) break;
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          break;
+        case "cache_warning":
+          if (msg.sessionId !== session.id) break;
+          toast("Prompt cache missed");
+          break;
+        case "notice":
+          setEntries((prev) => [
+            ...prev,
+            {
+              id: randomUUID(),
+              type: "system",
+              content: msg.message,
+              timestamp: new Date().toISOString(),
+            },
+          ]);
+          break;
+        case "error":
+          dispatchSessionRuntime({ type: "frame", frame: msg });
+          liveTurnStore.finish();
+          // Show the failure where the reply would have been — otherwise a
+          // failed run looks like a send that silently went nowhere.
+          if (msg.message) {
+            setEntries((prev) => [
+              ...prev,
+              {
+                id: randomUUID(),
+                type: "system",
+                content: `⚠ Run failed: ${msg.message}`,
+                timestamp: new Date().toISOString(),
+              },
+            ]);
+          }
+          break;
+      }
+    });
+    // Register first: `watch` synchronously receives a presence snapshot. On a
+    // reconnect, sending before this handler exists can drop the empty snapshot
+    // and leave a departed viewer's face rendered indefinitely.
+    send({
+      type: "watch",
+      sessionId: session.id,
+      user: getCurrentUser(),
+      supportsSeq: true,
+      supportsChangeSeq: true,
+      supportsTranscriptIndex: true,
+      ...resume,
+    });
+    return () => {
+      unsubscribe();
+      // Tell the server we stopped watching, so it can drop the transcript
+      // stream and our presence entry (otherwise we linger as a ghost viewer).
+      // send() is a no-op unless the socket is OPEN, so a dropped connection
+      // (the usual reason this effect re-runs) never throws here.
+      send({ type: "unwatch", sessionId: session.id });
+    };
+    // `ran` in deps: new sessions start with no engine conversation and no
+    // transcript file — re-watch once the first run makes one so the live
+    // tail attaches. It stands in for `transcriptPath`, which said the same
+    // thing a moment later but is detail-only now: reading it here would
+    // re-watch every session ONCE MORE the instant its detail hydrated.
+  });
+  useEffect(
+    () => subscribeToSession(),
+    [session.id, connected, session.ran, liveTurnStore],
+  );
+}


### PR DESCRIPTION
## Summary

- extract session preview and portal rendering into a dedicated component
- move transcript WebSocket subscription and history settlement into a focused hook
- move model, account, goal, and workflow-run state into a controller hook
- add focused regression tests around the extracted boundaries

## Verification

- `bun run check`

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/bks-04afe389-b601-790e-a951-3b4f27e97bd9)
