### PR TITLE
Maintain Open Session verification skill

### DIFF
--- a/.agents/skills/verify-opensession/SKILL.md
+++ b/.agents/skills/verify-opensession/SKILL.md
@@ -21,7 +21,7 @@ export RUN_ID="verify-$(date +%Y%m%d-%H%M%S)-$$"
 
 The command prints `APP_URL`, `STATE_DIR`, and `EVIDENCE_DIR`. It starts the real Bun gateway and SessionKernel with a shared scratch credential, `OPENSESSION_DEV=1`, `OPENSESSION_DEMO=1`, and a disposable `OPENSESSION_STATE_DIR` under `/tmp`. The demo seed supplies sessions, transcripts, a repository, pull request state, automations, and a paused goal. External agents, schedulers, webhooks, executor work, and live credentials stay off.
 
-The instance is ready when launch returns successfully. Its log remains at `/tmp/opensession-verify-$RUN_ID/server.log` until cleanup.
+The instance is ready when launch returns successfully. Its log remains at `/tmp/opensession-verify-$RUN_ID/server.log` until cleanup. The demo does not seed archived records. Archive checks need a session archived through the UI first.
 
 Teardown what this run started:
 
@@ -67,7 +67,7 @@ Common actions:
 ./.agents/skills/verify-opensession/bin/verify-opensession browser "$RUN_ID" url
 ```
 
-`wait`, `click`, and `fill` require one exact accessible match. Add `--index 1` only when the UI intentionally exposes duplicate names. A lookup failure prints nearby names for that role. Use `snapshot` to inspect the current tree instead of guessing selectors:
+`wait`, `click`, and `fill` require one exact accessible match. `click` scrolls an off-screen match into view before pressing it. Add `--index 1` only when the UI intentionally exposes duplicate names. A lookup failure prints nearby names for that role. Use `snapshot` to inspect the current tree instead of guessing selectors:
 
 ```bash
 ./.agents/skills/verify-opensession/bin/verify-opensession browser "$RUN_ID" snapshot

