### PR TITLE
Review label forces a re-review of an already-reviewed head

### DIFF
--- a/packages/core/opensession-server/src/agents/github/webhook.ts
+++ b/packages/core/opensession-server/src/agents/github/webhook.ts
@@ -370,15 +370,17 @@ export async function handleGithubPrEvent(
 
 export async function fireReview(
   ref: PrRef,
-  _byLabel: boolean,
+  byLabel: boolean,
   preflightDetails?: PrAutomationDetails,
 ): Promise<ReviewResult | null> {
   const { config } = resolveReviewConfig();
+  // A label is an explicit human ask: force so an already-reviewed head is
+  // re-reviewed instead of dedup-skipped.
   const result = await runReview(
     ref,
     config,
     onSessionInvalidate,
-    false,
+    byLabel,
     undefined,
     preflightDetails,
   ).catch((e) => {


### PR DESCRIPTION
\`fireReview\` receives the label flag but drops it (\`_byLabel\` unused) and hardcodes \`force: false\` into \`runReview\`. Labeling a PR whose head SHA is already in \`reviewedShas\` therefore logs "already reviewed" and does nothing — the explicit re-review path can never deliver a re-review. One-line fix: pass the flag through as \`force\`. Automatic paths (\`synchronize\`, reconcile, preflight) still pass \`false\`, so dedup and push-debounce behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioQmE91ZTAfnobuTeMD5L