### PR TITLE
Sandboxes: open the Sandbox desktop from the session

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -178,8 +178,8 @@ where your disk goes:
 
 **Sandboxes** are optional per-session machines used instead of the host: a
 Daytona or Box VM with the repository checked out and a durable disk that
-sleeps between turns and wakes with files and Portals intact:
-[docs/self-hosting-sandboxes.md](docs/self-hosting-sandboxes.md).
+sleeps between turns, wakes with files and Portals intact, and can show you
+its desktop: [docs/self-hosting-sandboxes.md](docs/self-hosting-sandboxes.md).
 
 **Runners** are trusted persistent machines paired with
 `opensession runner connect` for platform-, toolchain-, or GPU-specific work.

--- a/docs/self-hosting-sandboxes.md
+++ b/docs/self-hosting-sandboxes.md
@@ -70,6 +70,23 @@ Needs attention, with manual sleep, wake, and recreate, plus the `setup` and
 
 Terminal tabs land inside the Sandbox (Daytona's native PTY, Box's SSH).
 
+## Desktop
+
+Both providers can show a person the Sandbox's screen. The Sandbox popover in a
+session offers **Open desktop** while the Sandbox is awake; it opens a new tab
+with a live, controllable desktop. The agent keeps working underneath it, so
+this is the way to watch a browser test, log into something the agent cannot,
+or take over for a moment.
+
+- **Box** mints a 60fps stream page (`POST /boxes/{id}/desktop`).
+- **Daytona** starts its computer-use stack (Xvfb, xfce4, x11vnc, noVNC) on
+  first use and hands out a signed preview URL for noVNC; it stops working
+  after an hour, so click again for a fresh one.
+
+The URL is a bearer secret minted for one viewer: the API returns it once and
+the audit log records the request, not the URL. Asleep Sandboxes answer
+"Wake the sandbox first".
+
 ## Project snapshots
 
 The slow part of a fresh Sandbox is `.agents/setup`. Opt a project into

--- a/packages/core/opensession-server/src/frontend/components/SandboxBadge.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SandboxBadge.tsx
@@ -3,6 +3,7 @@ import { Popover } from "../ui/popover";
 import { cn } from "../ui/cn";
 import {
   fetchSessionSandbox,
+  openSandboxDesktop,
   sandboxAction,
   type SessionSandboxStatus,
 } from "../lib/api/sandboxes";
@@ -161,6 +162,30 @@ export function SandboxBadge({
       });
   }
 
+  async function openDesktop() {
+    // Open the tab inside the click so popup blockers allow it, then point it
+    // at the minted URL once the provider answers.
+    const tab = window.open("", "_blank");
+    setWorking("desktop");
+    setError(null);
+    await (async () => {
+      const desktop = await openSandboxDesktop(sessionId);
+      if (tab) {
+        tab.opener = null;
+        tab.location.href = desktop.url;
+      } else {
+        window.location.assign(desktop.url);
+      }
+    })()
+      .catch(async (cause) => {
+        tab?.close();
+        setError(errorMessage(cause, "Could not open the desktop"));
+      })
+      .finally(async () => {
+        setWorking(null);
+      });
+  }
+
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger
@@ -196,6 +221,15 @@ export function SandboxBadge({
             </div>
           ) : null}
         </div>
