### PR TITLE
Separate git-transport credential

### DIFF
--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -90,6 +90,28 @@ calls receive a short-lived App token in their process environment. HTTPS Git
 operations use a process-local credential helper, and SSH GitHub remotes are
 rewritten to HTTPS for that process so host keys cannot bypass the App.
 
+## Separate git-transport credential
+
+Opt-in: set `OPENSESSION_GITHUB_PUSH_TOKEN` (in `~/.opensession.env`) and the
+credential helper answers git transport — clone, pull, push — with it instead
+of the run's session token, on every run that already carries a GitHub
+credential. API calls (`gh`, octokit tooling) keep `GH_TOKEN` unchanged, and a
+run that carries no GitHub credential still receives nothing. Unset, git
+transport uses the run's session token.
+
+The hardened deployment this enables: cap the GitHub App at **Contents: read**
+so no App or user-to-server token can write repository contents, then mint a
+fine-grained PAT on the bot account with **Contents: read and write** — plus
+**Workflows: read and write** if sessions push workflow files — restricted to
+the repositories this instance should push to, and set it as
+`OPENSESSION_GITHUB_PUSH_TOKEN`. Add branch rulesets so the bot identity can
+push branches but never merge to protected ones.
+
+Threat model: agent bash shares the server's uid, so every credential present
+on an Open Session host should be scoped as if the agent will read and use it
+directly. The split does not hide the push token from the agent — it bounds
+what any token on the box can do on GitHub.
+
 ## Webhook intake
 
 The fail-closed public ingress gateway listens on `127.0.0.1:3860`. Choose

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -92,6 +92,13 @@ rewritten to HTTPS for that process so host keys cannot bypass the App.
 
 ## Separate git-transport credential
 
+By default, one credential does everything a session needs on GitHub. If you
+prefer that the identity-bearing session token never be able to write
+repository contents, you can split the roles: keep the session token for PR,
+review, and comment operations, and give git transport (push) its own
+narrower credential. Combined with branch rulesets, this makes merging
+something no credential on the host can do alone.
+
 Opt-in: set `OPENSESSION_GITHUB_PUSH_TOKEN` (in `~/.opensession.env`) and the
 credential helper answers git transport — clone, pull, push — with it instead
 of the run's session token, on every run that already carries a GitHub

--- a/packages/core/opensession-server/opensession.ts
+++ b/packages/core/opensession-server/opensession.ts
@@ -714,6 +714,14 @@ if (!g.__opensessionBooted) {
     }
   }
 
+  // Which credential answers git transport (clone/pull/push) for runs that
+  // carry a GitHub token. API calls always keep the session token.
+  console.log(
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN
+      ? "[github] git transport uses the dedicated push credential (OPENSESSION_GITHUB_PUSH_TOKEN)"
+      : "[github] git transport uses the session token (no OPENSESSION_GITHUB_PUSH_TOKEN configured)",
+  );
+
   // Pi's SDK can take over a minute to load cold. Keep the loader import-inert,
   // then warm it explicitly from the process boot owner when Pi is enabled.
   void import("./src/server/pi-config")

--- a/packages/core/opensession-server/src/server/git-status.test.ts
+++ b/packages/core/opensession-server/src/server/git-status.test.ts
@@ -10,6 +10,7 @@ import {
   gitPush,
   porcelainPaths,
 } from "./git-status";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import type { WorkspaceExec } from "./sandbox/workspace-exec";
 
 const roots: string[] = [];
@@ -245,5 +246,32 @@ describe("scoped Git credentials", () => {
       });
       expect(JSON.stringify(env)).not.toContain("/home/user");
     }