--- a/.agents/skills/verify-opensession/bin/browser.mjs
+++ b/.agents/skills/verify-opensession/bin/browser.mjs
@@ -148,6 +148,9 @@ async function matchingNode() {
 }
 
 async function clickNode(node) {
+  await send("DOM.scrollIntoViewIfNeeded", {
+    backendNodeId: node.backendDOMNodeId,
+  });
   const model = await send("DOM.getBoxModel", {
     backendNodeId: node.backendDOMNodeId,
   });

--- a/.agents/skills/verify-opensession/features/README.md
+++ b/.agents/skills/verify-opensession/features/README.md
@@ -17,7 +17,8 @@ This directory is the maintained source for verifying Open Session's user-facing
 - Every browser command takes `"$RUN_ID"` before its subcommand.
 - Prefer accessibility roles and exact accessible names. Take a current `snapshot` when a lookup fails.
 - Desktop and phone are one web bundle. Check both widths for visible changes.
-- The demo seed is synthetic. Its stable sessions include `bks-demo-pr`, `bks-demo-failed`, and `bks-demo-automation-run`.
+- The demo seed is synthetic. Its stable sessions include `bks-demo-pr`, `bks-demo-failed`, `bks-demo-cancelled`, and `bks-demo-automation-run`.
+- The seed has no archived records. Archive a disposable seeded session through its visible session menu before checking archive results.
 - External integrations, schedulers, and engine execution are disabled. Report those paths as unproved rather than steering production.
 
 ## Proof and skip reporting

--- a/.agents/skills/verify-opensession/features/archived-sessions.md
+++ b/.agents/skills/verify-opensession/features/archived-sessions.md
@@ -22,11 +22,11 @@ Archived sessions are removed from active workspace lanes but remain searchable,
 Preconditions:
 
 - Doctor passes for the isolated demo run.
-- The demo seed has finished and cancelled sessions available to the archive UI.
+- The demo seed has no archived records. Open `/session/bks-demo-cancelled`, choose `More actions`, then choose menu item `Archive session Ctrl+Shift+A`. Require the action to finish before opening the archive. If it remains `Archiving… Ctrl+Shift+A`, run doctor, capture the stuck state, and report the archive feature as unreachable.
 
-- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for textbox `Search archived sessions` and capture the unfiltered state.
-- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role textbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
-- **Clear and filter.** Refill the search textbox with an empty value, choose the `Filters` button using the exact accessible name from the current snapshot, and select one visible repository or person. Capture the filter state and narrowed result list.
+- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for searchbox `Search archived sessions` and capture the unfiltered state.
+- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role searchbox --name "Search archived sessions" --value "date helpers"`. The visible results narrow to the session archived during setup.
+- **Clear and filter.** Refill the searchbox with an empty value. The owner picker is named `Owner, My archived`. Repository and reason pickers appear only when the archived records contain more than one repository or an auto-archive reason. Use the exact names from a current snapshot and capture any applicable narrowed state.
 - **Open a result.** Choose a visible archived session title. Its transcript opens and keeps the archived state visible.
 - **Restore.** From `/archived`, choose `Restore session` on one disposable demo result. Confirm it disappears from the matching archived results and reappears in its active workspace or `/api/sessions` response.
 - **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover.
@@ -36,6 +36,6 @@ Preconditions:
 
 - Searching is read-only. It does not prove restore behavior.
 - A session may be hidden by archive reason or current-person defaults. Record active filters in proof.
-- The filter button's accessible name includes the active-filter count. Take a fresh snapshot after each change.
-- Restoring mutates disposable demo state. Run it last if later checks depend on the seeded archive list.
+- Filter controls are separate pickers whose names include their current values. Take a fresh snapshot after each change.
+- Restoring mutates disposable demo state. Run it last if later checks depend on the archived setup record.
 - Opening a direct session URL does not prove the archived index entry point.

--- a/.agents/skills/verify-opensession/features/archived-sessions.md
+++ b/.agents/skills/verify-opensession/features/archived-sessions.md
@@ -29,7 +29,7 @@ Preconditions:
 - **Clear and filter.** Refill the searchbox with an empty value. The owner picker is named `Owner, My archived`. Repository and reason pickers appear only when the archived records contain more than one repository or an auto-archive reason. Use the exact names from a current snapshot and capture any applicable narrowed state.
 - **Open a result.** Choose a visible archived session title. Its transcript opens and keeps the archived state visible.
 - **Restore.** From `/archived`, choose `Restore session` on one disposable demo result. Confirm it disappears from the matching archived results and reappears in its active workspace or `/api/sessions` response.
-- **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover.
+- **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover. Restore is a left-swipe row action on phone, not the desktop button.
 - **Proof.** Capture unfiltered, filtered, and resulting states. For restore behavior, save a read-only session API response after the UI action.
 
 ## Gotchas

--- a/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
+++ b/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
@@ -24,10 +24,10 @@ Preconditions:
 - Doctor passes for the isolated demo run.
 - Demo session `bks-demo-pr` exists with title `Fix flaky upload retry test`.
 
-- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role heading --name "Fix flaky upload retry test"`. The session title and transcript appear.
-- **Inspect transcript semantics.** Run `verify-opensession browser "$RUN_ID" snapshot`. The tree contains the upload retry prompt and transcript controls. Capture a screenshot after expanding any collapsed tool call through its visible button.
+- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait for the title with `verify-opensession browser "$RUN_ID" wait --role StaticText --name "Fix flaky upload retry test"`, then wait for the seeded upload retry prompt before capturing proof. The title arrives before transcript hydration, so it is not a sufficient readiness check.
+- **Inspect transcript semantics.** Run `verify-opensession browser "$RUN_ID" snapshot`. The tree contains the upload retry prompt and transcript controls. Expand the `Worked 2m · 4 steps +1 -1` button, then capture the expanded state. Take a fresh snapshot first if the seeded duration or diff summary has changed.
 - **Inspect a failure.** Open `/session/bks-demo-failed`. The page identifies `Investigate memory spike in export worker` and shows its run failure instead of presenting the transcript as complete.
-- **Open the global composer.** Open `/new`, then wait for `group` named `New session`. The textbox placeholder is `What do you want to work on?`. Choose `Ask mode` and verify the placeholder changes to `What do you want to find out?`.
+- **Open the global composer.** Open `/new`, then wait for `dialog` named `New session`. The prompt is a `combobox` named `What do you want to work on?`. Choose `Ask mode` and verify its accessible name changes to `What do you want to find out?`.
 - **Check phone layout.** Reopen `/session/bks-demo-pr` at 390x844. Capture the transcript, then focus the composer and verify its controls remain reachable without horizontal scrolling.
 - **Proof.** Save before and after accessibility snapshots and screenshots. If the check creates a session, confirm its new ID through `/api/sessions` and reopen it from the sidebar before reporting persistence.
 

--- a/.agents/skills/verify-opensession/features/settings.md
+++ b/.agents/skills/verify-opensession/features/settings.md
@@ -29,7 +29,7 @@ Preconditions:
 - **Use search.** Return to `/settings`, take a snapshot to read the current search textbox name, fill it with `providers`, and choose the `Providers` result. The route becomes `/settings/providers` and the Providers heading appears.
 - **Change a personal preference.** Choose the target control by its exact label, record its initial state from the accessibility snapshot, change it through the UI, navigate to another section, and return. Require the changed state to remain. Reload by opening `/settings/preferences` again and check once more.
 - **Change instance configuration.** Use only the disposable demo instance. Save through the visible form, then read the matching read-only API response and revisit the section. Never copy live credentials into this run.
-- **Check phone navigation.** Open `/settings` at 390x844. The settings section list appears first. Choose a section, then use its visible back action to return to the list.
+- **Check phone navigation.** Open `/settings` at 390x844 and wait for dialog `Settings`. The settings section list appears first. Choose a section, then use button `Back to settings` to return to the list.
 - **Proof.** Capture the initial control state, action, persisted state after navigation, and the phone section flow. Add the read-only API response for instance mutations.
 
 ## Gotchas


### PR DESCRIPTION
## Summary

- update session, archive, and phone settings recipes to match the current accessibility tree
- document that the demo seed has no archived records and how to establish archive state through the UI
- scroll off-screen accessibility targets into view before browser clicks

Supersedes #311 with the harness and settings corrections found in today's full pass.

## Verification

- `bun run check`
- isolated run `verify-maint-20260905-060136-963664` across sessions, automations, goals, archived sessions, and settings at desktop and phone widths
- fresh isolated run `verify-maint-retry-20260905-061022-970600` re-proved off-screen clicks and reproduced the archive failure

## Product gap

The isolated server primes its session list at zero before generating nine demo sessions. Archiving `bks-demo-cancelled` stays on `Archiving…`, so archived result, filter, open, and restore checks remain unreachable. The updated recipe records that prerequisite and failure path rather than claiming seeded archive state exists.

Started by Daily verification skill maintenance in [this OS session](https://os.tella.dev/session/os-01a07027-0d5a-770f-9cec-d9dfc5012c4d)
