### PR TITLE
Resolve the session owner's credential for auto-continue turns

### DIFF
--- a/packages/core/opensession-server/src/server/auto-continue.test.ts
+++ b/packages/core/opensession-server/src/server/auto-continue.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { announcesNextAction } from "./auto-continue";
+import {
+  announcesNextAction,
+  AUTO_CONTINUE_USER,
+  githubCredentialUser,
+} from "./auto-continue";
 
 describe("announcesNextAction", () => {
   test("matches the observed bks-019f533e announce-then-stop tail", () => {
@@ -132,5 +136,23 @@ describe("announcesNextAction", () => {
   test("ignores empty and trivial tails", () => {
     expect(announcesNextAction("")).toBe(false);
     expect(announcesNextAction("Done.")).toBe(false);
+  });
+});
+
+describe("githubCredentialUser", () => {
+  test("a human sender resolves as themselves", () => {
+    expect(githubCredentialUser("Michiel", "Johnny")).toBe("Michiel");
+  });
+
+  test("the synthetic auto-continue sender must not shadow the session owner", () => {
+    // commitAuthorFor already falls back to the session owner for senderless
+    // and synthetic turns; the credential must follow the same identity.
+    expect(githubCredentialUser(AUTO_CONTINUE_USER, "Johnny")).toBe("Johnny");
+  });
+
+  test("a senderless turn falls back to the owner; no owner resolves nothing", () => {
+    expect(githubCredentialUser(undefined, "Johnny")).toBe("Johnny");
+    expect(githubCredentialUser(AUTO_CONTINUE_USER, undefined)).toBeUndefined();
+    expect(githubCredentialUser(undefined, undefined)).toBeUndefined();
   });
 });

--- a/packages/core/opensession-server/src/server/auto-continue.ts
+++ b/packages/core/opensession-server/src/server/auto-continue.ts
@@ -11,6 +11,22 @@
 /** Sentinel user for the auto-continue turn (also keys the one-nudge guard). */
 export const AUTO_CONTINUE_USER = "auto-continue";
 
+/**
+ * The identity a turn's GitHub credential resolves for: its sender, unless the
+ * sender is the synthetic auto-continue driver. "auto-continue" is a turn's
+ * sender, not a person — it must not shadow the session owner that
+ * commitAuthorFor already carries as the author fallback, or a nudged turn
+ * loses the owner credential every other turn in the session resolves. A turn
+ * with no resolvable owner still yields nothing.
+ */
+export function githubCredentialUser(
+  user?: string | null,
+  authorName?: string | null,
+): string | undefined {
+  if (user && user !== AUTO_CONTINUE_USER) return user;
+  return authorName || undefined;
+}
+
 export const AUTO_CONTINUE_PROMPT =
   "[auto-continue] Your previous turn ended by announcing a next step without " +
   "executing it. Continue now: perform the step you announced, and keep working " +

--- a/packages/core/opensession-server/src/server/github-auth.test.ts
+++ b/packages/core/opensession-server/src/server/github-auth.test.ts
@@ -33,6 +33,7 @@ import {
   validateGithubTokenLogin,
 } from "./github-auth";
 import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
+import { AUTO_CONTINUE_USER, githubCredentialUser } from "./auto-continue";
 import { botGhToken } from "./github-limit";
 import {
   ensureAutomationWebSession,
@@ -256,6 +257,24 @@ describe("token lookups + runner env", () => {
     // An unconnected user resolves no session token; the push credential must
     // not turn that credential-free run into one that can push.
     expect(githubRunEnv("Bob")).not.toHaveProperty(GITHUB_PUSH_TOKEN_RUN_ENV);
+  });
+
+  test("an auto-continue turn resolves the session owner's credential; automations still get nothing", () => {
+    enableFeature();
+    seedToken();
+    // A drained nudge/handoff turn is sent by the synthetic auto-continue
+    // driver while the commit author carries the session owner. The
+    // credential follows the owner — the same token every other turn in the
+    // session resolves.
+    expect(
+      githubRunEnv(githubCredentialUser(AUTO_CONTINUE_USER, "Alice Example")),
+    ).toMatchObject({ GH_TOKEN: "gho_test123" });
+    // An automation-owned turn has no sender and a non-roster owner label, so
+    // it still resolves no token (and unattended journal kinds never reach
+    // the interactive credential path at all).
+    expect(
+      githubRunEnv(githubCredentialUser(undefined, "Nightly sweep")),
+    ).toMatchObject({ GH_TOKEN: "" });
   });
 
   test("projected file carries the push credential to the remote run", () => {

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -101,7 +101,10 @@ import {
   sessionStartContext,
 } from "./context-log";
 import { wrapContext } from "./prompt-context";
-import { EMPTY_REPLY_RETRY_PROMPT } from "./auto-continue";
+import {
+  EMPTY_REPLY_RETRY_PROMPT,
+  githubCredentialUser,
+} from "./auto-continue";
 import {
   bashAskPolicyReply,
   publicationPolicyDenyReason,
@@ -2012,8 +2015,12 @@ async function* runPiAttempt(
     const interactiveGithub =
       !policy.unattended &&
       INTERACTIVE_KINDS.has(baseJournalKind(journal?.kind));
+    // The sender, unless it is the synthetic auto-continue driver — the
+    // author fallback then names the session owner, whose credential this
+    // turn deserves like any other turn in the session.
+    const githubUser = githubCredentialUser(user, author?.name);
     const githubUserLogin = interactiveGithub
-      ? githubUserLoginForRun(user || author?.name)
+      ? githubUserLoginForRun(githubUser)
       : null;
     // Only the dedicated GitHub code workflows may inject a service
     // credential into an unattended run. Other automations remain credential-
@@ -2025,7 +2032,7 @@ async function* runPiAttempt(
         ? opts.githubEnv
         : await githubCodeRunEnv(cwd)
       : interactiveGithub
-        ? githubRunEnv(user || author?.name)
+        ? githubRunEnv(githubUser)
         : {};
 
     const binding = await createPiRuntimeBinding({

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -102,6 +102,7 @@ import {
 } from "../../models";
 import { filterMcpServers } from "../../runner-shared";
 import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../../../scripts/lib/github-credential";
+import { githubCredentialUser } from "../../auto-continue";
 import { GITHUB_RUN_AUTH_FILE_ENV, githubAuthEnv } from "../../github-auth";
 import {
   appendTranscriptEntries,
@@ -2170,7 +2171,7 @@ function makeRemoteLauncher(
       // every other automation stays credential-free.
       let githubAuth = automationProfile
         ? {}
-        : githubAuthEnv(spec.user || spec.author?.name);
+        : githubAuthEnv(githubCredentialUser(spec.user, spec.author?.name));
       const githubCodeAutomation =
         automationProfile &&
         spec.mode === "code" &&


### PR DESCRIPTION
A drained nudge or review-handoff turn is sent by the synthetic `auto-continue` driver. `commitAuthorFor` already resolves such senderless and synthetic turns to the session owner for commit attribution, but the GitHub credential lookup used `user || author?.name` — the truthy sentinel shadowed the owner, so the turn ran with no GitHub credential and its pushes and review-thread replies failed, in a session whose every other turn resolves the owner's token.

`githubCredentialUser()` gives the credential the same identity the commit author carries: the sender, unless it is the auto-continue sentinel, then the session owner. Applied at the three call sites that had the shadowing pattern (the pi runner's login and env resolution, and the sandbox bootstrap).

Scope: only the interactive credential path consults this — unattended and event-driven kinds never reach it and still resolve nothing, as does a turn whose owner is off the roster (an automation label). Regression tests cover the owner resolution for auto-continue turns and that automation turns still get nothing.

Simpler alternative to #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioQmE91ZTAfnobuTeMD5L
