### PR TITLE
Refine archived session hierarchy

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/Archived.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Archived.tsx
@@ -510,18 +510,21 @@ export function Archived({
       </Menu.Root>
     </>
   );
-  const actions = (
-    <>
-      {searchAction}
-      {filterAction}
-    </>
-  );
-
   const count = loaded
     ? archived.length === allArchived.length
       ? `${archived.length} archived session${archived.length === 1 ? "" : "s"}`
       : `${archived.length} of ${allArchived.length} archived sessions`
     : "Loading archived sessions";
+
+  const actions = (
+    <>
+      <span className="whitespace-nowrap text-supporting text-dim tabular-nums">
+        {count}
+      </span>
+      {searchAction}
+      {filterAction}
+    </>
+  );
 
   const desktopPortaled = !!topbarActionsEl && !isPhone;
   const mobileFilterPortaled = !!mobileActionsEl && isPhone;
@@ -536,7 +539,7 @@ export function Archived({
         {!isPhone && !desktopPortaled ? (
           <div className="mb-3 flex items-center gap-2">{actions}</div>
         ) : null}
-        <p className="m-0 mb-[18px] text-supporting text-dim phone:mb-3.5">
+        <p className="m-0 mb-3.5 hidden text-supporting text-dim tabular-nums phone:block">
           {count}
         </p>
         {archived.length === 0 && !loaded ? (
@@ -566,7 +569,7 @@ export function Archived({
             {sections.map((section, sectionIndex) => (
               <section
                 key={section.key}
-                className={sectionIndex > 0 ? "mt-4" : undefined}
+                className={sectionIndex > 0 ? "mt-6" : undefined}
               >
                 <h2 className={ARCHIVED_SECTION_LABEL}>{section.label}</h2>
                 <ul className={ARCHIVED_SECTION_ROWS}>

--- a/packages/core/opensession-server/src/frontend/lib/archived-classes.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/archived-classes.test.ts
@@ -3,6 +3,7 @@ import {
   ARCHIVED_PHONE_SEARCH_DOCK,
   ARCHIVED_ROW,
   ARCHIVED_ROW_ACTION,
+  ARCHIVED_SECTION_LABEL,
   ARCHIVED_SWIPE_ACTION,
   ARCHIVED_SWIPE_ROW,
 } from "./archived-classes";
@@ -12,6 +13,10 @@ test("archived phone search stays at the thumb edge", () => {
   expect(ARCHIVED_PHONE_SEARCH_DOCK).toContain("bottom-0");
   expect(ARCHIVED_PHONE_SEARCH_DOCK).toContain("safe-area-inset-bottom");
   expect(ARCHIVED_PHONE_SEARCH_DOCK).toContain("phone:block");
+});
+
+test("archived day headings sit above the row title scale", () => {
+  expect(ARCHIVED_SECTION_LABEL).toContain("text-body");
 });
 
 test("archived phone rows reveal Restore instead of reserving a button", () => {

--- a/packages/core/opensession-server/src/frontend/lib/archived-classes.ts
+++ b/packages/core/opensession-server/src/frontend/lib/archived-classes.ts
@@ -20,7 +20,7 @@ export const ARCHIVED_PHONE_SEARCH_DOCK =
 /** Section labels and row contents share the page's content edge. The list
  * itself extends 12px beyond it so the hover wash has room to breathe. */
 export const ARCHIVED_SECTION_LABEL =
-  "m-0 px-3 pb-1.5 text-meta font-semibold text-faint";
+  "m-0 px-3 pb-1.5 text-body font-semibold text-faint";
 
 export const ARCHIVED_SECTION_ROWS = "m-0 list-none p-0";
 


### PR DESCRIPTION
## Summary
- move the archived session count into the desktop top bar
- increase day-heading size and spacing between day groups
- preserve the phone count above the archive list

## Verification
- `bun run check`
- isolated `/archived` verification at 1440x900 and 390x844

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a060f4-5846-727d-b655-74c4ffcde660)