### PR TITLE
Make main CI green again: rootless gateway control socket, stale CI assertions, host-bound test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,23 @@ jobs:
             > "$RUNNER_TEMP/transcript-motion-fixture.log" 2>&1 &
           fixture_pid=$!
           trap 'kill "$fixture_pid" "$chrome_pid" 2>/dev/null || true' EXIT
+          # The fuzz tool dials CDP_PORT at once and does not retry, so both
+          # the fixture and Chrome's debugging port have to answer first;
+          # a cold Chrome on a shared runner can take longer than the
+          # fixture does.
           for attempt in {1..120}; do
             curl -fsS http://127.0.0.1:4899/__fixtures/transcript-motion >/dev/null && break
             if [ "$attempt" -eq 120 ]; then
               cat "$RUNNER_TEMP/transcript-motion-fixture.log"
+              exit 1
+            fi
+            sleep 1
+          done
+          for attempt in {1..120}; do
+            curl -fsS http://127.0.0.1:9222/json/version >/dev/null && break
+            if [ "$attempt" -eq 120 ] || ! kill -0 "$chrome_pid" 2>/dev/null; then
+              echo "Chrome never answered on 9222"
+              cat "$RUNNER_TEMP/transcript-motion-chrome.log"
               exit 1
             fi
             sleep 1
@@ -97,6 +110,15 @@ jobs:
               --out "$RUNNER_TEMP/transcript-stream-report.json"
           CDP_PORT=9222 OPENSESSION_URL=http://127.0.0.1:4899 \
             bun run test:transcript-scroll
+
+      - name: Chrome and fixture logs from the motion check
+        if: failure()
+        run: |
+          for log in transcript-motion-chrome transcript-motion-fixture; do
+            echo "::group::$log.log"
+            cat "$RUNNER_TEMP/$log.log" 2>/dev/null || echo "(no $log.log)"
+            echo "::endgroup::"
+          done
 
       # The snapshot scenarios are exactly the part of that sweep the ordering
       # problem eats: they redirect the sessions dir, transcript store, MCP
@@ -233,7 +255,13 @@ jobs:
             const text = kind === "launchd"
               ? `${renderPlist()}\n${renderLauncher()}`
               : await renderUnit();
