### PR TITLE
Refuse a seventh image before the outbox can loop on it

### DIFF
--- a/packages/core/opensession-server/src/agents/slack/slack-api.ts
+++ b/packages/core/opensession-server/src/agents/slack/slack-api.ts
@@ -5,6 +5,7 @@
  * using fetch() + SLACK_BOT_TOKEN from process.env.
  */
 
+import { MAX_PROMPT_IMAGES } from "@tellahq/opensession-protocol/session";
 import { fetchWithTimeout } from "../../server/shared/fetch-with-timeout";
 import { personaName } from "../../server/config";
 import type { ImageInput } from "../../server/run-events";
@@ -48,7 +49,6 @@ export function slackFileRefs(files: any[] | undefined): SlackFileRef[] {
 
 // Anthropic caps images at 5MB; stay under it, and bound the total payload.
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
-const MAX_IMAGES_PER_PROMPT = 6;
 
 /**
  * Download the image attachments among `files` (bot-token auth) and return
@@ -67,7 +67,7 @@ export async function downloadSlackImages(
       lines.push(`- ${f.name} (${f.mimetype || "unknown type"}) — not inlined`);
       continue;
     }
-    if (images.length >= MAX_IMAGES_PER_PROMPT) {
+    if (images.length >= MAX_PROMPT_IMAGES) {
       lines.push(`- ${f.name} (${f.mimetype}) — skipped, image limit reached`);
       continue;
     }

--- a/packages/core/opensession-server/src/frontend/lib/attachments.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/attachments.test.ts
@@ -222,3 +222,22 @@ test("what is staging is counted by kind", () => {
     ]),
   ).toEqual({ images: 1, files: 1 });
 });
+
+// The server refuses a message with more than the cap, and a refused message
+// used to sit in the outbox retrying with nothing to press. Stop at the cap
+// while attaching and say what was left out.
+test("a seventh image is left out of the draft and named", async () => {
+  const server = stagingServer();
+  server.release();
+  saveDraft(KEY, {
+    images: Array.from({ length: 5 }, (_, i) => `/media?path=${i}`),
+  });
+
+  const result = await attachToDraft(KEY, [png("six.png"), png("seven.png")]);
+
+  expect(loadDraft(KEY).images).toHaveLength(6);
+  expect(loadDraft(KEY).images[5]).toBe(
+    `/media?path=${encodeURIComponent("/uploads/staged/six.png")}`,
+  );
+  expect(result.rejected).toEqual(["1 image (a message holds up to 6)"]);
+});

--- a/packages/core/opensession-server/src/frontend/lib/attachments.ts
+++ b/packages/core/opensession-server/src/frontend/lib/attachments.ts
@@ -20,8 +20,14 @@
  * workspace — a completion that lands afterwards must not write the image
  * back and resurrect a draft that is finished.
  */
+import { MAX_PROMPT_IMAGES } from "@tellahq/opensession-protocol/session";
 import { loadDraft, saveDraft } from "./drafts";
 import { splitAttachments, type FileAttachment } from "./images";
+
+/** Why an image past the per-message cap was left out of the draft. */
+export function imageCapReason(dropped: number): string {
+  return `${dropped} image${dropped === 1 ? "" : "s"} (a message holds up to ${MAX_PROMPT_IMAGES})`;
+}
 
 /** Bumped whenever a key's draft is consumed, so in-flight staging for it can
  *  tell that the composer it belongs to has moved on. */
@@ -115,8 +121,14 @@ export async function attachToDraft(
   }
   if (images.length || files.length) {
     const stored = loadDraft(key);
+    // The server refuses a longer list outright, so stop at the cap here and
+    // name what was left out: the store, not the caller's stale array, is
+    // what decides how much room a paste still has.
+    const room = Math.max(0, MAX_PROMPT_IMAGES - stored.images.length);
+    if (images.length > room)
+      rejected.push(imageCapReason(images.length - room));
     saveDraft(key, {
-      images: [...stored.images, ...images],
+      images: [...stored.images, ...images.slice(0, room)],
       files: [...stored.files, ...files],
     });
   }

--- a/packages/core/opensession-server/src/frontend/lib/session-viewer-send.ts
+++ b/packages/core/opensession-server/src/frontend/lib/session-viewer-send.ts
@@ -2,6 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { getCurrentUser } from "../components/UserPicker";
 import type { SessionSocketSend } from "../hooks/useSessionSocket";
 import { postSessionNoteApi } from "./api";
+import { MAX_PROMPT_IMAGES } from "@tellahq/opensession-protocol/session";
 import { dropStagingAttachments } from "./attachments";
 import type { ComposerSendOptions } from "./composer-types";
 import { unhideForSession } from "./hides";
@@ -102,6 +103,13 @@ export function sendSessionMessage(
     pastedTexts.length === 0
   )
     return false;
+  // Attaching already stops at the cap; this catches a message brought back
+  // for editing with more. The server would refuse it, and a refused message
+  // used to sit in the outbox retrying with nothing to press.
+  if (images.length > MAX_PROMPT_IMAGES) {
+    toast(`Attach up to ${MAX_PROMPT_IMAGES} images per message`);
+    return false;
+  }
 
   // Note mode: post a team note on this session — never a prompt. The
   // server broadcast echoes it back into `notes` for every viewer, so

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -77,7 +77,14 @@ import {
   sessionRuntimeSnapshot,
   type SessionRuntimeSnapshot,
 } from "../session-cache";
-import { asDataUrlList, countImageRefs, parseImageDataUrls } from "../uploads";
+import {
+  asDataUrlList,
+  countImageRefs,
+  InvalidUploadError,
+  parseImageDataUrls,
+} from "../uploads";
+import { MAX_PROMPT_IMAGES } from "@tellahq/opensession-protocol/session";
+import { SessionKernelActorError } from "../session-kernel/actor-client";
 import { notifyMentions } from "../mentions";
 import { reviewTeamFor } from "../people";
 import { sendPushToUser } from "../push";
@@ -1260,6 +1267,15 @@ export async function handleSessionsRoutes(
           { status: 400 },
         );
       }
