### PR TITLE
Split-credential deployments: keep App write mints viable, drop gh's ambient identity fallback

### DIFF
--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -30,6 +30,7 @@ import {
   GITHUB_APP_CODE_PERMISSIONS as CODE_PERMISSIONS,
   GITHUB_APP_READ_PERMISSIONS as READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS as WRITE_PERMISSIONS,
+  githubAppMintPermissions,
 } from "../shared/github-app-permissions";
 
 let keyPathOverride: string | undefined;
@@ -300,7 +301,9 @@ export async function githubAppInstallationToken(
         method: "POST",
         headers,
         body: JSON.stringify({
-          permissions: opts.write ? WRITE_PERMISSIONS : READ_PERMISSIONS,
+          permissions: githubAppMintPermissions(
+            opts.write ? WRITE_PERMISSIONS : READ_PERMISSIONS,
+          ),
         }),
       },
     );
@@ -531,7 +534,7 @@ export async function githubAppRepositoryToken(
           repositories: [repo],
           // Trusted repository code runs can push/reply and inspect the
           // failing checks and Actions logs they are expected to repair.
-          permissions: CODE_PERMISSIONS,
+          permissions: githubAppMintPermissions(CODE_PERMISSIONS),
         }),
       },
     );

--- a/packages/core/opensession-server/src/server/pi-runner.test.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.test.ts
@@ -1309,6 +1309,20 @@ describe("local-tool path containment", () => {
   );
 });
 