-            if (!text.includes("opensession.ts") && !text.includes("opensession server")) {
+            // A source install runs the gateway supervisor; a compiled one
+            // runs `opensession server`.
+            if (
+              !text.includes("gateway-supervisor.ts") &&
+              !text.includes("opensession.ts") &&
+              !text.includes("opensession server")
+            ) {
               throw new Error("no service command");
             }
             const user = text.match(/^User=(.*)$/m)?.[1];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,36 @@ jobs:
           OPENSESSION_ALLOW_IMDS=1 \
             bash install.sh --yes --no-engine
 
+      # The installer only says "the server did not start" and points at
+      # `opensession logs`, which nobody can run on a finished runner. Dump
+      # every unit's state and journal here so the log explains itself.
+      - name: Why the service did not come up
+        if: failure() && runner.os == 'Linux'
+        run: |
+          systemctl --user --no-pager --full status 'opensession*' || true
+          for unit in opensession opensession-ingress opensession-session-kernel; do
+            echo "::group::journalctl --user -u $unit"
+            journalctl --user --no-pager -o short-iso -n 200 -u "$unit" || true
+            echo "::endgroup::"
+          done
+          echo "::group::listeners"
+          ss -ltnp || true
+          curl -sS --max-time 5 -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3850/api/health || true
+          echo "::endgroup::"
+          echo "::group::log files"
+          ls -la "$HOME/.opensession" "$HOME/.opensession/logs" 2>/dev/null || true
+          tail -n 100 "$HOME"/.opensession/logs/* 2>/dev/null || true
+          echo "::endgroup::"
+
+      - name: Why the service did not come up
+        if: failure() && runner.os == 'macOS'
+        run: |
+          for label in dev.opensession.server dev.opensession.session-kernel; do
+            launchctl print "gui/$(id -u)/$label" 2>/dev/null || true
+          done
+          ls -la "$HOME/.opensession/logs" 2>/dev/null || true
+          tail -n 200 "$HOME"/.opensession/logs/* 2>/dev/null || true
+
       - name: Put the command and bun on PATH for later steps
         # Steps do not share a shell and do not source profiles, so the
         # installer's profile edits are invisible here. install.sh already

--- a/packages/core/opensession-server/src/frontend/tools/transcript-scroll-regression.ts
+++ b/packages/core/opensession-server/src/frontend/tools/transcript-scroll-regression.ts
@@ -111,7 +111,10 @@ function turnOf(anchorId: string): {
   role: "user" | "assistant";
   turn: number;
 } | null {
-  const match = anchorId.match(/^hydration-(user|assistant)-(\d+)/);
+  // Mid-scroll the probe can land on a virtualised range row rather than a
+  // mounted entry; its key is `range:` plus the id of the entry that opens
+  // the range, which is the turn a reader at that spot is looking at.
+  const match = anchorId.match(/^(?:range:)?hydration-(user|assistant)-(\d+)/);
   if (!match) return null;
   const role = match[1] === "user" ? "user" : "assistant";
   return { role, turn: Number(match[2]) };

--- a/packages/core/opensession-server/src/server/gateway-supervisor.test.ts
+++ b/packages/core/opensession-server/src/server/gateway-supervisor.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   discoverRuntimePeerGenerations,
+  gatewayControlSocketPath,
   GatewaySupervisor,
   inheritedGatewaySocketFd,
   type ManagedGateway,
@@ -52,6 +53,31 @@ function controlledGateway(pid: number, releaseRoot: string, standby = false) {
 }
 
 describe("gateway supervisor", () => {
+  test("listens for control in the runtime directory systemd hands it", () => {
+    // The system unit's RuntimeDirectory= is under /run; a rootless user
+    // unit's is under $XDG_RUNTIME_DIR, where the fixed /run path does not
+    // exist. Both arrive through RUNTIME_DIRECTORY.
+    expect(gatewayControlSocketPath({})).toBe(
+      "/run/opensession-gateway/control.sock",
+    );
+    expect(
+      gatewayControlSocketPath({
+        RUNTIME_DIRECTORY: "/run/user/1001/opensession-gateway",
+      }),
+    ).toBe("/run/user/1001/opensession-gateway/control.sock");
+    expect(
+      gatewayControlSocketPath({
+        RUNTIME_DIRECTORY: "/run/opensession-gateway:/run/other",
+      }),
+    ).toBe("/run/opensession-gateway/control.sock");
+    expect(
+      gatewayControlSocketPath({
+        RUNTIME_DIRECTORY: "/run/user/1001/opensession-gateway",
+        OPENSESSION_GATEWAY_CONTROL_SOCKET: "/tmp/dev.sock",
+      }),
+    ).toBe("/tmp/dev.sock");
+  });
+
   test("accepts only systemd descriptors addressed to this supervisor", () => {
     expect(
       inheritedGatewaySocketFd({ LISTEN_PID: "42", LISTEN_FDS: "1" }, 42),

--- a/packages/core/opensession-server/src/server/gateway-supervisor.ts
+++ b/packages/core/opensession-server/src/server/gateway-supervisor.ts
@@ -19,9 +19,25 @@ import {
 import { createStableFrontendResponder } from "./stable-frontend";
 import { publishGatewayBackendPort } from "./gateway-routing";
 
-export const GATEWAY_CONTROL_SOCKET =
-  process.env.OPENSESSION_GATEWAY_CONTROL_SOCKET ||
-  "/run/opensession-gateway/control.sock";
+/**
+ * Where the supervisor listens for handoff commands. systemd hands a unit
+ * with `RuntimeDirectory=` its directory through RUNTIME_DIRECTORY:
+ * /run/opensession-gateway for the system service, and
+ * $XDG_RUNTIME_DIR/opensession-gateway for a rootless user install. The fixed
+ * /run path exists only on the former, so a user service that assumed it died
+ * at boot with ENOENT and the installer reported a server that never came up.
+ */
+export function gatewayControlSocketPath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  if (env.OPENSESSION_GATEWAY_CONTROL_SOCKET)
+    return env.OPENSESSION_GATEWAY_CONTROL_SOCKET;
+  // Several RuntimeDirectory= entries arrive colon-separated; ours is one.
+  const runtimeDir = env.RUNTIME_DIRECTORY?.split(":")[0];
+  return `${runtimeDir || "/run/opensession-gateway"}/control.sock`;
+}
+
+export const GATEWAY_CONTROL_SOCKET = gatewayControlSocketPath();
 
 const PUBLIC_HOST = process.env.HOST || "127.0.0.1";
 const PUBLIC_PORT = Number(process.env.PORT || 3850);