+      // Same terminal answer for a list the queue would refuse to stage. Ask
+      // before delivery so the kernel never records a receipt for a message
+      // that can only ever fail the same way.
+      if ((images?.length ?? 0) > MAX_PROMPT_IMAGES) {
+        return Response.json(
+          { error: `Attach up to ${MAX_PROMPT_IMAGES} images per message.` },
+          { status: 400 },
+        );
+      }
       const clientId =
         typeof body?.clientId === "string" && body.clientId.trim()
           ? body.clientId.trim().slice(0, 200)
@@ -1289,20 +1305,38 @@ export async function handleSessionsRoutes(
           typeof body?.fastMode === "boolean" ? body.fastMode : undefined,
         );
       }
-      const result = await getSessionControl().deliverToSession(
-        sessionId,
-        content,
-        user,
-        {
-          busy: busyMode,
-          hold: busyMode === "queue",
-          images,
-          imageUrls,
-          files,
-          contextSessions,
-          ...(clientId ? { deliveryId: clientId } : {}),
-        },
-      );
+      let result: Awaited<
+        ReturnType<ReturnType<typeof getSessionControl>["deliverToSession"]>
+      >;
+      try {
+        result = await getSessionControl().deliverToSession(
+          sessionId,
+          content,
+          user,
+          {
+            busy: busyMode,
+            hold: busyMode === "queue",
+            images,
+            imageUrls,
+            files,
+            contextSessions,
+            ...(clientId ? { deliveryId: clientId } : {}),
+          },
+        );
+      } catch (error) {
+        // A rejected attachment list, or the kernel replaying the failure it
+        // recorded for this client id, will not change on retry. Say so with
+        // a 4xx: a 500 reads as transient and keeps the outbox looping on a
+        // message nobody can edit or discard.
+        if (error instanceof InvalidUploadError)
+          return Response.json(
+            { error: error.message },
+            { status: error.status },
+          );
+        if (error instanceof SessionKernelActorError && !error.retryable)
+          return Response.json({ error: error.message }, { status: 409 });
+        throw error;
+      }
       if (result.status === "error") {
         return Response.json(
           { ...result, error: result.message },

--- a/packages/core/opensession-server/src/server/session-notes.test.ts
+++ b/packages/core/opensession-server/src/server/session-notes.test.ts
@@ -72,7 +72,7 @@ describe("session notes", () => {
         "os-too-many-images",
         Array(7).fill("data:image/png;base64,iVBORw0KGgo="),
       ),
-    ).toThrow("too many images");
+    ).toThrow("Attach up to 6 images per message.");
   });
 
   test("activity reports the latest note per session", () => {

--- a/packages/core/opensession-server/src/server/uploads.test.ts
+++ b/packages/core/opensession-server/src/server/uploads.test.ts
@@ -21,6 +21,7 @@ const {
   parseImageDataUrls,
   prepareCreationAttachmentSources,
   stageCreationAttachment,
+  InvalidUploadError,
   stageInlineImages,
 } = await import("./uploads");
 if (saved === undefined) delete process.env.OPENSESSION_STATE_DIR;
@@ -162,5 +163,24 @@ describe("staging images for a note", () => {
     expect(() =>
       stageInlineImages("os-note", ["/media?path=%2Fetc%2Fpasswd"]),
     ).toThrow("unsupported image type");
+  });
+
+  // A seventh screenshot used to surface as a 500, which the browser outbox
+  // reads as transient: the message retried every 30 seconds with no way to
+  // edit or discard it. The error names its status so the route answers 400.
+  test("refuses a seventh image as a client error", () => {
+    const refs = Array.from({ length: 7 }, (_, i) => stage(`shot-${i}.png`));
+    let thrown: unknown;
+    try {
+      stageInlineImages("os-note", refs);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(InvalidUploadError);
+    expect(thrown).toMatchObject({
+      status: 400,
+      message: "Attach up to 6 images per message.",
+    });
+    expect(stageInlineImages("os-note", refs.slice(0, 6))).toHaveLength(6);
   });
 });

--- a/packages/core/opensession-server/src/server/uploads.ts
+++ b/packages/core/opensession-server/src/server/uploads.ts
@@ -20,8 +20,20 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
+import { MAX_PROMPT_IMAGES } from "@tellahq/opensession-protocol/session";
 import type { ImageInput } from "./run-events";
 import { SESSIONS_DIR } from "./session-cache";
+
+/** The sender's attachment list cannot be staged as sent. Carries the HTTP
+ * status so a route answers 400: the browser outbox parks a 4xx as failed with
+ * Edit and Discard, while a 5xx retries forever behind a fixed message. */
+export class InvalidUploadError extends Error {
+  readonly status = 400;
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidUploadError";
+  }
+}
 
 /** Keep only the string image references from a composer `images` payload: the
  *  display/queue form (parsed to ImageInput at delivery via parseImageDataUrls).
@@ -124,7 +136,6 @@ const STAGED_UPLOADS_DIR = `${UPLOADS_DIR}/staged`;
 // inline base64/WS path buffers, so keep it modest.
 export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 const MAX_CREATION_ATTACHMENTS = 32;
-const MAX_INLINE_IMAGES = 6;
 const INLINE_IMAGE_EXTENSIONS: Record<string, string> = {
   "image/png": ".png",
   "image/jpeg": ".jpg",
@@ -201,22 +212,28 @@ export function stageInlineImages(
   subdir = "images",
 ): string[] {
   if (urls === undefined) return [];
-  if (!Array.isArray(urls)) throw new Error("images must be an array");
-  if (urls.length > MAX_INLINE_IMAGES)
-    throw new Error(`too many images (max ${MAX_INLINE_IMAGES})`);
+  if (!Array.isArray(urls))
+    throw new InvalidUploadError("images must be an array");
+  if (urls.length > MAX_PROMPT_IMAGES)
+    throw new InvalidUploadError(
+      `Attach up to ${MAX_PROMPT_IMAGES} images per message.`,
+    );
   const images = urls.map(
     (url): { data: string; extension: string } | { url: string } => {
-      if (typeof url !== "string") throw new Error("invalid image");
+      if (typeof url !== "string")
+        throw new InvalidUploadError("invalid image");
       // The web composer stages an image at attach time and sends the ref. It
       // already lives under the uploads dir and /media already serves it, so a
       // note keeps the ref instead of rewriting the same bytes to a second file.
       if (url.startsWith("/media?")) {
-        if (!stagedImageRef(url)) throw new Error("unsupported image type");
+        if (!stagedImageRef(url))
+          throw new InvalidUploadError("unsupported image type");
         return { url };
       }
       const match = url.match(/^data:([^;]+);base64,(.+)$/s);
       const extension = match && INLINE_IMAGE_EXTENSIONS[match[1]];
-      if (!match || !extension) throw new Error("unsupported image type");
+      if (!match || !extension)
+        throw new InvalidUploadError("unsupported image type");
       return { data: match[2], extension };
     },
   );
@@ -228,7 +245,9 @@ export function stageInlineImages(
         ? (stagedImageRef(image.url)?.size ?? 0)
         : Buffer.byteLength(image.data, "base64");
     if (totalBytes > MAX_UPLOAD_BYTES)
-      throw new Error(`images too large (max ${MAX_UPLOAD_BYTES} bytes total)`);
+      throw new InvalidUploadError(
+        `images too large (max ${MAX_UPLOAD_BYTES} bytes total)`,
+      );
   }
   const dir = `${UPLOADS_DIR}/${sanitizeFilename(subdir)}/${sanitizeFilename(sessionId)}`;
   mkdirSync(dir, { recursive: true });
@@ -242,7 +261,7 @@ export function stageInlineImages(
         continue;
       }
       const data = Buffer.from(image.data, "base64");
-      if (!data.length) throw new Error("empty image");
+      if (!data.length) throw new InvalidUploadError("empty image");
       const path = uniqueUploadPath(
         dir,
         `${Date.now()}-${index + 1}${image.extension}`,

--- a/packages/core/protocol/src/session.ts
+++ b/packages/core/protocol/src/session.ts
@@ -699,3 +699,8 @@ export type ProtocolServerMessage =
   | { type: "notice"; sessionId?: string; message: string }
   | { type: "pong" }
   | { type: "error"; sessionId?: string; message: string };
+
+/** Images one message may carry. The server refuses a longer list at intake
+ * and every composer stops at the same count, so a sender learns while
+ * attaching rather than from a rejected send. */
+export const MAX_PROMPT_IMAGES = 6;


