### PR TITLE
Refresh Open Session verification recipes

### DIFF
--- a/.agents/skills/verify-opensession/features/archived-sessions.md
+++ b/.agents/skills/verify-opensession/features/archived-sessions.md
@@ -22,20 +22,20 @@ Archived sessions are removed from active workspace lanes but remain searchable,
 Preconditions:
 
 - Doctor passes for the isolated demo run.
-- The demo seed has finished and cancelled sessions available to the archive UI.
+- The archived index contains at least one disposable row. Check with `verify-opensession api "$RUN_ID" '/api/sessions?archived=only&slim=1' | jq .`. If it is empty, report the archive list, filters, opening, and restore checks as unreachable because the isolated seed supplied no archived row. Do not create archive state through an internal endpoint.
 
-- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for textbox `Search archived sessions` and capture the unfiltered state.
-- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role textbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
-- **Clear and filter.** Refill the search textbox with an empty value, choose the `Filters` button using the exact accessible name from the current snapshot, and select one visible repository or person. Capture the filter state and narrowed result list.
+- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for `searchbox` named `Search archived sessions` and capture the unfiltered state.
+- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role searchbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
+- **Clear and filter.** Refill the searchbox with an empty value. Use a current snapshot to choose the individual `Owner, …`, `Repository, …`, or `Reason, …` button, then select one visible option. There is no combined Filters button. Capture the selected control and narrowed list.
 - **Open a result.** Choose a visible archived session title. Its transcript opens and keeps the archived state visible.
 - **Restore.** From `/archived`, choose `Restore session` on one disposable demo result. Confirm it disappears from the matching archived results and reappears in its active workspace or `/api/sessions` response.
-- **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover.
+- **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover. Restore is a left-swipe row action on phone, not the desktop button.
 - **Proof.** Capture unfiltered, filtered, and resulting states. For restore behavior, save a read-only session API response after the UI action.
 
 ## Gotchas
 
 - Searching is read-only. It does not prove restore behavior.
 - A session may be hidden by archive reason or current-person defaults. Record active filters in proof.
-- The filter button's accessible name includes the active-filter count. Take a fresh snapshot after each change.
+- Each filter button's accessible name includes its selected value. Take a fresh snapshot after each change.
 - Restoring mutates disposable demo state. Run it last if later checks depend on the seeded archive list.
 - Opening a direct session URL does not prove the archived index entry point.

--- a/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
+++ b/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
@@ -24,10 +24,10 @@ Preconditions:
 - Doctor passes for the isolated demo run.
 - Demo session `bks-demo-pr` exists with title `Fix flaky upload retry test`.
 
-- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role heading --name "Fix flaky upload retry test"`. The session title and transcript appear.
+- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role button --name "More actions"`, then take a snapshot and require the static text `Fix flaky upload retry test`. The session title and transcript appear.
 - **Inspect transcript semantics.** Run `verify-opensession browser "$RUN_ID" snapshot`. The tree contains the upload retry prompt and transcript controls. Capture a screenshot after expanding any collapsed tool call through its visible button.
 - **Inspect a failure.** Open `/session/bks-demo-failed`. The page identifies `Investigate memory spike in export worker` and shows its run failure instead of presenting the transcript as complete.
-- **Open the global composer.** Open `/new`, then wait for `group` named `New session`. The textbox placeholder is `What do you want to work on?`. Choose `Ask mode` and verify the placeholder changes to `What do you want to find out?`.
+- **Open the global composer.** Open `/new`, then wait for `dialog` named `New session`. The `combobox` is named `What do you want to work on?`. Choose `Ask mode` and wait for the combobox name to change to `What do you want to find out?`.
 - **Check phone layout.** Reopen `/session/bks-demo-pr` at 390x844. Capture the transcript, then focus the composer and verify its controls remain reachable without horizontal scrolling.
 - **Proof.** Save before and after accessibility snapshots and screenshots. If the check creates a session, confirm its new ID through `/api/sessions` and reopen it from the sidebar before reporting persistence.
 


### PR DESCRIPTION
## Summary

- update session verification selectors to match the current dialog and accessibility tree
- update archived-session search and filter recipes after the archive UI changes
- document the archived-index prerequisite and phone swipe restore action

## Verification

- `bun run check`
- isolated UI run `verify-20260904-060126-812150` across sessions, automations, goals, archived sessions, and settings at desktop and phone widths

## Product gaps

- `bks-demo-pr` renders "No transcript available" although the demo fixture contains transcript lines
- `/api/sessions?archived=only&slim=1` returns an empty list, and archiving `bks-demo-failed` through the UI does not produce an archived row, so archived result opening and restore were unreachable

Started by Daily verification skill maintenance in [this OS session](https://os.tella.dev/session/os-01a06b00-c5d1-764f-8c46-161ca45ff607)
