### PR TITLE
Maintain Open Session verification skill

### DIFF
--- a/.agents/skills/verify-opensession/bin/browser.mjs
+++ b/.agents/skills/verify-opensession/bin/browser.mjs
@@ -148,12 +148,27 @@ async function matchingNode() {
 }
 
 async function clickNode(node) {
-  const model = await send("DOM.getBoxModel", {
-    backendNodeId: node.backendDOMNodeId,
-  });
-  const quad = model?.model?.border;
-  if (!Array.isArray(quad) || quad.length < 8)
-    fail("target has no clickable box");
+  const deadline = Date.now() + timeout;
+  let previousQuad;
+  let quad;
+  while (Date.now() <= deadline) {
+    const model = await send("DOM.getBoxModel", {
+      backendNodeId: node.backendDOMNodeId,
+    });
+    quad = model?.model?.border;
+    if (!Array.isArray(quad) || quad.length < 8)
+      fail("target has no clickable box");
+    if (
+      previousQuad?.every(
+        (coordinate, coordinateIndex) =>
+          Math.abs(coordinate - quad[coordinateIndex]) < 0.5,
+      )
+    )
+      break;
+    previousQuad = quad;
+    await Bun.sleep(100);
+  }
+  if (Date.now() > deadline) fail("target did not settle before click");
   const x = (quad[0] + quad[2] + quad[4] + quad[6]) / 4;
   const y = (quad[1] + quad[3] + quad[5] + quad[7]) / 4;
   await send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y });

--- a/.agents/skills/verify-opensession/features/archived-sessions.md
+++ b/.agents/skills/verify-opensession/features/archived-sessions.md
@@ -24,9 +24,9 @@ Preconditions:
 - Doctor passes for the isolated demo run.
 - The demo seed has finished and cancelled sessions available to the archive UI.
 
-- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for textbox `Search archived sessions` and capture the unfiltered state.
-- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role textbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
-- **Clear and filter.** Refill the search textbox with an empty value, choose the `Filters` button using the exact accessible name from the current snapshot, and select one visible repository or person. Capture the filter state and narrowed result list.
+- **Open the index.** Run `verify-opensession browser "$RUN_ID" open --route /archived --width 1440 --height 900`. Wait for searchbox `Search archived sessions` and capture the unfiltered state.
+- **Search.** Run `verify-opensession browser "$RUN_ID" fill --role searchbox --name "Search archived sessions" --value "retry"`. The visible results narrow to archived work matching `retry`, or an explicit no-results state appears if the seed's archive rules changed.
+- **Clear and filter.** Refill the searchbox with an empty value. Choose the current owner button, such as `Owner, My archived`, then select `Everyone` or one visible person. Repository and reason pickers appear only when the archived set supplies those choices. Capture the filter state and narrowed result list.
 - **Open a result.** Choose a visible archived session title. Its transcript opens and keeps the archived state visible.
 - **Restore.** From `/archived`, choose `Restore session` on one disposable demo result. Confirm it disappears from the matching archived results and reappears in its active workspace or `/api/sessions` response.
 - **Check phone layout.** Repeat search and result opening at 390x844. Search and filters must remain reachable without desktop hover.
@@ -36,6 +36,6 @@ Preconditions:
 
 - Searching is read-only. It does not prove restore behavior.
 - A session may be hidden by archive reason or current-person defaults. Record active filters in proof.
-- The filter button's accessible name includes the active-filter count. Take a fresh snapshot after each change.
+- Filter button names include the current selection, such as `Owner, Everyone`. Take a fresh snapshot after each change.
 - Restoring mutates disposable demo state. Run it last if later checks depend on the seeded archive list.
 - Opening a direct session URL does not prove the archived index entry point.

--- a/.agents/skills/verify-opensession/features/automations.md
+++ b/.agents/skills/verify-opensession/features/automations.md
@@ -13,7 +13,7 @@ Automations create fresh sessions from schedules or external events. Users inspe
 
 ## How to get to it (user POV)
 
-- Choose `Automations` in the sidebar.
+- Choose `Automations` from settings tools.
 - Open `/automations` or a shared `/automations/<id>` link.
 - Choose `New automation`, then describe the task or select a template.
 - Open an automation row to inspect its runs and edit, run, or delete it.
