### PR TITLE
Give review handoff fix rounds a repo-scoped GitHub credential

### DIFF
--- a/packages/core/opensession-server/src/agents/github/handoff.ts
+++ b/packages/core/opensession-server/src/agents/github/handoff.ts
@@ -159,6 +159,9 @@ export async function maybeHandoffFindings(
     const res = await control.deliverToSession(target.id, message, "GitHub", {
       busy: "queue",
       reviewHandoff: true,
+      // The fix round pushes and replies against THIS PR's repository, which
+      // may be one attached to the target session rather than its primary.
+      githubFixRoundRepo: repoFull,
       deliveryId: `github-handoff:${repoFull}:${pr.number}:${sha}:${round}`,
     });
     if (res.status === "error") {

--- a/packages/core/opensession-server/src/runner-host/host.ts
+++ b/packages/core/opensession-server/src/runner-host/host.ts
@@ -602,7 +602,7 @@ try {
     accountStrict: spec.accountStrict,
     usageCredits: spec.usageCredits,
     prReviewer: spec.prReviewer,
-    githubFixRound: spec.githubFixRound,
+    githubFixRoundRepo: spec.githubFixRoundRepo,
     journal: {
       ...(spec.lifecycle === "auxiliary"
         ? {}

--- a/packages/core/opensession-server/src/runner-host/host.ts
+++ b/packages/core/opensession-server/src/runner-host/host.ts
@@ -602,6 +602,7 @@ try {
     accountStrict: spec.accountStrict,
     usageCredits: spec.usageCredits,
     prReviewer: spec.prReviewer,
+    githubFixRound: spec.githubFixRound,
     journal: {
       ...(spec.lifecycle === "auxiliary"
         ? {}

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -105,11 +105,13 @@ export interface RunAgentOpts {
   /** Ephemeral GitHub capability for a narrowly scoped trusted GitHub code run.
    * Never persist this value in a host spec, journal, or session file. */
   githubEnv?: Record<string, string>;
-  /** This code-mode turn is a review/handoff fix round in an owning
-   * interactive session: resolve the repo-scoped App credential
-   * (githubCodeRunEnv) so it can push fixes and reply in review threads, even
-   * though its auto-continue sender resolves no session user token. */
-  githubFixRound?: boolean;
+  /** `owner/name` of the PR a review/handoff fix round targets. Presence marks
+   * this code-mode turn a fix round: resolve the repo-scoped App credential
+   * for this repository (githubServiceCredentialEnv) so it can push fixes and
+   * reply in review threads, even though its auto-continue sender resolves no
+   * session user token. The repository may be one attached to the session, not
+   * its primary, so the credential binds to this id rather than the cwd. */
+  githubFixRoundRepo?: string;
   /** Session-scoped scratch dir (session-scratch.ts). runAgent ensures it for
    *  any run with an osSessionId; engines export it (pi sets TMPDIR +
    *  OPENSESSION_SCRATCH in the bash env) and the run instructions name it,

--- a/packages/core/opensession-server/src/server/agent-runner.ts
+++ b/packages/core/opensession-server/src/server/agent-runner.ts
@@ -105,6 +105,11 @@ export interface RunAgentOpts {
   /** Ephemeral GitHub capability for a narrowly scoped trusted GitHub code run.
    * Never persist this value in a host spec, journal, or session file. */
   githubEnv?: Record<string, string>;
+  /** This code-mode turn is a review/handoff fix round in an owning
+   * interactive session: resolve the repo-scoped App credential
+   * (githubCodeRunEnv) so it can push fixes and reply in review threads, even
+   * though its auto-continue sender resolves no session user token. */
+  githubFixRound?: boolean;
   /** Session-scoped scratch dir (session-scratch.ts). runAgent ensures it for
    *  any run with an osSessionId; engines export it (pi sets TMPDIR +
    *  OPENSESSION_SCRATCH in the bash env) and the run instructions name it,

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -244,6 +244,9 @@ export interface HostedRunOpts {
    *  automation-owned sessions, defaults to interactive. */
   trustProfile?: "interactive" | "automation";
   journalKind?: string;
+  /** Review/handoff fix round: earn the repo-scoped App credential in the
+   *  host even though the auto-continue sender resolves no user token. */
+  githubFixRound?: boolean;
   firstJournaledAt?: string;
   resumeAttempts?: number;
   lastResumeAt?: string;
@@ -433,6 +436,7 @@ async function* runAgentInProcess(
     accountStrict: opts.accountStrict,
     usageCredits: opts.usageCredits,
     prReviewer: opts.prReviewer,
+    githubFixRound: opts.githubFixRound,
     journal: {
       ...(lifecycle === "auxiliary" ? {} : { osSessionId: opts.osSessionId }),
       kind: opts.journalKind || "prompt",
@@ -626,6 +630,7 @@ async function spawnHostRun(
     prReviewer: opts.prReviewer,
     trustProfile: opts.trustProfile,
     journalKind: opts.journalKind,
+    githubFixRound: opts.githubFixRound,
     firstJournaledAt: opts.firstJournaledAt || new Date().toISOString(),
     resumeAttempts: opts.resumeAttempts,
     lastResumeAt: opts.lastResumeAt,

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -244,9 +244,10 @@ export interface HostedRunOpts {
    *  automation-owned sessions, defaults to interactive. */
   trustProfile?: "interactive" | "automation";
   journalKind?: string;
-  /** Review/handoff fix round: earn the repo-scoped App credential in the
-   *  host even though the auto-continue sender resolves no user token. */
-  githubFixRound?: boolean;
+  /** `owner/name` of the PR a review/handoff fix round targets. Presence earns
+   *  the repo-scoped App credential for that repo in the host, even though the
+   *  auto-continue sender resolves no user token. */
+  githubFixRoundRepo?: string;
   firstJournaledAt?: string;
   resumeAttempts?: number;
   lastResumeAt?: string;
@@ -436,7 +437,7 @@ async function* runAgentInProcess(
     accountStrict: opts.accountStrict,
     usageCredits: opts.usageCredits,
     prReviewer: opts.prReviewer,
-    githubFixRound: opts.githubFixRound,
+    githubFixRoundRepo: opts.githubFixRoundRepo,
     journal: {
       ...(lifecycle === "auxiliary" ? {} : { osSessionId: opts.osSessionId }),
       kind: opts.journalKind || "prompt",
@@ -630,7 +631,7 @@ async function spawnHostRun(
     prReviewer: opts.prReviewer,
     trustProfile: opts.trustProfile,
     journalKind: opts.journalKind,
-    githubFixRound: opts.githubFixRound,
+    githubFixRoundRepo: opts.githubFixRoundRepo,
     firstJournaledAt: opts.firstJournaledAt || new Date().toISOString(),
     resumeAttempts: opts.resumeAttempts,
     lastResumeAt: opts.lastResumeAt,

--- a/packages/core/opensession-server/src/server/pi-runner.test.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.test.ts
@@ -8,7 +8,15 @@
  * A real engine turn is covered by the smoke harness
  * (POST /api/admin/pi-smoke) against a live bridge, not unit tests.
  */
-import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -30,6 +38,7 @@ import {
   makeGuardedToolOps,
   makePiBashTool,
   parsePiModel,
+  githubFixRoundEnv,
   piBashHomeEnv,
   piAssistantTranscriptEntries,
   PI_STATE_DIR,
@@ -1307,6 +1316,44 @@ describe("local-tool path containment", () => {
       expect(res.content[0]?.text).toContain("needle-inside");
     },
   );
+});
+
+describe("githubFixRoundEnv (review/handoff fix-round credential)", () => {
+  const savedAuthFile = process.env.OPENSESSION_GITHUB_RUN_AUTH_FILE;
+  const fixRoundDirs: string[] = [];
+  afterEach(() => {
+    if (savedAuthFile === undefined)
+      delete process.env.OPENSESSION_GITHUB_RUN_AUTH_FILE;
+    else process.env.OPENSESSION_GITHUB_RUN_AUTH_FILE = savedAuthFile;
+    for (const dir of fixRoundDirs.splice(0))
+      rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mints nothing without a target repository", async () => {
+    // A fix round binds to the PR's own repo id, never the run cwd. With no
+    // repo it must resolve nothing rather than silently minting for a cwd repo.
+    delete process.env.OPENSESSION_GITHUB_RUN_AUTH_FILE;
+    expect(await githubFixRoundEnv("")).toEqual({});
+  });
+
+  test("a remote run consumes its projected credential file, not a fresh mint", async () => {
+    // On a Runner/sandbox the launcher writes the run's credential to a private
+    // file; the fix round reads THAT (repo-scoped, projected) rather than
+    // minting in-process, so remote fix rounds are credentialed too.
+    const dir = mkdtempSync(join(tmpdir(), "fixround-projected-"));
+    fixRoundDirs.push(dir);
+    const file = join(dir, "github-auth.json");
+    writeFileSync(
+      file,
+      JSON.stringify({
+        GH_TOKEN: "ghs_projected",
+        GITHUB_TOKEN: "ghs_projected",
+      }),
+    );
+    process.env.OPENSESSION_GITHUB_RUN_AUTH_FILE = file;
+    const env = await githubFixRoundEnv("tellahq/attached-repo");
+    expect(env.GH_TOKEN).toBe("ghs_projected");
+  });
 });
 
 test("host runs never resolve the operator's ambient gh identity", () => {

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -86,6 +86,7 @@ import {
   INTERACTIVE_KINDS,
   isUnattendedKind,
   baseJournalKind,
+  githubRunCredentialKind,
   runToolPolicy,
   readLocalInstructions,
 } from "./run-policy";
@@ -2015,18 +2016,25 @@ async function* runPiAttempt(
     const githubUserLogin = interactiveGithub
       ? githubUserLoginForRun(user || author?.name)
       : null;
-    // Only the dedicated GitHub code workflows may inject a service
-    // credential into an unattended run. Other automations remain credential-
-    // free even if a caller accidentally supplies githubEnv.
-    const githubCodeRun =
-      mode === "code" && baseJournalKind(journal?.kind).startsWith("github-");
-    const githubEnv = githubCodeRun
-      ? opts.githubEnv?.GH_TOKEN
-        ? opts.githubEnv
-        : await githubCodeRunEnv(cwd)
-      : interactiveGithub
-        ? githubRunEnv(user || author?.name)
-        : {};
+    // Which GitHub credential this run earns: the repo-scoped App credential
+    // for `github-*` code workflows and review/handoff fix rounds, the owner's
+    // own token for ordinary interactive turns, nothing for event automations.
+    // A dedicated github- code run may hand its pre-minted env in via
+    // opts.githubEnv; every other "code" case re-mints from the cwd.
+    const githubCred = githubRunCredentialKind({
+      mode,
+      kind: journal?.kind,
+      fixRound: opts.githubFixRound,
+      interactive: interactiveGithub,
+    });
+    const githubEnv =
+      githubCred === "code"
+        ? opts.githubEnv?.GH_TOKEN
+          ? opts.githubEnv
+          : await githubCodeRunEnv(cwd)
+        : githubCred === "user"
+          ? githubRunEnv(user || author?.name)
+          : {};
 
     const binding = await createPiRuntimeBinding({
       providerID: parsed.providerID,

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -179,6 +179,21 @@ export async function githubCodeRunEnv(
   return githubServiceCredentialEnv(repo.ghRepo);
 }
 
+/** Fresh authority for a review/handoff fix round, minted for the PR's own
+ * repository rather than the run cwd: a handoff can target a repo attached to
+ * the session, whose PR lives outside the primary worktree. The mint is
+ * owner-verified against the App installation (githubServiceCredentialEnv →
+ * githubAppRepositoryToken), so the repo id it binds to cannot escalate beyond
+ * what the App already reaches. Remote runners consume the projected file. */
+export async function githubFixRoundEnv(
+  ghRepo: string,
+): Promise<Record<string, string>> {
+  if (process.env[GITHUB_RUN_AUTH_FILE_ENV]) return projectedGithubRunEnv();
+  if (!ghRepo) return {};
+  const { githubServiceCredentialEnv } = await import("./github-app");
+  return githubServiceCredentialEnv(ghRepo);
+}
+
 /** State root: server-owned agentDir, per-unified-session pi session dirs,
  *  and the smoke-turn scratch cwd. Never ~/.pi. */
 export const PI_STATE_DIR = stateDir("pi");
@@ -2021,17 +2036,20 @@ async function* runPiAttempt(
     // own token for ordinary interactive turns, nothing for event automations.
     // A dedicated github- code run may hand its pre-minted env in via
     // opts.githubEnv; every other "code" case re-mints from the cwd.
+    const fixRoundRepo = opts.githubFixRoundRepo;
     const githubCred = githubRunCredentialKind({
       mode,
       kind: journal?.kind,
-      fixRound: opts.githubFixRound,
+      fixRound: Boolean(fixRoundRepo),
       interactive: interactiveGithub,
     });
     const githubEnv =
       githubCred === "code"
         ? opts.githubEnv?.GH_TOKEN
           ? opts.githubEnv
-          : await githubCodeRunEnv(cwd)
+          : fixRoundRepo
+            ? await githubFixRoundEnv(fixRoundRepo)
+            : await githubCodeRunEnv(cwd)
         : githubCred === "user"
           ? githubRunEnv(user || author?.name)
           : {};

--- a/packages/core/opensession-server/src/server/queue-state.ts
+++ b/packages/core/opensession-server/src/server/queue-state.ts
@@ -72,6 +72,10 @@ export type QueueItem = {
   /** Review feedback must start its own turn after any user work already in
    * flight. Never batch it into that work or steer it mid-turn. */
   reviewHandoff?: boolean;
+  /** `owner/name` of the PR a review/handoff fix round targets — the drained
+   * turn mints the repo-scoped GitHub App credential for it so the fix round
+   * can push and reply in review threads. */
+  githubFixRoundRepo?: string;
   /** When the engine ACCEPTED this message as a steer (epoch ms). Set by
    * acceptQueuedSteer, read by the clients to show how long the fold-in has been
    * waiting. Acceptance is not delivery: the current tool or assistant message

--- a/packages/core/opensession-server/src/server/run-policy.test.ts
+++ b/packages/core/opensession-server/src/server/run-policy.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { githubAutomationKind, githubRunCredentialKind } from "./run-policy";
+
+describe("githubAutomationKind", () => {
+  test("matches the GitHub agent's github-* code workflow kinds", () => {
+    for (const kind of [
+      "github-review",
+      "github-autofix",
+      "github-simplify",
+      "github-mention",
+      "github-followup",
+      "github-adversarial",
+      "github-public-review",
+    ])
+      expect(githubAutomationKind(kind)).toBe(true);
+  });
+
+  test("ignores the recovery suffixes baseJournalKind strips", () => {
+    expect(githubAutomationKind("github-review-resume")).toBe(true);
+    expect(githubAutomationKind("github-autofix-rerun-fallback")).toBe(true);
+  });
+
+  test("does not match interactive or event-automation kinds", () => {
+    for (const kind of [
+      "prompt",
+      "goal",
+      "slack",
+      "linear",
+      "plain",
+      "automation",
+      undefined,
+    ])
+      expect(githubAutomationKind(kind)).toBe(false);
+  });
+});
+
+describe("githubRunCredentialKind", () => {
+  // (a) GitHub-automation code runs and review/handoff fix rounds earn the
+  // repo-scoped App credential.
+  test("github-* code workflows earn the repo-scoped App credential", () => {
+    expect(
+      githubRunCredentialKind({
+        mode: "code",
+        kind: "github-autofix",
+        interactive: false,
+      }),
+    ).toBe("code");
+  });
+
+  test("a review/handoff fix round earns the App credential despite an interactive kind", () => {
+    // The owning session is an interactive `prompt`, driven by auto-continue
+    // (no user token resolves), so without the fix-round mark it would fall to
+    // "user" and post as nobody. The mark lifts it to the App credential.
+    expect(
+      githubRunCredentialKind({
+        mode: "code",
+        kind: "prompt",
+        fixRound: true,
+        interactive: true,
+      }),
+    ).toBe("code");
+  });
+
+  // (b) Event-driven automations never receive the App credential.
+  test("event automations never receive the App credential", () => {
+    // Unattended event turns resolve nothing at all.
+    for (const kind of ["plain", "automation"])
+      expect(
+        githubRunCredentialKind({ mode: "code", kind, interactive: false }),
+      ).toBe("none");
+    // slack/linear are interactive kinds, so a mapped user still posts as
+    // themselves — but they must NEVER escalate to the repo-scoped App
+    // credential the way a fix round does.
+    for (const kind of ["slack", "linear"])
+      expect(
+        githubRunCredentialKind({ mode: "code", kind, interactive: true }),
+      ).not.toBe("code");
+    // A fix-round mark that somehow rode an event automation still cannot
+    // reach the App credential unless the run is genuinely code mode with the
+    // mark — an event automation carrying neither stays credential-free.
+    expect(
+      githubRunCredentialKind({
+        mode: "code",
+        kind: "plain",
+        interactive: false,
+      }),
+    ).toBe("none");
+  });
+
+  // (c) Ordinary interactive turns are unchanged: the owner's own token.
+  test("ordinary interactive turns keep the owner token", () => {
+    expect(
+      githubRunCredentialKind({
+        mode: "code",
+        kind: "prompt",
+        interactive: true,
+      }),
+    ).toBe("user");
+    expect(
+      githubRunCredentialKind({
+        mode: "ask",
+        kind: "prompt",
+        interactive: true,
+      }),
+    ).toBe("user");
+  });
+
+  test("a fix-round mark only earns the App credential in code mode", () => {
+    // An ask-mode review round reads threads but does not push; it stays on the
+    // interactive (user) path rather than minting a push-capable credential.
+    expect(
+      githubRunCredentialKind({
+        mode: "ask",
+        kind: "prompt",
+        fixRound: true,
+        interactive: true,
+      }),
+    ).toBe("user");
+  });
+});

--- a/packages/core/opensession-server/src/server/run-policy.ts
+++ b/packages/core/opensession-server/src/server/run-policy.ts
@@ -26,6 +26,45 @@ export function isUnattendedKind(base: string): boolean {
   return UNATTENDED_KINDS.has(base) || base.startsWith("github-");
 }
 
+/**
+ * Trusted GitHub-automation code runs that may carry a repo-scoped App
+ * credential (githubCodeRunEnv). These are the GitHub agent's own `github-*`
+ * code workflows — review, autofix, simplify, mention, followup, adversarial,
+ * public-review — every one launched as `github-<kind>` by the agent's runner.
+ * A predicate rather than an inline prefix test so the one credential-gating
+ * rule has a name and a test. Event-driven automations (slack/linear/plain/
+ * webhook intake) are deliberately absent and stay credential-free.
+ */
+export function githubAutomationKind(kind?: string): boolean {
+  return baseJournalKind(kind).startsWith("github-");
+}
+
+/** Which GitHub credential a run's child environment earns:
+ *  - "code": the repo-scoped App credential (githubCodeRunEnv) — for the
+ *    GitHub agent's `github-*` code workflows and for review/handoff fix
+ *    rounds (`fixRound`), which push fixes and reply in review threads;
+ *  - "user": the run owner's own token (githubRunEnv), for ordinary
+ *    interactive turns;
+ *  - "none": nothing — every unattended, event-driven automation
+ *    (slack/linear/plain/webhook intake) that is not one of the two above.
+ *  The App code credential is reserved for code-mode runs; it never reaches an
+ *  event automation, which carries neither a `github-*` kind nor a fix-round
+ *  mark. */
+export function githubRunCredentialKind(input: {
+  mode?: string;
+  kind?: string;
+  fixRound?: boolean;
+  /** interactiveGithub: a non-unattended run of an INTERACTIVE_KIND. */
+  interactive: boolean;
+}): "code" | "user" | "none" {
+  if (
+    input.mode === "code" &&
+    (githubAutomationKind(input.kind) || Boolean(input.fixRound))
+  )
+    return "code";
+  return input.interactive ? "user" : "none";
+}
+
 const POOL_WAIT_UNATTENDED_MS = Number(
   process.env.OPENSESSION_POOL_WAIT_MS || 10 * 60_000,
 );

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -1510,6 +1510,11 @@ async function drainQueueInner(sessionId: string): Promise<void> {
     const slackReplyTo = [...batch]
       .reverse()
       .find((m) => m.slackReplyTo)?.slackReplyTo;
+    // A review/handoff fix round enters the queue with this flag. The drained
+    // turn must carry the repo-scoped GitHub App credential so it can push
+    // fixes and reply in review threads — its auto-continue driver resolves no
+    // session user token.
+    const reviewHandoff = batch.some((m) => m.reviewHandoff);
     const sourceMessageIds = batch.flatMap((item) =>
       item.id ? [item.id] : [],
     );
@@ -1524,6 +1529,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
         slackReplyTo,
         promptEntryId,
         sourceMessageIds,
+        reviewHandoff,
       );
     } catch (e) {
       // The batch was already spliced out and persisted away — put it back at
@@ -2495,6 +2501,9 @@ export async function runSessionPrompt(
   slackReplyTo?: { channel: string; threadTs: string },
   promptEntryId?: string,
   sourceMessageIds?: string[],
+  /** This turn is a review/handoff fix round — carry the repo-scoped GitHub
+   *  App credential into the run so it can push fixes and reply in threads. */
+  reviewHandoff?: boolean,
 ): Promise<void> {
   // Any explicit new run lifts a user stop — the queue may drain again.
   stoppedSessions.delete(sessionId);
@@ -2563,6 +2572,7 @@ export async function runSessionPrompt(
       startToken,
       durablePromptEntryId,
       sourceMessageIds,
+      reviewHandoff,
     );
     // Sandboxes and non-standard runners may not create an active-run journal.
     // A completed turn is nevertheless a safe acknowledgement of its dispatch.
@@ -2599,6 +2609,7 @@ async function runSessionPromptInner(
   startToken?: string,
   promptEntryId?: string,
   sourceMessageIds?: string[],
+  reviewHandoff?: boolean,
 ): Promise<void> {
   const autoRetry = await retryAutoFallbackModel(sessionId);
   const session = findSession(sessionId);
@@ -3138,6 +3149,7 @@ async function runSessionPromptInner(
           accountId: session.accountId,
           trustProfile: isAutomationSession ? "automation" : "interactive",
           journalKind: "prompt",
+          githubFixRound: reviewHandoff,
           onAskUser: makeAskHandler(sessionId),
           onSteerFailed: (text) => requeueFailedSteer(session.id, text, user),
           fallbackInProcessMcp: () =>
@@ -3252,6 +3264,7 @@ async function runSessionPromptInner(
       // synthetic continuations such as worker reports and restart recovery.
       mcpGrantUser: runInputs.mcpGrantUser,
       journal: { osSessionId: session.id, kind: "prompt" },
+      githubFixRound: reviewHandoff,
       startToken,
       onAskUser: makeAskHandler(sessionId),
     })) {

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -1510,11 +1510,14 @@ async function drainQueueInner(sessionId: string): Promise<void> {
     const slackReplyTo = [...batch]
       .reverse()
       .find((m) => m.slackReplyTo)?.slackReplyTo;
-    // A review/handoff fix round enters the queue with this flag. The drained
-    // turn must carry the repo-scoped GitHub App credential so it can push
-    // fixes and reply in review threads — its auto-continue driver resolves no
-    // session user token.
-    const reviewHandoff = batch.some((m) => m.reviewHandoff);
+    // A review/handoff fix round enters the queue flagged, carrying the PR's
+    // own `owner/name` (which may be a repo attached to the session, not its
+    // primary). The drained turn must mint the repo-scoped GitHub App
+    // credential for THAT repo so it can push fixes and reply in review
+    // threads — its auto-continue driver resolves no session user token.
+    const githubFixRoundRepo = [...batch]
+      .reverse()
+      .find((m) => m.reviewHandoff && m.githubFixRoundRepo)?.githubFixRoundRepo;
     const sourceMessageIds = batch.flatMap((item) =>
       item.id ? [item.id] : [],
     );
@@ -1529,7 +1532,7 @@ async function drainQueueInner(sessionId: string): Promise<void> {
         slackReplyTo,
         promptEntryId,
         sourceMessageIds,
-        reviewHandoff,
+        githubFixRoundRepo,
       );
     } catch (e) {
       // The batch was already spliced out and persisted away — put it back at
@@ -1892,6 +1895,9 @@ export async function maybeLaunchSandboxedRun(
     deniedTools?: Record<string, string>;
     isAutomationSession: boolean;
     startToken?: string;
+    /** `owner/name` of the PR a review/handoff fix round targets — minted for
+     *  in the sandbox bootstrap so the turn can push fixes and reply. */
+    githubFixRoundRepo?: string;
   },
 ): Promise<
   | (AsyncGenerator<StreamEvent> & {
@@ -2185,6 +2191,7 @@ export async function maybeLaunchSandboxedRun(
       usageCredits: disposableAutomationResume
         ? owningAutomation?.usageCredits
         : undefined,
+      githubFixRoundRepo: opts.githubFixRoundRepo,
     };
     if (isAgentSessionCancelled(session.id, opts.startToken)) {
       unregisterRunToken(rpcToken);
@@ -2501,9 +2508,10 @@ export async function runSessionPrompt(
   slackReplyTo?: { channel: string; threadTs: string },
   promptEntryId?: string,
   sourceMessageIds?: string[],
-  /** This turn is a review/handoff fix round — carry the repo-scoped GitHub
-   *  App credential into the run so it can push fixes and reply in threads. */
-  reviewHandoff?: boolean,
+  /** `owner/name` of the PR a review/handoff fix round targets — carry the
+   *  repo-scoped GitHub App credential for it into the run so the turn can
+   *  push fixes and reply in threads. */
+  githubFixRoundRepo?: string,
 ): Promise<void> {
   // Any explicit new run lifts a user stop — the queue may drain again.
   stoppedSessions.delete(sessionId);
@@ -2572,7 +2580,7 @@ export async function runSessionPrompt(
       startToken,
       durablePromptEntryId,
       sourceMessageIds,
-      reviewHandoff,
+      githubFixRoundRepo,
     );
     // Sandboxes and non-standard runners may not create an active-run journal.
     // A completed turn is nevertheless a safe acknowledgement of its dispatch.
@@ -2609,7 +2617,7 @@ async function runSessionPromptInner(
   startToken?: string,
   promptEntryId?: string,
   sourceMessageIds?: string[],
-  reviewHandoff?: boolean,
+  githubFixRoundRepo?: string,
 ): Promise<void> {
   const autoRetry = await retryAutoFallbackModel(sessionId);
   const session = findSession(sessionId);
@@ -3033,6 +3041,7 @@ async function runSessionPromptInner(
     images,
     mcpServers: mcpServers ?? "all",
     user,
+    githubFixRoundRepo,
     reposNote: isAutomationSession
       ? undefined
       : await buildSessionNote(session, user),
@@ -3052,6 +3061,7 @@ async function runSessionPromptInner(
         deniedTools,
         isAutomationSession,
         startToken,
+        githubFixRoundRepo,
       });
 
   // Defensive guard: a session with an explicit runnable provider must never
@@ -3149,7 +3159,7 @@ async function runSessionPromptInner(
           accountId: session.accountId,
           trustProfile: isAutomationSession ? "automation" : "interactive",
           journalKind: "prompt",
-          githubFixRound: reviewHandoff,
+          githubFixRoundRepo,
           onAskUser: makeAskHandler(sessionId),
           onSteerFailed: (text) => requeueFailedSteer(session.id, text, user),
           fallbackInProcessMcp: () =>
@@ -3264,7 +3274,7 @@ async function runSessionPromptInner(
       // synthetic continuations such as worker reports and restart recovery.
       mcpGrantUser: runInputs.mcpGrantUser,
       journal: { osSessionId: session.id, kind: "prompt" },
-      githubFixRound: reviewHandoff,
+      githubFixRoundRepo,
       startToken,
       onAskUser: makeAskHandler(sessionId),
     })) {

--- a/packages/core/opensession-server/src/server/runner-session.ts
+++ b/packages/core/opensession-server/src/server/runner-session.ts
@@ -59,6 +59,9 @@ type RunnerLaunchOpts = {
   mcpServers?: McpScope;
   user?: string;
   reposNote?: string;
+  /** `owner/name` of the PR a review/handoff fix round targets — carried into
+   *  the Runner spec so the fix round mints the repo-scoped App credential. */
+  githubFixRoundRepo?: string;
   shouldCancel?: () => boolean;
 };
 
@@ -186,6 +189,9 @@ export async function maybeLaunchRunnerRun(
     fallbackModel: interactiveFallbackModel(session.model),
     journalKind: runInputs.isAutomationSession ? "automation" : "prompt",
     trustProfile: runInputs.isAutomationSession ? "automation" : "interactive",
+    githubFixRoundRepo: runInputs.isAutomationSession
+      ? undefined
+      : opts.githubFixRoundRepo,
   };
   if (!spec.rpcToken || !spec.wsToken)
     throw new Error(

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2179,16 +2179,25 @@ function makeRemoteLauncher(
         !githubAuth.GH_TOKEN &&
         (!automationProfile || githubCodeAutomation)
       ) {
-        // The sandbox origin is mutable by repository setup code. Bind service
-        // authority only to the server-owned repo id recorded at ensure time.
+        // A review/handoff fix round names the PR's own repository (possibly
+        // one attached to the session, not its primary). Otherwise bind to the
+        // server-owned repo id recorded at ensure time — the sandbox origin is
+        // mutable by repository setup code. Either way the mint is
+        // owner-verified against the App installation, so the id it names
+        // cannot reach a repository the App does not already hold.
         const repoId = readRemoteState(provider, sandboxId)?.repoId;
         const registeredRepo = repoId
           ? (await import("../../worktree")).getRepo(repoId)
           : undefined;
-        if (registeredRepo?.host !== "codestorage" && registeredRepo?.ghRepo) {
+        const ghRepo =
+          spec.githubFixRoundRepo ||
+          (registeredRepo?.host !== "codestorage"
+            ? registeredRepo?.ghRepo
+            : undefined);
+        if (ghRepo) {
           const { githubServiceCredentialEnv } =
             await import("../../github-app");
-          githubAuth = await githubServiceCredentialEnv(registeredRepo.ghRepo);
+          githubAuth = await githubServiceCredentialEnv(ghRepo);
         }
       }
       const githubAuthPath = `${dir}/github-auth.json`;

--- a/packages/core/opensession-server/src/server/session-control-wiring.ts
+++ b/packages/core/opensession-server/src/server/session-control-wiring.ts
@@ -332,6 +332,7 @@ registerSessionControl({
       busy: opts?.busy,
       hold: opts?.hold,
       reviewHandoff: opts?.reviewHandoff,
+      githubFixRoundRepo: opts?.githubFixRoundRepo,
       admissionKey: opts?.admissionKey,
       contextSessions: opts?.contextSessions,
       slackReplyTo: opts?.slackReplyTo,
@@ -416,6 +417,9 @@ registerSessionControl({
         slackReplyTo: opts?.slackReplyTo,
         ...(opts?.hold ? { hold: true } : {}),
         ...(opts?.reviewHandoff ? { reviewHandoff: true } : {}),
+        ...(opts?.githubFixRoundRepo
+          ? { githubFixRoundRepo: opts.githubFixRoundRepo }
+          : {}),
       };
 
       // A draining server accepts durable intake but must not steer it into an
@@ -453,6 +457,9 @@ registerSessionControl({
             contextSessions: opts?.contextSessions,
             ...(opts?.hold ? { hold: true } : {}),
             ...(opts?.reviewHandoff ? { reviewHandoff: true } : {}),
+            ...(opts?.githubFixRoundRepo
+              ? { githubFixRoundRepo: opts.githubFixRoundRepo }
+              : {}),
           });
           const steerResult = await prepareAndSteerQueuedPrompt({
             sessionId: id,

--- a/packages/core/opensession-server/src/server/session-control.ts
+++ b/packages/core/opensession-server/src/server/session-control.ts
@@ -242,6 +242,9 @@ export interface SessionControl {
       deliveryId?: string;
       /** Automated PR findings wait behind an active user turn and drain alone. */
       reviewHandoff?: boolean;
+      /** `owner/name` of the PR a review/handoff fix round targets, so the
+       *  drained turn mints the repo-scoped GitHub App credential for it. */
+      githubFixRoundRepo?: string;
       /** Stable identity included in the durable command payload. */
       admissionKey?: string;
       /** Trusted synchronous precondition checked inside the session lease. */

--- a/packages/core/opensession-server/src/server/workflow-sessions.ts
+++ b/packages/core/opensession-server/src/server/workflow-sessions.ts
@@ -492,10 +492,17 @@ export function createWorkflowSessionController(
       ]
         .filter(Boolean)
         .join("\n\n");
+      // `owner/name` from the PR URL: the fix round pushes and replies against
+      // this PR's repository, which may be attached to the session, not its
+      // primary. The mint stays owner-verified against the App installation.
+      const prRepo = current.prUrl.match(
+        /github\.com\/([^/]+\/[^/]+)\/pull\//,
+      )?.[1];
       return await control.deliverToSession(id, prompt, opts.user, {
         deliveryId: requestId,
         busy: "queue",
         reviewHandoff: true,
+        githubFixRoundRepo: prRepo,
       });
     },
 

--- a/packages/core/protocol/src/runner.ts
+++ b/packages/core/protocol/src/runner.ts
@@ -125,6 +125,11 @@ export interface RunHostSpec {
    *  automation's PR-review policy when its turn moves into a host. */
   prReviewer?: string;
   journalKind?: string;
+  /** This interactive turn is a review/handoff fix round: it must push fixes
+   *  and reply in review threads with the repo-scoped GitHub App credential,
+   *  not the (absent) session user token. The host re-mints from the cwd; no
+   *  token is ever serialized here. */
+  githubFixRound?: boolean;
   /** Durable restart-recovery lineage (see server/run-journal.ts). */
   firstJournaledAt?: string;
   resumeAttempts?: number;

--- a/packages/core/protocol/src/runner.ts
+++ b/packages/core/protocol/src/runner.ts
@@ -125,11 +125,13 @@ export interface RunHostSpec {
    *  automation's PR-review policy when its turn moves into a host. */
   prReviewer?: string;
   journalKind?: string;
-  /** This interactive turn is a review/handoff fix round: it must push fixes
-   *  and reply in review threads with the repo-scoped GitHub App credential,
-   *  not the (absent) session user token. The host re-mints from the cwd; no
-   *  token is ever serialized here. */
-  githubFixRound?: boolean;
+  /** `owner/name` of the PR a review/handoff fix round targets. Presence marks
+   *  the turn a fix round: it must push fixes and reply in review threads with
+   *  the repo-scoped GitHub App credential for THIS repository (which may be an
+   *  attached repo, not the session's primary), not the absent session user
+   *  token. The host mints the credential itself, owner-verified against the
+   *  App installation; no token is ever serialized here. */
+  githubFixRoundRepo?: string;
   /** Durable restart-recovery lineage (see server/run-journal.ts). */
   firstJournaledAt?: string;
   resumeAttempts?: number;


### PR DESCRIPTION
When an automatic PR review finishes with blocking findings, the findings are delivered into the live session that owns the PR branch so the agent that wrote the code fixes it in place, then pushes the fix and replies in the review threads.

Those fix-round turns run inside an interactive session and are driven by an automated continuation, so no session user token resolves — the turn reached `git` and `gh` with no GitHub credential, and the push and thread replies failed.

This marks the delivered fix round so its run earns the same repo-scoped, owner-verified App credential a dedicated `github-*` code run already gets (`githubCodeRunEnv`), minted inside the run host from the working directory so no token is serialized into a host spec.

The credential decision is now a named, tested predicate, `githubRunCredentialKind`, replacing the inline gate:
- repo-scoped App credential — `github-*` code workflows and code-mode fix rounds;
- the run owner's own token — ordinary interactive turns (unchanged);
- nothing — event-driven automations (slack/linear/plain/webhook intake), which carry neither a `github-*` kind nor a fix-round mark.

Regression tests (`run-policy.test.ts`) cover all three: fix-round and `github-*` code kinds resolve the App credential, ordinary interactive turns keep the owner token, and event-automation kinds never escalate to the App credential.

Note: the fix-round mark is a per-turn boolean threaded additively through the run dispatch and host spec — an unmarked run behaves exactly as before, so no other run kind changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioQmE91ZTAfnobuTeMD5L
