### PR TITLE
Refuse an env file the service user cannot edit

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -327,6 +327,18 @@ if [ -z "$RUN_HOST_ENV_FILE" ]; then
   echo "[deploy] ERROR: gateway EnvironmentFile is required for run hosts" >&2
   exit 1
 fi
+# Settings edits this file through a .bak-<n> copy and an atomic .tmp rename,
+# both created beside it, so the service user needs the directory, not just
+# the file. Root-only /etc/opensession is reset to 0700 below and never works.
+RUN_HOST_ENV_DIR="$(dirname "$RUN_HOST_ENV_FILE")"
+if ! run_as_service_user test -w "$RUN_HOST_ENV_DIR" || ! run_as_service_user test -x "$RUN_HOST_ENV_DIR"; then
+  echo "[deploy] ERROR: env file directory $RUN_HOST_ENV_DIR is not writable by $SERVICE_USER; move $RUN_HOST_ENV_FILE to a directory the service user owns and update EnvironmentFile=" >&2
+  exit 1
+fi
+if [ -e "$RUN_HOST_ENV_FILE" ] && ! run_as_service_user test -w "$RUN_HOST_ENV_FILE"; then
+  echo "[deploy] ERROR: env file $RUN_HOST_ENV_FILE is not writable by $SERVICE_USER" >&2
+  exit 1
+fi
 SESSIONS_DIR="$(read_env_value OPENSESSION_SESSIONS_DIR "$RUN_HOST_ENV_FILE")"
 STATE_DIR="$(read_env_value OPENSESSION_STATE_DIR "$RUN_HOST_ENV_FILE")"
 if [ -z "$SESSIONS_DIR" ]; then

--- a/deploy/executor-service.test.ts
+++ b/deploy/executor-service.test.ts
@@ -110,6 +110,18 @@ describe("executor deployment", () => {
     expect(helper).toContain('set -- "$systemd_run"');
   });
 