+        {lifecycle === "awake" && status?.canDesktop ? (
+          <button
+            className={actionClass}
+            disabled={Boolean(working)}
+            onClick={() => void openDesktop()}
+          >
+            {working === "desktop" ? "Opening desktop…" : "Open desktop"}
+          </button>
+        ) : null}
         {lifecycle === "awake" && status?.canPause ? (
           <button
             className={actionClass}

--- a/packages/core/opensession-server/src/frontend/lib/api/sandboxes.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/sandboxes.ts
@@ -18,7 +18,23 @@ export interface SessionSandboxStatus {
   cwd?: string | null;
   canPause?: boolean;
   canResume?: boolean;
+  canDesktop?: boolean;
   logs?: { setup?: string; resume?: string };
+}
+
+export interface SandboxDesktopLink {
+  url: string;
+  expiresAt?: number;
+}
+
+/** Mints a one-viewer desktop URL. Open it in a new tab; never persist it. */
+export function openSandboxDesktop(
+  sessionId: string,
+): Promise<SandboxDesktopLink> {
+  return request(`/sessions/${encodeURIComponent(sessionId)}/sandbox/desktop`, {
+    method: "POST",
+    label: "Failed to open the sandbox desktop",
+  });
 }
 
 export function fetchSessionSandbox(

--- a/packages/core/opensession-server/src/server/routes/sandbox.ts
+++ b/packages/core/opensession-server/src/server/routes/sandbox.ts
@@ -112,6 +112,7 @@ async function sandboxView(
     cwd: sandbox?.cwd || session.worktreeDir || null,
     canPause: Boolean(provider.pause),
     canResume: Boolean(provider.resume),
+    canDesktop: Boolean(provider.desktop),
     logs,
   };
 }
@@ -120,7 +121,7 @@ export async function handleSandboxRoutes(
   ctx: RouteContext,
 ): Promise<Response | undefined> {
   const match = ctx.path.match(
-    /^\/api\/sessions\/([^/]+)\/sandbox(?:\/(pause|resume|recreate))?$/,
+    /^\/api\/sessions\/([^/]+)\/sandbox(?:\/(pause|resume|recreate|desktop))?$/,
   );
   if (!match) return undefined;
   const session = await findSessionAsync(decodeURIComponent(match[1]!));
@@ -151,6 +152,33 @@ export async function handleSandboxRoutes(
       },
       { status: 410 },
     );
+  if (action === "desktop") {
+    // Watching the desktop is the point while the agent is working, so this
+    // is not behind the lifecycle lock. The URL is a bearer secret; log the
+    // request, never the URL.
+    const provider = getSandboxProvider(recorded.provider);
+    if (!provider.desktop)
+      return Response.json(
+        { error: `${recorded.provider} does not expose a desktop` },
+        { status: 400 },
+      );
+    try {
+      const desktop = await provider.desktop(recorded.sandboxId);
+      audit({
+        msg: "sandbox_desktop",
+        session_id: session.id,
+        provider: recorded.provider,
+        sandbox_id: recorded.sandboxId,
+      });
+      return Response.json(desktop);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return Response.json(
+        { error: message },
+        { status: /wake the sandbox/i.test(message) ? 409 : 502 },
+      );
+    }
+  }
   if (hostRunBusy(session.id))
     return Response.json(
       { error: "Sandbox lifecycle is locked while the agent is running" },

--- a/packages/core/opensession-server/src/server/sandbox/adapters/box.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/box.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  boxDesktopUrl,
   BOX_RUNTIME_HOME_COMMAND,
   BOX_RUNTIME_HOME_LAZY_MARKER,
   boxCommandPlaneUnavailable,
@@ -151,5 +152,21 @@ describe("Box command readiness", () => {
     expect(boxCommandPlaneUnavailable({ status: 409, code: "other" })).toBe(
       false,
     );
+  });
+});
+
+describe("Box desktop", () => {
+  test("returns the tokenized stream page Box mints", () => {
+    expect(
+      boxDesktopUrl({
+        desktopUrl:
+          "https://name-desktop.on.ascii.dev/stream.html?fps=60#token=abc",
+      }),
+    ).toBe("https://name-desktop.on.ascii.dev/stream.html?fps=60#token=abc");
+  });
+
+  test("refuses a missing or non-https desktop URL", () => {
+    expect(() => boxDesktopUrl({})).toThrow(/did not return a desktop URL/);
+    expect(() => boxDesktopUrl({ desktopUrl: "http://x" })).toThrow();
   });
 });

--- a/packages/core/opensession-server/src/server/sandbox/adapters/box.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/box.ts
@@ -53,6 +53,7 @@ import type {
   SandboxProvider,
   SandboxSessionSpec,
   SandboxStatus,
+  SandboxDesktop,
 } from "../provider";
 import {
   assertDialbackReachable,
@@ -97,6 +98,16 @@ const TEMPLATE_WAIT_MS = 15 * 60_000;
 /** States where the VM is up and can take commands. `running` is their
  *  "agent busy" state — still a live VM. */
 const LIVE_STATES = new Set(["ready", "idle", "running"]);
+
+/** `POST /boxes/{id}/desktop` answers with a tokenized 60fps stream page.
+ * The token rides in the URL fragment, so the URL itself is the secret. */
+export function boxDesktopUrl(response: { desktopUrl?: unknown }): string {
+  const url =
+    typeof response.desktopUrl === "string" ? response.desktopUrl : "";
+  if (!/^https:\/\//.test(url))
+    throw new Error("Box did not return a desktop URL");
+  return url;
+}
 
 interface BoxRecord {
   id: string;
@@ -1264,6 +1275,21 @@ export class BoxProvider implements SandboxProvider {
       console.warn(`[sandbox:box] get(${sandboxId}) failed:`, e);
       return null;
     }
+  }
+
+  async desktop(sandboxId: string): Promise<SandboxDesktop> {
+    const cfg = boxClientConfig();
+    const box = await getBox(cfg, sandboxId);
+    if (!box || !LIVE_STATES.has(String(box.state || "")))
+      throw new Error("Wake the sandbox first");
+    const response = await boxApi<{ desktopUrl?: unknown }>(
+      cfg,
+      "POST",
+      `/boxes/${sandboxId}/desktop`,
+      undefined,
+      60_000,
+    );
+    return { url: boxDesktopUrl(response) };
   }
 
   async pause(sandboxId: string): Promise<void> {

--- a/packages/core/opensession-server/src/server/sandbox/adapters/daytona.test.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/daytona.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   assertAutomationEgressRestricted,
+  daytonaDesktopUrl,
   daytonaCreateResources,
   daytonaCreateSource,
   daytonaSnapshotIsRecent,
@@ -150,5 +151,15 @@ describe("Daytona egress policy probe", () => {
         { intervalMs: 1_000, settleMs: 2_000, ...clock() },
       ),
     ).rejects.toThrow(/blocks the dial-back URL/);
+  });
+});
+
+describe("Daytona desktop", () => {
+  test("opens noVNC on the signed preview host with autoconnect", () => {
+    expect(
+      daytonaDesktopUrl("https://6080-4kvyxv1qzdawyntz.daytonaproxy01.net"),
+    ).toBe(
+      "https://6080-4kvyxv1qzdawyntz.daytonaproxy01.net/vnc.html?autoconnect=1&resize=scale",
+    );
   });
 });

