### PR TITLE
Re-enable sandbox automations on disposable Executors

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -172,8 +172,8 @@ This is a boot path, so it needs a real restart.
 ## 5. Sandbox providers — run sessions somewhere else
 
 `packages/core/opensession-server/src/server/sandbox/` holds the local and Docker
-providers at the root, with Daytona, E2B, Box, Modal, MicroVM, and Lambda
-MicroVM under `adapters/`. Implement `SandboxProvider.ensure()`, `get()`, and
+providers at the root, with Daytona, E2B, Box, Modal, and Lambda MicroVM under
+`adapters/`. Implement `SandboxProvider.ensure()`, `get()`, and
 `destroy()`, returning a `Sandbox` that implements `exec()`, `launchRun()`,
 `ports()`, and `status()`.
 
@@ -247,7 +247,10 @@ enforced at the tool and environment layer, never in a prompt:
   opt into Claude or Codex CLI credentials.
 - Automations can carry an MCP-server allowlist. Omitted means all configured
   servers for host runs, so explicitly name only the servers a job needs.
-  Sandbox automations require an explicit list; use `[]` for none.
+  Sandbox automations use a fresh disposable Daytona Executor and require a
+  qualified provider, a hard-pinned Anthropic or OpenAI subscription account,
+  and an explicit list; use `[]` for none. They fail closed without provider-
+  enforced egress.
 - Customer, identity, and money protections are literal tool-ID catalogs in
   `AUTOMATION_DENIED_TOOLS` and `STRIPE_CONFIRM_TOOLS`. When adding a dangerous
   tool, add its exact ID and tests to the appropriate catalog, or keep its server

--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -210,13 +210,13 @@ List all of Assistant's automations (routines): scheduled, event- and webhook-tr
 
 ### `create_automation`
 
-`mcp__opensession-admin__create_automation` · input: `name` (string, required), `prompt` (string, required), `schedule` (string), `mode` ("ask" | "code"), `repo` (string), `mcpServers` (string[]), `model` (string), `accountId` (string), `accountStrict` (boolean), `usageCredits` (boolean), `prReviewer` (string), `owner` (string), `workspaceId` (string)
+`mcp__opensession-admin__create_automation` · input: `name` (string, required), `prompt` (string, required), `schedule` (string), `mode` ("ask" | "code"), `repo` (string), `mcpServers` (string[]), `sandbox` (boolean), `model` (string), `accountId` (string), `accountStrict` (boolean), `usageCredits` (boolean), `prReviewer` (string), `owner` (string), `workspaceId` (string)
 
-Create a new automation (routine). Provide a clear prompt describing the task. Set `repo` to the repository it works in, or it runs against the instance default. Use a 5-field UTC cron `schedule` for recurring jobs (omit for manual/webhook only). Pick mode 'ask' for read-only or 'code' if it must edit and commit files. Ordinary automations receive no GitHub credential, so code mode alone cannot push or open a GitHub PR. Optionally restrict tools with mcpServers and set a model.
+Create a new automation (routine). Provide a clear prompt describing the task. Set `repo` to the repository it works in, or it runs against the instance default. Use a 5-field UTC cron `schedule` for recurring jobs (omit for manual/webhook only). Pick mode 'ask' for read-only or 'code' if it must edit and commit files. Ordinary automations receive no GitHub credential, so code mode alone cannot push or open a GitHub PR. Set sandbox true to use a fresh disposable Executor. Sandboxed automations require an explicit mcpServers list, a pinned accountId, a supported model, and a configured qualified provider.
 
 ### `update_automation`
 
-`mcp__opensession-admin__update_automation` · input: `id` (string, required), `name` (string), `prompt` (string), `schedule` (string), `mode` ("ask" | "code"), `enabled` (boolean), `repo` (string), `mcpServers` (string[]), `model` (string), `accountId` (string), `accountStrict` (boolean), `usageCredits` (boolean), `prReviewer` (string), `owner` (string), `workspaceId` (string)
+`mcp__opensession-admin__update_automation` · input: `id` (string, required), `name` (string), `prompt` (string), `schedule` (string), `mode` ("ask" | "code"), `enabled` (boolean), `repo` (string), `mcpServers` (string[]), `sandbox` (boolean), `model` (string), `fallbackModel` (string), `accountId` (string), `accountStrict` (boolean), `usageCredits` (boolean), `prReviewer` (string), `owner` (string), `workspaceId` (string)
 
 Update an existing automation by id. Only provided fields change. Use enabled to pause/resume.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -67,6 +67,16 @@ configuration for the run.
   open a GitHub PR; trusted `github-*` code workflows have a separate,
   repository-scoped credential path. Every other scope still applies: MCP
   allowlist, denied writes, IMDS blocking, and the explicit environment.
+- A sandboxed automation runs in a fresh disposable Daytona Executor. Open
+  Session admits it only after Daytona has passed qualification, including a
+  live domain-allowlist check. The provider applies that allowlist before
+  runner bootstrap, repository setup hooks, private workspace seeds, or model
+  credentials enter the guest. Each run requires one hard-pinned Anthropic or
+  OpenAI subscription account, no fallback model, no nested CLI credentials,
+  and an explicit MCP allowlist. The launcher adds only the callback, clone,
+  runner bootstrap, model API, configured MCP, and operator-approved domains.
+  It probes one allowed and one blocked destination before continuing, and
+  strictly deletes the Executor after the run. There is no host fallback.
 - When adding an automation, scope it: pick ask mode unless it must write, and
   name only the MCP servers it uses.
 - A code automation's `prReviewer` is preserved and added to its instructions,

--- a/docs/setup/engines.md
+++ b/docs/setup/engines.md
@@ -72,6 +72,68 @@ remain supported when the grouped path is absent. Run `opensession doctor`
 after setup to verify that the engine and the default model have usable
 capacity.
 
+### Custom OpenAI-compatible providers
+
+A provider id Pi does not know runs when its entry in
+`~/.opensession/model-providers.json` declares the protocol. Only
+`openai-completions` is accepted, and it needs a base URL. Each provider under
+`providers.<id>` takes:
+
+| Field            | Meaning                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `apiKey`         | Bearer key sent to the provider                                                                         |
+| `baseURL`        | OpenAI-compatible base URL, for example `https://gateway.example/v1`                                    |
+| `api`            | `openai-completions`; lets an id unknown to Pi and Open Session run                                     |
+| `name`           | Display name in Settings                                                                                |
+| `catalog`        | Per-model metadata keyed by model id (see below)                                                        |
+| `catalogFile`    | JSON file with more catalog rows; relative paths resolve next to `model-providers.json`                 |
+| `discoverModels` | `true` to read `GET {baseURL}/models` on save and from **Discover models** in Settings; picker ids only |
+| `discovered`     | Written by discovery: the last listed ids and any extended fields the gateway sent                      |
+
+A catalog row fills the fields a model unknown to every catalog would otherwise
+get from the conservative stub (131072 context, 32768 output tokens, text
+only, zero cost). Rows accept our camelCase names or the snake_case fields
+gateway model objects tend to carry: `name` or `display_name`, `contextWindow`
+or `context_length`, `maxTokens` or `max_output_tokens`, `input` or
+`input_modalities` (`["text", "image"]`), `reasoning`, `efforts` (the
+reasoning levels the gateway accepts, from `none`, `low`, `medium`, `high`,
+`xhigh`, `max`), and `cost` with `input`, `output`, `cacheRead` and
+`cacheWrite` in USD per million tokens. Layers apply weakest first: discovered
+fields, then `catalogFile`, then inline `catalog`. A row for a model id Pi or
+Open Session already knows overrides that entry.
+
+```json
+{
+  "providers": {
+    "my-gateway": {
+      "apiKey": "…",
+      "baseURL": "https://gateway.example/v1",
+      "api": "openai-completions",
+      "name": "My gateway",
+      "catalogFile": "my-gateway-catalog.json",
+      "catalog": {
+        "big-model": {
+          "name": "Big Model",
+          "contextWindow": 1000000,
+          "maxTokens": 131072,
+          "input": ["text", "image"],
+          "efforts": ["low", "high"],
+          "cost": { "input": 1, "output": 4, "cacheRead": 0.1, "cacheWrite": 0 }
+        }
+      },
+      "discoverModels": true
+    }
+  },
+  "pickerModels": ["pi/my-gateway/big-model"]
+}
+```
+
+The catalog file holds the same rows, either as a map keyed by model id or as
+a list of objects with `id`. Discovery only adds ids to `pickerModels`; it
+never removes hand-written ones, and a failed poll leaves the file untouched.
+The stock OpenAI models object carries no limits or pricing, so keep those in
+the catalog. Settings writes preserve every field the form does not edit.
+
 ## Defaults and fallbacks
 
 **Settings → Providers** controls the default model and whether interactive

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -460,8 +460,10 @@ third-party provider API key and select one of its models. Subscription account
 stores live at `~/.opensession/claude-accounts.json` and
 `~/.opensession/codex-accounts.json`; provider keys live at
 `~/.opensession/model-providers.json`. All are server-managed mode-`0600`
-files, so use the UI rather than hand-editing them. Pi configuration is covered
-in [engines.md](engines.md).
+files, so use the UI rather than hand-editing them. The exception is a custom
+OpenAI-compatible gateway's per-model catalog, which is hand-written and
+preserved across Settings writes. Pi configuration, including custom providers
+and catalogs, is covered in [engines.md](engines.md).
 
 ## 7. `mcp-config.json`
 

--- a/docs/setup/plain.md
+++ b/docs/setup/plain.md
@@ -140,7 +140,9 @@ Scope the automation deliberately:
   `workos`, `tinybird`, `linear`, `sentry`, and `stripe`; remove servers you do
   not use. `[]` means no external MCP servers. For an ordinary unsandboxed
   automation, omitting the field preserves the legacy behavior of exposing all
-  configured servers; sandbox automations require an explicit allowlist.
+  configured servers. Sandbox automations run in fresh disposable Daytona
+  Executors and require a qualified provider, a pinned subscription account,
+  and an explicit allowlist.
 - **Denied writes** are stripped before the model sees its tools. The policy in
   `packages/core/opensession-server/src/server/automation-denied-tools.ts`
   blocks Plain customer replies and thread-state changes, plus WorkOS identity

--- a/packages/clients/ios/OS1/Models/ThinkingMessages.swift
+++ b/packages/clients/ios/OS1/Models/ThinkingMessages.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// How much provider reasoning stays in the visible transcript. The durable
+/// transcript is never changed; this only filters the grouped display blocks.
+enum ThinkingMessages: String {
+    case none
+    case latest
+    case all
+
+    static let standard = ThinkingMessages.latest
+    static let storageKey = "os1.transcript.thinkingMessages"
+    static let prefKey = "thinking-messages"
+
+    init(_ rawValue: String?) {
+        self = ThinkingMessages(rawValue: rawValue ?? "") ?? .standard
+    }
+
+    func visibleBlocks(_ blocks: [TranscriptBlock]) -> [TranscriptBlock] {
+        guard self != .all else { return blocks }
+        let latestId = self == .latest ? Self.latestReasoningId(in: blocks) : nil
+        return Self.filter(blocks, latestId: latestId)
+    }
+
+    private static func latestReasoningId(in blocks: [TranscriptBlock]) -> String? {
+        var latestId: String?
+        for block in blocks {
+            switch block {
+            case .message(let entry):
+                if entry.isReasoning == true { latestId = entry.id }
+            case .work(let turn):
+                for item in turn.items {
+                    if case .message(let entry) = item, entry.isReasoning == true {
+                        latestId = entry.id
+                    }
+                }
+            case .reviewLoop(let loop):
+                latestId = latestReasoningId(in: loop.blocks) ?? latestId
+            case .tool, .footer, .walkthrough, .note:
+                break
+            }
+        }
+        return latestId
+    }
+
+    private static func filter(
+        _ blocks: [TranscriptBlock],
+        latestId: String?
+    ) -> [TranscriptBlock] {
+        blocks.compactMap { block in
+            switch block {
+            case .message(let entry) where entry.isReasoning == true:
+                return entry.id == latestId ? block : nil
+            case .work(var turn):
+                turn.items.removeAll { item in
+                    guard case .message(let entry) = item,
+                          entry.isReasoning == true
+                    else { return false }
+                    return entry.id != latestId
+                }
+                guard let first = turn.items.first, let last = turn.items.last else {
+                    return nil
+                }
+                turn.id = first.id
+                turn.anchorId = last.id
+                turn.hasNarration = turn.items.contains {
+                    if case .message = $0 { return true }
+                    return false
+                }
+                return .work(turn)
+            case .reviewLoop(var loop):
+                loop.blocks = filter(loop.blocks, latestId: latestId)
+                return .reviewLoop(loop)
+            case .message, .tool, .footer, .walkthrough, .note:
+                return block
+            }
+        }
+    }
+}

--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -162,6 +162,13 @@ enum NativePreferences {
             resetMissing: changedIdentity,
             in: defaults
         )
