### PR TITLE
Stop socket-activating the compiled service

### DIFF
--- a/docs/gateway-handoffs.md
+++ b/docs/gateway-handoffs.md
@@ -30,6 +30,13 @@ The lease is an independent fence, not an optimization. If the supervisor is
 stale or crashes, a replacement child fails closed while the surviving gateway
 still holds the lock.
 
+These invariants describe a source install. A compiled release runs
+`opensession server` directly under `opensession.service`: it binds the public
+port itself, has no ingress process, and installs no `opensession.socket`.
+`opensession service install` removes a socket unit that an older compiled
+install left behind, since a systemd-held listener would keep the server from
+binding.
+
 ## Handoff sequence
 
 `deploy/self-deploy.sh` prepares and validates the candidate frontend first. A

--- a/opensession.socket
+++ b/opensession.socket
@@ -1,6 +1,11 @@
 # Stable public listener for Open Session. systemd retains this socket while
 # opensession-ingress.service is upgraded. Gateway and peer rollouts never
 # restart the ingress process.
+#
+# Source installs only. A compiled release has no ingress process and its
+# server binds 127.0.0.1:PORT itself, so `opensession service install` neither
+# ships nor renders this unit there. Copying it in by hand takes the port away
+# from the server (tellahq/opensession#297).
 [Unit]
 Description=Open Session stable gateway listener
 

--- a/scripts/lib/release-artefact.test.ts
+++ b/scripts/lib/release-artefact.test.ts
@@ -50,8 +50,13 @@ describe("compiled release artefact", () => {
     expect(missing).toEqual([]);
   });
 
