### PR TITLE
Preserve custom provider protocol on update

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/ModelProviders.tsx
+++ b/packages/core/opensession-server/src/frontend/components/ModelProviders.tsx
@@ -25,6 +25,7 @@ import { Checkbox } from "../ui/checkbox";
 import { IconTile } from "./BrandTile";
 import { IconDotsHorizontal, IconPlus, IconSearch, IconTrash } from "./icons";
 import { errorMessage } from "../lib/error-message";
+import { modelProviderSettingsPayload } from "../lib/model-provider-settings";
 
 // Settings → Model providers: third-party Pi providers (xai, openrouter,
 // groq, …) — API key + optional baseURL, stored server-side (0600, returned
@@ -281,15 +282,16 @@ function AddProviderForm({
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            // Strip all whitespace — pasted keys often carry newlines.
-            ...(apiKey.trim() ? { apiKey: apiKey.replace(/\s+/g, "") } : {}),
-            ...(baseURL.trim() ? { baseURL: baseURL.trim() } : {}),
-            ...(modelIds.length ? { models: modelIds } : {}),
-            api: custom ? "openai-completions" : "",
-            ...(name.trim() ? { name: name.trim() } : {}),
-            discoverModels: discover,
-          }),
+          body: JSON.stringify(
+            modelProviderSettingsPayload({
+              apiKey,
+              baseURL,
+              models: modelIds,
+              custom,
+              name,
+              discoverModels: discover,
+            }),
+          ),
         },
       );
       const body = await res.json();

--- a/packages/core/opensession-server/src/frontend/lib/model-provider-settings.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/model-provider-settings.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { modelProviderSettingsPayload } from "./model-provider-settings";
+
+describe("model provider settings payload", () => {
+  test("omits the protocol when the custom gateway option is unchanged", () => {
+    expect(
+      modelProviderSettingsPayload({
+        apiKey: " new-key\n",
+        baseURL: "",
+        models: [],
+        custom: false,
+        name: "",
+        discoverModels: false,
+      }),
+    ).toEqual({
+      apiKey: "new-key",
+      discoverModels: false,
+    });
+  });
+
+  test("declares the protocol for an OpenAI-compatible gateway", () => {
+    expect(
+      modelProviderSettingsPayload({
+        apiKey: "key",
+        baseURL: " https://gateway.test/v1 ",
+        models: ["model-a"],
+        custom: true,
+        name: " Gateway ",
+        discoverModels: true,
+      }),
+    ).toEqual({
+      apiKey: "key",
+      baseURL: "https://gateway.test/v1",
+      models: ["model-a"],
+      api: "openai-completions",
+      name: "Gateway",
+      discoverModels: true,
+    });
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/model-provider-settings.ts
+++ b/packages/core/opensession-server/src/frontend/lib/model-provider-settings.ts
@@ -1,0 +1,39 @@
+export interface ModelProviderSettingsInput {
+  apiKey: string;
+  baseURL: string;
+  models: string[];
+  custom: boolean;
+  name: string;
+  discoverModels: boolean;
+}
+
+interface ModelProviderSettingsPayload {
+  apiKey?: string;
+  baseURL?: string;
+  models?: string[];
+  api?: "openai-completions";
+  name?: string;
+  discoverModels: boolean;
+}
+
+export function modelProviderSettingsPayload({
+  apiKey,
+  baseURL,
+  models,
+  custom,
+  name,
+  discoverModels,
+}: ModelProviderSettingsInput): ModelProviderSettingsPayload {
+  const cleanApiKey = apiKey.replace(/\s+/g, "");
+  const cleanBaseURL = baseURL.trim();
+  const cleanName = name.trim();
+
+  return {
+    ...(cleanApiKey ? { apiKey: cleanApiKey } : {}),
+    ...(cleanBaseURL ? { baseURL: cleanBaseURL } : {}),
+    ...(models.length ? { models } : {}),
+    ...(custom ? { api: "openai-completions" } : {}),
+    ...(cleanName ? { name: cleanName } : {}),
+    discoverModels,
+  };
+}


### PR DESCRIPTION
## Summary
- omit the provider protocol when the add form leaves the custom gateway option unchecked
- preserve an existing custom provider protocol during key or catalog updates
- cover both standard and custom provider request payloads

## Testing
- `bun run check`

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-498d77f8-9c4c-7c51-b671-cff1b49c1a39)