### PR TITLE
Preserve trusted Slack creator identity

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/handlers.ts
+++ b/packages/core/opensession-server/src/agents/slack/handlers.ts
@@ -54,6 +54,7 @@ import { isStopMessage, cancelSession } from "./cancel";
 import { pollForVercelPreview } from "./github-reviews";
 import {
   gitIdentityFor,
+  githubLoginForTrustedSlackId,
   slackIdToFirstName,
 } from "../../server/shared/user-mappings";
 import { oneShot } from "../../server/one-shot";
@@ -946,6 +947,7 @@ export async function processMessage(
         }),
         "opensession-sessions": createSessionsMcpServer({
           createdBy: userName || msg.userId,
+          createdByLogin: githubLoginForTrustedSlackId(msg.userId) || undefined,
           isAdmin,
           currentSessionId: `slack-${sessionKey}`,
         }),

--- a/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/ownership.test.ts
@@ -521,6 +521,9 @@ describe("single session ownership", () => {
     expect(read("report-sessions.ts")).toContain(
       "createdByLogin: input.createdByLogin",
     );
+    expect(read("../agents/slack/handlers.ts")).toContain(
+      "createdByLogin: githubLoginForTrustedSlackId(msg.userId) || undefined",
+    );
     expect(wiring).not.toContain("updateCreatePlan(");
     expect(wiring).toContain("await requestCreationWorkspace({");
     // Both adapters materialize through the one actor-backed materializer, so

--- a/packages/core/opensession-server/src/server/shared/user-mappings.test.ts
+++ b/packages/core/opensession-server/src/server/shared/user-mappings.test.ts
@@ -6,6 +6,7 @@ import {
   deriveIdentityTables,
   gitIdentityEnv,
   labelIdentity,
+  githubLoginForTrustedSlackId,
   githubLoginToPersonKeyFromTeam,
   isTrustedGithubLogin,
   isTrustedUser,
@@ -106,6 +107,22 @@ describe("commit attribution", () => {
     expect(isTrustedUser("alice@work.example")).toBe(true);
     expect(isTrustedUser("ali")).toBe(false); // aliases are not authentication evidence
     expect(isTrustedUser("mallory")).toBe(false);
+  });
+
+  test("trusted Slack login lookup uses one exact roster entry", () => {
+    expect(githubLoginForTrustedSlackId("U_ALICE")).toBe("alice");
+    expect(githubLoginForTrustedSlackId("U_SYSTEM")).toBeNull();
+    expect(githubLoginForTrustedSlackId("alice")).toBeNull();
+
+    const restoreDuplicate = __setIdentitiesForTest([
+      ...TEAM,
+      { name: "Mallory", slackId: "U_ALICE", github: "mallory" },
+    ]);
+    try {
+      expect(githubLoginForTrustedSlackId("U_ALICE")).toBeNull();
+    } finally {
+      restoreDuplicate();
+    }
   });
 
   test("the prompt's sender wins", () => {

--- a/packages/core/opensession-server/src/server/shared/user-mappings.ts
+++ b/packages/core/opensession-server/src/server/shared/user-mappings.ts
@@ -244,6 +244,19 @@ export function githubLoginFor(ref?: string | null): string | null {
 }
 
 /**
+ * Resolve an authenticated Slack sender to the GitHub login on that same
+ * roster entry. Display names and legacy Slack aliases are not authority.
+ */
+export function githubLoginForTrustedSlackId(
+  slackId?: string | null,
+): string | null {
+  if (!slackId) return null;
+  const matches = identity.team.filter((member) => member.slackId === slackId);
+  if (matches.length !== 1) return null;
+  return matches[0]?.github ?? null;
+}
+
+/**
  * Ground-truth git identities — the exact (name, email) each teammate's
  * commits already use, so GitHub attributes commits we author on their behalf
  * to the right account (`noreply` addresses where the person commits with


### PR DESCRIPTION
## Summary
- resolve an authenticated Slack sender only through an exact `identity.team[].slackId` roster match
- fail closed when the Slack ID is absent, display-only, or duplicated across roster entries
- pass only that verified GitHub login into delegated session creation and personal OAuth authority
- lock the server-owned identity wiring and ambiguous-roster behavior in regression tests

Follow-up to #291. Supersedes #294 with a clean branch based on current main after unrelated nondeterministic CI failures that the available GitHub token cannot rerun.

## Verification
- `bun run check`
- focused identity, Slack sessions-tool, and session ownership tests

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a057a7-74e5-7b22-86d1-fcc0e4448bc8)
