### PR TITLE
Open a new workspace tab with the workspace's PR already attached

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -699,15 +699,6 @@ export function SessionViewer({
   const { canKeepInSidebar, keepInSidebar, promoting } = agentsController;
   const { isAsk, hasWorkspace, hasRepoWork, handlePromote } = agentsController;
   const { gitRefreshTick, setGitRefreshTick } = presenceController;
-  // PR and git reads issued while this tab was still a client-side shell were
-  // answered 404, and SWR keeps that answer. Once the create lands, ask every
-  // mounted PR surface again so the workspace's PR shows without a poll.
-  const wasPendingCreation = useRef(pendingCreation);
-  useEffect(() => {
-    const settled = wasPendingCreation.current && !pendingCreation;
-    wasPendingCreation.current = pendingCreation;
-    if (settled) setGitRefreshTick((tick) => tick + 1);
-  }, [pendingCreation, setGitRefreshTick]);
   const { sessionPrTargetsRef, viewers, setViewers } = presenceController;
   const { typingUsers, setTypingUsers } = presenceController;
   const { workspacePreparing, setWorkspacePreparing } = presenceController;

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -699,6 +699,15 @@ export function SessionViewer({
   const { canKeepInSidebar, keepInSidebar, promoting } = agentsController;
   const { isAsk, hasWorkspace, hasRepoWork, handlePromote } = agentsController;
   const { gitRefreshTick, setGitRefreshTick } = presenceController;
+  // PR and git reads issued while this tab was still a client-side shell were
+  // answered 404, and SWR keeps that answer. Once the create lands, ask every
+  // mounted PR surface again so the workspace's PR shows without a poll.
+  const wasPendingCreation = useRef(pendingCreation);
+  useEffect(() => {
+    const settled = wasPendingCreation.current && !pendingCreation;
+    wasPendingCreation.current = pendingCreation;
+    if (settled) setGitRefreshTick((tick) => tick + 1);
+  }, [pendingCreation, setGitRefreshTick]);
   const { sessionPrTargetsRef, viewers, setViewers } = presenceController;
   const { typingUsers, setTypingUsers } = presenceController;
   const { workspacePreparing, setWorkspacePreparing } = presenceController;

--- a/packages/core/opensession-server/src/frontend/hooks/new-tab-workspace-pr.test.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/new-tab-workspace-pr.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+const tabsSource = await Bun.file(
+  new URL("./useSessionTabs.tsx", import.meta.url),
+).text();
+const viewerSource = await Bun.file(
+  new URL("../components/SessionViewer.tsx", import.meta.url),
+).text();
+
+test("a new tab's local shell inherits the workspace's PRs, not the source's flat PR fields", () => {
+  const draft = tabsSource.slice(
+    tabsSource.indexOf("const draft: UnifiedSession = {"),
+    tabsSource.indexOf('if (mode === "ask") {'),
+  );
+  expect(draft).toContain("prs: siblingTabPrRefs(src)");
+  expect(draft).toContain("prUrl: undefined");
+  expect(draft).toContain("prNumber: undefined");
+  expect(draft).toContain("prState: undefined");
+});
+
+test("PR surfaces revalidate once a pending create lands", () => {
+  expect(viewerSource).toContain(
+    "const settled = wasPendingCreation.current && !pendingCreation;",
+  );
+  expect(viewerSource).toContain(
+    "if (settled) setGitRefreshTick((tick) => tick + 1);",
+  );
+});

--- a/packages/core/opensession-server/src/frontend/hooks/new-tab-workspace-pr.test.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/new-tab-workspace-pr.test.ts
@@ -3,9 +3,6 @@ import { expect, test } from "bun:test";
 const tabsSource = await Bun.file(
   new URL("./useSessionTabs.tsx", import.meta.url),
 ).text();
-const viewerSource = await Bun.file(
-  new URL("../components/SessionViewer.tsx", import.meta.url),
-).text();
 
 test("a new tab's local shell inherits the workspace's PRs, not the source's flat PR fields", () => {
   const draft = tabsSource.slice(
@@ -18,11 +15,16 @@ test("a new tab's local shell inherits the workspace's PRs, not the source's fla
   expect(draft).toContain("prState: undefined");
 });
 
-test("PR surfaces revalidate once a pending create lands", () => {
-  expect(viewerSource).toContain(
-    "const settled = wasPendingCreation.current && !pendingCreation;",
+test("the tab's resources are asked again once the create has landed", () => {
+  const landed = tabsSource.indexOf(
+    "void revalidateApiResources(sessionApiKeyFilter(createdId));",
   );
-  expect(viewerSource).toContain(
-    "if (settled) setGitRefreshTick((tick) => tick + 1);",
+  expect(landed).toBeGreaterThan(0);
+  // After the server copy is in the list, before the pending shell is released.
+  const before = tabsSource.slice(
+    tabsSource.indexOf("const created = await newSessionApi("),
+    landed,
   );
+  expect(before).toContain("inject(");
+  expect(before).not.toContain("clearTimeout(pendingTimer.current)");
 });

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionTabs.tsx
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionTabs.tsx
@@ -25,6 +25,7 @@ import {
 import { setLane, type Lane } from "../lib/lanes";
 import { dedupeViewers, otherViewers } from "../lib/presence";
 import { newClientSessionId } from "../lib/session-id";
+import { siblingTabPrRefs } from "../lib/session-prs";
 import type { NewTabMorphOrigin, ViewTab } from "../lib/session-tabs-types";
 import { sessionPath, workspacePanePath } from "../lib/share-link";
 import { matchesShortcut } from "../lib/shortcuts";
@@ -773,8 +774,26 @@ export function useSessionTabs({
       archived: false,
       waitingForInput: false,
       queuedCount: 0,
+      // The source tab's PR is the workspace's PR. Keep it, as a shared ref
+      // rather than this shell's own: the flat fields describe the source's
+      // branch, which a stack or ask sibling does not have.
+      prs: siblingTabPrRefs(src),
+      linkedPrs: undefined,
       prUrl: undefined,
       prState: undefined,
+      prNumber: undefined,
+      prTitle: undefined,
+      prIsDraft: undefined,
+      prMergeable: undefined,
+      prReviewDecision: undefined,
+      prReviewRequested: undefined,
+      prReviewedBy: undefined,
+      prAdditions: undefined,
+      prDeletions: undefined,
+      prChangedFiles: undefined,
+      prChecks: undefined,
+      prAuthor: undefined,
+      prUpdatedAt: undefined,
       automation: undefined,
       plainThreadId: undefined,
       goal: undefined,

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionTabs.tsx
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionTabs.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
+import { mutate as revalidateApiResources } from "swr";
 import type { SplitSide } from "../components/SessionSplit";
 import { SessionTabs } from "../components/SessionTabs";
 import { getCurrentUser } from "../components/UserPicker";
@@ -24,6 +25,7 @@ import {
 } from "../lib/landing-session";
 import { setLane, type Lane } from "../lib/lanes";
 import { dedupeViewers, otherViewers } from "../lib/presence";
+import { sessionApiKeyFilter } from "../lib/api-swr";
 import { newClientSessionId } from "../lib/session-id";
 import { siblingTabPrRefs } from "../lib/session-prs";
 import type { NewTabMorphOrigin, ViewTab } from "../lib/session-tabs-types";
@@ -860,6 +862,11 @@ export function useSessionTabs({
         },
         { sticky: true },
       );
+      // The tab's PR and git surfaces already asked the server about this id
+      // while it was only a local shell, and SWR kept the 404. The server
+      // knows the id now: ask again, so the workspace's PR fills in without
+      // waiting for a poll.
+      void revalidateApiResources(sessionApiKeyFilter(createdId));
       clearTimeout(pendingTimer.current);
       setPendingSessionId((pending) => (pending === id ? null : pending));
       setOptimisticSession((pending) => (pending?.id === id ? null : pending));

--- a/packages/core/opensession-server/src/frontend/lib/api-swr.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api-swr.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { apiSWRKey, sessionApiKeyFilter } from "./api-swr";
+
+describe("sessionApiKeyFilter", () => {
+  const matches = sessionApiKeyFilter("os-new");
+
+  test("selects every resource keyed by that session", () => {
+    expect(matches(apiSWRKey.session("os-new"))).toBe(true);
+    expect(matches(apiSWRKey.sessionPr("os-new", "opensession", "main"))).toBe(
+      true,
+    );
+    expect(matches(apiSWRKey.sessionGit("os-new"))).toBe(true);
+    expect(matches(apiSWRKey.sessionDiff("os-new"))).toBe(true);
+    expect(matches(apiSWRKey.sessionAssets("os-new"))).toBe(true);
+    expect(matches(apiSWRKey.workspaceOverview("sessions:os-new"))).toBe(true);
+  });
+
+  test("leaves other sessions, workspaces, and previews alone", () => {
+    expect(matches(apiSWRKey.session("os-other"))).toBe(false);
+    expect(matches(apiSWRKey.sessionPr("os-other", "opensession"))).toBe(false);
+    expect(matches(apiSWRKey.workspaceOverview("ws-1"))).toBe(false);
+    expect(matches(apiSWRKey.previewPr("opensession", "os-new"))).toBe(false);
+    expect(matches("api/session/os-new")).toBe(false);
+    expect(matches(null)).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/api-swr.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api-swr.ts
@@ -1,4 +1,4 @@
-import type { SWRConfiguration } from "swr";
+import type { Arguments, SWRConfiguration } from "swr";
 
 /**
  * Shared defaults for read-only API resources. SWR keeps the last successful
@@ -49,3 +49,17 @@ export const apiSWRKey = {
   previewPrDiff: (repo: string, branch: string) =>
     ["api", "preview-pr-diff", repo, branch] as const,
 };
+
+/**
+ * Every resource keyed by one session, for `mutate(filter)` once the server
+ * has learned a client-minted id. Reads issued before the create landed were
+ * answered 404, and SWR keeps that answer until something asks again.
+ */
+export function sessionApiKeyFilter(
+  sessionId: string,
+): (key: Arguments) => boolean {
+  return (key) =>
+    Array.isArray(key) &&
+    key[0] === "api" &&
+    (key[2] === sessionId || key[2] === `sessions:${sessionId}`);
+}

--- a/packages/core/opensession-server/src/frontend/lib/session-prs.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/session-prs.test.ts
@@ -11,6 +11,7 @@ import {
   sessionPrPresentation,
   sessionPrRefs,
   sessionUsesPrLink,
+  siblingTabPrRefs,
 } from "./session-prs";
 
 function session(overrides: Partial<UnifiedSession>): UnifiedSession {
@@ -466,5 +467,53 @@ describe("sessionCarriesPr", () => {
     expect(sessionCarriesPr(value, { repo: "tella-fusion", number: 955 })).toBe(
       false,
     );
+  });
+});
+
+describe("siblingTabPrRefs", () => {
+  test("a new tab inherits the workspace's PRs as shared refs", () => {
+    const source = session({
+      repo: "opensession",
+      branch: "feature",
+      prNumber: 42,
+      prUrl: "https://github.com/tellahq/opensession/pull/42",
+      prState: "OPEN",
+      prAuthor: "kent",
+      prs: [
+        { repo: "tella-fusion", branch: "feature", source: "attached" },
+        {
+          repo: "tella-fusion",
+          branch: "other",
+          source: "linked",
+          number: 7,
+          url: "https://github.com/tellahq/tella-fusion/pull/7",
+        },
+      ],
+    });
+
+    const refs = siblingTabPrRefs(source);
+
+    expect(refs).toEqual([
+      {
+        repo: "opensession",
+        branch: "feature",
+        source: "discovered",
+        number: 42,
+        url: "https://github.com/tellahq/opensession/pull/42",
+        state: "OPEN",
+      },
+      {
+        repo: "tella-fusion",
+        branch: "other",
+        source: "discovered",
+        number: 7,
+        url: "https://github.com/tellahq/tella-fusion/pull/7",
+      },
+    ]);
+    expect(refs[0]).not.toHaveProperty("author");
+  });
+
+  test("a tab without a PR opens without one", () => {
+    expect(siblingTabPrRefs(session({}))).toEqual([]);
   });
 });

--- a/packages/core/opensession-server/src/frontend/lib/session-prs.ts
+++ b/packages/core/opensession-server/src/frontend/lib/session-prs.ts
@@ -182,6 +182,22 @@ function pullRequests(session: UnifiedSession) {
 }
 
 /**
+ * The PRs a new tab carries before the server has projected its workspace.
+ * A PR belongs to the workspace, not to the tab that opened it, so the local
+ * shell inherits every actual PR of its source tab the same way the server
+ * shares sibling PRs: as discovered refs. The create response then settles
+ * which of them this tab owns outright.
+ */
+export function siblingTabPrRefs(source: UnifiedSession): SessionPrRef[] {
+  return pullRequests(source)
+    .filter((ref) => ref.number != null || Boolean(ref.url))
+    .map(({ updatedAt: _updatedAt, author: _author, ...ref }) => ({
+      ...ref,
+      source: "discovered" as const,
+    }));
+}
+
+/**
  * Pick the PR that owns the normal single-PR surface. A branch-derived PR is
  * always primary; when there is no such PR, a sole linked/discovered PR fills
  * that role instead of rendering as a one-item multi-PR stack.

--- a/packages/core/opensession-server/src/server/routes/sessions.ts
+++ b/packages/core/opensession-server/src/server/routes/sessions.ts
@@ -540,6 +540,31 @@ function enrichSession(
 }
 
 /**
+ * One session as the detail and create responses serialize it: enriched like
+ * a list row, plus the PR refs its workspace siblings contribute. A new tab
+ * shows the workspace's PR from its first paint this way, instead of waiting
+ * for the next list poll to project it.
+ */
+export async function sessionDetail(
+  session: UnifiedSession,
+): Promise<UnifiedSession> {
+  const signals = await sessionListRuntimeSignals();
+  const context = sessionEnrichmentContext();
+  const enriched = enrichSession(session, signals, context);
+  if (!enriched.workspaceId) return enriched;
+  return projectWorkspacePrRefs(
+    enriched,
+    indexedWorkspaceMemberSessions(enriched.workspaceId).map((member) =>
+      enrichSessionPrRefs(member, {
+        defaultRepoId: context.defaultRepoId,
+        prsByRepo: context.prsByRepo,
+        footerMatches: footerPrsFor(context.prsBySession, member),
+      }),
+    ),
+  );
+}
+
+/**
  * A session as list clients consume it.
  *
  * The detail route keeps the full UnifiedSession. The list drops fields used
@@ -1978,22 +2003,7 @@ export async function handleSessionsRoutes(
       const session = await findSessionAsync(sessionId);
       if (!session)
         return Response.json({ error: "Session not found" }, { status: 404 });
-      const signals = await sessionListRuntimeSignals();
-      const context = sessionEnrichmentContext();
-      const enriched = enrichSession(session, signals, context);
-      const detail = enriched.workspaceId
-        ? projectWorkspacePrRefs(
-            enriched,
-            indexedWorkspaceMemberSessions(enriched.workspaceId).map((member) =>
-              enrichSessionPrRefs(member, {
-                defaultRepoId: context.defaultRepoId,
-                prsByRepo: context.prsByRepo,
-                footerMatches: footerPrsFor(context.prsBySession, member),
-              }),
-            ),
-          )
-        : enriched;
-      return Response.json(detail, {
+      return Response.json(await sessionDetail(session), {
         headers: { "Cache-Control": "private, no-cache" },
       });
     }

--- a/packages/core/opensession-server/src/server/routes/workspace.test.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.test.ts
@@ -47,3 +47,18 @@ test("workspace deletion ignores a raced 404 but stops on another session failur
   expect(calls).toBe(2);
   expect(failure?.status).toBe(409);
 });
+
+test("every new-session response carries the workspace PR projection", async () => {
+  const source = await Bun.file(
+    new URL("./workspace.ts", import.meta.url),
+  ).text();
+  const route = source.slice(
+    source.indexOf("/new-session$/"),
+    source.indexOf("/promote$/"),
+  );
+  // The existing tab, the reusable empty tab, and the freshly created one.
+  expect(route.match(/await sessionDetail\(/g)).toHaveLength(3);
+  expect(route).not.toContain("session: existing }");
+  expect(route).not.toContain("session: reusable }");
+  expect(route).not.toContain("session: (await findSessionAsync(bksId))");
+});

--- a/packages/core/opensession-server/src/server/routes/workspace.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.ts
@@ -7,7 +7,7 @@
  */
 
 import { requestUser, type RouteContext } from "./context";
-import { handleSessionsRoutes } from "./sessions";
+import { handleSessionsRoutes, sessionDetail } from "./sessions";
 import { searchRepoEntries } from "../file-index";
 import {
   RepoAppearanceError,
@@ -734,7 +734,11 @@ export async function handleWorkspaceRoutes(
       );
     const bksId = requestedId || newSessionId();
     const existing = await findSessionAsync(bksId);
-    if (existing) return Response.json({ id: bksId, session: existing });
+    if (existing)
+      return Response.json({
+        id: bksId,
+        session: await sessionDetail(existing),
+      });
     // One reusable empty tab per workspace. This server-side check closes the
     // multi-window race that hiding the + in one browser cannot prevent.
     const reusable = body.duplicate
@@ -748,7 +752,11 @@ export async function handleWorkspaceRoutes(
         : isReusableEmptySession(src)
           ? src
           : undefined;
-    if (reusable) return Response.json({ id: reusable.id, session: reusable });
+    if (reusable)
+      return Response.json({
+        id: reusable.id,
+        session: await sessionDetail(reusable),
+      });
     let branch = src.branch || "";
     let worktreeDir = src.worktreeDir || "";
     let mode: "ask" | "code" | "scratch" = src.mode || "code";
@@ -930,10 +938,13 @@ export async function handleWorkspaceRoutes(
     if (body.duplicate) await duplicateSessionTranscript(src, bksId);
     // Also return the full unified session so the client can drop it into
     // its session list and render the new session instantly, instead of
-    // flashing a loading screen until the next sessions poll lands.
+    // flashing a loading screen until the next sessions poll lands. The
+    // workspace's PRs ride along: the PR belongs to the workspace, so a new
+    // tab must not open without it.
+    const created = await findSessionAsync(bksId);
     return Response.json({
       id: bksId,
-      session: (await findSessionAsync(bksId)) ?? null,
+      session: created ? await sessionDetail(created) : null,
     });
   }
 


### PR DESCRIPTION
A new tab in a workspace opened without the workspace's PR until the next sessions poll landed. The PR belongs to the workspace, and the summary card already says so; the PR strip now agrees.

**Before:** open `+` in a workspace with an open PR. The summary's PR band says "PR status unavailable · Session not found" (and the header chip is empty) until a later poll or focus change, and the stale answer can stay for minutes.

**After:** the new tab paints with the workspace's PR straight away, and the PR band fills in ("Ready to merge #128") as soon as the create lands.

Three gaps, each closed:

- `POST /api/sessions/:id/new-session` returned the raw session file. It now returns the same enriched, workspace-projected session as `GET /api/sessions/:id` (shared `sessionDetail` helper), for the created, existing, and reusable-tab responses.
- The client-side shell copied the source tab but cleared only `prUrl`/`prState`, leaving half a PR. It now inherits the source tab's actual PRs as shared (`discovered`) refs and clears every flat PR field.
- The first PR and git reads fire against the client-minted id before the server knows it, and SWR keeps that 404. Once the create lands, the create path revalidates every resource keyed by the new id (`sessionApiKeyFilter`), so the PR and git surfaces ask again without waiting for a poll.

Verified on an isolated demo instance (`verify-opensession`): after clicking `+`, the page re-requested `/pr` and `/git-status` right after `/new-session` returned, and the new tab's summary showed "Ready to merge #128 · 5 checks" at desktop and phone widths. Baseline `main` kept "PR status unavailable · Session not found".

Tests: unit tests for `siblingTabPrRefs` and `sessionApiKeyFilter`, plus source checks for the route and the create path. `bun run check` passes.

Rebased on #308, which made `main` green again; the CI fixes this branch carried in the meantime dropped out.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a066a2-0e26-7182-a707-ed001e129325)

