### PR TITLE
Give ask-mode github-* runs a repository-scoped read-only App token

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -63,9 +63,13 @@ configuration for the run.
   repository configured as a shared self-development checkout uses its live
   checkout. Sandboxed ask runs use the sandbox workspace. Code gets an
   isolated writable workspace/worktree and can edit and commit. Ordinary
-  automations currently receive no GitHub credential, so they cannot push or
-  open a GitHub PR; trusted `github-*` code workflows have a separate,
-  repository-scoped credential path. Every other scope still applies: MCP
+  automations receive no GitHub credential, so they cannot push or open a
+  GitHub PR. Trusted `github-*` workflows have separate, repository-scoped
+  credential paths by mode: code runs mint the code permission set (reply,
+  inspect checks and Actions logs), while ask runs — the review workflows,
+  which process untrusted PR content — mint the read-only set and ignore any
+  launcher-supplied token, so nothing they can be injected into holds write
+  capability. Every other scope still applies: MCP
   allowlist, denied writes, IMDS blocking, and the explicit environment.
 - A sandboxed automation runs in a fresh disposable Daytona Executor. Open
   Session admits it only after Daytona has passed qualification, including a

--- a/packages/core/opensession-server/src/server/github-app.test.ts
+++ b/packages/core/opensession-server/src/server/github-app.test.ts
@@ -9,10 +9,12 @@ import {
   githubAppInstallationToken,
   githubAppRepositoryToken,
   githubRepositoryMatchesInstallation,
+  githubServiceReadOnlyEnv,
   githubToken,
   listGithubAppInstallations,
   updateGithubAppWebhook,
 } from "./github-app";
+import { GITHUB_PUSH_TOKEN_RUN_ENV } from "../../../../../scripts/lib/github-credential";
 
 const savedConfig = process.env.OPENSESSION_CONFIG;
 const savedClientId = process.env.OPENSESSION_GITHUB_CLIENT_ID;
@@ -358,5 +360,22 @@ describe("repository-scoped App installation identity", () => {
     expect(
       Object.values(bodies[0].permissions).every((v) => v === "read"),
     ).toBe(true);
+
+    // The env a read-only run receives never carries the operator's
+    // git-transport push credential, even when one is configured: ask-mode
+    // runs can print their environment, so a write-capable token next to the
+    // read token would defeat the ceiling.
+    const savedPush = process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+    process.env.OPENSESSION_GITHUB_PUSH_TOKEN = "operator-push-token";
+    try {
+      const env = await githubServiceReadOnlyEnv("owner-a/tool");
+      expect(env.GH_TOKEN).toBe("ghs_1_repo:tool");
+      expect(env).not.toHaveProperty(GITHUB_PUSH_TOKEN_RUN_ENV);
+      expect(Object.values(env)).not.toContain("operator-push-token");
+    } finally {
+      if (savedPush === undefined)
+        delete process.env.OPENSESSION_GITHUB_PUSH_TOKEN;
+      else process.env.OPENSESSION_GITHUB_PUSH_TOKEN = savedPush;
+    }
   });
 });

--- a/packages/core/opensession-server/src/server/github-app.test.ts
+++ b/packages/core/opensession-server/src/server/github-app.test.ts
@@ -320,4 +320,43 @@ describe("repository-scoped App installation identity", () => {
     expect(githubAppCredentialHealth()).toBe("unavailable");
     expect(await githubToken({ repo: "owner-b/app" })).toBe("ghs_2_read");
   });
