### PR TITLE
Copy the pull request's GitHub link with ⌘⇧G

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/PrStatusBar.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PrStatusBar.tsx
@@ -271,6 +271,8 @@ function PrBarButton({
 function PrCopyItems({ pr }: { pr: PrDetails }) {
   const [copied, setCopied] = useState<"link" | "number" | null>(null);
   const provider = providerFromUrl(pr.url);
+  const openChord = useShortcutLabel("open-pr");
+  const copyChord = useShortcutLabel("pr-copy-link");
 
   const copy = (kind: "link" | "number", text: string) => {
     navigator.clipboard?.writeText(text).then(() => {
@@ -293,6 +295,7 @@ function PrCopyItems({ pr }: { pr: PrDetails }) {
       >
         <IconArrowUpRight size={20} className={MENU_ICON} />
         <span className="grow">Open on {provider.name}</span>
+        {openChord && <ContextMenu.Shortcut>{openChord}</ContextMenu.Shortcut>}
       </ContextMenu.Item>
       <ContextMenu.Item
         closeOnClick={false}
@@ -306,6 +309,7 @@ function PrCopyItems({ pr }: { pr: PrDetails }) {
         <span className="grow">
           {copied === "link" ? "Copied" : "Copy link"}
         </span>
+        {copyChord && <ContextMenu.Shortcut>{copyChord}</ContextMenu.Shortcut>}
       </ContextMenu.Item>
       <ContextMenu.Item
         closeOnClick={false}

--- a/packages/core/opensession-server/src/frontend/components/app-command-actions.tsx
+++ b/packages/core/opensession-server/src/frontend/components/app-command-actions.tsx
@@ -83,6 +83,12 @@ export function buildAppCommandActions({
   toggleSidebarCollapsed,
   showToast,
 }: BuildAppCommandActionsOptions): CommandPaletteAction[] {
+  // Same target as the ⌘G/⌘⇧G chords: the primary branch's PR, else the
+  // first linked repo PR on a multi-repo session.
+  const prUrl =
+    currentSession?.prUrl ??
+    currentSession?.prs?.find((ref) => ref.url)?.url ??
+    null;
   return [
     {
       id: "new-session",
@@ -193,6 +199,23 @@ export function buildAppCommandActions({
             run: () =>
               copyToClipboard(absoluteLink(copyLinkPath), () =>
                 showToast("Link copied"),
+              ),
+          },
+        ]
+      : []),
+    ...(prUrl
+      ? [
+          {
+            id: "copy-pr-link",
+            label: "Copy pull request link",
+            description: "Copy the GitHub link to this session's pull request",
+            category: "Actions" as const,
+            keywords: ["url", "share", "clipboard", "github", "pr"],
+            shortcut: shortcutPrimaryKeys("pr-copy-link") ?? undefined,
+            icon: <IconPullRequest size={18} />,
+            run: () =>
+              copyToClipboard(prUrl, () =>
+                showToast("Pull request link copied"),
               ),
           },
         ]

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionRuntimeController.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionRuntimeController.ts
@@ -32,6 +32,7 @@ import { withPreviewPath } from "../lib/preview-url";
 import type { SessionViewerProps } from "../lib/session-viewer-bindings";
 import { sessionHasWorkspace } from "../lib/session-workspace";
 import { ownedBy } from "../lib/sidebar-lanes";
+import { copyToClipboard } from "../lib/share-link";
 import { matchesShortcut } from "../lib/shortcuts";
 import type {
   SessionPrRef,
@@ -422,16 +423,18 @@ export function useSessionRuntimeController({
   }, [showStaging, stagingSettled, stagingUrl, onCloseStaging]);
 
   // ⌘O opens the PR's preview environment (the Vercel preview StagingLink's globe
-  // points at); ⌘G opens its GitHub PR. Chords without a target (no staging
-  // deploy / no PR) fall through to the browser.
+  // points at); ⌘G opens its GitHub PR and ⌘⇧G copies that URL instead.
+  // Chords without a target (no staging deploy / no PR) fall through to the
+  // browser.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (!focused) return;
       const openPr = matchesShortcut(e, "open-pr");
+      const copyPr = matchesShortcut(e, "pr-copy-link");
       const openPreview = matchesShortcut(e, "open-preview");
       if (
         e.defaultPrevented ||
-        (!openPr && !openPreview) ||
+        (!openPr && !copyPr && !openPreview) ||
         blockingOverlayOpen()
       )
         return;
@@ -446,12 +449,16 @@ export function useSessionRuntimeController({
             )
           : null;
       if (editable && !editable.classList.contains("composer-textarea")) return;
-      if (openPr) {
+      if (openPr || copyPr) {
         // Primary branch's PR, falling back to the first attached/linked
         // repo PR on multi-repo sessions.
         const prUrl = session.prUrl ?? session.prs?.find((ref) => ref.url)?.url;
         if (!prUrl) return;
         e.preventDefault();
+        if (copyPr) {
+          copyToClipboard(prUrl, () => toast("Pull request link copied"));
+          return;
+        }
         window.open(prUrl, "_blank", "noopener");
       } else if (openPreview && staging) {
         e.preventDefault();

--- a/packages/core/opensession-server/src/frontend/lib/shortcuts.ts
+++ b/packages/core/opensession-server/src/frontend/lib/shortcuts.ts
@@ -67,6 +67,7 @@ export type ShortcutId =
   | "effort-up"
   | "effort-down"
   | "open-pr"
+  | "pr-copy-link"
   | "open-preview";
 
 export interface ShortcutCommand {
@@ -237,7 +238,8 @@ export const SHORTCUT_COMMANDS: ShortcutCommand[] = [
   {
     id: "session-copy-link",
     title: "Copy link",
-    description: "Copy a link to the open session or pull request",
+    description:
+      "Copy the Open Session link to the open session, workspace, or review",
     group: "Sessions",
     defaults: ["mod+shift+c"],
   },
@@ -303,6 +305,16 @@ export const SHORTCUT_COMMANDS: ShortcutCommand[] = [
     description: "Open the session's pull request on GitHub",
     group: "Links",
     defaults: ["mod+g"],
+  },
+  // ⌘⇧G is to ⌘G what ⌘⇧C is to the session: the same target, copied
+  // rather than opened. It hands out the GitHub URL, where ⌘⇧C on a review
+  // hands out the Open Session one.
+  {
+    id: "pr-copy-link",
+    title: "Copy pull request link",
+    description: "Copy the GitHub link to the session's pull request",
+    group: "Links",
+    defaults: ["mod+shift+g"],
   },
   {
     id: "open-preview",


### PR DESCRIPTION
## What

- **⌘⇧G** (new, `pr-copy-link`, Links group): copies the session's GitHub pull request URL, the same target **⌘G** opens. Falls back to the first linked repo PR on multi-repo sessions, like ⌘G. Rebindable in Settings → Keyboard shortcuts and listed on the ⌘/ cheat sheet.
- **⌘⇧C** (existing, `session-copy-link`): unchanged behavior, it copies the Open Session link to the open session, workspace, or review. Its description now says so, so the two rows read apart.
- The PR chip's context menu shows the chord beside "Open on GitHub" (⌘G) and "Copy link" (⌘⇧G).
- Command palette gains "Copy pull request link" when the session has a PR.

## Verification

`bun run check` passes. Screenshots to follow in a comment.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a063cf-f901-764c-9078-ffaa81c82083)