+  });
+
+  test("local Docker git transport prefers the injected push credential", async () => {
+    const envs: Array<Record<string, string> | undefined> = [];
+    const exec = Object.assign(
+      async (_cmd: string[], opts?: { env?: Record<string, string> }) => {
+        envs.push(opts?.env);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      { sandboxed: true, remote: false },
+    ) as WorkspaceExec;
+    const hostEnv = {
+      GH_TOKEN: "session-token",
+      GITHUB_TOKEN: "session-token",
+      [GITHUB_PUSH_TOKEN_RUN_ENV]: "github_pat_push_only",
+    };
+
+    expect(await gitPush("/repo", "feature", exec, hostEnv)).toEqual({
+      ok: true,
+    });
+    // `gh auth git-credential` answers from GH_TOKEN, so the transport token
+    // must land there — the session token can be read-only for contents.
+    expect(envs[0]).toMatchObject({
+      GH_TOKEN: "github_pat_push_only",
+      GITHUB_TOKEN: "github_pat_push_only",
+      GIT_CONFIG_VALUE_1: "!gh auth git-credential",
+    });
   });
 });

--- a/packages/core/opensession-server/src/server/git-status.ts
+++ b/packages/core/opensession-server/src/server/git-status.ts
@@ -12,6 +12,7 @@
  * inside the session's sandbox. Omitted = the host path, unchanged.
  */
 import { $ } from "bun";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import { audited } from "./audit";
 import { personaName } from "./config";
 import { isSharedCheckoutDir } from "./worktree";
