### PR TITLE
Review only skips bot synchronize pushes from an in-flight code loop

### DIFF
--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -106,6 +106,12 @@ credential. API calls (`gh`, octokit tooling) keep `GH_TOKEN` unchanged, and a
 run that carries no GitHub credential still receives nothing. Unset, git
 transport uses the run's session token.
 
+With the push token set, every session push reaches GitHub as the bot account,
+so the PR webhook sees the bot as the `synchronize` sender. The review
+automation treats those pushes like human pushes; it only skips a bot-sender
+push while one of its own code loops (auto-fix, simplify, adversarial, or an
+@mention reply) is in flight on that PR.
+
 The hardened deployment this enables: cap the GitHub App at **Contents: read**
 so no App or user-to-server token can write repository contents, then mint a
 fine-grained PAT on the bot account with **Contents: read and write** — plus

--- a/packages/core/opensession-server/src/agents/github/webhook.test.ts
+++ b/packages/core/opensession-server/src/agents/github/webhook.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { skipBotSynchronize } from "./webhook";
+
+const base = {
+  senderIsBot: true,
+  action: "synchronize",
+  codeLockHeld: false,
+  autoFixActive: false,
+  handoffActive: false,
+};
+
+describe("bot-sender synchronize gate", () => {
+  // Regression (tella-fusion #6295, 2026-09-07): with a split push token every
+  // session `git push` arrives as the bot sender. Once the handoff cleared on a
+  // satisfied review, every later push was dropped and the PR was never
+  // re-reviewed until someone toggled the review label.
+  test("a session push with no code loop in flight is admitted", () => {
+    expect(skipBotSynchronize(base)).toBe(false);
+  });
+
+  test("a push while a code loop holds the PR is skipped", () => {
+    expect(skipBotSynchronize({ ...base, codeLockHeld: true })).toBe(true);
+  });
+
+  test("a push while auto-fix is marked active is skipped", () => {
+    expect(skipBotSynchronize({ ...base, autoFixActive: true })).toBe(true);
+  });
+
+  test("an active handoff round always admits the push", () => {
+    expect(
+      skipBotSynchronize({ ...base, codeLockHeld: true, handoffActive: true }),
+    ).toBe(false);
+  });
+
+  test("human senders and non-synchronize actions are never skipped here", () => {
+    expect(
+      skipBotSynchronize({ ...base, senderIsBot: false, codeLockHeld: true }),
+    ).toBe(false);
+    expect(
+      skipBotSynchronize({ ...base, action: "opened", codeLockHeld: true }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/agents/github/webhook.ts
+++ b/packages/core/opensession-server/src/agents/github/webhook.ts
@@ -127,10 +127,15 @@ export async function handleGithubPrEvent(
     const isDefaultRepo =
       !ghRepo || ghRepo.toLowerCase() === defaultRepo().ghRepo.toLowerCase();
 
-    // Our bot account shows up as `sender` both when we comment/review AND when we
-    // push (auto-fix/simplify/mention commits land as a `synchronize`). We must not
-    // react to those self-triggers — but we DO want to review PRs the bot *opens*
-    // (e.g. automated security fixes). So apply the guard per-event below, not blanket.
+    // Our bot account shows up as `sender` when we comment/review, when a code
+    // loop (auto-fix/simplify/adversarial/mention) pushes, AND — with a split push
+    // token (`OPENSESSION_GITHUB_PUSH_TOKEN`) — on EVERY session `git push`, since
+    // git transport then authenticates as the bot regardless of who runs the
+    // session. So a bot `sender` on `synchronize` does not mean "our own work";
+    // it usually means a human-driven session pushed. We must not react to real
+    // self-triggers (our comments, a loop's own push) — but we DO want to review
+    // PRs the bot *opens* (e.g. automated security fixes) and session pushes. So
+    // apply the guard per-event below, not blanket.
     const senderLogin: string = payload?.sender?.login || "";
     const senderIsBot = !!senderLogin && isGithubBotLogin(senderLogin);
     const senderIsTrusted = isTrustedGithubLogin(senderLogin);
@@ -335,18 +340,31 @@ export async function handleGithubPrEvent(
         );
         return;
       }
-      // A `synchronize` from the bot is our own push (auto-fix/simplify/mention) —
-      // skip it so we don't review our own work mid-loop. But reviewing a PR the bot
-      // *opened* (opened/reopened/ready_for_review) is fine: read-only, no push, no loop.
+      // A `synchronize` from the bot while a code loop (auto-fix/simplify/
+      // adversarial/mention) holds this PR is that loop's own push — skip it so
+      // we don't review our own work mid-loop (auto-fix reviews its final push
+      // through its own gate). Any other bot-sender push is a session's push
+      // arriving under the split push token, or a loop's push whose review is
+      // deduped by reviewedShas anyway — treat it like a human push. Reviewing a
+      // PR the bot *opened* (opened/reopened/ready_for_review) is fine too:
+      // read-only, no push, no loop.
       // Carve-out: while a handoff fix round is active, a bot-credentialed push IS
-      // the owning session's fix (sessions without per-user GitHub auth push as the
-      // bot) — it must be re-reviewed or the handoff loop never closes.
+      // the owning session's fix — it must be re-reviewed or the handoff loop
+      // never closes.
       if (
-        senderIsBot &&
-        action === "synchronize" &&
-        !isHandoffActive(pr.number, ghRepo)
-      )
+        skipBotSynchronize({
+          senderIsBot,
+          action,
+          codeLockHeld: isLockHeld("code", pr.number, ghRepo),
+          autoFixActive: !!readPrState(pr.number, ghRepo)?.autoFix?.active,
+          handoffActive: isHandoffActive(pr.number, ghRepo),
+        })
+      ) {
+        console.log(
+          `[github] PR #${pr.number} synchronize ${ref.headSha.slice(0, 7)} from bot code loop skipped`,
+        );
         return;
+      }
       const labeled = (pr.labels || []).some((l) =>
         labelMatches(l.name, LABEL_REVIEW),
       );
@@ -366,6 +384,26 @@ export async function handleGithubPrEvent(
     console.error("[github] handleGithubPrEvent error:", e);
     throw e;
   }
+}
+
+/**
+ * Is a bot-sender `synchronize` the push of an in-flight bot code loop? Only
+ * those are skipped; every other bot-sender push (sessions pushing under the
+ * split push token) is admitted like a human push. A handoff round always wins.
+ */
+export function skipBotSynchronize(input: {
+  senderIsBot: boolean;
+  action: string;
+  codeLockHeld: boolean;
+  autoFixActive: boolean;
+  handoffActive: boolean;
+}): boolean {
+  return (
+    input.senderIsBot &&
+    input.action === "synchronize" &&
+    !input.handoffActive &&
+    (input.codeLockHeld || input.autoFixActive)
+  );
 }
 
 export async function fireReview(


### PR DESCRIPTION
## Problem

tellahq/tella-fusion#6295 got a 5/5 approve, then two evening pushes on 2026-09-07 were never re-reviewed until the `os-review` label was toggled. `~/.opensession-github/6295.json` had `reviewedShas` for cce93e0 and 6250059 but not 5235cff, no `handoff`, no `pendingReview`, and the audit log showed nothing for either push.

## Root cause

- `webhook.ts` dropped every bot-sender `synchronize` unless a handoff round was active, with no log.
- On this instance `OPENSESSION_GITHUB_PUSH_TOKEN` is set, so git transport for **every** session push authenticates as the bot account. The webhook `sender` is therefore the bot for all session pushes, not just auto-fix/simplify/adversarial/mention loops. The sender comment in `webhook.ts` predated the split push token and was wrong.
- `handoff.ts` `maybeHandoffFindings` calls `clearHandoff` once a review is satisfied (no blocking findings, confidence >= 4). After that `isHandoffActive` is false and every later session push was silently discarded. The `labeled` branch only rejects bot senders and calls `fireReview` directly, which is why the label toggle worked (the session's `gh api` call used the user's `GH_TOKEN`).

## Change

- `webhook.ts`: a bot-sender `synchronize` is skipped only while a code loop actually owns the PR: the `code` lock is held (auto-fix, simplify, adversarial, mention all hold it across their push) or `autoFix.active` is set. The skip is logged. Everything else is admitted to the debounced review scheduler like a human push; an already-reviewed SHA is still deduped by `reviewedShas`. The handoff carve-out is unchanged. The gate is a small exported pure function, `skipBotSynchronize`.
- Fixed the stale sender comment.
- `webhook.test.ts`: no lock + no auto-fix + no handoff admits; lock held skips; auto-fix active skips; active handoff always admits; human sender / non-synchronize never skipped.
- `docs/setup/github.md`: split push token section notes pushes arrive as the bot and how the review webhook treats them.

Race check: all four loops release the `code` lock only after their post-push work (review gate, status comment, thread resolution), so the webhook for the loop's own push lands while the lock is still held. `autoFix.active` covers the restart case where the in-memory lock is gone.

Not touched: ask-mode allowlist and review worktree re-pin (separate follow-up).

`bun run check` passed.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-adc585bd-60c6-70b7-afda-c4065351890b)