+        set(
+            prefs[ThinkingMessages.prefKey].flatMap(ThinkingMessages.init(rawValue:))?.rawValue,
+            default: ThinkingMessages.standard.rawValue,
+            key: ThinkingMessages.storageKey,
+            resetMissing: true,
+            in: defaults
+        )
         setBool(
             replySuggestionsEnabled(prefs["reply-suggestions"]),
             default: true,

--- a/packages/clients/ios/OS1/ViewModels/CatchUpViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/CatchUpViewModel.swift
@@ -311,7 +311,10 @@ final class CatchUpViewModel {
             from: items,
             live: session.isRunning == true,
             worktreeDir: session.worktreeDir,
-            walkthrough: session.walkthrough
+            walkthrough: session.walkthrough,
+            thinkingMessages: ThinkingMessages(
+                UserDefaults.standard.string(forKey: ThinkingMessages.storageKey)
+            )
         ))
     }
 }

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -2125,6 +2125,9 @@ final class SessionViewModel {
     /// scroll pin follows its count — grouping alone would hold that count
     /// steady while a live turn grows, and new output would stop following.
     private(set) var displayBlocks: [TranscriptBlock] = []
+    @ObservationIgnored private var thinkingMessages = ThinkingMessages(
+        UserDefaults.standard.string(forKey: ThinkingMessages.storageKey)
+    )
     /// The current person's visible prompts, prepared beside the transcript
     /// blocks so a pointer moving over the rail never scans the conversation.
     private(set) var sentMessageAnchors: [SentMessageAnchor] = []
@@ -2164,6 +2167,12 @@ final class SessionViewModel {
 
     func expansionState(id: String, defaultExpanded: Bool = false) -> TurnFoldState {
         folds.expansion(id: id, defaultExpanded: defaultExpanded)
+    }
+
+    func setThinkingMessages(_ value: ThinkingMessages) {
+        guard value != thinkingMessages else { return }
+        thinkingMessages = value
+        rebuildDisplayItems()
     }
 
     /// Which block currently renders `entryId`. A history page can regroup an
@@ -2213,7 +2222,8 @@ final class SessionViewModel {
             worktreeDir: session.worktreeDir,
             walkthrough: session.walkthrough,
             notes: sessionNotes,
-            reviewResult: ReviewLoopResult(session: session)
+            reviewResult: ReviewLoopResult(session: session),
+            thinkingMessages: thinkingMessages
         )
         // What the transcript may link: the files this session's own tools
         // touched. Registering the set here — rather than fetching the diff —

--- a/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
+++ b/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
@@ -452,7 +452,8 @@ enum TranscriptGrouping {
         worktreeDir: String?,
         walkthrough: SessionWalkthrough? = nil,
         notes: [SessionNote] = [],
-        reviewResult: ReviewLoopResult? = nil
+        reviewResult: ReviewLoopResult? = nil,
+        thinkingMessages: ThinkingMessages = .standard
     ) -> [TranscriptBlock] {
         var blocks: [TranscriptBlock] = []
         var turn: [TurnItem] = []
@@ -580,11 +581,12 @@ enum TranscriptGrouping {
             }
             if isLast { flush(isTrailing: true) }
         }
-        return groupReviewLoops(
+        let grouped = groupReviewLoops(
             place(notes, into: place(walkthrough, into: blocks)),
             live: live,
             result: reviewResult
         )
+        return thinkingMessages.visibleBlocks(grouped)
     }
 
     private enum ReviewBlockRole {

--- a/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
+++ b/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
@@ -111,6 +111,7 @@ struct PreferencesSettingsView: View {
     @AppStorage("os1.composer.busySendMod") private var nativeBusySendMod = "steer"
     @AppStorage("os1.appearance.turnActivity") private var nativeTurnWork = "running"
     @AppStorage("os1.appearance.toolCalls") private var nativeToolCalls = "folded"
+    @AppStorage(ThinkingMessages.storageKey) private var nativeThinkingMessages = "latest"
     @AppStorage("os1.composer.replySuggestions") private var nativeReplySuggestions = true
     @AppStorage("os1.composer.nextChatButton") private var nativeNextChatButton = true
     @AppStorage("os1.transcript.liveTyping") private var nativeLiveTyping = false
@@ -132,6 +133,7 @@ struct PreferencesSettingsView: View {
     @State private var busySendMod: String
     @State private var turnWork: String
     @State private var toolCalls: String
+    @State private var thinkingMessages: String
     @State private var replySuggestions: Bool
     @State private var nextChatButton: Bool
     @State private var liveTyping: Bool
@@ -172,6 +174,9 @@ struct PreferencesSettingsView: View {
             "busy-send-mod": defaults.string(forKey: "os1.composer.busySendMod") ?? "steer",
             "turn-activity": activity.work.rawValue,
             "tool-calls": activity.tools.rawValue,
+            ThinkingMessages.prefKey: ThinkingMessages(
+                defaults.string(forKey: ThinkingMessages.storageKey)
+            ).rawValue,
             "reply-suggestions": (defaults.object(forKey: "os1.composer.replySuggestions") as? Bool ?? true) ? "on" : "off",
             "next-chat-button": (defaults.object(forKey: "os1.composer.nextChatButton") as? Bool ?? true) ? "on" : "off",
             "live-typing": (defaults.object(forKey: "os1.transcript.liveTyping") as? Bool ?? false) ? "on" : "off",
@@ -186,6 +191,9 @@ struct PreferencesSettingsView: View {
         _busySendMod = State(initialValue: seeded["busy-send-mod"] ?? "steer")
         _turnWork = State(initialValue: seeded["turn-activity"] ?? "running")
         _toolCalls = State(initialValue: seeded["tool-calls"] ?? "folded")
+        _thinkingMessages = State(
+            initialValue: seeded[ThinkingMessages.prefKey] ?? ThinkingMessages.standard.rawValue
+        )
         _replySuggestions = State(initialValue: seeded["reply-suggestions"] != "off")
         _nextChatButton = State(initialValue: seeded["next-chat-button"] != "off")
         _liveTyping = State(initialValue: seeded["live-typing"] == "on")
@@ -334,6 +342,11 @@ struct PreferencesSettingsView: View {
                     Text("With updates").tag("running")
                     Text("Open").tag("open")
                 }
+                Picker("Thinking messages", selection: $thinkingMessages) {
+                    Text("None").tag(ThinkingMessages.none.rawValue)
+                    Text("Latest").tag(ThinkingMessages.latest.rawValue)
+                    Text("All").tag(ThinkingMessages.all.rawValue)
+                }
                 Picker("Tool calls", selection: $toolCalls) {
                     Text("Closed").tag("folded")
                     Text("Open").tag("open")
@@ -342,7 +355,7 @@ struct PreferencesSettingsView: View {
             } header: {
                 Text("Transcript")
             } footer: {
-                Text("By default, steps stay open while a turn runs, then close. Closed tool calls stay one tap away. Live typing types the reply out as the model writes it. Off, each part appears when it is finished.")
+                Text("By default, steps stay open while a turn runs, then close. Latest keeps only the newest thinking message. Closed tool calls stay one tap away. Live typing types the reply out as the model writes it. Off, each part appears when it is finished.")
             }
 
             Section {
@@ -378,6 +391,7 @@ struct PreferencesSettingsView: View {
         .onChange(of: busySendMod) { _, _ in commit() }
         .onChange(of: turnWork) { _, _ in commit() }
         .onChange(of: toolCalls) { _, _ in commit() }
+        .onChange(of: thinkingMessages) { _, _ in commit() }
         .onChange(of: replySuggestions) { _, _ in commit() }
         .onChange(of: nextChatButton) { _, _ in commit() }
         .onChange(of: liveTyping) { _, _ in commit() }
@@ -435,6 +449,9 @@ struct PreferencesSettingsView: View {
                 // picker to a default the account never chose.
                 "turn-activity": remoteActivity.work.rawValue,
                 "tool-calls": remoteActivity.tools.rawValue,
+                ThinkingMessages.prefKey: ThinkingMessages(
+                    prefs[ThinkingMessages.prefKey]
+                ).rawValue,
                 "reply-suggestions": (
                     NativePreferences.replySuggestionsEnabled(prefs["reply-suggestions"])
                         ?? replySuggestions
@@ -462,6 +479,9 @@ struct PreferencesSettingsView: View {
             if busySendMod == seededPrefs["busy-send-mod"] { busySendMod = server["busy-send-mod"] ?? busySendMod }
             if turnWork == seededPrefs["turn-activity"] { turnWork = server["turn-activity"] ?? turnWork }
             if toolCalls == seededPrefs["tool-calls"] { toolCalls = server["tool-calls"] ?? toolCalls }
+            if thinkingMessages == seededPrefs[ThinkingMessages.prefKey] {
+                thinkingMessages = server[ThinkingMessages.prefKey] ?? thinkingMessages
+            }
             if (replySuggestions ? "on" : "off") == seededPrefs["reply-suggestions"] {
                 replySuggestions = server["reply-suggestions"] != "off"
             }
@@ -481,6 +501,7 @@ struct PreferencesSettingsView: View {
             nativeBusySendMod = busySendMod
             nativeTurnWork = turnWork
             nativeToolCalls = toolCalls
+            nativeThinkingMessages = thinkingMessages
             nativeReplySuggestions = replySuggestions
             nativeNextChatButton = nextChatButton
             nativeLiveTyping = liveTyping
@@ -583,6 +604,9 @@ struct PreferencesSettingsView: View {
             busySendMod = confirmed["busy-send-mod"] == "queue" ? "queue" : "steer"
             turnWork = TurnActivity.Work(rawValue: confirmed["turn-activity"] ?? "")?.rawValue ?? turnWork
             toolCalls = TurnActivity.Tools(rawValue: confirmed["tool-calls"] ?? "")?.rawValue ?? toolCalls
+            thinkingMessages = ThinkingMessages(
+                confirmed[ThinkingMessages.prefKey] ?? thinkingMessages
+            ).rawValue
             replySuggestions = NativePreferences.replySuggestionsEnabled(
                 confirmed["reply-suggestions"]
             ) ?? replySuggestions
@@ -603,6 +627,7 @@ struct PreferencesSettingsView: View {
             nativeBusySendMod = busySendMod
             nativeTurnWork = turnWork
             nativeToolCalls = toolCalls
+            nativeThinkingMessages = thinkingMessages
             nativeReplySuggestions = replySuggestions
             nativeNextChatButton = nextChatButton
             nativeLiveTyping = liveTyping
@@ -646,6 +671,7 @@ struct PreferencesSettingsView: View {
             "busy-send-mod": busySendMod,
             "turn-activity": turnWork,
             "tool-calls": toolCalls,
+            ThinkingMessages.prefKey: thinkingMessages,
             "reply-suggestions": replySuggestions ? "on" : "off",
             "next-chat-button": nextChatButton ? "on" : "off",
             "live-typing": liveTyping ? "on" : "off",

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -167,6 +167,7 @@ struct SessionView: View {
     /// web.
     @AppStorage("os1.appearance.turnActivity") private var turnWork = "running"
     @AppStorage("os1.appearance.toolCalls") private var toolCalls = "folded"
+    @AppStorage(ThinkingMessages.storageKey) private var thinkingMessages = "latest"
     private var turnActivity: TurnActivity {
         TurnActivity(work: turnWork, tools: toolCalls)
     }
@@ -1002,6 +1003,9 @@ struct SessionView: View {
             .onChange(of: DraftsStore.shared.remoteRevision) {
                 let remote = DraftsStore.shared.mountedText(for: viewModel.session.id)
                 if viewModel.draft != remote { viewModel.draft = remote }
+            }
+            .onChange(of: thinkingMessages, initial: true) { _, value in
+                viewModel.setThinkingMessages(ThinkingMessages(value))
             }
     }
 

--- a/packages/clients/ios/OS1/Views/SubagentView.swift
+++ b/packages/clients/ios/OS1/Views/SubagentView.swift
@@ -14,6 +14,7 @@ struct SubagentView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("os1.appearance.turnActivity") private var turnWork = "running"
     @AppStorage("os1.appearance.toolCalls") private var toolCalls = "folded"
+    @AppStorage(ThinkingMessages.storageKey) private var thinkingMessages = "latest"
     private var turnActivity: TurnActivity {
         TurnActivity(work: turnWork, tools: toolCalls)
     }
@@ -51,7 +52,7 @@ struct SubagentView: View {
                 }
             }
         }
-        .task {
+        .task(id: thinkingMessages) {
             await load()
             // A worker keeps writing while its parent runs; stop as soon as
             // the parent settles rather than polling a finished transcript.
@@ -120,7 +121,8 @@ struct SubagentView: View {
             let next = TranscriptGrouping.blocks(
                 from: TranscriptGrouping.displayItems(from: entries),
                 live: loaded.sessionRunning == true,
-                worktreeDir: worktreeDir
+                worktreeDir: worktreeDir,
+                thinkingMessages: ThinkingMessages(thinkingMessages)
             )
             transcript = loaded
             if next != blocks { blocks = next }

--- a/packages/clients/ios/OS1/Views/WorkflowRunsView.swift
+++ b/packages/clients/ios/OS1/Views/WorkflowRunsView.swift
@@ -414,6 +414,7 @@ private struct WorkflowAgentTranscriptView: View {
 
     @AppStorage("os1.appearance.turnActivity") private var turnWork = "running"
     @AppStorage("os1.appearance.toolCalls") private var toolCalls = "folded"
+    @AppStorage(ThinkingMessages.storageKey) private var thinkingMessages = "latest"
     private var turnActivity: TurnActivity {
         TurnActivity(work: turnWork, tools: toolCalls)
     }
@@ -455,7 +456,7 @@ private struct WorkflowAgentTranscriptView: View {
         .background(OS1VisualStyle.background)
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
-        .task(id: seq) {
+        .task(id: "\(seq):\(thinkingMessages)") {
             await load()
             while !Task.isCancelled, keepsPolling {
                 try? await Task.sleep(for: .seconds(2))
@@ -496,7 +497,8 @@ private struct WorkflowAgentTranscriptView: View {
             let next = TranscriptGrouping.blocks(
                 from: TranscriptGrouping.displayItems(from: transcript.entries),
                 live: keepsPolling,
-                worktreeDir: nil
+                worktreeDir: nil,
+                thinkingMessages: ThinkingMessages(thinkingMessages)
             )
             if next != blocks { blocks = next }
             loaded = true

--- a/packages/clients/ios/OS1Tests/TranscriptGroupingTests.swift
+++ b/packages/clients/ios/OS1Tests/TranscriptGroupingTests.swift
@@ -215,8 +215,18 @@ final class TranscriptGroupingTests: XCTestCase {
             ),
         ]
         let items = TranscriptGrouping.displayItems(from: entries)
-        let live = TranscriptGrouping.blocks(from: items, live: true, worktreeDir: nil)
-        let durable = TranscriptGrouping.blocks(from: items, live: false, worktreeDir: nil)
+        let live = TranscriptGrouping.blocks(
+            from: items,
+            live: true,
+            worktreeDir: nil,
+            thinkingMessages: .all
+        )
+        let durable = TranscriptGrouping.blocks(
+            from: items,
+            live: false,
+            worktreeDir: nil,
+            thinkingMessages: .all
+        )
 
         guard case .work(let liveTurn) = live[1],
               case .work(let durableTurn) = durable[1] else {
@@ -224,6 +234,54 @@ final class TranscriptGroupingTests: XCTestCase {
         }
         XCTAssertEqual(liveTurn.items.map(\.id), ["r1", "tool-t1", "r2"])
         XCTAssertEqual(durableTurn.items.map(\.id), liveTurn.items.map(\.id))
+    }
+
+    func testThinkingMessagePreferenceKeepsOnlyTheLatestByDefault() {
+        let entries = [
+            TranscriptEntry(id: "u1", type: "user", content: "check it"),
+            TranscriptEntry(
+                id: "r1", type: "assistant", content: "**Reading logs**", isReasoning: true
+            ),
+            toolUse("t1", name: "Bash"),
+            TranscriptEntry(
+                id: "r2", type: "assistant", content: "Still comparing.", isReasoning: true
+            ),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Done."),
+        ]
+        let items = TranscriptGrouping.displayItems(from: entries)
+
+        let latest = TranscriptGrouping.blocks(
+            from: items,
+            live: false,
+            worktreeDir: nil,
+            thinkingMessages: .latest
+        )
+        guard case .work(let latestTurn) = latest[1] else {
+            return XCTFail("expected the remaining thinking message inside work")
+        }
+        XCTAssertEqual(latestTurn.items.map(\.id), ["tool-t1", "r2"])
+
+        let none = TranscriptGrouping.blocks(
+            from: items,
+            live: false,
+            worktreeDir: nil,
+            thinkingMessages: .none
+        )
+        guard case .work(let noneTurn) = none[1] else {
+            return XCTFail("expected the tool call to keep the work fold")
+        }
+        XCTAssertEqual(noneTurn.items.map(\.id), ["tool-t1"])
+
+        let all = TranscriptGrouping.blocks(
+            from: items,
+            live: false,
+            worktreeDir: nil,
+            thinkingMessages: .all
+        )
+        guard case .work(let allTurn) = all[1] else {
+            return XCTFail("expected all thinking messages inside work")
+        }
+        XCTAssertEqual(allTurn.items.map(\.id), ["r1", "tool-t1", "r2"])
     }
 
     func testLegacyBoldIntermediateSummaryIsNormalizedButBoldFinalIsNot() {

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -97,7 +97,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   for an edit, the command for a shell call, file content for a write.
   Routine calls fold into one `N steps` run, and consecutive edits to the same
   file into one row — the path once, the summed ±lines, and a `×3` count —
-  both opening to the individual calls.
+  both opening to the individual calls. The shared Thinking messages preference
+  shows none, all, or only the newest provider reasoning row, with Latest as the
+  default.
   Transcript videos stream inline on both platforms. Tool-result screenshots
   and recordings marked as featured stay visible when their work fold closes,
   while incidental media remains inside the producing tool row.

--- a/packages/core/opensession-server/src/agents/github/public-review.test.ts
+++ b/packages/core/opensession-server/src/agents/github/public-review.test.ts
@@ -184,9 +184,11 @@ describe("public PR review policy", () => {
     expect(source.slice(verify, toolLess)).not.toContain(
       'getSandboxProvider("microvm")',
     );
-    expect(daytona).toContain("if (!sbx && !sourceVerification)");
-    expect(daytona).toContain("const template = sourceVerification");
-    expect(daytona).toContain("sourceVerification\n            ? undefined");
+    expect(daytona).toContain("if (!sbx && !disposable)");
+    expect(daytona).toContain("const template = disposable");
+    expect(daytona).toContain(
+      "sbx = await create(\n          disposable\n            ? undefined",
+    );
     expect(daytona).toContain("runLifecycleHooks: !sourceVerification");
     expect(daytona).toContain("await client.delete(sbx, 120)");
     expect(source).toContain("provider.destroy(sandbox.id, { strict: true })");

--- a/packages/core/opensession-server/src/agents/slack/admin-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/admin-tools.ts
@@ -179,7 +179,7 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
       ),
       tool(
         "create_automation",
-        "Create a new automation (routine). Provide a clear prompt describing the task. Set `repo` to the repository it works in, or it runs against the instance default. Use a 5-field UTC cron `schedule` for recurring jobs (omit for manual/webhook only). Pick mode 'ask' for read-only or 'code' if it must edit and commit files. Ordinary automations receive no GitHub credential, so code mode alone cannot push or open a GitHub PR. Optionally restrict tools with mcpServers and set a model.",
+        "Create a new automation (routine). Provide a clear prompt describing the task. Set `repo` to the repository it works in, or it runs against the instance default. Use a 5-field UTC cron `schedule` for recurring jobs (omit for manual/webhook only). Pick mode 'ask' for read-only or 'code' if it must edit and commit files. Ordinary automations receive no GitHub credential, so code mode alone cannot push or open a GitHub PR. Set sandbox true to use a fresh disposable Executor. Sandboxed automations require an explicit mcpServers list, a pinned accountId, a supported model, and a configured qualified provider.",
         {
           name: z.string().describe("Short display name."),
           prompt: z
@@ -202,7 +202,13 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
             .array(z.string())
             .optional()
             .describe(
-              "Optional allowlist of MCP server names this run may use.",
+              "Optional allowlist of MCP server names this run may use. Required with sandbox true; use [] for none.",
+            ),
+          sandbox: z
+            .boolean()
+            .optional()
+            .describe(
+              "Run in a fresh disposable sandbox Executor. Requires a pinned accountId and explicit mcpServers allowlist. Fails closed when no qualified provider is configured.",
             ),
           model: z
             .string()
@@ -254,6 +260,7 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
           mode?: "ask" | "code";
           repo?: string;
           mcpServers?: string[];
+          sandbox?: boolean;
           model?: string;
           accountId?: string;
           accountStrict?: boolean;
@@ -270,6 +277,7 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
             createdBy: ctx.createdBy,
             repo: args.repo,
             mcpServers: args.mcpServers,
+            sandbox: args.sandbox,
             model: args.model,
             accountId: args.accountId,
             accountStrict: args.accountStrict,
@@ -314,12 +322,29 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
             .describe(
               `${repoParamHelp()} '' resets it to the instance default.`,
             ),
-          mcpServers: z.array(z.string()).optional(),
+          mcpServers: z
+            .array(z.string())
+            .optional()
+            .describe(
+              "Explicit MCP allowlist. Required when enabling sandbox; use [] for none.",
+            ),
+          sandbox: z
+            .boolean()
+            .optional()
+            .describe(
+              "Use a fresh disposable sandbox Executor. Set false to return to host runs.",
+            ),
           model: z
             .string()
             .optional()
             .describe(
               "Model id — a tier ('claude-opus-5', 'gpt-5.6-sol') or an engine-prefixed id ('pi/anthropic/claude-opus-5'); '' resets to the default.",
+            ),
+          fallbackModel: z
+            .string()
+            .optional()
+            .describe(
+              "Fallback model id. Sandboxed automations require 'none'.",
             ),
           accountId: z
             .string()
@@ -365,7 +390,9 @@ export function createAdminMcpServer(ctx: AdminToolContext) {
           enabled?: boolean;
           repo?: string;
           mcpServers?: string[];
+          sandbox?: boolean;
           model?: string;
+          fallbackModel?: string;
           accountId?: string;
           accountStrict?: boolean;
           usageCredits?: boolean;

--- a/packages/core/opensession-server/src/frontend/components/Automations.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Automations.tsx
@@ -12,6 +12,7 @@ import {
   draftAutomationApi,
   fetchConnections,
   fetchProviderAccounts,
+  fetchSandboxStatus,
   relativeTime,
   type ModelOption,
   type ProviderAccountOption,
@@ -21,6 +22,7 @@ import {
   type AutomationOutput,
   type AutomationTemplate,
   type AutomationDraft,
+  type SandboxStatusInfo,
 } from "../lib/api";
 import { fetchWorkspaces } from "../lib/api/workspaces";
 import { providerAccountLabel } from "../lib/provider-account";
@@ -53,7 +55,11 @@ import { WorkingPill } from "../ui/status";
 import { Switch } from "../ui/switch";
 import { formatDuration } from "../lib/time";
 import { errorMessage } from "../lib/error-message";
-import { FIELD_LABEL, FORM_ROW } from "../lib/automation-form";
+import {
+  FIELD_LABEL,
+  FORM_ROW,
+  sandboxProviderLabel,
+} from "../lib/automation-form";
 import { AutomationDataFlowEditor } from "./AutomationDataFlowEditor";
 
 /* The old .automation-form family, as utilities. Two of its rules reached in
@@ -133,6 +139,9 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
   const toggleRequest = React.useRef(0);
   const [defaultModel, setDefaultModel] = useState("");
   const [modelLoadError, setModelLoadError] = useState<string | null>(null);
+  const [sandboxStatus, setSandboxStatus] = useState<SandboxStatusInfo | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const {
     accounts: providerAccounts,
@@ -146,6 +155,9 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
       .catch((cause: unknown) =>
         setModelLoadError(errorMessage(cause, "Could not load models")),
       );
+    fetchSandboxStatus(getCurrentUser())
+      .then(setSandboxStatus)
+      .catch(() => setSandboxStatus(null));
   }, []);
   // The modal is create-only; editing happens inline in the detail drawer.
   const [showModal, setShowModal] = useState(false);
@@ -587,16 +599,22 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
 
                     <DetailKey>Mode</DetailKey>
                     <span className="text-dim">
-                      {sel.sandbox
-                        ? "Unavailable legacy sandbox configuration"
-                        : sel.mode === "ask"
-                          ? "Ask · read-only on the main checkout"
+                      {sel.mode === "ask"
+                        ? sel.sandbox
+                          ? "Ask · disposable Sandbox workspace"
+                          : "Ask · read-only on the main checkout"
+                        : sel.sandbox
+                          ? "Code · disposable Sandbox workspace"
                           : "Code · isolated worktree, can open PRs"}
                     </span>
 
                     <DetailKey>Environment</DetailKey>
                     <span className="text-dim">
-                      {sel.sandbox ? "Unavailable" : "Host worktree"}
+                      {sel.sandbox
+                        ? sandboxStatus?.automation?.available
+                          ? `${sandboxProviderLabel(sandboxStatus.automation.provider)} · fresh disposable Executor`
+                          : `Sandbox unavailable${sandboxStatus?.automation?.reason ? ` · ${sandboxStatus.automation.reason}` : ""}`
+                        : "Host worktree"}
                     </span>
 
                     <DetailKey>Model</DetailKey>
@@ -1496,7 +1514,13 @@ function AutomationForm({
     initial?.accountStrict !== false,
   );
   const [usageCredits, setUsageCredits] = useState(!!initial?.usageCredits);
-  const sandbox = false;
+  const [sandbox, setSandbox] = useState(!!initial?.sandbox);
+  const [sandboxAvailability, setSandboxAvailability] = useState<
+    SandboxStatusInfo["automation"] | null
+  >(null);
+  const [sandboxProviders, setSandboxProviders] = useState<
+    SandboxStatusInfo["providers"]
+  >([]);
   const [models, setModels] = useState<ModelOption[]>([]);
   const [defaultModel, setDefaultModel] = useState("");
   const [modelLoadError, setModelLoadError] = useState<string | null>(null);
@@ -1522,6 +1546,27 @@ function AutomationForm({
       onError: (cause) =>
         setWorkspaceLoadError(errorMessage(cause, "Could not load workspaces")),
     }).then(setWorkspaces);
+    fetchSandboxStatus(getCurrentUser())
+      .then((status) => {
+        setSandboxProviders(status.providers);
+        setSandboxAvailability(
+          status.automation || {
+            provider: "daytona",
+            available: false,
+            reason: "The server does not support sandbox automations yet.",
+          },
+        );
+      })
+      .catch((cause: unknown) =>
+        setSandboxAvailability({
+          provider: "daytona",
+          available: false,
+          reason: errorMessage(
+            cause,
+            "Could not check sandbox automation availability",
+          ),
+        }),
+      );
   }, []);
   const effectiveModel = model || defaultModel;
   const accountProvider = models.find(
@@ -1773,7 +1818,7 @@ function AutomationForm({
       </div>
 
       {showAdvanced && (
-        <div className={FORM_ROW}>
+        <div className={cn(FORM_ROW, "desktop:flex-wrap")}>
           <label className={FIELD_LABEL}>
             Mode
             <Select
@@ -1783,6 +1828,46 @@ function AutomationForm({
               <option value="ask">Ask · read-only on main</option>
               <option value="code">Code · fresh worktree per run</option>
             </Select>
+          </label>
+
+          <label
+            className={cn(FIELD_LABEL, "desktop:w-full desktop:flex-none")}
+          >
+            Execution environment
+            <Select
+              value={sandbox ? "daytona" : ""}
+              onChange={(event) => {
+                const checked = event.target.value === "daytona";
+                setSandbox(checked);
+                if (checked) {
+                  setAccountStrict(true);
+                  setFallbackModel("");
+                  setMcpServers((current) => current ?? []);
+                }
+              }}
+            >
+              <option value="">Host worktree</option>
+              <option
+                value="daytona"
+                disabled={!sandbox && !sandboxAvailability?.available}
+              >
+                Daytona
+                {sandboxAvailability?.available ? "" : " · unavailable"}
+              </option>
+              {sandboxProviders
+                .filter((provider) => provider.id !== "daytona")
+                .map((provider) => (
+                  <option key={provider.id} value={provider.id} disabled>
+                    {sandboxProviderLabel(provider.id)} · unavailable for
+                    automations
+                  </option>
+                ))}
+            </Select>
+            <span className="mt-1 text-supporting leading-snug text-faint">
+              {sandboxAvailability?.available
+                ? "Daytona uses a fresh disposable Executor with pinned credentials and restricted network access."
+                : sandboxAvailability?.reason || "Checking availability"}
+            </span>
           </label>
 
           <label className={FIELD_LABEL}>
@@ -1920,7 +2005,7 @@ function AutomationForm({
             !prompt.trim() ||
             !scheduleValid ||
             !watchValid ||
-            (sandbox && !accountId)
+            (sandbox && (!accountId || sandboxAvailability?.available !== true))
           }
         >
           {saving ? "Saving…" : initial ? "Save changes" : "Create automation"}

--- a/packages/core/opensession-server/src/frontend/components/Automations.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Automations.tsx
@@ -12,6 +12,7 @@ import {
   draftAutomationApi,
   fetchConnections,
   fetchProviderAccounts,
+  fetchSandboxStatus,
   relativeTime,
   type ModelOption,
   type ProviderAccountOption,
@@ -133,6 +134,10 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
   const toggleRequest = React.useRef(0);
   const [defaultModel, setDefaultModel] = useState("");
   const [modelLoadError, setModelLoadError] = useState<string | null>(null);
+  const [sandboxAvailability, setSandboxAvailability] = useState<{
+    available: boolean;
+    reason?: string;
+  } | null>(null);
   const [loading, setLoading] = useState(true);
   const {
     accounts: providerAccounts,
@@ -146,6 +151,9 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
       .catch((cause: unknown) =>
         setModelLoadError(errorMessage(cause, "Could not load models")),
       );
+    fetchSandboxStatus(getCurrentUser())
+      .then((status) => setSandboxAvailability(status.automation || null))
+      .catch(() => setSandboxAvailability(null));
   }, []);
   // The modal is create-only; editing happens inline in the detail drawer.
   const [showModal, setShowModal] = useState(false);
@@ -587,16 +595,22 @@ export function Automations({ onOpenSession, selectedId, onSelect }: Props) {
 
                     <DetailKey>Mode</DetailKey>
                     <span className="text-dim">
-                      {sel.sandbox
-                        ? "Unavailable legacy sandbox configuration"
-                        : sel.mode === "ask"
-                          ? "Ask · read-only on the main checkout"
+                      {sel.mode === "ask"
+                        ? sel.sandbox
+                          ? "Ask · disposable Sandbox workspace"
+                          : "Ask · read-only on the main checkout"
+                        : sel.sandbox
+                          ? "Code · disposable Sandbox workspace"
                           : "Code · isolated worktree, can open PRs"}
                     </span>
 
                     <DetailKey>Environment</DetailKey>
                     <span className="text-dim">
-                      {sel.sandbox ? "Unavailable" : "Host worktree"}
+                      {sel.sandbox
+                        ? sandboxAvailability?.available
+                          ? "Sandbox · fresh disposable Executor"
+                          : `Sandbox unavailable${sandboxAvailability?.reason ? ` · ${sandboxAvailability.reason}` : ""}`
+                        : "Host worktree"}
                     </span>
 
                     <DetailKey>Model</DetailKey>
@@ -1496,7 +1510,11 @@ function AutomationForm({
     initial?.accountStrict !== false,
   );
   const [usageCredits, setUsageCredits] = useState(!!initial?.usageCredits);
-  const sandbox = false;
+  const [sandbox, setSandbox] = useState(!!initial?.sandbox);
+  const [sandboxAvailability, setSandboxAvailability] = useState<{
+    available: boolean;
+    reason?: string;
+  } | null>(null);
   const [models, setModels] = useState<ModelOption[]>([]);
   const [defaultModel, setDefaultModel] = useState("");
   const [modelLoadError, setModelLoadError] = useState<string | null>(null);
@@ -1522,6 +1540,24 @@ function AutomationForm({
       onError: (cause) =>
         setWorkspaceLoadError(errorMessage(cause, "Could not load workspaces")),
     }).then(setWorkspaces);
+    fetchSandboxStatus(getCurrentUser())
+      .then((status) =>
+        setSandboxAvailability(
+          status.automation || {
+            available: false,
+            reason: "The server does not support sandbox automations yet.",
+          },
+        ),
+      )
+      .catch((cause: unknown) =>
+        setSandboxAvailability({
+          available: false,
+          reason: errorMessage(
+            cause,
+            "Could not check sandbox automation availability",
+          ),
+        }),
+      );
   }, []);
   const effectiveModel = model || defaultModel;
   const accountProvider = models.find(
@@ -1773,7 +1809,7 @@ function AutomationForm({
       </div>
 
       {showAdvanced && (
-        <div className={FORM_ROW}>
+        <div className={cn(FORM_ROW, "desktop:flex-wrap")}>
           <label className={FIELD_LABEL}>
             Mode
             <Select
@@ -1783,6 +1819,30 @@ function AutomationForm({
               <option value="ask">Ask · read-only on main</option>
               <option value="code">Code · fresh worktree per run</option>
             </Select>
+          </label>
+
+          <label className="flex min-h-11 flex-1 items-center justify-between gap-3 pb-1 text-label font-medium text-dim phone:items-start desktop:w-full desktop:flex-none">
+            <span className="flex flex-col gap-1">
+              <span>Run in a Sandbox</span>
+              <span className="font-normal text-faint">
+                {sandboxAvailability?.available
+                  ? "Fresh disposable Executor with pinned credentials and restricted network"
+                  : sandboxAvailability?.reason || "Checking availability"}
+              </span>
+            </span>
+            <Switch
+              checked={sandbox}
+              disabled={!sandbox && !sandboxAvailability?.available}
+              onCheckedChange={(checked) => {
+                setSandbox(checked);
+                if (checked) {
+                  setAccountStrict(true);
+                  setFallbackModel("");
+                  setMcpServers((current) => current ?? []);
+                }
+              }}
+              aria-label="Run this automation in a Sandbox"
+            />
           </label>
 
           <label className={FIELD_LABEL}>
@@ -1920,7 +1980,7 @@ function AutomationForm({
             !prompt.trim() ||
             !scheduleValid ||
             !watchValid ||
-            (sandbox && !accountId)
+            (sandbox && (!accountId || sandboxAvailability?.available !== true))
           }
         >
           {saving ? "Saving…" : initial ? "Save changes" : "Create automation"}

--- a/packages/core/opensession-server/src/frontend/components/ModelProviders.tsx
+++ b/packages/core/opensession-server/src/frontend/components/ModelProviders.tsx
@@ -21,8 +21,9 @@ import {
   settingsInputClass,
 } from "../ui/settings";
 import { Menu } from "../ui/menu";
+import { Checkbox } from "../ui/checkbox";
 import { IconTile } from "./BrandTile";
-import { IconDotsHorizontal, IconPlus, IconTrash } from "./icons";
+import { IconDotsHorizontal, IconPlus, IconSearch, IconTrash } from "./icons";
 import { errorMessage } from "../lib/error-message";
 
 // Settings → Model providers: third-party Pi providers (xai, openrouter,
@@ -35,6 +36,15 @@ interface ProviderInfo {
   id: string;
   apiKeyMasked: string;
   baseURL?: string;
+  /** Set when the id is a custom OpenAI-compatible gateway rather than a
+   *  slug Pi already knows. */
+  api?: string;
+  name?: string;
+  discoverModels?: boolean;
+  discoveredAt?: string;
+  catalogFile?: string;
+  /** Rows in the operator catalog (inline, file, or discovered). */
+  catalogModels: number;
   /** Full picker ids (pi/<provider>/<model>) registered for it. */
   models: string[];
 }
@@ -74,6 +84,25 @@ export function ModelProvidersPanel() {
   useEffect(() => {
     load();
   }, [load]);
+
+  async function handleDiscover(p: ProviderInfo) {
+    await (async () => {
+      const res = await fetch(
+        `${BASE_PATH}/api/settings/model-providers/${encodeURIComponent(p.id)}/discover`,
+        { method: "POST" },
+      );
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
+      toast(
+        `${body.models.length} models listed, ${body.added} added to the picker`,
+      );
+      load();
+    })().catch(async (error) => {
+      toast(errorMessage(error, "Failed to discover models"), {
+        variant: "error",
+      });
+    });
+  }
 
   async function handleRemove(p: ProviderInfo) {
     if (
@@ -139,10 +168,21 @@ export function ModelProvidersPanel() {
             <SettingRow key={p.id} className="items-start gap-x-3">
               <IconTile name={p.id} size={28} />
               <SettingRowText>
-                <SettingRowTitle>{p.id}</SettingRowTitle>
+                <SettingRowTitle>
+                  {p.name || p.id}
+                  {p.name && (
+                    <span className="ml-1.5 text-meta text-faint">{p.id}</span>
+                  )}
+                </SettingRowTitle>
                 <SettingRowDescription className="truncate">
                   {p.apiKeyMasked || "no API key stored"}
                   {p.baseURL && ` · ${p.baseURL}`}
+                  {p.api && " · OpenAI-compatible"}
+                  {p.catalogModels > 0 &&
+                    ` · ${p.catalogModels} catalog ${
+                      p.catalogModels === 1 ? "row" : "rows"
+                    }`}
+                  {p.discoverModels && " · discovery on"}
                 </SettingRowDescription>
                 {p.models.length > 0 ? (
                   <div className="mt-1.5 flex flex-wrap gap-1">
@@ -172,6 +212,12 @@ export function ModelProvidersPanel() {
                     <IconDotsHorizontal size={18} />
                   </Menu.Trigger>
                   <Menu.Popup align="end" sideOffset={4}>
+                    {p.baseURL && (
+                      <Menu.Item onClick={() => handleDiscover(p)}>
+                        <IconSearch size={16} />
+                        Discover models
+                      </Menu.Item>
+                    )}
                     <Menu.Item
                       onClick={() => handleRemove(p)}
                       className="text-red data-[highlighted]:bg-red-soft"
@@ -189,11 +235,13 @@ export function ModelProvidersPanel() {
 
       <SettingsHint>
         Any provider the Pi engine supports (xAI, OpenRouter, Groq, Mistral, …)
-        with your API key. Keys are stored on the server (0600) and only ever
-        shown masked. Changes apply to new session runs immediately, and saved
-        models appear in the picker without a restart. To update a provider, add
-        it again with the same id. The key, base URL and model list are
-        replaced.
+        with your API key, or any OpenAI-compatible gateway with its base URL.
+        Keys are stored on the server (0600) and only ever shown masked. Changes
+        apply to new session runs immediately, and saved models appear in the
+        picker without a restart. To update a provider, add it again with the
+        same id. The key, base URL and model list are replaced. Discover models
+        reads the gateway's model list into the picker. Per-model limits and
+        pricing come from a catalog in model-providers.json.
       </SettingsHint>
     </>
   );
@@ -210,11 +258,15 @@ function AddProviderForm({
   const [apiKey, setApiKey] = useState("");
   const [baseURL, setBaseURL] = useState("");
   const [models, setModels] = useState("");
+  const [custom, setCustom] = useState(false);
+  const [name, setName] = useState("");
+  const [discover, setDiscover] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const cleanId = id.trim().toLowerCase();
   const idValid = /^[a-z0-9-]+$/.test(cleanId);
+  const needsBaseURL = (custom || discover) && !baseURL.trim();
 
   async function handleSave() {
     setSaving(true);
@@ -234,12 +286,23 @@ function AddProviderForm({
             ...(apiKey.trim() ? { apiKey: apiKey.replace(/\s+/g, "") } : {}),
             ...(baseURL.trim() ? { baseURL: baseURL.trim() } : {}),
             ...(modelIds.length ? { models: modelIds } : {}),
+            api: custom ? "openai-completions" : "",
+            ...(name.trim() ? { name: name.trim() } : {}),
+            discoverModels: discover,
           }),
         },
       );
       const body = await res.json();
       if (!res.ok) throw new Error(body.error || `Failed: ${res.status}`);
-      toast(`Provider ${cleanId} saved`);
+      if (body.discoveryError) {
+        toast(`Provider ${cleanId} saved. ${body.discoveryError}`, {
+          variant: "error",
+        });
+      } else if (body.discovery) {
+        toast(
+          `Provider ${cleanId} saved, ${body.discovery.models.length} models discovered`,
+        );
+      } else toast(`Provider ${cleanId} saved`);
       onSaved();
     })().catch(async (error) => {
       setError(errorMessage(error, "Failed to save provider"));
@@ -251,10 +314,10 @@ function AddProviderForm({
     <SettingsForm>
       <SettingsFormTitle>Add provider</SettingsFormTitle>
       <SettingRowDescription className="-mt-2 mb-3">
-        The provider id must match pi's slug for it (xai, openrouter, groq, …).
-        Models are registered in the picker as{" "}
-        <code>pi/&lt;provider&gt;/&lt;model&gt;</code>. List the provider's own
-        model ids, e.g. <code>grok-4</code> for xai.
+        Use pi's slug for a known provider (xai, openrouter, groq, …), or any id
+        with a base URL for an OpenAI-compatible gateway. Models are registered
+        in the picker as <code>pi/&lt;provider&gt;/&lt;model&gt;</code>. List
+        the provider's own model ids, e.g. <code>grok-4</code> for xai.
       </SettingRowDescription>
 
       <SettingsFormRow>
@@ -307,6 +370,37 @@ function AddProviderForm({
         </SettingsField>
       </SettingsFormRow>
 
+      <SettingsFormRow>
+        <SettingsField>
+          Display name (optional)
+          <input
+            className={settingsInputClass}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My gateway"
+          />
+        </SettingsField>
+        <div className="flex flex-col justify-end gap-2 pb-1.5">
+          <label className="flex cursor-pointer items-center gap-2 text-label">
+            <Checkbox
+              checked={custom}
+              onCheckedChange={(v) => setCustom(v === true)}
+            />
+            OpenAI-compatible gateway (id not known to pi)
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-label">
+            <Checkbox
+              checked={discover}
+              onCheckedChange={(v) => setDiscover(v === true)}
+            />
+            Discover models from /v1/models on save
+          </label>
+        </div>
+      </SettingsFormRow>
+      {needsBaseURL && (
+        <SettingsHint>A base URL is required for these options.</SettingsHint>
+      )}
+
       {error && <InlineAlert>{error}</InlineAlert>}
 
       <SettingsFormActions>
@@ -316,7 +410,9 @@ function AddProviderForm({
         <Button
           variant="primary"
           onClick={handleSave}
-          disabled={saving || !cleanId || !idValid || !apiKey.trim()}
+          disabled={
+            saving || !cleanId || !idValid || !apiKey.trim() || needsBaseURL
+          }
         >
           {saving ? "Saving…" : "Save provider"}
         </Button>

--- a/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SetupRepos.tsx
@@ -7,6 +7,7 @@ import { Segmented, SegmentedOption } from "../ui/segmented";
 import { Switch } from "../ui/switch";
 import { Menu } from "../ui/menu";
 import { cn } from "../ui/cn";
+import { OptionSelect } from "../ui/select";
 import { EmptyState, InlineAlert, LoadingState } from "../ui/state";
 import { Spinner } from "../ui/spinner";
 import {
@@ -711,11 +712,38 @@ function LetterTile({ id, color }: { id: string; color?: string }) {
   );
 }
 
+/** One account the workspace GitHub App is installed on. `selected` marks the
+ * installation the configured owner pins, the one whose repos are listed. */
+interface BrowseInstallation {
+  login: string;
+  type?: string;
+  selected?: boolean;
+}
+
 interface BrowseResult {
   source: "user" | "app" | null;
   repos: BrowseRepo[];
   appConfigured?: boolean;
   appInstallUrl?: string | null;
+  /** The configured installation owner, when the App identity can answer. */
+  installationOwner?: string | null;
+  /** Every account the App is installed on, so the picker can offer a switch
+   * when the App is installed beyond the pinned owner (repos alone cannot
+   * reveal that). Absent when the App identity cannot list them. */
+  installations?: BrowseInstallation[];
+}
+
+/** Explains an empty App installation instead of a bare "No repositories
+ * match.", which reads as a filter miss. */
+export function emptyAppInstallationMessage(browse: {
+  installationOwner?: string | null;
+  installations?: BrowseInstallation[];
+}): string {
+  const owner = browse.installationOwner;
+  if ((browse.installations?.length ?? 0) > 1) {
+    return `This installation${owner ? ` (${owner})` : ""} can’t see any repositories. Switch installations above, or grant the App repository access on GitHub.`;
+  }
+  return `The App installation${owner ? ` for ${owner}` : ""} can’t see any repositories yet. Grant it repository access on GitHub, then reopen this window.`;
 }
 
 /** GET /api/setup/codestorage/repos — `source: null` when the code.storage
@@ -942,6 +970,10 @@ function RemoteRepoPicker({
   const [filter, setFilter] = useState("");
   const [added, setAdded] = useState<ReadonlySet<string>>(new Set());
   const [manual, setManual] = useState("");
+  // Repinning the App installation (below) is a config write plus a refetch;
+  // both gate the switcher so a slow answer can't interleave two switches.
+  const [switching, setSwitching] = useState(false);
+  const [switchError, setSwitchError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -982,6 +1014,27 @@ function RemoteRepoPicker({
     if (active && (browse || browseFailed)) inputRef?.current?.focus();
   }, [active, browse, browseFailed, inputRef]);
 
+  /** Pin a different App installation and refetch the repo list it can see.
+   * PUT /api/setup/github applies live, so no restart stands between
+   * switching and browsing. */
+  async function selectInstallation(login: string) {
+    if (switching) return;
+    setSwitching(true);
+    setSwitchError(null);
+    try {
+      await setupRequest("/api/setup/github", {
+        method: "PUT",
+        json: { installationOwner: login },
+      });
+      const body = await setupRequest<BrowseResult>("/api/setup/github/repos");
+      setBrowse(body);
+      setBrowseFailed(false);
+    } catch (e) {
+      setSwitchError(errorMessage(e, "Couldn’t switch the installation."));
+    }
+    setSwitching(false);
+  }
+
   async function addRepo(fullName: string, source: RepoSource = "github") {
     const key = `${source}:${fullName}`;
     await registerRepo({
@@ -1003,6 +1056,11 @@ function RemoteRepoPicker({
   const totalListed =
     (browse?.source ? browse.repos.length : 0) +
     (csConfigured ? (csBrowse?.repos.length ?? 0) : 0);
+  const installations = browse?.installations ?? [];
+  const selectedInstallation =
+    installations.find((installation) => installation.selected)?.login ??
+    browse?.installationOwner ??
+    "";
 
   return (
     <>
@@ -1012,6 +1070,28 @@ function RemoteRepoPicker({
         </LoadingState>
       ) : browse && browse.source !== null ? (
         <>
+          {browse.source === "app" && installations.length > 1 && (
+            <div className="mb-2 flex items-center gap-2">
+              <span className="shrink-0 text-supporting text-dim">
+                Installation
+              </span>
+              <OptionSelect
+                className="min-w-0 flex-1"
+                size="sm"
+                label="GitHub App installation"
+                value={selectedInstallation}
+                options={installations.map((installation) => ({
+                  value: installation.login,
+                  label: installation.login,
+                }))}
+                onChange={(login) => void selectInstallation(login)}
+                disabled={switching}
+              />
+            </div>
+          )}
+          {switchError && (
+            <InlineAlert className="mb-2">{switchError}</InlineAlert>
+          )}
           <input
             ref={inputRef}
             className={settingsInputClass}
@@ -1029,7 +1109,9 @@ function RemoteRepoPicker({
           <div className="mt-2 max-h-[320px] overflow-y-auto">
             {filtered.length === 0 ? (
               <EmptyState placement="row" className="px-1">
-                No repositories match.
+                {browse.repos.length > 0 || browse.source !== "app"
+                  ? "No repositories match."
+                  : emptyAppInstallationMessage(browse)}
               </EmptyState>
             ) : (
               filtered.map((r) => (
@@ -1056,11 +1138,26 @@ function RemoteRepoPicker({
             {browseFailed ? (
               <>Couldn&rsquo;t load the GitHub repo list right now.</>
             ) : browse?.appConfigured ? (
-              <>
-                The GitHub App installation isn&rsquo;t available yet. Check
-                that Installation owner matches the account where the App is
-                installed, then reopen this window.
-              </>
+              installations.length > 0 ? (
+                <>
+                  The App is installed on{" "}
+                  {installations
+                    .map((installation) => installation.login)
+                    .join(", ")}
+                  , but the configured installation owner
+                  {browse.installationOwner
+                    ? ` (${browse.installationOwner})`
+                    : ""}{" "}
+                  doesn&rsquo;t match any of them. Pick the installation to
+                  browse:
+                </>
+              ) : (
+                <>
+                  The GitHub App installation isn&rsquo;t available yet. Check
+                  that Installation owner matches the account where the App is
+                  installed, then reopen this window.
+                </>
+              )
             ) : (
               <>
                 No GitHub credential yet, so the repo list can&rsquo;t be
@@ -1072,6 +1169,22 @@ function RemoteRepoPicker({
             )}{" "}
             You can still register a repo by name:
           </div>
+          {browse?.appConfigured && installations.length > 0 && (
+            <div className="mt-2.5 flex flex-wrap items-center gap-2">
+              {installations.map((installation) => (
+                <Button
+                  key={installation.login}
+                  disabled={switching}
+                  onClick={() => void selectInstallation(installation.login)}
+                >
+                  {installation.login}
+                </Button>
+              ))}
+            </div>
+          )}
+          {switchError && (
+            <InlineAlert className="mt-2">{switchError}</InlineAlert>
+          )}
           {browse?.appConfigured && browse.appInstallUrl && (
             <Button
               className="mt-2.5"

--- a/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.test-setup.ts
+++ b/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.test-setup.ts
@@ -28,17 +28,26 @@ Object.assign(
   },
 );
 
-/** The two transcript preferences as the browser store holds them: whether a
- *  turn's work shows, and whether that includes its tool calls. Absent is the
- *  default (work "running", tool calls "folded"); an old single value in the
- *  work key still answers both. */
+let turnWork: string | null = null;
+let toolCalls: string | null = null;
+let thinkingMessages: string | null = null;
+
+(
+  globalThis.localStorage as { getItem: (key: string) => string | null }
+).getItem = (key) => {
+  if (key === "opensession-turn-activity") return turnWork;
+  if (key === "opensession-tool-calls") return toolCalls;
+  if (key === "opensession-thinking-messages") return thinkingMessages;
+  return null;
+};
+
+/** The two work preferences as the browser store holds them. */
 export function setTurnPrefs(work: string | null, tools: string | null = null) {
-  (
-    globalThis.localStorage as { getItem: (key: string) => string | null }
-  ).getItem = (key) =>
-    key === "opensession-turn-activity"
-      ? work
-      : key === "opensession-tool-calls"
-        ? tools
-        : null;
+  turnWork = work;
+  toolCalls = tools;
+}
+
+/** Which provider thinking rows the transcript keeps on screen. */
+export function setThinkingMessagesPref(value: string | null) {
+  thinkingMessages = value;
 }

--- a/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { TranscriptEntry } from "../lib/types";
-import { setTurnPrefs } from "./TranscriptBlocks.test-setup";
+import {
+  setThinkingMessagesPref,
+  setTurnPrefs,
+} from "./TranscriptBlocks.test-setup";
 
 const { TranscriptBlocks } = await import("./TranscriptBlocks");
 
@@ -876,6 +879,7 @@ describe("TranscriptBlocks turn work and tool call preferences", () => {
   });
 
   test("coalesces consecutive reasoning revisions into their latest visible step", () => {
+    setThinkingMessagesPref("all");
     const entries: TranscriptEntry[] = [
       {
         id: "prompt",
@@ -930,6 +934,7 @@ describe("TranscriptBlocks turn work and tool call preferences", () => {
     expect(html).toContain("Checking deployment status");
     expect(html).toContain("Verifying the release");
     setTurnPrefs(null);
+    setThinkingMessagesPref(null);
   });
 
   test("repairs fragmented reasoning inside open work", () => {
@@ -992,6 +997,7 @@ describe("TranscriptBlocks turn work and tool call preferences", () => {
   });
 
   test("keeps reasoning quiet inside one work disclosure", () => {
+    setThinkingMessagesPref("all");
     const entries: TranscriptEntry[] = [
       {
         id: "prompt",
@@ -1095,6 +1101,66 @@ describe("TranscriptBlocks turn work and tool call preferences", () => {
     );
     expect(proseReasoning).toContain('data-text-shimmer=""');
     setTurnPrefs(null);
+    setThinkingMessagesPref(null);
+  });
+
+  test("shows only the newest thinking message by default", () => {
+    setTurnPrefs("open", "folded");
+    const entries: TranscriptEntry[] = [
+      {
+        id: "prompt",
+        type: "user",
+        content: "Check it",
+        timestamp: "2026-08-28T08:00:00Z",
+      },
+      {
+        id: "reasoning-1",
+        type: "assistant",
+        content: "**Reading the current state**",
+        isReasoning: true,
+        timestamp: "2026-08-28T08:00:01Z",
+      },
+      {
+        id: "tool",
+        type: "tool_use",
+        toolUseId: "tool-call",
+        toolName: "bash",
+        content: "Using bash",
+        timestamp: "2026-08-28T08:00:02Z",
+      },
+      {
+        id: "reasoning-2",
+        type: "assistant",
+        content: "**Verifying the result**",
+        isReasoning: true,
+        timestamp: "2026-08-28T08:00:03Z",
+      },
+      {
+        id: "answer",
+        type: "assistant",
+        content: "Done.",
+        timestamp: "2026-08-28T08:00:04Z",
+      },
+    ];
+
+    const latest = renderToStaticMarkup(<TranscriptBlocks entries={entries} />);
+    expect(latest).not.toContain("Reading the current state");
+    expect(latest).toContain("Verifying the result");
+    expect(latest.match(/data-reasoning=""/g)).toHaveLength(1);
+
+    setThinkingMessagesPref("none");
+    const none = renderToStaticMarkup(<TranscriptBlocks entries={entries} />);
+    expect(none).not.toContain('data-reasoning=""');
+    expect(none).not.toContain("Verifying the result");
+
+    setThinkingMessagesPref("all");
+    const all = renderToStaticMarkup(<TranscriptBlocks entries={entries} />);
+    expect(all).toContain("Reading the current state");
+    expect(all).toContain("Verifying the result");
+    expect(all.match(/data-reasoning=""/g)).toHaveLength(2);
+
+    setTurnPrefs(null);
+    setThinkingMessagesPref(null);
   });
 });
 

--- a/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.tsx
+++ b/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.tsx
@@ -10,7 +10,6 @@ import {
   type TranscriptIndexedRange,
 } from "../lib/transcript-index";
 import {
-  shouldAnimateTranscriptEntryPosition,
   transcriptArrivalAliases,
   transcriptEntryMountKey,
   turnMountKey,
@@ -47,7 +46,6 @@ import {
 } from "./ShippedChangeComposer";
 import { SessionContextMessage } from "./SessionContextMessage";
 import {
-  transcriptRangeHasLoadedSuffix,
   transcriptRangesContainPayload,
   visibleTranscriptHydrationDemand,
 } from "./session-viewer/transcript-hydration";
@@ -864,16 +862,6 @@ function IndexedTranscriptBlocks(props: Props) {
   const firstRenderedRangeKey = firstRenderedRange
     ? indexedItemKey(firstRenderedRange.item, firstRenderedRange.index)
     : null;
-  const firstRenderedRangeIds = firstRenderedRange
-    ? indexedItemEntryIds(firstRenderedRange.item)
-    : [];
-  const firstRenderedRangeLoaded = firstRenderedRangeIds.filter((id) =>
-    payloadById.has(id),
-  ).length;
-  const firstRenderedRangeIsPartialSuffix = transcriptRangeHasLoadedSuffix(
-    firstRenderedRangeIds,
-    (id) => payloadById.has(id),
-  );
   // Fired when the reader nears the top of the mounted window: collect the
   // next batch of missing ranges walking backwards from the window's head.
   // Start AT the head because the bounded opening payload can begin partway
@@ -957,9 +945,6 @@ function IndexedTranscriptBlocks(props: Props) {
         // it must not slide settled work or runner notices below it. Loose
         // entries are the live/optimistic atoms outside those durable ranges.
         animateArrival: item.kind === "entry",
-        animatePositionChanges:
-          item.kind === "entry" &&
-          shouldAnimateTranscriptEntryPosition(item.entry),
         estimateSize,
         measure: true,
         content:
@@ -1019,10 +1004,6 @@ function IndexedTranscriptBlocks(props: Props) {
       onLayout={props.onLayout}
       onTopApproach={handleTopApproach}
       topApproachGeneration={props.transcriptRangeRetryGeneration}
-      topGrowthKey={firstRenderedRangeKey}
-      topGrowthVersion={
-        firstRenderedRangeIsPartialSuffix ? firstRenderedRangeLoaded : undefined
-      }
       onVisibleItems={(visible) => {
         const wanted = visibleTranscriptHydrationDemand(
           hydrationOutline,

--- a/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.tsx
+++ b/packages/core/opensession-server/src/frontend/components/TranscriptBlocks.tsx
@@ -52,6 +52,13 @@ import {
   visibleTranscriptHydrationDemand,
 } from "./session-viewer/transcript-hydration";
 import { isLegacyReasoningHeading } from "../lib/reasoning-display";
+import {
+  getThinkingMessagesPref,
+  onThinkingMessagesChanged,
+  thinkingMessageIsVisible,
+  thinkingMessageVisibility,
+  type ThinkingMessageVisibility,
+} from "../lib/thinking-messages-pref";
 
 type RenderBlock =
   | { kind: "entry"; entry: TranscriptEntry; reasoning?: boolean }
@@ -126,6 +133,9 @@ interface Props {
   virtualize?: boolean;
   /** Stable outer range identity for the one work turn rendered inside it. */
   turnMountScope?: string;
+  /** Resolved once against the full loaded payload, then shared with indexed
+   * range renderers so "Latest" means one row across the whole transcript. */
+  thinkingVisibility?: ThinkingMessageVisibility;
 }
 
 type ReviewBlockRole =
@@ -299,8 +309,21 @@ export const TranscriptBlocks = function TranscriptBlocks(props: Props) {
   const entries = props.optimisticEntries?.length
     ? mergeOptimisticTranscriptEntries(props.entries, props.optimisticEntries)
     : props.entries;
-  const renderedProps =
-    entries === props.entries ? props : { ...props, entries };
+  const [thinkingMessages, setThinkingMessages] = React.useState(
+    getThinkingMessagesPref,
+  );
+  useEffect(
+    () =>
+      onThinkingMessagesChanged(() =>
+        setThinkingMessages(getThinkingMessagesPref()),
+      ),
+    [],
+  );
+  const renderedProps: Props = {
+    ...props,
+    entries,
+    thinkingVisibility: thinkingMessageVisibility(entries, thinkingMessages),
+  };
   return (
     <>
       {props.sessionId && <SessionContextMessage sessionId={props.sessionId} />}
@@ -336,6 +359,7 @@ const LoadedTranscriptBlocks = function LoadedTranscriptBlocks({
   scrollElement,
   shouldMaintainEnd,
   onLayout,
+  thinkingVisibility,
 }: Props) {
   // Top level only (nested per-range instances pass virtualize={false} and are
   // suppressed): without an outline every block renders real content, so the
@@ -352,7 +376,11 @@ const LoadedTranscriptBlocks = function LoadedTranscriptBlocks({
   const pendingDeliveryEntryIds = new Set(pendingDeliveryIds ?? []);
   const renderedEntries = normalizeLegacyVoiceToolEntries(entries)
     .map(classifyEntry)
-    .filter((entry) => entry.turnBoundary || !isRenderlessUserEntry(entry));
+    .filter(
+      (entry) =>
+        thinkingMessageIsVisible(entry, thinkingVisibility) &&
+        (entry.turnBoundary || !isRenderlessUserEntry(entry)),
+    );
   const shareAfterEntryIds = new Set<string>();
   if (slackShare) {
     for (let i = 0; i < renderedEntries.length; i++) {
@@ -801,6 +829,12 @@ function IndexedTranscriptBlocks(props: Props) {
   const renderedTimeline = timeline
     .map((item, index) => ({ item, index }))
     .filter(({ item }) => {
+      if (
+        item.kind === "entry" &&
+        !thinkingMessageIsVisible(item.entry, props.thinkingVisibility)
+      ) {
+        return false;
+      }
       const itemRanges = indexedItemRanges(item);
       return (
         itemRanges.length === 0 ||

--- a/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.test.tsx
@@ -7,8 +7,8 @@ import {
   measureTranscriptElement,
   VirtualTranscriptList,
   shouldAdjustTranscriptScroll,
-  shouldRestoreTranscriptInnerAnchor,
-  shouldTransitionTranscriptItemPosition,
+  shouldCaptureReaderAnchor,
+  shouldDeferReaderCorrection,
   transcriptOverscan,
   transcriptViewportNeedsHistory,
   type VirtualTranscriptItem,
@@ -40,8 +40,7 @@ describe("VirtualTranscriptList", () => {
     expect(source).toMatch(
       /if \(this\.committing\) \{[\s\S]*this\.renderAfterCommit = true;/,
     );
-    expect(source).toContain("if (this.rendering || sync) this.queueRender()");
-    expect(source).not.toContain("flushSync");
+    expect(source).toContain("if (sync) this.queueRender()");
   });
 
   test("captures history intent before scroll-driven rerenders", () => {
@@ -85,9 +84,51 @@ describe("VirtualTranscriptList", () => {
     expect(didScrollTranscriptTowardHistory(0, 0, 745, 900)).toBe(false);
   });
 
-  test("does not restore while reader movement awaits a fresh anchor", () => {
-    expect(shouldRestoreTranscriptInnerAnchor(false)).toBe(true);
-    expect(shouldRestoreTranscriptInnerAnchor(true)).toBe(false);
+  test("captures the reader anchor only from a consistent, non-following DOM", () => {
+    const base = { held: false, virtualizerWrote: false, following: false };
+    expect(shouldCaptureReaderAnchor(base)).toBe(true);
+    // The host's live-edge glue owns a following reader.
+    expect(shouldCaptureReaderAnchor({ ...base, following: true })).toBe(false);
+    // Rows have not re-rendered against a virtualizer scroll write: that DOM
+    // is no viewport a reader ever saw. Keep the earlier anchor instead.
+    expect(shouldCaptureReaderAnchor({ ...base, virtualizerWrote: true })).toBe(
+      false,
+    );
+    expect(shouldCaptureReaderAnchor({ ...base, held: true })).toBe(false);
+  });
+
+  test("captures before the DOM mutates and settles only deltas", () => {
+    expect(source).toContain("getSnapshotBeforeUpdate()");
+    expect(source).toContain("this.heldAnchor = this.captureReaderAnchor()");
+    expect(source).toContain("container.scrollTop += delta");
+    expect(source).not.toContain("container.scrollTop = ");
+    // A nested virtualizer render is pending: measure after it commits.
+    expect(source).toContain("if (this.renderAfterCommit) return;");
+  });
+
+  test("defers corrections while touch momentum may be in flight", () => {
+    expect(
+      shouldDeferReaderCorrection({ touching: true, sinceTouchEnd: 5_000 }),
+    ).toBe(true);
+    expect(
+      shouldDeferReaderCorrection({ touching: false, sinceTouchEnd: 40 }),
+    ).toBe(true);
+    expect(
+      shouldDeferReaderCorrection({ touching: false, sinceTouchEnd: 400 }),
+    ).toBe(false);
+  });
+
+  test("never transitions row position against instant scroll compensation", () => {
+    expect(source).not.toContain("transition:transform");
+    expect(source).not.toContain("ARRIVING_POSITION");
+  });
+
+  test("commits a virtualizer scroll write with its rows in one frame", () => {
+    expect(source).toContain("scrollToFn: this.scrollToFn");
+    expect(source).toContain("this.writeAwaitingRender = true;");
+    expect(source).toMatch(
+      /if \(this\.writeAwaitingRender\) \{[\s\S]*flushSync/,
+    );
   });
 
   test("keeps TanStack's ordinary measurement anchoring semantics", () => {
@@ -123,38 +164,10 @@ describe("VirtualTranscriptList", () => {
     ).toBe(false);
   });
 
-  test("compensates only hydration that grows at the row start", () => {
-    expect(
-      shouldAdjustTranscriptScroll({
-        itemStart: 200,
-        itemEnd: 1_200,
-        scrollOffset: 600,
-        growsAtStart: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldAdjustTranscriptScroll({
-        itemStart: 700,
-        itemEnd: 1_200,
-        scrollOffset: 600,
-        growsAtStart: true,
-      }),
-    ).toBe(false);
-    // A continuation page appends below the point being read inside this row.
-    expect(
-      shouldAdjustTranscriptScroll({
-        itemStart: 200,
-        itemEnd: 1_200,
-        scrollOffset: 600,
-      }),
-    ).toBe(false);
-  });
-
   test("uses native keyed prepend anchoring without a competing end owner", () => {
     expect(source).toContain('anchorTo: "end"');
     expect(source).toContain("scrollEndThreshold: -1");
     expect(source).toContain("this.props.shouldMaintainEnd?.()");
-    expect(source).not.toContain("getSnapshotBeforeUpdate");
   });
 
   test("remeasures semantic changes through the observed measurement path", () => {
@@ -200,22 +213,6 @@ describe("VirtualTranscriptList", () => {
         itemEnd: 1_200,
         scrollOffset: 600,
         liveEdgeDelta: -140,
-      }),
-    ).toBe(false);
-  });
-
-  test("keeps prompt reconciliation out of position transitions", () => {
-    expect(shouldTransitionTranscriptItemPosition(item(0))).toBe(true);
-    expect(
-      shouldTransitionTranscriptItemPosition({
-        ...item(0),
-        arrivalAliases: ["outbox-prompt"],
-      }),
-    ).toBe(false);
-    expect(
-      shouldTransitionTranscriptItemPosition({
-        ...item(0),
-        animatePositionChanges: false,
       }),
     ).toBe(false);
   });

--- a/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.tsx
+++ b/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.tsx
@@ -822,6 +822,12 @@ class TranscriptVirtualizer extends React.Component<
       // then the corrected bottom. Shrinks still fall through to the browser's
       // clamp/follow pass; compensating only positive growth avoids pushing a
       // reader past the new end during a turn's final restructure.
+      // One owner per commit. While a reader anchor is held, the entry at
+      // the viewport top goes back where it was after the rows commit, from
+      // the DOM itself. A size-based guess here (a spanning row measured for
+      // the first time, a grouped row growing below the reader) would only
+      // be undone by that settle: two writes in one frame instead of one.
+      if (this.heldAnchor) return false;
       const liveEdgeDelta = this.props.shouldMaintainEnd?.()
         ? delta
         : undefined;

--- a/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.tsx
+++ b/packages/core/opensession-server/src/frontend/components/VirtualTranscriptList.tsx
@@ -8,6 +8,7 @@ import {
   type VirtualizerOptions,
 } from "@tanstack/react-virtual";
 import React from "react";
+import { flushSync } from "react-dom";
 import { PHONE_QUERY } from "../lib/breakpoints";
 import {
   loadTranscriptSizes,
@@ -19,10 +20,7 @@ import {
   newTailBlockKeys,
   shouldAnimateTranscriptItemArrival,
 } from "../lib/transcript-block-identity";
-import {
-  TRANSCRIPT_ARRIVING_POSITION_CLASS,
-  transcriptEnterClass,
-} from "../lib/transcript-motion";
+import { transcriptEnterClass } from "../lib/transcript-motion";
 import { TranscriptTopApproachGate } from "../lib/transcript-top-approach";
 import {
   registerTranscriptVirtualNavigation,
@@ -44,9 +42,6 @@ export interface VirtualTranscriptItem {
   /** False for indexed ranges whose payload arrives in read-only hydration
    * slices. Those rows are appearing from history, not arriving live. */
   animateArrival?: boolean;
-  /** False when position changes represent hydration rather than a live
-   * semantic insert. */
-  animatePositionChanges?: boolean;
   estimateSize: number;
   /** Keep the estimate until sparse payload content is available to measure. */
   measure?: boolean;
@@ -82,10 +77,6 @@ interface Props {
   onTopApproach?: () => boolean;
   /** Re-evaluate visible demand after the caller enables or retries loading. */
   topApproachGeneration?: number;
-  /** Head range whose missing prefix is hydrating into an existing row. */
-  topGrowthKey?: string | null;
-  /** Loaded-row count while that head range is a partial suffix. */
-  topGrowthVersion?: number;
   /** Range children reuse the renderer without nesting another virtualizer. */
   enabled?: boolean;
   /** Session identity for the measured-height cache. */
@@ -125,6 +116,17 @@ export function VirtualTranscriptList({ enabled = true, ...props }: Props) {
 
 type AdapterState = { revision: number };
 
+/** The entry the reader is looking at and where it sat in the viewport. */
+interface ReaderAnchor {
+  node: HTMLElement;
+  id: string;
+  top: number;
+}
+
+/** How long after the last touch a momentum scroll may still be in flight.
+ * Writing scrollTop inside that window cancels the fling on touch browsers. */
+const TOUCH_SETTLE_MS = 150;
+
 /** Imperative adapter for TanStack Virtual core. Class components are outside
  * the React Compiler's function-component transform, so no compiler bailout or
  * opt-out is involved. Its lifecycle mirrors TanStack's official React hook. */
@@ -149,11 +151,21 @@ class TranscriptVirtualizer extends React.Component<
   private containerFor: HTMLDivElement | null = null;
   private explicitContainerFor: HTMLDivElement | null | undefined;
   private container: HTMLDivElement | null = null;
-  private innerAnchorContainer: HTMLDivElement | null = null;
-  private innerAnchor:
-    | { node: HTMLElement; id: string; top: number }
-    | undefined;
-  private innerAnchorFrame: number | undefined;
+  /** Captured immediately before a commit mutates the DOM. Held across a
+   * nested virtualizer commit until the rows and scrollTop agree again. */
+  private heldAnchor: ReaderAnchor | undefined;
+  /** The virtualizer wrote scrollTop since the last consistent commit. Rows
+   * may not have re-rendered against that write yet, so the DOM cannot be
+   * measured as a reader viewport until they do. */
+  private virtualizerWrote = false;
+  /** A virtualizer scroll write whose row transforms have not been rendered.
+   * Consumed by the notification that immediately follows the write. */
+  private writeAwaitingRender = false;
+  private readerInputContainer: HTMLDivElement | null = null;
+  private touching = false;
+  private touchEndedAt = Number.NEGATIVE_INFINITY;
+  private deferredDelta = 0;
+  private deferredFlushTimer: number | undefined;
   private topApproachContainer: HTMLDivElement | null = null;
   private topApproachCallback: (() => boolean) | undefined;
   private topApproachTimer: number | undefined;
@@ -163,16 +175,6 @@ class TranscriptVirtualizer extends React.Component<
   private topApproachGate = new TranscriptTopApproachGate();
   private rowObserver: ResizeObserver | null = null;
   private rowRefs = new Map<string, (node: HTMLDivElement | null) => void>();
-  /** A bounded opening payload can be a suffix of its structural row. When
-   * older payload joins that row's start, preserve the point inside the row;
-   * ordinary pages append at the end and native keyed anchoring owns them. */
-  private headGrowthKeys = new Set<string>();
-  private headGrowthGeneration = 0;
-  private scheduledHeadGrowthGeneration = 0;
-  private headGrowthTimer: number | undefined;
-  private renderedGrowth:
-    | { key: string; version: number | undefined }
-    | undefined;
   /** Every block key this adapter instance has ever mounted. The first build
    *  seeds it (opening a session is not an arrival); afterwards, a tail key
    *  missing from the set just arrived live and plays the entrance fade. Keys
@@ -188,6 +190,9 @@ class TranscriptVirtualizer extends React.Component<
     super(props);
     this.syncSeeded(props.sizeCacheKey);
     this.virtualizer = new Virtualizer(this.options(props));
+    // Row refs measure during React's commit, before componentDidMount. A
+    // notification raised there must wait for the lifecycle, not flush.
+    this.committing = true;
   }
 
   componentDidMount() {
@@ -195,31 +200,43 @@ class TranscriptVirtualizer extends React.Component<
     this.runCommitLifecycle(() => {
       this.mountCleanup = this.virtualizer._didMount();
       this.virtualizer._willUpdate();
+      this.settleReaderAnchor();
       this.syncTopApproach();
+      this.syncReaderInput();
       this.scheduleUnderfilledHistory();
       this.syncNavigation();
-      this.syncInnerAnchor();
       this.scheduleVisibleItems();
       this.notifyLayout();
     });
+  }
+
+  getSnapshotBeforeUpdate() {
+    // Ref callbacks run between here and componentDidUpdate.
+    this.committing = true;
+    if (
+      shouldCaptureReaderAnchor({
+        held: this.heldAnchor !== undefined,
+        virtualizerWrote: this.virtualizerWrote,
+        following: Boolean(this.props.shouldMaintainEnd?.()),
+      })
+    )
+      this.heldAnchor = this.captureReaderAnchor();
+    return null;
   }
 
   componentDidUpdate(prevProps: Omit<Props, "enabled">) {
     this.runCommitLifecycle(() => {
       this.measureCommittedRows(prevProps);
       this.virtualizer._willUpdate();
-      this.restoreInnerAnchor();
-      this.scheduleHeadGrowthClear();
+      this.settleReaderAnchor();
       this.syncTopApproach();
+      this.syncReaderInput();
       if (
         prevProps.items.length !== this.props.items.length ||
-        prevProps.topGrowthKey !== this.props.topGrowthKey ||
-        prevProps.topGrowthVersion !== this.props.topGrowthVersion ||
         prevProps.topApproachGeneration !== this.props.topApproachGeneration
       )
         this.scheduleUnderfilledHistory();
       this.syncNavigation();
-      this.syncInnerAnchor();
       this.scheduleVisibleItems();
       this.notifyLayout();
     });
@@ -229,13 +246,11 @@ class TranscriptVirtualizer extends React.Component<
     this.mounted = false;
     this.mountCleanup?.();
     this.navigationCleanup?.();
-    this.clearInnerAnchor();
+    this.clearReaderInput();
     this.clearTopApproach();
     if (this.underfilledHistoryTimer !== undefined)
       window.clearTimeout(this.underfilledHistoryTimer);
     if (this.visibleTimer !== undefined) window.clearTimeout(this.visibleTimer);
-    if (this.headGrowthTimer !== undefined)
-      window.clearTimeout(this.headGrowthTimer);
     this.rowObserver?.disconnect();
   }
 
@@ -243,41 +258,6 @@ class TranscriptVirtualizer extends React.Component<
     if (this.renderedTotalSize === this.notifiedTotalSize) return;
     this.notifiedTotalSize = this.renderedTotalSize;
     this.props.onLayout?.();
-  }
-
-  private prepareHeadGrowth(props: Omit<Props, "enabled">) {
-    const key = props.topGrowthKey ?? "";
-    const next = { key, version: props.topGrowthVersion };
-    const previous = this.renderedGrowth;
-    this.renderedGrowth = next;
-    if (
-      !previous ||
-      !key ||
-      key !== previous.key ||
-      next.version === previous.version
-    )
-      return;
-    // This is the one hydration shape that is not a keyed insertion: the
-    // opening payload was a suffix of the row, and older content joined its
-    // start. Ordinary range pages append at the end and must not use this path.
-    this.headGrowthKeys.add(key);
-    this.headGrowthGeneration++;
-  }
-
-  private scheduleHeadGrowthClear() {
-    if (
-      this.headGrowthKeys.size === 0 ||
-      this.scheduledHeadGrowthGeneration === this.headGrowthGeneration
-    )
-      return;
-    this.scheduledHeadGrowthGeneration = this.headGrowthGeneration;
-    if (this.headGrowthTimer !== undefined)
-      window.clearTimeout(this.headGrowthTimer);
-    const generation = this.headGrowthGeneration;
-    this.headGrowthTimer = window.setTimeout(() => {
-      this.headGrowthTimer = undefined;
-      if (this.headGrowthGeneration === generation) this.headGrowthKeys.clear();
-    }, 750);
   }
 
   private syncSeeded(sizeCacheKey?: string) {
@@ -313,18 +293,37 @@ class TranscriptVirtualizer extends React.Component<
       this.renderAfterCommit = true;
       return;
     }
-    // setOptions can notify while render is deriving the next range, and DOM
-    // observers can notify while React is committing a different subtree.
-    // A microtask still lands before the next paint without forcing React to
-    // flush from inside a lifecycle. Coalesce same-turn geometry notifications
-    // so a theme-wide style change costs one render rather than one per row.
-    if (this.rendering || sync) this.queueRender();
+    // setOptions can notify while render is deriving the next range. A
+    // microtask still lands before the next paint without forcing React to
+    // flush from inside render.
+    if (this.rendering) {
+      this.queueRender();
+      return;
+    }
+    // The virtualizer just wrote scrollTop to compensate a row measured above
+    // the reader (its ResizeObserver path runs in an animation frame, outside
+    // any React work). The moved rows must commit in this same frame, or one
+    // paint shows the new scrollTop against the old transforms: a visible
+    // jump that then snaps back.
+    if (this.writeAwaitingRender) {
+      this.writeAwaitingRender = false;
+      flushSync(() =>
+        this.setState(({ revision }) => ({ revision: revision + 1 })),
+      );
+      return;
+    }
+    // Scroll-driven range changes also arrive as "sync" notifications. A
+    // microtask still lands before paint and coalesces same-turn geometry
+    // notifications, so a theme-wide style change costs one render.
+    if (sync) this.queueRender();
     else this.setState(({ revision }) => ({ revision: revision + 1 }));
   };
 
   private runCommitLifecycle(work: () => void) {
+    // `renderAfterCommit` is deliberately not reset here: ref callbacks run
+    // before this lifecycle with `committing` already set, and a measurement
+    // that wrote scrollTop there must still get its nested render.
     this.committing = true;
-    this.renderAfterCommit = false;
     try {
       work();
     } finally {
@@ -372,7 +371,7 @@ class TranscriptVirtualizer extends React.Component<
         ),
       observeElementRect,
       observeElementOffset,
-      scrollToFn: elementScroll,
+      scrollToFn: this.scrollToFn,
       measureElement: measureTranscriptElement,
       // Semantic transcript revisions are measured synchronously in
       // componentDidUpdate. ResizeObserver is only the fallback for external
@@ -386,6 +385,15 @@ class TranscriptVirtualizer extends React.Component<
 
   private setRoot = (node: HTMLDivElement | null) => {
     this.root = node;
+  };
+
+  private scrollToFn: VirtualizerOptions<
+    HTMLDivElement,
+    HTMLDivElement
+  >["scrollToFn"] = (offset, options, instance) => {
+    this.virtualizerWrote = true;
+    this.writeAwaitingRender = true;
+    elementScroll(offset, options, instance);
   };
 
   private measureCommittedRows(prevProps: Omit<Props, "enabled">) {
@@ -425,102 +433,125 @@ class TranscriptVirtualizer extends React.Component<
     return this.container;
   }
 
-  private captureInnerAnchor = () => {
-    const container = this.innerAnchorContainer;
-    const root = this.root;
-    if (!container || !root) return;
-    const viewport = container.getBoundingClientRect();
-    let deepest:
-      | { node: HTMLElement; id: string; top: number; bottom: number }
-      | undefined;
-    for (const node of root.querySelectorAll<HTMLElement>(
-      "[data-eid]:not([data-transcript-key])",
-    )) {
-      const id = node.dataset.eid;
-      if (!id) continue;
-      const rect = node.getBoundingClientRect();
-      if (
-        rect.height <= 0 ||
-        rect.bottom <= viewport.top + 1 ||
-        rect.top >= viewport.bottom - 1 ||
-        (deepest && rect.bottom <= deepest.bottom)
-      )
-        continue;
-      deepest = {
-        node,
-        id,
-        top: rect.top - viewport.top,
-        bottom: rect.bottom,
-      };
-    }
-    this.innerAnchor = deepest;
-  };
-
-  private onInnerAnchorScroll = () => {
-    if (this.props.shouldMaintainEnd?.()) return;
-    if (!this.innerAnchor) {
-      this.captureInnerAnchor();
-      return;
-    }
-    if (this.innerAnchorFrame !== undefined) return;
-    this.innerAnchorFrame = requestAnimationFrame(() => {
-      this.innerAnchorFrame = undefined;
-      this.captureInnerAnchor();
-    });
-  };
-
-  private clearInnerAnchor() {
-    this.innerAnchorContainer?.removeEventListener(
-      "scroll",
-      this.onInnerAnchorScroll,
-      true,
-    );
-    if (this.innerAnchorFrame !== undefined)
-      cancelAnimationFrame(this.innerAnchorFrame);
-    this.innerAnchorFrame = undefined;
-    this.innerAnchorContainer = null;
-    this.innerAnchor = undefined;
-  }
-
-  private syncInnerAnchor() {
-    const container = this.scrollContainer();
-    if (container !== this.innerAnchorContainer) {
-      this.clearInnerAnchor();
-      this.innerAnchorContainer = container;
-      container?.addEventListener("scroll", this.onInnerAnchorScroll, {
-        passive: true,
-        capture: true,
-      });
-    }
-    this.captureInnerAnchor();
-  }
-
-  /** Native keyed anchoring owns the structural move first. Grouped rows can
-   * still change internally, and estimate-to-measurement correction may leave
-   * a small residual. Preserve the deepest entry the reader could actually
-   * see, then yield again until the next committed item revision. */
-  private restoreInnerAnchor() {
+  private captureReaderAnchor(): ReaderAnchor | undefined {
     const container = this.scrollContainer();
     const root = this.root;
-    const anchor = this.innerAnchor;
-    if (
-      !container ||
-      !root ||
-      !anchor ||
-      this.props.shouldMaintainEnd?.() ||
-      !shouldRestoreTranscriptInnerAnchor(this.innerAnchorFrame !== undefined)
-    )
-      return;
+    if (!container || !root) return undefined;
+    return pickReaderAnchor(root, container.getBoundingClientRect().top);
+  }
+
+  /** Native keyed anchoring owns structural prepends. Grouped rows can still
+   * change internally, estimates resolve to measurements, and a partial row
+   * can grow at its start. Whatever moved, the entry the reader was looking at
+   * goes back where it was before this commit, as a delta on the current
+   * scroll position: the snapshot was taken synchronously before the DOM
+   * changed, so no reader movement can hide inside it. */
+  private settleReaderAnchor() {
+    // A virtualizer scroll write raised a nested render. Until it commits,
+    // scrollTop and the row transforms describe different layouts, so hold
+    // the anchor and measure after that commit instead.
+    if (this.renderAfterCommit) return;
+    const anchor = this.heldAnchor;
+    this.heldAnchor = undefined;
+    this.virtualizerWrote = false;
+    if (!anchor) return;
+    const container = this.scrollContainer();
+    const root = this.root;
+    if (!container || !root || this.props.shouldMaintainEnd?.()) return;
     const node = anchor.node.isConnected
       ? anchor.node
-      : [...root.querySelectorAll<HTMLElement>("[data-eid]")].find(
-          (candidate) => candidate.dataset.eid === anchor.id,
-        );
+      : findTranscriptEntry(root, anchor.id);
     if (!node) return;
-    const top =
-      node.getBoundingClientRect().top - container.getBoundingClientRect().top;
-    const delta = top - anchor.top;
-    if (Math.abs(delta) > 0.5) container.scrollTop += delta;
+    const delta =
+      node.getBoundingClientRect().top -
+      container.getBoundingClientRect().top -
+      anchor.top;
+    if (Math.abs(delta) <= 0.5) return;
+    this.correctReader(container, delta);
+  }
+
+  private correctReader(container: HTMLDivElement, delta: number) {
+    if (
+      shouldDeferReaderCorrection({
+        touching: this.touching,
+        sinceTouchEnd: performance.now() - this.touchEndedAt,
+      })
+    ) {
+      this.deferredDelta += delta;
+      this.scheduleDeferredFlush();
+      return;
+    }
+    container.scrollTop += delta;
+  }
+
+  private scheduleDeferredFlush() {
+    if (this.deferredFlushTimer !== undefined)
+      window.clearTimeout(this.deferredFlushTimer);
+    this.deferredFlushTimer = window.setTimeout(() => {
+      this.deferredFlushTimer = undefined;
+      const container = this.readerInputContainer;
+      const delta = this.deferredDelta;
+      if (!container || delta === 0) return;
+      if (
+        shouldDeferReaderCorrection({
+          touching: this.touching,
+          sinceTouchEnd: performance.now() - this.touchEndedAt,
+        })
+      ) {
+        this.scheduleDeferredFlush();
+        return;
+      }
+      this.deferredDelta = 0;
+      container.scrollTop += delta;
+    }, TOUCH_SETTLE_MS);
+  }
+
+  private onReaderTouchStart = () => {
+    this.touching = true;
+  };
+
+  private onReaderTouchEnd = () => {
+    this.touching = false;
+    this.touchEndedAt = performance.now();
+    if (this.deferredDelta !== 0) this.scheduleDeferredFlush();
+  };
+
+  private onReaderScroll = () => {
+    // Momentum keeps scrolling after the finger lifts. Restart the settle
+    // window on every scroll event so the flush lands once movement stops.
+    if (this.deferredDelta !== 0) this.scheduleDeferredFlush();
+  };
+
+  private clearReaderInput() {
+    const container = this.readerInputContainer;
+    if (container) {
+      container.removeEventListener("touchstart", this.onReaderTouchStart);
+      container.removeEventListener("touchend", this.onReaderTouchEnd);
+      container.removeEventListener("touchcancel", this.onReaderTouchEnd);
+      container.removeEventListener("scroll", this.onReaderScroll, true);
+    }
+    if (this.deferredFlushTimer !== undefined)
+      window.clearTimeout(this.deferredFlushTimer);
+    this.deferredFlushTimer = undefined;
+    this.deferredDelta = 0;
+    this.touching = false;
+    this.readerInputContainer = null;
+  }
+
+  private syncReaderInput() {
+    const container = this.scrollContainer();
+    if (container === this.readerInputContainer) return;
+    this.clearReaderInput();
+    this.readerInputContainer = container;
+    if (!container) return;
+    const passive = { passive: true } as const;
+    container.addEventListener("touchstart", this.onReaderTouchStart, passive);
+    container.addEventListener("touchend", this.onReaderTouchEnd, passive);
+    container.addEventListener("touchcancel", this.onReaderTouchEnd, passive);
+    container.addEventListener("scroll", this.onReaderScroll, {
+      passive: true,
+      capture: true,
+    });
   }
 
   private observeRowNode(key: string, node: HTMLElement) {
@@ -775,8 +806,10 @@ class TranscriptVirtualizer extends React.Component<
 
   render() {
     this.rendering = true;
+    // Any render lays the rows out against the latest virtualizer offsets, so
+    // a write that reached here through a lifecycle render needs no flush.
+    this.writeAwaitingRender = false;
     this.syncSeeded(this.props.sizeCacheKey);
-    this.prepareHeadGrowth(this.props);
     this.virtualizer.setOptions(this.options(this.props));
     this.virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (
       item,
@@ -798,7 +831,6 @@ class TranscriptVirtualizer extends React.Component<
         scrollOffset: instance.scrollOffset ?? 0,
         firstMeasurement: !instance.itemSizeCache.has(item.key),
         scrollingBackward: instance.scrollDirection === "backward",
-        growsAtStart: this.headGrowthKeys.has(String(item.key)),
         liveEdgeDelta,
       });
     };
@@ -846,19 +878,11 @@ class TranscriptVirtualizer extends React.Component<
               data-index={virtualItem.index}
               data-eid={item.anchorId}
               data-transcript-key={item.key}
-              className={cn(
-                "absolute left-0 top-0 w-full",
-                item.className,
-                // Live machine rows glide when their measured position moves.
-                // Indexed transcript slices opt out: hydration is not arrival.
-                virtualItem.index >=
-                  Math.max(
-                    0,
-                    this.props.items.length - this.props.trailingMounted,
-                  ) &&
-                  shouldTransitionTranscriptItemPosition(item) &&
-                  TRANSCRIPT_ARRIVING_POSITION_CLASS,
-              )}
+              // Never transition transform here. A row's position is
+              // compensated by instant scrollTop writes (the virtualizer's
+              // and this adapter's), and a 200ms glide against an instant
+              // scroll reads as the transcript wobbling on its own.
+              className={cn("absolute left-0 top-0 w-full", item.className)}
               style={{ transform: `translateY(${virtualItem.start}px)` }}
             >
               <EnterRow enter={enteringSet.has(item.key)}>
@@ -901,13 +925,79 @@ export function committedTranscriptMeasureKeys(
   return changed;
 }
 
-export function shouldTransitionTranscriptItemPosition(
-  item: VirtualTranscriptItem,
-): boolean {
-  // A prompt may move when its optimistic row becomes a durable transcript
-  // range. That identity handoff must be visually inert, not a delayed glide.
-  // Indexed range payload slices likewise fill history rather than arrive live.
-  return item.animatePositionChanges !== false && !item.arrivalAliases?.length;
+/**
+ * The entry the reader is looking at: the first entry-level node at or
+ * straddling the viewport top, descended to its innermost `[data-eid]`. That
+ * is the choice browser scroll anchoring makes, which Chrome cannot make for
+ * transform-positioned rows (measured: 0px compensation in every case). The
+ * innermost node matters because a grouped row keeps its outer identity while
+ * older steps hydrate into it above the reader.
+ */
+export function pickReaderAnchor(
+  root: HTMLElement,
+  viewportTop: number,
+): ReaderAnchor | undefined {
+  const intersects = (rect: DOMRect) =>
+    rect.height > 0 && rect.bottom > viewportTop + 1;
+  for (const row of root.children) {
+    if (!(row instanceof HTMLElement)) continue;
+    const rowRect = row.getBoundingClientRect();
+    if (!intersects(rowRect)) continue;
+    const rowId = row.dataset.eid;
+    let anchor: ReaderAnchor | undefined = rowId
+      ? { node: row, id: rowId, top: rowRect.top - viewportTop }
+      : undefined;
+    for (const node of row.querySelectorAll<HTMLElement>("[data-eid]")) {
+      const id = node.dataset.eid;
+      if (!id) continue;
+      const rect = node.getBoundingClientRect();
+      if (!intersects(rect)) continue;
+      // Doc order lists a node's interior right after it: keep descending
+      // while the qualifying node is inside the current pick, and stop at the
+      // first qualifying node that is not.
+      if (anchor && !anchor.node.contains(node)) break;
+      anchor = { node, id, top: rect.top - viewportTop };
+    }
+    return anchor;
+  }
+  return undefined;
+}
+
+function findTranscriptEntry(
+  root: HTMLElement,
+  id: string,
+): HTMLElement | null {
+  return typeof CSS !== "undefined"
+    ? root.querySelector<HTMLElement>(`[data-eid="${CSS.escape(id)}"]`)
+    : null;
+}
+
+export function shouldCaptureReaderAnchor({
+  held,
+  virtualizerWrote,
+  following,
+}: {
+  held: boolean;
+  virtualizerWrote: boolean;
+  following: boolean;
+}): boolean {
+  // A following reader is owned by the host's live-edge glue. A held anchor
+  // predates a virtualizer write whose rows have not committed; the DOM in
+  // between describes no viewport a reader ever saw, so keep the earlier one.
+  return !following && !held && !virtualizerWrote;
+}
+
+export function shouldDeferReaderCorrection({
+  touching,
+  sinceTouchEnd,
+}: {
+  touching: boolean;
+  sinceTouchEnd: number;
+}): boolean {
+  // Touch browsers cancel an in-flight fling on any programmatic scroll
+  // write. A wheel animation survives one (measured in Chrome), so only touch
+  // input defers. The residual is applied once movement settles.
+  return touching || sinceTouchEnd < TOUCH_SETTLE_MS;
 }
 
 export function transcriptViewportNeedsHistory(
@@ -935,24 +1025,12 @@ export function didScrollTranscriptTowardHistory(
   );
 }
 
-export function shouldRestoreTranscriptInnerAnchor(
-  readerAnchorCapturePending: boolean,
-): boolean {
-  // A pending frame means a scroll event moved the reader after this child
-  // coordinate was captured. Let that frame record the new viewport instead
-  // of restoring the stale one over the gesture. TanStack's synchronous keyed
-  // compensation does not schedule this reader-capture frame, so prepend
-  // residuals still get corrected before paint.
-  return !readerAnchorCapturePending;
-}
-
 export function shouldAdjustTranscriptScroll({
   itemStart,
   itemEnd,
   scrollOffset,
   firstMeasurement = false,
   scrollingBackward = false,
-  growsAtStart = false,
   liveEdgeDelta,
 }: {
   itemStart: number;
@@ -960,17 +1038,14 @@ export function shouldAdjustTranscriptScroll({
   scrollOffset: number;
   firstMeasurement?: boolean;
   scrollingBackward?: boolean;
-  growsAtStart?: boolean;
   liveEdgeDelta?: number;
 }): boolean {
   if (liveEdgeDelta !== undefined) return liveEdgeDelta > 0;
-  // Preserve the point inside a partial opening suffix as older content joins
-  // its start. A continuation page grows at the end and should not move a
-  // reader whose viewport intersects that row.
-  if (growsAtStart) return itemStart < scrollOffset + 1;
   // Match TanStack's native measurement predicate everywhere else. Supplying
-  // the transcript exception above replaces the core callback, so its default
-  // behavior needs to remain intact here.
+  // the live-edge exception above replaces the core callback, so its default
+  // behavior needs to remain intact here. A row that spans the fold and grows
+  // (a partial opening suffix hydrating at its start, a streaming step) is
+  // not compensated here; the reader anchor settles it after the commit.
   if (firstMeasurement) return itemStart < scrollOffset;
   return itemEnd <= scrollOffset + 1 && !scrollingBackward;
 }

--- a/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-hydration.test.ts
+++ b/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-hydration.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TranscriptIndexedRange } from "../../lib/transcript-index";
 import {
-  transcriptRangeHasLoadedSuffix,
   transcriptRangesContainPayload,
   visibleTranscriptHydrationDemand,
   type TranscriptHydrationOutlineItem,
@@ -95,22 +94,6 @@ describe("visible transcript hydration", () => {
         (id) => id.startsWith("loaded"),
       ),
     ).toEqual([]);
-  });
-
-  test("distinguishes start-growing opening suffixes from appended pages", () => {
-    const ids = ["one", "two", "three", "four"];
-    expect(
-      transcriptRangeHasLoadedSuffix(ids, (id) =>
-        ["three", "four"].includes(id),
-      ),
-    ).toBe(true);
-    expect(
-      transcriptRangeHasLoadedSuffix(ids, (id) => ["one", "two"].includes(id)),
-    ).toBe(false);
-    expect(
-      transcriptRangeHasLoadedSuffix(ids, (id) => ["two", "four"].includes(id)),
-    ).toBe(false);
-    expect(transcriptRangeHasLoadedSuffix(ids, () => true)).toBe(false);
   });
 
   test("does not claim readiness before the virtualizer reports a window", () => {

--- a/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-hydration.ts
+++ b/packages/core/opensession-server/src/frontend/components/session-viewer/transcript-hydration.ts
@@ -13,19 +13,6 @@ export function transcriptRangesContainPayload(
   return ranges.some((range) => range.entryIds.some(hasPayload));
 }
 
-/** The bounded opening payload may cut into a range and leave a loaded suffix.
- * Only that shape inserts later hydration at the start of an existing row.
- * Normal range pagination starts at firstSeq and appends at the row's end. */
-export function transcriptRangeHasLoadedSuffix(
-  entryIds: readonly string[],
-  hasPayload: (entryId: string) => boolean,
-): boolean {
-  const firstLoaded = entryIds.findIndex(hasPayload);
-  return (
-    firstLoaded > 0 && entryIds.slice(firstLoaded).every((id) => hasPayload(id))
-  );
-}
-
 /**
  * Missing payload can move the opening viewport only when it belongs to a row
  * the virtualizer actually reports as visible. Unloaded ranges occupy no

--- a/packages/core/opensession-server/src/frontend/components/settings/PreferencesPanel.tsx
+++ b/packages/core/opensession-server/src/frontend/components/settings/PreferencesPanel.tsx
@@ -81,6 +81,12 @@ import {
   setLiveTypingPref,
 } from "../../lib/live-typing-pref";
 import {
+  getThinkingMessagesPref,
+  onThinkingMessagesChanged,
+  setThinkingMessagesPref,
+  type ThinkingMessagesPref,
+} from "../../lib/thinking-messages-pref";
+import {
   getReplySuggestionsPref,
   onReplySuggestionsChanged,
   setReplySuggestionsPref,
@@ -518,6 +524,15 @@ export function PreferencesPanel() {
     () => onTurnActivityChanged(() => setTurnActivity(getTurnActivityPrefs())),
     [],
   );
+  const [thinkingMessages, setThinkingMessages] =
+    useState<ThinkingMessagesPref>(getThinkingMessagesPref);
+  useEffect(
+    () =>
+      onThinkingMessagesChanged(() =>
+        setThinkingMessages(getThinkingMessagesPref()),
+      ),
+    [],
+  );
   const [liveTyping, setLiveTyping] = useState<boolean>(getLiveTypingPref);
   useEffect(
     () => onLiveTypingChanged(() => setLiveTyping(getLiveTypingPref())),
@@ -890,6 +905,21 @@ export function PreferencesPanel() {
                   { value: "open", label: "Open" },
                 ]}
                 onChange={setTurnWorkPref}
+              />
+            }
+          />
+          <SettingRow
+            title="Thinking messages"
+            control={
+              <Select
+                label="Thinking messages"
+                value={thinkingMessages}
+                options={[
+                  { value: "none", label: "None" },
+                  { value: "latest", label: "Latest" },
+                  { value: "all", label: "All" },
+                ]}
+                onChange={setThinkingMessagesPref}
               />
             }
           />

--- a/packages/core/opensession-server/src/frontend/lib/api/automations.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/automations.ts
@@ -334,6 +334,12 @@ export interface SandboxStatusInfo {
   canManage?: boolean;
   /** Absent on a pre-upgrade server = no client-side combo warnings. */
   modelFamilies?: SandboxModelFamilyInfo[];
+  /** Disposable automation Executor availability. */
+  automation?: {
+    provider: "daytona";
+    available: boolean;
+    reason?: string;
+  };
 }
 
 export type SandboxConnectionState =

--- a/packages/core/opensession-server/src/frontend/lib/automation-form.ts
+++ b/packages/core/opensession-server/src/frontend/lib/automation-form.ts
@@ -5,6 +5,16 @@ export const FIELD_LABEL =
 /** .automation-form-row */
 export const FORM_ROW = "flex gap-3.5 phone:flex-col";
 
+export function sandboxProviderLabel(id: string): string {
+  if (id === "docker") return "Docker";
+  if (id === "daytona") return "Daytona";
+  if (id === "e2b") return "E2B";
+  if (id === "box") return "Box";
+  if (id === "modal") return "Modal";
+  if (id === "lambda-microvm") return "AWS Lambda MicroVM";
+  return id;
+}
+
 export function uniqueFlowId(prefix: string, used: string[]): string {
   let candidate = prefix;
   let index = 2;

--- a/packages/core/opensession-server/src/frontend/lib/thinking-messages-pref.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/thinking-messages-pref.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const store = new Map<string, string>();
+const listeners = new Map<string, Set<() => void>>();
+Object.assign(globalThis, {
+  localStorage: {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  },
+  window: {
+    addEventListener(type: string, handler: () => void) {
+      const handlers = listeners.get(type) ?? new Set();
+      handlers.add(handler);
+      listeners.set(type, handlers);
+    },
+    removeEventListener(type: string, handler: () => void) {
+      listeners.get(type)?.delete(handler);
+    },
+    dispatchEvent(event: { type: string }) {
+      for (const handler of listeners.get(event.type) ?? []) handler();
+    },
+  },
+  Event: class {
+    type: string;
+    constructor(type: string) {
+      this.type = type;
+    }
+  },
+  fetch: () => Promise.reject(new Error("offline in tests")),
+});
+
+let pref: typeof import("./thinking-messages-pref");
+
+beforeAll(async () => {
+  pref = await import("./thinking-messages-pref");
+});
+
+beforeEach(() => store.clear());
+
+describe("Thinking messages preference", () => {
+  test("defaults to the latest thinking message", () => {
+    expect(pref.getThinkingMessagesPref()).toBe("latest");
+  });
+
+  test("stores an explicit mode and notifies mounted transcripts", () => {
+    let changed = 0;
+    const unsubscribe = pref.onThinkingMessagesChanged(() => changed++);
+    pref.setThinkingMessagesPref("all");
+    unsubscribe();
+
+    expect(pref.getThinkingMessagesPref()).toBe("all");
+    expect(store.get("opensession-thinking-messages")).toBe("all");
+    expect(changed).toBe(1);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/thinking-messages-pref.ts
+++ b/packages/core/opensession-server/src/frontend/lib/thinking-messages-pref.ts
@@ -1,0 +1,85 @@
+import type { TranscriptEntry } from "./types";
+import { isLegacyReasoningHeading } from "./reasoning-display";
+import { makeUserPref } from "./user-pref";
+
+export type ThinkingMessagesPref = "none" | "latest" | "all";
+
+const pref = makeUserPref<ThinkingMessagesPref>({
+  localKey: "opensession-thinking-messages",
+  prefKey: "thinking-messages",
+  changeEvent: "opensession-thinking-messages-changed",
+  defaultValue: "latest",
+  decode: (value) =>
+    value === "none" || value === "latest" || value === "all" ? value : null,
+  encode: (value) => value,
+});
+
+export const getThinkingMessagesPref = pref.get;
+export const setThinkingMessagesPref = pref.set;
+export const onThinkingMessagesChanged = pref.onChanged;
+
+/**
+ * Find reasoning rows using the same turn boundary rule as TranscriptBlocks.
+ * A legacy bold-only assistant row counts only after a later turn item proves
+ * it was an intermediate update, so a bold final answer stays an answer.
+ */
+export function thinkingMessageEntryIds(
+  entries: TranscriptEntry[],
+): ReadonlySet<string> {
+  const ids = new Set<string>();
+  let turn: TranscriptEntry[] = [];
+
+  function flushTurn() {
+    const last = turn[turn.length - 1];
+    const finalId =
+      last?.type === "assistant" && !last.isReasoning ? last.id : null;
+    for (const entry of turn) {
+      if (
+        entry.type === "assistant" &&
+        (entry.isReasoning ||
+          (entry.id !== finalId && isLegacyReasoningHeading(entry.content)))
+      ) {
+        ids.add(entry.id);
+      }
+    }
+    turn = [];
+  }
+
+  for (const entry of entries) {
+    if (entry.type === "tool_result") continue;
+    if (entry.type === "assistant" || entry.type === "tool_use") {
+      turn.push(entry);
+    } else {
+      flushTurn();
+    }
+  }
+  flushTurn();
+  return ids;
+}
+
+export interface ThinkingMessageVisibility {
+  mode: ThinkingMessagesPref;
+  entryIds: ReadonlySet<string>;
+  latestId: string | null;
+}
+
+export function thinkingMessageVisibility(
+  entries: TranscriptEntry[],
+  mode: ThinkingMessagesPref,
+): ThinkingMessageVisibility {
+  const entryIds = thinkingMessageEntryIds(entries);
+  return {
+    mode,
+    entryIds,
+    latestId: Array.from(entryIds).at(-1) ?? null,
+  };
+}
+
+export function thinkingMessageIsVisible(
+  entry: TranscriptEntry,
+  visibility: ThinkingMessageVisibility | undefined,
+): boolean {
+  if (!visibility?.entryIds.has(entry.id)) return true;
+  if (visibility.mode === "all") return true;
+  return visibility.mode === "latest" && entry.id === visibility.latestId;
+}

--- a/packages/core/opensession-server/src/frontend/lib/transcript-block-identity.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-block-identity.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   newTailBlockKeys,
-  shouldAnimateTranscriptEntryPosition,
   shouldAnimateTranscriptItemArrival,
   transcriptArrivalAliases,
   transcriptEntryMountKey,
@@ -10,22 +9,6 @@ import {
 } from "./transcript-block-identity";
 
 const entry = (id: string) => ({ id });
-
-describe("transcript decorations", () => {
-  test("keeps live and durable model switches out of position motion", () => {
-    expect(
-      shouldAnimateTranscriptEntryPosition(entry("model-switch-live-1")),
-    ).toBe(false);
-    expect(
-      shouldAnimateTranscriptEntryPosition(
-        entry("model-switch-2026-08-31T14:00:00Z"),
-      ),
-    ).toBe(false);
-    expect(shouldAnimateTranscriptEntryPosition(entry("retry-notice"))).toBe(
-      true,
-    );
-  });
-});
 
 describe("transcript turn identity", () => {
   test("keeps the mounted component when live steps append", () => {

--- a/packages/core/opensession-server/src/frontend/lib/transcript-block-identity.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-block-identity.ts
@@ -9,15 +9,6 @@ type TranscriptArrivalItem = {
   animateArrival?: boolean;
 };
 
-/** Model switches are timeline decorations, not rows whose later displacement
- * carries meaning. Their immediate arrival may fade in, but transcript
- * hydration must never glide an already-settled divider vertically. */
-export function shouldAnimateTranscriptEntryPosition(entry: {
-  id: string;
-}): boolean {
-  return !entry.id.startsWith("model-switch-");
-}
-
 /** Keep one React/virtualizer identity while a locally-created user row receives
  * its durable transcript id. For a batched row, the first source owns the
  * mounted bubble that survives the merge. */

--- a/packages/core/opensession-server/src/frontend/lib/transcript-motion.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-motion.test.ts
@@ -1,11 +1,7 @@
 import { expect, test } from "bun:test";
-import {
-  TRANSCRIPT_ARRIVING_POSITION_CLASS,
-  transcriptEnterClass,
-} from "./transcript-motion";
+import { transcriptEnterClass } from "./transcript-motion";
 
-test("live transcript inserts opt into restrained arrival motion", () => {
+test("live transcript inserts opt into restrained arrival motion only", () => {
   expect(transcriptEnterClass(true)).toContain("transcript-enter");
   expect(transcriptEnterClass(false)).toBeUndefined();
-  expect(TRANSCRIPT_ARRIVING_POSITION_CLASS).toContain("transition:transform");
 });

--- a/packages/core/opensession-server/src/frontend/lib/transcript-motion.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-motion.ts
@@ -1,9 +1,6 @@
 export const TRANSCRIPT_ENTER_CLASS =
   "[animation:transcript-enter_var(--dur)_var(--ease)]";
 
-export const TRANSCRIPT_ARRIVING_POSITION_CLASS =
-  "motion-safe:[transition:transform_var(--dur)_var(--ease)]";
-
 export function transcriptEnterClass(enter: boolean): string | undefined {
   return enter ? TRANSCRIPT_ENTER_CLASS : undefined;
 }

--- a/packages/core/opensession-server/src/frontend/tools/transcript-scroll-regression.ts
+++ b/packages/core/opensession-server/src/frontend/tools/transcript-scroll-regression.ts
@@ -124,13 +124,25 @@ try {
           ? [...root.querySelectorAll("[data-eid]:not([data-transcript-key])")]
               .find(node => node.getAttribute("data-eid") === expectedId)
           : null;
-        const visible = [...root.querySelectorAll("[data-eid]:not([data-transcript-key])")]
-          .map(node => ({ node, rect: node.getBoundingClientRect() }))
-          .filter(({ rect }) => rect.height > 0 && rect.bottom > box.top + 1 && rect.top < box.bottom - 1)
-          .sort((left, right) => right.rect.bottom - left.rect.bottom || right.rect.top - left.rect.top);
+        // The entry at the viewport top, descended to its innermost [data-eid]:
+        // the node browser scroll anchoring would hold still.
+        const intersects = (rect) => rect.height > 0 && rect.bottom > box.top + 1;
+        let picked = null;
+        for (const row of root.children) {
+          const rowRect = row.getBoundingClientRect();
+          if (!intersects(rowRect)) continue;
+          picked = row.hasAttribute("data-eid") ? { node: row, rect: rowRect } : null;
+          for (const node of row.querySelectorAll("[data-eid]")) {
+            const rect = node.getBoundingClientRect();
+            if (!intersects(rect)) continue;
+            if (picked && !picked.node.contains(node)) break;
+            picked = { node, rect };
+          }
+          break;
+        }
         const anchor = expected
           ? { node: expected, rect: expected.getBoundingClientRect() }
-          : visible[0];
+          : picked;
         return {
           event: Number(player.dataset.transcriptMotionEvent || 0),
           totalEvents: Number(lab.dataset.transcriptMotionEvents || 0),
@@ -298,8 +310,9 @@ try {
       );
 
       // A small upward gesture must disengage following even inside TanStack's
-      // former 120px geometry threshold. Growing the tail must not move the
-      // reader or change the viewport height.
+      // former 120px geometry threshold. Growing the tail below the reader
+      // must not move what they are reading, must not write scrollTop, and
+      // must not change the viewport height: new text appears beneath them.
       await evaluate<void>(`window.__transcriptMotionControl.followLatest()`);
       await settle();
       await send("Input.dispatchMouseEvent", {
@@ -331,13 +344,13 @@ try {
         `near-end reader moved during tail growth (${tailDrift.toFixed(1)}px): ${JSON.stringify({ beforeTail, afterTail })}`,
       );
       assert(
-        Math.abs(afterTail.scrollTop - beforeTail.scrollTop - tailGrowth) <=
-          1.5,
-        `near-end scrollTop did not track ${tailGrowth}px of growth above the anchor`,
+        Math.abs(afterTail.scrollTop - beforeTail.scrollTop) <= 1.5,
+        `near-end scrollTop was written during tail growth: ${beforeTail.scrollTop} -> ${afterTail.scrollTop}`,
       );
       assert(
-        Math.abs(afterTail.bottomGap - beforeTail.bottomGap) <= 1.5,
-        `near-end bottom gap changed ${Math.abs(afterTail.bottomGap - beforeTail.bottomGap).toFixed(1)}px`,
+        Math.abs(afterTail.bottomGap - beforeTail.bottomGap - tailGrowth) <=
+          1.5,
+        `tail growth of ${tailGrowth}px did not appear below the reader (gap ${beforeTail.bottomGap} -> ${afterTail.bottomGap})`,
       );
 
       results.push({

--- a/packages/core/opensession-server/src/server/anthropic-bridge.ts
+++ b/packages/core/opensession-server/src/server/anthropic-bridge.ts
@@ -200,6 +200,11 @@ export interface BridgeAccountPin {
   /** Accounts this turn already burned, skipped on every path. Drives the pi
    *  provider's in-turn account walk (see resolveAccount's excludeIds). */
   excludeIds?: readonly string[];
+  /** The account whose isolated config dir already holds this session's SDK
+   *  conversation. Preferred over the least-used pick while it is usable, so
+   *  a session keeps its SDK resume and prompt cache instead of replaying the
+   *  whole context onto a different subscription every request. */
+  stickyId?: string;
 }
 
 /** Pick the account to serve a bridge/pi request (utilization-gated).
@@ -232,6 +237,7 @@ export function pickBridgeAccount(
     model,
     pinnedId: pin?.accountId,
     strictPin: pin?.accountStrict,
+    stickyId: pin?.stickyId,
     designatedIds: ids,
     allowExtraUsage: pin?.usageCredits,
     excludeIds: pin?.excludeIds,

--- a/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
+++ b/packages/core/opensession-server/src/server/automation-run-settlement.test.ts
@@ -493,6 +493,27 @@ describe("automation run settlement", () => {
     expect(loopStart).toBeGreaterThan(backendDispatch);
   });
 
+  test("intent recovery persists the replacement Executor id", () => {
+    const source = readFileSync(
+      resolve(import.meta.dir, "automations.ts"),
+      "utf8",
+    );
+    const persistDefinition = source.indexOf("const persistSession = (");
+    const existingFields = source.indexOf("...existing,", persistDefinition);
+    const authoritativeSandbox = source.indexOf(
+      "Intent recovery reuses the session id",
+      existingFields,
+    );
+    const prelaunchPersist = source.indexOf(
+      'await persistSession("");',
+      authoritativeSandbox,
+    );
+
+    expect(existingFields).toBeGreaterThan(persistDefinition);
+    expect(authoritativeSandbox).toBeGreaterThan(existingFields);
+    expect(prelaunchPersist).toBeGreaterThan(authoritativeSandbox);
+  });
+
   test("a terminal event before init persists its error before immediate projection", async () => {
     const id = sid();
     created.push(id);

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -78,7 +78,16 @@ import { createSessionsMcpServer } from "../agents/slack/sessions-tools";
 import { createSelfImproveMcpServer } from "../agents/slack/self-improve-tools";
 import { AUTOMATION_DENIED_TOOLS } from "./automation-denied-tools";
 import { audit } from "./audit";
-import type { Sandbox } from "./sandbox";
+import { getSandboxProvider, type Sandbox } from "./sandbox";
+import {
+  sandboxAutomationAvailability,
+  sandboxAutomationConfig,
+} from "./sandbox/config";
+import {
+  automationModelEgressDestinations,
+  mcpEgressDestinations,
+} from "./sandbox/automation-egress";
+import { disposeAutomationSandbox } from "./sandbox/automation-disposal";
 import type { RunHostSpec } from "../runner-host/protocol";
 import { configuredIntegration, personaName } from "./config";
 import { shouldPersistModelSwitch, type StreamEvent } from "./run-events";
@@ -455,14 +464,79 @@ function sanitizeAccountId(
   return id;
 }
 
-function validateSandboxAutomation(
-  automation: Pick<Automation, "sandbox">,
+/**
+ * Fail-closed contract for a sandboxed automation (docs/security-model.md):
+ * a disposable Daytona Executor, one hard-pinned model account, no fallback
+ * model, an explicit MCP allowlist, and no nested CLI credentials. Checked on
+ * create, update, and again at launch so a config change after save cannot
+ * widen a stored job.
+ */
+export function validateSandboxAutomation(
+  automation: Pick<
+    Automation,
+    | "sandbox"
+    | "model"
+    | "accountId"
+    | "accountStrict"
+    | "fallbackModel"
+    | "mcpServers"
+    | "claudeCliEnv"
+    | "codexCliEnv"
+  >,
 ): { error: string } | null {
   if (!automation.sandbox) return null;
-  return {
-    error:
-      "sandbox automations are unavailable while managed Executor automation isolation is being qualified",
-  };
+  const availability = sandboxAutomationAvailability();
+  if (!availability.available) {
+    return {
+      error: `sandbox automations are unavailable: ${availability.reason}`,
+    };
+  }
+  if (!automation.accountId) {
+    return { error: "sandbox automations require a pinned model account" };
+  }
+  const runModel = automationModel(automation.model) || "";
+  if (/^pi\/anthropic\//.test(runModel)) {
+    if (!getAccountById(automation.accountId)) {
+      return {
+        error:
+          "the pinned account does not belong to the selected Claude model",
+      };
+    }
+  } else if (/^pi\/openai\//.test(runModel)) {
+    if (!getCodexAccountById(automation.accountId)) {
+      return {
+        error:
+          "the pinned account does not belong to the selected OpenAI model",
+      };
+    }
+  } else {
+    return {
+      error:
+        "sandbox automations require an Anthropic or OpenAI subscription model with a pinned account",
+    };
+  }
+  if (automation.accountStrict === false) {
+    return { error: "sandbox automation account pins must be strict" };
+  }
+  if (automation.fallbackModel && automation.fallbackModel !== "none") {
+    return {
+      error:
+        "sandbox automations cannot widen credentials through a fallback model; set fallbackModel to none",
+    };
+  }
+  if (!Array.isArray(automation.mcpServers)) {
+    return {
+      error:
+        "sandbox automations require an explicit mcpServers allowlist (use [] for none)",
+    };
+  }
+  if (automation.claudeCliEnv || automation.codexCliEnv) {
+    return {
+      error:
+        "sandbox automations cannot provision nested Claude/Codex CLI credentials",
+    };
+  }
+  return null;
 }
 
 function sanitizeModel(
@@ -1525,6 +1599,10 @@ export async function runAutomation(
   const stamp = startedAt.toISOString().slice(0, 16).replace("T", " ");
   automationPreparations.add(bksId);
   let sandboxRpcToken: string | undefined;
+  // The disposable Executor this run owns, destroyed once the run settles.
+  let disposableSandbox:
+    | { provider: ReturnType<typeof getSandboxProvider>; id: string }
+    | undefined;
   // One physical run id for whichever backend runs this turn. Every backend
   // journals `run_registered` under it, so it becomes the session's
   // `currentRunId` and lets the terminal settlement be fenced to this exact
@@ -1533,7 +1611,13 @@ export async function runAutomation(
   const automationRunKey = `rh-${randomUUIDv7()}`;
 
   try {
-    const runtimeSandboxValidation = validateSandboxAutomation(automation);
+    const runModel = automationModel(
+      options?.modelOverride || automation.model,
+    );
+    const runtimeSandboxValidation = validateSandboxAutomation({
+      ...automation,
+      model: options?.modelOverride || automation.model,
+    });
     if (runtimeSandboxValidation)
       throw new Error(runtimeSandboxValidation.error);
     // The automation's repo (instance default when omitted). Ask mode reads the repo's
@@ -1561,9 +1645,29 @@ export async function runAutomation(
       if (!automation.sandbox) cwd = await ensureAskCheckout(repo.id);
     }
     if (automation.sandbox) {
-      throw new Error(
-        "sandbox automations are unavailable while managed Executor automation isolation is being qualified",
-      );
+      // A fresh disposable Executor per run (the same path isolated public
+      // review uses). The automation trust profile makes the provider refuse
+      // prewarm/template adoption, project only the pinned account and the
+      // explicit MCP allowlist, and install the egress allowlist before the
+      // run host launches. It is destroyed in the finally below.
+      const automationSandbox = sandboxAutomationConfig();
+      const provider = getSandboxProvider(automationSandbox.provider);
+      sandbox = await provider.ensure({
+        sessionId: bksId,
+        repo: repo.id,
+        branch,
+        mode: automation.mode,
+        trustProfile: "automation",
+        egressAllowlist: [
+          ...(automationSandbox.egressAllowlist || []),
+          ...automationModelEgressDestinations(runModel || ""),
+          ...mcpEgressDestinations(
+            filterMcpServers(automation.mcpServers || [], undefined, []),
+          ),
+        ],
+      });
+      disposableSandbox = { provider, id: sandbox.id };
+      cwd = sandbox.cwd;
     }
 
     recordRunStart(automation.id, {
@@ -1695,9 +1799,6 @@ export async function runAutomation(
     // Automations dispatch on Pi (tier-preserving mapping; see
     // automationModel). The effective model/provider can change mid-run on a
     // usage-limit fallback, so track it from runner events for persistence.
-    const runModel = automationModel(
-      options?.modelOverride || automation.model,
-    );
     let effectiveModel = runModel;
     let selectedModel = runModel;
     let effectiveProvider = providerFor(effectiveModel);
@@ -1733,9 +1834,9 @@ export async function runAutomation(
     };
     // Field-scoped write: creation fields are create-if-absent defaults (an
     // existing file — e.g. one an interactive thread-reply resume already
-    // wrote to — wins); this run only owns the engine-id/model fields, the
-    // HEAD-synced branch, and the Slack threads it posted. Serialized via
-    // updateSessionFile.
+    // wrote to — wins); this run owns the current disposable sandbox mapping,
+    // engine-id/model fields, HEAD-synced branch, and Slack threads it posted.
+    // Serialized via updateSessionFile.
     const persistSession = (engineSessionId: string) =>
       updateSessionFile(bksId, (data) => {
         // Widen to Partial: the file may not exist yet (create-if-absent).
@@ -1750,15 +1851,6 @@ export async function runAutomation(
           mode: automation.mode,
           automation: automation.name,
           automationId: automation.id,
-          ...(sandbox
-            ? {
-                sandbox: {
-                  provider: sandbox.provider,
-                  sandboxId: sandbox.id,
-                  workspace: sandbox.workspace,
-                },
-              }
-            : {}),
           // Keep the automation's account pin on the session so interactive
           // resumes of this session run on the same subscription.
           ...(automation.accountId ? { accountId: automation.accountId } : {}),
@@ -1770,6 +1862,18 @@ export async function runAutomation(
           ...(plainThreadId ? { plainThreadId } : {}),
           ...(ticketWorkspaceId ? { workspaceId: ticketWorkspaceId } : {}),
           ...existing,
+          // Intent recovery reuses the session id but may materialize a new
+          // Executor. The current successful ensure is authoritative over a
+          // stale sandbox id from the pre-crash session file.
+          ...(sandbox
+            ? {
+                sandbox: {
+                  provider: sandbox.provider,
+                  sandboxId: sandbox.id,
+                  workspace: sandbox.workspace,
+                },
+              }
+            : {}),
           ...(engineSessionId
             ? engineSessionPatch(effectiveProvider, engineSessionId)
             : {}),
@@ -2075,6 +2179,23 @@ export async function runAutomation(
     activeAutomationIntentSessions.delete(bksId);
     unregisterRunToken(sandboxRpcToken);
     unregisterSessionMcpServers(bksId);
+    if (disposableSandbox) {
+      // Retain the provider selection but not the destroyed Executor id. A
+      // scoped follow-up can create another credential-minimal Executor; a
+      // failed strict disposal remains visible and is never silently reused.
+      try {
+        await disposeAutomationSandbox({
+          provider: disposableSandbox.provider,
+          sandboxId: disposableSandbox.id,
+          sessionId: bksId,
+        });
+      } catch (error) {
+        console.error(
+          `[automations] could not dispose Executor ${disposableSandbox.id} for "${automation.name}":`,
+          error,
+        );
+      }
+    }
     const left = (runningCounts.get(automation.id) || 1) - 1;
     if (left <= 0) runningCounts.delete(automation.id);
     else runningCounts.set(automation.id, left);

--- a/packages/core/opensession-server/src/server/automations.ts
+++ b/packages/core/opensession-server/src/server/automations.ts
@@ -78,7 +78,15 @@ import { createSessionsMcpServer } from "../agents/slack/sessions-tools";
 import { createSelfImproveMcpServer } from "../agents/slack/self-improve-tools";
 import { AUTOMATION_DENIED_TOOLS } from "./automation-denied-tools";
 import { audit } from "./audit";
-import type { Sandbox } from "./sandbox";
+import { getSandboxProvider, type Sandbox } from "./sandbox";
+import {
+  sandboxAutomationAvailability,
+  sandboxAutomationConfig,
+} from "./sandbox/config";
+import {
+  automationModelEgressDestinations,
+  mcpEgressDestinations,
+} from "./sandbox/automation-egress";
 import type { RunHostSpec } from "../runner-host/protocol";
 import { configuredIntegration, personaName } from "./config";
 import { shouldPersistModelSwitch, type StreamEvent } from "./run-events";
@@ -455,14 +463,79 @@ function sanitizeAccountId(
   return id;
 }
 
+/**
+ * Fail-closed contract for a sandboxed automation (docs/security-model.md):
+ * a disposable Daytona Executor, one hard-pinned model account, no fallback
+ * model, an explicit MCP allowlist, and no nested CLI credentials. Checked on
+ * create, update, and again at launch so a config change after save cannot
+ * widen a stored job.
+ */
 function validateSandboxAutomation(
-  automation: Pick<Automation, "sandbox">,
+  automation: Pick<
+    Automation,
+    | "sandbox"
+    | "model"
+    | "accountId"
+    | "accountStrict"
+    | "fallbackModel"
+    | "mcpServers"
+    | "claudeCliEnv"
+    | "codexCliEnv"
+  >,
 ): { error: string } | null {
   if (!automation.sandbox) return null;
-  return {
-    error:
-      "sandbox automations are unavailable while managed Executor automation isolation is being qualified",
-  };
+  const availability = sandboxAutomationAvailability();
+  if (!availability.available) {
+    return {
+      error: `sandbox automations are unavailable: ${availability.reason}`,
+    };
+  }
+  if (!automation.accountId) {
+    return { error: "sandbox automations require a pinned model account" };
+  }
+  const runModel = automationModel(automation.model) || "";
+  if (/^pi\/anthropic\//.test(runModel)) {
+    if (!getAccountById(automation.accountId)) {
+      return {
+        error:
+          "the pinned account does not belong to the selected Claude model",
+      };
+    }
+  } else if (/^pi\/openai\//.test(runModel)) {
+    if (!getCodexAccountById(automation.accountId)) {
+      return {
+        error:
+          "the pinned account does not belong to the selected OpenAI model",
+      };
+    }
+  } else {
+    return {
+      error:
+        "sandbox automations require an Anthropic or OpenAI subscription model with a pinned account",
+    };
+  }
+  if (automation.accountStrict === false) {
+    return { error: "sandbox automation account pins must be strict" };
+  }
+  if (automation.fallbackModel && automation.fallbackModel !== "none") {
+    return {
+      error:
+        "sandbox automations cannot widen credentials through a fallback model; set fallbackModel to none",
+    };
+  }
+  if (!Array.isArray(automation.mcpServers)) {
+    return {
+      error:
+        "sandbox automations require an explicit mcpServers allowlist (use [] for none)",
+    };
+  }
+  if (automation.claudeCliEnv || automation.codexCliEnv) {
+    return {
+      error:
+        "sandbox automations cannot provision nested Claude/Codex CLI credentials",
+    };
+  }
+  return null;
 }
 
 function sanitizeModel(
@@ -1525,6 +1598,10 @@ export async function runAutomation(
   const stamp = startedAt.toISOString().slice(0, 16).replace("T", " ");
   automationPreparations.add(bksId);
   let sandboxRpcToken: string | undefined;
+  // The disposable Executor this run owns, destroyed once the run settles.
+  let disposableSandbox:
+    | { provider: ReturnType<typeof getSandboxProvider>; id: string }
+    | undefined;
   // One physical run id for whichever backend runs this turn. Every backend
   // journals `run_registered` under it, so it becomes the session's
   // `currentRunId` and lets the terminal settlement be fenced to this exact
@@ -1533,7 +1610,13 @@ export async function runAutomation(
   const automationRunKey = `rh-${randomUUIDv7()}`;
 
   try {
-    const runtimeSandboxValidation = validateSandboxAutomation(automation);
+    const runModel = automationModel(
+      options?.modelOverride || automation.model,
+    );
+    const runtimeSandboxValidation = validateSandboxAutomation({
+      ...automation,
+      model: options?.modelOverride || automation.model,
+    });
     if (runtimeSandboxValidation)
       throw new Error(runtimeSandboxValidation.error);
     // The automation's repo (instance default when omitted). Ask mode reads the repo's
@@ -1561,9 +1644,29 @@ export async function runAutomation(
       if (!automation.sandbox) cwd = await ensureAskCheckout(repo.id);
     }
     if (automation.sandbox) {
-      throw new Error(
-        "sandbox automations are unavailable while managed Executor automation isolation is being qualified",
-      );
+      // A fresh disposable Executor per run (the same path isolated public
+      // review uses). The automation trust profile makes the provider refuse
+      // prewarm/template adoption, project only the pinned account and the
+      // explicit MCP allowlist, and install the egress allowlist before the
+      // run host launches. It is destroyed in the finally below.
+      const automationSandbox = sandboxAutomationConfig();
+      const provider = getSandboxProvider(automationSandbox.provider);
+      sandbox = await provider.ensure({
+        sessionId: bksId,
+        repo: repo.id,
+        branch,
+        mode: automation.mode,
+        trustProfile: "automation",
+        egressAllowlist: [
+          ...(automationSandbox.egressAllowlist || []),
+          ...automationModelEgressDestinations(runModel || ""),
+          ...mcpEgressDestinations(
+            filterMcpServers(automation.mcpServers || [], undefined, []),
+          ),
+        ],
+      });
+      disposableSandbox = { provider, id: sandbox.id };
+      cwd = sandbox.cwd;
     }
 
     recordRunStart(automation.id, {
@@ -1695,9 +1798,6 @@ export async function runAutomation(
     // Automations dispatch on Pi (tier-preserving mapping; see
     // automationModel). The effective model/provider can change mid-run on a
     // usage-limit fallback, so track it from runner events for persistence.
-    const runModel = automationModel(
-      options?.modelOverride || automation.model,
-    );
     let effectiveModel = runModel;
     let selectedModel = runModel;
     let effectiveProvider = providerFor(effectiveModel);
@@ -2075,6 +2175,42 @@ export async function runAutomation(
     activeAutomationIntentSessions.delete(bksId);
     unregisterRunToken(sandboxRpcToken);
     unregisterSessionMcpServers(bksId);
+    if (disposableSandbox) {
+      // Strict: a run whose Executor cannot be confirmed gone is logged
+      // loudly rather than left as a warm credential-bearing sandbox. The
+      // session record keeps the sandbox id for the audit trail; its provider
+      // is no longer resumable, so the session cannot be reopened in it.
+      try {
+        await disposableSandbox.provider.destroy(disposableSandbox.id, {
+          strict: true,
+        });
+        await updateSessionFile(bksId, (data) => ({
+          ...data,
+          ...(data.sandbox
+            ? {
+                sandbox: {
+                  ...data.sandbox,
+                  lifecycle: "needs_attention" as const,
+                  lastLifecycleError:
+                    "Disposable automation Executor was destroyed after the run",
+                },
+              }
+            : {}),
+        }));
+      } catch (error) {
+        console.error(
+          `[automations] could not dispose Executor ${disposableSandbox.id} for "${automation.name}":`,
+          error,
+        );
+        audit({
+          kind: "sandbox_automation_dispose_failed",
+          session_id: bksId,
+          provider: disposableSandbox.provider.id,
+          sandbox_id: disposableSandbox.id,
+          error: String((error as Error)?.message || error),
+        });
+      }
+    }
     const left = (runningCounts.get(automation.id) || 1) - 1;
     if (left <= 0) runningCounts.delete(automation.id);
     else runningCounts.set(automation.id, left);

--- a/packages/core/opensession-server/src/server/github-app.test.ts
+++ b/packages/core/opensession-server/src/server/github-app.test.ts
@@ -8,6 +8,7 @@ import {
   githubAppCredentialHealth,
   githubAppInstallationToken,
   githubRepositoryMatchesInstallation,
+  listGithubAppInstallations,
   updateGithubAppWebhook,
 } from "./github-app";
 
@@ -29,6 +30,7 @@ afterEach(() => {
   cache.__ghAppTokenCacheWrite = null;
   cache.__ghAppLastMintOk = undefined;
   cache.__ghAppLastMintIdentity = undefined;
+  cache.__ghAppInstallationsCache = null;
   for (const dir of dirs.splice(0))
     rmSync(dir, { recursive: true, force: true });
 });
@@ -73,6 +75,83 @@ describe("GitHub App webhook", () => {
       "https://ingress.example.test",
       "shared-secret",
     );
+  });
+});
+
+function writeAppIdentity(prefix: string, clientId: string): void {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  const config = join(dir, "config.json");
+  const keyPath = join(dir, "github-app.pem");
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  writeFileSync(keyPath, privateKey.export({ format: "pem", type: "pkcs8" }));
+  writeFileSync(
+    config,
+    JSON.stringify({
+      integrations: { github: { oauthClientId: clientId } },
+    }),
+  );
+  process.env.OPENSESSION_CONFIG = config;
+  delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+  __setGithubAppKeyPathForTest(keyPath);
+}
+
+describe("App installation directory", () => {
+  test("lists every account the App is installed on", async () => {
+    writeAppIdentity(
+      "opensession-github-installations-",
+      "Iv-installations-test",
+    );
+    const urls: string[] = [];
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      urls.push(url);
+      expect(
+        String((init?.headers as Record<string, string>).Authorization),
+      ).toMatch(/^Bearer /);
+      if (url.endsWith("page=2")) {
+        return Response.json([
+          { id: 2, account: { login: "acme-org", type: "Organization" } },
+          // No account: dropped rather than listed as an empty login.
+          { id: 3 },
+        ]);
+      }
+      return Response.json(
+        [{ id: 1, account: { login: "solo-dev", type: "User" } }],
+        {
+          headers: {
+            Link: '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"',
+          },
+        },
+      );
+    }) as typeof fetch;
+
+    const expected = [
+      { login: "solo-dev", type: "User" },
+      { login: "acme-org", type: "Organization" },
+    ];
+    expect(await listGithubAppInstallations()).toEqual(expected);
+    // Briefly cached: the picker refetches on every open.
+    expect(await listGithubAppInstallations()).toEqual(expected);
+    expect(urls).toEqual([
+      "https://api.github.com/app/installations?per_page=100",
+      "https://api.github.com/app/installations?per_page=100&page=2",
+    ]);
+  });
+
+  test("answers null rather than none when GitHub cannot be reached", async () => {
+    writeAppIdentity(
+      "opensession-github-installations-",
+      "Iv-installations-down",
+    );
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    expect(await listGithubAppInstallations()).toBeNull();
   });
 });
 
@@ -127,8 +206,15 @@ describe("repository-scoped App installation identity", () => {
     globalThis.fetch = (async (input: string | URL | Request) => {
       const url = String(input);
       requests.push(url);
-      if (url.endsWith("/app/installations")) {
+      if (url.endsWith("page=2")) {
         return Response.json([{ id: 2, account: { login: "owner-b" } }]);
+      }
+      if (url.endsWith("/app/installations?per_page=100")) {
+        return Response.json([], {
+          headers: {
+            Link: '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"',
+          },
+        });
       }
       if (url.endsWith("/app/installations/2/access_tokens")) {
         return Response.json({
@@ -157,7 +243,8 @@ describe("repository-scoped App installation identity", () => {
     process.env.OPENSESSION_CONFIG = changedConfig;
     expect(githubAppCredentialHealth()).toBe("unchecked");
     expect(requests).toEqual([
-      "https://api.github.com/app/installations",
+      "https://api.github.com/app/installations?per_page=100",
+      "https://api.github.com/app/installations?per_page=100&page=2",
       "https://api.github.com/app/installations/2/access_tokens",
     ]);
   });

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -57,6 +57,11 @@ const g = globalThis as {
   __ghAppTokenWarned?: boolean;
   __ghAppLastMintOk?: boolean;
   __ghAppLastMintIdentity?: string;
+  __ghAppInstallationsCache?: {
+    clientId: string;
+    at: number;
+    installations: GithubAppInstallation[];
+  } | null;
 };
 
 // READ_PERMISSIONS / WRITE_PERMISSIONS are the canonical sets imported at the
@@ -146,15 +151,8 @@ export async function githubAppInstallationToken(
           ? matchingWrite.installationOwner
           : undefined;
     if (!installationId) {
-      const res = await fetch("https://api.github.com/app/installations", {
-        headers,
-      });
-      const installs = (await res.json()) as Array<{
-        id: number;
-        account?: { login?: string };
-      }>;
-      if (!Array.isArray(installs) || !installs.length)
-        throw new Error("no installations");
+      const installs = await githubAppInstallations(clientId, headers);
+      if (!installs.length) throw new Error("no installations");
       // Prefer an explicit installation owner, then the org captured at setup
       // (appOrg) — the same precedence setup-team.ts uses. An org App installed
       // on more than one account must be selected explicitly.
@@ -245,6 +243,95 @@ export function githubConfiguredCredential(): boolean {
   const github = configuredIntegration("github");
   const owner = github.installationOwner || github.appOrg;
   return githubAppConfigured() && !!githubAppIdentity().slug && !!owner;
+}
+
+/** The account pinned as the App's installation selection, from config
+ * (installationOwner, with the setup-era appOrg as fallback). Empty when
+ * nothing is pinned yet. */
+export function configuredGithubInstallationOwner(): string {
+  const github = configuredIntegration("github");
+  return String(github.installationOwner || github.appOrg || "").trim();
+}
+
+interface GithubAppInstallation {
+  id: number;
+  account?: { login?: string; type?: string };
+}
+
+export interface GithubAppInstallationAccount {
+  /** Account login, e.g. "my-organization". */
+  login: string;
+  /** GitHub account type: "User" or "Organization". */
+  type: string;
+}
+
+async function githubAppInstallations(
+  clientId: string,
+  headers: Record<string, string>,
+): Promise<GithubAppInstallation[]> {
+  const cached = g.__ghAppInstallationsCache;
+  if (
+    cached &&
+    cached.clientId === clientId &&
+    Date.now() - cached.at < 60_000
+  ) {
+    return cached.installations;
+  }
+
+  const installations: GithubAppInstallation[] = [];
+  let url: string | null =
+    "https://api.github.com/app/installations?per_page=100";
+  while (url) {
+    const res: Response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(15_000),
+    });
+    const page = (await res.json().catch(() => null)) as unknown;
+    if (!res.ok || !Array.isArray(page)) {
+      throw new Error(`cannot list GitHub App installations (${res.status})`);
+    }
+    for (const installation of page) {
+      if (
+        installation &&
+        typeof installation === "object" &&
+        typeof installation.id === "number"
+      ) {
+        installations.push(installation as GithubAppInstallation);
+      }
+    }
+    const next: RegExpMatchArray | null | undefined = res.headers
+      .get("link")
+      ?.match(/<([^>]+)>;\s*rel="next"/i);
+    url = next?.[1] || null;
+  }
+
+  g.__ghAppInstallationsCache = { clientId, at: Date.now(), installations };
+  return installations;
+}
+
+/** Every account the App is installed on, listed with the App JWT alone (no
+ * installation token involved, so this answers even when the pinned owner
+ * matches no installation). Null when the App identity or key is missing or
+ * GitHub cannot answer: "unknown", never "none". Briefly cached because the
+ * setup picker refetches each time it opens. */
+export async function listGithubAppInstallations(): Promise<
+  GithubAppInstallationAccount[] | null
+> {
+  const { clientId } = githubUserAuthSettings();
+  if (!clientId || !existsSync(keyPath())) return null;
+  try {
+    const key = await Bun.file(keyPath()).text();
+    const installations = await githubAppInstallations(clientId, {
+      Authorization: `Bearer ${appJwt(clientId, key)}`,
+      Accept: "application/vnd.github+json",
+    });
+    return installations.flatMap((installation) => {
+      const login = installation.account?.login;
+      return login ? [{ login, type: installation.account?.type || "" }] : [];
+    });
+  } catch {
+    return null;
+  }
 }
 
 /** Last observed App availability for synchronous health snapshots. Startup and

--- a/packages/core/opensession-server/src/server/model-discovery.ts
+++ b/packages/core/opensession-server/src/server/model-discovery.ts
@@ -1,0 +1,71 @@
+/**
+ * Opt-in model discovery for OpenAI-compatible providers: `GET
+ * {baseURL}/models` with the provider's own key. The stock OpenAI models object
+ * is ids-only, so discovery mainly fills the picker; extended fields a gateway
+ * sends (context_length, max_output_tokens, input_modalities, …) are recorded
+ * beneath the operator's own catalog rows, which always win.
+ */
+
+import {
+  addPickerModels,
+  catalogRows,
+  configuredPickerModels,
+  modelProviders,
+  setProviderDiscovered,
+  type ProviderCatalogModel,
+} from "./model-providers";
+
+const DISCOVERY_TIMEOUT_MS = 15_000;
+
+/** `{baseURL}/models`, tolerating a trailing slash on the base URL. */
+export function discoveryUrl(baseURL: string): string {
+  return `${baseURL.replace(/\/+$/, "")}/models`;
+}
+
+/** Fetch and normalize a provider's model list. Throws with a short reason on
+ *  a network or shape failure; the caller decides what to keep. */
+export async function fetchProviderModels(
+  baseURL: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, ProviderCatalogModel>> {
+  const res = await fetchImpl(discoveryUrl(baseURL), {
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`GET /models returned ${res.status}`);
+  const body = await res.json().catch(() => {
+    throw new Error("GET /models did not return JSON");
+  });
+  const models = catalogRows(body);
+  if (!Object.keys(models).length)
+    throw new Error("GET /models returned no model ids");
+  return models;
+}
+
+/**
+ * Discover a configured provider's models, record them under `discovered`,
+ * and add their ids to pickerModels. Operator-pinned picker ids are never
+ * removed, and a failed poll leaves the stored config untouched.
+ */
+export async function discoverProviderModels(
+  id: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ models: string[]; added: number }> {
+  const provider = modelProviders()[id];
+  if (!provider?.apiKey) throw new Error(`Provider "${id}" has no API key`);
+  if (!provider.baseURL) throw new Error(`Provider "${id}" has no base URL`);
+  const models = await fetchProviderModels(
+    provider.baseURL,
+    provider.apiKey,
+    fetchImpl,
+  );
+  setProviderDiscovered(id, { at: new Date().toISOString(), models });
+  const ids = Object.keys(models).map((m) => `pi/${id}/${m}`);
+  const before = new Set(configuredPickerModels());
+  addPickerModels(ids);
+  return {
+    models: Object.keys(models),
+    added: ids.filter((m) => !before.has(m)).length,
+  };
+}

--- a/packages/core/opensession-server/src/server/model-providers-custom.test.ts
+++ b/packages/core/opensession-server/src/server/model-providers-custom.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, test } from "bun:test";
+import {
+  catalogRows,
+  configuredProviderCatalog,
+  mergeCatalogs,
+  normalizeCatalogModel,
+  normalizeModelProviderConfig,
+  FALLBACK_CONTEXT_WINDOW,
+  FALLBACK_MAX_TOKENS,
+} from "./model-providers";
+import { buildPiThirdPartyProviderPlan } from "./pi-runner";
+import { discoveryUrl, fetchProviderModels } from "./model-discovery";
+
+describe("custom provider config", () => {
+  test("parses api, name, discovery flag and inline catalog rows", () => {
+    const cfg = normalizeModelProviderConfig({
+      providers: {
+        "my-gateway": {
+          apiKey: "k",
+          baseURL: "https://gateway.example/v1",
+          api: "openai-completions",
+          name: "My gateway",
+          discoverModels: true,
+          catalog: {
+            "big-model": {
+              display_name: "Big Model",
+              context_length: 200000,
+              max_output_tokens: 65536,
+              input_modalities: ["text", "image"],
+              efforts: ["low", "HIGH", "bogus"],
+              cost: { input: 1.5, output: 6, cache_read: 0.2 },
+            },
+          },
+        },
+      },
+    });
+    expect(cfg?.providers?.["my-gateway"]).toMatchObject({
+      apiKey: "k",
+      baseURL: "https://gateway.example/v1",
+      api: "openai-completions",
+      name: "My gateway",
+      discoverModels: true,
+      catalog: {
+        "big-model": {
+          id: "big-model",
+          name: "Big Model",
+          contextWindow: 200000,
+          maxTokens: 65536,
+          input: ["text", "image"],
+          efforts: ["low", "high"],
+          reasoning: true,
+          cost: { input: 1.5, output: 6, cacheRead: 0.2, cacheWrite: 0 },
+        },
+      },
+    });
+  });
+
+  test("rejects an unknown api and drops junk fields", () => {
+    const cfg = normalizeModelProviderConfig({
+      providers: {
+        gw: { apiKey: "k", api: "anthropic-messages", name: "   " },
+      },
+    });
+    expect(cfg?.providers?.gw).toEqual({ apiKey: "k" });
+  });
+
+  test("layers discovered, file and inline rows (inline wins)", () => {
+    const cfg = normalizeModelProviderConfig(
+      {
+        providers: {
+          gw: {
+            apiKey: "k",
+            baseURL: "https://gw.test/v1",
+            catalogFile: "gw-catalog.json",
+            discovered: {
+              at: "2026-09-01T00:00:00Z",
+              models: {
+                data: [{ id: "a", context_length: 1000 }, { id: "b" }],
+              },
+            },
+            catalog: { a: { maxTokens: 999 } },
+          },
+        },
+      },
+      (file) => {
+        expect(file).toBe("gw-catalog.json");
+        return { a: { id: "a", contextWindow: 5000 }, c: { id: "c" } };
+      },
+    );
+    const catalog = cfg?.providers?.gw.catalog;
+    expect(Object.keys(catalog || {}).sort()).toEqual(["a", "b", "c"]);
+    expect(catalog?.a).toEqual({
+      id: "a",
+      contextWindow: 5000,
+      maxTokens: 999,
+    });
+    expect(cfg?.providers?.gw.discovered?.at).toBe("2026-09-01T00:00:00Z");
+  });
+
+  test("catalogRows accepts maps, lists and wrapped lists", () => {
+    expect(Object.keys(catalogRows({ x: {}, y: {} }))).toEqual(["x", "y"]);
+    expect(Object.keys(catalogRows([{ id: "x" }, { noid: 1 }]))).toEqual(["x"]);
+    expect(Object.keys(catalogRows({ models: [{ id: "m" }] }))).toEqual(["m"]);
+    expect(Object.keys(catalogRows({ data: [{ id: "d" }] }))).toEqual(["d"]);
+    expect(catalogRows("nope")).toEqual({});
+  });
+
+  test("normalizeCatalogModel ignores half-specified pricing", () => {
+    expect(normalizeCatalogModel("m", { cost: { input: 1 } })?.cost).toBe(
+      undefined,
+    );
+    expect(normalizeCatalogModel("m", { vision: true })?.input).toEqual([
+      "text",
+      "image",
+    ]);
+    expect(normalizeCatalogModel("", {})).toBeUndefined();
+  });
+
+  test("mergeCatalogs merges field by field", () => {
+    expect(
+      mergeCatalogs(
+        { a: { id: "a", name: "A", contextWindow: 1 } },
+        undefined,
+        { a: { id: "a", contextWindow: 2 } },
+      ),
+    ).toEqual({ a: { id: "a", name: "A", contextWindow: 2 } });
+  });
+});
+
+describe("configuredProviderCatalog", () => {
+  test("is empty without api, name or rows", () => {
+    expect(configuredProviderCatalog("gw", { apiKey: "k" })).toBeUndefined();
+    expect(configuredProviderCatalog("gw", undefined)).toBeUndefined();
+  });
+
+  test("fills missing row fields with the fallback stub", () => {
+    const catalog = configuredProviderCatalog("gw", {
+      api: "openai-completions",
+      baseURL: "https://gw.test/v1",
+      catalog: { m: { id: "m", contextWindow: 500000 } },
+    });
+    expect(catalog).toMatchObject({
+      name: "gw",
+      api: "openai-completions",
+      baseUrl: "https://gw.test/v1",
+    });
+    expect(catalog?.models[0]).toEqual({
+      id: "m",
+      name: "m",
+      reasoning: true,
+      thinkingLevelMap: {},
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 500000,
+      maxTokens: FALLBACK_MAX_TOKENS,
+    });
+  });
+});
+
+describe("buildPiThirdPartyProviderPlan with configured providers", () => {
+  test("a declared api makes an unknown slug runnable", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "my-gateway",
+      modelID: "some-model",
+      apiKey: "k",
+      baseURL: "https://gateway.example/v1",
+      configured: {
+        apiKey: "k",
+        baseURL: "https://gateway.example/v1",
+        api: "openai-completions",
+        name: "My gateway",
+      },
+      builtinModelIds: [],
+    });
+    if ("error" in plan) throw new Error(plan.error);
+    expect(plan.config).toMatchObject({
+      apiKey: "k",
+      api: "openai-completions",
+      name: "My gateway",
+      baseUrl: "https://gateway.example/v1",
+    });
+    expect(plan.config.models).toEqual([
+      expect.objectContaining({
+        id: "some-model",
+        contextWindow: FALLBACK_CONTEXT_WINDOW,
+        maxTokens: FALLBACK_MAX_TOKENS,
+      }),
+    ]);
+  });
+
+  test("keeps a case-sensitive catalog model id in the provider plan", () => {
+    const modelID = "Qwen/Qwen3-Coder";
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "my-gateway",
+      modelID,
+      apiKey: "k",
+      baseURL: "https://gateway.example/v1",
+      configured: {
+        apiKey: "k",
+        baseURL: "https://gateway.example/v1",
+        api: "openai-completions",
+        catalog: {
+          [modelID]: { id: modelID, contextWindow: 262_144 },
+        },
+      },
+      builtinModelIds: [],
+    });
+    if ("error" in plan) throw new Error(plan.error);
+    expect(plan.config.models).toEqual([
+      expect.objectContaining({ id: modelID, contextWindow: 262_144 }),
+    ]);
+  });
+
+  test("a declared api without a base URL is refused", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "my-gateway",
+      modelID: "m",
+      apiKey: "k",
+      configured: { apiKey: "k", api: "openai-completions" },
+      builtinModelIds: [],
+    });
+    expect("error" in plan && plan.error).toMatch(/no base URL/);
+  });
+
+  test("an unknown slug without an api still fails clearly", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "my-gateway",
+      modelID: "m",
+      apiKey: "k",
+      baseURL: "https://gateway.example/v1",
+      configured: { apiKey: "k", baseURL: "https://gateway.example/v1" },
+      builtinModelIds: [],
+    });
+    expect("error" in plan && plan.error).toMatch(/openai-completions/);
+  });
+
+  test("a catalog row replaces the fallback stub", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "my-gateway",
+      modelID: "big-model",
+      apiKey: "k",
+      baseURL: "https://gateway.example/v1",
+      configured: {
+        apiKey: "k",
+        baseURL: "https://gateway.example/v1",
+        api: "openai-completions",
+        catalog: {
+          "big-model": {
+            id: "big-model",
+            name: "Big Model",
+            contextWindow: 1_000_000,
+            maxTokens: 100_000,
+            input: ["text", "image"],
+            cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+          },
+        },
+      },
+      builtinModelIds: [],
+    });
+    if ("error" in plan) throw new Error(plan.error);
+    expect(plan.config.models).toEqual([
+      expect.objectContaining({
+        id: "big-model",
+        name: "Big Model",
+        contextWindow: 1_000_000,
+        maxTokens: 100_000,
+        input: ["text", "image"],
+        cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0 },
+      }),
+    ]);
+  });
+
+  test("a catalog row on a Pi-known provider overrides the builtin entry", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "together",
+      modelID: "org/model",
+      apiKey: "k",
+      baseURL: "https://other.example/v1",
+      configured: {
+        apiKey: "k",
+        baseURL: "https://other.example/v1",
+        catalog: { "org/model": { id: "org/model", contextWindow: 64_000 } },
+      },
+      builtinModelIds: ["org/model", "org/other"],
+    });
+    if ("error" in plan) throw new Error(plan.error);
+    // No api/name guessed for a Pi-known slug; only the model table changes.
+    expect(plan.config.api).toBeUndefined();
+    expect(plan.config.name).toBeUndefined();
+    expect(plan.config.models).toEqual([
+      expect.objectContaining({ id: "org/model", contextWindow: 64_000 }),
+    ]);
+  });
+
+  test("a catalog row overrides our own catalog for the same id", () => {
+    const plan = buildPiThirdPartyProviderPlan({
+      providerID: "wafer",
+      modelID: "glm-5.2",
+      apiKey: "k",
+      configured: {
+        apiKey: "k",
+        catalog: { "glm-5.2": { id: "glm-5.2", maxTokens: 4096 } },
+      },
+      builtinModelIds: [],
+    });
+    if ("error" in plan) throw new Error(plan.error);
+    const models = plan.config.models as Array<Record<string, unknown>>;
+    expect(models.filter((m) => m.id === "glm-5.2")).toHaveLength(1);
+    expect(models.find((m) => m.id === "glm-5.2")?.maxTokens).toBe(4096);
+    expect(plan.config.baseUrl).toBe("https://pass.wafer.ai/v1");
+  });
+});
+
+describe("model discovery", () => {
+  test("builds the models URL", () => {
+    expect(discoveryUrl("https://gw.test/v1/")).toBe(
+      "https://gw.test/v1/models",
+    );
+  });
+
+  test("reads the OpenAI list shape with extended fields", async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      calls.push([url, init]);
+      return Response.json({
+        object: "list",
+        data: [
+          { id: "m1", object: "model" },
+          { id: "m2", context_length: 32000, max_output_tokens: 4000 },
+        ],
+      });
+    }) as unknown as typeof fetch;
+    const models = await fetchProviderModels(
+      "https://gw.test/v1",
+      "k",
+      fetchImpl,
+    );
+    expect(calls[0][0]).toBe("https://gw.test/v1/models");
+    expect((calls[0][1]?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer k",
+    );
+    expect(models).toEqual({
+      m1: { id: "m1" },
+      m2: { id: "m2", contextWindow: 32000, maxTokens: 4000 },
+    });
+  });
+
+  test("fails on non-2xx and on an empty list", async () => {
+    const bad = (async () =>
+      new Response("nope", { status: 401 })) as unknown as typeof fetch;
+    await expect(
+      fetchProviderModels("https://gw.test", "k", bad),
+    ).rejects.toThrow(/401/);
+    const empty = (async () =>
+      Response.json({ data: [] })) as unknown as typeof fetch;
+    await expect(
+      fetchProviderModels("https://gw.test", "k", empty),
+    ).rejects.toThrow(/no model ids/);
+  });
+});
+
+describe("Settings writes", () => {
+  test("reject invalid custom providers before writing", async () => {
+    const { mkdtempSync, readFileSync, writeFileSync } = await import("fs");
+    const { tmpdir } = await import("os");
+    const { join } = await import("path");
+    const { setModelProvider } = await import("./model-providers");
+    const dir = mkdtempSync(join(tmpdir(), "os-model-providers-"));
+    const path = join(dir, "model-providers.json");
+    const original = JSON.stringify({
+      providers: { gw: { apiKey: "stored", baseURL: "https://gw.test/v1" } },
+    });
+    writeFileSync(path, original);
+    const prev = process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+    process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = path;
+    try {
+      expect(() =>
+        setModelProvider("gw", {
+          api: "openai-completions",
+          baseURL: "",
+        }),
+      ).toThrow(/needs a base URL/);
+      expect(readFileSync(path, "utf-8")).toBe(original);
+    } finally {
+      if (prev === undefined)
+        delete process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+      else process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = prev;
+    }
+  });
+
+  test("preserve catalog, catalogFile and discovered rows", async () => {
+    const { mkdtempSync, readFileSync, writeFileSync } = await import("fs");
+    const { tmpdir } = await import("os");
+    const { join } = await import("path");
+    const { setModelProvider, setProviderDiscovered } =
+      await import("./model-providers");
+    const dir = mkdtempSync(join(tmpdir(), "os-model-providers-"));
+    const path = join(dir, "model-providers.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        providers: {
+          gw: {
+            apiKey: "old",
+            baseURL: "https://gw.test/v1",
+            catalogFile: "gw.json",
+            catalog: { m: { contextWindow: 1 } },
+            future: "keep",
+          },
+        },
+      }),
+    );
+    const prev = process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+    process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = path;
+    try {
+      setModelProvider("gw", {
+        apiKey: "new",
+        api: "openai-completions",
+        name: "Gateway",
+        discoverModels: true,
+      });
+      setProviderDiscovered("gw", {
+        at: "2026-09-01T00:00:00Z",
+        models: { d: { id: "d" } },
+      });
+      setModelProvider("gw", { api: "", discoverModels: false });
+      expect(JSON.parse(readFileSync(path, "utf-8")).providers.gw).toEqual({
+        apiKey: "new",
+        baseURL: "https://gw.test/v1",
+        catalogFile: "gw.json",
+        catalog: { m: { contextWindow: 1 } },
+        future: "keep",
+        name: "Gateway",
+        discovered: { at: "2026-09-01T00:00:00Z", models: { d: { id: "d" } } },
+      });
+    } finally {
+      if (prev === undefined)
+        delete process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+      else process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = prev;
+    }
+  });
+});

--- a/packages/core/opensession-server/src/server/model-providers.ts
+++ b/packages/core/opensession-server/src/server/model-providers.ts
@@ -8,6 +8,7 @@ import { homeDir } from "./paths";
 import { stateDir } from "./paths";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import { chmodSync, existsSync, readFileSync } from "fs";
+import { dirname, isAbsolute, resolve } from "path";
 
 const HOME = homeDir();
 
@@ -19,10 +20,64 @@ export function configPath(): string {
   );
 }
 
+/** The reasoning levels a configured catalog row may list. Mirrors models.ts'
+ *  SessionEffort, spelled out here so this module stays free of an import
+ *  back into the registry. */
+export const CATALOG_EFFORTS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+export type CatalogEffort = (typeof CATALOG_EFFORTS)[number];
+
+/** Per-model metadata an operator attaches to a provider (`catalog`,
+ *  `catalogFile`) or that `/v1/models` discovery recorded. Every field but the
+ *  id is optional: a missing one falls back to the conservative stub the
+ *  runner registers for unknown models. Costs are USD per million tokens. */
+export interface ProviderCatalogModel {
+  id: string;
+  name?: string;
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: Array<"text" | "image">;
+  /** Reasoning ladder offered in the picker; implies `reasoning`. */
+  efforts?: CatalogEffort[];
+  cost?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+}
+
+/** The wire protocols a custom provider may declare. OpenAI-compatible only:
+ *  a random slug never gets an Anthropic or OpenAI native protocol guessed. */
+export const PROVIDER_APIS = ["openai-completions"] as const;
+export type ProviderApi = (typeof PROVIDER_APIS)[number];
+
 /** One configured third-party provider (xai, openrouter, groq, …). */
 export interface ModelProviderConfig {
   apiKey?: string;
   baseURL?: string;
+  /** Explicit protocol. Lets a provider id unknown to both Pi and Open
+   *  Session run, the same way Wafer is injected. Needs `baseURL`. */
+  api?: ProviderApi;
+  /** Display name for the provider (defaults to the id). */
+  name?: string;
+  /** Operator-pinned per-model metadata, keyed by model id. */
+  catalog?: Record<string, ProviderCatalogModel>;
+  /** JSON file with more catalog rows; relative to the config file's
+   *  directory (the state dir) unless absolute. Inline `catalog` rows win. */
+  catalogFile?: string;
+  /** Opt in to `GET {baseURL}/models` discovery of picker ids. */
+  discoverModels?: boolean;
+  /** What the last discovery recorded (ids plus any extended metadata).
+   *  Overlaid beneath the operator catalog. */
+  discovered?: { at: string; models: Record<string, ProviderCatalogModel> };
 }
 
 /** Cerebras' public, open-weight model catalog. Kept here so adding a key in
@@ -280,6 +335,154 @@ function stringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
+function record(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
+function positiveInt(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) && v > 0
+    ? Math.floor(v)
+    : undefined;
+}
+
+function nonNegative(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : undefined;
+}
+
+/**
+ * One catalog row from either our camelCase shape or the snake_case fields a
+ * gateway's extended `/v1/models` object tends to carry (`display_name`,
+ * `context_length`, `max_output_tokens`, `input_modalities`). Pricing is read
+ * only in our own per-million shape (`cost.input`/`cost.output`): the stock
+ * OpenAI models object has none, and OpenRouter's per-token strings would
+ * silently mis-scale. Undefined when the row is not an object.
+ */
+export function normalizeCatalogModel(
+  id: string,
+  raw: unknown,
+): ProviderCatalogModel | undefined {
+  const r = record(raw);
+  if (!r || !id) return undefined;
+  const out: ProviderCatalogModel = { id };
+  const name = r.name ?? r.display_name ?? r.displayName;
+  if (typeof name === "string" && name.trim()) out.name = name.trim();
+  const context = positiveInt(
+    r.contextWindow ?? r.context_window ?? r.context_length ?? r.contextLength,
+  );
+  if (context) out.contextWindow = context;
+  const output = positiveInt(
+    r.maxTokens ??
+      r.max_tokens ??
+      r.max_output_tokens ??
+      r.maxOutputTokens ??
+      r.max_completion_tokens,
+  );
+  if (output) out.maxTokens = output;
+  const reasoning = r.reasoning ?? r.supports_reasoning ?? r.supportsReasoning;
+  if (typeof reasoning === "boolean") out.reasoning = reasoning;
+  const modalities = stringArray(
+    r.input ?? r.input_modalities ?? r.inputModalities,
+  );
+  const vision = r.vision ?? r.supports_vision ?? r.supportsVision;
+  if (modalities) {
+    const lowered = modalities.map((m) => m.toLowerCase());
+    out.input = lowered.includes("image") ? ["text", "image"] : ["text"];
+  } else if (typeof vision === "boolean") {
+    out.input = vision ? ["text", "image"] : ["text"];
+  }
+  const efforts = stringArray(r.efforts)
+    ?.map((e) => e.toLowerCase())
+    .filter((e): e is CatalogEffort =>
+      (CATALOG_EFFORTS as readonly string[]).includes(e),
+    );
+  if (efforts?.length) {
+    out.efforts = [...new Set(efforts)];
+    out.reasoning = true;
+  }
+  const cost = record(r.cost ?? r.pricing);
+  if (cost) {
+    const input = nonNegative(cost.input);
+    const outputCost = nonNegative(cost.output);
+    if (input !== undefined && outputCost !== undefined) {
+      out.cost = {
+        input,
+        output: outputCost,
+        cacheRead: nonNegative(cost.cacheRead ?? cost.cache_read) ?? 0,
+        cacheWrite: nonNegative(cost.cacheWrite ?? cost.cache_write) ?? 0,
+      };
+    }
+  }
+  return out;
+}
+
+/**
+ * A catalog document in any of its accepted shapes: a map keyed by model id, a
+ * list of rows carrying `id`, or either one wrapped as `{ "models": … }`. The
+ * OpenAI `/v1/models` list (`{ "data": [ { "id": … } ] }`) is the same shape,
+ * so discovery reuses this. Rows without a usable id are skipped.
+ */
+export function catalogRows(
+  raw: unknown,
+): Record<string, ProviderCatalogModel> {
+  const out: Record<string, ProviderCatalogModel> = {};
+  const wrapper = record(raw);
+  const body =
+    wrapper && ("models" in wrapper || "data" in wrapper)
+      ? (wrapper.models ?? wrapper.data)
+      : raw;
+  if (Array.isArray(body)) {
+    for (const row of body) {
+      const r = record(row);
+      const id = typeof r?.id === "string" ? r.id.trim() : "";
+      const model = normalizeCatalogModel(id, r);
+      if (model) out[id] = model;
+    }
+    return out;
+  }
+  for (const [id, row] of Object.entries(record(body) || {})) {
+    const model = normalizeCatalogModel(id.trim(), row);
+    if (model) out[id.trim()] = model;
+  }
+  return out;
+}
+
+/** Merge catalog layers; later layers win per model id, field by field. */
+export function mergeCatalogs(
+  ...layers: Array<Record<string, ProviderCatalogModel> | undefined>
+): Record<string, ProviderCatalogModel> {
+  const out: Record<string, ProviderCatalogModel> = {};
+  for (const layer of layers) {
+    for (const [id, row] of Object.entries(layer || {})) {
+      out[id] = { ...out[id], ...row, id };
+    }
+  }
+  return out;
+}
+
+/** Where a provider's `catalogFile` lives: as given when absolute, else next
+ *  to the config file (the state dir). */
+export function catalogFilePath(file: string): string {
+  return isAbsolute(file) ? file : resolve(dirname(configPath()), file);
+}
+
+function readCatalogFile(
+  file: string,
+): Record<string, ProviderCatalogModel> | undefined {
+  const path = catalogFilePath(file);
+  if (!existsSync(path)) {
+    console.warn(`[model-providers] Catalog file ${path} does not exist`);
+    return undefined;
+  }
+  try {
+    return catalogRows(JSON.parse(readFileSync(path, "utf-8")));
+  } catch (e) {
+    console.warn(`[model-providers] Failed to parse ${path}:`, e);
+    return undefined;
+  }
+}
+
 function canonicalPickerModels(v: unknown): string[] | undefined {
   const ids = stringArray(v);
   return ids
@@ -289,6 +492,9 @@ function canonicalPickerModels(v: unknown): string[] | undefined {
 
 function providerMap(
   v: unknown,
+  loadCatalogFile: (
+    file: string,
+  ) => Record<string, ProviderCatalogModel> | undefined,
 ): Record<string, ModelProviderConfig> | undefined {
   if (!v || typeof v !== "object" || Array.isArray(v)) return undefined;
   const out: Record<string, ModelProviderConfig> = {};
@@ -301,19 +507,49 @@ function providerMap(
     )
       continue;
     const r = raw as Record<string, unknown>;
-    out[id] = {
+    const cfg: ModelProviderConfig = {
       ...(typeof r.apiKey === "string" && r.apiKey ? { apiKey: r.apiKey } : {}),
       ...(typeof r.baseURL === "string" && r.baseURL
         ? { baseURL: r.baseURL }
         : {}),
     };
+    if (
+      typeof r.api === "string" &&
+      (PROVIDER_APIS as readonly string[]).includes(r.api)
+    )
+      cfg.api = r.api as ProviderApi;
+    if (typeof r.name === "string" && r.name.trim()) cfg.name = r.name.trim();
+    if (typeof r.catalogFile === "string" && r.catalogFile.trim())
+      cfg.catalogFile = r.catalogFile.trim();
+    if (r.discoverModels === true) cfg.discoverModels = true;
+    const discovered = record(r.discovered);
+    if (discovered) {
+      const models = catalogRows(discovered.models);
+      cfg.discovered = {
+        at: typeof discovered.at === "string" ? discovered.at : "",
+        models,
+      };
+    }
+    // Layer order, weakest first: discovery, the catalog file, inline rows.
+    const inline = r.catalog !== undefined ? catalogRows(r.catalog) : undefined;
+    const fromFile = cfg.catalogFile
+      ? loadCatalogFile(cfg.catalogFile)
+      : undefined;
+    const catalog = mergeCatalogs(cfg.discovered?.models, fromFile, inline);
+    if (Object.keys(catalog).length) cfg.catalog = catalog;
+    out[id] = cfg;
   }
   return Object.keys(out).length ? out : undefined;
 }
 
-/** Pure normalization (exported for tests): raw JSON → typed config. */
+/** Pure normalization (exported for tests): raw JSON → typed config.
+ *  `loadCatalogFile` resolves each provider's `catalogFile`; the default reads
+ *  it from disk, tests pass their own. */
 export function normalizeModelProviderConfig(
   raw: unknown,
+  loadCatalogFile: (
+    file: string,
+  ) => Record<string, ProviderCatalogModel> | undefined = readCatalogFile,
 ): ModelProviderSettings | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const r = raw as Record<string, unknown>;
@@ -334,9 +570,70 @@ export function normalizeModelProviderConfig(
         ? r.bridgeMaxRequestsPerHour
         : undefined,
     openaiAccounts: stringArray(bridge?.openaiAccounts),
-    providers: providerMap(r.providers),
+    providers: providerMap(r.providers, loadCatalogFile),
     orchestrator: r.orchestrator === true,
   };
+}
+
+/**
+ * A configured provider's metadata in Pi's registerProvider shape, layered
+ * onto whatever Open Session already knows about the id. Undefined when the
+ * config adds nothing (no `api`, no catalog rows).
+ *
+ * A declared `api` makes an id unknown to both Pi and Open Session runnable:
+ * the run registers it as a plain OpenAI-compatible provider at `baseURL`.
+ * Catalog rows fill the fields the conservative stub otherwise guesses;
+ * unknown fields keep the stub's value, so a row with only `contextWindow`
+ * still runs. Pi's six thinking rungs pass through unmapped: an operator who
+ * lists `efforts` names the levels the gateway itself accepts.
+ */
+export function configuredProviderCatalog(
+  id: string,
+  cfg: ModelProviderConfig | undefined,
+): PiProviderCatalog | undefined {
+  if (!cfg) return undefined;
+  const rows = Object.values(cfg.catalog || {});
+  if (!cfg.api && !cfg.name && !rows.length) return undefined;
+  return {
+    name: cfg.name || id,
+    api: cfg.api || "openai-completions",
+    baseUrl: cfg.baseURL || "",
+    models: rows.map((row) => ({
+      id: row.id,
+      name: row.name || row.id,
+      reasoning: row.reasoning ?? true,
+      thinkingLevelMap: {},
+      input: row.input || ["text"],
+      cost: row.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: row.contextWindow || FALLBACK_CONTEXT_WINDOW,
+      maxTokens: row.maxTokens || FALLBACK_MAX_TOKENS,
+    })),
+  };
+}
+
+/** The conservative table a model unknown to every catalog registers with:
+ *  safe window and output floors, zero cost because unknown pricing must
+ *  under-report. */
+export const FALLBACK_CONTEXT_WINDOW = 131_072;
+export const FALLBACK_MAX_TOKENS = 32_768;
+
+/** The configured catalog row for `pi/<provider>/<model>` (undefined when the
+ *  operator pinned nothing and discovery recorded nothing). Reads the config
+ *  fresh unless the caller passes a snapshot; loops over many models should
+ *  pass one, since each fresh read reparses every catalog file. */
+export function configuredCatalogModel(
+  provider: string,
+  model: string,
+  providers: Record<string, ModelProviderConfig> = modelProviders(),
+): ProviderCatalogModel | undefined {
+  const catalog = providers[provider]?.catalog;
+  if (!catalog) return undefined;
+  return (
+    catalog[model] ??
+    Object.values(catalog).find(
+      (row) => row.id.toLowerCase() === model.toLowerCase(),
+    )
+  );
 }
 
 export function readModelProviderConfig(): ModelProviderSettings | null {
@@ -426,12 +723,36 @@ export function modelProviders(): Record<string, ModelProviderConfig> {
   return readModelProviderConfig()?.providers || {};
 }
 
+/** The Settings-writable subset of a provider. Catalog rows, the catalog file
+ *  and discovery results are hand-edited or recorded by discovery, never
+ *  replaced from the form. */
+export interface ModelProviderSettingsInput {
+  apiKey?: string;
+  baseURL?: string;
+  /** `""` clears the protocol (back to a Pi-known slug). */
+  api?: ProviderApi | "";
+  name?: string;
+  discoverModels?: boolean;
+}
+
+function rawProvider(
+  providers: Record<string, unknown>,
+  id: string,
+): Record<string, unknown> {
+  return record(providers[id]) || {};
+}
+
 /**
  * Upsert a third-party provider. Field semantics: `undefined` keeps the stored
- * value, `""` clears it, anything else replaces it. Throws on invalid ids and
- * on the bridge providers (anthropic/openai run on subscriptions, not keys).
+ * value, `""` clears it, anything else replaces it. Fields the form does not
+ * own (catalog, catalogFile, discovered, anything unknown) are preserved as
+ * stored. Throws on invalid ids and on the bridge providers (anthropic/openai
+ * run on subscriptions, not keys).
  */
-export function setModelProvider(id: string, cfg: ModelProviderConfig): void {
+export function setModelProvider(
+  id: string,
+  cfg: ModelProviderSettingsInput,
+): void {
   if (!PROVIDER_ID_RE.test(id)) {
     throw new Error(
       `Invalid provider id "${id}" (lowercase letters, digits and dashes only)`,
@@ -444,29 +765,41 @@ export function setModelProvider(id: string, cfg: ModelProviderConfig): void {
   }
   const raw = readRawModelProviderConfig();
   const providers = rawProviders(raw);
-  const existing =
-    providers[id] &&
-    typeof providers[id] === "object" &&
-    !Array.isArray(providers[id])
-      ? (providers[id] as Record<string, unknown>)
-      : {};
-  const next: ModelProviderConfig = {
-    ...(typeof existing.apiKey === "string" && existing.apiKey
-      ? { apiKey: existing.apiKey }
-      : {}),
-    ...(typeof existing.baseURL === "string" && existing.baseURL
-      ? { baseURL: existing.baseURL }
-      : {}),
+  const next: Record<string, unknown> = { ...rawProvider(providers, id) };
+  const setString = (key: "apiKey" | "baseURL" | "api" | "name") => {
+    const value = cfg[key];
+    if (value === undefined) return;
+    if (value) next[key] = value;
+    else delete next[key];
   };
-  if (cfg.apiKey !== undefined) {
-    if (cfg.apiKey) next.apiKey = cfg.apiKey;
-    else delete next.apiKey;
+  setString("apiKey");
+  setString("baseURL");
+  setString("api");
+  setString("name");
+  if (cfg.discoverModels !== undefined) {
+    if (cfg.discoverModels) next.discoverModels = true;
+    else delete next.discoverModels;
   }
-  if (cfg.baseURL !== undefined) {
-    if (cfg.baseURL) next.baseURL = cfg.baseURL;
-    else delete next.baseURL;
+  // Validate the effective provider before anything touches disk: a custom
+  // protocol without a base URL can never run, so it must not be stored.
+  if (next.api && !next.baseURL) {
+    throw new Error(`Provider "${id}" declares an api and needs a base URL`);
   }
   providers[id] = next;
+  raw.providers = providers;
+  writeRawModelProviderConfig(raw);
+}
+
+/** Record what `/v1/models` discovery returned for a provider. Replaces the
+ *  previous discovery block only; operator rows are untouched. */
+export function setProviderDiscovered(
+  id: string,
+  discovered: { at: string; models: Record<string, ProviderCatalogModel> },
+): void {
+  const raw = readRawModelProviderConfig();
+  const providers = rawProviders(raw);
+  if (!(id in providers)) throw new Error(`Provider "${id}" is not configured`);
+  providers[id] = { ...rawProvider(providers, id), discovered };
   raw.providers = providers;
   writeRawModelProviderConfig(raw);
 }
@@ -485,9 +818,14 @@ export function removeModelProvider(id: string): boolean {
 
 /** Add an id to pickerModels (idempotent). Returns the stored list. */
 export function addPickerModel(id: string): string[] {
+  return addPickerModels([id]);
+}
+
+/** Add ids to pickerModels in one write (idempotent). Returns the stored list. */
+export function addPickerModels(ids: readonly string[]): string[] {
   const raw = readRawModelProviderConfig();
   const list = rawPickerModels(raw);
-  if (!list.includes(id)) list.push(id);
+  for (const id of ids) if (!list.includes(id)) list.push(id);
   raw.pickerModels = list;
   writeRawModelProviderConfig(raw);
   return list;

--- a/packages/core/opensession-server/src/server/models.test.ts
+++ b/packages/core/opensession-server/src/server/models.test.ts
@@ -49,8 +49,14 @@ describe("Pi-only model routing", () => {
     expect(toPiModel("gpt-5.6-sol")).toBe("pi/openai/gpt-5.6-sol");
   });
 
-  test("preserves explicit Pi ids", () => {
+  test("preserves explicit Pi ids and case-sensitive model suffixes", () => {
     expect(toPiModel("pi/wafer/glm-5.2")).toBe("pi/wafer/glm-5.2");
+    expect(toPiModel(" pi/My-Gateway/Qwen/Qwen3-Coder ")).toBe(
+      "pi/my-gateway/Qwen/Qwen3-Coder",
+    );
+    expect(resolveModel("pi/My-Gateway/Qwen/Qwen3-Coder")?.id).toBe(
+      "pi/my-gateway/Qwen/Qwen3-Coder",
+    );
     expect(explicitEngineFor("pi/openai/gpt-5.6-sol")).toBe("pi");
   });
 

--- a/packages/core/opensession-server/src/server/models.ts
+++ b/packages/core/opensession-server/src/server/models.ts
@@ -7,12 +7,14 @@ import { existsSync, readFileSync } from "fs";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import {
   canonicalProviderPickerModelId,
+  configuredCatalogModel,
   configuredPickerModels,
   modelProviders,
   waferModelEfforts,
   waferModelName,
   BRIDGE_PROVIDER_IDS,
   GLM_5_3_MODEL_ID,
+  type ModelProviderConfig,
 } from "./model-providers";
 import { stateDir } from "./paths";
 import { piEngineEnabled, piPickerModels } from "./pi-config";
@@ -80,7 +82,10 @@ const CLAUDE_EFFORTS: SessionEffort[] = [
 /** Pi variants exposed by the configured model. Keep this aligned with
  * `Pi models <provider> --verbose`; the selected value is sent verbatim
  * as the prompt's `variant`. */
-export function modelEfforts(model: string): SessionEffort[] {
+export function modelEfforts(
+  model: string,
+  providers: Record<string, ModelProviderConfig> = modelProviders(),
+): SessionEffort[] {
   // Every engine exposes the same variants as its Pi sibling: our
   // effort levels map 1:1 onto pi's ThinkingLevel (pi-runner.ts) and onto the
   // direct SDKs' reasoning levels.
@@ -114,6 +119,11 @@ export function modelEfforts(model: string): SessionEffort[] {
     if (efforts.length) return [...efforts];
   }
   if (provider === "meta" && slug === "muse-spark-1.1") return OPENAI_EFFORTS;
+  // An operator's catalog row names the levels its gateway accepts.
+  const configured = provider
+    ? configuredCatalogModel(provider, slug, providers)
+    : null;
+  if (configured?.efforts?.length) return [...configured.efforts];
   return [];
 }
 
@@ -650,13 +660,23 @@ function prettifyModelSlug(slug: string): string {
 
 /** Friendly model label for a Pi model id. The engine is now an
  * implementation detail, so names stay model-first in every picker. */
-export function piModelLabel(id: string): string {
+export function piModelLabel(
+  id: string,
+  providers: Record<string, ModelProviderConfig> = modelProviders(),
+): string {
   const preset = modelPreset(id);
   if (preset) return preset.label;
   const canonical = canonicalProviderPickerModelId(
     id.startsWith("pi/") ? id : `pi/${id}`,
   );
   const tail = canonical.split("/").pop() || id;
+  // A configured catalog row's name beats the generic prettifier.
+  const [, provider, ...rest] = canonical.split("/");
+  const configured =
+    provider && rest.length
+      ? configuredCatalogModel(provider, rest.join("/"), providers)
+      : undefined;
+  if (configured?.name) return configured.name;
   const native = KNOWN_MODELS.find((m) => m.provider !== "pi" && m.id === tail);
   return (native?.label || prettifyModelSlug(tail))
     .replace(/^Claude\s+/i, "")
@@ -683,8 +703,11 @@ export function refreshPickerModels(): void {
     if (KNOWN_MODELS[i].provider === "pi") KNOWN_MODELS.splice(i, 1);
   }
   try {
+    // One config read per refresh: the per-model label lookup below would
+    // otherwise reparse the file (and every catalog file) once per entry.
+    const providers = modelProviders();
     const keyed = new Set(
-      Object.entries(modelProviders())
+      Object.entries(providers)
         .filter(([, provider]) => !!provider.apiKey)
         .map(([id]) => id),
     );
@@ -712,7 +735,7 @@ export function refreshPickerModels(): void {
       KNOWN_MODELS.push({
         id,
         provider: "pi",
-        label: piModelLabel(id),
+        label: piModelLabel(id, providers),
         aliases: [],
       });
     }
@@ -1002,10 +1025,22 @@ const RETIRED_CODEX_REROUTE: Record<string, string> = {
   "gpt-5.3-codex-spark": "gpt-5.6-luna",
 };
 
-/** Route a model or preset to Pi. */
+function isAppRoutedPiProvider(provider: string): boolean {
+  return (
+    provider === "dial" ||
+    provider === "orchestrator" ||
+    provider === "workspace-preset"
+  );
+}
+
+/** Route a model or preset to Pi. Explicit Pi ids keep the model suffix's
+ * casing because OpenAI-compatible gateways may treat model ids as
+ * case-sensitive; only the provider and app-owned routing ids are normalized. */
 export function toPiModel(model?: string | null): string | undefined {
-  let requested = (model || "").trim().toLowerCase();
+  const raw = (model || "").trim();
+  let requested = raw.toLowerCase();
   if (!requested) return model ?? undefined;
+  const inputLower = requested;
   if (requested.startsWith("claude/") || requested.startsWith("codex/")) {
     requested = requested.slice(requested.indexOf("/") + 1);
   }
@@ -1023,7 +1058,24 @@ export function toPiModel(model?: string | null): string | undefined {
   if (requested.startsWith("pi/")) {
     const match = requested.match(/^pi\/openai\/(.+)$/);
     const replacement = match && RETIRED_CODEX_REROUTE[match[1]];
-    return replacement ? `pi/openai/${replacement}` : requested;
+    if (replacement) return `pi/openai/${replacement}`;
+
+    const explicitSource = requested !== inputLower ? requested : raw;
+    const explicit = explicitSource.match(/^pi\/([^/]+)\/(.+)$/i);
+    if (explicit) {
+      const provider = explicit[1]!.toLowerCase();
+      const suffix = explicit[2]!;
+      // App-owned preset ids are case-insensitive routing keys. Provider model
+      // ids are not, so prefer the picker/catalog's exact casing when known
+      // and otherwise preserve what the caller supplied.
+      if (isAppRoutedPiProvider(provider)) return requested;
+      const lowerId = `pi/${provider}/${suffix.toLowerCase()}`;
+      const known = KNOWN_MODELS.find(
+        (candidate) => candidate.id.toLowerCase() === lowerId,
+      );
+      return known?.id ?? `pi/${provider}/${suffix}`;
+    }
+    return requested;
   }
   if (requested.startsWith("openai/")) {
     const native = requested.slice("openai/".length);
@@ -1237,10 +1289,11 @@ export function fallbackPlan(
  * registry bump; anything else is rejected.
  */
 export function resolveModel(input: string): ModelInfo | null {
-  const value = input.trim().toLowerCase();
+  const raw = input.trim();
+  const value = raw.toLowerCase();
   if (!value) return null;
   for (const model of KNOWN_MODELS) {
-    if (model.id === value || model.aliases.includes(value)) {
+    if (model.id.toLowerCase() === value || model.aliases.includes(value)) {
       const replacement =
         RETIRED_CLAUDE_REROUTE[model.id] || RETIRED_CODEX_REROUTE[model.id];
       return replacement
@@ -1256,7 +1309,8 @@ export function resolveModel(input: string): ModelInfo | null {
   const pickerAlias = value.replace(/\s+/g, "-");
   const pickerMatches = KNOWN_MODELS.filter(
     (model) =>
-      model.provider === "pi" && model.id.split("/").at(-1) === pickerAlias,
+      model.provider === "pi" &&
+      model.id.split("/").at(-1)?.toLowerCase() === pickerAlias,
   );
   if (pickerMatches.length === 1) return pickerMatches[0];
   if (value.startsWith("dial/") || value.startsWith("orchestrator/")) {
@@ -1273,7 +1327,7 @@ export function resolveModel(input: string): ModelInfo | null {
       : null;
   }
   if (value.startsWith("pi/")) {
-    const routed = toPiModel(value) || value;
+    const routed = toPiModel(raw) || raw;
     return routed.slice("pi/".length).includes("/")
       ? { id: routed, provider: "pi", label: piModelLabel(routed), aliases: [] }
       : null;
@@ -1287,7 +1341,7 @@ export function resolveModel(input: string): ModelInfo | null {
     return resolveModel(value.slice(value.indexOf("/") + 1));
   }
   if (value.includes("/")) {
-    const id = toPiModel(value);
+    const id = toPiModel(raw);
     return id
       ? { id, provider: "pi", label: piModelLabel(id), aliases: [] }
       : null;

--- a/packages/core/opensession-server/src/server/pi-anthropic-provider.test.ts
+++ b/packages/core/opensession-server/src/server/pi-anthropic-provider.test.ts
@@ -1147,4 +1147,36 @@ describe("pickBridgeAccount pool mode (no designation — picks like pi)", () =>
     const anonymous = pickBridgeAccount("claude-sonnet-5");
     expect((anonymous as any).id).toBe("pool-shared");
   });
+
+  test("a sticky account beats the least-used round-robin while usable", () => {
+    designate([]);
+    seedAccounts(["pool-sticky-a", "pool-sticky-b", "pool-sticky-c"]);
+    for (const id of ["pool-sticky-a", "pool-sticky-b", "pool-sticky-c"])
+      accounts.__setUsageCacheForTest(id, freshUsage);
+    // Consume the round-robin turn on the sticky account so the plain pick
+    // would move elsewhere; the sticky preference must hold it in place.
+    expect((pickBridgeAccount("claude-sonnet-5") as any).id).toBe(
+      "pool-sticky-a",
+    );
+    expect(
+      (
+        pickBridgeAccount("claude-sonnet-5", {
+          stickyId: "pool-sticky-a",
+        }) as any
+      ).id,
+    ).toBe("pool-sticky-a");
+    // Burned this turn: the walk moves on instead of retrying the sticky one.
+    const walked = pickBridgeAccount("claude-sonnet-5", {
+      stickyId: "pool-sticky-a",
+      excludeIds: ["pool-sticky-a"],
+    });
+    expect((walked as any).id).not.toBe("pool-sticky-a");
+    // Exhausted: falls through to the least-used pick.
+    accounts.__setUsageCacheForTest("pool-sticky-a", maxedUsage);
+    const moved = pickBridgeAccount("claude-sonnet-5", {
+      stickyId: "pool-sticky-a",
+    });
+    expect((moved as any).id).not.toBe("pool-sticky-a");
+    expect("error" in moved).toBe(false);
+  });
 });

--- a/packages/core/opensession-server/src/server/pi-model-runtime.ts
+++ b/packages/core/opensession-server/src/server/pi-model-runtime.ts
@@ -879,12 +879,21 @@ async function* runSdkAttempt(
       return;
     }
 
+    // Stay on the account that already holds this session's SDK conversation
+    // while it is usable. Every request re-picks, and the least-used tiebreak
+    // round-robins equal accounts, so without this a session hopped
+    // subscriptions on nearly every step and replayed its full context (a
+    // cache write, not a read) each time. The sticky step sits below the pin
+    // and above the least-used pool pick; exhaustion, sidelining, and the
+    // in-turn walk (excludeIds) still move the session off it.
+    const stickyId = piSdkSessionStore().get(storeKey)?.accountId;
     const picked = pickBridgeAccount(model.id, {
       accountId: opts.accountId,
       accountStrict: opts.accountStrict,
       usageCredits: opts.usageCredits,
       user: opts.user,
       excludeIds: excluded.size ? [...excluded] : undefined,
+      stickyId,
     });
     if ("error" in picked) throw new Error(picked.error);
     account = picked;

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -55,9 +55,14 @@ import {
 } from "./runner-shared";
 import { ensureAnthropicBridge } from "./anthropic-bridge";
 import {
+  FALLBACK_CONTEXT_WINDOW,
+  FALLBACK_MAX_TOKENS,
+  configuredProviderCatalog,
   modelProviders,
   piProviderCatalog,
   readModelProviderConfig,
+  type ModelProviderConfig,
+  type PiProviderCatalog,
 } from "./model-providers";
 import { markCodexExhausted, type CodexAccount } from "./codex-accounts";
 import { pickAccount as pickClaudeAccount } from "./claude-accounts";
@@ -359,39 +364,58 @@ export function piDialOracleAgent(
  * Model metadata comes from Pi's built-in provider catalog when Pi knows the
  * provider (Cerebras, Moonshot, xAI, and others). piProviderCatalog supplies a
  * provider Pi does not know (Wafer) and models newer than its bundled snapshot
- * (GLM-5.3 on OpenRouter). A provider in neither catalog fails clearly rather
- * than guessing a protocol. A model id newer than both catalogs gets a
- * conservative fallback entry: zero cost because unknown pricing must
- * under-report, plus safe window and output floors. It inherits the provider's
- * API and base URL, so catalog lag never blocks a run.
+ * (GLM-5.3 on OpenRouter). The operator's config adds a third layer: a
+ * declared `api` makes a slug unknown to both catalogs runnable as a plain
+ * OpenAI-compatible provider at its `baseURL`, and its catalog rows (inline,
+ * file, or discovered) override the other layers per model id. A provider in
+ * no catalog fails clearly rather than guessing a protocol. A model id in none
+ * of them gets a conservative fallback entry: zero cost because unknown
+ * pricing must under-report, plus safe window and output floors. It inherits
+ * the provider's API and base URL, so catalog lag never blocks a run.
  */
 export function buildPiThirdPartyProviderPlan(input: {
   providerID: string;
   modelID: string;
   apiKey: string;
   baseURL?: string;
+  /** The provider's stored config beyond the key and base URL. */
+  configured?: ModelProviderConfig;
   /** Model ids pi's built-in catalog holds for this provider (may be empty). */
   builtinModelIds: readonly string[];
 }): { config: PiProviderConfigInput } | { error: string } {
-  const catalog = piProviderCatalog(input.providerID);
+  const ours = piProviderCatalog(input.providerID);
+  const custom = configuredProviderCatalog(input.providerID, input.configured);
   const builtin = new Set(input.builtinModelIds);
-  if (!catalog && !builtin.size) {
+  const declared = !!input.configured?.api;
+  if (!ours && !builtin.size && !declared) {
     return {
       error:
         `Provider "${input.providerID}" is in neither Pi's built-in catalog nor ours, ` +
-        "so the Pi engine cannot guess its protocol. Configure a supported provider for this model.",
+        "so the Pi engine cannot guess its protocol. Set its api to openai-completions " +
+        "with a base URL, or configure a supported provider for this model.",
     };
   }
-  const builtinKnown = builtin.has(input.modelID);
-  const catalogKnown = !!catalog?.models.some((m) => m.id === input.modelID);
+  if (declared && !input.baseURL) {
+    return {
+      error: `Provider "${input.providerID}" declares an api but no base URL. Set its base URL first.`,
+    };
+  }
+  const configuredRow = custom?.models.find((m) => m.id === input.modelID);
+  const builtinKnown = builtin.has(input.modelID) && !configuredRow;
+  const catalogKnown =
+    !!configuredRow || !!ours?.models.some((m) => m.id === input.modelID);
   // Registering `models` REPLACES the provider's model list in Pi's extension
   // layer. Preserve Pi's full built-in list when it already knows the selected
-  // model. A self-catalogued model carries its complete table, while a model
-  // unknown to both catalogs gets that table plus a conservative fallback row.
+  // model and the operator pinned nothing for it. Otherwise the table carries
+  // our rows, the configured rows on top (same id wins), and a conservative
+  // fallback row when the selected model is in none of them.
+  const table = new Map<string, PiProviderCatalog["models"][number]>();
+  for (const m of ours?.models ?? []) table.set(m.id, m);
+  for (const m of custom?.models ?? []) table.set(m.id, m);
   const models = builtinKnown
     ? []
     : [
-        ...(catalog?.models ?? []),
+        ...table.values(),
         ...(catalogKnown
           ? []
           : [
@@ -401,19 +425,22 @@ export function buildPiThirdPartyProviderPlan(input: {
                 reasoning: true,
                 input: ["text"] as Array<"text" | "image">,
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 131_072,
-                maxTokens: 32_768,
+                contextWindow: FALLBACK_CONTEXT_WINDOW,
+                maxTokens: FALLBACK_MAX_TOKENS,
               },
             ]),
       ];
+  const api = custom?.api ?? ours?.api;
+  const name = input.configured?.name || ours?.name;
   return {
     config: {
       apiKey: input.apiKey,
-      ...(catalog ? { name: catalog.name, api: catalog.api } : {}),
+      ...(api && (declared || ours) ? { api } : {}),
+      ...(name && (declared || ours) ? { name } : {}),
       ...(input.baseURL
         ? { baseUrl: input.baseURL }
-        : catalog
-          ? { baseUrl: catalog.baseUrl }
+        : ours
+          ? { baseUrl: ours.baseUrl }
           : {}),
       ...(models.length ? { models } : {}),
     },

--- a/packages/core/opensession-server/src/server/pi-runtime-binding.ts
+++ b/packages/core/opensession-server/src/server/pi-runtime-binding.ts
@@ -1,6 +1,7 @@
 import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { CodexAccount } from "./codex-accounts";
 import type { SeededOpenaiAuth } from "./openai-auth";
+import type { ModelProviderConfig } from "./model-providers";
 
 export type PiSdk = typeof import("@earendil-works/pi-coding-agent");
 type PiModel = NonNullable<ReturnType<ModelRuntime["getModel"]>>;
@@ -44,10 +45,7 @@ export interface PiRuntimeBinding extends PiRuntimeAccountEvidence {
   usesOpenaiOAuth: boolean;
 }
 
-interface ConfiguredProvider {
-  apiKey?: string;
-  baseURL?: string;
-}
+type ConfiguredProvider = ModelProviderConfig;
 
 interface OpenaiPickOut {
   reason?: string;
@@ -86,6 +84,7 @@ export interface PiRuntimeBindingDependencies {
     modelID: string;
     apiKey: string;
     baseURL?: string;
+    configured?: ModelProviderConfig;
     builtinModelIds: readonly string[];
   }) => { config: PiProviderConfigInput } | { error: string };
   now?: () => number;
@@ -301,6 +300,7 @@ export async function createPiRuntimeBinding(
       modelID: input.modelID,
       apiKey: provider.apiKey!,
       baseURL: provider.baseURL,
+      configured: provider,
       builtinModelIds: runtime
         .getModels(input.providerID)
         .map((candidate) => candidate.id),

--- a/packages/core/opensession-server/src/server/routes/connections.test.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.test.ts
@@ -27,6 +27,7 @@ import type { RouteContext } from "./context";
 
 const ENV_KEYS = [
   "OPENSESSION_CONFIG",
+  "OPENSESSION_MODEL_PROVIDERS_CONFIG",
   "OPENSESSION_GITHUB_CLIENT_ID",
   "OPENSESSION_GITHUB_APP_SLUG",
   "OPENSESSION_GITHUB_APP_KEY",
@@ -273,6 +274,38 @@ describe("Apple release connection authorization", () => {
     expect(setup?.status).toBe(200);
     expect(storedMcpServers(mcpConfig)["apple-build"]).toBeUndefined();
     expect(storedMcpServers(mcpConfig)["apple-release"]).toBeUndefined();
+  });
+});
+
+describe("Model provider authorization", () => {
+  test("rejects non-admin provider mutations and discovery", async () => {
+    enableRoleAwareConnections();
+    const providerConfig = join(dir, "model-providers.json");
+    const original = JSON.stringify({
+      providers: {
+        gateway: {
+          apiKey: "stored-secret",
+          baseURL: "https://gateway.test/v1",
+          api: "openai-completions",
+        },
+      },
+    });
+    writeFileSync(providerConfig, original);
+    process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = providerConfig;
+
+    const requests = [
+      context("/api/settings/model-providers/gateway/discover", "POST", MEMBER),
+      context("/api/settings/model-providers/gateway", "PUT", MEMBER, {
+        baseURL: "https://attacker.test/v1",
+        discoverModels: true,
+      }),
+      context("/api/settings/model-providers/gateway", "DELETE", MEMBER),
+    ];
+    for (const request of requests) {
+      const response = await handleConnectionsRoutes(request);
+      expect(response?.status).toBe(403);
+    }
+    expect(readFileSync(providerConfig, "utf-8")).toBe(original);
   });
 });
 

--- a/packages/core/opensession-server/src/server/routes/connections.ts
+++ b/packages/core/opensession-server/src/server/routes/connections.ts
@@ -29,6 +29,7 @@ import {
 import { stateDir } from "../paths";
 import {
   BRIDGE_PROVIDER_IDS,
+  PROVIDER_APIS,
   PROVIDER_ID_RE,
   addPickerModel,
   defaultPickerModelsForProvider,
@@ -38,7 +39,9 @@ import {
   removeModelProvider,
   removePickerModel,
   setModelProvider,
+  type ModelProviderConfig,
 } from "../model-providers";
+import { discoverProviderModels } from "../model-discovery";
 import {
   isPiModelId,
   piEngineEnabled,
@@ -47,6 +50,28 @@ import {
   setPiPickerModels,
 } from "../pi-config";
 import { requireWorkspaceAdmin } from "../workspace-auth";
+
+/** The client-facing shape of a configured provider: the key masked, plus the
+ *  fields Settings edits and a summary of the catalog it cannot edit. */
+function publicProvider(
+  id: string,
+  p: ModelProviderConfig,
+  pickerModels: readonly string[],
+) {
+  const catalogIds = Object.keys(p.catalog || {});
+  return {
+    id,
+    apiKeyMasked: maskProviderKey(p.apiKey),
+    ...(p.baseURL ? { baseURL: p.baseURL } : {}),
+    ...(p.api ? { api: p.api } : {}),
+    ...(p.name ? { name: p.name } : {}),
+    ...(p.discoverModels ? { discoverModels: true } : {}),
+    ...(p.discovered?.at ? { discoveredAt: p.discovered.at } : {}),
+    ...(p.catalogFile ? { catalogFile: p.catalogFile } : {}),
+    catalogModels: catalogIds.length,
+    models: pickerModels.filter((m) => m.startsWith(`pi/${id}/`)),
+  };
+}
 
 /** Navigate `integrations.github` in a raw parsed config object so the App
  *  routes can set or drop its keys without disturbing anything else the file
@@ -542,20 +567,49 @@ export async function handleConnectionsRoutes(
   if (path === "/api/settings/model-providers" && req.method === "GET") {
     const pickerModels = readModelProviderConfig()?.pickerModels || [];
     return Response.json({
-      providers: Object.entries(modelProviders()).map(([id, p]) => ({
-        id,
-        apiKeyMasked: maskProviderKey(p.apiKey),
-        ...(p.baseURL ? { baseURL: p.baseURL } : {}),
-        models: pickerModels.filter((m) => m.startsWith(`pi/${id}/`)),
-      })),
+      providers: Object.entries(modelProviders()).map(([id, p]) =>
+        publicProvider(id, p, pickerModels),
+      ),
       pickerModels,
     });
+  }
+
+  // Opt-in `GET {baseURL}/models` poll: records what the gateway lists and
+  // adds the ids to the picker without removing operator-pinned ones.
+  const discoverMatch = path.match(
+    /^\/api\/settings\/model-providers\/([^/]+)\/discover$/,
+  );
+  if (discoverMatch && req.method === "POST") {
+    // Discovery sends the stored key to whatever base URL is configured, so
+    // it is a shared-configuration mutation and stays admin-only.
+    const forbidden = requireWorkspaceAdmin(ctx);
+    if (forbidden) return forbidden;
+    const id = decodeURIComponent(discoverMatch[1]);
+    if (!modelProviders()[id]) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
+    try {
+      const result = await discoverProviderModels(id);
+      refreshPickerModels();
+      const pickerModels = readModelProviderConfig()?.pickerModels || [];
+      return Response.json({
+        ...result,
+        provider: publicProvider(id, modelProviders()[id], pickerModels),
+      });
+    } catch (e: any) {
+      return Response.json(
+        { error: e?.message || "Discovery failed" },
+        { status: 502 },
+      );
+    }
   }
 
   const modelProviderMatch = path.match(
     /^\/api\/settings\/model-providers\/([^/]+)$/,
   );
   if (modelProviderMatch && req.method === "PUT") {
+    const forbidden = requireWorkspaceAdmin(ctx);
+    if (forbidden) return forbidden;
     const id = decodeURIComponent(modelProviderMatch[1]);
     if (!PROVIDER_ID_RE.test(id)) {
       return Response.json(
@@ -585,11 +639,31 @@ export async function handleConnectionsRoutes(
         : undefined;
     const baseURL =
       typeof body.baseURL === "string" ? body.baseURL.trim() : undefined;
+    const api = typeof body.api === "string" ? body.api.trim() : undefined;
+    if (api && !(PROVIDER_APIS as readonly string[]).includes(api)) {
+      return Response.json(
+        { error: `Unsupported api "${api}" (expected openai-completions)` },
+        { status: 400 },
+      );
+    }
+    const name = typeof body.name === "string" ? body.name.trim() : undefined;
+    const discoverModels =
+      typeof body.discoverModels === "boolean"
+        ? body.discoverModels
+        : undefined;
     const models = Array.isArray(body.models)
       ? body.models.filter((m: unknown): m is string => typeof m === "string")
       : undefined;
     try {
-      setModelProvider(id, { apiKey, baseURL });
+      setModelProvider(id, {
+        apiKey,
+        baseURL,
+        api: api as ModelProviderConfig["api"] | "" | undefined,
+        name,
+        discoverModels,
+      });
+      // setModelProvider validated the effective provider before writing.
+      const savedProvider = modelProviders()[id];
       const pickerModels = readModelProviderConfig()?.pickerModels || [];
       const providerModels =
         models ??
@@ -610,16 +684,22 @@ export async function handleConnectionsRoutes(
           if (tail) addPickerModel(`${prefix}${tail}`);
         }
       }
+      let discovery: { added: number; models: string[] } | undefined;
+      let discoveryError: string | undefined;
+      if (discoverModels && savedProvider?.baseURL && savedProvider.apiKey) {
+        try {
+          discovery = await discoverProviderModels(id);
+        } catch (e: any) {
+          discoveryError = e?.message || "Discovery failed";
+        }
+      }
       refreshPickerModels();
       const stored = modelProviders()[id] || {};
       const savedPickerModels = readModelProviderConfig()?.pickerModels || [];
       return Response.json({
-        provider: {
-          id,
-          apiKeyMasked: maskProviderKey(stored.apiKey),
-          ...(stored.baseURL ? { baseURL: stored.baseURL } : {}),
-          models: savedPickerModels.filter((m) => m.startsWith(`pi/${id}/`)),
-        },
+        provider: publicProvider(id, stored, savedPickerModels),
+        ...(discovery ? { discovery } : {}),
+        ...(discoveryError ? { discoveryError } : {}),
       });
     } catch (e: any) {
       return Response.json(
@@ -630,6 +710,8 @@ export async function handleConnectionsRoutes(
   }
 
   if (modelProviderMatch && req.method === "DELETE") {
+    const forbidden = requireWorkspaceAdmin(ctx);
+    if (forbidden) return forbidden;
     const id = decodeURIComponent(modelProviderMatch[1]);
     try {
       const removed = removeModelProvider(id);

--- a/packages/core/opensession-server/src/server/routes/models.ts
+++ b/packages/core/opensession-server/src/server/routes/models.ts
@@ -25,7 +25,7 @@ import {
   setModelFallbackAuto,
   toPiModel,
 } from "../models";
-import { orchestratorEnabled } from "../model-providers";
+import { modelProviders, orchestratorEnabled } from "../model-providers";
 import {
   configuredInteractiveDefaultModel,
   configuredModelProviders,
@@ -198,9 +198,11 @@ export async function handleModelsRoutes(
         ? `${pi ? "pi/" : ""}workspace-preset/${workspace.id}/${preset.id}`
         : interactiveDefault;
     })();
+    // One provider config read for the whole catalog, not one per model.
+    const providers = modelProviders();
     const catalogModels = [...presetModels, ...visibleModels].map((model) => ({
       ...model,
-      efforts: modelEfforts(model.id),
+      efforts: modelEfforts(model.id, providers),
       accountProvider: accountProviderForModel(model.id),
       fastModeSupported: supportsOpenaiFastMode(toPiModel(model.id)),
     }));

--- a/packages/core/opensession-server/src/server/routes/setup-github-toggle.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-github-toggle.test.ts
@@ -155,4 +155,20 @@ describe("GitHub App identity settings", () => {
       installationOwner: "acme",
     });
   });
+
+  test("clears a legacy installation id when changing owners", async () => {
+    const config = setupFiles();
+    const current = JSON.parse(readFileSync(config, "utf8"));
+    current.integrations.github.installationId = 123;
+    writeFileSync(config, JSON.stringify(current));
+
+    const response = await handleSetupRoutes(
+      githubRequest({ installationOwner: "other-owner" }),
+    );
+
+    expect(response?.status).toBe(200);
+    const written = JSON.parse(readFileSync(config, "utf8"));
+    expect(written.integrations.github.installationOwner).toBe("other-owner");
+    expect(written.integrations.github.installationId).toBeUndefined();
+  });
 });

--- a/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.test.ts
@@ -13,7 +13,9 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 import { pathToFileURL } from "url";
+import { generateKeyPairSync } from "node:crypto";
 import { createWorktree } from "../worktree";
+import { __setGithubAppKeyPathForTest } from "../github-app";
 import {
   adoptExistingCheckout,
   githubCredentialHelperCommand,
@@ -151,6 +153,160 @@ describe("App installation repository listing", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("GET /api/setup/github/repos with several App installations", () => {
+  const originalFetch = globalThis.fetch;
+  const originalClientId = process.env.OPENSESSION_GITHUB_CLIENT_ID;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalClientId === undefined)
+      delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+    else process.env.OPENSESSION_GITHUB_CLIENT_ID = originalClientId;
+    __setGithubAppKeyPathForTest(undefined);
+    const cache = globalThis as any;
+    cache.__ghAppTokenCacheRead = null;
+    cache.__ghAppTokenCacheWrite = null;
+    cache.__ghAppLastMintOk = undefined;
+    cache.__ghAppLastMintIdentity = undefined;
+    cache.__ghAppInstallationsCache = null;
+  });
+
+  function writeAppConfig(path: string, installationOwner: string): void {
+    writeFileSync(
+      path,
+      JSON.stringify({
+        integrations: {
+          github: {
+            oauthClientId: "Iv-picker-test",
+            appSlug: "open-session-picker-test",
+            installationOwner,
+          },
+        },
+      }),
+    );
+  }
+
+  async function getRepos(): Promise<any> {
+    const url = new URL("http://localhost/api/setup/github/repos");
+    const response = await handleSetupRepoRoutes({
+      req: new Request(url),
+      url,
+      path: url.pathname,
+      publicPrefix: "",
+    } as RouteContext);
+    expect(response?.status).toBe(200);
+    return response!.json();
+  }
+
+  test("names every installation, marks the pinned one, and refetches after a switch", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-picker-installs-"));
+    tempDirs.push(dir);
+    const config = join(dir, "config.json");
+    const keyPath = join(dir, "github-app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(keyPath, privateKey.export({ format: "pem", type: "pkcs8" }));
+    writeAppConfig(config, "solo-dev");
+    process.env.OPENSESSION_CONFIG = config;
+    delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+    __setGithubAppKeyPathForTest(keyPath);
+
+    const installs = [
+      { id: 1, account: { login: "solo-dev", type: "User" } },
+      { id: 2, account: { login: "acme-org", type: "Organization" } },
+    ];
+    const repoLists = new Map<number, string[]>([
+      [1, []],
+      [2, ["acme-org/app"]],
+    ]);
+    const listCalls: string[] = [];
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.startsWith("https://api.github.com/app/installations?"))
+        return Response.json(installs);
+      if (url === "https://api.github.com/app/installations")
+        return Response.json(installs);
+      const mint = url.match(/\/app\/installations\/(\d+)\/access_tokens$/);
+      if (mint)
+        return Response.json({
+          token: `ghs_install_${mint[1]}`,
+          expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
+        });
+      if (url.startsWith("https://api.github.com/installation/repositories")) {
+        const auth = String(
+          (init?.headers as Record<string, string>).Authorization,
+        );
+        listCalls.push(auth);
+        const id = Number(auth.replace(/^Bearer ghs_install_/, ""));
+        return Response.json({
+          repositories: (repoLists.get(id) ?? []).map((fullName) => ({
+            full_name: fullName,
+            private: true,
+            default_branch: "main",
+            pushed_at: "2026-08-24T00:00:00Z",
+          })),
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const pinnedToPersonal = await getRepos();
+    expect(pinnedToPersonal.source).toBe("app");
+    expect(pinnedToPersonal.repos).toEqual([]);
+    expect(pinnedToPersonal.installationOwner).toBe("solo-dev");
+    expect(pinnedToPersonal.installations).toEqual([
+      { login: "solo-dev", type: "User", selected: true },
+      { login: "acme-org", type: "Organization", selected: false },
+    ]);
+
+    // Switching the pinned owner must not serve the previous installation's
+    // (empty) list from the 60s cache.
+    const switched = join(dir, "config-acme.json");
+    writeAppConfig(switched, "acme-org");
+    process.env.OPENSESSION_CONFIG = switched;
+    const pinnedToOrg = await getRepos();
+    expect(pinnedToOrg.installationOwner).toBe("acme-org");
+    expect(pinnedToOrg.repos.map((repo: any) => repo.fullName)).toEqual([
+      "acme-org/app",
+    ]);
+    expect(pinnedToOrg.installations.find((i: any) => i.selected)?.login).toBe(
+      "acme-org",
+    );
+    expect(listCalls).toEqual(["Bearer ghs_install_1", "Bearer ghs_install_2"]);
+  });
+
+  test("still names the installations when the pinned owner matches none", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-picker-orphan-"));
+    tempDirs.push(dir);
+    const config = join(dir, "config.json");
+    const keyPath = join(dir, "github-app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(keyPath, privateKey.export({ format: "pem", type: "pkcs8" }));
+    writeAppConfig(config, "gone-org");
+    process.env.OPENSESSION_CONFIG = config;
+    delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+    __setGithubAppKeyPathForTest(keyPath);
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.startsWith("https://api.github.com/app/installations"))
+        return Response.json([
+          { id: 2, account: { login: "acme-org", type: "Organization" } },
+        ]);
+      throw new Error(`Unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const body = await getRepos();
+    expect(body.source).toBeNull();
+    expect(body.appConfigured).toBe(true);
+    expect(body.installationOwner).toBe("gone-org");
+    expect(body.installations).toEqual([
+      { login: "acme-org", type: "Organization", selected: false },
+    ]);
   });
 });
 

--- a/packages/core/opensession-server/src/server/routes/setup-repos.ts
+++ b/packages/core/opensession-server/src/server/routes/setup-repos.ts
@@ -891,6 +891,11 @@ export async function handleSetupRepoRoutes(
     // Browse the repositories selected for the workspace App installation.
     // A connected teammate is only a compatibility path when no App service
     // credential is configured; ambient credentials are never consulted.
+    const {
+      configuredGithubInstallationOwner,
+      githubConfiguredCredential,
+      listGithubAppInstallations,
+    } = await import("../github-app");
     const credential = await setupGithubCredential(ctx);
     const token = credential?.env.GH_TOKEN;
     const source: "user" | "app" | null = credential
@@ -898,19 +903,42 @@ export async function handleSetupRepoRoutes(
         ? "user"
         : "app"
       : null;
+    const configuredOwner = configuredGithubInstallationOwner();
+    // The App's installation list rides along whenever the App identity can
+    // produce one, so the picker can name the selectable owners. An empty repo
+    // list alone cannot reveal that the App is installed elsewhere (say, on an
+    // organization while the pinned owner is the repo-less personal account
+    // that created the App).
+    const appInstallations = githubConfiguredCredential()
+      ? await listGithubAppInstallations()
+      : null;
+    const installationContext = appInstallations
+      ? {
+          installationOwner: configuredOwner || null,
+          installations: appInstallations.map((installation) => ({
+            ...installation,
+            selected:
+              installation.login.toLowerCase() ===
+              configuredOwner.toLowerCase(),
+          })),
+        }
+      : {};
     if (!token || !source) {
-      const { githubConfiguredCredential } = await import("../github-app");
       return Response.json({
         source: null,
         repos: [],
         appConfigured: githubConfiguredCredential(),
         appInstallUrl: githubAppInstallUrl(),
+        ...installationContext,
       });
     }
-    const cacheKey = credential.principal;
+    // The service credential's repo horizon follows the pinned installation
+    // owner, so the owner is part of the cache identity. Switching owners must
+    // not serve the previous installation's list for the TTL.
+    const cacheKey = `${credential.principal}:${configuredOwner.toLowerCase()}`;
     const cached = repoListCache.get(cacheKey);
     if (cached && Date.now() - cached.at < REPO_CACHE_TTL_MS) {
-      return Response.json(cached.payload);
+      return Response.json({ ...cached.payload, ...installationContext });
     }
     try {
       // Installation tokens have a direct repository list. App user tokens list
@@ -927,7 +955,7 @@ export async function handleSetupRepoRoutes(
         repos: repos.map(({ pushedAt: _pushedAt, ...repo }) => repo),
       };
       repoListCache.set(cacheKey, { at: Date.now(), payload });
-      return Response.json(payload);
+      return Response.json({ ...payload, ...installationContext });
     } catch (e) {
       return Response.json(
         { error: e instanceof Error ? e.message : String(e) },

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -739,6 +739,9 @@ export async function handleSetupRoutes(
           delete github[field]; // empty string clears
         else github[field] = value;
       }
+      // installationId is a legacy selector that takes precedence during token
+      // minting. Changing the owner must clear it in the same config write.
+      if (body.installationOwner !== undefined) delete github.installationId;
       try {
         const { commitGithubAppKeyMutation } = await import("../github-app");
         await commitGithubAppKeyMutation(keyMutation, () =>

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -76,6 +76,7 @@ import { registerRunToken, unregisterRunToken } from "./run-rpc";
 import { createSlackPostScanner, linkThreadInIndex } from "./slack-links";
 import {
   STRIPE_CONFIRM_TOOLS,
+  filterMcpServers,
   looksLikeFabricatedToolTranscript,
 } from "./runner-shared";
 import {
@@ -97,10 +98,21 @@ import {
 import {
   isRemoteSandboxProvider,
   isRunnableSandboxProvider,
+  sandboxAutomationConfig,
   sandboxesEnabled,
   sandboxProviderConfigured,
 } from "./sandbox/config";
+import { disposeAutomationSandbox } from "./sandbox/automation-disposal";
+import {
+  automationModelEgressDestinations,
+  mcpEgressDestinations,
+} from "./sandbox/automation-egress";
 import { ensureSandboxWithTransientRetry } from "./sandbox/reliability";
+import {
+  automationModel,
+  getAutomation,
+  validateSandboxAutomation,
+} from "./automations";
 import {
   portableWorkspacePresetRun,
   resolveWorkspaceModelPreset,
@@ -1801,9 +1813,9 @@ export async function autoPushSessionBranches(
  * session records a provider, every unavailable/config/launch failure is
  * surfaced by the caller and the prompt is not run on the host. Changing the
  * execution, trust or billing boundary always requires a person's choice.
- * Automation-owned sessions are refused outright — sandboxes carry
- * interactive-parity credentials (~/.ssh, gh, account pool / scoped OAuth
- * upload) that untrusted prompt text must not reach.
+ * Automation-owned root sessions use a separate disposable path: every turn
+ * revalidates the owning automation, reapplies its minimal credentials and
+ * egress policy, and destroys the Executor when the stream closes.
  */
 export function sandboxRunSecuritySpec(
   session: UnifiedSession,
@@ -1898,14 +1910,47 @@ export async function maybeLaunchSandboxedRun(
       `Sandbox provider "${sbProvider}" is not configured and Ready`,
     );
   }
-  if (opts.isAutomationSession && !session.automationDescendantPolicy) {
-    throw new Error(
-      "Interactive sandbox connections are unavailable to automation sessions",
-    );
+  const disposableAutomationResume =
+    opts.isAutomationSession && !session.automationDescendantPolicy;
+  const owningAutomation = disposableAutomationResume
+    ? session.automationId
+      ? getAutomation(session.automationId)
+      : null
+    : null;
+  if (disposableAutomationResume) {
+    if (
+      !owningAutomation ||
+      !owningAutomation.sandbox ||
+      owningAutomation.name !== session.automation ||
+      owningAutomation.accountId !== session.accountId ||
+      !!session.sandbox?.sandboxId
+    ) {
+      throw new Error(
+        "Sandbox automation resume policy is unavailable or has changed",
+      );
+    }
+    const validation = validateSandboxAutomation({
+      ...owningAutomation,
+      model: session.model || owningAutomation.model,
+    });
+    if (validation) throw new Error(validation.error);
   }
-  // Hoisted so the catch below can unregister it — a failed launch must not
-  // leak the run token (spawnHostRun's error path does the same cleanup).
+  // Hoisted so the catch below can unregister credentials and dispose a
+  // sandbox when launch fails after ensure but before the event stream exists.
   let rpcToken: string | undefined;
+  let disposableResumeSandbox:
+    | { provider: ReturnType<typeof getSandboxProvider>; id: string }
+    | undefined;
+  const disposeResumeSandbox = async () => {
+    const owned = disposableResumeSandbox;
+    if (!owned) return;
+    disposableResumeSandbox = undefined;
+    await disposeAutomationSandbox({
+      provider: owned.provider,
+      sandboxId: owned.id,
+      sessionId: session.id,
+    });
+  };
   const sandboxStartedAt = Date.now();
   try {
     if (isAgentSessionCancelled(session.id, opts.startToken))
@@ -1920,19 +1965,44 @@ export async function maybeLaunchSandboxedRun(
       });
     }
     const provider = getSandboxProvider(sbProvider);
+    const automationSandbox = disposableAutomationResume
+      ? sandboxAutomationConfig()
+      : undefined;
+    const resumeModel = disposableAutomationResume
+      ? automationModel(session.model || owningAutomation?.model)
+      : undefined;
     const sandbox = await ensureSandboxWithTransientRetry(
       provider,
       {
         sessionId: session.id,
-        repo: session.repo,
+        repo: owningAutomation
+          ? getRepo(owningAutomation.repo).id
+          : session.repo,
         branch: session.branch || undefined,
         mode: session.mode,
-        cwd: opts.cwd,
-        // Bind-mode containers mount attached repos too (a changed set
-        // recreates the container); volume mode rejects them in ensure().
-        attachedDirs: (session.attachedRepos || [])
-          .map((r) => r.dir)
-          .filter(Boolean),
+        ...(disposableAutomationResume
+          ? {
+              trustProfile: "automation" as const,
+              egressAllowlist: [
+                ...(automationSandbox?.egressAllowlist || []),
+                ...automationModelEgressDestinations(resumeModel || ""),
+                ...mcpEgressDestinations(
+                  filterMcpServers(
+                    owningAutomation?.mcpServers || [],
+                    undefined,
+                    [],
+                  ),
+                ),
+              ],
+            }
+          : {
+              cwd: opts.cwd,
+              // Bind-mode containers mount attached repos too (a changed set
+              // recreates the container); volume mode rejects them in ensure().
+              attachedDirs: (session.attachedRepos || [])
+                .map((r) => r.dir)
+                .filter(Boolean),
+            }),
       },
       {
         onRetry(error) {
@@ -1948,8 +2018,13 @@ export async function maybeLaunchSandboxedRun(
         },
       },
     );
-    if (isAgentSessionCancelled(session.id, opts.startToken))
+    if (disposableAutomationResume) {
+      disposableResumeSandbox = { provider, id: sandbox.id };
+    }
+    if (isAgentSessionCancelled(session.id, opts.startToken)) {
+      await disposeResumeSandbox();
       return cancelledRun(sandbox);
+    }
     // Remote engine databases live inside the sandbox. A replacement VM cannot
     // resume the old engine id, even when its git workspace was safely pushed.
     const previousSandboxId = session.sandbox?.sandboxId;
@@ -2057,13 +2132,23 @@ export async function maybeLaunchSandboxedRun(
         opts.isAutomationSession ? undefined : opts.user,
         opts.isAutomationSession ? undefined : session.startedBy,
       ),
-      fallbackModel: interactiveFallbackModel(session.model),
+      fallbackModel: opts.isAutomationSession
+        ? undefined
+        : interactiveFallbackModel(session.model),
       effort: portablePreset?.effort ?? session.effort,
       fastMode: session.fastMode,
-      accountId: session.accountId,
+      accountId: disposableAutomationResume
+        ? owningAutomation?.accountId
+        : session.accountId,
+      accountStrict: disposableAutomationResume ? true : undefined,
+      usageCredits: disposableAutomationResume
+        ? owningAutomation?.usageCredits
+        : undefined,
     };
     if (isAgentSessionCancelled(session.id, opts.startToken)) {
       unregisterRunToken(rpcToken);
+      rpcToken = undefined;
+      await disposeResumeSandbox();
       return cancelledRun(sandbox);
     }
     const runCallbacks = {
@@ -2081,12 +2166,32 @@ export async function maybeLaunchSandboxedRun(
     if (isAgentSessionCancelled(session.id, opts.startToken)) {
       handle.cancel();
       unregisterRunToken(rpcToken);
+      rpcToken = undefined;
+      await disposeResumeSandbox();
       return cancelledRun(sandbox);
     }
     console.log(
       `[sandbox] ${session.id}: running in ${sandbox.id} (${sandbox.cwd})`,
     );
-    return Object.assign(handle.events(), {
+    const events = disposableAutomationResume
+      ? (async function* (): AsyncGenerator<StreamEvent> {
+          try {
+            yield* handle.events();
+          } finally {
+            unregisterRunToken(rpcToken);
+            rpcToken = undefined;
+            try {
+              await disposeResumeSandbox();
+            } catch (error) {
+              console.error(
+                `[sandbox] could not dispose automation Executor ${sandbox.id} after follow-up:`,
+                error,
+              );
+            }
+          }
+        })()
+      : handle.events();
+    return Object.assign(events, {
       freshEngine: remoteSandboxReplaced || undefined,
       sandboxProvider: sbProvider,
       sandboxId: sandbox.id,
@@ -2095,7 +2200,22 @@ export async function maybeLaunchSandboxedRun(
   } catch (e: any) {
     unregisterRunToken(rpcToken);
     const reason = String(e?.message || e).slice(0, 200);
-    if (session.source === "opensession" && session.sandbox) {
+    const hadDisposableResumeSandbox = !!disposableResumeSandbox;
+    if (hadDisposableResumeSandbox) {
+      try {
+        await disposeResumeSandbox();
+      } catch (error) {
+        console.error(
+          `[sandbox] could not dispose automation Executor after launch failure:`,
+          error,
+        );
+      }
+    }
+    if (
+      (!disposableAutomationResume || !hadDisposableResumeSandbox) &&
+      session.source === "opensession" &&
+      session.sandbox
+    ) {
       touchNativeSession(session.id, {
         sandbox: {
           ...session.sandbox,

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap-credentials.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
   projectRemoteClaudeAccounts,
@@ -203,6 +204,44 @@ describe("remote engine credential projection", () => {
     expect(JSON.parse(projected.content).providers).toEqual({
       cerebras: { apiKey: "csk-secret", baseURL: "https://cerebras.test" },
     });
+  });
+
+  test("projects merged catalog-file rows without exposing the host path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "os-sandbox-catalog-"));
+    const configPath = join(dir, "model-providers.json");
+    const previous = process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+    process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = configPath;
+    writeFileSync(
+      join(dir, "gateway-catalog.json"),
+      JSON.stringify({ m: { contextWindow: 32_000, maxTokens: 4_000 } }),
+    );
+    const source = {
+      providers: {
+        gateway: {
+          apiKey: "secret",
+          api: "openai-completions",
+          baseURL: "https://gateway.test/v1",
+          catalogFile: "gateway-catalog.json",
+        },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(source));
+    try {
+      const projected = projectRemoteModelProviderConfig(
+        source,
+        "pi/gateway/m",
+      );
+      const provider = JSON.parse(projected.content).providers.gateway;
+      expect(provider.catalog).toEqual({
+        m: { id: "m", contextWindow: 32_000, maxTokens: 4_000 },
+      });
+      expect(provider.catalogFile).toBeUndefined();
+    } finally {
+      if (previous === undefined)
+        delete process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG;
+      else process.env.OPENSESSION_MODEL_PROVIDERS_CONFIG = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("interactive provider projection follows only the reachable fallback walk", () => {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -82,7 +82,10 @@ import { authedRemoteUrl } from "../../codestorage/auth";
 import { parseCsRemote } from "../../codestorage/remote";
 import { redactUrl } from "../../shared/redact";
 import { listCodexAccounts } from "../../codex-accounts";
-import { readModelProviderConfig } from "../../model-providers";
+import {
+  normalizeModelProviderConfig,
+  readModelProviderConfig,
+} from "../../model-providers";
 import { normalizePiConfig, readPiEngineConfig } from "../../pi-config";
 import {
   buildOpenaiRemoteSeedUpload,
@@ -393,6 +396,11 @@ export function projectRemoteModelProviderConfig(
     fallbackModel,
   );
   if (reachableSettingsProviders.size) {
+    // The normalized read merges `catalogFile` and `discovered` rows into one
+    // `catalog` per provider; the guest gets that merged table, never the
+    // host path.
+    const normalizedProviders =
+      normalizeModelProviderConfig(source)?.providers || {};
     for (const [id, value] of Object.entries(
       jsonRecord(source.providers) || {},
     )) {
@@ -405,6 +413,14 @@ export function projectRemoteModelProviderConfig(
         projected.apiKey = provider.apiKey;
       if (typeof provider.baseURL === "string" && provider.baseURL)
         projected.baseURL = provider.baseURL;
+      // A custom OpenAI-compatible gateway needs its protocol and catalog in
+      // the guest too.
+      if (typeof provider.api === "string" && provider.api)
+        projected.api = provider.api;
+      if (typeof provider.name === "string" && provider.name)
+        projected.name = provider.name;
+      const catalog = normalizedProviders[id]?.catalog;
+      if (catalog && Object.keys(catalog).length) projected.catalog = catalog;
       if (Object.keys(projected).length) settingsProviders[id] = projected;
     }
   }

--- a/packages/core/opensession-server/src/server/sandbox/adapters/daytona.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/daytona.ts
@@ -35,7 +35,13 @@
 
 import type { Daytona, Sandbox as DaytonaSandbox } from "@daytonaio/sdk";
 import { getRepo, worktreePathFor } from "../../worktree";
-import { sandboxConfig } from "../config";
+import { sandboxConfig, remoteSandboxCallbackBaseUrl } from "../config";
+import { audit } from "../../audit";
+import {
+  automationEgressDomains,
+  automationEgressProbeBlockedUrl,
+  daytonaDomainAllowList,
+} from "../automation-egress";
 import {
   getSandboxConnection,
   sandboxProviderCredential,
@@ -81,6 +87,52 @@ import {
 
 const SESSION_LABEL = "opensession.session";
 const DEFAULT_IDLE_STOP_MINUTES = 30;
+/** Automation Executors are destroyed by the launcher after the run; the
+ *  provider-side stop/delete intervals only catch a crashed coordinator. */
+const AUTOMATION_IDLE_STOP_MINUTES = 60;
+/**
+ * Prove the domain allowlist is enforced inside the guest: the dial-back host
+ * must answer and a host outside the list must not. Qualification confirms the
+ * Daytona base image provides curl before automation use is enabled.
+ */
+export async function assertAutomationEgressRestricted(
+  driver: RemoteDriver,
+  callbackBaseUrl: string,
+  blockedUrl: string,
+): Promise<void> {
+  const httpBase = callbackBaseUrl
+    .replace(/\/+$/, "")
+    .replace(/^ws(s?):\/\//, "http$1://");
+  const probe = await driver.exec(
+    `command -v curl >/dev/null 2>&1 || { echo __OPENSESSION_NO_CURL__; exit 0; }; ` +
+      `a=$(curl -sS -o /dev/null -m 10 -w '%{http_code}' ${shellQuoteWord(`${httpBase}/`)} 2>/dev/null || true); ` +
+      `b=$(curl -sS -o /dev/null -m 10 -w '%{http_code}' ${shellQuoteWord(blockedUrl)} 2>/dev/null || true); ` +
+      `echo "allowed=$a blocked=$b"`,
+    { timeoutMs: 40_000 },
+  );
+  if (probe.stdout.includes("__OPENSESSION_NO_CURL__")) {
+    throw new Error(
+      "automation egress policy cannot be verified: curl is missing in the Executor",
+    );
+  }
+  const match = /allowed=(\d{3}) blocked=(\d{3})/.exec(probe.stdout);
+  if (!match) {
+    throw new Error(
+      `automation egress probe failed: ${(probe.stderr || probe.stdout).trim().slice(0, 300)}`,
+    );
+  }
+  const [, allowed, blocked] = match;
+  if (allowed === "000") {
+    throw new Error(
+      `automation egress policy blocks the dial-back URL ${httpBase}; check callbackBaseUrl and the Daytona org tier`,
+    );
+  }
+  if (blocked !== "000") {
+    throw new Error(
+      `automation egress policy is not enforced by this Daytona org (unlisted host answered ${blocked}); sandbox automations need a Tier 3+ or self-hosted Daytona`,
+    );
+  }
+}
 // Daytona's image keeps the process user + passwordless-sudo contract that
 // bootstrapRemoteSandbox needs. A plain Ubuntu image launches correctly but
 // cannot create the stable /home/ubuntu layout.
@@ -444,8 +496,28 @@ export class DaytonaProvider implements SandboxProvider {
         "source verification requires the automation trust profile and a credential-free clone",
       );
     }
+    // Unattended runs (public review and sandboxed automations) get a fresh
+    // disposable Executor: no prewarm or repo-template adoption, short
+    // provider-side auto-delete backstops, and strict disposal on failure.
+    const disposable =
+      sourceVerification || trust.trustProfile === "automation";
     const repo = getRepo(spec.repo || prevState?.repoId);
     const branch = spec.branch || prevState?.branch || repo.defaultBranch;
+    const cloneUrl = await remoteCloneUrl(repo, {
+      credential: spec.cloneCredential,
+    });
+    const automationDomains =
+      trust.trustProfile === "automation" && !sourceVerification
+        ? automationEgressDomains({
+            callbackBaseUrl: remoteSandboxCallbackBaseUrl(),
+            cloneUrl,
+            extra: [
+              ...trust.egressAllowlist,
+              ...(cfg.runnerBundleUrl ? [cfg.runnerBundleUrl] : []),
+              ...(cfg.runnerRepoUrl ? [cfg.runnerRepoUrl] : []),
+            ],
+          })
+        : undefined;
     const verificationKey = spec.sessionId.replace(/[^A-Za-z0-9_.-]+/g, "-");
     const cwd =
       spec.cwd ||
@@ -467,7 +539,7 @@ export class DaytonaProvider implements SandboxProvider {
       } catch {}
     }
     if (sbx && stateOf(sbx) === "gone") sbx = null;
-    if (!sbx && !sourceVerification) {
+    if (!sbx && !disposable) {
       // Warm-on-typing adoption (src/server/sandbox/prewarm.ts): a ready
       // prewarm for (daytona, repo) whose runner pin + snapshot still match
       // is claimed atomically and relabeled to this session — the expensive
@@ -518,7 +590,7 @@ export class DaytonaProvider implements SandboxProvider {
       // 2026-07). Unset = Daytona's default snapshot (1 vCPU/1GB/3GiB disk),
       // too small for real repo workspaces: the runner payload alone is ~2GB
       // and a large repo's clone died on ENOSPC. See SandboxDaytonaConfig.
-      const template = sourceVerification
+      const template = disposable
         ? undefined
         : await recoverDaytonaRepoTemplate(client, repo.id);
       // A prepared repo template already carries its machine shape. When the
@@ -538,18 +610,26 @@ export class DaytonaProvider implements SandboxProvider {
               ...(sourceVerification
                 ? { "opensession.public-review": "1" }
                 : {}),
+              ...(trust.trustProfile === "automation" && !sourceVerification
+                ? { "opensession.automation": "1" }
+                : {}),
             },
             autoStopInterval: sourceVerification
               ? 10
-              : cfg.idleStopMinutes || DEFAULT_IDLE_STOP_MINUTES,
-            ...(sourceVerification ? { autoDeleteInterval: 30 } : {}),
+              : disposable
+                ? AUTOMATION_IDLE_STOP_MINUTES
+                : cfg.idleStopMinutes || DEFAULT_IDLE_STOP_MINUTES,
+            ...(automationDomains
+              ? { domainAllowList: daytonaDomainAllowList(automationDomains) }
+              : {}),
+            ...(disposable ? { autoDeleteInterval: 30 } : {}),
           } as any,
           { timeout: 300 },
         );
       };
       try {
         sbx = await create(
-          sourceVerification
+          disposable
             ? undefined
             : template?.artifactId || cfg.daytona?.snapshot,
         );
@@ -591,6 +671,29 @@ export class DaytonaProvider implements SandboxProvider {
       // A second refresh/start round trip added 2–3s to every snapshot restore.
       if (!newlyCreated) await driver.ensureStarted();
       mark("sandbox started");
+      if (automationDomains) {
+        // Enforce before bootstrap, repository setup hooks, private workspace
+        // seeds, or model credentials can enter the guest. Reapplying also
+        // closes a crash-recovery path where the provider created the sandbox
+        // but had not yet persisted its network policy.
+        await sbx.updateNetworkSettings({
+          domainAllowList: daytonaDomainAllowList(automationDomains),
+        });
+        await assertAutomationEgressRestricted(
+          driver,
+          remoteSandboxCallbackBaseUrl(),
+          automationEgressProbeBlockedUrl(automationDomains),
+        );
+        audit({
+          kind: "sandbox_automation_egress",
+          session_id: spec.sessionId,
+          provider: this.id,
+          sandbox_id: sbx.id,
+          resolved_targets: automationDomains,
+          outcome: "ok",
+        });
+        mark("egress restricted");
+      }
       const prepareRunner = async () => {
         if (sourceVerification) return;
         // A sandbox that cannot reach our callback URL can never run anything.
@@ -603,7 +706,7 @@ export class DaytonaProvider implements SandboxProvider {
         await setupRemoteWorkspace(
           driver,
           cwd,
-          await remoteCloneUrl(repo, { credential: spec.cloneCredential }),
+          cloneUrl,
           branch,
           repo.defaultBranch,
           repo.id,
@@ -615,7 +718,8 @@ export class DaytonaProvider implements SandboxProvider {
             trustProfile: trust.trustProfile,
           },
           {
-            seedPrivateFiles: !sourceVerification,
+            seedPrivateFiles:
+              trust.trustProfile !== "automation" && !sourceVerification,
             runLifecycleHooks: !sourceVerification,
           },
         );
@@ -644,13 +748,13 @@ export class DaytonaProvider implements SandboxProvider {
       });
       return this.makeHandle(sbx, spec.sessionId, cwd);
     } catch (error) {
-      if (sourceVerification) {
+      if (disposable) {
         try {
           await this.destroy(sbx.id, { strict: true });
         } catch (cleanupError) {
           throw new AggregateError(
             [error, cleanupError],
-            "public review Executor setup failed and strict disposal also failed",
+            "disposable Executor setup failed and strict disposal also failed",
           );
         }
       }
@@ -953,6 +1057,19 @@ export async function qualifyDaytonaConnection(): Promise<void> {
     );
     if (lifecycle.exitCode !== 0)
       throw new Error("Daytona stop/start lost filesystem state");
+    await source.updateNetworkSettings({ domainAllowList: "example.com" });
+    const egress = await sourceDriver.exec(
+      "a=$(curl -sS -o /dev/null -m 10 -w '%{http_code}' https://example.com/ 2>/dev/null || true); " +
+        "b=$(curl -sS -o /dev/null -m 10 -w '%{http_code}' https://www.iana.org/ 2>/dev/null || true); " +
+        'echo "allowed=$a blocked=$b"',
+      { timeoutMs: 40_000 },
+    );
+    if (!/allowed=(?!000)\d{3} blocked=000/.test(egress.stdout)) {
+      throw new Error(
+        "Daytona runner did not enforce the sandbox domain allowlist",
+      );
+    }
+    await source.updateNetworkSettings({ networkBlockAll: false });
     // Even a nearly-empty Daytona sandbox can take 8–10 minutes to seal when
     // the provider is busy. Keep this aligned with repository templates: a
     // shorter client wait reports a false SNAPSHOT_FAILED while Daytona keeps

--- a/packages/core/opensession-server/src/server/sandbox/automation-disposal.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/automation-disposal.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "fs";
+import { disposeAutomationSandbox } from "./automation-disposal";
+import { SESSIONS_DIR, updateSessionFile } from "../session-cache";
+
+const created: string[] = [];
+
+async function writeSession(sessionId: string, sandboxId: string) {
+  created.push(sessionId);
+  mkdirSync(SESSIONS_DIR, { recursive: true });
+  await updateSessionFile(sessionId, () => ({
+    id: sessionId,
+    claudeSessionId: "",
+    branch: "main",
+    worktreeDir: "/remote/worktree",
+    createdBy: "Automation (automation)",
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    sandbox: {
+      provider: "daytona",
+      sandboxId,
+      workspace: "volume",
+      lifecycle: "awake",
+    },
+  }));
+}
+
+afterEach(() => {
+  for (const sessionId of created.splice(0)) {
+    const path = `${SESSIONS_DIR}/${sessionId}.json`;
+    if (existsSync(path)) unlinkSync(path);
+  }
+});
+
+describe("disposable automation Executor cleanup", () => {
+  test("removes the destroyed id but retains the provider for a fresh resume", async () => {
+    const sessionId = `automation-disposal-${crypto.randomUUID()}`;
+    await writeSession(sessionId, "executor-old");
+    const destroyed: string[] = [];
+
+    await disposeAutomationSandbox({
+      sessionId,
+      sandboxId: "executor-old",
+      provider: {
+        id: "daytona",
+        destroy: async (sandboxId) => {
+          destroyed.push(sandboxId);
+        },
+      },
+    });
+
+    expect(destroyed).toEqual(["executor-old"]);
+    const written = JSON.parse(
+      readFileSync(`${SESSIONS_DIR}/${sessionId}.json`, "utf8"),
+    );
+    expect(written.sandbox).toEqual({
+      provider: "daytona",
+      lifecycle: "sleeping",
+    });
+  });
+
+  test("stale cleanup cannot erase a replacement Executor id", async () => {
+    const sessionId = `automation-disposal-${crypto.randomUUID()}`;
+    await writeSession(sessionId, "executor-new");
+
+    await disposeAutomationSandbox({
+      sessionId,
+      sandboxId: "executor-old",
+      provider: {
+        id: "daytona",
+        destroy: async () => {},
+      },
+    });
+
+    const written = JSON.parse(
+      readFileSync(`${SESSIONS_DIR}/${sessionId}.json`, "utf8"),
+    );
+    expect(written.sandbox.sandboxId).toBe("executor-new");
+  });
+
+  test("failed strict disposal keeps the Executor fenced", async () => {
+    const sessionId = `automation-disposal-${crypto.randomUUID()}`;
+    await writeSession(sessionId, "executor-live");
+
+    await expect(
+      disposeAutomationSandbox({
+        sessionId,
+        sandboxId: "executor-live",
+        provider: {
+          id: "daytona",
+          destroy: async () => {
+            throw new Error("delete unconfirmed");
+          },
+        },
+      }),
+    ).rejects.toThrow("delete unconfirmed");
+
+    const written = JSON.parse(
+      readFileSync(`${SESSIONS_DIR}/${sessionId}.json`, "utf8"),
+    );
+    expect(written.sandbox).toMatchObject({
+      sandboxId: "executor-live",
+      lifecycle: "needs_attention",
+      lastLifecycleError: "delete unconfirmed",
+    });
+  });
+});

--- a/packages/core/opensession-server/src/server/sandbox/automation-disposal.ts
+++ b/packages/core/opensession-server/src/server/sandbox/automation-disposal.ts
@@ -1,0 +1,57 @@
+import { audit } from "../audit";
+import { updateSessionFile } from "../session-cache";
+import type { SandboxProvider } from "./provider";
+
+/**
+ * Destroy one disposable automation Executor and leave only the provider
+ * selection on the session. A later prompt can then create a fresh Executor,
+ * while a stale cleanup cannot erase a newer run's sandbox mapping.
+ */
+export async function disposeAutomationSandbox(args: {
+  provider: Pick<SandboxProvider, "id" | "destroy">;
+  sandboxId: string;
+  sessionId: string;
+}): Promise<void> {
+  const { provider, sandboxId, sessionId } = args;
+  try {
+    await provider.destroy(sandboxId, { strict: true });
+    await updateSessionFile(sessionId, (data) => {
+      if (data.sandbox?.sandboxId !== sandboxId) return data;
+      return {
+        ...data,
+        sandbox: {
+          provider: data.sandbox.provider,
+          lifecycle: "sleeping",
+        },
+      };
+    });
+    audit({
+      kind: "sandbox_automation_disposed",
+      session_id: sessionId,
+      provider: provider.id,
+      sandbox_id: sandboxId,
+    });
+  } catch (error) {
+    await updateSessionFile(sessionId, (data) => {
+      if (data.sandbox?.sandboxId !== sandboxId) return data;
+      return {
+        ...data,
+        sandbox: {
+          ...data.sandbox,
+          lifecycle: "needs_attention",
+          lastLifecycleError: String(
+            error instanceof Error ? error.message : error,
+          ).slice(0, 200),
+        },
+      };
+    }).catch(() => {});
+    audit({
+      kind: "sandbox_automation_dispose_failed",
+      session_id: sessionId,
+      provider: provider.id,
+      sandbox_id: sandboxId,
+      error: String(error instanceof Error ? error.message : error),
+    });
+    throw error;
+  }
+}

--- a/packages/core/opensession-server/src/server/sandbox/automation-egress.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/automation-egress.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  automationEgressDomains,
+  automationEgressProbeBlockedUrl,
+  automationModelEgressDestinations,
+  DAYTONA_DOMAIN_ALLOWLIST_MAX,
+  parseAutomationEgressDomain,
+} from "./automation-egress";
+
+describe("sandbox automation egress", () => {
+  test("normalizes URLs and wildcard domains", () => {
+    expect(parseAutomationEgressDomain("https://API.Example.com/path")).toBe(
+      "api.example.com",
+    );
+    expect(parseAutomationEgressDomain("*.Example.com")).toBe("*.example.com");
+  });
+
+  test("refuses destinations Daytona cannot enforce as domains", () => {
+    for (const value of ["*", "127.0.0.1", "10.0.0.0/8", "example.com:443"]) {
+      expect(() => parseAutomationEgressDomain(value)).toThrow();
+    }
+  });
+
+  test("adds only the selected model provider", () => {
+    expect(
+      automationModelEgressDestinations("pi/anthropic/claude-sonnet-5"),
+    ).toEqual(["api.anthropic.com"]);
+    expect(automationModelEgressDestinations("pi/openai/gpt-5.6-sol")).toEqual([
+      "api.openai.com",
+      "chatgpt.com",
+    ]);
+  });
+
+  test("includes run infrastructure and explicit destinations", () => {
+    const domains = automationEgressDomains({
+      callbackBaseUrl: "wss://sessions.example.com",
+      cloneUrl: "https://github.com/tellahq/opensession.git",
+      mcpDestinations: ["https://api.plain.com/v1"],
+      extra: ["uploads.example.com", "api.anthropic.com"],
+    });
+
+    expect(domains).toContain("sessions.example.com");
+    expect(domains).toContain("github.com");
+    expect(domains).toContain("api.anthropic.com");
+    expect(domains).toContain("registry.npmjs.org");
+    expect(domains).toContain("api.plain.com");
+    expect(domains).toContain("uploads.example.com");
+  });
+
+  test("chooses a blocked probe outside wildcard policy entries", () => {
+    expect(
+      automationEgressProbeBlockedUrl(["example.com", "*.example.com"]),
+    ).toBe("https://www.iana.org/");
+  });
+
+  test("fails instead of truncating Daytona's allowlist", () => {
+    const extras = Array.from(
+      { length: DAYTONA_DOMAIN_ALLOWLIST_MAX },
+      (_, index) => `service-${index}.example.com`,
+    );
+    expect(() =>
+      automationEgressDomains({
+        callbackBaseUrl: "wss://sessions.example.com",
+        cloneUrl: "https://github.com/tellahq/opensession.git",
+        extra: extras,
+      }),
+    ).toThrow(`Daytona allows at most ${DAYTONA_DOMAIN_ALLOWLIST_MAX}`);
+  });
+});

--- a/packages/core/opensession-server/src/server/sandbox/automation-egress.ts
+++ b/packages/core/opensession-server/src/server/sandbox/automation-egress.ts
@@ -1,0 +1,175 @@
+/**
+ * Outbound policy for sandboxed automation runs.
+ *
+ * A sandboxed automation runs in a disposable Daytona Executor whose egress is
+ * restricted with Daytona's per-sandbox domain allowlist (runner-enforced, no
+ * essential-services bypass). This module turns the launch's inputs into that
+ * list: the hosts every run needs (model APIs, GitHub, the Open Session
+ * dial-back), runner bootstrap services, the run's MCP destinations, and the
+ * operator's extra entries.
+ *
+ * Daytona accepts hostnames and `*.` wildcards only, at most 20 entries, and
+ * its domain and CIDR allowlists are mutually exclusive. Anything that cannot
+ * be expressed inside those limits fails closed here instead of launching a
+ * run with a wider policy than the operator configured.
+ */
+
+export const AUTOMATION_BASELINE_EGRESS_DOMAINS = [
+  "github.com",
+  "api.github.com",
+  "codeload.github.com",
+  "objects.githubusercontent.com",
+  "raw.githubusercontent.com",
+  "bun.sh",
+  "nodejs.org",
+  "registry.npmjs.org",
+] as const;
+
+/** Daytona's documented ceiling for `domainAllowList`. */
+export const DAYTONA_DOMAIN_ALLOWLIST_MAX = 20;
+
+export function automationModelEgressDestinations(model: string): string[] {
+  if (/^pi\/anthropic\//.test(model)) return ["api.anthropic.com"];
+  if (/^pi\/openai\//.test(model)) return ["api.openai.com", "chatgpt.com"];
+  throw new Error(`unsupported sandbox automation model: ${model}`);
+}
+
+const HOSTNAME_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/i;
+
+function looksLikeIp(host: string): boolean {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host) || host.includes(":");
+}
+
+/**
+ * Normalize one operator- or config-supplied egress entry to a Daytona domain
+ * allowlist item. Accepts a bare hostname, a `*.example.com` wildcard, or a
+ * URL (only its host is kept). Refuses IPs, CIDRs, ports, paths, and
+ * bare wildcards: Daytona cannot combine a domain list with CIDRs, and a run
+ * must never be admitted with a policy Daytona will silently drop.
+ */
+export function parseAutomationEgressDomain(value: string): string {
+  const raw = value.trim();
+  if (!raw) throw new Error("empty automation egress destination");
+  let host = raw;
+  let wildcard = false;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      throw new Error(`invalid automation egress destination: ${value}`);
+    }
+    if (!/^(?:https?|wss?):$/.test(url.protocol)) {
+      throw new Error(`unsupported automation egress destination: ${value}`);
+    }
+    host = url.hostname;
+  } else {
+    if (raw.startsWith("*.")) {
+      wildcard = true;
+      host = raw.slice(2);
+    }
+    if (/[/?#:@\s]/.test(host)) {
+      throw new Error(
+        `automation egress destinations must be hostnames, not URLs with paths, ports, or CIDRs: ${value}`,
+      );
+    }
+  }
+  host = host.toLowerCase().replace(/\.$/, "");
+  if (!host || host === "*") {
+    throw new Error(`wildcards are not allowed in automation egress: ${value}`);
+  }
+  if (looksLikeIp(host) || /^\[/.test(host)) {
+    throw new Error(
+      `automation egress destinations must be domains, not IP addresses or CIDRs: ${value}`,
+    );
+  }
+  const labels = host.split(".");
+  if (
+    labels.length < 2 ||
+    !labels.every((label) => HOSTNAME_LABEL.test(label))
+  ) {
+    throw new Error(`invalid automation egress destination: ${value}`);
+  }
+  return wildcard ? `*.${host}` : host;
+}
+
+/** Hosts a run's projected MCP configuration will contact. */
+export function mcpEgressDestinations(
+  projected: Record<string, unknown>,
+): string[] {
+  const destinations = new Set<string>();
+  for (const config of Object.values(projected)) {
+    if (!config || typeof config !== "object") continue;
+    const entry = config as Record<string, unknown>;
+    if (typeof entry.url === "string") destinations.add(entry.url);
+    if (entry.env && typeof entry.env === "object") {
+      for (const value of Object.values(entry.env as Record<string, unknown>)) {
+        if (typeof value === "string" && /^(?:https?|wss?):\/\//i.test(value))
+          destinations.add(value);
+      }
+    }
+  }
+  return [...destinations];
+}
+
+/**
+ * The complete domain allowlist for one automation launch, deduplicated and
+ * bounded by Daytona's limit. Throws when the run cannot be expressed within
+ * that limit rather than dropping entries.
+ */
+export function automationEgressDomains(input: {
+  callbackBaseUrl: string;
+  cloneUrl: string;
+  mcpDestinations?: string[];
+  extra?: string[];
+}): string[] {
+  const domains = new Set<string>();
+  for (const value of [
+    input.callbackBaseUrl,
+    input.cloneUrl,
+    ...AUTOMATION_BASELINE_EGRESS_DOMAINS,
+    ...(input.mcpDestinations || []),
+    ...(input.extra || []),
+  ]) {
+    domains.add(parseAutomationEgressDomain(value));
+  }
+  const list = [...domains];
+  if (list.length > DAYTONA_DOMAIN_ALLOWLIST_MAX) {
+    throw new Error(
+      `automation egress allowlist has ${list.length} domains; Daytona allows at most ${DAYTONA_DOMAIN_ALLOWLIST_MAX}. Trim the automation's MCP servers or the configured egressAllowlist.`,
+    );
+  }
+  return list;
+}
+
+const EGRESS_PROBE_CANDIDATES = [
+  "https://example.com/",
+  "https://www.iana.org/",
+  "https://example.org/",
+] as const;
+
+function domainAllowsHost(domain: string, host: string): boolean {
+  return (
+    domain === host ||
+    (domain.startsWith("*.") && host.endsWith(domain.slice(1)))
+  );
+}
+
+/** Pick a real reachable host outside the policy so the launch can prove it is blocked. */
+export function automationEgressProbeBlockedUrl(domains: string[]): string {
+  const candidate = EGRESS_PROBE_CANDIDATES.find((url) => {
+    const host = new URL(url).hostname;
+    return !domains.some((domain) => domainAllowsHost(domain, host));
+  });
+  if (!candidate) {
+    throw new Error(
+      "automation egress allowlist includes every policy probe host; remove example.com, iana.org, or example.org",
+    );
+  }
+  return candidate;
+}
+
+/** Comma-separated form Daytona's API expects. */
+export function daytonaDomainAllowList(domains: string[]): string {
+  return domains.join(",");
+}

--- a/packages/core/opensession-server/src/server/sandbox/capability-status.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/capability-status.test.ts
@@ -284,6 +284,23 @@ describe("sandboxCapabilityStatus (the /api/sandbox/status payload)", () => {
       SANDBOX_MODEL_FAMILIES,
     );
   });
+
+  test("sandbox automations require a qualified Daytona provider and dial-back URL", () => {
+    write({
+      provider: "daytona",
+      callbackBaseUrl: "wss://sessions.example.com",
+    });
+    expect(sandboxCapabilityStatus().automation).toMatchObject({
+      provider: "daytona",
+      available: false,
+    });
+
+    ready("daytona");
+    expect(sandboxCapabilityStatus().automation).toEqual({
+      provider: "daytona",
+      available: true,
+    });
+  });
 });
 
 describe("provider-independent model-family sandboxability", () => {

--- a/packages/core/opensession-server/src/server/sandbox/config.ts
+++ b/packages/core/opensession-server/src/server/sandbox/config.ts
@@ -175,6 +175,18 @@ export interface SandboxAwsLambdaMicrovmConfig {
   logGroup?: string;
 }
 
+export interface SandboxAutomationConfig {
+  /** Unattended runs are admitted only on a provider whose outbound policy is
+   *  enforced natively per sandbox. Daytona applies a per-sandbox domain
+   *  allowlist on its runner, so it is the only admitted backend. */
+  provider: "daytona";
+  /** Extra hostnames (or URLs, or `*.example.com` wildcards) an automation may
+   *  contact. Model, git, and the Open Session callback hosts are added by the
+   *  launcher. IP addresses and CIDRs are refused: Daytona's domain and CIDR
+   *  allowlists are mutually exclusive. */
+  egressAllowlist?: string[];
+}
+
 export interface SandboxConfig {
   provider: SandboxProviderId;
   /** Shared default for NEW interactive sessions. Absent/"none" = host. */
@@ -219,6 +231,8 @@ export interface SandboxConfig {
   modal?: SandboxModalConfig;
   /** AWS Lambda MicroVM adapter (provider "lambda-microvm"). */
   awsLambdaMicrovm?: SandboxAwsLambdaMicrovmConfig;
+  /** Credential-minimal unattended-run profile. */
+  automation?: SandboxAutomationConfig;
   /** Clone auth for remote-provider workspaces + runner bootstrap. The selected
    *  live GitHub service credential takes precedence; App mode never falls back
    *  to a persisted token because it may be stale static authority. */
@@ -385,6 +399,23 @@ export function sandboxConfig(): SandboxConfig {
                 logGroup: str(raw.awsLambdaMicrovm.logGroup),
               }
             : undefined,
+        automation:
+          raw?.automation && typeof raw.automation === "object"
+            ? {
+                provider: "daytona",
+                egressAllowlist: Array.isArray(raw.automation.egressAllowlist)
+                  ? raw.automation.egressAllowlist
+                      .filter(
+                        (value: unknown): value is string =>
+                          typeof value === "string" &&
+                          value.trim().length > 0 &&
+                          value.trim().length <= 512,
+                      )
+                      .map((value: string) => value.trim())
+                      .slice(0, 128)
+                  : undefined,
+              }
+            : undefined,
         cloneCredential:
           raw?.cloneCredential?.type === "https-token" ||
           raw?.cloneCredential?.type === "none"
@@ -488,6 +519,38 @@ export function sandboxPrewarmConfig(): SandboxPrewarmConfig {
  *  their own "ws" regardless). */
 export function sandboxTransport(): SandboxTransport {
   return sandboxConfig().transport === "ws" ? "ws" : "socket";
+}
+
+/** Effective unattended-run policy. The provider is deliberately not a
+ *  generic selector: Daytona is the only backend whose per-sandbox outbound
+ *  policy Open Session can install and verify before a run starts. */
+export function sandboxAutomationConfig(): SandboxAutomationConfig {
+  return sandboxConfig().automation || { provider: "daytona" };
+}
+
+export interface SandboxAutomationAvailability {
+  provider: "daytona";
+  available: boolean;
+  /** Operator-facing reason when unavailable. */
+  reason?: string;
+}
+
+/** Whether a sandboxed automation can be created, updated, or launched right
+ *  now. Fails closed on every provider gate an interactive Daytona session
+ *  also passes through, plus the dial-back URL a detached run needs. */
+export function sandboxAutomationAvailability(): SandboxAutomationAvailability {
+  const provider = sandboxAutomationConfig().provider;
+  const error = sandboxProviderSelectionError(provider);
+  if (error) return { provider, available: false, reason: error };
+  if (!sandboxConfig().callbackBaseUrl && !configuredIngress().publicBaseUrl) {
+    return {
+      provider,
+      available: false,
+      reason:
+        "sandbox automations need a dial-back URL: set callbackBaseUrl or enable public ingress in Workspace > Sandboxes",
+    };
+  }
+  return { provider, available: true };
 }
 
 // ── Provider capability status (per-session provider picker) ────────────────
@@ -792,6 +855,8 @@ export interface SandboxCapabilityStatus {
   killSwitch: boolean;
   /** Provider-independent family sandboxability for the NewSession picker. */
   modelFamilies: SandboxModelFamily[];
+  /** Whether automations may opt into a disposable Executor right now. */
+  automation: SandboxAutomationAvailability;
 }
 
 function sandboxProviderSelectionError(
@@ -957,6 +1022,7 @@ export function sandboxCapabilityStatus(): SandboxCapabilityStatus {
     providers,
     killSwitch: !sandboxesEnabled(),
     modelFamilies: SANDBOX_MODEL_FAMILIES,
+    automation: sandboxAutomationAvailability(),
   };
 }
 

--- a/packages/core/opensession-server/src/server/sandbox/connections.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/connections.test.ts
@@ -132,7 +132,7 @@ describe("workspace sandbox connections", () => {
     const path = process.env.OPENSESSION_SANDBOX_CONFIG!;
     const raw = JSON.parse(readFileSync(path, "utf-8"));
     raw.connections[0].qualification.adapterSignature =
-      "daytona:connection-v1:old-runner-pin+node@24.18.1+workspace-runtime-v7";
+      "daytona:connection-v2:old-runner-pin+node@24.18.1+workspace-runtime-v7";
     writeFileSync(path, JSON.stringify(raw));
 
     expect(sandboxConnectionReady("daytona")).toBe(true);

--- a/packages/core/opensession-server/src/server/sandbox/connections.ts
+++ b/packages/core/opensession-server/src/server/sandbox/connections.ts
@@ -224,7 +224,12 @@ export function getSandboxConnection(
 export function sandboxAdapterSignature(
   provider: WorkspaceSandboxProvider,
 ): string {
-  const version = provider === "box" ? "connection-v4" : "connection-v1";
+  const version =
+    provider === "box"
+      ? "connection-v4"
+      : provider === "daytona"
+        ? "connection-v2"
+        : "connection-v1";
   return `${provider}:${version}`;
 }
 


### PR DESCRIPTION
## Summary

- restore `sandbox: true` automations on fresh disposable Daytona Executors
- require a qualified provider, strict pinned subscription account, explicit MCP allowlist, no model fallback, and no nested CLI credentials
- apply and probe Daytona's domain allowlist before bootstrap, repository hooks, private seeds, or run credentials enter the guest
- expose sandbox selection in the Automations UI and the create/update automation MCP tools
- update security and extension docs for the disposable Executor contract

## Verification

- `bun run check`
- targeted sandbox egress, Daytona, capability, connection, public review, and generated catalog tests
- isolated desktop and phone verification on `/automations/auto-demo-nightly-audit`

Closes #249

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-431feea6-d802-7514-8a59-27303719587c)