@@ -26,7 +26,7 @@ Preconditions:
 - The demo seed contains `Nightly dependency audit` and `Deploy notes on release webhook`.
 
 - **Open the list.** Run `verify-opensession browser "$RUN_ID" open --route /automations --width 1440 --height 900`, then `verify-opensession browser "$RUN_ID" wait --role heading --name "Automations"`. A row for each seeded automation appears.
-- **Open details.** Run `verify-opensession browser "$RUN_ID" open --route /automations/auto-demo-nightly-audit --width 1440 --height 900`. The detail view shows `Nightly dependency audit`, its cron trigger, disabled state, and three seeded runs. Separately choose the seeded row from `/automations` when the list entry point is in scope.
+- **Open details.** Run `verify-opensession browser "$RUN_ID" open --route /automations/auto-demo-nightly-audit --width 1440 --height 900`, then wait for button `Edit`. The detail drawer shows `Nightly dependency audit`, its cron trigger, disabled state, and three seeded runs. Separately choose button `Open Nightly dependency audit` from `/automations` when the list entry point is in scope.
 - **Open authoring.** Choose `New automation`. A dialog headed `New automation` appears and focus moves to the textbox named `Describe the automation`.
 - **Use a template or description.** Enter a description and continue, or choose a visible template. Verify the generated form remains editable before saving.
 - **Confirm persistence.** After a create, edit, or toggle through the UI, run `verify-opensession api "$RUN_ID" /api/automations | jq .`. Match the saved name, trigger, mode, and enabled state, then reopen the automation from the list.

--- a/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
+++ b/.agents/skills/verify-opensession/features/sessions-and-transcripts.md
@@ -24,10 +24,10 @@ Preconditions:
 - Doctor passes for the isolated demo run.
 - Demo session `bks-demo-pr` exists with title `Fix flaky upload retry test`.
 
-- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role heading --name "Fix flaky upload retry test"`. The session title and transcript appear.
+- **Open a direct session link.** Run `verify-opensession browser "$RUN_ID" open --route /session/bks-demo-pr --width 1440 --height 900`. Wait with `verify-opensession browser "$RUN_ID" wait --role button --name "More actions"`, then take a snapshot and require `Fix flaky upload retry test`. The session title and transcript appear.
 - **Inspect transcript semantics.** Run `verify-opensession browser "$RUN_ID" snapshot`. The tree contains the upload retry prompt and transcript controls. Capture a screenshot after expanding any collapsed tool call through its visible button.
 - **Inspect a failure.** Open `/session/bks-demo-failed`. The page identifies `Investigate memory spike in export worker` and shows its run failure instead of presenting the transcript as complete.
-- **Open the global composer.** Open `/new`, then wait for `group` named `New session`. The textbox placeholder is `What do you want to work on?`. Choose `Ask mode` and verify the placeholder changes to `What do you want to find out?`.
+- **Open the global composer.** Open `/new`, then wait for `combobox` named `What do you want to work on?`. Choose `Ask mode` and wait for the combobox name to change to `What do you want to find out?`.
 - **Check phone layout.** Reopen `/session/bks-demo-pr` at 390x844. Capture the transcript, then focus the composer and verify its controls remain reachable without horizontal scrolling.
 - **Proof.** Save before and after accessibility snapshots and screenshots. If the check creates a session, confirm its new ID through `/api/sessions` and reopen it from the sidebar before reporting persistence.
 


### PR DESCRIPTION
## Summary

- update stale session, automation, and archive verification recipes
- wait for moving controls to settle before the CDP helper clicks them
- keep the feature map aligned with the current settings and accessibility entry points

## Verification

- `bun run check`
- completed source review for all five mapped feature files
- ran `verify-20260907-060052-3679386` across sessions, automations, goals, archive, and settings at desktop and phone widths
- reproved the stable-click fix on the phone settings and automation flows

## Product gaps found

- `/session/bks-demo-pr` loads its title but shows `No transcript available for this session`, so seeded transcript and tool-call proof is unreachable
- `/archived` has no seeded results even with `Owner, Everyone`, so archived-session open and restore proof is unreachable

Started by Daily verification skill maintenance in [this OS session](https://os.tella.dev/session/os-01a07a73-bcf8-7080-8b1e-44ed8185d22a)