### PR DESCRIPTION
## What happened

A message with seven screenshots in `os-01a04d8f-91ca-783e-ac32-6088f1a551b6` failed inside delivery with a plain `Error("too many images (max 6)")` from `stageInlineImages`. The prompt route had no catch on that path, so Bun answered 500. The browser outbox treats 5xx as transient, so the message retried every 30 seconds from 19:48 with no Retry, Edit or Discard control (those only render for `state === "failed"`), never reached the agent, and could not be deleted from the queue view because it never existed server-side. Later messages under the cap drained around it during its backoff.

## Changes

- `MAX_PROMPT_IMAGES = 6` lives in `@tellahq/opensession-protocol/session`; the server, Slack intake and the web composer all read it.
- `stageInlineImages` throws `InvalidUploadError` (`status: 400`) for a rejected list.
- The prompt route answers 400 before delivery when the image list is over the cap, maps `InvalidUploadError` to its status, and maps a non-retryable `SessionKernelActorError` (the kernel replaying the failure it recorded for that client id) to 409. Timeouts and transport failures stay `retryable: true` and still surface as 500.
- `attachToDraft` stops at the cap and names what it left out in the existing "Couldn't attach" notice.
- `sendSessionMessage` refuses a draft over the cap with a toast, which covers a failed message brought back through Edit.

## Effect on the stuck message

After deploy, the outbox's next automatic retry gets a 400, the card flips to failed with Retry / Edit / Discard, and Edit or Discard clears it. No storage surgery needed.

## Verification

`bun run check` passes. New tests: `uploads.test.ts` (seventh image is a 400 with the message; six stage fine), `attachments.test.ts` (seventh image left out of the draft and named); `session-notes.test.ts` updated for the new message.

Started by Grant Shaddick in [this OS session](https://os.tella.dev/session/os-01a063bf-dbb2-7167-86c3-86e83bc1bc70)
