### PR TITLE
Preserve Slack creator login in delegated sessions

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/handlers.ts
+++ b/packages/core/opensession-server/src/agents/slack/handlers.ts
@@ -54,6 +54,7 @@ import { isStopMessage, cancelSession } from "./cancel";
 import { pollForVercelPreview } from "./github-reviews";
 import {
   gitIdentityFor,
+  githubLoginFor,
   slackIdToFirstName,
 } from "../../server/shared/user-mappings";
 import { oneShot } from "../../server/one-shot";
@@ -946,6 +947,7 @@ export async function processMessage(
         }),
         "opensession-sessions": createSessionsMcpServer({
           createdBy: userName || msg.userId,
+          createdByLogin: githubLoginFor(msg.userId) || undefined,
           isAdmin,
           currentSessionId: `slack-${sessionKey}`,
         }),

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -482,6 +482,9 @@ describe("single session ownership", () => {
     expect(read("report-sessions.ts")).toContain(
       "createdByLogin: input.createdByLogin",
     );
+    expect(read("../agents/slack/handlers.ts")).toContain(
+      "createdByLogin: githubLoginFor(msg.userId) || undefined",
+    );
     expect(wiring).not.toContain("updateCreatePlan(");
     expect(wiring).toContain("await requestCreationWorkspace({");
     expect(wiring.match(/await requestCreationCredential\(\{/g)?.length).toBe(


### PR DESCRIPTION
## Summary
- resolve a trusted Slack user's GitHub login through the existing identity mapping
- pass that verified login into the sessions MCP context so delegated sessions retain personal OAuth grant authority
- keep unmapped/untrusted Slack callers fail-closed
- lock the server-owned identity wiring in the ownership contract test

Follow-up to #291 and its current-head review finding.

## Verification
- `bun run check`
- focused Slack sessions-tool and session ownership tests

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a057a7-74e5-7b22-86d1-fcc0e4448bc8)
