### PR TITLE
Maintain Open Session verification skill

### DIFF
--- a/.agents/skills/verify-opensession/SKILL.md
+++ b/.agents/skills/verify-opensession/SKILL.md
@@ -19,7 +19,7 @@ export RUN_ID="verify-$(date +%Y%m%d-%H%M%S)-$$"
 ./.agents/skills/verify-opensession/bin/verify-opensession launch "$RUN_ID"
 ```
 
-The command prints `APP_URL`, `STATE_DIR`, and `EVIDENCE_DIR`. It starts the real Bun gateway and SessionKernel with a shared scratch credential, `OPENSESSION_DEV=1`, `OPENSESSION_DEMO=1`, and a disposable `OPENSESSION_STATE_DIR` under `/tmp`. The demo seed supplies sessions, transcripts, a repository, pull request state, automations, and a paused goal. External agents, schedulers, webhooks, executor work, and live credentials stay off.
+The command prints `APP_URL`, `STATE_DIR`, and `EVIDENCE_DIR`. It writes the demo dataset before starting the real Bun gateway and SessionKernel, then archives three stable fixtures for archive verification. Both services use a shared scratch credential, `OPENSESSION_DEV=1`, `OPENSESSION_DEMO=1`, and a disposable `OPENSESSION_STATE_DIR` under `/tmp`. The demo seed supplies sessions, transcripts, a repository, pull request state, automations, and a paused goal. External agents, schedulers, webhooks, executor work, and live credentials stay off.
 
 The instance is ready when launch returns successfully. Its log remains at `/tmp/opensession-verify-$RUN_ID/server.log` until cleanup.
 

--- a/.agents/skills/verify-opensession/bin/browser.mjs
+++ b/.agents/skills/verify-opensession/bin/browser.mjs
@@ -148,6 +148,15 @@ async function matchingNode() {
 }
 
 async function clickNode(node) {
+  const objectId = await resolveNode(node);
+  await send("Runtime.callFunctionOn", {
+    objectId,
+    functionDeclaration:
+      'function () { this.scrollIntoView({ behavior: "instant", block: "center", inline: "center" }); }',
+  });
+  // Let nested scroll containers and their compositor state reach the target
+  // before resolving its click coordinates.
+  await Bun.sleep(350);
   const model = await send("DOM.getBoxModel", {
     backendNodeId: node.backendDOMNodeId,
   });

--- a/.agents/skills/verify-opensession/bin/verify-opensession
+++ b/.agents/skills/verify-opensession/bin/verify-opensession
@@ -91,9 +91,20 @@ case "$COMMAND" in
     START_HEAD="$(git -C "$ROOT" rev-parse HEAD)"
     SERVER_LOG="$RUN_DIR/server.log"
     KERNEL_LOG="$RUN_DIR/session-kernel.log"
+    SEED_LOG="$RUN_DIR/seed.log"
     KERNEL_TOKEN="$(bun -e 'process.stdout.write(crypto.randomUUID() + crypto.randomUUID())')"
 
     cd "$ROOT"
+    trap 'stop_run' ERR
+    env -i \
+      PATH="$PATH" \
+      HOME="$HOME" \
+      USER="${USER:-}" \
+      LANG="${LANG:-C.UTF-8}" \
+      OPENSESSION_STATE_DIR="$RUN_DIR/state" \
+      NODE_ENV=development \
+      bun scripts/demo-data.ts >"$SEED_LOG" 2>&1
+
     setsid env -i \
       PATH="$PATH" \
       HOME="$HOME" \
@@ -119,9 +130,9 @@ KERNEL_PORT=$KERNEL_PORT
 KERNEL_PID=$KERNEL_PID
 KERNEL_LOG=$KERNEL_LOG
 SERVER_LOG=$SERVER_LOG
+SEED_LOG=$SEED_LOG
 START_HEAD=$START_HEAD
 EOF
-    trap 'stop_run' ERR
 
     kernel_ready=""
     for _ in $(seq 1 300); do
@@ -191,6 +202,23 @@ EOF
       stop_run
       exit 1
     fi
+
+    # Archive stable completed, failed, and cancelled fixtures before the
+    # browser starts. Product demo data stays inert at boot, while the archive
+    # feature needs disposable rows for search, opening, and restore proof.
+    for demo_archive_id in bks-demo-pr bks-demo-failed bks-demo-cancelled; do
+      curl -fsS \
+        -X POST \
+        -H 'content-type: application/json' \
+        -d '{"archived":true}' \
+        "$APP_URL/api/sessions/$demo_archive_id/archive" >/dev/null
+    done
+    archived_count="$(curl -fsS "$APP_URL/api/sessions?archived=only&slim=1" | jq 'length')"
+    if [ "$archived_count" -lt 3 ]; then
+      echo "Demo archive setup returned only $archived_count sessions" >&2
+      exit 1
+    fi
+
     BOOT_ID="$(jq -r '.bootId // empty' <<<"$ready")"
     FRONTEND_VERSION="$(jq -r '.frontendVersion // empty' <<<"$ready")"
     printf 'BOOT_ID=%s\nFRONTEND_VERSION=%s\n' "$BOOT_ID" "$FRONTEND_VERSION" >>"$RUN_FILE"

--- a/.agents/skills/verify-opensession/features/archived-sessions.md
+++ b/.agents/skills/verify-opensession/features/archived-sessions.md
@@ -1,11 +1,11 @@
 # Archived sessions
 
-Archived sessions are removed from active workspace lanes but remain searchable, restorable conversations. Users can search, filter by repository or person, inspect a result, and restore it.
+Archived sessions are removed from active workspace lanes but remain searchable, restorable conversations. Users can search session titles and row metadata, filter by repository, owner, or archive reason, inspect a result, and restore it.
 
 ## Sub-features
 
 - `archive-list` groups archived sessions by time and workspace context.
-- `archive-search` filters titles and transcript metadata.
+- `archive-search` filters titles, repositories, branches, owners, and automation names.
 - `archive-filters` narrows results by repository, person, and archive reason.
 - `archive-open` opens a matching archived session without restoring it.
 - `archive-restore` returns a session to its active workspace.
@@ -22,11 +22,11 @@ Archived sessions are removed from active workspace lanes but remain searchable,
 Preconditions:
 
 - Doctor passes for the isolated demo run.
-- The demo seed has finished and cancelled sessions available to the archive UI.
+- The launcher archives stable completed, failed, and cancelled demo sessions before returning. The archive defaults to `My archived`, but seeded sessions belong to synthetic teammates, so choose `Owner, My archived` and then `Everyone` before checking seeded rows.
 
-- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for textbox `Search archived sessions` and capture the unfiltered state.
-- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role textbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
-- **Clear and filter.** Refill the search textbox with an empty value, choose the `Filters` button using the exact accessible name from the current snapshot, and select one visible repository or person. Capture the filter state and narrowed result list.
+- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for `searchbox` named `Search archived sessions`, choose `Owner, My archived`, then choose the `menuitemradio` named `Everyone`. Capture the unfiltered state.
+- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role searchbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
+- **Clear and filter.** Refill the searchbox with an empty value. Use the separately named `Owner, …` button and, when present, `Repository, …` or `Reason, …` to select one visible filter. Their options use the `menuitemradio` role. Capture the filter state and narrowed result list.
 - **Open a result.** Choose a visible archived session title. Its transcript opens and keeps the archived state visible.
 - **Restore.** From `/archived`, choose `Restore session` on one disposable demo result. Confirm it disappears from the matching archived results and reappears in its active workspace or `/api/sessions` response.
 - **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover.

--- a/.agents/skills/verify-opensession/features/goals.md
+++ b/.agents/skills/verify-opensession/features/goals.md
@@ -30,7 +30,7 @@ Preconditions:
 - **Enter the mission.** Run `verify-opensession browser "$RUN_ID" fill --role textbox --name "Name" --value "$GOAL_NAME"` and `verify-opensession browser "$RUN_ID" fill --role textbox --name "Mission" --value "Inspect the isolated demo state and record one verification result."`. Capture the filled form so the action is visible.
 - **Save.** Run `verify-opensession browser "$RUN_ID" click --role button --name "Create goal"`. The form closes and the goals list returns.
 - **Confirm stored state.** Run `verify-opensession api "$RUN_ID" /api/goals | jq --arg name "$GOAL_NAME" '.[] | select(.name == $name)'`. Require one object with the entered mission. Set `GOAL_ID="$(verify-opensession api "$RUN_ID" /api/goals | jq -r --arg name "$GOAL_NAME" '.[] | select(.name == $name) | .id')"`, then open `/goals/$GOAL_ID`. The detail view names the saved goal.
-- **Check phone layout.** Open `/goals/$GOAL_ID` at 390x844. The saved detail appears with a visible `Goals` back action. Use that action to reach the phone list when list navigation is in scope.
+- **Check phone layout.** Open `/goals/$GOAL_ID` at 390x844 and wait for the `button` named `Goals`. The saved detail appears with that back action. Use it to reach the phone list when list navigation is in scope.
 - **Proof.** Save before, filled-form, and after snapshots and screenshots. Save the matching API object as `goals-api.json`.
 
 ## Gotchas

--- a/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
+++ b/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
@@ -22,12 +22,12 @@ Sessions are conversations with an agent. Users open them from a workspace or di
 Preconditions:
 
 - Doctor passes for the isolated demo run.
-- Demo session `bks-demo-pr` exists with title `Fix flaky upload retry test`.
+- Demo session `bks-demo-pr` exists with title `Fix flaky upload retry test` in workspace `demo/fix-flaky-upload`.
 
-- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role heading --name "Fix flaky upload retry test"`. The session title and transcript appear.
+- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role RootWebArea --name "demo/fix-flaky-upload"`. The workspace name and transcript appear. The session title remains available in the archived index.
 - **Inspect transcript semantics.** Run `verify-opensession browser "$RUN_ID" snapshot`. The tree contains the upload retry prompt and transcript controls. Capture a screenshot after expanding any collapsed tool call through its visible button.
 - **Inspect a failure.** Open `/session/bks-demo-failed`. The page identifies `Investigate memory spike in export worker` and shows its run failure instead of presenting the transcript as complete.
-- **Open the global composer.** Open `/new`, then wait for `group` named `New session`. The textbox placeholder is `What do you want to work on?`. Choose `Ask mode` and verify the placeholder changes to `What do you want to find out?`.
+- **Open the global composer.** Open `/new`, then wait for `dialog` named `New session`. The composer is a `combobox` named `What do you want to work on?`. Choose `Ask mode` and verify its name changes to `What do you want to find out?`.
 - **Check phone layout.** Reopen `/session/bks-demo-pr` at 390x844. Capture the transcript, then focus the composer and verify its controls remain reachable without horizontal scrolling.
 - **Proof.** Save before and after accessibility snapshots and screenshots. If the check creates a session, confirm its new ID through `/api/sessions` and reopen it from the sidebar before reporting persistence.
 


### PR DESCRIPTION
## Summary

- preseed the isolated demo dataset before server startup so session indexes and transcripts are complete
- add disposable archived fixtures and make CDP clicks scroll offscreen controls into view
- refresh session, archive, and goal recipes to match current accessible roles and names

## Verification

- `bun run check`
- full source and live pass for sessions and transcripts, automations, goals, archived sessions, and settings at desktop and phone widths
- fresh-launch proof for seeded transcripts, archived fixtures, archive search, and an offscreen phone preference toggle

Started by Daily verification skill maintenance in [this OS session](https://os.tella.dev/session/os-01a0754d-875c-76dc-920a-add01adc361d)