--- a/packages/core/opensession-server/src/server/sandbox/adapters/daytona.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/daytona.ts
@@ -52,6 +52,7 @@ import type {
   SandboxProvider,
   SandboxSessionSpec,
   SandboxStatus,
+  SandboxDesktop,
 } from "../provider";
 import {
   assertDialbackReachable,
@@ -476,6 +477,18 @@ export async function daytonaPtySession(
   };
 }
 
+/** Daytona's computer-use stack serves noVNC (websockify) on this port. */
+const DAYTONA_NOVNC_PORT = 6080;
+const DAYTONA_DESKTOP_URL_TTL_SECONDS = 60 * 60;
+
+/** The signed preview host is the secret; noVNC's page and its websocket
+ * both resolve relative to it, verified live 2026-09-04 (RFB banner over wss). */
+export function daytonaDesktopUrl(signedPreviewUrl: string): string {
+  const url = new URL("/vnc.html", signedPreviewUrl);
+  url.search = "?autoconnect=1&resize=scale";
+  return url.toString();
+}
+
 function stateOf(sbx: DaytonaSandbox): SandboxStatus {
   const s = String((sbx as any).state || "");
   if (s === "started") return "running";
@@ -869,6 +882,24 @@ export class DaytonaProvider implements SandboxProvider {
   }
 
   /** Release compute while retaining the session's exact volume workspace. */
+  async desktop(sandboxId: string): Promise<SandboxDesktop> {
+    const client = await daytonaClient();
+    const sbx = await client.get(sandboxId);
+    if (!sbx || stateOf(sbx) !== "running")
+      throw new Error("Wake the sandbox first");
+    // Xvfb + xfce4 + x11vnc + noVNC. start() is not idempotent, so ask first.
+    const status = await sbx.computerUse.getStatus().catch(() => null);
+    if (status?.status !== "active") await sbx.computerUse.start();
+    const signed = await sbx.getSignedPreviewUrl(
+      DAYTONA_NOVNC_PORT,
+      DAYTONA_DESKTOP_URL_TTL_SECONDS,
+    );
+    return {
+      url: daytonaDesktopUrl(signed.url),
+      expiresAt: Date.now() + DAYTONA_DESKTOP_URL_TTL_SECONDS * 1000,
+    };
+  }
+
   async pause(sandboxId: string): Promise<void> {
     const client = await daytonaClient();
     const sbx = await client.get(sandboxId);

--- a/packages/core/opensession-server/src/server/sandbox/provider.ts
+++ b/packages/core/opensession-server/src/server/sandbox/provider.ts
@@ -197,6 +197,13 @@ export interface Sandbox {
   status(): Promise<SandboxStatus>;
 }
 
+export interface SandboxDesktop {
+  /** Opens straight into the live desktop; treat it like a password. */
+  url: string;
+  /** Epoch ms after which the URL stops working, when the provider says. */
+  expiresAt?: number;
+}
+
 export interface SandboxProvider {
   id: SandboxProviderId;
   /** Create-or-reuse the sandbox for a session. Idempotent. */
@@ -206,6 +213,10 @@ export interface SandboxProvider {
   /** Release compute while retaining the durable workspace. Optional only for
    *  providers whose own idle policy cannot expose this directly. */
   pause?(sandboxId: string): Promise<void>;
+  /** A desktop a person can watch and control from the browser. The URL is a
+   *  bearer secret minted for one viewer; providers that cannot expose a
+   *  desktop leave this undefined. Rejects while the sandbox is asleep. */
+  desktop?(sandboxId: string): Promise<SandboxDesktop>;
   /** Wake a paused sandbox and return its live handle. */
   resume?(sandboxId: string): Promise<Sandbox | null>;
   /** Persist a session-owned filesystem checkpoint after a clean turn.


### PR DESCRIPTION
## What

A person can now watch and control a Sandbox's screen from the session. The Sandbox popover gets **Open desktop** while the Sandbox is awake; it opens a new tab with a live desktop. The agent keeps working underneath it.

- **Box**: `POST /boxes/{id}/desktop` returns a tokenized 60fps stream page (`*-desktop.on.ascii.dev/stream.html#token=…`). The box record already advertised `desktopAvailable: true`.
- **Daytona**: `sandbox.computerUse.start()` brings up Xvfb, xfce4, x11vnc and noVNC (websockify on 6080); a signed preview URL for 6080 opens `vnc.html?autoconnect=1&resize=scale`. Verified live that the signed host carries the websocket (RFB banner over `wss`). Start is not idempotent, so `getStatus()` is consulted first. URL TTL is one hour.

## Change

- `SandboxProvider.desktop?(sandboxId) → { url, expiresAt? }` plus `SandboxDesktop` type (`sandbox/provider.ts`).
- Box and Daytona implementations; pure helpers `boxDesktopUrl` and `daytonaDesktopUrl` with unit tests. Asleep sandboxes reject with "Wake the sandbox first".
- `POST /api/sessions/:id/sandbox/desktop` returns the link. It is deliberately not behind the `hostRunBusy` lifecycle lock. Audit records the request, never the URL. 409 when asleep, 502 on provider failure.
- `canDesktop` in the sandbox status view; `openSandboxDesktop()` in `lib/api/sandboxes.ts`; **Open desktop** in `SandboxBadge` (tab opened synchronously in the click so popup blockers allow it, then pointed at the minted URL; `opener` cleared).
- Docs: `docs/self-hosting-sandboxes.md` "Desktop" section, one line in `CONCEPTS.md`.

## Verification

- Live, from the branch worktree through `getSandboxProvider()`: Box `bx_shxuudkn` → stream page 200; Daytona `bbc11bc5-…` → computer-use started in ~10s, `vnc.html` 200, websocket handshake OK; unknown id → `DaytonaNotFoundError`.
- `bun run check`: format, typecheck, lint and snapshots pass. Two test failures are pre-existing on untouched `main`: `sandbox project environments > every provider starts unprepared…` (reads the host's real environment state; papercut logged) and the known `setup-repos` flake.
- No screenshot of the new popover item: the demo dataset has no sandboxed session and the button is gated on live provider status, so a visual needs this deployed to an instance with a Sandbox connection. Happy to add one after merge.

## Not in this PR

Agent-side desktop tools (Daytona's screenshot/mouse/keyboard API is right there), and restarting Daytona's computer-use stack automatically on wake (it is started on demand per click instead).

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a068e8-6246-75b7-bf7f-2a9ac1051a27)