-  test("the socket unit is staged next to the service it activates", () => {
-    expect(RELEASE_SERVICE_TEMPLATES).toContain("opensession.socket");
+  test("the socket unit stays out of the compiled release", () => {
+    // A compiled `opensession server` binds its port through Bun.serve and
+    // never adopts a systemd fd, so a shipped socket unit only takes the port
+    // away from it (tellahq/opensession#297). The installer skips it; the
+    // artefact must not tempt anyone into copying it in by hand.
+    expect(RELEASE_SERVICE_TEMPLATES).not.toContain("opensession.socket");
+    expect(RELEASE_TEMPLATE_EXEMPTIONS.has("opensession.socket")).toBe(true);
   });
 
   test("every staged file exists in the checkout", () => {

--- a/scripts/lib/release-artefact.ts
+++ b/scripts/lib/release-artefact.ts
@@ -8,12 +8,13 @@
  * here. `release-artefact.test.ts` cross-checks this list against the
  * templates `service.ts` actually opens; a template missing from this list
  * is the v0.4.52 bug where `opensession service install` died with
- * "missing socket unit template" on every published Linux release.
+ * "missing socket unit template" on every published Linux release. The fix
+ * for that was not to ship the socket: a compiled server binds its port
+ * itself, so the installer no longer renders socket activation for it
+ * (tellahq/opensession#297).
  */
 export const RELEASE_SERVICE_TEMPLATES: readonly string[] = [
   "opensession.service",
-  "opensession.socket",
-
   "opensession-executor.service",
   "opensession-session-kernel.service",
   "deploy/install-resource-control.sh",
@@ -34,6 +35,10 @@ export const RELEASE_TEMPLATE_EXEMPTIONS: ReadonlyMap<string, string> = new Map(
     [
       "opensession-ingress.service",
       "source-install only: renderIngressUnit is skipped when isCompiledBinary()",
+    ],
+    [
+      "opensession.socket",
+      "source-install only: the compiled server binds its port directly, so renderSocketUnit is skipped when isCompiledBinary()",
     ],
     [
       "bin/bun",

--- a/scripts/lib/service.test.ts
+++ b/scripts/lib/service.test.ts
@@ -23,10 +23,11 @@ import {
   renderIngressUnit,
   renderLauncher,
   renderPlist,
+  renderSocketUnit,
   renderUnit,
   serviceWorkdir,
 } from "./service";
-import { ENV_PATH, HOME } from "./paths";
+import { ENV_PATH, HOME, SHIM_PATH } from "./paths";
 
 // Both renderers interpolate host paths and the local bun, so on Windows they
 // produce a unit and a plist that could never be installed. Neither service
@@ -183,6 +184,42 @@ describe.skipIf(!onServiceHost)("systemd unit", () => {
       "";
     expect(path).toContain("/usr/bin");
     expect(path.split(":").every((p) => p.startsWith("/"))).toBe(true);
+  });
+});
+
+// A compiled `opensession server` is opensession.ts binding PORT through
+// Bun.serve; it never adopts a systemd fd and no ingress process ships with the
+// release. 0.4.52 to 0.4.55 rendered `Requires=opensession.socket` for it
+// anyway, so the install either died on the missing template or, with one
+// supplied, systemd held 3850 and the server crash-looped on EADDRINUSE
+// (tellahq/opensession#297).
+describe.skipIf(!onServiceHost)("compiled systemd unit", () => {
+  test("binds the port itself instead of expecting socket activation", async () => {
+    const unit = await renderUnit("user", true);
+    expect(unit).toContain(`ExecStart=${SHIM_PATH} server`);
+    expect(unit).not.toContain("opensession.socket");
+    expect(unit).not.toContain("opensession-ingress.service");
+    expect(unit).not.toMatch(/^(Sockets|Requires|Wants)=/m);
+    expect(unit).not.toContain("OPENSESSION_EXTERNAL_INGRESS");
+    expect(unit).toContain(
+      "After=network.target opensession-session-kernel.service\n",
+    );
+  });
+
+  test("system scope still orders the executor ahead of the gateway", async () => {
+    const unit = await renderUnit("system", true);
+    expect(unit).not.toContain("opensession.socket");
+    expect(unit).toContain(
+      "After=network.target opensession-session-kernel.service opensession-executor.service\n",
+    );
+  });
+
+  test("the socket unit only ever activates the source ingress", async () => {
+    for (const scope of ["user", "system"] as const) {
+      const unit = await renderSocketUnit(scope);
+      expect(unit).toContain("Service=opensession-ingress.service");
+      expect(unit).not.toContain("Service=opensession.service");
+    }
   });
 });
 

--- a/scripts/lib/service.ts
+++ b/scripts/lib/service.ts
@@ -306,6 +306,49 @@ function servicePath(bunDir: string): string {
 }
 
 /**
+ * Does this install use systemd socket activation?
+ *
+ * Only a source install does. There `opensession.socket` holds 127.0.0.1:PORT
+ * and hands the fd to `opensession-ingress.service`, which relays to whichever
+ * gateway child the supervisor currently runs. The compiled binary's `server`
+ * subcommand is `opensession.ts` itself: it binds PORT directly through
+ * `Bun.serve` and never reads LISTEN_FDS, and no ingress process exists in a
+ * release artefact. Rendering `Requires=opensession.socket` for it therefore
+ * fails twice over: the tarball has no socket template, and a hand-supplied
+ * one takes the port before the server can (tellahq/opensession#297).
+ */
+function socketActivated(compiled = isCompiledBinary()): boolean {
+  return !compiled;
+}
+
+function socketUnitPath(scope: SystemdScope): string {
+  return scope === "system" ? SOCKET_PATH : USER_SOCKET_PATH;
+}
+
+/**
+ * Drop a socket unit that an earlier compiled install (0.4.52 to 0.4.55) or
+ * the hand-written workaround for it left behind. While it exists the old
+ * `Requires=` still resolves and a 3850 listener may still be held by systemd,
+ * so the freshly rendered socket-free service could not bind.
+ */
+async function removeStaleSocketUnit(
+  scope: SystemdScope,
+  env?: Record<string, string>,
+): Promise<void> {
+  const path = socketUnitPath(scope);
+  if (!existsSync(path)) return;
+  info(dim(`removing ${path}: the compiled server binds its port directly`));
+  await runInherit(
+    systemctl(scope, ["disable", "--now", SOCKET_NAME]),
+    undefined,
+    env,
+  );
+  await runInherit(
+    scope === "system" ? ["sudo", "rm", "-f", path] : ["rm", "-f", path],
+  );
+}
+
+/**
  * How the service starts the server, and the dir to head the PATH with.
  *
  * Compiled-binary install: the binary is the server behind `server`, and the
@@ -316,9 +359,11 @@ function servicePath(bunDir: string): string {
  * Source install: `bun run packages/core/opensession-server/opensession.ts`
  * from the checkout.
  */
-function serverExec(): { cmd: string; binDir: string } {
-  if (isCompiledBinary())
-    return { cmd: `${SHIM_PATH} server`, binDir: BIN_DIR };
+function serverExec(compiled = isCompiledBinary()): {
+  cmd: string;
+  binDir: string;
+} {
+  if (compiled) return { cmd: `${SHIM_PATH} server`, binDir: BIN_DIR };
   const bun = bunPath();
   return {
     cmd: `${bun} run packages/core/opensession-server/opensession.ts`,
@@ -404,12 +449,6 @@ export async function renderSocketUnit(
   let unit = (await Bun.file(template).text())
     .replace(/^ListenStream=.*$/m, `ListenStream=127.0.0.1:${port}`)
     .replace(
-      /^Service=.*$/m,
-      isCompiledBinary()
-        ? "Service=opensession.service"
-        : "Service=opensession-ingress.service",
-    )
-    .replace(
       /^WantedBy=.*$/m,
       scope === "system"
         ? "WantedBy=sockets.target"
@@ -446,13 +485,13 @@ export async function renderIngressUnit(
 
 export async function renderUnit(
   scope: SystemdScope = "user",
+  compiled = isCompiledBinary(),
 ): Promise<string> {
   const template = join(REPO_ROOT, "opensession.service");
   if (!existsSync(template)) {
     throw new Error(`missing unit template at ${template}`);
   }
-  const exec = serverExec();
-  const compiled = isCompiledBinary();
+  const exec = serverExec(compiled);
   let unit = (await Bun.file(template).text())
     .replace(/^WorkingDirectory=.*$/m, `WorkingDirectory=${serviceWorkdir()}`)
     .replace(
@@ -465,17 +504,14 @@ export async function renderUnit(
       /^Environment="PATH=.*"$/m,
       `Environment="PATH=${servicePath(exec.binDir)}"`,
     );
-  if (compiled) {
+  if (!socketActivated(compiled)) {
+    // The compiled server owns its listener: no socket, no ingress peer.
     unit = unit
+      .replace(/^Wants=opensession\.socket opensession-ingress\.service\n/m, "")
       .replace(
-        /^Wants=opensession\.socket opensession-ingress\.service$/m,
-        "Requires=opensession.socket",
+        /^After=network\.target opensession-ingress\.service /m,
+        "After=network.target ",
       )
-      .replace(
-        /^After=network\.target opensession-ingress\.service/m,
-        "After=network.target opensession.socket",
-      )
-      .replace(/^Type=simple$/m, "Type=simple\nSockets=opensession.socket")
       .replace(/^Environment="OPENSESSION_EXTERNAL_INGRESS=1"\n/m, "");
   }
   const credentialMarker =
@@ -505,10 +541,7 @@ export async function renderUnit(
       /^# SESSION_KERNEL_CREDENTIAL$/m,
       `LoadCredential=session-kernel-token:${USER_SESSION_KERNEL_TOKEN_PATH}`,
     )
-    .replace(
-      /^After=network\.target opensession-ingress\.service opensession-session-kernel\.service opensession-executor\.service$/m,
-      "After=network.target opensession-ingress.service opensession-session-kernel.service",
-    )
+    .replace(/^(After=.*) opensession-executor\.service$/m, "$1")
     .replace(
       credentialMarker,
       'Environment="OPENSESSION_EXECUTOR=0"\n' +
@@ -808,9 +841,9 @@ export async function install(
       const scope = opts.scope ?? "user";
       const wasActive = installedScope() === scope && (await isActive());
       const unit = await renderUnit(scope);
-      const sourceIngress = !isCompiledBinary();
+      const sourceIngress = socketActivated();
       const ingressUnit = sourceIngress ? await renderIngressUnit(scope) : "";
-      const socketUnit = await renderSocketUnit(scope);
+      const socketUnit = sourceIngress ? await renderSocketUnit(scope) : "";
       const kernelUnit = await renderSessionKernelUnit(scope);
       const env = userEnv();
       let migratedUserUnit: string | null = null;
@@ -836,6 +869,7 @@ export async function install(
           return false;
         }
         mkdirSync(dirname(USER_UNIT_PATH), { recursive: true });
+        if (!sourceIngress) await removeStaleSocketUnit("user", env);
         if (!existsSync(USER_SESSION_KERNEL_TOKEN_PATH)) {
           await Bun.write(
             USER_SESSION_KERNEL_TOKEN_PATH,
@@ -844,12 +878,16 @@ export async function install(
           chmodSync(USER_SESSION_KERNEL_TOKEN_PATH, 0o600);
         }
         await Bun.write(USER_UNIT_PATH, unit);
-        if (sourceIngress) await Bun.write(USER_INGRESS_UNIT_PATH, ingressUnit);
-        await Bun.write(USER_SOCKET_PATH, socketUnit);
+        if (sourceIngress) {
+          await Bun.write(USER_INGRESS_UNIT_PATH, ingressUnit);
+          await Bun.write(USER_SOCKET_PATH, socketUnit);
+        }
         await Bun.write(USER_SESSION_KERNEL_UNIT_PATH, kernelUnit);
         info(dim(`installed ${USER_UNIT_PATH}`));
-        if (sourceIngress) info(dim(`installed ${USER_INGRESS_UNIT_PATH}`));
-        info(dim(`installed ${USER_SOCKET_PATH}`));
+        if (sourceIngress) {
+          info(dim(`installed ${USER_INGRESS_UNIT_PATH}`));
+          info(dim(`installed ${USER_SOCKET_PATH}`));
+        }
         info(dim(`installed ${USER_SESSION_KERNEL_UNIT_PATH}`));
         await enableLinger();
         const runtimeDir =
@@ -864,9 +902,10 @@ export async function install(
       } else {
         const executorUnit = await renderExecutorUnit();
         await Bun.write(STAGED_UNIT_PATH, unit);
-        if (sourceIngress)
+        if (sourceIngress) {
           await Bun.write(STAGED_INGRESS_UNIT_PATH, ingressUnit);
-        await Bun.write(STAGED_SOCKET_PATH, socketUnit);
+          await Bun.write(STAGED_SOCKET_PATH, socketUnit);
+        }
         await Bun.write(STAGED_EXECUTOR_UNIT_PATH, executorUnit);
         await Bun.write(STAGED_SESSION_KERNEL_UNIT_PATH, kernelUnit);
         const serviceUser = await resolveUsername();
@@ -922,9 +961,11 @@ export async function install(
           ["sudo", "-n", RUN_HOST_HELPER, "check"],
           ["sudo", "cp", STAGED_UNIT_PATH, SERVICE_PATH],
           ...(sourceIngress
-            ? [["sudo", "cp", STAGED_INGRESS_UNIT_PATH, INGRESS_SERVICE_PATH]]
+            ? [
+                ["sudo", "cp", STAGED_INGRESS_UNIT_PATH, INGRESS_SERVICE_PATH],
+                ["sudo", "cp", STAGED_SOCKET_PATH, SOCKET_PATH],
+              ]
             : []),
-          ["sudo", "cp", STAGED_SOCKET_PATH, SOCKET_PATH],
           ["sudo", "cp", STAGED_EXECUTOR_UNIT_PATH, EXECUTOR_SERVICE_PATH],
           [
             "sudo",
@@ -1006,12 +1047,13 @@ export async function install(
             env,
           );
         }
+        if (!sourceIngress) await removeStaleSocketUnit("system");
         const start = [
           ...(wasActive ? [["sudo", "systemctl", "stop", SERVICE_NAME]] : []),
           ["sudo", "systemctl", "daemon-reload"],
-          ["sudo", "systemctl", "enable", "--now", SOCKET_NAME],
           ...(sourceIngress
             ? [
+                ["sudo", "systemctl", "enable", "--now", SOCKET_NAME],
                 [
                   "sudo",
                   "systemctl",
@@ -1076,11 +1118,12 @@ export async function install(
                   undefined,
                   env,
                 );
-              await runInherit(
-                systemctl("user", ["enable", "--now", SOCKET_NAME]),
-                undefined,
-                env,
-              );
+              if (migratedUserSocketUnit)
+                await runInherit(
+                  systemctl("user", ["enable", "--now", SOCKET_NAME]),
+                  undefined,
+                  env,
+                );
               await runInherit(
                 systemctl("user", ["enable", "--now", SERVICE_NAME]),
                 undefined,
@@ -1101,9 +1144,9 @@ export async function install(
       for (const cmd of [
         ...(wasActive ? [systemctl(scope, ["stop", SERVICE_NAME])] : []),
         systemctl(scope, ["daemon-reload"]),
-        systemctl(scope, ["enable", "--now", SOCKET_NAME]),
         ...(sourceIngress
           ? [
+              systemctl(scope, ["enable", "--now", SOCKET_NAME]),
               systemctl(scope, [
                 "enable",
                 "--now",
@@ -1257,12 +1300,16 @@ export async function control(
 
   const scope = installedScope() ?? "user";
   const env = userEnv();
+  // Source installs own a socket unit; compiled ones bind the port directly.
+  const socketInstalled = existsSync(socketUnitPath(scope));
   if (action === "start") {
-    const socket = await runInherit(
-      systemctl(scope, ["start", SOCKET_NAME]),
-      undefined,
-      env,
-    );
+    const socket = socketInstalled
+      ? await runInherit(
+          systemctl(scope, ["start", SOCKET_NAME]),
+          undefined,
+          env,
+        )
+      : 0;
     if (socket !== 0) return socket;
     const actor = await runInherit(
       systemctl(scope, ["start", SESSION_KERNEL_SERVICE_NAME]),
@@ -1291,11 +1338,13 @@ export async function control(
     env,
   );
   if (action === "stop") {
-    const socket = await runInherit(
-      systemctl(scope, ["stop", SOCKET_NAME]),
-      undefined,
-      env,
-    );
+    const socket = socketInstalled
+      ? await runInherit(
+          systemctl(scope, ["stop", SOCKET_NAME]),
+          undefined,
+          env,
+        )
+      : 0;
     return gateway || actor || socket;
   }
   return actor === 0
@@ -1356,11 +1405,12 @@ export async function uninstall(): Promise<boolean> {
         undefined,
         env,
       );
-      await runInherit(
-        systemctl(scope, ["disable", "--now", SOCKET_NAME]),
-        undefined,
-        env,
-      );
+      if (existsSync(socketUnitPath(scope)))
+        await runInherit(
+          systemctl(scope, ["disable", "--now", SOCKET_NAME]),
+          undefined,
+          env,
+        );
       if (scope === "user") {
         await runInherit(
           systemctl(scope, ["disable", "--now", SESSION_KERNEL_SERVICE_NAME]),


### PR DESCRIPTION
Closes #297.

## What broke

A compiled install's `opensession server` is `opensession.ts` itself: it binds `127.0.0.1:PORT` through `Bun.serve` and never reads `LISTEN_FDS`, and no `opensession-ingress.service` ships in a release artefact. `renderUnit` still rendered `Requires=opensession.socket` + `Sockets=opensession.socket` for it, and `renderSocketUnit` pointed the socket at `opensession.service`. So on 0.4.52 to 0.4.55:

- without the template, `service install` died with `missing socket unit template`;
- with one copied in by hand, systemd held 3850 and the server crash-looped on `EADDRINUSE`.

#270 staged the template into the tarball, which would have turned failure 1 into failure 2 on the next release.

## What changes

Socket activation is now a source-install-only concept (option 2 from the issue):

- `renderUnit` for a compiled binary drops `Wants=`/`Requires=`/`Sockets=`, drops `opensession-ingress.service` from `After=`, and drops `OPENSESSION_EXTERNAL_INGRESS`. The server binds directly, as it always did.
- `renderSocketUnit` always targets `opensession-ingress.service`; the installer only renders, copies, and enables it for source installs.
- `service install` on a compiled binary removes a stale `opensession.socket` left by 0.4.52 to 0.4.55 or by the workaround in the issue, in both user and system scope, so `opensession update` cannot reintroduce the collision.
- `start`/`stop`/`uninstall` only touch the socket unit when its file exists, so a socket-free install no longer fails on `Unit opensession.socket not found`.
- `opensession.socket` leaves `RELEASE_SERVICE_TEMPLATES` and becomes an explicit exemption. The artefact test now asserts it stays out of the tarball.
- `renderUnit` takes an explicit `compiled` flag (defaulting to `isCompiledBinary()`) so the compiled rendering has tests without mocking `process.execPath`.

Source installs (including os.tella.dev) render exactly as before: the only source-path change is that `start`/`stop` check for the socket file that a source install always has.

## Verification

- `bun run check` passes on this branch.
- New tests: compiled user and system units contain no `Requires=`/`Sockets=`/`Wants=` directives, no ingress or socket references, and keep the kernel/executor ordering; the socket unit only ever activates the ingress; the release manifest excludes and exempts the socket.
- Not exercised on a real compiled host from here. The reporter offered to test on the same Hetzner box; the expected result is a clean `service install` with no `opensession.socket` in `~/.config/systemd/user`, `NRestarts=0`, and `GET /api/health` 200.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a062ec-a4b3-7df0-8608-1eec732727ef)
