### PR TITLE
Sandbox runner: re-invoke the compiled binary as the git credential helper

### DIFF
--- a/packages/core/opensession-server/src/server/github-git-credential.test.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { githubGitCredentialEnv } from "./github-git-credential";
+import {
+  githubCredentialHelperCommand,
+  githubGitCredentialEnv,
+} from "./github-git-credential";
 
 describe("GitHub Git credential environment", () => {
   test("rewrites SSH remotes to process-local HTTPS authority", () => {
@@ -21,5 +24,30 @@ describe("GitHub Git credential environment", () => {
     expect(env.GH_TOKEN).toBe("");
     expect(env.GIT_CONFIG_VALUE_2).toBe("git@github.com:");
     expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+  });
+});
+
+describe("GitHub Git credential helper command", () => {
+  test("prefers the installed shim", () => {
+    expect(
+      githubCredentialHelperCommand("/opt/os/bin/opensession", true, true),
+    ).toBe("!/opt/os/bin/opensession github-credential");
+  });
+
+  test("re-invokes a compiled binary that has no shim, such as the Sandbox runner", () => {
+    expect(
+      githubCredentialHelperCommand(
+        "/home/ubuntu/.opensession/bin/opensession",
+        false,
+        true,
+        "/home/ubuntu/.local/bin/opensession-runner",
+      ),
+    ).toBe("!/home/ubuntu/.local/bin/opensession-runner github-credential");
+  });
+
+  test("runs the source script under bun when developing from source", () => {
+    expect(
+      githubCredentialHelperCommand("/nowhere/opensession", false, false),
+    ).toMatch(/^!bun \S*scripts\/gh-credential\.ts$/);
   });
 });

--- a/packages/core/opensession-server/src/server/github-git-credential.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.ts
@@ -3,6 +3,7 @@
 import { existsSync } from "fs";
 import { resolve } from "path";
 import { SHIM_PATH } from "../../../../../scripts/lib/paths";
+import { isCompiledBinary } from "../runner-host/exe";
 
 const GH_CREDENTIAL_SCRIPT = resolve(
   import.meta.dir,
@@ -16,14 +17,20 @@ function shellQuoteWord(word: string): string {
 
 /**
  * Use the stable installed command so compiled releases need neither Bun nor a
- * scripts sidecar. The source-tree fallback keeps direct development runs
- * useful before install.sh creates the shim.
+ * scripts sidecar. A compiled binary without the shim, such as the Sandbox
+ * runner host, re-invokes itself: its `import.meta.dir` is virtual, so the
+ * source-tree path would name a file that does not exist in the guest. The
+ * source-tree fallback keeps direct development runs useful before install.sh
+ * creates the shim.
  */
 export function githubCredentialHelperCommand(
   shimPath = SHIM_PATH,
   shimExists = existsSync(shimPath),
+  compiled = isCompiledBinary(),
+  execPath = process.execPath,
 ): string {
   if (shimExists) return `!${shellQuoteWord(shimPath)} github-credential`;
+  if (compiled) return `!${shellQuoteWord(execPath)} github-credential`;
   return `!bun ${shellQuoteWord(GH_CREDENTIAL_SCRIPT)}`;
 }
 


### PR DESCRIPTION
## Problem

Inside a Box or Daytona Sandbox every `git fetch` / `git push` over https fails:

```
error: Module not found "/scripts/gh-credential.ts"
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The run env carries `GIT_CONFIG_VALUE_1=!bun /scripts/gh-credential.ts`. `githubCredentialHelperCommand()` runs inside the compiled runner host, which has no installed `opensession` shim, so it took the source-tree fallback. In a `bun build --compile` binary `import.meta.dir` is virtual, so `resolve(import.meta.dir, "../../../../../scripts/gh-credential.ts")` becomes `/scripts/gh-credential.ts`, a file that does not exist in the guest. `GH_TOKEN` was present the whole time; only the helper path was wrong.

Found by two test sessions (Box `bks-17f011a0`, Daytona `bks-a4895220`) while validating the tella-local Portal.

## Change

`githubCredentialHelperCommand` gains a compiled-binary branch: when there is no shim and the process is a compiled binary, the helper is `!<process.execPath> github-credential`. `src/main.ts` already forwards unknown subcommands to `scripts/cli.ts`, which implements `github-credential`. Source-tree runs and installed shims are unchanged.

Tests cover the three shapes (shim, compiled without shim, source).

## Checks

`bun run check` in the branch worktree: one failure, `sandbox project environments > every provider starts unprepared and a disabled connection removes readiness`, which fails identically on untouched `main` (`59467c272`) and is unrelated to this change.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a068e8-6246-75b7-bf7f-2a9ac1051a27)