+test("host runs never resolve the operator's ambient gh identity", () => {
+  const env = piBashHomeEnv({
+    runKey: "run/unsafe",
+    scratchDir: "/scratch/session",
+    isolated: false,
+    hostHome: "/Users/operator",
+  });
+  expect(env.HOME).toBe("/Users/operator");
+  // gh answers from GH_TOKEN when a credential was injected; without one it
+  // must fail "not logged in" rather than act as whatever identity the host's
+  // ~/.config/gh/hosts.yml holds.
+  expect(env.GH_CONFIG_DIR).toBe("/scratch/session/gh-config-run_unsafe");
+});
+
 test("automation descendants receive an isolated CLI home", () => {
   expect(
     piBashHomeEnv({

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -1389,8 +1389,18 @@ export function piBashHomeEnv(input: {
   isolated: boolean;
   hostHome?: string;
 }): Record<string, string> {
-  if (!input.isolated) return input.hostHome ? { HOME: input.hostHome } : {};
-  const home = `${input.scratchDir || "/tmp"}/automation-home-${input.runKey.replace(/[^A-Za-z0-9_-]/g, "_")}`;
+  const key = input.runKey.replace(/[^A-Za-z0-9_-]/g, "_");
+  if (!input.isolated)
+    return {
+      ...(input.hostHome ? { HOME: input.hostHome } : {}),
+      // Without GH_TOKEN in its env, gh resolves whatever identity the host's
+      // ~/.config/gh/hosts.yml holds. A run must never inherit that ambient
+      // login: a run-scoped config dir makes a credential-free run fail with
+      // a clear "not logged in" instead of silently acting as the host
+      // operator — the same fail-closed posture server-owned gh calls have.
+      GH_CONFIG_DIR: `${input.scratchDir || "/tmp"}/gh-config-${key}`,
+    };
+  const home = `${input.scratchDir || "/tmp"}/automation-home-${key}`;
   return {
     HOME: home,
     XDG_CONFIG_HOME: `${home}/.config`,
@@ -2150,6 +2160,8 @@ async function* runPiAttempt(
     });
     if (opts.publicationPolicy && homeEnv.HOME)
       mkdirSync(homeEnv.HOME, { recursive: true, mode: 0o700 });
+    if (homeEnv.GH_CONFIG_DIR)
+      mkdirSync(homeEnv.GH_CONFIG_DIR, { recursive: true, mode: 0o700 });
     const bashEnv: Record<string, string> = {
       ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
       ...homeEnv,

--- a/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.test.ts
@@ -10,6 +10,7 @@ import {
   GITHUB_APP_GRANT_PERMISSIONS,
   GITHUB_APP_READ_PERMISSIONS,
   GITHUB_APP_WRITE_PERMISSIONS,
+  githubAppMintPermissions,
 } from "./github-app-permissions";
 
 /** A mint scope is covered when the grant holds the same key at an access level
@@ -65,5 +66,42 @@ describe("github app permission sets", () => {
     // App without them granted would otherwise reject the whole write token.
     expect(GITHUB_APP_WRITE_PERMISSIONS.checks).toBeUndefined();
     expect(GITHUB_APP_WRITE_PERMISSIONS.statuses).toBeUndefined();
+  });
+
+  test("with a git-transport credential, no mint requests contents:write", () => {
+    // Split-credential deployments cap the installation at contents:read.
+    // All-or-nothing minting means one over-requested scope fails the whole
+    // token — reviews and comments included, not just pushes.
+    expect(
+      githubAppMintPermissions(GITHUB_APP_WRITE_PERMISSIONS, true),
+    ).toEqual({
+      pull_requests: "write",
+      issues: "write",
+      contents: "read",
+      metadata: "read",
+    });
+    expect(githubAppMintPermissions(GITHUB_APP_CODE_PERMISSIONS, true)).toEqual(
+      {
+        pull_requests: "write",
+        issues: "write",
+        contents: "read",
+        metadata: "read",
+        actions: "read",
+        checks: "read",
+        statuses: "read",
+      },
+    );
+    expect(githubAppMintPermissions(GITHUB_APP_READ_PERMISSIONS, true)).toEqual(
+      GITHUB_APP_READ_PERMISSIONS,
+    );
+  });
+
+  test("without a git-transport credential, the mint sets pass through unchanged", () => {
+    expect(githubAppMintPermissions(GITHUB_APP_WRITE_PERMISSIONS, false)).toBe(
+      GITHUB_APP_WRITE_PERMISSIONS,
+    );
+    expect(githubAppMintPermissions(GITHUB_APP_CODE_PERMISSIONS, false)).toBe(
+      GITHUB_APP_CODE_PERMISSIONS,
+    );
   });
 });

--- a/packages/core/opensession-server/src/shared/github-app-permissions.ts
+++ b/packages/core/opensession-server/src/shared/github-app-permissions.ts
@@ -11,6 +11,14 @@
  * A mint is all-or-nothing: it succeeds only if every requested scope is a
  * subset of what the installation holds. So each mint set below is a strict
  * subset of the grant set, and the grant set is what the create URL requests.
+ *
+ * Split-credential deployments (docs/setup/github.md, "Separate git-transport
+ * credential") cap the installation itself at contents:read: git transport
+ * rides the dedicated push credential, so App tokens never push. Because
+ * mints are all-or-nothing, a write mint still requesting contents:write
+ * against that capped installation would 422 and take every App write
+ * operation down with it — githubAppMintPermissions() below narrows the
+ * request instead.
  */
 
 /** The full set the App is granted at creation — the create-URL permission
@@ -19,7 +27,7 @@ export const GITHUB_APP_GRANT_PERMISSIONS: Record<string, string> = {
   actions: "read", // workflow runs/logs for trusted autofix diagnosis
   checks: "read", // CI check runs
   statuses: "read", // commit statuses, the other half of the status rollup
-  contents: "write", // push fixes, clone
+  contents: "write", // clone; pushes only while git transport rides App tokens
   pull_requests: "write", // reviews, comments, open/merge
   issues: "write", // issue and PR comments
   members: "read", // team roster / attribution
@@ -70,3 +78,18 @@ export const GITHUB_APP_CODE_PERMISSIONS: Record<string, string> = {
   checks: "read",
   statuses: "read",
 };
+
+/** The set a mint actually requests. With a dedicated git-transport
+ * credential configured, git pushes never ride App tokens, so no mint asks
+ * for contents:write — which also keeps write mints viable against an
+ * installation the operator capped at contents:read (all-or-nothing: the
+ * over-request would fail the whole token, reviews and comments included).
+ * Without the split, the sets pass through unchanged and code workflows keep
+ * pushing with the App token. */
+export function githubAppMintPermissions(
+  set: Record<string, string>,
+  pushCredentialConfigured = Boolean(process.env.OPENSESSION_GITHUB_PUSH_TOKEN),
+): Record<string, string> {
+  if (!pushCredentialConfigured || set.contents !== "write") return set;
+  return { ...set, contents: "read" };
+}


### PR DESCRIPTION
Two fixes for split-credential deployments (docs/setup/github.md, "Separate git-transport credential").

**App mints never request contents:write under the split.** Installation-token mints are all-or-nothing: one scope above what the installation holds fails the entire token. A split-credential deployment caps the installation at contents:read, so a write/code mint still requesting contents:write 422s and takes every App write operation down with it — review submission and PR comments included, not just pushes. With the git-transport credential configured, pushes never ride App tokens, so `githubAppMintPermissions()` narrows `contents` to read in every mint request. Unconfigured deployments are untouched: the sets pass through unchanged and code workflows keep pushing with the App token.

**Host runs get a run-scoped `GH_CONFIG_DIR`.** Without `GH_TOKEN` in its environment, `gh` resolves whatever identity the host's `~/.config/gh/hosts.yml` holds, so a run turn that carries no injected GitHub credential silently acts as the host operator's login — with whatever scopes that login happens to have — producing confusing permission errors instead of failing closed. Isolated automation homes already point `GH_CONFIG_DIR` into run scratch; host runs now do the same, so a credential-free run fails with a clear "not logged in" while injected tokens keep working (env `GH_TOKEN` takes precedence over `hosts.yml`).

Regression tests: mint sets under the split cap at `contents:read` (write and code) while the read set and unconfigured deployments are unchanged; host-run bash env resolves no ambient gh identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioQmE91ZTAfnobuTeMD5L