+  test("refuses an env file the service user cannot edit", async () => {
+    // Issue #282: the gateway edits the env file through sibling backup and
+    // temp files, so a root-only directory breaks Settings after a deploy
+    // that looked healthy.
+    const deploy = await Bun.file(resolve(import.meta.dir, "deploy.sh")).text();
+    expect(deploy).toContain('run_as_service_user test -w "$RUN_HOST_ENV_DIR"');
+    expect(deploy).toContain(
+      'run_as_service_user test -w "$RUN_HOST_ENV_FILE"',
+    );
+    expect(deploy).toContain("is not writable by $SERVICE_USER");
+  });
+
   test("credential installation rejects link redirection", async () => {
     const installer = await Bun.file(
       resolve(repoRoot, "deploy/install-executor-credential.sh"),

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -344,6 +344,16 @@ set +a
 opensession start --foreground
 ```
 
+Settings writes integration credentials, `ENABLE_*` flags, and ingress origins
+back into this file. Each write copies the current file to `.bak-<n>` and then
+replaces it through an atomic rename, both created beside it, so the service
+user must own the directory, not just the file. `OPENSESSION_ENV_FILE` moves
+the file, but keep it somewhere the service user can write. Do not put it in
+`/etc/opensession`: that directory holds the root-only executor and session
+kernel credentials, every install and deploy resets it to `root:root 0700`,
+and `service install --system` and `deploy/deploy.sh` refuse an env file the
+service user cannot edit.
+
 The server settings are optional, but an enabled integration needs the
 credentials its setup page marks as required. Common operator-facing variables:
 
@@ -573,7 +583,9 @@ Unit choices worth knowing (comments in the file itself):
 - `ExecStart` uses the stable installed shim for compiled releases and Bun for
   source installs.
 - The gateway's `EnvironmentFile=<your home>/.opensession.env` loads your
-  secrets. It is optional in user scope and required in system scope.
+  secrets. It is optional in user scope and required in system scope. Its
+  directory must be writable by the service user so Settings can edit it; see
+  [section 4](#4-secrets-opensessionenv).
 - System scope loads separate executor and session-kernel credentials. User
   scope keeps its session-kernel token under `~/.opensession/` and disables the
   executor and detached runs.

--- a/packages/core/opensession-server/src/server/env-file-edit.test.ts
+++ b/packages/core/opensession-server/src/server/env-file-edit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -12,7 +13,9 @@ import { join } from "path";
 import {
   applyEnvEdits,
   applyEnvFileEdits,
+  EnvFileWriteError,
   envFilePath,
+  envFileWriteRequirement,
   prepareEnvFileEdits,
   readEnvFileValues,
   validateEnvValue,
@@ -158,6 +161,37 @@ describe("applyEnvFileEdits (disk)", () => {
   test("envFilePath honors the OPENSESSION_ENV_FILE override", () => {
     expect(envFilePath()).toBe(file);
   });
+
+  // Root ignores directory modes, so the read-only setup below cannot fail
+  // there. Issue #282: a system-scope install with the env file inside
+  // root-only /etc/opensession 500s on every Settings save.
+  test.skipIf(process.getuid?.() === 0)(
+    "explains the directory requirement when the env file's directory is read-only",
+    () => {
+      writeFileSync(file, "SLACK_BOT_TOKEN=old\n");
+      chmodSync(root, 0o555);
+      try {
+        let caught: unknown;
+        try {
+          prepareEnvFileEdits({ SLACK_BOT_TOKEN: "new" }).commit();
+        } catch (error) {
+          caught = error;
+        }
+        expect(caught).toBeInstanceOf(EnvFileWriteError);
+        const error = caught as EnvFileWriteError;
+        expect(error.path).toBe(file);
+        expect(error.message).toBe(envFileWriteRequirement(file));
+        expect(error.message).toContain(root);
+        expect(error.message).toContain("OPENSESSION_ENV_FILE");
+        expect((error.cause as { code?: string }).code).toBe("EACCES");
+        // Nothing was touched: no stray backup, original content intact.
+        expect(existsSync(`${file}.bak-1`)).toBe(false);
+        expect(readFileSync(file, "utf-8")).toBe("SLACK_BOT_TOKEN=old\n");
+      } finally {
+        chmodSync(root, 0o755);
+      }
+    },
+  );
 });
 
 describe("validateEnvValue", () => {

--- a/packages/core/opensession-server/src/server/env-file-edit.ts
+++ b/packages/core/opensession-server/src/server/env-file-edit.ts
@@ -17,6 +17,7 @@
  */
 
 import { chmodSync, existsSync, readFileSync, rmSync } from "fs";
+import { dirname } from "path";
 import { statePath } from "./paths";
 import { backupFile } from "./config-mutation";
 import { writeFileAtomic } from "./shared/atomic-write";
@@ -25,6 +26,38 @@ import { writeFileAtomic } from "./shared/atomic-write";
  *  then the dual-read home path. Read per call so tests can repoint it. */
 export function envFilePath(): string {
   return process.env.OPENSESSION_ENV_FILE || statePath(".opensession.env");
+}
+
+const PERMISSION_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
+
+/**
+ * The env file cannot be edited from this process. Every write creates two
+ * siblings (`.bak-<n>`, then the atomic `.tmp.*` rename source), so write
+ * access on the file alone is not enough: the directory must be writable by
+ * the service user. A system-scope install that points OPENSESSION_ENV_FILE
+ * into root-only `/etc/opensession` hits this on every Settings save.
+ */
+export class EnvFileWriteError extends Error {
+  readonly path: string;
+  constructor(path: string, cause: unknown) {
+    super(envFileWriteRequirement(path), { cause });
+    this.name = "EnvFileWriteError";
+    this.path = path;
+  }
+}
+
+/** One sentence shared by the server error and the installer check. */
+export function envFileWriteRequirement(path: string): string {
+  return (
+    `Cannot write the env file ${path}: the service user needs write access to ${dirname(path)} ` +
+    "because backups and atomic writes create files beside it. Move the file to a directory " +
+    "the service user owns, set OPENSESSION_ENV_FILE to match, and reinstall the service."
+  );
+}
+
+function isPermissionError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" && PERMISSION_CODES.has(code);
 }
 
 export const WEB_SETUP_MARKER = "# --- added via web setup ---";
@@ -130,8 +163,13 @@ export function prepareEnvFileEdits(
   return {
     commit() {
       if (committed) return;
-      backupFile(path);
-      writeFileAtomic(path, after);
+      try {
+        backupFile(path);
+        writeFileAtomic(path, after);
+      } catch (error) {
+        if (isPermissionError(error)) throw new EnvFileWriteError(path, error);
+        throw error;
+      }
       committed = true;
       try {
         chmodSync(path, 0o600);

--- a/packages/core/opensession-server/src/server/routes/setup.ts
+++ b/packages/core/opensession-server/src/server/routes/setup.ts
@@ -439,13 +439,23 @@ export async function handleSetupRoutes(
       return Response.json({ error: "Nothing to change" }, { status: 400 });
     }
 
-    const { applyEnvFileEdits, readEnvFileValues } =
+    const { EnvFileWriteError, applyEnvFileEdits, readEnvFileValues } =
       await import("../env-file-edit");
     const { rawConfig, persistRawConfig, withConfigMutationLock } =
       await import("../config-mutation");
 
     return withConfigMutationLock(async () => {
-      applyEnvFileEdits(edits);
+      try {
+        applyEnvFileEdits(edits);
+      } catch (error) {
+        // A misplaced env file is an install problem, not a request problem.
+        // Name the path and the fix instead of leaking a raw fs error as 500.
+        if (error instanceof EnvFileWriteError) {
+          console.error(`[setup] ${error.message}`);
+          return Response.json({ error: error.message }, { status: 500 });
+        }
+        throw error;
+      }
       if (enabled !== undefined) {
         const config = rawConfig();
         const integrations =

--- a/scripts/lib/service.test.ts
+++ b/scripts/lib/service.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, test } from "bun:test";
 import { platform } from "os";
 import {
   bootstrapLaunchAgent,
+  envFileWriteProblem,
   LAUNCHD_LABEL,
   LAUNCHD_LAUNCHER,
   metadataInstallBlockGuidance,
@@ -107,6 +108,41 @@ describe("cloud metadata install refusal", () => {
     );
     expect(guidance).toContain("OPENSESSION_ALLOW_IMDS=1");
     expect(guidance).toContain("explicitly skip this safety check");
+  });
+});
+
+describe("env file write check", () => {
+  // Issue #282: pointing OPENSESSION_ENV_FILE into root-only /etc/opensession
+  // installs fine and then 500s on every Settings save. The check runs before
+  // any sudo step so the operator sees the problem at install time.
+  const denied = (paths: Set<string>) => (target: string, _mode: number) => {
+    if (paths.has(target)) {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    }
+  };
+
+  test("refuses a directory the service user cannot write", () => {
+    const problem = envFileWriteProblem(
+      "/etc/opensession/opensession.env",
+      denied(new Set(["/etc/opensession"])),
+    );
+    expect(problem).toContain("/etc/opensession is not writable");
+    expect(problem).toContain("/etc/opensession/opensession.env");
+    expect(problem).toContain("backups and atomic writes");
+  });
+
+  test("refuses an existing env file the service user cannot write", () => {
+    const problem = envFileWriteProblem(ENV_PATH, denied(new Set([ENV_PATH])));
+    // ENV_PATH may not exist on the test host; then only the directory counts.
+    if (problem !== undefined) {
+      expect(problem).toBe(`${ENV_PATH} is not writable by this user`);
+    }
+  });
+
+  test("accepts a writable directory", () => {
+    expect(
+      envFileWriteProblem("/tmp/does-not-matter/opensession.env", () => {}),
+    ).toBeUndefined();
   });
 });
 

--- a/scripts/lib/service.ts
+++ b/scripts/lib/service.ts
@@ -26,7 +26,14 @@
  * server in the foreground.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync } from "fs";
+import {
+  accessSync,
+  chmodSync,
+  constants as fsConstants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from "fs";
 import { userInfo } from "os";
 import { dirname, join } from "path";
 import {
@@ -108,6 +115,35 @@ function envFileValue(name: string): string | undefined {
     return raw.slice(1, -1);
   }
   return raw;
+}
+
+/**
+ * Why the service user cannot edit `path` from Settings, or undefined when it
+ * can. The server writes the env file through a `.bak-<n>` copy and an atomic
+ * `.tmp.*` rename, both created beside the file, so the directory must be
+ * writable and traversable; write access on the file alone is not enough. A
+ * system-scope install pointed at root-only `/etc/opensession` (the credential
+ * and run-host directory, reset to 0700 on every install) fails this check.
+ */
+export function envFileWriteProblem(
+  path: string,
+  access: (target: string, mode: number) => void = accessSync,
+): string | undefined {
+  const dir = dirname(path);
+  const { W_OK, X_OK } = fsConstants;
+  try {
+    access(dir, W_OK | X_OK);
+  } catch {
+    return `${dir} is not writable by this user; Settings edits ${path} through backups and atomic writes created beside it`;
+  }
+  if (existsSync(path)) {
+    try {
+      access(path, W_OK);
+    } catch {
+      return `${path} is not writable by this user`;
+    }
+  }
+  return undefined;
 }
 
 function defaultStatePath(base: string): string {
@@ -900,6 +936,20 @@ export async function install(
           await Bun.sleep(500);
         }
       } else {
+        const envProblem = envFileWriteProblem(ENV_PATH);
+        if (envProblem) {
+          fail(
+            "service installation blocked: the gateway cannot edit its env file",
+            envProblem,
+          );
+          info(
+            "move the file to a directory the service user owns (for example ~/.opensession.env),",
+          );
+          info(
+            "set OPENSESSION_ENV_FILE to that path, and rerun the same installation command",
+          );
+          return false;
+        }
         const executorUnit = await renderExecutorUnit();
         await Bun.write(STAGED_UNIT_PATH, unit);
         if (sourceIngress) {


### PR DESCRIPTION
Fixes #282.

Settings writes the env file through a `.bak-<n>` copy and an atomic `.tmp` rename, both created beside it, so the gateway needs write access to the directory, not just the file. A system-scope install that points `OPENSESSION_ENV_FILE` into `/etc/opensession` passes installation and then 500s on every integration save with a raw `EACCES`, because the three root-run credential and run-host installers reset that directory to `root:root 0700` on purpose: it holds the executor and session-kernel tokens.

**Changes**

- `opensession service install --system` refuses an env file whose directory the service user cannot write, before any sudo step, with the fix in the message (`scripts/lib/service.ts`, new `envFileWriteProblem()`).
- `deploy/deploy.sh` runs the same check as the service user via `runuser`, so a root deploy cannot leave an install that looks healthy but cannot save settings.
- `prepareEnvFileEdits().commit()` wraps `EACCES`/`EPERM`/`EROFS` in `EnvFileWriteError`; the integrations PUT route returns its message as `{ error }` instead of Bun's default error page, so the Settings dialog shows the path and the fix.
- `docs/setup/install.md` says where the env file may live and why `/etc/opensession` is not an option.

**Deliberately not done**

- No ACL or group grant on the file alone: the sibling backup and temp files still fail, and `commit()` runs `chmod 0600` afterward, which rewrites the ACL mask.
- No non-atomic in-place write fallback: a truncated secrets file is worse than a clear refusal.
- No loosening of `/etc/opensession`.

**Tests**

- `env-file-edit.test.ts`: read-only directory reproduces the reporter's `EACCES ... copyfile` and surfaces `EnvFileWriteError` with nothing written (skipped as root).
- `service.test.ts`: installer check with an injected access function.
- `executor-service.test.ts`: guards that `deploy.sh` keeps the check.

Note for operators: `deploy/deploy.sh` is a root-deploy artifact, so landing this on a live host is `sudo deploy/deploy.sh <sha>`, not `deploy_self`.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a0637f-9d63-79cb-93c7-4d9ced18c09b)