+
+  test("a read-only repository token mints the read set", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opensession-github-readonly-"));
+    dirs.push(dir);
+    const config = join(dir, "config.json");
+    const keyPath = join(dir, "github-app.pem");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    writeFileSync(keyPath, privateKey.export({ format: "pem", type: "pkcs8" }));
+    writeOwnerConfig(config, "owner-a");
+    process.env.OPENSESSION_CONFIG = config;
+    delete process.env.OPENSESSION_GITHUB_CLIENT_ID;
+    __setGithubAppKeyPathForTest(keyPath);
+    const bodies: Array<{
+      repositories?: string[];
+      permissions: Record<string, string>;
+    }> = [];
+    const base = twoInstallationFetch([]);
+    globalThis.fetch = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      if (/access_tokens$/.test(String(input)))
+        bodies.push(JSON.parse(String(init?.body)));
+      return base(input as string, init);
+    }) as typeof fetch;
+
+    expect(
+      await githubAppRepositoryToken("owner-a/tool", { readOnly: true }),
+    ).toBe("ghs_1_repo:tool");
+    expect(bodies).toHaveLength(1);
+    // Still repository-scoped, and every requested scope is read: the token
+    // a review run holds must not be able to write anything.
+    expect(bodies[0].repositories).toEqual(["tool"]);
+    expect(bodies[0].permissions.pull_requests).toBe("read");
+    expect(bodies[0].permissions.contents).toBe("read");
+    expect(
+      Object.values(bodies[0].permissions).every((v) => v === "read"),
+    ).toBe(true);
+  });
 });

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -510,6 +510,7 @@ export function githubRepositoryMatchesInstallation(
 
 export async function githubAppRepositoryToken(
   ghRepo: string,
+  opts: { readOnly?: boolean } = {},
 ): Promise<string | null> {
   if (!githubConfiguredCredential()) return null;
   const owner = githubRepoOwner(ghRepo);
@@ -534,7 +535,11 @@ export async function githubAppRepositoryToken(
           repositories: [repo],
           // Trusted repository code runs can push/reply and inspect the
           // failing checks and Actions logs they are expected to repair.
-          permissions: githubAppMintPermissions(CODE_PERMISSIONS),
+          // Read-only callers (ask-mode github-* runs) get the read set: the
+          // same visibility with no write capability behind it.
+          permissions: githubAppMintPermissions(
+            opts.readOnly ? READ_PERMISSIONS : CODE_PERMISSIONS,
+          ),
         }),
       },
     );
