### PR TITLE
Stage opensession.socket in the compiled release

### DIFF
--- a/scripts/build-compile.ts
+++ b/scripts/build-compile.ts
@@ -18,7 +18,8 @@
  *       The full release artefact `opensession-<ver>-<os>-<arch>.tar.gz`:
  *         opensession                 the target binary
  *         node_modules/               sharp + @img/sharp-<target> sidecar
- *         opensession*.service        system service templates
+ *         opensession*.service        system service and socket templates
+ *         opensession.socket          (see scripts/lib/release-artefact.ts)
  *         deploy/                     fixed executor credential/helper policy
  *         LICENSE + notices + SBOM    project and third-party licensing
  *         release.json                version, commit, target, kind
@@ -43,6 +44,7 @@ import {
 } from "fs";
 import { dirname, join, relative, resolve } from "path";
 import { generateReleaseMetadata } from "./generate-release-metadata";
+import { RELEASE_SERVICE_TEMPLATES } from "./lib/release-artefact";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 const EMBED_MODULE = join(
@@ -445,18 +447,7 @@ async function main(): Promise<void> {
   // System scope is optional, but it must be fully installable from the same
   // binary artifact. These root-owned policy files are inputs to the installer,
   // never caller-controlled argv passed across the executor boundary.
-  for (const rel of [
-    "opensession.service",
-    "opensession-executor.service",
-    "opensession-session-kernel.service",
-    "deploy/install-resource-control.sh",
-    "deploy/install-executor-credential.sh",
-    "deploy/install-session-kernel-credential.sh",
-    "deploy/install-run-host-helper.sh",
-    "deploy/opensession-run-host",
-    "deploy/systemd/opensession-control.slice",
-    "deploy/systemd/opensession-workloads.slice",
-  ]) {
+  for (const rel of RELEASE_SERVICE_TEMPLATES) {
     const source = join(REPO_ROOT, rel);
     const destination = join(stage, rel);
     mkdirSync(dirname(destination), { recursive: true });

--- a/scripts/lib/release-artefact.test.ts
+++ b/scripts/lib/release-artefact.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The compiled release must carry every template the service installer opens
+ * from the release directory. v0.4.52 shipped without `opensession.socket`, so
+ * `opensession service install` failed on every published Linux artefact
+ * (tellahq/opensession#244). This scans `service.ts` for the literal paths it
+ * resolves from REPO_ROOT / serviceWorkdir() and fails when one is neither
+ * staged nor explicitly exempted with a reason.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+import {
+  RELEASE_SERVICE_TEMPLATES,
+  RELEASE_TEMPLATE_EXEMPTIONS,
+} from "./release-artefact";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+/** Every `join(REPO_ROOT | serviceWorkdir(), "a", "b")` literal in service.ts. */
+function releaseDirPathsReadByServiceInstaller(): string[] {
+  const source = readFileSync(join(import.meta.dir, "service.ts"), "utf8");
+  const calls = source.matchAll(
+    /join\(\s*(?:REPO_ROOT|serviceWorkdir\(\))\s*,((?:\s*"[^"]+"\s*,?)+)\s*\)/g,
+  );
+  const paths = new Set<string>();
+  for (const match of calls) {
+    const segments = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    paths.add(segments.join("/"));
+  }
+  return [...paths].sort();
+}
+
+describe("compiled release artefact", () => {
+  test("service.ts resolves at least the known unit templates", () => {
+    const paths = releaseDirPathsReadByServiceInstaller();
+    // Guards the scanner itself: if the regex silently matched nothing the
+    // staging assertion below would pass vacuously.
+    expect(paths).toContain("opensession.service");
+    expect(paths).toContain("opensession.socket");
+    expect(paths).toContain("opensession-executor.service");
+    expect(paths).toContain("opensession-session-kernel.service");
+  });
+
+  test("every template the service installer reads is staged or exempted", () => {
+    const staged = new Set(RELEASE_SERVICE_TEMPLATES);
+    const missing = releaseDirPathsReadByServiceInstaller().filter(
+      (rel) => !staged.has(rel) && !RELEASE_TEMPLATE_EXEMPTIONS.has(rel),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  test("the socket unit is staged next to the service it activates", () => {
+    expect(RELEASE_SERVICE_TEMPLATES).toContain("opensession.socket");
+  });
+
+  test("every staged file exists in the checkout", () => {
+    const absent = RELEASE_SERVICE_TEMPLATES.filter(
+      (rel) => !existsSync(join(REPO_ROOT, rel)),
+    );
+    expect(absent).toEqual([]);
+  });
+
+  test("exemptions only cover paths service.ts still reads", () => {
+    const read = new Set(releaseDirPathsReadByServiceInstaller());
+    const stale = [...RELEASE_TEMPLATE_EXEMPTIONS.keys()].filter(
+      (rel) => !read.has(rel),
+    );
+    expect(stale).toEqual([]);
+  });
+});

--- a/scripts/lib/release-artefact.ts
+++ b/scripts/lib/release-artefact.ts
@@ -29,8 +29,8 @@ export const RELEASE_SERVICE_TEMPLATES: readonly string[] = [
  * Paths `service.ts` resolves from the release directory that are
  * deliberately NOT part of the tarball. Each entry needs a reason.
  */
-export const RELEASE_TEMPLATE_EXEMPTIONS: ReadonlyMap<string, string> =
-  new Map([
+export const RELEASE_TEMPLATE_EXEMPTIONS: ReadonlyMap<string, string> = new Map(
+  [
     [
       "opensession-ingress.service",
       "source-install only: renderIngressUnit is skipped when isCompiledBinary()",
@@ -39,4 +39,5 @@ export const RELEASE_TEMPLATE_EXEMPTIONS: ReadonlyMap<string, string> =
       "bin/bun",
       "install.sh places the runtime bun for source installs; the compiled binary embeds its own",
     ],
-  ]);
+  ],
+);

--- a/scripts/lib/release-artefact.ts
+++ b/scripts/lib/release-artefact.ts
@@ -1,0 +1,42 @@
+/**
+ * Files copied verbatim from the checkout into the compiled release artefact
+ * next to the `opensession` binary.
+ *
+ * For a compiled install, `scripts/lib/service.ts` resolves every unit
+ * template and installer it needs from the release directory (REPO_ROOT is
+ * `dirname(process.execPath)` there), so anything it reads must be listed
+ * here. `release-artefact.test.ts` cross-checks this list against the
+ * templates `service.ts` actually opens; a template missing from this list
+ * is the v0.4.52 bug where `opensession service install` died with
+ * "missing socket unit template" on every published Linux release.
+ */
+export const RELEASE_SERVICE_TEMPLATES: readonly string[] = [
+  "opensession.service",
+  "opensession.socket",
+
+  "opensession-executor.service",
+  "opensession-session-kernel.service",
+  "deploy/install-resource-control.sh",
+  "deploy/install-executor-credential.sh",
+  "deploy/install-session-kernel-credential.sh",
+  "deploy/install-run-host-helper.sh",
+  "deploy/opensession-run-host",
+  "deploy/systemd/opensession-control.slice",
+  "deploy/systemd/opensession-workloads.slice",
+];
+
+/**
+ * Paths `service.ts` resolves from the release directory that are
+ * deliberately NOT part of the tarball. Each entry needs a reason.
+ */
+export const RELEASE_TEMPLATE_EXEMPTIONS: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "opensession-ingress.service",
+      "source-install only: renderIngressUnit is skipped when isCompiledBinary()",
+    ],
+    [
+      "bin/bun",
+      "install.sh places the runtime bun for source installs; the compiled binary embeds its own",
+    ],
+  ]);


### PR DESCRIPTION
Closes #244

## Problem

The compiled Linux artefact (`scripts/build-compile.ts`) copied the service unit templates, credential installers, and slices into the release directory, but not `opensession.socket`. `scripts/lib/service.ts` `renderSocketUnit()` hard-requires `$REPO_ROOT/opensession.socket`, and REPO_ROOT is the release directory for a compiled binary, so every v0.4.52 install died at `opensession service install` with `missing socket unit template`.

## Change

- Move the staged-file list into `scripts/lib/release-artefact.ts` and add `opensession.socket`.
- `scripts/build-compile.ts` imports that list instead of inlining it.
- New `scripts/lib/release-artefact.test.ts` scans `service.ts` for every literal `join(REPO_ROOT | serviceWorkdir(), ...)` path and fails if one is neither staged nor exempted with a reason. Exemptions: `opensession-ingress.service` (source-install only, `renderIngressUnit` is skipped when `isCompiledBinary()`) and `bin/bun` (runtime placed by `install.sh`, the compiled binary embeds its own). The test also guards the scanner against matching nothing, checks every staged file exists in the checkout, and flags stale exemptions.

Audit result: `opensession.socket` was the only template `service.ts` reads from the release dir that was missing from the artefact.

## Verification

- `bun test scripts/lib/release-artefact.test.ts` passes; removing the socket entry makes it fail.
- `bun run check` passes.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-d8db478c-5860-797e-9cc8-894f013b35ba)