### PR TITLE
Add OpenAI chat completion wire mapping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -142,6 +142,10 @@
     "packages/core/subscription-gateway": {
       "name": "@tellahq/subscription-gateway",
       "version": "0.0.0",
+      "dependencies": {
+        "@earendil-works/pi-ai": "0.84.3",
+        "zod": "^4.3.6",
+      },
     },
     "packages/integrations/apple-mobile": {
       "name": "@tellahq/opensession-apple-mobile",
@@ -1810,6 +1814,8 @@
     "@team-plain/typescript-sdk/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
     "@tellahq/opensession-server/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@tellahq/subscription-gateway/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/packages/core/subscription-gateway/package.json
+++ b/packages/core/subscription-gateway/package.json
@@ -13,6 +13,11 @@
   "exports": {
     ".": "./src/index.ts",
     "./pool": "./src/pool/index.ts",
-    "./storage": "./src/storage/index.ts"
+    "./storage": "./src/storage/index.ts",
+    "./openai": "./src/openai/index.ts"
+  },
+  "dependencies": {
+    "@earendil-works/pi-ai": "0.84.3",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/core/subscription-gateway/src/index.ts
+++ b/packages/core/subscription-gateway/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./openai";
 export * from "./pool";
 export * from "./storage";

--- a/packages/core/subscription-gateway/src/openai/chat-completions.test.ts
+++ b/packages/core/subscription-gateway/src/openai/chat-completions.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { decodeChatCompletionRequest } from "./chat-completions";
+import { OpenAIRequestError } from "./errors";
+
+function request(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    model: "claude-sonnet-5",
+    messages: [{ role: "user", content: "Hello" }],
+    ...overrides,
+  };
+}
+
+describe("decodeChatCompletionRequest", () => {
+  test("maps OpenAI messages and tools into a pi context", () => {
+    const decoded = decodeChatCompletionRequest(
+      request({
+        messages: [
+          { role: "system", content: "System rules" },
+          { role: "developer", content: [{ type: "text", text: "Be terse" }] },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this" },
+              {
+                type: "image_url",
+                image_url: { url: "data:image/png;base64,aGVsbG8=" },
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "weather",
+                  arguments: '{"city":"Amsterdam"}',
+                },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "Rain" },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "weather",
+              description: "Get weather",
+              parameters: {
+                type: "object",
+                properties: { city: { type: "string" } },
+                required: ["city"],
+              },
+            },
+          },
+        ],
+        tool_choice: "none",
+        max_completion_tokens: 512,
+        stream: true,
+        stream_options: { include_usage: true },
+        user: "principal-a",
+      }),
+      123,
+    );
+
+    expect(decoded).toMatchObject({
+      model: "claude-sonnet-5",
+      stream: true,
+      includeUsage: true,
+      maxTokens: 512,
+      toolChoice: "none",
+      endUserId: "principal-a",
+      context: {
+        systemPrompt: "System rules\n\nBe terse",
+        tools: [
+          {
+            name: "weather",
+            description: "Get weather",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+          },
+        ],
+      },
+    });
+    expect(decoded.context.messages).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this" },
+          { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+        ],
+        timestamp: 123,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "weather",
+            arguments: { city: "Amsterdam" },
+          },
+        ],
+        api: "openai-completions",
+        provider: "subscription-gateway",
+        model: "claude-sonnet-5",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        stopReason: "stop",
+        timestamp: 123,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "weather",
+        content: [{ type: "text", text: "Rain" }],
+        isError: false,
+        timestamp: 123,
+      },
+    ]);
+  });
+
+  test("rejects remote image URLs", () => {
+    expect(() =>
+      decodeChatCompletionRequest(
+        request({
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image_url",
+                  image_url: { url: "https://example.com/image.png" },
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toThrow("Only base64 data URLs are supported");
+  });
+
+  test("rejects tool results without an earlier matching call", () => {
+    expect(() =>
+      decodeChatCompletionRequest(
+        request({
+          messages: [
+            { role: "tool", tool_call_id: "missing", content: "result" },
+          ],
+        }),
+      ),
+    ).toThrow("No earlier assistant tool call matches missing");
+  });
+
+  test("rejects unsupported values instead of ignoring them", () => {
+    for (const [field, value] of [
+      ["n", 2],
+      ["temperature", 0.5],
+      ["stop", "END"],
+    ] as const) {
+      try {
+        decodeChatCompletionRequest(request({ [field]: value }));
+        throw new Error(`Expected ${field} to fail`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(OpenAIRequestError);
+        if (error instanceof OpenAIRequestError)
+          expect(error.param).toBe(field);
+      }
+    }
+    expect(() =>
+      decodeChatCompletionRequest(
+        request({ response_format: { type: "json" } }),
+      ),
+    ).toThrow("Unrecognized key");
+  });
+
+  test("rejects stream options on a non-streaming request", () => {
+    expect(() =>
+      decodeChatCompletionRequest(
+        request({ stream_options: { include_usage: true } }),
+      ),
+    ).toThrow("stream_options requires stream=true");
+  });
+});

--- a/packages/core/subscription-gateway/src/openai/chat-completions.ts
+++ b/packages/core/subscription-gateway/src/openai/chat-completions.ts
@@ -1,0 +1,348 @@
+import type {
+  AssistantMessage,
+  Context,
+  ImageContent,
+  Message,
+  TextContent,
+  Tool,
+  ToolCall,
+  ToolResultMessage,
+  Usage,
+} from "@earendil-works/pi-ai";
+import { z } from "zod";
+import { OpenAIRequestError } from "./errors";
+
+const textPartSchema = z
+  .object({ type: z.literal("text"), text: z.string() })
+  .strict();
+const imagePartSchema = z
+  .object({
+    type: z.literal("image_url"),
+    image_url: z
+      .object({
+        url: z.string(),
+        detail: z.enum(["auto", "low", "high"]).optional(),
+      })
+      .strict(),
+  })
+  .strict();
+const textContentSchema = z.union([z.string(), z.array(textPartSchema).min(1)]);
+const userContentSchema = z.union([
+  z.string(),
+  z
+    .array(z.discriminatedUnion("type", [textPartSchema, imagePartSchema]))
+    .min(1),
+]);
+const toolArgumentsObjectSchema = z.record(z.string(), z.unknown());
+const toolCallSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.literal("function"),
+    function: z
+      .object({ name: z.string().min(1), arguments: z.string() })
+      .strict(),
+  })
+  .strict();
+const messageSchema = z.discriminatedUnion("role", [
+  z.object({ role: z.literal("system"), content: textContentSchema }).strict(),
+  z
+    .object({ role: z.literal("developer"), content: textContentSchema })
+    .strict(),
+  z.object({ role: z.literal("user"), content: userContentSchema }).strict(),
+  z
+    .object({
+      role: z.literal("assistant"),
+      content: z.union([z.string(), z.null()]).optional(),
+      tool_calls: z.array(toolCallSchema).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("tool"),
+      tool_call_id: z.string().min(1),
+      content: textContentSchema,
+    })
+    .strict(),
+]);
+const functionToolSchema = z
+  .object({
+    type: z.literal("function"),
+    function: z
+      .object({
+        name: z.string().min(1),
+        description: z.string().optional(),
+        parameters: z.record(z.string(), z.unknown()).optional(),
+        strict: z.boolean().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+const requestSchema = z
+  .object({
+    model: z.string().min(1),
+    messages: z.array(messageSchema).min(1),
+    stream: z.boolean().optional(),
+    stream_options: z
+      .object({ include_usage: z.boolean().optional() })
+      .strict()
+      .optional(),
+    tools: z.array(functionToolSchema).optional(),
+    tool_choice: z.enum(["auto", "none"]).optional(),
+    max_tokens: z.number().int().positive().optional(),
+    max_completion_tokens: z.number().int().positive().optional(),
+    n: z.number().int().positive().optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    stop: z.union([z.string(), z.array(z.string()).min(1).max(4)]).optional(),
+    user: z.string().optional(),
+  })
+  .strict();
+
+type ParsedRequest = z.infer<typeof requestSchema>;
+
+export interface DecodedChatCompletionRequest {
+  readonly model: string;
+  readonly context: Context;
+  readonly stream: boolean;
+  readonly includeUsage: boolean;
+  readonly maxTokens?: number;
+  readonly toolChoice: "auto" | "none";
+  /** Client-provided provider metadata. Never use this value for pool ownership. */
+  readonly endUserId?: string;
+}
+
+const zeroUsage = (): Usage => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+});
+
+function textContent(
+  content: string | readonly { readonly type: "text"; readonly text: string }[],
+): string {
+  return typeof content === "string"
+    ? content
+    : content.map((part) => part.text).join("");
+}
+
+function dataUrlImage(url: string, param: string): ImageContent {
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/]+={0,2})$/.exec(url);
+  if (!match) {
+    throw new OpenAIRequestError(
+      "Only base64 data URLs are supported for image inputs",
+      { param, code: "unsupported_image_url" },
+    );
+  }
+  return { type: "image", mimeType: match[1], data: match[2] };
+}
+
+function toolArguments(value: string, param: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new OpenAIRequestError("Tool arguments must be valid JSON", {
+      param,
+      code: "invalid_tool_arguments",
+    });
+  }
+  const object = toolArgumentsObjectSchema.safeParse(parsed);
+  if (!object.success) {
+    throw new OpenAIRequestError("Tool arguments must be a JSON object", {
+      param,
+      code: "invalid_tool_arguments",
+    });
+  }
+  return object.data;
+}
+
+function assistantMessage(
+  message: Extract<ParsedRequest["messages"][number], { role: "assistant" }>,
+  model: string,
+  timestamp: number,
+  toolNames: Map<string, string>,
+  messageIndex: number,
+): AssistantMessage {
+  const content: AssistantMessage["content"] = [];
+  if (message.content) content.push({ type: "text", text: message.content });
+  for (const [toolIndex, call] of (message.tool_calls ?? []).entries()) {
+    toolNames.set(call.id, call.function.name);
+    content.push({
+      type: "toolCall",
+      id: call.id,
+      name: call.function.name,
+      arguments: toolArguments(
+        call.function.arguments,
+        `messages.${messageIndex}.tool_calls.${toolIndex}.function.arguments`,
+      ),
+    });
+  }
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "subscription-gateway",
+    model,
+    usage: zeroUsage(),
+    stopReason: "stop",
+    timestamp,
+  };
+}
+
+function toolResult(
+  message: Extract<ParsedRequest["messages"][number], { role: "tool" }>,
+  timestamp: number,
+  toolNames: ReadonlyMap<string, string>,
+  messageIndex: number,
+): ToolResultMessage {
+  const toolName = toolNames.get(message.tool_call_id);
+  if (!toolName) {
+    throw new OpenAIRequestError(
+      `No earlier assistant tool call matches ${message.tool_call_id}`,
+      {
+        param: `messages.${messageIndex}.tool_call_id`,
+        code: "unknown_tool_call",
+      },
+    );
+  }
+  return {
+    role: "toolResult",
+    toolCallId: message.tool_call_id,
+    toolName,
+    content: [{ type: "text", text: textContent(message.content) }],
+    isError: false,
+    timestamp,
+  };
+}
+
+function toolsFromRequest(request: ParsedRequest): Tool[] | undefined {
+  if (!request.tools?.length) return undefined;
+  return request.tools.map((tool, index) => {
+    if (tool.function.strict) {
+      throw new OpenAIRequestError(
+        "Strict function schemas are not supported",
+        {
+          param: `tools.${index}.function.strict`,
+          code: "unsupported_parameter",
+        },
+      );
+    }
+    return {
+      name: tool.function.name,
+      description: tool.function.description ?? "",
+      parameters: tool.function.parameters ?? {
+        type: "object",
+        properties: {},
+      },
+    };
+  });
+}
+
+function parseRequest(input: unknown): ParsedRequest {
+  const parsed = requestSchema.safeParse(input);
+  if (parsed.success) return parsed.data;
+  const issue = parsed.error.issues[0];
+  const param = issue?.path.join(".") || null;
+  throw new OpenAIRequestError(issue?.message ?? "Invalid request", {
+    ...(param ? { param } : {}),
+  });
+}
+
+export function decodeChatCompletionRequest(
+  input: unknown,
+  timestamp = Date.now(),
+): DecodedChatCompletionRequest {
+  const request = parseRequest(input);
+  if (request.n !== undefined && request.n !== 1) {
+    throw new OpenAIRequestError("Only n=1 is supported", {
+      param: "n",
+      code: "unsupported_parameter",
+    });
+  }
+  if (request.temperature !== undefined) {
+    throw new OpenAIRequestError("temperature is not supported", {
+      param: "temperature",
+      code: "unsupported_parameter",
+    });
+  }
+  if (request.stop !== undefined) {
+    throw new OpenAIRequestError("stop is not supported", {
+      param: "stop",
+      code: "unsupported_parameter",
+    });
+  }
+  if (
+    request.max_tokens !== undefined &&
+    request.max_completion_tokens !== undefined
+  ) {
+    throw new OpenAIRequestError(
+      "Use max_tokens or max_completion_tokens, not both",
+      { param: "max_tokens", code: "conflicting_parameters" },
+    );
+  }
+  if (request.stream_options && !request.stream) {
+    throw new OpenAIRequestError("stream_options requires stream=true", {
+      param: "stream_options",
+      code: "invalid_parameter",
+    });
+  }
+
+  const system: string[] = [];
+  const messages: Message[] = [];
+  const toolNames = new Map<string, string>();
+  for (const [index, message] of request.messages.entries()) {
+    switch (message.role) {
+      case "system":
+      case "developer":
+        system.push(textContent(message.content));
+        break;
+      case "user": {
+        if (typeof message.content === "string") {
+          messages.push({ role: "user", content: message.content, timestamp });
+          break;
+        }
+        const content: (TextContent | ImageContent)[] = message.content.map(
+          (part, partIndex) =>
+            part.type === "text"
+              ? { type: "text", text: part.text }
+              : dataUrlImage(
+                  part.image_url.url,
+                  `messages.${index}.content.${partIndex}.image_url.url`,
+                ),
+        );
+        messages.push({ role: "user", content, timestamp });
+        break;
+      }
+      case "assistant":
+        messages.push(
+          assistantMessage(message, request.model, timestamp, toolNames, index),
+        );
+        break;
+      case "tool":
+        messages.push(toolResult(message, timestamp, toolNames, index));
+        break;
+      default: {
+        const exhaustive: never = message;
+        throw new Error(`Unhandled message: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  return {
+    model: request.model,
+    context: {
+      ...(system.length ? { systemPrompt: system.join("\n\n") } : {}),
+      messages,
+      ...(request.tools?.length ? { tools: toolsFromRequest(request) } : {}),
+    },
+    stream: request.stream ?? false,
+    includeUsage: request.stream_options?.include_usage ?? false,
+    ...((request.max_completion_tokens ?? request.max_tokens)
+      ? { maxTokens: request.max_completion_tokens ?? request.max_tokens }
+      : {}),
+    toolChoice: request.tool_choice ?? "auto",
+    ...(request.user ? { endUserId: request.user } : {}),
+  };
+}

--- a/packages/core/subscription-gateway/src/openai/errors.ts
+++ b/packages/core/subscription-gateway/src/openai/errors.ts
@@ -1,0 +1,42 @@
+export interface OpenAIErrorEnvelope {
+  readonly error: {
+    readonly message: string;
+    readonly type: "invalid_request_error" | "server_error";
+    readonly param: string | null;
+    readonly code: string | null;
+  };
+}
+
+export class OpenAIRequestError extends Error {
+  readonly param: string | null;
+  readonly code: string;
+
+  constructor(message: string, options?: { param?: string; code?: string }) {
+    super(message);
+    this.name = "OpenAIRequestError";
+    this.param = options?.param ?? null;
+    this.code = options?.code ?? "invalid_request";
+  }
+
+  toEnvelope(): OpenAIErrorEnvelope {
+    return {
+      error: {
+        message: this.message,
+        type: "invalid_request_error",
+        param: this.param,
+        code: this.code,
+      },
+    };
+  }
+}
+
+export function serverErrorEnvelope(message: string): OpenAIErrorEnvelope {
+  return {
+    error: {
+      message,
+      type: "server_error",
+      param: null,
+      code: null,
+    },
+  };
+}

--- a/packages/core/subscription-gateway/src/openai/index.ts
+++ b/packages/core/subscription-gateway/src/openai/index.ts
@@ -1,0 +1,3 @@
+export * from "./chat-completions";
+export * from "./errors";
+export * from "./responses";

--- a/packages/core/subscription-gateway/src/openai/responses.test.ts
+++ b/packages/core/subscription-gateway/src/openai/responses.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  ToolCall,
+  Usage,
+} from "@earendil-works/pi-ai";
+import {
+  chatCompletionMetadata,
+  serializeChatCompletion,
+  serializeChatCompletionStream,
+} from "./responses";
+
+const usage: Usage = {
+  input: 11,
+  output: 7,
+  cacheRead: 3,
+  cacheWrite: 0,
+  totalTokens: 18,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistant(
+  input: Pick<AssistantMessage, "content" | "stopReason">,
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content: input.content,
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.6-sol",
+    usage,
+    stopReason: input.stopReason,
+    timestamp: 123,
+  };
+}
+
+const metadata = chatCompletionMetadata({
+  id: "chatcmpl-test",
+  model: "gpt-5.6-sol",
+  now: 123_000,
+});
+
+describe("serializeChatCompletion", () => {
+  test("serializes text, tool calls, finish reason, and usage", () => {
+    expect(
+      serializeChatCompletion(
+        assistant({
+          content: [
+            { type: "thinking", thinking: "private" },
+            { type: "text", text: "Checking." },
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "weather",
+              arguments: { city: "Amsterdam" },
+            },
+          ],
+          stopReason: "toolUse",
+        }),
+        metadata,
+      ),
+    ).toEqual({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 123,
+      model: "gpt-5.6-sol",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Checking.",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "weather",
+                  arguments: '{"city":"Amsterdam"}',
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+      usage: {
+        prompt_tokens: 11,
+        completion_tokens: 7,
+        total_tokens: 18,
+      },
+    });
+  });
+
+  test("does not expose thinking as assistant content", () => {
+    const completion = serializeChatCompletion(
+      assistant({
+        content: [{ type: "thinking", thinking: "private" }],
+        stopReason: "stop",
+      }),
+      metadata,
+    );
+    expect(completion.choices[0].message.content).toBeNull();
+  });
+});
+
+describe("serializeChatCompletionStream", () => {
+  test("writes OpenAI chunks, streamed tool arguments, usage, and DONE", async () => {
+    const partial = assistant({
+      content: [
+        { type: "text", text: "Checking" },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "weather",
+          arguments: {},
+        },
+      ],
+      stopReason: "pending",
+    });
+    const completeToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call_1",
+      name: "weather",
+      arguments: { city: "Amsterdam" },
+    };
+    const done = assistant({
+      content: [{ type: "text", text: "Checking" }, completeToolCall],
+      stopReason: "toolUse",
+    });
+    async function* events(): AsyncGenerator<AssistantMessageEvent> {
+      yield { type: "start", partial };
+      yield { type: "text_start", contentIndex: 0, partial };
+      yield {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Checking",
+        partial,
+      };
+      yield { type: "text_end", contentIndex: 0, content: "Checking", partial };
+      yield { type: "toolcall_start", contentIndex: 1, partial };
+      yield {
+        type: "toolcall_delta",
+        contentIndex: 1,
+        delta: '{"city":',
+        partial,
+      };
+      yield {
+        type: "toolcall_delta",
+        contentIndex: 1,
+        delta: '"Amsterdam"}',
+        partial,
+      };
+      yield {
+        type: "toolcall_end",
+        contentIndex: 1,
+        toolCall: completeToolCall,
+        partial: done,
+      };
+      yield { type: "done", reason: "toolUse", message: done };
+    }
+
+    const chunks: string[] = [];
+    for await (const chunk of serializeChatCompletionStream(
+      events(),
+      metadata,
+      {
+        includeUsage: true,
+      },
+    )) {
+      chunks.push(chunk);
+    }
+    const payloads = chunks.map((chunk) => chunk.trim().replace(/^data: /, ""));
+    expect(payloads).toEqual([
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Checking"},"finish_reason":null}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"weather","arguments":""}}]},"finish_reason":null}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\\"city\\\":"}}]},"finish_reason":null}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\\"Amsterdam\\\"}"}}]},"finish_reason":null}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":null}',
+      '{"id":"chatcmpl-test","created":123,"model":"gpt-5.6-sol","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}',
+      "[DONE]",
+    ]);
+  });
+
+  test("emits a complete tool call when the provider skips start and delta", async () => {
+    const done = assistant({
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "weather",
+          arguments: { city: "Amsterdam" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+    async function* events(): AsyncGenerator<AssistantMessageEvent> {
+      const toolCall = done.content[0];
+      if (toolCall.type !== "toolCall") return;
+      yield {
+        type: "toolcall_end",
+        contentIndex: 0,
+        toolCall,
+        partial: done,
+      };
+      yield { type: "done", reason: "toolUse", message: done };
+    }
+    const chunks: string[] = [];
+    for await (const chunk of serializeChatCompletionStream(
+      events(),
+      metadata,
+    )) {
+      chunks.push(chunk);
+    }
+    expect(chunks.join("")).toContain(
+      '"function":{"name":"weather","arguments":"{\\"city\\":\\"Amsterdam\\"}"}',
+    );
+  });
+
+  test("turns provider errors into an SSE error envelope and DONE", async () => {
+    const failed = assistant({ content: [], stopReason: "error" });
+    failed.errorMessage = "Provider unavailable";
+    async function* events(): AsyncGenerator<AssistantMessageEvent> {
+      yield { type: "error", reason: "error", error: failed };
+    }
+    const chunks: string[] = [];
+    for await (const chunk of serializeChatCompletionStream(
+      events(),
+      metadata,
+    )) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toContain('"message":"Provider unavailable"');
+    expect(chunks[1]).toBe("data: [DONE]\n\n");
+  });
+});

--- a/packages/core/subscription-gateway/src/openai/responses.ts
+++ b/packages/core/subscription-gateway/src/openai/responses.ts
@@ -1,0 +1,315 @@
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  ToolCall,
+  Usage,
+} from "@earendil-works/pi-ai";
+import { serverErrorEnvelope } from "./errors";
+
+export interface ChatCompletionMetadata {
+  readonly id: string;
+  readonly created: number;
+  readonly model: string;
+}
+
+export interface ChatCompletionUsage {
+  readonly prompt_tokens: number;
+  readonly completion_tokens: number;
+  readonly total_tokens: number;
+}
+
+export type ChatFinishReason = "stop" | "length" | "tool_calls";
+
+interface WireToolCall {
+  readonly id: string;
+  readonly type: "function";
+  readonly function: { readonly name: string; readonly arguments: string };
+}
+
+export interface ChatCompletion {
+  readonly id: string;
+  readonly object: "chat.completion";
+  readonly created: number;
+  readonly model: string;
+  readonly choices: readonly [
+    {
+      readonly index: 0;
+      readonly message: {
+        readonly role: "assistant";
+        readonly content: string | null;
+        readonly tool_calls?: readonly WireToolCall[];
+      };
+      readonly finish_reason: ChatFinishReason;
+    },
+  ];
+  readonly usage: ChatCompletionUsage;
+}
+
+interface ChatCompletionChunk {
+  readonly id: string;
+  readonly object: "chat.completion.chunk";
+  readonly created: number;
+  readonly model: string;
+  readonly choices: readonly {
+    readonly index: 0;
+    readonly delta: {
+      readonly role?: "assistant";
+      readonly content?: string;
+      readonly tool_calls?: readonly {
+        readonly index: number;
+        readonly id?: string;
+        readonly type?: "function";
+        readonly function?: {
+          readonly name?: string;
+          readonly arguments?: string;
+        };
+      }[];
+    };
+    readonly finish_reason: ChatFinishReason | null;
+  }[];
+  readonly usage?: ChatCompletionUsage | null;
+}
+
+export function chatCompletionMetadata(input: {
+  readonly model: string;
+  readonly id?: string;
+  readonly now?: number;
+}): ChatCompletionMetadata {
+  return {
+    id: input.id ?? `chatcmpl-${crypto.randomUUID()}`,
+    created: Math.floor((input.now ?? Date.now()) / 1_000),
+    model: input.model,
+  };
+}
+
+function finishReason(message: AssistantMessage): ChatFinishReason {
+  switch (message.stopReason) {
+    case "stop":
+      return "stop";
+    case "length":
+      return "length";
+    case "toolUse":
+      return "tool_calls";
+    case "pending":
+    case "deferred":
+    case "error":
+    case "aborted":
+      throw new Error(
+        `Cannot serialize assistant stop reason ${message.stopReason}`,
+      );
+    default: {
+      const exhaustive: never = message.stopReason;
+      throw new Error(`Unhandled stop reason: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function usage(value: Usage): ChatCompletionUsage {
+  return {
+    prompt_tokens: value.input,
+    completion_tokens: value.output,
+    total_tokens: value.totalTokens,
+  };
+}
+
+function wireToolCall(call: ToolCall): WireToolCall {
+  return {
+    id: call.id,
+    type: "function",
+    function: { name: call.name, arguments: JSON.stringify(call.arguments) },
+  };
+}
+
+export function serializeChatCompletion(
+  message: AssistantMessage,
+  metadata: ChatCompletionMetadata,
+): ChatCompletion {
+  const text = message.content
+    .filter((content) => content.type === "text")
+    .map((content) => content.text)
+    .join("");
+  const toolCalls = message.content
+    .filter((content) => content.type === "toolCall")
+    .map(wireToolCall);
+  return {
+    ...metadata,
+    object: "chat.completion",
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: text || null,
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: finishReason(message),
+      },
+    ],
+    usage: usage(message.usage),
+  };
+}
+
+function sse(value: unknown): string {
+  return `data: ${JSON.stringify(value)}\n\n`;
+}
+
+export class ChatCompletionSseEncoder {
+  readonly #metadata: ChatCompletionMetadata;
+  readonly #includeUsage: boolean;
+  readonly #toolIndexes = new Map<number, number>();
+  #nextToolIndex = 0;
+  #started = false;
+
+  constructor(
+    metadata: ChatCompletionMetadata,
+    options?: { readonly includeUsage?: boolean },
+  ) {
+    this.#metadata = metadata;
+    this.#includeUsage = options?.includeUsage ?? false;
+  }
+
+  encode(event: AssistantMessageEvent): readonly string[] {
+    switch (event.type) {
+      case "start":
+        return this.#start();
+      case "text_start":
+      case "text_end":
+      case "thinking_start":
+      case "thinking_delta":
+      case "thinking_end":
+        return [];
+      case "text_delta":
+        return [...this.#start(), this.#chunk({ content: event.delta }, null)];
+      case "toolcall_start": {
+        const call = event.partial.content[event.contentIndex];
+        if (!call || call.type !== "toolCall") return [];
+        const index = this.#toolIndex(event.contentIndex);
+        return [
+          ...this.#start(),
+          this.#chunk(
+            {
+              tool_calls: [
+                {
+                  index,
+                  id: call.id,
+                  type: "function",
+                  function: { name: call.name, arguments: "" },
+                },
+              ],
+            },
+            null,
+          ),
+        ];
+      }
+      case "toolcall_delta":
+        return [
+          ...this.#start(),
+          this.#chunk(
+            {
+              tool_calls: [
+                {
+                  index: this.#toolIndex(event.contentIndex),
+                  function: { arguments: event.delta },
+                },
+              ],
+            },
+            null,
+          ),
+        ];
+      case "toolcall_end": {
+        if (this.#toolIndexes.has(event.contentIndex)) return [];
+        const index = this.#toolIndex(event.contentIndex);
+        return [
+          ...this.#start(),
+          this.#chunk(
+            {
+              tool_calls: [
+                {
+                  index,
+                  id: event.toolCall.id,
+                  type: "function",
+                  function: {
+                    name: event.toolCall.name,
+                    arguments: JSON.stringify(event.toolCall.arguments),
+                  },
+                },
+              ],
+            },
+            null,
+          ),
+        ];
+      }
+      case "done": {
+        if (event.reason === "deferred") {
+          return this.#error("Deferred responses are not supported");
+        }
+        const output = [
+          ...this.#start(),
+          this.#chunk({}, finishReason(event.message)),
+        ];
+        if (this.#includeUsage) {
+          output.push(
+            sse({
+              ...this.#metadata,
+              object: "chat.completion.chunk",
+              choices: [],
+              usage: usage(event.message.usage),
+            } satisfies ChatCompletionChunk),
+          );
+        }
+        output.push("data: [DONE]\n\n");
+        return output;
+      }
+      case "error":
+        return this.#error(
+          event.error.errorMessage ?? `Provider ${event.reason}`,
+        );
+      default: {
+        const exhaustive: never = event;
+        throw new Error(`Unhandled event: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  #start(): string[] {
+    if (this.#started) return [];
+    this.#started = true;
+    return [this.#chunk({ role: "assistant" }, null)];
+  }
+
+  #chunk(
+    delta: ChatCompletionChunk["choices"][number]["delta"],
+    reason: ChatFinishReason | null,
+  ): string {
+    return sse({
+      ...this.#metadata,
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta, finish_reason: reason }],
+      usage: null,
+    } satisfies ChatCompletionChunk);
+  }
+
+  #toolIndex(contentIndex: number): number {
+    const existing = this.#toolIndexes.get(contentIndex);
+    if (existing !== undefined) return existing;
+    const index = this.#nextToolIndex;
+    this.#nextToolIndex += 1;
+    this.#toolIndexes.set(contentIndex, index);
+    return index;
+  }
+
+  #error(message: string): string[] {
+    return [sse(serverErrorEnvelope(message)), "data: [DONE]\n\n"];
+  }
+}
+
+export async function* serializeChatCompletionStream(
+  events: AsyncIterable<AssistantMessageEvent>,
+  metadata: ChatCompletionMetadata,
+  options?: { readonly includeUsage?: boolean },
+): AsyncGenerator<string> {
+  const encoder = new ChatCompletionSseEncoder(metadata, options);
+  for await (const event of events) {
+    for (const chunk of encoder.encode(event)) yield chunk;
+  }
+}


### PR DESCRIPTION
## Summary

- validate the supported OpenAI Chat Completions request subset and reject unsupported fields
- translate system, developer, user, assistant, tool, and base64 image messages into pi-ai contexts
- serialize non-streaming completions and SSE chunks with tool-call deltas, finish reasons, usage, errors, and `data: [DONE]` termination
- keep reasoning content out of OpenAI assistant content

## Testing

- `bun run check`
- 10 focused OpenAI wire tests, 25 package tests in total

Stack 2 of 2, based on #278.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a05e8c-02a5-7eda-b6bc-4317e2d1833b)