--- a/packages/core/opensession-server/src/server/pr-webhook.test.ts
+++ b/packages/core/opensession-server/src/server/pr-webhook.test.ts
@@ -1,10 +1,32 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { TeamMember } from "./config";
 import {
   CI_COALESCE_MS,
   isCiWebhookEvent,
   reviewerRemovalClearsSessionRequest,
   sandboxEnvironmentInvalidationNeeded,
 } from "./pr-webhook";
+import { __setIdentitiesForTest } from "./shared/user-mappings";
+
+// The reviewer check resolves a request's first name to a GitHub login
+// through the roster, which is baked from this host's config at module load.
+// On a host with no roster (CI) "Kent" resolves to nothing and the check
+// reads a remaining "kentdebruin" as someone else, so the roster is a
+// fixture here rather than whatever the machine happens to have.
+const TEAM: TeamMember[] = [
+  {
+    name: "Kent de Bruin",
+    email: "kent@example.com",
+    aliases: ["kent"],
+    github: "kentdebruin",
+  },
+];
+
+let restore: (() => void) | undefined;
+beforeAll(() => {
+  restore = __setIdentitiesForTest(TEAM);
+});
+afterAll(() => restore?.());
 
 describe("CI delivery coalescing", () => {
   test("folds check and workflow progress, not PR activity", () => {


### PR DESCRIPTION
## Why

Every `main` CI run has been red since 2026-08-28 (last green: 9937a125d, 2026-08-27). Four independent causes, each hidden behind the one before it:

1. **Install (ubuntu-latest)**: the gateway supervisor bound its control socket at the fixed `/run/opensession-gateway/control.sock`. That directory is what `RuntimeDirectory=` creates for the *system* service; a rootless user install gets `$XDG_RUNTIME_DIR/opensession-gateway` instead. The user unit died at boot with `ENOENT`, the socket unit kept 3850 open with nothing behind it, and the installer reported "the server did not start" after 120 s of 3 s curl timeouts. CI printed only that line and a hint to run `opensession logs` on a runner that no longer exists.
2. **Type-check and tests**: `pr-webhook.test.ts` resolves "Kent" to `kentdebruin` through the roster, which `user-mappings` bakes from the host's `~/.opensession/config.json` at module load. It passed on the instance and failed on every runner since it landed (152096c12).
3. With those fixed, two stale CI steps surface: the installer job's "Service definition renders" check still expects the pre-supervisor `ExecStart`, and the transcript motion step dials Chrome's CDP port the moment the fixture answers, with no wait and no Chrome log on failure.
4. With Chrome reachable, the transcript scroll regression (added 09-02 while main was already red) fails its phone pass: mid-fling the probe lands on a virtualised range row whose anchor id is `range:hydration-user-N`, and `turnOf()` only understood bare `hydration-…` ids.

## What changes

- `gateway-supervisor.ts`: `gatewayControlSocketPath()` derives the socket from `RUNTIME_DIRECTORY` (set by systemd for both scopes), keeping the fixed `/run` path as the fallback outside systemd and `OPENSESSION_GATEWAY_CONTROL_SOCKET` as the explicit override. Unit test added.
- `pr-webhook.test.ts`: seeds a fixture roster via `__setIdentitiesForTest`, the way the analytics tests do. (Same commit is on tellahq/opensession#306, which is how this was found.)
- `transcript-scroll-regression.ts`: `turnOf()` accepts the `range:` prefix; the range starts at that turn, which is what a reader parked there sees.
- `ci.yml`: failure-only diagnostics after the installer step (unit status, journals, listeners, health probe, log files) so the next such failure explains itself; accept `gateway-supervisor.ts` as a valid service command; poll `9222/json/version` before the motion fuzz and print Chrome's and the fixture's logs on failure.

## Proof

- First run of the diagnostics step showed the `ENOENT` on `/run/opensession-gateway/control.sock` in `opensession.service`'s journal, with `opensession.socket` and `opensession-ingress.service` healthy.
- After the supervisor fix, `Install (ubuntu-latest)` passed for the first time since 08-28.
- After the CDP wait, the motion fuzz ran (24 seeds, 0 failed) and the scroll regression reached its fling assertion; with the `range:` fix it passes locally (`bun run test:transcript-scroll`, exit 0, fling section present).
- CI on this PR is the proof for the whole set.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/os-01a0663f-dd57-73db-b9c5-5dddcfa36814)