@@ -99,7 +100,11 @@ export function gitCredentialEnvForExec(
   if (!env) return undefined;
   if (exec?.remote) return undefined;
   if (!exec?.sandboxed) return env;
-  const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+  // `gh auth git-credential` answers from GH_TOKEN, so hand it the run's
+  // git-transport credential when one was injected — the session token can be
+  // read-only for repository contents in a split-credential deployment.
+  const token =
+    env[GITHUB_PUSH_TOKEN_RUN_ENV] || env.GH_TOKEN || env.GITHUB_TOKEN;
   if (!token) return undefined;
   return {
     GH_TOKEN: token,

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -32,6 +32,7 @@ import {
   startGithubDeviceFlow,
   validateGithubTokenLogin,
 } from "./github-auth";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import { botGhToken } from "./github-limit";
 import {
   ensureAutomationWebSession,
@@ -49,6 +50,7 @@ const ENV_KEYS = [
   "OPENSESSION_GITHUB_AUTH_STORE",
   GITHUB_RUN_AUTH_FILE_ENV,
   "OPENSESSION_GITHUB_PUSH_TOKEN",
+  GITHUB_PUSH_TOKEN_RUN_ENV,
   "OPENSESSION_WEB_SESSIONS_STORE",
   "KEYPAD_TOKEN",
 ] as const;
@@ -249,13 +251,11 @@ describe("token lookups + runner env", () => {
     seedToken();
     expect(githubRunEnv("Alice")).toMatchObject({
       GH_TOKEN: "gho_test123",
-      OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+      [GITHUB_PUSH_TOKEN_RUN_ENV]: "github_pat_push_only",
     });
     // An unconnected user resolves no session token; the push credential must
     // not turn that credential-free run into one that can push.
-    expect(githubRunEnv("Bob")).not.toHaveProperty(
-      "OPENSESSION_GITHUB_PUSH_TOKEN",
-    );
+    expect(githubRunEnv("Bob")).not.toHaveProperty(GITHUB_PUSH_TOKEN_RUN_ENV);
   });
 
   test("projected file carries the push credential to the remote run", () => {
@@ -264,13 +264,13 @@ describe("token lookups + runner env", () => {
       projected,
       JSON.stringify({
         GH_TOKEN: "ghu_remote123",
-        OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+        [GITHUB_PUSH_TOKEN_RUN_ENV]: "github_pat_push_only",
       }),
     );
     process.env[GITHUB_RUN_AUTH_FILE_ENV] = projected;
     expect(githubRunEnv("Alice")).toMatchObject({
       GH_TOKEN: "ghu_remote123",
-      OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+      [GITHUB_PUSH_TOKEN_RUN_ENV]: "github_pat_push_only",
     });
   });
 

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -48,6 +48,7 @@ const ENV_KEYS = [
   "OPENSESSION_GITHUB_CLIENT_ID",
   "OPENSESSION_GITHUB_AUTH_STORE",
   GITHUB_RUN_AUTH_FILE_ENV,
+  "OPENSESSION_GITHUB_PUSH_TOKEN",
   "OPENSESSION_WEB_SESSIONS_STORE",
   "KEYPAD_TOKEN",
 ] as const;
@@ -240,6 +241,37 @@ describe("token lookups + runner env", () => {
     expect(JSON.stringify(githubRunEnv("Alice"))).not.toContain(
       "must-not-be-read",
     );
+  });
+
+  test("run env carries the operator push credential only with a session token", () => {
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN = "github_pat_push_only";
+    enableFeature();
+    seedToken();
+    expect(githubRunEnv("Alice")).toMatchObject({
+      GH_TOKEN: "gho_test123",
+      OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+    });
+    // An unconnected user resolves no session token; the push credential must
+    // not turn that credential-free run into one that can push.
+    expect(githubRunEnv("Bob")).not.toHaveProperty(
+      "OPENSESSION_GITHUB_PUSH_TOKEN",
+    );
+  });
+
+  test("projected file carries the push credential to the remote run", () => {
+    const projected = join(dir, "run-github-auth.json");
+    writeFileSync(
+      projected,
+      JSON.stringify({
+        GH_TOKEN: "ghu_remote123",
+        OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+      }),
+    );
+    process.env[GITHUB_RUN_AUTH_FILE_ENV] = projected;
+    expect(githubRunEnv("Alice")).toMatchObject({
+      GH_TOKEN: "ghu_remote123",
+      OPENSESSION_GITHUB_PUSH_TOKEN: "github_pat_push_only",
+    });
   });
 
   test("connectedGithubAccounts never exposes tokens", () => {

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -51,6 +51,7 @@ import { audit } from "./audit";
 import { configuredIdentity, getConfig } from "./config";
 import { writeJsonAtomic } from "./shared/atomic-write";
 import { fetchWithTimeout } from "./shared/fetch-with-timeout";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import { githubGitCredentialEnv } from "./github-git-credential";
 
 /** Env override is for tests/sandboxes; read per call so it can change. */
@@ -874,14 +875,14 @@ function projectedGithubAuthEnv(): Record<string, string> {
     // The launcher projects the operator's git-transport credential alongside
     // the run token; a remote host has no ~/.opensession.env to read it from.
     const pushToken =
-      typeof parsed.OPENSESSION_GITHUB_PUSH_TOKEN === "string"
-        ? parsed.OPENSESSION_GITHUB_PUSH_TOKEN
+      typeof parsed[GITHUB_PUSH_TOKEN_RUN_ENV] === "string"
+        ? (parsed[GITHUB_PUSH_TOKEN_RUN_ENV] as string)
         : "";
     return token
       ? {
           GH_TOKEN: token,
           GITHUB_TOKEN: token,
-          ...(pushToken ? { OPENSESSION_GITHUB_PUSH_TOKEN: pushToken } : {}),
+          ...(pushToken ? { [GITHUB_PUSH_TOKEN_RUN_ENV]: pushToken } : {}),
         }
       : {};
   } catch {
@@ -897,7 +898,7 @@ function githubProcessEnv(
   return githubGitCredentialEnv(
     auth.GH_TOKEN || "",
     undefined,
-    auth.OPENSESSION_GITHUB_PUSH_TOKEN ||
+    auth[GITHUB_PUSH_TOKEN_RUN_ENV] ||
       process.env.OPENSESSION_GITHUB_PUSH_TOKEN,
   );
 }

--- a/packages/core/opensession-server/src/server/github-auth.ts
+++ b/packages/core/opensession-server/src/server/github-auth.ts
@@ -871,7 +871,19 @@ function projectedGithubAuthEnv(): Record<string, string> {
         : typeof parsed.GITHUB_TOKEN === "string"
           ? parsed.GITHUB_TOKEN
           : "";
-    return token ? { GH_TOKEN: token, GITHUB_TOKEN: token } : {};
+    // The launcher projects the operator's git-transport credential alongside
+    // the run token; a remote host has no ~/.opensession.env to read it from.
+    const pushToken =
+      typeof parsed.OPENSESSION_GITHUB_PUSH_TOKEN === "string"
+        ? parsed.OPENSESSION_GITHUB_PUSH_TOKEN
+        : "";
+    return token
+      ? {
+          GH_TOKEN: token,
+          GITHUB_TOKEN: token,
+          ...(pushToken ? { OPENSESSION_GITHUB_PUSH_TOKEN: pushToken } : {}),
+        }
+      : {};
   } catch {
     return {};
   }
@@ -882,7 +894,12 @@ function githubProcessEnv(
 ): Record<string, string> {
   // Empty authority still rewrites GitHub SSH remotes to non-interactive HTTPS.
   // A missing projected user token must fail closed, never inherit a host key.
-  return githubGitCredentialEnv(auth.GH_TOKEN || "");
+  return githubGitCredentialEnv(
+    auth.GH_TOKEN || "",
+    undefined,
+    auth.OPENSESSION_GITHUB_PUSH_TOKEN ||
+      process.env.OPENSESSION_GITHUB_PUSH_TOKEN,
+  );
 }
 
 /** Consume only the private run-scoped file projected by a remote launcher.

--- a/packages/core/opensession-server/src/server/github-git-credential.test.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.test.ts
@@ -25,6 +25,35 @@ describe("GitHub Git credential environment", () => {
     expect(env.GIT_CONFIG_VALUE_2).toBe("git@github.com:");
     expect(env.GIT_TERMINAL_PROMPT).toBe("0");
   });
+
+  test("carries the configured push credential next to a session token", () => {
+    const env = githubGitCredentialEnv(
+      "projected-token",
+      "!credential-helper",
+      "github_pat_push_only",
+    );
+    expect(env.OPENSESSION_GITHUB_PUSH_TOKEN).toBe("github_pat_push_only");
+    expect(env.GH_TOKEN).toBe("projected-token");
+  });
+
+  test("omits the push credential when none is configured", () => {
+    const env = githubGitCredentialEnv(
+      "projected-token",
+      "!credential-helper",
+      undefined,
+    );
+    expect(env).not.toHaveProperty("OPENSESSION_GITHUB_PUSH_TOKEN");
+  });
+
+  test("keeps a credential-free run credential-free despite a push token", () => {
+    const env = githubGitCredentialEnv(
+      "",
+      "!credential-helper",
+      "github_pat_push_only",
+    );
+    expect(env).not.toHaveProperty("OPENSESSION_GITHUB_PUSH_TOKEN");
+    expect(env.GH_TOKEN).toBe("");
+  });
 });
 
 describe("GitHub Git credential helper command", () => {

--- a/packages/core/opensession-server/src/server/github-git-credential.test.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import {
   githubCredentialHelperCommand,
   githubGitCredentialEnv,
@@ -32,7 +33,7 @@ describe("GitHub Git credential environment", () => {
       "!credential-helper",
       "github_pat_push_only",
     );
-    expect(env.OPENSESSION_GITHUB_PUSH_TOKEN).toBe("github_pat_push_only");
+    expect(env[GITHUB_PUSH_TOKEN_RUN_ENV]).toBe("github_pat_push_only");
     expect(env.GH_TOKEN).toBe("projected-token");
   });
 
@@ -42,7 +43,7 @@ describe("GitHub Git credential environment", () => {
       "!credential-helper",
       undefined,
     );
-    expect(env).not.toHaveProperty("OPENSESSION_GITHUB_PUSH_TOKEN");
+    expect(env).not.toHaveProperty(GITHUB_PUSH_TOKEN_RUN_ENV);
   });
 
   test("keeps a credential-free run credential-free despite a push token", () => {
@@ -51,7 +52,7 @@ describe("GitHub Git credential environment", () => {
       "!credential-helper",
       "github_pat_push_only",
     );
-    expect(env).not.toHaveProperty("OPENSESSION_GITHUB_PUSH_TOKEN");
+    expect(env).not.toHaveProperty(GITHUB_PUSH_TOKEN_RUN_ENV);
     expect(env.GH_TOKEN).toBe("");
   });
 });

--- a/packages/core/opensession-server/src/server/github-git-credential.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.ts
@@ -39,14 +39,21 @@ export function githubCredentialHelperCommand(
  * environment. Git receives only process-local helper and URL-rewrite config,
  * so existing SSH checkouts use the projected HTTPS identity without mutating
  * .git/config or falling through to a host SSH key.
+ *
+ * An operator-configured OPENSESSION_GITHUB_PUSH_TOKEN rides along so the
+ * credential helper answers git transport with it while API calls keep
+ * GH_TOKEN — but only next to a real session token: a run that carries no
+ * GitHub credential must stay credential-free.
  */
 export function githubGitCredentialEnv(
   token: string,
   helper = githubCredentialHelperCommand(),
+  pushToken = process.env.OPENSESSION_GITHUB_PUSH_TOKEN,
 ): Record<string, string> {
   return {
     GH_TOKEN: token,
     GITHUB_TOKEN: token,
+    ...(token && pushToken ? { OPENSESSION_GITHUB_PUSH_TOKEN: pushToken } : {}),
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_COUNT: "4",
     GIT_CONFIG_KEY_0: "credential.https://github.com.helper",

--- a/packages/core/opensession-server/src/server/github-git-credential.ts
+++ b/packages/core/opensession-server/src/server/github-git-credential.ts
@@ -2,6 +2,7 @@
 
 import { existsSync } from "fs";
 import { resolve } from "path";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 import { SHIM_PATH } from "../../../../../scripts/lib/paths";
 import { isCompiledBinary } from "../runner-host/exe";
 
@@ -40,10 +41,12 @@ export function githubCredentialHelperCommand(
  * so existing SSH checkouts use the projected HTTPS identity without mutating
  * .git/config or falling through to a host SSH key.
  *
- * An operator-configured OPENSESSION_GITHUB_PUSH_TOKEN rides along so the
- * credential helper answers git transport with it while API calls keep
- * GH_TOKEN — but only next to a real session token: a run that carries no
- * GitHub credential must stay credential-free.
+ * An operator-configured OPENSESSION_GITHUB_PUSH_TOKEN rides along — under
+ * the run-scoped name the credential helper reads — so git transport uses it
+ * while API calls keep GH_TOKEN. It rides only next to a real session token:
+ * a run that carries no GitHub credential must stay credential-free, and the
+ * distinct name keeps the operator's ambient variable inert in children that
+ * merely inherit the server's environment.
  */
 export function githubGitCredentialEnv(
   token: string,
@@ -53,7 +56,7 @@ export function githubGitCredentialEnv(
   return {
     GH_TOKEN: token,
     GITHUB_TOKEN: token,
-    ...(token && pushToken ? { OPENSESSION_GITHUB_PUSH_TOKEN: pushToken } : {}),
+    ...(token && pushToken ? { [GITHUB_PUSH_TOKEN_RUN_ENV]: pushToken } : {}),
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_COUNT: "4",
     GIT_CONFIG_KEY_0: "credential.https://github.com.helper",

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -101,6 +101,7 @@ import {
   toPiModel,
 } from "../../models";
 import { filterMcpServers } from "../../runner-shared";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../../../scripts/lib/github-credential";
 import { GITHUB_RUN_AUTH_FILE_ENV, githubAuthEnv } from "../../github-auth";
 import {
   appendTranscriptEntries,
@@ -2196,12 +2197,12 @@ function makeRemoteLauncher(
         // token — the remote host cannot read ~/.opensession.env. It rides
         // only with a real token, so credential-free runs stay that way.
         if (
-          !githubAuth.OPENSESSION_GITHUB_PUSH_TOKEN &&
+          !githubAuth[GITHUB_PUSH_TOKEN_RUN_ENV] &&
           process.env.OPENSESSION_GITHUB_PUSH_TOKEN
         )
           githubAuth = {
             ...githubAuth,
-            OPENSESSION_GITHUB_PUSH_TOKEN:
+            [GITHUB_PUSH_TOKEN_RUN_ENV]:
               process.env.OPENSESSION_GITHUB_PUSH_TOKEN,
           };
         await driver.writeFile(githubAuthPath, JSON.stringify(githubAuth));

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2192,6 +2192,18 @@ function makeRemoteLauncher(
       }
       const githubAuthPath = `${dir}/github-auth.json`;
       if (githubAuth.GH_TOKEN) {
+        // Project the operator's git-transport credential alongside the run
+        // token — the remote host cannot read ~/.opensession.env. It rides
+        // only with a real token, so credential-free runs stay that way.
+        if (
+          !githubAuth.OPENSESSION_GITHUB_PUSH_TOKEN &&
+          process.env.OPENSESSION_GITHUB_PUSH_TOKEN
+        )
+          githubAuth = {
+            ...githubAuth,
+            OPENSESSION_GITHUB_PUSH_TOKEN:
+              process.env.OPENSESSION_GITHUB_PUSH_TOKEN,
+          };
         await driver.writeFile(githubAuthPath, JSON.stringify(githubAuth));
         secureFiles.push(githubAuthPath);
       } else {

--- a/scripts/lib/github-credential.test.ts
+++ b/scripts/lib/github-credential.test.ts
@@ -1,10 +1,18 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { githubCredentialResponse } from "./github-credential";
 
+beforeEach(() => {
+  delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+});
+
 const savedToken = process.env.GH_TOKEN;
+const savedPushToken = process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
 afterEach(() => {
   if (savedToken === undefined) delete process.env.GH_TOKEN;
   else process.env.GH_TOKEN = savedToken;
+  if (savedPushToken === undefined)
+    delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+  else process.env.OPENSESSION_GITHUB_PUSH_TOKEN = savedPushToken;
 });
 
 describe("GitHub credential helper", () => {
@@ -22,6 +30,28 @@ describe("GitHub credential helper", () => {
         "get",
         "protocol=https\nhost=github.com\nusername=alice\n\n",
       ),
+    ).toBe("");
+  });
+
+  test("prefers the dedicated push credential over the session token", () => {
+    process.env.GH_TOKEN = "ghu_run_scoped";
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN = "github_pat_push_only";
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
+    ).toBe("username=x-access-token\npassword=github_pat_push_only\n");
+  });
+
+  test("answers with the session token when no push credential is configured", () => {
+    process.env.GH_TOKEN = "ghu_run_scoped";
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
+    ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
+  });
+
+  test("answers nothing for a credential-free run even with both unset", () => {
+    delete process.env.GH_TOKEN;
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
     ).toBe("");
   });
 

--- a/scripts/lib/github-credential.test.ts
+++ b/scripts/lib/github-credential.test.ts
@@ -1,18 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { githubCredentialResponse } from "./github-credential";
-
-beforeEach(() => {
-  delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
-});
+import {
+  GITHUB_PUSH_TOKEN_RUN_ENV,
+  githubCredentialResponse,
+} from "./github-credential";
 
 const savedToken = process.env.GH_TOKEN;
-const savedPushToken = process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+const savedRunPushToken = process.env[GITHUB_PUSH_TOKEN_RUN_ENV];
+const savedOperatorPushToken = process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+beforeEach(() => {
+  delete process.env[GITHUB_PUSH_TOKEN_RUN_ENV];
+  delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+});
 afterEach(() => {
   if (savedToken === undefined) delete process.env.GH_TOKEN;
   else process.env.GH_TOKEN = savedToken;
-  if (savedPushToken === undefined)
+  if (savedRunPushToken === undefined)
+    delete process.env[GITHUB_PUSH_TOKEN_RUN_ENV];
+  else process.env[GITHUB_PUSH_TOKEN_RUN_ENV] = savedRunPushToken;
+  if (savedOperatorPushToken === undefined)
     delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
-  else process.env.OPENSESSION_GITHUB_PUSH_TOKEN = savedPushToken;
+  else process.env.OPENSESSION_GITHUB_PUSH_TOKEN = savedOperatorPushToken;
 });
 
 describe("GitHub credential helper", () => {
@@ -33,22 +40,38 @@ describe("GitHub credential helper", () => {
     ).toBe("");
   });
 
-  test("prefers the dedicated push credential over the session token", () => {
+  test("prefers the injected push credential over the session token", () => {
     process.env.GH_TOKEN = "ghu_run_scoped";
-    process.env.OPENSESSION_GITHUB_PUSH_TOKEN = "github_pat_push_only";
+    process.env[GITHUB_PUSH_TOKEN_RUN_ENV] = "github_pat_push_only";
     expect(
       githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
     ).toBe("username=x-access-token\npassword=github_pat_push_only\n");
   });
 
-  test("answers with the session token when no push credential is configured", () => {
+  test("answers with the session token when no push credential was injected", () => {
     process.env.GH_TOKEN = "ghu_run_scoped";
     expect(
       githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
     ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
   });
 
-  test("answers nothing for a credential-free run even with both unset", () => {
+  test("never answers from the operator's ambient variable", () => {
+    // A credential-free host git call inherits the server's whole environment
+    // ({...process.env, ...operationEnv}) — including the operator's
+    // OPENSESSION_GITHUB_PUSH_TOKEN from ~/.opensession.env. Only the
+    // run-scoped name, set exclusively by explicit injection, may answer.
+    delete process.env.GH_TOKEN;
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN = "github_pat_push_only";
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
+    ).toBe("");
+    process.env.GH_TOKEN = "ghu_run_scoped";
+    expect(
+      githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),
+    ).toBe("username=x-access-token\npassword=ghu_run_scoped\n");
+  });
+
+  test("answers nothing for a credential-free run with both unset", () => {
     delete process.env.GH_TOKEN;
     expect(
       githubCredentialResponse("get", "protocol=https\nhost=github.com\n\n"),

--- a/scripts/lib/github-credential.ts
+++ b/scripts/lib/github-credential.ts
@@ -2,10 +2,13 @@
  * Git credential helper for github.com remotes.
  *
  * Registered per checkout by setup-repos.ts and reached through the stable
- * `opensession github-credential` command. It answers only from GH_TOKEN in
- * this process. Trusted interactive runs and explicit server-side Git calls
- * inject that value; unattended runs receive neither the token nor a way to
- * resolve one from the server-side account store.
+ * `opensession github-credential` command. It answers only from this
+ * process's environment: OPENSESSION_GITHUB_PUSH_TOKEN when the operator
+ * configured a dedicated git-transport credential, otherwise GH_TOKEN. The
+ * split lets git clone/pull/push run as a push-scoped identity while API
+ * calls (gh, octokit) keep GH_TOKEN. Trusted interactive runs and explicit
+ * server-side Git calls inject those values; unattended runs receive neither
+ * a token nor a way to resolve one from the server-side account store.
  */
 
 export function githubCredentialResponse(
@@ -22,7 +25,8 @@ export function githubCredentialResponse(
   }
   if (attrs.protocol !== "https" || attrs.host !== "github.com") return "";
 
-  const token = process.env.GH_TOKEN;
+  const token =
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN || process.env.GH_TOKEN;
   return token ? `username=x-access-token\npassword=${token}\n` : "";
 }
 

--- a/scripts/lib/github-credential.ts
+++ b/scripts/lib/github-credential.ts
@@ -3,13 +3,20 @@
  *
  * Registered per checkout by setup-repos.ts and reached through the stable
  * `opensession github-credential` command. It answers only from this
- * process's environment: OPENSESSION_GITHUB_PUSH_TOKEN when the operator
- * configured a dedicated git-transport credential, otherwise GH_TOKEN. The
- * split lets git clone/pull/push run as a push-scoped identity while API
- * calls (gh, octokit) keep GH_TOKEN. Trusted interactive runs and explicit
- * server-side Git calls inject those values; unattended runs receive neither
- * a token nor a way to resolve one from the server-side account store.
+ * process's environment: the run-scoped git-transport credential when one was
+ * injected, otherwise GH_TOKEN. The split lets git clone/pull/push run as a
+ * push-scoped identity while API calls (gh, octokit) keep GH_TOKEN. Trusted
+ * interactive runs and explicit server-side Git calls inject those values;
+ * unattended runs receive neither a token nor a way to resolve one from the
+ * server-side account store.
  */
+
+/** Child-env name for the injected git-transport credential. Deliberately not
+ * the operator's OPENSESSION_GITHUB_PUSH_TOKEN: children inherit the server's
+ * environment wholesale, so the operator's variable must stay inert in a run
+ * that was never explicitly handed a credential. Only githubGitCredentialEnv
+ * and the remote launcher's projected auth file set this name. */
+export const GITHUB_PUSH_TOKEN_RUN_ENV = "OPENSESSION_GITHUB_RUN_PUSH_TOKEN";
 
 export function githubCredentialResponse(
   action: string | undefined,
@@ -25,8 +32,7 @@ export function githubCredentialResponse(
   }
   if (attrs.protocol !== "https" || attrs.host !== "github.com") return "";
 
-  const token =
-    process.env.OPENSESSION_GITHUB_PUSH_TOKEN || process.env.GH_TOKEN;
+  const token = process.env[GITHUB_PUSH_TOKEN_RUN_ENV] || process.env.GH_TOKEN;
   return token ? `username=x-access-token\npassword=${token}\n` : "";
 }
 


### PR DESCRIPTION
## Summary

Opt-in split between the credential used for git transport and the one used for API operations. When `OPENSESSION_GITHUB_PUSH_TOKEN` is set in `~/.opensession.env`, the git credential helper answers clone/pull/push with it; `gh` and API calls keep the run's session token. Unset, behavior is unchanged. Runs that carry no GitHub credential continue to receive none.

Lets deployments follow a least-privilege pattern where the identity-bearing session token holds no repository-write permission and a narrowly scoped credential carries transport — documented in `docs/setup/github.md` along with the threat-model note.

## Changes

- `scripts/lib/github-credential.ts` — helper prefers `OPENSESSION_GITHUB_PUSH_TOKEN` over `GH_TOKEN` for git's `get`
- `github-git-credential.ts` — child env includes the push token only when a session token is present
- `github-auth.ts` / `sandbox/adapters/bootstrap.ts` — push token flows through projected auth for remote sandbox runs
- `opensession.ts` — boot log line stating which transport-credential mode is active
- Tests for helper preference, fallback, and no-credential runs staying credential-free

## Review notes

- With a push token configured, pushes attribute to the token's owner; PR authorship and reviews keep the session identity.
- The projected auth file carries the push token to remote sandbox hosts (0600, same handling as run tokens).
- The helper prefers the push token unconditionally; the only-alongside-a-session-token guard is enforced at injection time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)