@@ -572,5 +577,19 @@ export async function githubServiceCredentialEnv(
   // Even a failed mint carries the process-local SSH-to-HTTPS rewrite. That
   // turns an existing git@github.com origin into a non-interactive HTTPS
   // failure instead of escaping through a host SSH key.
+  return githubGitCredentialEnv(token || "");
+}
+
+/** Read-only sibling of githubServiceCredentialEnv for runs that inspect
+ * GitHub state through `gh` while processing untrusted repository content:
+ * same fail-closed env shape (including the SSH-to-HTTPS rewrite), minting
+ * the repository-scoped read permission set so nothing behind the token can
+ * write. */
+export async function githubServiceReadOnlyEnv(
+  ghRepo?: string,
+): Promise<Record<string, string>> {
+  const token = ghRepo
+    ? await githubAppRepositoryToken(ghRepo, { readOnly: true })
+    : await githubToken();
   return githubGitCredentialEnv(token || "");
 }

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -367,7 +367,9 @@ export function githubConfiguredCredential(): boolean {
  * every default-installation GitHub request update this state through
  * installation-token minting. */
 export function githubAppCredentialHealth():
-  "operational" | "unavailable" | "unchecked" {
+  | "operational"
+  | "unavailable"
+  | "unchecked" {
   if (!githubConfiguredCredential()) return "unavailable";
   const identity = `${githubUserAuthSettings().clientId || ""}:${installationSelector()}`;
   if (

--- a/packages/core/opensession-server/src/server/github-app.ts
+++ b/packages/core/opensession-server/src/server/github-app.ts
@@ -367,9 +367,7 @@ export function githubConfiguredCredential(): boolean {
  * every default-installation GitHub request update this state through
  * installation-token minting. */
 export function githubAppCredentialHealth():
-  | "operational"
-  | "unavailable"
-  | "unchecked" {
+  "operational" | "unavailable" | "unchecked" {
   if (!githubConfiguredCredential()) return "unavailable";
   const identity = `${githubUserAuthSettings().clientId || ""}:${installationSelector()}`;
   if (
@@ -591,5 +589,9 @@ export async function githubServiceReadOnlyEnv(
   const token = ghRepo
     ? await githubAppRepositoryToken(ghRepo, { readOnly: true })
     : await githubToken();
-  return githubGitCredentialEnv(token || "");
+  // The empty push token matters: by default the operator's git-transport
+  // credential rides along next to any real session token, and ask-mode runs
+  // can print their environment — the write-capable credential must never be
+  // readable from a run whose whole point is a read-only ceiling.
+  return githubGitCredentialEnv(token || "", undefined, "");
 }

--- a/packages/core/opensession-server/src/server/pi-runner-github.test.ts
+++ b/packages/core/opensession-server/src/server/pi-runner-github.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { GITHUB_RUN_AUTH_FILE_ENV } from "./github-auth";
-import { githubCodeRunEnv } from "./pi-runner";
+import { githubCodeRunEnv, githubReadRunEnv } from "./pi-runner";
 
 const keys = [
   "OPENSESSION_CONFIG",
@@ -62,6 +62,14 @@ describe("recovered GitHub code-run credentials", () => {
       expect(env.GH_TOKEN).toBe("");
       expect(env.GIT_CONFIG_VALUE_2).toBe("git@github.com:");
       expect(Object.values(env)).not.toContain("human-token");
+
+      // The read-run variant holds the same boundary: an unavailable App
+      // mint yields an empty credential with the SSH rewrite, never a
+      // connected human's token.
+      const readEnv = await githubReadRunEnv(cwd);
+      expect(readEnv.GH_TOKEN).toBe("");
+      expect(readEnv.GIT_CONFIG_VALUE_2).toBe("git@github.com:");
+      expect(Object.values(readEnv)).not.toContain("human-token");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/opensession-server/src/server/pi-runner.ts
+++ b/packages/core/opensession-server/src/server/pi-runner.ts
@@ -181,6 +181,22 @@ export async function githubCodeRunEnv(
   return githubServiceCredentialEnv(repo.ghRepo);
 }
 
+/** Read-only authority for an unattended GitHub ask run (the review
+ * workflows): they read PR threads, checks, and Actions logs through `gh`
+ * while processing untrusted repository content, so their token is the
+ * repository-scoped read set — visibility with no write capability. Same
+ * fail-closed resolution as githubCodeRunEnv. */
+export async function githubReadRunEnv(
+  cwd: string,
+): Promise<Record<string, string>> {
+  if (process.env[GITHUB_RUN_AUTH_FILE_ENV]) return projectedGithubRunEnv();
+  const { repoForPathOrNull } = await import("./worktree");
+  const repo = repoForPathOrNull(cwd);
+  if (!repo || repo.host === "codestorage" || !repo.ghRepo) return {};
+  const { githubServiceReadOnlyEnv } = await import("./github-app");
+  return githubServiceReadOnlyEnv(repo.ghRepo);
+}
+
 /** State root: server-owned agentDir, per-unified-session pi session dirs,
  *  and the smoke-turn scratch cwd. Never ~/.pi. */
 export const PI_STATE_DIR = stateDir("pi");
@@ -2022,18 +2038,24 @@ async function* runPiAttempt(
     const githubUserLogin = interactiveGithub
       ? githubUserLoginForRun(githubUser)
       : null;
-    // Only the dedicated GitHub code workflows may inject a service
-    // credential into an unattended run. Other automations remain credential-
-    // free even if a caller accidentally supplies githubEnv.
-    const githubCodeRun =
-      mode === "code" && baseJournalKind(journal?.kind).startsWith("github-");
+    // Only the dedicated GitHub workflows may inject a service credential
+    // into an unattended run: code mode gets the repository-scoped code set,
+    // ask mode (the review workflows, which chew on untrusted PR content)
+    // gets the repository-scoped read set and ignores any caller-supplied
+    // githubEnv, so a launcher can never hand a review run a writable token.
+    // Other automations remain credential-free even if a caller accidentally
+    // supplies githubEnv.
+    const githubKindRun = baseJournalKind(journal?.kind).startsWith("github-");
+    const githubCodeRun = mode === "code" && githubKindRun;
     const githubEnv = githubCodeRun
       ? opts.githubEnv?.GH_TOKEN
         ? opts.githubEnv
         : await githubCodeRunEnv(cwd)
-      : interactiveGithub
-        ? githubRunEnv(githubUser)
-        : {};
+      : githubKindRun
+        ? await githubReadRunEnv(cwd)
+        : interactiveGithub
+          ? githubRunEnv(githubUser)
+          : {};
 
     const binding = await createPiRuntimeBinding({
       providerID: parsed.providerID,

--- a/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
+++ b/packages/core/opensession-server/src/server/sandbox/adapters/bootstrap.ts
@@ -2168,17 +2168,18 @@ function makeRemoteLauncher(
       // never spec.json, argv, or the persisted origin. Interactive runs prefer
       // their user's token. GitHub code automations and user-less interactive
       // runs receive a freshly resolved service credential for this one repo;
-      // every other automation stays credential-free.
+      // GitHub ask automations (the review workflows) receive the read-only
+      // credential; every other automation stays credential-free.
       let githubAuth = automationProfile
         ? {}
         : githubAuthEnv(githubCredentialUser(spec.user, spec.author?.name));
-      const githubCodeAutomation =
-        automationProfile &&
-        spec.mode === "code" &&
-        (spec.journalKind || "").startsWith("github-");
+      const githubKindAutomation =
+        automationProfile && (spec.journalKind || "").startsWith("github-");
+      const githubCodeAutomation = githubKindAutomation && spec.mode === "code";
+      const githubReadAutomation = githubKindAutomation && spec.mode !== "code";
       if (
         !githubAuth.GH_TOKEN &&
-        (!automationProfile || githubCodeAutomation)
+        (!automationProfile || githubKindAutomation)
       ) {
         // The sandbox origin is mutable by repository setup code. Bind service
         // authority only to the server-owned repo id recorded at ensure time.
@@ -2187,17 +2188,23 @@ function makeRemoteLauncher(
           ? (await import("../../worktree")).getRepo(repoId)
           : undefined;
         if (registeredRepo?.host !== "codestorage" && registeredRepo?.ghRepo) {
-          const { githubServiceCredentialEnv } =
+          const { githubServiceCredentialEnv, githubServiceReadOnlyEnv } =
             await import("../../github-app");
-          githubAuth = await githubServiceCredentialEnv(registeredRepo.ghRepo);
+          githubAuth = githubReadAutomation
+            ? await githubServiceReadOnlyEnv(registeredRepo.ghRepo)
+            : await githubServiceCredentialEnv(registeredRepo.ghRepo);
         }
       }
       const githubAuthPath = `${dir}/github-auth.json`;
       if (githubAuth.GH_TOKEN) {
         // Project the operator's git-transport credential alongside the run
         // token — the remote host cannot read ~/.opensession.env. It rides
-        // only with a real token, so credential-free runs stay that way.
+        // only with a real token, so credential-free runs stay that way —
+        // and never next to a read-only token: ask-mode review runs process
+        // untrusted PR content and can print their environment, so the
+        // write-capable transport credential stays off those hosts entirely.
         if (
+          !githubReadAutomation &&
           !githubAuth[GITHUB_PUSH_TOKEN_RUN_ENV] &&
           process.env.OPENSESSION_GITHUB_PUSH_TOKEN
         )


### PR DESCRIPTION
Review workflows (`github-pr-review`, ask mode) read PR threads, check runs, and Actions logs through `gh`, but their runs receive no GitHub credential, so every such read fails with gh's sign-in error and the session stalls.

This gives ask-mode `github-*` runs a repository-scoped **read-only** installation token, minted at the same injection point that gives code runs the code permission set:

- `githubAppRepositoryToken` takes `{ readOnly }` and mints `GITHUB_APP_READ_PERMISSIONS` instead of the code set — still restricted to the run's single repository.
- `githubServiceReadOnlyEnv` / `githubReadRunEnv` mirror the code-run helpers, including the fail-closed empty-token + SSH-to-HTTPS rewrite when no mint is available.
- The runner's credential gate routes `github-*` + ask mode to the read mint, and **ignores any caller-supplied `githubEnv`** for those runs: review sessions process untrusted PR content, so the read set is a ceiling no launcher can raise. Other automations remain credential-free.
- `docs/security-model.md` documents the per-mode split.

Formal review posting is unaffected — the server posts reviews with its own token; this only lets the review session's in-run reads work.

Stacked on #322 (this PR's base branch); merges after it, then retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QioQmE91ZTAfnobuTeMD5L