### PR TITLE
Preserve Slack creator login in delegated sessions

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/handlers.ts
+++ b/packages/core/opensession-server/src/agents/slack/handlers.ts
@@ -54,6 +54,7 @@ import { isStopMessage, cancelSession } from "./cancel";
 import { pollForVercelPreview } from "./github-reviews";
 import {
   gitIdentityFor,
+  githubLoginFor,
   slackIdToFirstName,
 } from "../../server/shared/user-mappings";
 import { oneShot } from "../../server/one-shot";
@@ -946,6 +947,7 @@ export async function processMessage(
         }),
         "opensession-sessions": createSessionsMcpServer({
           createdBy: userName || msg.userId,
+          createdByLogin: githubLoginFor(msg.userId) || undefined,
           isAdmin,
           currentSessionId: `slack-${sessionKey}`,
         }),

--- a/packages/core/opensession-server/src/agents/slack/handlers.ts
+++ b/packages/core/opensession-server/src/agents/slack/handlers.ts
@@ -54,7 +54,7 @@ import { isStopMessage, cancelSession } from "./cancel";
 import { pollForVercelPreview } from "./github-reviews";
 import {
   gitIdentityFor,
-  githubLoginFor,
+  githubLoginForTrustedSlackId,
   slackIdToFirstName,
 } from "../../server/shared/user-mappings";
 import { oneShot } from "../../server/one-shot";
@@ -947,7 +947,7 @@ export async function processMessage(
         }),
         "opensession-sessions": createSessionsMcpServer({
           createdBy: userName || msg.userId,
-          createdByLogin: githubLoginFor(msg.userId) || undefined,
+          createdByLogin: githubLoginForTrustedSlackId(msg.userId) || undefined,
           isAdmin,
           currentSessionId: `slack-${sessionKey}`,
         }),

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -482,6 +482,9 @@ describe("single session ownership", () => {
     expect(read("report-sessions.ts")).toContain(
       "createdByLogin: input.createdByLogin",
     );
+    expect(read("../agents/slack/handlers.ts")).toContain(
+      "createdByLogin: githubLoginFor(msg.userId) || undefined",
+    );
     expect(wiring).not.toContain("updateCreatePlan(");
     expect(wiring).toContain("await requestCreationWorkspace({");
     expect(wiring.match(/await requestCreationCredential\(\{/g)?.length).toBe(

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -483,7 +483,7 @@ describe("single session ownership", () => {
       "createdByLogin: input.createdByLogin",
     );
     expect(read("../agents/slack/handlers.ts")).toContain(
-      "createdByLogin: githubLoginFor(msg.userId) || undefined",
+      "createdByLogin: githubLoginForTrustedSlackId(msg.userId) || undefined",
     );
     expect(wiring).not.toContain("updateCreatePlan(");
     expect(wiring).toContain("await requestCreationWorkspace({");

--- a/packages/core/opensession-server/src/server/shared/user-mappings.test.ts
+++ b/packages/core/opensession-server/src/server/shared/user-mappings.test.ts
@@ -6,6 +6,7 @@ import {
   deriveIdentityTables,
   gitIdentityEnv,
   labelIdentity,
+  githubLoginForTrustedSlackId,
   githubLoginToPersonKeyFromTeam,
   isTrustedGithubLogin,
   isTrustedUser,
@@ -106,6 +107,12 @@ describe("commit attribution", () => {
     expect(isTrustedUser("alice@work.example")).toBe(true);
     expect(isTrustedUser("ali")).toBe(false); // aliases are not authentication evidence
     expect(isTrustedUser("mallory")).toBe(false);
+  });
+
+  test("trusted Slack login lookup uses only the exact roster entry", () => {
+    expect(githubLoginForTrustedSlackId("U_ALICE")).toBe("alice");
+    expect(githubLoginForTrustedSlackId("U_SYSTEM")).toBeNull();
+    expect(githubLoginForTrustedSlackId("alice")).toBeNull();
   });
 
   test("the prompt's sender wins", () => {

--- a/packages/core/opensession-server/src/server/shared/user-mappings.ts
+++ b/packages/core/opensession-server/src/server/shared/user-mappings.ts
@@ -244,6 +244,19 @@ export function githubLoginFor(ref?: string | null): string | null {
 }
 
 /**
+ * Resolve an authenticated Slack sender to the GitHub login on that same
+ * roster entry. Display names and legacy Slack aliases are not authority.
+ */
+export function githubLoginForTrustedSlackId(
+  slackId?: string | null,
+): string | null {
+  if (!slackId) return null;
+  return (
+    identity.team.find((member) => member.slackId === slackId)?.github ?? null
+  );
+}
+
+/**
  * Ground-truth git identities — the exact (name, email) each teammate's
  * commits already use, so GitHub attributes commits we author on their behalf
  * to the right account (`noreply` addresses where the person commits with


### PR DESCRIPTION
## Summary
- resolve a trusted Slack user's GitHub login through the existing identity mapping
- pass that verified login into the sessions MCP context so delegated sessions retain personal OAuth grant authority
- keep unmapped/untrusted Slack callers fail-closed
- lock the server-owned identity wiring in the ownership contract test

Follow-up to #291. Supersedes #292 with a clean branch based on current main after unrelated CI flakes could not be rerun with the available GitHub token.

## Verification
- `bun run check`
- focused Slack sessions-tool and session ownership tests

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a057a7-74e5-7b22-86d1-fcc0e4448bc8)
