### PR TITLE
Design: GitHub authority model for humans, delegates, and automations

### DIFF
--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -148,6 +148,7 @@ decides this, and it errs toward the bot: an unknown sender is not the owner.
 | Force-push own branch               | yes   | lease    | no         | no       | no      |
 | Open a PR                           | yes   | yes      | yes        | no       | no      |
 | Comment, reply in threads           | yes   | yes      | yes        | yes      | yes     |
+| Resolve or unresolve a thread       | yes   | yes      | yes        | no       | yes     |
 | Submit an approving review          | yes   | ask      | no         | no       | no      |
 | Merge                               | yes   | ask      | no         | no       | no      |
 | Update or push the default branch   | PR    | ask      | no         | no       | no      |
@@ -248,8 +249,10 @@ equivalent.
 - Delegate PRs are authored by the owner and carry the attribution footer
   from the session context, no assignee. Automation PRs are authored by the
   bot, carry the footer, and assign the human the automation names.
-- Review threads and fix-round replies post as the bot. This is the decided
-  behavior for handoffs and it is what the Automation credential produces.
+- Review threads and fix-round replies post as the bot, and the bot resolves
+  the threads it has addressed. This is the decided behavior for handoffs
+  and it is what the Automation credential produces. A Delegate turn replies
+  and resolves as the owner, the same as the owner would on github.com.
 
 ### Host hygiene
 
@@ -275,12 +278,18 @@ equivalent.
 
 `PublicationPolicy` becomes a property of every delegate and automation run,
 not only descendants: `{repo, baseBranch, headBranches}` where `headBranches`
-is the session branch plus each attached repository's branch. It matches
-`gh pr merge`, `gh pr review --approve`, `gh api` with a mutating method,
-`git push` to `baseBranch` or to a branch outside `headBranches`, `--force`
-without `--force-with-lease`, `git push --delete`, and any `--repo` outside the
-session's repositories. Automation turns get a refusal. Delegate turns get a
-question card with the exact command, answered "once", never "always".
+is the session branch plus each attached repository's branch. It matches by
+effect, not by HTTP verb: `gh pr merge`, `gh pr review --approve`, `git push`
+to `baseBranch` or to a branch outside `headBranches`, `--force` without
+`--force-with-lease`, `git push --delete`, any `--repo` outside the session's
+repositories, and the `gh api` forms of the same outcomes (the merge
+endpoints, a review with the `APPROVE` event, ref updates and deletes,
+`mergePullRequest`, `enablePullRequestAutoMerge`). Commenting, replying in a
+thread, and `resolveReviewThread` / `unresolveReviewThread` are not
+publication and pass in every turn kind; an agent that has fixed a finding
+replies and resolves the thread without a card. Automation turns get a
+refusal on the matched set. Delegate turns get a question card with the
+exact command, answered "once", never "always".
 
 For Automation this is a tripwire, as `command-policy.ts` says of itself;
 the boundary is the token and the rulesets. For Delegate the card is the

--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -1,0 +1,374 @@
+# GitHub authority: who may do what, and with which credential
+
+Status: proposal, 2026-09-08. Written after the credential split (#318, #319,
+#325) made the merge button unusable on split-credential deployments. It
+replaces the ad-hoc rules that accumulated across `security-model.md` and
+`setup/github.md` with one model. Instance-specific findings that motivated it
+live in the operator's private notes, not here.
+
+## The requirement
+
+1. A human who explicitly triggers an action in Open Session acts with their
+   full GitHub permissions. Merge, close, review, push: whatever they could do
+   on github.com, they can do from the OS UI, attributed to them.
+2. An agent, whether it is working on a human's behalf in an interactive
+   session or running unattended in an automation, can never update a
+   protected branch, merge a pull request, or perform a destructive action,
+   no matter what it finds on the host or what its prompt is told.
+
+These are two different principals with two different ceilings. The current
+system gives them one ceiling and has been moving it up and down.
+
+## How a split-credential deployment fails today
+
+A split-credential deployment caps the App installation at `contents: read`
+and hands pushes to a separate git-transport token. Each part is locally
+sound and the combination fails both requirements.
+
+### The merge button
+
+`POST /api/sessions/:id/pr-merge` runs `gh pr merge` with the signed-in
+human's App user token (`githubMutationCredential`). A GitHub App user token
+can never exceed the App's own permissions, and merging needs
+`contents: write` as well as `pull_requests: write`. Once the installation is
+capped at `contents: read`, every human merge from the UI fails, and the
+human falls back to github.com. `audited()` records each failure as
+`ok: true`, because a resolved `{ error }` object counts as success.
+
+The cap was deliberate: `setup/github.md` says the split "makes merging
+something no credential on the host can do alone". That is requirement 2
+applied to principal 1. The App permission set is the ceiling for humans and
+bots at once, so lowering it for bots lowers it for humans.
+
+### Agents on a human's behalf
+
+Interactive runs (`prompt`, `goal`, `create`, `linear`, `slack`, `workflow`)
+receive the session owner's App user token as `GH_TOKEN` so that PRs are
+authored by the human. Whatever the human may do, the agent may do with that
+token. Before the cap this included merging; the cap removed it by removing
+it from the human too. GitHub has no narrower delegated form of a user token,
+so requirement 2 can only be met if agent runs never carry a human token.
+
+A related live bug: `agents/github/handoff.ts` delivers fix-round handoffs
+with sender `"GitHub"`. `githubCredentialUser` (#322) treats only the
+auto-continue sender as synthetic, so `"GitHub"` shadows the session owner and
+the turn runs with an empty token. Michiel and John have already decided that
+fix-round replies should post as the bot, not the human. The Delegate
+principal below is exactly that: the turn credential is an installation token
+whatever the sender string says, so the shadowing class of bug disappears.
+
+### Unattended runs
+
+Ordinary automations are credential-free by design. A run with no injected
+credential also gets no `git@github.com` to HTTPS rewrite and no isolated
+`gh` config, so `git push` and `gh` fall through to whatever ambient
+credential the host accumulated: an SSH key, a `gh` login, a transport token
+in a config file. Split-credential deployments accumulate these by nature,
+because the split needs a second credential that the App cannot mint. The
+result is that "credential-free" runs push branches with an identity nobody
+chose for them, and an agent that hits a permission error goes looking for
+the next credential on disk.
+
+The `github-*` code workflows receive a repository-scoped installation token
+with the code permission set. Ask-mode review runs receive the read set,
+with the transport token explicitly excluded at both injection points
+(#325). Automation descendants additionally get a `PublicationPolicy`
+(`command-policy.ts`) that refuses `gh pr merge`, `gh api`, pushes to the
+base branch, and pushes to any branch other than the one they own. That
+policy is the right shape and applies to the wrong population: only
+descendants have it.
+
+### Rulesets
+
+The split moved enforcement into tokens, so the rulesets on protected
+branches were never asked to carry it. A repository whose default-branch
+ruleset only forbids deletion and force-push lets any identity with
+`contents: write` commit straight to it. In that state the transport token,
+and any ambient credential with push access, can update `main`.
+
+## Why the current direction cannot converge
+
+Every recent change tunes a single knob, the App's permission set, and
+compensates elsewhere: cap contents to read, add a transport token for
+pushes, narrow mints so they do not 422, project the transport token into
+Sandboxes, keep it out of read-only runs. Each step is locally correct and
+the sum still fails both requirements: humans cannot merge, and the
+transport token can reach `main` wherever a ruleset does not stop it.
+
+Three facts fix the shape of any working design:
+
+- App permissions are one ceiling for humans and bots. Do not use them to
+  separate the two.
+- GitHub separates identities per ref only through rulesets. That is the one
+  place where "the bot may push branches but not `main`" can be enforced
+  server-side, independent of which token leaked where.
+- A human's token grants the human's authority to whoever holds it. Agent
+  runs therefore must not hold it; attribution has to come from somewhere
+  else.
+
+## Design
+
+### Principals
+
+| Principal  | Who                                                                    | GitHub identity   |
+| ---------- | ---------------------------------------------------------------------- | ----------------- |
+| Human      | A signed-in person clicking a button in any OS client                  | Their own account |
+| Delegate   | The agent in an interactive session, acting for the session owner      | `<app-slug>[bot]` |
+| Automation | Unattended code runs: automations, `github-*` code loops, descendants  | `<app-slug>[bot]` |
+| Reviewer   | Unattended ask runs over untrusted content: PR review, merge risk      | `<app-slug>[bot]` |
+| Service    | Server-owned calls: PR cache, review posting, webhooks, worktree setup | `<app-slug>[bot]` |
+
+Human is the only principal that ever holds a user token. Every other
+principal is the App.
+
+### Capabilities
+
+| Capability                          | Human | Delegate | Automation | Reviewer | Service |
+| ----------------------------------- | ----- | -------- | ---------- | -------- | ------- |
+| Read repo, PRs, checks, Actions     | yes   | yes      | yes        | yes      | yes     |
+| Push the session's own branch       | yes   | yes      | own branch | no       | no      |
+| Force-push own branch               | yes   | lease    | no         | no       | no      |
+| Open a PR                           | yes   | yes      | yes        | no       | no      |
+| Comment, reply in threads           | yes   | yes      | yes        | yes      | yes     |
+| Submit an approving review          | yes   | no       | no         | no       | no      |
+| Merge                               | yes   | no       | no         | no       | no      |
+| Update or push the default branch   | PR    | no       | no         | no       | no      |
+| Delete a branch                     | yes   | no       | no         | no       | no      |
+| Repository settings, rulesets, apps | no    | no       | no         | no       | no      |
+
+"PR" means the human reaches `main` only by merging a PR that satisfies the
+integrity ruleset. "lease" means `--force-with-lease` only.
+
+### Credentials
+
+- **Human**: the App user token from device-flow sign-in, as today. It is used
+  by server routes for human-initiated actions only (`pr-merge`,
+  `pr-stack-merge`, `pr-close`, `pr-review`, `pr-comment`, `git-push`, and the
+  proposal endpoints below). It is never placed in a run environment, a
+  projected auth file, or a Sandbox. Every client (web, phone, Electron, iOS,
+  Chrome) already goes through these routes, so this needs no client change.
+  Auto-continue keeps resolving the session owner for these routes (#322);
+  the owner's identity is still needed for attribution and for the proposal
+  cards, it just no longer becomes a run credential.
+- **Delegate and Automation**: a repository-scoped installation token with the
+  code permission set (`contents: write`, `pull_requests: write`,
+  `issues: write`, `checks/actions/statuses: read`, `metadata: read`), minted
+  per turn, one hour, never persisted. This is `githubServiceCredentialEnv`,
+  which the `github-*` code loops already use. Interactive runs and fix-round
+  handoff turns switch to it.
+- **Reviewer**: the read set, exactly as #325 shipped it. The read-only
+  ceiling is preserved by construction: the read set has no `contents: write`
+  and there is no longer a transport token to exclude.
+- **Service**: installation token selected by repository owner, as today.
+- **Retired**: the git-transport credential and everything that carries it
+  (`OPENSESSION_GITHUB_PUSH_TOKEN`, `GITHUB_PUSH_TOKEN_RUN_ENV`, the Sandbox
+  projection in `sandbox/adapters/bootstrap.ts`, the special case in
+  `gitCredentialEnvForExec`, the `githubAppMintPermissions` narrowing). Every
+  ambient credential on the host that is not the App key or the human token
+  store is revoked and removed. The App installation goes back to the grant
+  set in code, including `contents: write`.
+
+The App can push branches again with this. It still cannot touch `main`, and
+that is enforced by GitHub, not by the token.
+
+### Rulesets are the boundary
+
+Two rulesets on every covered repository, both targeting the default branch.
+Rulesets are additive and bypass lists are per ruleset, which is what makes
+this work.
+
+1. **Integrity** (no bypass actors): require a pull request, required status
+   checks, linear history, no deletion, no force push. Everyone, humans
+   included, reaches `main` through a green PR.
+2. **Humans only** (bypass: the existing `mergers` team, mode "always"): the
+   single rule "restrict updates". Only bypass actors may update the ref. A
+   merge is an update, so only team members can merge, and the App, any
+   PAT, any SSH key, and any leaked bot token cannot merge or push `main`
+   whatever permissions they hold. `mergers` already exists and its roster is
+   part of submitted SOC2 evidence; reuse it rather than creating a team.
+
+Repositories whose release process pushes `main` from GitHub Actions need a
+`DeployKey` bypass actor on the humans-only ruleset, because Actions cannot
+be a bypass actor and those workflows push through a deploy key. The gitops
+repository is the known case.
+
+Verify the humans-only ruleset on a scratch repository before rollout:
+confirm a `mergers` member can squash-merge through the API, and that an
+installation token with `contents: write` gets refused on merge and on
+`git push origin HEAD:main` while still pushing a feature branch.
+
+With these two in place the question "which credential is on the box" stops
+deciding whether `main` is safe. It decides only how much cleanup a leak
+costs.
+
+### Human actions are server-executed; agents propose
+
+Everything in the Human column runs in a server route with the human's token,
+triggered by a click. The agent never calls these itself. Where the agent
+needs the outcome, it proposes and the human confirms:
+
+- `opensession-repos` gains `propose_pull_request({repo, base, title, body,
+reviewers})` and `propose_merge({repo, number, method})`. Each writes a
+  proposal card into the session transcript. The card's button calls the
+  existing routes with the human's credential, so a PR opened this way is
+  authored by the human and a merge is performed by the human.
+- A delegate may also open a PR directly as the bot when nobody is waiting on
+  the card. That PR carries the attribution footer and the human as assignee,
+  the pre-`userPrAuth` behavior.
+- The existing five-second Merge with Undo in `PrStatusBar` stays as the
+  human's merge control. A `propose_merge` card simply focuses it.
+
+### Attribution without authority
+
+- Commit author stays the human (`gitIdentityEnv(author)`), with the model as
+  `Co-Authored-By`. GitHub shows the human as author and the bot as pusher.
+- PR bodies end with the attribution footer from the session context. Bot
+  authored PRs assign the human; human authored ones do not.
+- Session context text changes from "PRs use @login's account; do not add an
+  assignee" to whichever of the two applies.
+- Review threads and fix-round replies post as the bot. This is the decided
+  behavior for handoffs and it is what the Delegate credential produces.
+
+Whether the team prefers bot-authored or human-authored PRs is a review
+policy question, not a security one: a human cannot approve their own PR, so
+bot-authored PRs let the session owner be the reviewer, while human-authored
+PRs force a second person. The proposal card gives either.
+
+### Host hygiene
+
+- Every run receives the `githubGitCredentialEnv` shape: the credential
+  helper, `GIT_TERMINAL_PROMPT=0`, the SSH to HTTPS `insteadOf` rewrite, and
+  an isolated `GH_CONFIG_DIR` (#319). The token inside is the principal's:
+  code set for Delegate and Automation, read set for Reviewer. A run that is
+  meant to have no write access gets the read token, not an empty helper,
+  because an empty helper today means "use whatever the host has". Git must
+  fail with a clear authentication error, never fall through.
+- No PAT, SSH key, or `gh` login on the host. `~/.opensession/github-auth.json`
+  and `github-app.pem` remain, readable by the gateway uid.
+- Agent bash still shares that uid on host runs. That is the residual risk:
+  an adversarial agent can read the human token store. The rulesets bound
+  what the bot can do with the App key, but a human token is the human. The
+  fix is uid separation for run hosts, or Sandboxes by default; until then
+  the invariant is "no human token in any run environment" and the threat
+  model is a confused agent, not a hostile one.
+
+### Command policy as a tripwire for every agent
+
+`PublicationPolicy` becomes a property of every delegate and automation run,
+not only descendants: `{repo, baseBranch, headBranches}` where `headBranches`
+is the session branch plus each attached repository's branch. It refuses
+`gh pr merge`, `gh pr review --approve`, `gh api` with a mutating method,
+`git push` to `baseBranch` or to a branch outside `headBranches`, `--force`
+without `--force-with-lease`, `git push --delete`, and any `--repo` outside the
+session's repositories. Interactive runs get a question card instead of a
+refusal, and the card offers the server-executed action when one exists.
+
+This is a tripwire, as `command-policy.ts` says of itself. The boundary is
+the token and the rulesets.
+
+### Observability
+
+- `audited()` marks a resolved `{ error }` result as `ok: false` and records
+  the error text. Failed merges must not read as successes.
+- Merge and push routes translate GitHub's permission errors into a sentence
+  that names the cause and the fix ("The GitHub App is capped at
+  `contents: read`, so nobody can merge from here"), the way
+  `device_flow_disabled` is handled.
+- Boot logs the credential posture: App permissions per installation, whether
+  any retired credential path is still configured, and which rulesets are
+  missing on covered repositories (read via the installation token; the App
+  has no admin permission and should not get one).
+
+## Migration
+
+Phase 0 is compliance and operator work and unblocks merging without a
+deploy. Phases 1 and 2 are code. Phase 3 is infrastructure.
+
+**Phase 0, compliance, GitHub and host (no deploy)**
+
+0. Before any live state changes: add a dated addendum to the deviation
+   record for the incident that introduced the App cap and the transport
+   token split. It states that the control objective is unchanged (no
+   automated identity can update a protected branch or merge a pull request)
+   and that enforcement moves from a permission cap plus credential split to
+   identity-based rulesets with the `mergers` team as the only human bypass.
+   Auditors were told the cap and split are the corrective actions; the
+   record has to say otherwise before the instance does.
+1. Add the humans-only ruleset to every covered repository, with the
+   `DeployKey` bypass where a release workflow pushes `main`. Add the pull
+   request rule to any integrity ruleset that lacks it. Verify on a scratch
+   repository first. See the first open question before applying this to
+   `opensession` itself.
+2. Restore `contents: write` on the installation (approve the updated
+   permissions in the org).
+3. Unset `OPENSESSION_GITHUB_PUSH_TOKEN`; revoke the transport token. Revoke
+   and remove every other ambient credential on the host.
+
+After this, humans merge from the UI again and no bot identity can touch
+`main`. Interactive runs still carry the human's token until phase 1, which
+is the pre-2026-09-07 state and should not be left for long.
+
+**Phase 1, credentials and policy**
+
+4. `pi-runner.ts`: interactive runs use `githubCodeRunEnv(cwd)` instead of
+   `githubRunEnv(user)`; fix-round handoff turns take the same path, which
+   also closes the `"GitHub"` sender bug. Remove `githubRunEnv`,
+   `githubAuthEnv`, the token half of `projectedGithubAuthEnv`, and the
+   Sandbox projection of user tokens. `githubCredentialForLogin`,
+   `githubCredentialUser`, and `soleGithubAccount` remain for routes and
+   attribution. Ask-mode `github-*` runs keep the #325 read path untouched.
+5. Give ordinary code automations the Automation credential plus a
+   `PublicationPolicy`, so they open real PRs instead of pushing with an
+   ambient identity.
+6. Inject the credential-helper env shape into every run, read token for
+   Reviewer, code token otherwise.
+7. Extend `PublicationPolicy` to every delegate and automation run.
+8. Delete the transport-token plumbing and its docs section. Fix
+   `audited()`.
+
+**Phase 2, product**
+
+9. `propose_pull_request` and `propose_merge` in `opensession-repos`, proposal
+   cards in the transcript, the routes behind them, session-context wording.
+10. Boot-time posture log and a Settings → Integrations panel that shows
+    installation permissions and missing rulesets per repository.
+
+**Phase 3, isolation**
+
+11. Run hosts under a separate uid, or Sandboxes by default for interactive
+    sessions, so the human token store is unreadable from agent bash.
+
+## What this removes
+
+- The "Separate git-transport credential" mechanism and its four code paths.
+- The contents-narrowing in `githubAppMintPermissions`.
+- The rule that ordinary automations get no GitHub credential, replaced by
+  "every agent gets a bot credential sized to its principal and a
+  publication policy".
+- The claim that "no credential on the host can merge". The claim becomes "no
+  bot credential can update `main`, and no run holds a human credential".
+
+## Open questions
+
+- **The `opensession` repository's own development model.** Sessions push
+  the shared checkout's `main` directly and the host self-builds from those
+  pushes. A humans-only ruleset on `opensession` `main` breaks that unless
+  session pushes carry a bypass identity, and under this design a session's
+  own push runs as the bot. The options are: keep `opensession` on the
+  integrity ruleset only and accept that the bot can update its `main`
+  through a PR-less push; route the shared-checkout push through a server
+  route that uses the session owner's token, which limits direct pushes to
+  `mergers` members; or move `opensession` to PR-only like every other
+  repository and let `deploy_self` promote merged commits. This is a
+  workflow decision for Michiel and it gates Phase 0 step 1 for
+  `opensession`.
+- Bot-authored or human-authored PRs by default? See Attribution.
+- Should the humans-only bypass stay a team (`mergers`) or become the
+  `maintain` role? The team is explicit, auditable, and already evidenced;
+  a role follows repository membership.
+- Simple mode (one person, personal App) has one token that is both the human
+  and, in effect, the delegate. The rulesets still hold; the token separation
+  does not. Acceptable for a single-user install, worth stating in the docs.
+- Code Storage hosts have no rulesets. Their "pushed branch is the change
+  request" model already keeps agents off the mainline; document it as the
+  equivalent.

--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -255,14 +255,15 @@ costs.
 
 ### The owner asks, the gateway acts as the owner
 
-A Delegate turn pushes its branch with the bot token; the commits are still
-authored by the owner. Then it calls `open_pull_request`, and the gateway
-creates the PR as the owner, with the attribution footer from the session
-context. On GitHub the PR reads exactly as if the owner had opened it, which
-is what the team wants to see, and the agent's process held nothing but a
-bot token throughout. Review-thread replies and resolves later in the PR's
-life are the bot's, in this turn kind as in every other: the human's name is
-on the PR and the commits, the bot's on the back-and-forth it did.
+A Delegate turn commits as the bot, with the owner as `Co-authored-by`, and
+pushes its branch with the bot token. Then it calls `open_pull_request`, and
+the gateway creates the PR as the owner, with the attribution footer from
+the session context. On GitHub the PR reads exactly as if the owner had
+opened it, which is what the team wants to see, and the agent's process held
+nothing but a bot identity throughout. Review-thread replies and resolves
+later in the PR's life are the bot's, in this turn kind as in every other:
+the human's name is on the PR and on every commit as co-author, the bot's on
+the commits it wrote and the back-and-forth it did.
 
 When the owner says "merge this", the agent calls `propose_merge`. That
 writes a merge card into the transcript: the PR, the method, the check and
@@ -278,8 +279,13 @@ Adding one is a security review, not a convenience.
 
 ### Attribution
 
-- Commit author stays the human (`gitIdentityEnv(author)`), with the model as
-  `Co-Authored-By`.
+- Commits are authored by the bot in every turn kind, with the human as
+  `Co-authored-by`: the session owner for Delegate, the human the automation
+  names for Automation. `gitIdentityEnv` sets the bot identity and the
+  trailer; no run carries a human `GIT_AUTHOR_*` or `GIT_COMMITTER_*`
+  identity, so nothing an agent commits can be mistaken for something the
+  human typed. Where a repository requires signed commits, the bot's signing
+  key is the only key on the host.
 - Delegate PRs are authored by the owner through the gateway tool and carry
   the attribution footer from the session context, no assignee. Automation
   PRs are authored by the bot, carry the footer, and assign the human the

--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -10,10 +10,9 @@ live in the operator's private notes, not here.
 
 1. A human who explicitly triggers an action in Open Session acts with their
    full GitHub permissions. Merge, close, review, push: whatever they could do
-   on github.com, they can do from the OS UI, attributed to them. Work the
-   agent does at the owner's request (a pull request, a comment, a resolved
-   thread) shows up under the owner's name, and "merge this" from the owner
-   is one tap away.
+   on github.com, they can do from the OS UI, attributed to them. A pull
+   request the agent opens at the owner's request shows up under the owner's
+   name, and "merge this" from the owner is one tap away.
 2. No agent process, in any kind of turn, ever holds a credential that can
    merge a pull request, update a protected branch, or approve a review. An
    unattended run, whether an automation, a `github-*` loop, a review, or a
@@ -159,19 +158,20 @@ mounted; the shell credential is the bot either way.
 | Push the session's own branch       | yes   | own, as bot   | own branch | no       | no      |
 | Force-push own branch               | yes   | lease, as bot | no         | no       | no      |
 | Open or edit a PR                   | yes   | as owner      | as bot     | no       | no      |
-| Comment, reply in threads           | yes   | as owner      | as bot     | as bot   | as bot  |
-| Resolve or unresolve a thread       | yes   | as owner      | as bot     | no       | as bot  |
+| Comment, reply in threads           | yes   | as bot        | as bot     | as bot   | as bot  |
+| Resolve or unresolve a thread       | yes   | as bot        | as bot     | no       | as bot  |
 | Submit an approving review          | yes   | no            | no         | no       | no      |
 | Merge                               | yes   | card          | no         | no       | no      |
 | Update or push the default branch   | yes   | no            | no         | no       | no      |
 | Delete a branch                     | yes   | no            | no         | no       | no      |
 | Repository settings, rulesets, apps | no    | no            | no         | no       | no      |
 
-"as bot" means the agent's shell does it with the installation token. "as
-owner" means the agent calls a gateway tool and the gateway does the request
-with the owner's token, on the server, without a tap: the PR, the comment,
-and the resolved thread are the owner's on GitHub, and the agent never held
-the credential. "lease" means `--force-with-lease` only. "card" means the
+"as bot" means the agent's shell does it with the installation token, in
+every turn kind: a reply in a review thread or a resolved thread is the
+bot's on GitHub, whoever started the turn. "as owner" means the agent calls
+a gateway tool and the gateway does the request with the owner's token, on
+the server, without a tap: the PR is the owner's on GitHub, and the agent
+never held the credential. "lease" means `--force-with-lease` only. "card" means the
 agent cannot do it at all; it writes a merge card into the session and the
 owner's tap calls the same `pr-merge` route the Merge button calls, with the
 owner's token. "Merge this" from the owner is therefore one tap, and a merge
@@ -186,13 +186,14 @@ the rulesets, and the human's own bypass status, apply unchanged.
   `pr-close`, `pr-review`, `pr-comment`, `git-push`). Every client (web,
   phone, Electron, iOS, Chrome) already goes through these routes, so this
   needs no client change.
-- **Delegate**: the Automation token below in the shell, plus the
-  owner-identity tools: `open_pull_request`, `edit_pull_request`,
-  `comment_pull_request`, `reply_review_thread`, `resolve_review_thread`, and
-  `propose_merge`, which only writes the card. Each tool runs one request on
-  the server with the owner's token, scoped to the session's repositories,
-  and is mounted only when `githubCredentialUser` (#322) says the turn's
-  sender is the owner. The token is never in `GH_TOKEN`, an auth file, a
+- **Delegate**: the Automation token below in the shell, plus three
+  owner-identity tools: `open_pull_request`, `edit_pull_request`, and
+  `propose_merge`, which only writes the card. The first two run one request
+  on the server with the owner's token, scoped to the session's
+  repositories, and are mounted only when `githubCredentialUser` (#322) says
+  the turn's sender is the owner. Comments, thread replies, and resolves are
+  not owner-identity actions; the shell does them with the bot token like
+  any other turn. The owner's token is never in `GH_TOKEN`, an auth file, a
   Sandbox volume, or anything else the run can read. `githubRunEnv(user)`
   and the user-token projection into runs are deleted.
 - **Automation**: a repository-scoped installation token with the code
@@ -257,10 +258,11 @@ costs.
 A Delegate turn pushes its branch with the bot token; the commits are still
 authored by the owner. Then it calls `open_pull_request`, and the gateway
 creates the PR as the owner, with the attribution footer from the session
-context. Later, `reply_review_thread` and `resolve_review_thread` post and
-resolve as the owner. On GitHub this reads exactly as if the owner had done
-it, which is what the team wants to see, and the agent's process held
-nothing but a bot token throughout.
+context. On GitHub the PR reads exactly as if the owner had opened it, which
+is what the team wants to see, and the agent's process held nothing but a
+bot token throughout. Review-thread replies and resolves later in the PR's
+life are the bot's, in this turn kind as in every other: the human's name is
+on the PR and the commits, the bot's on the back-and-forth it did.
 
 When the owner says "merge this", the agent calls `propose_merge`. That
 writes a merge card into the transcript: the PR, the method, the check and
@@ -270,9 +272,9 @@ agent has no path to the merge itself: not through a tool, not through the
 shell, not through the API, because nothing in its environment carries a
 token that GitHub would accept for an update to `main`.
 
-The gateway tools are the whole Delegate surface. They are few, they are
-named after their effect, and each does one request. Adding one is a
-security review, not a convenience.
+The gateway tools are the whole Delegate surface. There are two that touch
+GitHub, they are named after their effect, and each does one request.
+Adding one is a security review, not a convenience.
 
 ### Attribution
 
@@ -282,11 +284,10 @@ security review, not a convenience.
   the attribution footer from the session context, no assignee. Automation
   PRs are authored by the bot, carry the footer, and assign the human the
   automation names.
-- Review threads and fix-round replies post as the bot, and the bot resolves
-  the threads it has addressed. This is the decided behavior for handoffs
-  and it is what the Automation credential produces. A Delegate turn replies
-  and resolves as the owner through the gateway tools, the same as the owner
-  would on github.com.
+- Review threads, replies, and resolves post as the bot in every turn kind,
+  Delegate included. This is the decided behavior for handoffs and it is
+  what the shell credential produces without any tool; a human who wants
+  their own name on a reply writes it on github.com.
 
 ### Host hygiene
 
@@ -381,9 +382,9 @@ is what closes requirement 2.
    path untouched.
 5. `githubCredentialUser` decides Delegate versus Automation for every turn,
    defaulting to Automation for any sender that is not the session owner or
-   an auto-continue of the owner. Delegate turns get the owner-identity
-   gateway tools; the tools run the request server-side with the owner's
-   token and refuse repositories outside the session.
+   an auto-continue of the owner. Delegate turns get `open_pull_request`
+   and `edit_pull_request`; the tools run the request server-side with the
+   owner's token and refuse repositories outside the session.
 6. Give ordinary code automations the Automation credential plus a
    `PublicationPolicy`, so they open real PRs instead of pushing with an
    ambient identity.

--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -10,18 +10,21 @@ live in the operator's private notes, not here.
 
 1. A human who explicitly triggers an action in Open Session acts with their
    full GitHub permissions. Merge, close, review, push: whatever they could do
-   on github.com, they can do from the OS UI, attributed to them. That
-   includes telling the agent in their own session to do it: "merge this"
-   from the session owner merges as the session owner.
-2. An unattended run, whether an automation, a `github-*` loop, a review, or
-   a fix-round handoff into someone's session, can never update a protected
-   branch, merge a pull request, or perform a destructive action, no matter
-   what it finds on the host or what its prompt is told.
+   on github.com, they can do from the OS UI, attributed to them. Work the
+   agent does at the owner's request (a pull request, a comment, a resolved
+   thread) shows up under the owner's name, and "merge this" from the owner
+   is one tap away.
+2. No agent process, in any kind of turn, ever holds a credential that can
+   merge a pull request, update a protected branch, or approve a review. An
+   unattended run, whether an automation, a `github-*` loop, a review, or a
+   fix-round handoff into someone's session, can never do those things no
+   matter what it finds on the host or what its prompt is told, and neither
+   can an agent in the owner's own session.
 
 These are two different principals with two different ceilings. The current
 system gives them one ceiling and has been moving it up and down. The line
-between them is not "human versus agent"; it is "a human is present and
-asking" versus "nobody is".
+that matters is not "human versus agent"; it is "a human clicked" versus "a
+model decided". Only the first ever reaches `main`.
 
 ## How a split-credential deployment fails today
 
@@ -51,10 +54,15 @@ receive the session owner's App user token as `GH_TOKEN` so that PRs are
 authored by the human. Whatever the human may do, the agent may do with that
 token. Before the cap this included merging; the cap removed it by removing
 it from the human too. GitHub has no narrower delegated form of a user token,
-so the choice is binary: the interactive agent either holds the human's
-authority or none of it. This design keeps it, because the session owner
-wants "merge this" to work, and puts the guard on the turn instead: the
-token is present only while the owner is the one prompting.
+so as long as the token is in the agent's shell the choice is binary: the
+agent either holds the human's whole authority or none of it. Where the
+human is a ruleset bypass actor, "whole authority" means merging without a
+review or a green check. A command policy in front of the shell can ask
+before `gh pr merge`, but a policy is a check in our code, not in GitHub;
+anything it does not recognise goes through as the human. This design takes
+the token out of the shell instead. The agent gets the owner's identity only
+through tools the gateway executes on the server, and those tools do not
+include merge.
 
 A related live bug: `agents/github/handoff.ts` delivers fix-round handoffs
 with sender `"GitHub"`. `githubCredentialUser` (#322) treats only the
@@ -110,26 +118,28 @@ Three facts fix the shape of any working design:
 - GitHub separates identities per ref only through rulesets. That is the one
   place where "the bot may push branches but not `main`" can be enforced
   server-side, independent of which token leaked where.
-- A human's token grants the human's authority to whoever holds it. Only a
-  turn the human started may hold it, and the human must be able to see and
-  stop what it does with it.
+- A human's token grants the human's authority to whoever holds it. No agent
+  process may hold it. Where the agent needs to act under the human's name,
+  the gateway does the request for it, with a fixed list of things it will
+  do.
 
 ## Design
 
 ### Principals
 
-| Principal  | Who                                                                    | GitHub identity   |
-| ---------- | ---------------------------------------------------------------------- | ----------------- |
-| Human      | A signed-in person clicking a button in any OS client                  | Their own account |
-| Delegate   | The agent in a turn the session owner started, acting for the owner    | The owner         |
-| Automation | Turns no human started: automations, `github-*` code loops,            | `<app-slug>[bot]` |
-|            | descendants, fix-round handoffs, auto-continue of an automation        |                   |
-| Reviewer   | Unattended ask runs over untrusted content: PR review, merge risk      | `<app-slug>[bot]` |
-| Service    | Server-owned calls: PR cache, review posting, webhooks, worktree setup | `<app-slug>[bot]` |
+| Principal  | Who                                                                    | GitHub identity                 |
+| ---------- | ---------------------------------------------------------------------- | ------------------------------- |
+| Human      | A signed-in person clicking a button in any OS client                  | Their own account               |
+| Delegate   | The agent in a turn the session owner started                          | Bot in the shell, owner by tool |
+| Automation | Turns no human started: automations, `github-*` code loops,            | `<app-slug>[bot]`               |
+|            | descendants, fix-round handoffs, auto-continue of an automation        |                                 |
+| Reviewer   | Unattended ask runs over untrusted content: PR review, merge risk      | `<app-slug>[bot]`               |
+| Service    | Server-owned calls: PR cache, review posting, webhooks, worktree setup | `<app-slug>[bot]`               |
 
-Human and Delegate are the same GitHub identity. Delegate is the human's own
-token in the hands of the agent, for the length of a turn the human started.
-Every other principal is the App.
+Every agent process runs as the App. The owner's token exists in exactly two
+places: the routes behind the UI buttons, and a short list of gateway tools
+a Delegate turn can call, each of which does one request as the owner on the
+server and returns the result. The agent's shell never sees it.
 
 What makes a turn Delegate rather than Automation is who started it, not
 which session it lands in. A prompt typed by the session owner, an
@@ -138,31 +148,36 @@ session is Delegate. A GitHub webhook, a schedule, a fix-round handoff, or a
 message from another session is Automation, even when it is delivered into
 an interactive session. `githubCredentialUser` becomes the single place that
 decides this, and it errs toward the bot: an unknown sender is not the owner.
+The only thing the decision changes is whether the owner-identity tools are
+mounted; the shell credential is the bot either way.
 
 ### Capabilities
 
-| Capability                          | Human | Delegate | Automation | Reviewer | Service |
-| ----------------------------------- | ----- | -------- | ---------- | -------- | ------- |
-| Read repo, PRs, checks, Actions     | yes   | yes      | yes        | yes      | yes     |
-| Push the session's own branch       | yes   | yes      | own branch | no       | no      |
-| Force-push own branch               | yes   | lease    | no         | no       | no      |
-| Open a PR                           | yes   | yes      | yes        | no       | no      |
-| Comment, reply in threads           | yes   | yes      | yes        | yes      | yes     |
-| Resolve or unresolve a thread       | yes   | yes      | yes        | no       | yes     |
-| Submit an approving review          | yes   | ask      | no         | no       | no      |
-| Merge                               | yes   | ask      | no         | no       | no      |
-| Update or push the default branch   | PR    | ask      | no         | no       | no      |
-| Delete a branch                     | yes   | ask      | no         | no       | no      |
-| Repository settings, rulesets, apps | no    | no       | no         | no       | no      |
+| Capability                          | Human | Delegate      | Automation | Reviewer | Service |
+| ----------------------------------- | ----- | ------------- | ---------- | -------- | ------- |
+| Read repo, PRs, checks, Actions     | yes   | yes           | yes        | yes      | yes     |
+| Push the session's own branch       | yes   | own, as bot   | own branch | no       | no      |
+| Force-push own branch               | yes   | lease, as bot | no         | no       | no      |
+| Open or edit a PR                   | yes   | as owner      | as bot     | no       | no      |
+| Comment, reply in threads           | yes   | as owner      | as bot     | as bot   | as bot  |
+| Resolve or unresolve a thread       | yes   | as owner      | as bot     | no       | as bot  |
+| Submit an approving review          | yes   | no            | no         | no       | no      |
+| Merge                               | yes   | card          | no         | no       | no      |
+| Update or push the default branch   | yes   | no            | no         | no       | no      |
+| Delete a branch                     | yes   | no            | no         | no       | no      |
+| Repository settings, rulesets, apps | no    | no            | no         | no       | no      |
 
-"PR" means the human reaches `main` only by merging a PR that satisfies the
-integrity ruleset. "lease" means `--force-with-lease` only. "ask" means the
-agent can do it with the owner's token, and the command policy turns it into
-a question card first: the owner sees the exact command and approves it in
-the session. "Merge this" from the owner followed by one approval is the
-intended path; a merge the owner did not ask for never gets past the card.
-The Delegate column is also what the `mergers` roster bounds: an owner who
-is not on the team cannot merge, and neither can their agent.
+"as bot" means the agent's shell does it with the installation token. "as
+owner" means the agent calls a gateway tool and the gateway does the request
+with the owner's token, on the server, without a tap: the PR, the comment,
+and the resolved thread are the owner's on GitHub, and the agent never held
+the credential. "lease" means `--force-with-lease` only. "card" means the
+agent cannot do it at all; it writes a merge card into the session and the
+owner's tap calls the same `pr-merge` route the Merge button calls, with the
+owner's token. "Merge this" from the owner is therefore one tap, and a merge
+nobody tapped cannot happen, because nothing in the agent's reach can
+perform one. Whether the tap succeeds is GitHub's decision about the human:
+the rulesets, and the human's own bypass status, apply unchanged.
 
 ### Credentials
 
@@ -171,18 +186,22 @@ is not on the team cannot merge, and neither can their agent.
   `pr-close`, `pr-review`, `pr-comment`, `git-push`). Every client (web,
   phone, Electron, iOS, Chrome) already goes through these routes, so this
   needs no client change.
-- **Delegate**: the same token, injected as `GH_TOKEN` into a turn the owner
-  started, exactly as `githubRunEnv(user)` does today, with `githubCredentialUser`
-  (#322) deciding whether the turn's sender is the owner. Nothing else in the
-  run has it: not a projected auth file that outlives the turn, not a Sandbox
-  volume. A turn whose sender is not the owner gets the Automation token
-  instead, never an empty one.
+- **Delegate**: the Automation token below in the shell, plus the
+  owner-identity tools: `open_pull_request`, `edit_pull_request`,
+  `comment_pull_request`, `reply_review_thread`, `resolve_review_thread`, and
+  `propose_merge`, which only writes the card. Each tool runs one request on
+  the server with the owner's token, scoped to the session's repositories,
+  and is mounted only when `githubCredentialUser` (#322) says the turn's
+  sender is the owner. The token is never in `GH_TOKEN`, an auth file, a
+  Sandbox volume, or anything else the run can read. `githubRunEnv(user)`
+  and the user-token projection into runs are deleted.
 - **Automation**: a repository-scoped installation token with the code
   permission set (`contents: write`, `pull_requests: write`, `issues: write`,
   `checks/actions/statuses: read`, `metadata: read`), minted per turn, one
   hour, never persisted. This is `githubServiceCredentialEnv`, which the
-  `github-*` code loops already use. Ordinary code automations and fix-round
-  handoff turns switch to it.
+  `github-*` code loops already use. Every other agent run switches to it:
+  owner-started turns, ordinary code automations, and fix-round handoff
+  turns.
 - **Reviewer**: the read set, exactly as #325 shipped it. The read-only
   ceiling is preserved by construction: the read set has no `contents: write`
   and there is no longer a transport token to exclude.
@@ -196,7 +215,8 @@ is not on the team cannot merge, and neither can their agent.
   set in code, including `contents: write`.
 
 The App can push branches again with this. It still cannot touch `main`, and
-that is enforced by GitHub, not by the token.
+that is enforced by GitHub, not by the token. There is now exactly one kind
+of credential in any agent's reach, and it is one the rulesets bind.
 
 ### Rulesets are the boundary
 
@@ -204,15 +224,19 @@ Two rulesets on every covered repository, both targeting the default branch.
 Rulesets are additive and bypass lists are per ruleset, which is what makes
 this work.
 
-1. **Integrity** (no bypass actors): require a pull request, required status
-   checks, linear history, no deletion, no force push. Everyone, humans
-   included, reaches `main` through a green PR.
-2. **Humans only** (bypass: the existing `mergers` team, mode "always"): the
-   single rule "restrict updates". Only bypass actors may update the ref. A
-   merge is an update, so only team members can merge, and the App, any
-   PAT, any SSH key, and any leaked bot token cannot merge or push `main`
-   whatever permissions they hold. `mergers` already exists and its roster is
-   part of submitted SOC2 evidence; reuse it rather than creating a team.
+1. **Integrity**: the repository's existing default-branch ruleset, left
+   exactly as it is. Require a pull request, required status checks, linear
+   history, no deletion, no force push, with whatever human bypass actors
+   the repository already grants. This design does not change who among the
+   humans may skip review; that is a separate question for the people who
+   own the compliance record, and it stays separate.
+2. **Humans only** (bypass: the same human actors the integrity ruleset
+   already lists, teams and organization owners, mode "always"): the single
+   rule "restrict updates". Only bypass actors may update the ref. A merge is
+   an update, so only those humans can merge, and the App, any PAT, any SSH
+   key, and any leaked bot token cannot merge or push `main` whatever
+   permissions they hold. Humans notice nothing. Reuse the existing teams
+   rather than creating one; their rosters are already evidenced.
 
 Repositories whose release process pushes `main` from GitHub Actions need a
 `DeployKey` bypass actor on the humans-only ruleset, because Actions cannot
@@ -220,7 +244,7 @@ be a bypass actor and those workflows push through a deploy key. The gitops
 repository is the known case.
 
 Verify the humans-only ruleset on a scratch repository before rollout:
-confirm a `mergers` member can squash-merge through the API, and that an
+confirm a bypass-team member can squash-merge through the API, and that an
 installation token with `contents: write` gets refused on merge and on
 `git push origin HEAD:main` while still pushing a feature branch.
 
@@ -228,56 +252,64 @@ With these two in place the question "which credential is on the box" stops
 deciding whether `main` is safe. It decides only how much cleanup a leak
 costs.
 
-### The owner asks, the agent acts as the owner
+### The owner asks, the gateway acts as the owner
 
-A Delegate turn does the work directly: `git push`, `gh pr create`, and when
-the owner asks for it, `gh pr merge`. The push is the owner's, the PR is
-authored by the owner, the merge is performed by the owner, all under the
-owner's login, which is what the team wants to see on GitHub.
+A Delegate turn pushes its branch with the bot token; the commits are still
+authored by the owner. Then it calls `open_pull_request`, and the gateway
+creates the PR as the owner, with the attribution footer from the session
+context. Later, `reply_review_thread` and `resolve_review_thread` post and
+resolve as the owner. On GitHub this reads exactly as if the owner had done
+it, which is what the team wants to see, and the agent's process held
+nothing but a bot token throughout.
 
-The guard is the question card, not the token. `PublicationPolicy` runs in
-Delegate turns too, and where it would refuse an Automation it asks the
-owner instead: the card shows the command (`gh pr merge 327 --squash`), and
-"Merge this" from the owner plus one approval is the whole flow. The
-existing five-second Merge with Undo in `PrStatusBar` stays as the click
-equivalent.
+When the owner says "merge this", the agent calls `propose_merge`. That
+writes a merge card into the transcript: the PR, the method, the check and
+review state. The owner's tap calls `pr-merge` with the owner's token, the
+same route the Merge button uses, with the existing five-second Undo. The
+agent has no path to the merge itself: not through a tool, not through the
+shell, not through the API, because nothing in its environment carries a
+token that GitHub would accept for an update to `main`.
+
+The gateway tools are the whole Delegate surface. They are few, they are
+named after their effect, and each does one request. Adding one is a
+security review, not a convenience.
 
 ### Attribution
 
 - Commit author stays the human (`gitIdentityEnv(author)`), with the model as
   `Co-Authored-By`.
-- Delegate PRs are authored by the owner and carry the attribution footer
-  from the session context, no assignee. Automation PRs are authored by the
-  bot, carry the footer, and assign the human the automation names.
+- Delegate PRs are authored by the owner through the gateway tool and carry
+  the attribution footer from the session context, no assignee. Automation
+  PRs are authored by the bot, carry the footer, and assign the human the
+  automation names.
 - Review threads and fix-round replies post as the bot, and the bot resolves
   the threads it has addressed. This is the decided behavior for handoffs
   and it is what the Automation credential produces. A Delegate turn replies
-  and resolves as the owner, the same as the owner would on github.com.
+  and resolves as the owner through the gateway tools, the same as the owner
+  would on github.com.
 
 ### Host hygiene
 
 - Every run receives the `githubGitCredentialEnv` shape: the credential
   helper, `GIT_TERMINAL_PROMPT=0`, the SSH to HTTPS `insteadOf` rewrite, and
   an isolated `GH_CONFIG_DIR` (#319). The token inside is the principal's:
-  the owner's for Delegate, code set for Automation, read set for Reviewer.
-  A run that is meant to have no write access gets the read token, not an
-  empty helper, because an empty helper today means "use whatever the host
-  has". Git must fail with a clear authentication error, never fall through.
+  code set for Delegate and Automation, read set for Reviewer. A run that is
+  meant to have no write access gets the read token, not an empty helper,
+  because an empty helper today means "use whatever the host has". Git must
+  fail with a clear authentication error, never fall through.
 - No PAT, SSH key, or `gh` login on the host. `~/.opensession/github-auth.json`
   and `github-app.pem` remain, readable by the gateway uid.
-- Agent bash still shares that uid on host runs, and a Delegate turn holds
-  the owner's token by design. So on a host run the owner's authority is
-  available to the agent for the length of the turn, and the token store is
-  readable between turns. The rulesets bound what the bot can do with the
-  App key; a human token is the human, bounded only by the question card
-  and the `mergers` roster. The threat model for Delegate turns is a
-  confused agent, not a hostile one. Uid separation for run hosts, or
-  Sandboxes by default, closes the between-turns half.
+- Agent bash still shares that uid on host runs, so the human token store
+  and the App key are readable from the shell. The rulesets bound what the
+  App key can do; a human token read from that file is the human. That is
+  the one remaining way an agent could reach `main`, it requires the agent
+  to go looking for a file it was never handed, and uid separation for run
+  hosts, or Sandboxes by default, closes it.
 
 ### Command policy as a tripwire for every agent
 
-`PublicationPolicy` becomes a property of every delegate and automation run,
-not only descendants: `{repo, baseBranch, headBranches}` where `headBranches`
+`PublicationPolicy` becomes a property of every agent run, not only
+descendants: `{repo, baseBranch, headBranches}` where `headBranches`
 is the session branch plus each attached repository's branch. It matches by
 effect, not by HTTP verb: `gh pr merge`, `gh pr review --approve`, `git push`
 to `baseBranch` or to a branch outside `headBranches`, `--force` without
@@ -287,15 +319,14 @@ endpoints, a review with the `APPROVE` event, ref updates and deletes,
 `mergePullRequest`, `enablePullRequestAutoMerge`). Commenting, replying in a
 thread, and `resolveReviewThread` / `unresolveReviewThread` are not
 publication and pass in every turn kind; an agent that has fixed a finding
-replies and resolves the thread without a card. Automation turns get a
-refusal on the matched set. Delegate turns get a question card with the
-exact command, answered "once", never "always".
+replies and resolves the thread without a card. Every turn kind gets a
+refusal on the matched set. In a Delegate turn the refusal names the tool to
+use instead (`propose_merge`), so "merge this" still ends in a card rather
+than an error.
 
-For Automation this is a tripwire, as `command-policy.ts` says of itself;
-the boundary is the token and the rulesets. For Delegate the card is the
-boundary, because the token is the owner's. That is a deliberate choice: the
-owner asked for an agent that can merge on request, and a card per merge is
-the cheapest way to make "on request" mean something.
+This is a tripwire, as `command-policy.ts` says of itself. The boundary is
+the token and the rulesets; the policy exists so that a confused agent gets
+a clear message instead of a 403, and so that the attempt is logged.
 
 ### Observability
 
@@ -322,50 +353,58 @@ deploy. Phases 1 and 2 are code. Phase 3 is infrastructure.
    token split. It states that the control objective is unchanged (no
    automated identity can update a protected branch or merge a pull request)
    and that enforcement moves from a permission cap plus credential split to
-   identity-based rulesets with the `mergers` team as the only human bypass.
-   Auditors were told the cap and split are the corrective actions; the
-   record has to say otherwise before the instance does.
-1. Add the humans-only ruleset to every covered repository, with the
-   `DeployKey` bypass where a release workflow pushes `main`. Add the pull
-   request rule to any integrity ruleset that lacks it. Verify on a scratch
-   repository first. See the first open question before applying this to
-   `opensession` itself.
+   an identity-based ruleset that no automated identity can bypass, with no
+   agent process holding a human credential. Auditors were told the cap and
+   split are the corrective actions; the record has to say otherwise before
+   the instance does.
+1. Add the humans-only ruleset to every covered repository, bypass list
+   copied from the existing integrity ruleset, plus the `DeployKey` bypass
+   where a release workflow pushes `main`. Leave the integrity ruleset
+   untouched. Verify on a scratch repository first. See the first open
+   question before applying this to `opensession` itself.
 2. Restore `contents: write` on the installation (approve the updated
    permissions in the org).
 3. Unset `OPENSESSION_GITHUB_PUSH_TOKEN`; revoke the transport token. Revoke
    and remove every other ambient credential on the host.
 
-After this, humans merge from the UI again, the owner's agent merges on
-request again, and no bot identity can touch `main`.
+After this, humans merge from the UI again and no bot identity can touch
+`main`. Agents in owner-started turns still hold the owner's token until
+Phase 1 lands; the humans-only ruleset does not bound that token, so Phase 1
+is what closes requirement 2.
 
 **Phase 1, credentials and policy**
 
-4. `githubCredentialUser` decides Delegate versus Automation for every turn,
+4. Every agent run gets `githubCodeRunEnv(cwd)`; `githubRunEnv(user)` and the
+   user-token projection into runs are deleted. Fix-round handoff turns and
+   owner-started turns land on the same path, which closes the `"GitHub"`
+   sender bug as a side effect. Ask-mode `github-*` runs keep the #325 read
+   path untouched.
+5. `githubCredentialUser` decides Delegate versus Automation for every turn,
    defaulting to Automation for any sender that is not the session owner or
-   an auto-continue of the owner. `pi-runner.ts` injects `githubRunEnv(user)`
-   for Delegate and `githubCodeRunEnv(cwd)` for Automation; fix-round
-   handoff turns land on the Automation path, which closes the `"GitHub"`
-   sender bug. Ask-mode `github-*` runs keep the #325 read path untouched.
-5. Give ordinary code automations the Automation credential plus a
+   an auto-continue of the owner. Delegate turns get the owner-identity
+   gateway tools; the tools run the request server-side with the owner's
+   token and refuse repositories outside the session.
+6. Give ordinary code automations the Automation credential plus a
    `PublicationPolicy`, so they open real PRs instead of pushing with an
    ambient identity.
-6. Inject the credential-helper env shape into every run, read token for
-   Reviewer, code token for Automation, owner token for Delegate.
-7. Extend `PublicationPolicy` to every delegate and automation run: refusal
-   for Automation, question card for Delegate.
-8. Delete the transport-token plumbing and its docs section. Fix
+7. Inject the credential-helper env shape into every run, read token for
+   Reviewer, code token for everything else.
+8. Extend `PublicationPolicy` to every agent run as a refusal, with the
+   Delegate hint toward `propose_merge`. Render the merge card in every
+   client from the same `pr-merge` route the Merge button uses.
+9. Delete the transport-token plumbing and its docs section. Fix
    `audited()`.
 
 **Phase 2, product**
 
-9. Boot-time posture log and a Settings → Integrations panel that shows
-   installation permissions and missing rulesets per repository.
+10. Boot-time posture log and a Settings → Integrations panel that shows
+    installation permissions and missing rulesets per repository.
 
 **Phase 3, isolation**
 
-10. Run hosts under a separate uid, or Sandboxes by default for interactive
-    sessions, so the human token store is unreadable from agent bash between
-    turns.
+11. Run hosts under a separate uid, or Sandboxes by default for interactive
+    sessions, so the human token store and the App key are unreadable from
+    agent bash.
 
 ## What this removes
 
@@ -374,9 +413,11 @@ request again, and no bot identity can touch `main`.
 - The rule that ordinary automations get no GitHub credential, replaced by
   "every agent gets a bot credential sized to its principal and a
   publication policy".
+- The owner's token in the run environment (`githubRunEnv`, `githubAuthEnv`
+  for runs, the Sandbox auth-file projection).
 - The claim that "no credential on the host can merge". The claim becomes "no
-  bot credential can update `main`, and a human credential is present only in
-  a turn that human started, behind a card for anything that touches `main`".
+  agent process holds a credential that can update `main`, and the only
+  credential agents hold is one the rulesets refuse on `main`".
 
 ## Open questions
 
@@ -388,19 +429,17 @@ request again, and no bot identity can touch `main`.
   integrity ruleset only and accept that the bot can update its `main`
   through a PR-less push; route the shared-checkout push through a server
   route that uses the session owner's token, which limits direct pushes to
-  `mergers` members; or move `opensession` to PR-only like every other
+  bypass members; or move `opensession` to PR-only like every other
   repository and let `deploy_self` promote merged commits. This is a
   workflow decision for Michiel and it gates Phase 0 step 1 for
-  `opensession`. Under this design a Delegate turn pushes as the owner, so a
-  `mergers` member's session can already update `main` through the
-  humans-only ruleset; the question is only about Automation pushes and
-  about owners who are not on the team.
-- Should the merge card be skippable? A per-session or per-user "merge
-  without asking" toggle would make "merge this" a single step. It also
-  makes the token the only guard for the rest of the session.
-- Should the humans-only bypass stay a team (`mergers`) or become the
-  `maintain` role? The team is explicit, auditable, and already evidenced;
-  a role follows repository membership.
+  `opensession`. Under this design every session push runs as the bot, so
+  the humans-only ruleset would stop the shared-checkout push outright; the
+  gateway-route option (a `push_main` tool behind a card, owner's token) is
+  the one that keeps the current model.
+- Should the humans-only bypass list be copied from the integrity ruleset,
+  as proposed, or narrowed to one team? Copying changes nothing for humans
+  and keeps this change about agents. Narrowing is a people decision that
+  belongs with the compliance record, not here.
 - Simple mode (one person, personal App) has one token for every principal,
   Automation included. The rulesets still hold; the Delegate versus
   Automation split does not. Acceptable for a single-user install, worth

--- a/docs/github-authority.md
+++ b/docs/github-authority.md
@@ -10,14 +10,18 @@ live in the operator's private notes, not here.
 
 1. A human who explicitly triggers an action in Open Session acts with their
    full GitHub permissions. Merge, close, review, push: whatever they could do
-   on github.com, they can do from the OS UI, attributed to them.
-2. An agent, whether it is working on a human's behalf in an interactive
-   session or running unattended in an automation, can never update a
-   protected branch, merge a pull request, or perform a destructive action,
-   no matter what it finds on the host or what its prompt is told.
+   on github.com, they can do from the OS UI, attributed to them. That
+   includes telling the agent in their own session to do it: "merge this"
+   from the session owner merges as the session owner.
+2. An unattended run, whether an automation, a `github-*` loop, a review, or
+   a fix-round handoff into someone's session, can never update a protected
+   branch, merge a pull request, or perform a destructive action, no matter
+   what it finds on the host or what its prompt is told.
 
 These are two different principals with two different ceilings. The current
-system gives them one ceiling and has been moving it up and down.
+system gives them one ceiling and has been moving it up and down. The line
+between them is not "human versus agent"; it is "a human is present and
+asking" versus "nobody is".
 
 ## How a split-credential deployment fails today
 
@@ -47,15 +51,19 @@ receive the session owner's App user token as `GH_TOKEN` so that PRs are
 authored by the human. Whatever the human may do, the agent may do with that
 token. Before the cap this included merging; the cap removed it by removing
 it from the human too. GitHub has no narrower delegated form of a user token,
-so requirement 2 can only be met if agent runs never carry a human token.
+so the choice is binary: the interactive agent either holds the human's
+authority or none of it. This design keeps it, because the session owner
+wants "merge this" to work, and puts the guard on the turn instead: the
+token is present only while the owner is the one prompting.
 
 A related live bug: `agents/github/handoff.ts` delivers fix-round handoffs
 with sender `"GitHub"`. `githubCredentialUser` (#322) treats only the
 auto-continue sender as synthetic, so `"GitHub"` shadows the session owner and
 the turn runs with an empty token. Michiel and John have already decided that
-fix-round replies should post as the bot, not the human. The Delegate
-principal below is exactly that: the turn credential is an installation token
-whatever the sender string says, so the shadowing class of bug disappears.
+fix-round replies should post as the bot, not the human. That is the
+Automation principal below: a turn that no human started gets an
+installation token whatever the sender string says, so the shadowing class
+of bug disappears.
 
 ### Unattended runs
 
@@ -102,9 +110,9 @@ Three facts fix the shape of any working design:
 - GitHub separates identities per ref only through rulesets. That is the one
   place where "the bot may push branches but not `main`" can be enforced
   server-side, independent of which token leaked where.
-- A human's token grants the human's authority to whoever holds it. Agent
-  runs therefore must not hold it; attribution has to come from somewhere
-  else.
+- A human's token grants the human's authority to whoever holds it. Only a
+  turn the human started may hold it, and the human must be able to see and
+  stop what it does with it.
 
 ## Design
 
@@ -113,13 +121,23 @@ Three facts fix the shape of any working design:
 | Principal  | Who                                                                    | GitHub identity   |
 | ---------- | ---------------------------------------------------------------------- | ----------------- |
 | Human      | A signed-in person clicking a button in any OS client                  | Their own account |
-| Delegate   | The agent in an interactive session, acting for the session owner      | `<app-slug>[bot]` |
-| Automation | Unattended code runs: automations, `github-*` code loops, descendants  | `<app-slug>[bot]` |
+| Delegate   | The agent in a turn the session owner started, acting for the owner    | The owner         |
+| Automation | Turns no human started: automations, `github-*` code loops,            | `<app-slug>[bot]` |
+|            | descendants, fix-round handoffs, auto-continue of an automation        |                   |
 | Reviewer   | Unattended ask runs over untrusted content: PR review, merge risk      | `<app-slug>[bot]` |
 | Service    | Server-owned calls: PR cache, review posting, webhooks, worktree setup | `<app-slug>[bot]` |
 
-Human is the only principal that ever holds a user token. Every other
-principal is the App.
+Human and Delegate are the same GitHub identity. Delegate is the human's own
+token in the hands of the agent, for the length of a turn the human started.
+Every other principal is the App.
+
+What makes a turn Delegate rather than Automation is who started it, not
+which session it lands in. A prompt typed by the session owner, an
+auto-continue of that prompt (#322), or a worker report back into that
+session is Delegate. A GitHub webhook, a schedule, a fix-round handoff, or a
+message from another session is Automation, even when it is delivered into
+an interactive session. `githubCredentialUser` becomes the single place that
+decides this, and it errs toward the bot: an unknown sender is not the owner.
 
 ### Capabilities
 
@@ -130,31 +148,39 @@ principal is the App.
 | Force-push own branch               | yes   | lease    | no         | no       | no      |
 | Open a PR                           | yes   | yes      | yes        | no       | no      |
 | Comment, reply in threads           | yes   | yes      | yes        | yes      | yes     |
-| Submit an approving review          | yes   | no       | no         | no       | no      |
-| Merge                               | yes   | no       | no         | no       | no      |
-| Update or push the default branch   | PR    | no       | no         | no       | no      |
-| Delete a branch                     | yes   | no       | no         | no       | no      |
+| Submit an approving review          | yes   | ask      | no         | no       | no      |
+| Merge                               | yes   | ask      | no         | no       | no      |
+| Update or push the default branch   | PR    | ask      | no         | no       | no      |
+| Delete a branch                     | yes   | ask      | no         | no       | no      |
 | Repository settings, rulesets, apps | no    | no       | no         | no       | no      |
 
 "PR" means the human reaches `main` only by merging a PR that satisfies the
-integrity ruleset. "lease" means `--force-with-lease` only.
+integrity ruleset. "lease" means `--force-with-lease` only. "ask" means the
+agent can do it with the owner's token, and the command policy turns it into
+a question card first: the owner sees the exact command and approves it in
+the session. "Merge this" from the owner followed by one approval is the
+intended path; a merge the owner did not ask for never gets past the card.
+The Delegate column is also what the `mergers` roster bounds: an owner who
+is not on the team cannot merge, and neither can their agent.
 
 ### Credentials
 
-- **Human**: the App user token from device-flow sign-in, as today. It is used
-  by server routes for human-initiated actions only (`pr-merge`,
-  `pr-stack-merge`, `pr-close`, `pr-review`, `pr-comment`, `git-push`, and the
-  proposal endpoints below). It is never placed in a run environment, a
-  projected auth file, or a Sandbox. Every client (web, phone, Electron, iOS,
-  Chrome) already goes through these routes, so this needs no client change.
-  Auto-continue keeps resolving the session owner for these routes (#322);
-  the owner's identity is still needed for attribution and for the proposal
-  cards, it just no longer becomes a run credential.
-- **Delegate and Automation**: a repository-scoped installation token with the
-  code permission set (`contents: write`, `pull_requests: write`,
-  `issues: write`, `checks/actions/statuses: read`, `metadata: read`), minted
-  per turn, one hour, never persisted. This is `githubServiceCredentialEnv`,
-  which the `github-*` code loops already use. Interactive runs and fix-round
+- **Human**: the App user token from device-flow sign-in, as today. Server
+  routes use it for click-initiated actions (`pr-merge`, `pr-stack-merge`,
+  `pr-close`, `pr-review`, `pr-comment`, `git-push`). Every client (web,
+  phone, Electron, iOS, Chrome) already goes through these routes, so this
+  needs no client change.
+- **Delegate**: the same token, injected as `GH_TOKEN` into a turn the owner
+  started, exactly as `githubRunEnv(user)` does today, with `githubCredentialUser`
+  (#322) deciding whether the turn's sender is the owner. Nothing else in the
+  run has it: not a projected auth file that outlives the turn, not a Sandbox
+  volume. A turn whose sender is not the owner gets the Automation token
+  instead, never an empty one.
+- **Automation**: a repository-scoped installation token with the code
+  permission set (`contents: write`, `pull_requests: write`, `issues: write`,
+  `checks/actions/statuses: read`, `metadata: read`), minted per turn, one
+  hour, never persisted. This is `githubServiceCredentialEnv`, which the
+  `github-*` code loops already use. Ordinary code automations and fix-round
   handoff turns switch to it.
 - **Reviewer**: the read set, exactly as #325 shipped it. The read-only
   ceiling is preserved by construction: the read set has no `contents: write`
@@ -201,70 +227,66 @@ With these two in place the question "which credential is on the box" stops
 deciding whether `main` is safe. It decides only how much cleanup a leak
 costs.
 
-### Human actions are server-executed; agents propose
+### The owner asks, the agent acts as the owner
 
-Everything in the Human column runs in a server route with the human's token,
-triggered by a click. The agent never calls these itself. Where the agent
-needs the outcome, it proposes and the human confirms:
+A Delegate turn does the work directly: `git push`, `gh pr create`, and when
+the owner asks for it, `gh pr merge`. The push is the owner's, the PR is
+authored by the owner, the merge is performed by the owner, all under the
+owner's login, which is what the team wants to see on GitHub.
 
-- `opensession-repos` gains `propose_pull_request({repo, base, title, body,
-reviewers})` and `propose_merge({repo, number, method})`. Each writes a
-  proposal card into the session transcript. The card's button calls the
-  existing routes with the human's credential, so a PR opened this way is
-  authored by the human and a merge is performed by the human.
-- A delegate may also open a PR directly as the bot when nobody is waiting on
-  the card. That PR carries the attribution footer and the human as assignee,
-  the pre-`userPrAuth` behavior.
-- The existing five-second Merge with Undo in `PrStatusBar` stays as the
-  human's merge control. A `propose_merge` card simply focuses it.
+The guard is the question card, not the token. `PublicationPolicy` runs in
+Delegate turns too, and where it would refuse an Automation it asks the
+owner instead: the card shows the command (`gh pr merge 327 --squash`), and
+"Merge this" from the owner plus one approval is the whole flow. The
+existing five-second Merge with Undo in `PrStatusBar` stays as the click
+equivalent.
 
-### Attribution without authority
+### Attribution
 
 - Commit author stays the human (`gitIdentityEnv(author)`), with the model as
-  `Co-Authored-By`. GitHub shows the human as author and the bot as pusher.
-- PR bodies end with the attribution footer from the session context. Bot
-  authored PRs assign the human; human authored ones do not.
-- Session context text changes from "PRs use @login's account; do not add an
-  assignee" to whichever of the two applies.
+  `Co-Authored-By`.
+- Delegate PRs are authored by the owner and carry the attribution footer
+  from the session context, no assignee. Automation PRs are authored by the
+  bot, carry the footer, and assign the human the automation names.
 - Review threads and fix-round replies post as the bot. This is the decided
-  behavior for handoffs and it is what the Delegate credential produces.
-
-Whether the team prefers bot-authored or human-authored PRs is a review
-policy question, not a security one: a human cannot approve their own PR, so
-bot-authored PRs let the session owner be the reviewer, while human-authored
-PRs force a second person. The proposal card gives either.
+  behavior for handoffs and it is what the Automation credential produces.
 
 ### Host hygiene
 
 - Every run receives the `githubGitCredentialEnv` shape: the credential
   helper, `GIT_TERMINAL_PROMPT=0`, the SSH to HTTPS `insteadOf` rewrite, and
   an isolated `GH_CONFIG_DIR` (#319). The token inside is the principal's:
-  code set for Delegate and Automation, read set for Reviewer. A run that is
-  meant to have no write access gets the read token, not an empty helper,
-  because an empty helper today means "use whatever the host has". Git must
-  fail with a clear authentication error, never fall through.
+  the owner's for Delegate, code set for Automation, read set for Reviewer.
+  A run that is meant to have no write access gets the read token, not an
+  empty helper, because an empty helper today means "use whatever the host
+  has". Git must fail with a clear authentication error, never fall through.
 - No PAT, SSH key, or `gh` login on the host. `~/.opensession/github-auth.json`
   and `github-app.pem` remain, readable by the gateway uid.
-- Agent bash still shares that uid on host runs. That is the residual risk:
-  an adversarial agent can read the human token store. The rulesets bound
-  what the bot can do with the App key, but a human token is the human. The
-  fix is uid separation for run hosts, or Sandboxes by default; until then
-  the invariant is "no human token in any run environment" and the threat
-  model is a confused agent, not a hostile one.
+- Agent bash still shares that uid on host runs, and a Delegate turn holds
+  the owner's token by design. So on a host run the owner's authority is
+  available to the agent for the length of the turn, and the token store is
+  readable between turns. The rulesets bound what the bot can do with the
+  App key; a human token is the human, bounded only by the question card
+  and the `mergers` roster. The threat model for Delegate turns is a
+  confused agent, not a hostile one. Uid separation for run hosts, or
+  Sandboxes by default, closes the between-turns half.
 
 ### Command policy as a tripwire for every agent
 
 `PublicationPolicy` becomes a property of every delegate and automation run,
 not only descendants: `{repo, baseBranch, headBranches}` where `headBranches`
-is the session branch plus each attached repository's branch. It refuses
+is the session branch plus each attached repository's branch. It matches
 `gh pr merge`, `gh pr review --approve`, `gh api` with a mutating method,
 `git push` to `baseBranch` or to a branch outside `headBranches`, `--force`
 without `--force-with-lease`, `git push --delete`, and any `--repo` outside the
-session's repositories. Interactive runs get a question card instead of a
-refusal, and the card offers the server-executed action when one exists.
+session's repositories. Automation turns get a refusal. Delegate turns get a
+question card with the exact command, answered "once", never "always".
 
-This is a tripwire, as `command-policy.ts` says of itself. The boundary is
-the token and the rulesets.
+For Automation this is a tripwire, as `command-policy.ts` says of itself;
+the boundary is the token and the rulesets. For Delegate the card is the
+boundary, because the token is the owner's. That is a deliberate choice: the
+owner asked for an agent that can merge on request, and a card per merge is
+the cheapest way to make "on request" mean something.
 
 ### Observability
 
@@ -304,39 +326,37 @@ deploy. Phases 1 and 2 are code. Phase 3 is infrastructure.
 3. Unset `OPENSESSION_GITHUB_PUSH_TOKEN`; revoke the transport token. Revoke
    and remove every other ambient credential on the host.
 
-After this, humans merge from the UI again and no bot identity can touch
-`main`. Interactive runs still carry the human's token until phase 1, which
-is the pre-2026-09-07 state and should not be left for long.
+After this, humans merge from the UI again, the owner's agent merges on
+request again, and no bot identity can touch `main`.
 
 **Phase 1, credentials and policy**
 
-4. `pi-runner.ts`: interactive runs use `githubCodeRunEnv(cwd)` instead of
-   `githubRunEnv(user)`; fix-round handoff turns take the same path, which
-   also closes the `"GitHub"` sender bug. Remove `githubRunEnv`,
-   `githubAuthEnv`, the token half of `projectedGithubAuthEnv`, and the
-   Sandbox projection of user tokens. `githubCredentialForLogin`,
-   `githubCredentialUser`, and `soleGithubAccount` remain for routes and
-   attribution. Ask-mode `github-*` runs keep the #325 read path untouched.
+4. `githubCredentialUser` decides Delegate versus Automation for every turn,
+   defaulting to Automation for any sender that is not the session owner or
+   an auto-continue of the owner. `pi-runner.ts` injects `githubRunEnv(user)`
+   for Delegate and `githubCodeRunEnv(cwd)` for Automation; fix-round
+   handoff turns land on the Automation path, which closes the `"GitHub"`
+   sender bug. Ask-mode `github-*` runs keep the #325 read path untouched.
 5. Give ordinary code automations the Automation credential plus a
    `PublicationPolicy`, so they open real PRs instead of pushing with an
    ambient identity.
 6. Inject the credential-helper env shape into every run, read token for
-   Reviewer, code token otherwise.
-7. Extend `PublicationPolicy` to every delegate and automation run.
+   Reviewer, code token for Automation, owner token for Delegate.
+7. Extend `PublicationPolicy` to every delegate and automation run: refusal
+   for Automation, question card for Delegate.
 8. Delete the transport-token plumbing and its docs section. Fix
    `audited()`.
 
 **Phase 2, product**
 
-9. `propose_pull_request` and `propose_merge` in `opensession-repos`, proposal
-   cards in the transcript, the routes behind them, session-context wording.
-10. Boot-time posture log and a Settings → Integrations panel that shows
-    installation permissions and missing rulesets per repository.
+9. Boot-time posture log and a Settings → Integrations panel that shows
+   installation permissions and missing rulesets per repository.
 
 **Phase 3, isolation**
 
-11. Run hosts under a separate uid, or Sandboxes by default for interactive
-    sessions, so the human token store is unreadable from agent bash.
+10. Run hosts under a separate uid, or Sandboxes by default for interactive
+    sessions, so the human token store is unreadable from agent bash between
+    turns.
 
 ## What this removes
 
@@ -346,7 +366,8 @@ is the pre-2026-09-07 state and should not be left for long.
   "every agent gets a bot credential sized to its principal and a
   publication policy".
 - The claim that "no credential on the host can merge". The claim becomes "no
-  bot credential can update `main`, and no run holds a human credential".
+  bot credential can update `main`, and a human credential is present only in
+  a turn that human started, behind a card for anything that touches `main`".
 
 ## Open questions
 
@@ -361,14 +382,20 @@ is the pre-2026-09-07 state and should not be left for long.
   `mergers` members; or move `opensession` to PR-only like every other
   repository and let `deploy_self` promote merged commits. This is a
   workflow decision for Michiel and it gates Phase 0 step 1 for
-  `opensession`.
-- Bot-authored or human-authored PRs by default? See Attribution.
+  `opensession`. Under this design a Delegate turn pushes as the owner, so a
+  `mergers` member's session can already update `main` through the
+  humans-only ruleset; the question is only about Automation pushes and
+  about owners who are not on the team.
+- Should the merge card be skippable? A per-session or per-user "merge
+  without asking" toggle would make "merge this" a single step. It also
+  makes the token the only guard for the rest of the session.
 - Should the humans-only bypass stay a team (`mergers`) or become the
   `maintain` role? The team is explicit, auditable, and already evidenced;
   a role follows repository membership.
-- Simple mode (one person, personal App) has one token that is both the human
-  and, in effect, the delegate. The rulesets still hold; the token separation
-  does not. Acceptable for a single-user install, worth stating in the docs.
+- Simple mode (one person, personal App) has one token for every principal,
+  Automation included. The rulesets still hold; the Delegate versus
+  Automation split does not. Acceptable for a single-user install, worth
+  stating in the docs.
 - Code Storage hosts have no rulesets. Their "pushed branch is the change
   request" model already keeps agents off the mainline; document it as the
   equivalent.


### PR DESCRIPTION
A design doc, not code. It reviews how Open Session handles GitHub operations on behalf of humans versus agents and automations, why the credential split (#318, #319, #325) makes merging from the OS UI fail on split-credential deployments, and proposes one model to replace the knob-tuning. Instance-specific findings are in the operator's private notes on the VPS, not in this PR.

The mechanism: a GitHub App user token can never exceed the App's own permissions, and merging needs `contents: write`. Capping the installation at `contents: read` to stop bots therefore stops humans too, and `audited()` records the failed merges as `ok: true`. A run with no injected credential also gets no SSH-to-HTTPS rewrite, so "credential-free" automations push with whatever ambient identity the host has. A fix-round handoff delivered with sender `"GitHub"` shadows the owner and runs with no token at all.

The proposal:

- **No agent process ever holds a human credential.** Every agent run, including a turn the session owner typed, runs with a repository-scoped installation token in its shell. The owner's token lives in two places only: the routes behind the UI buttons, and two gateway tools (`open_pull_request`, `edit_pull_request`) that a Delegate turn can call and the gateway executes server-side as the owner. PRs show up under the owner's name without a tap. Commits, comments, review-thread replies, and resolves are the bot's in every turn kind, with the human as `Co-authored-by` on commits. Merge is a `propose_merge` card whose tap calls the same `pr-merge` route the Merge button uses.
- Five principals: Human, Delegate, Automation, Reviewer, Service. `githubCredentialUser` (#322) decides whether the owner-identity tools are mounted and defaults to Automation, which fixes the handoff sender bug and matches the decision that fix-round replies post as the bot. Reviewer keeps the #325 read set.
- Rulesets: leave each repository's existing integrity ruleset untouched, bypass list included. Add one "restrict updates" ruleset on the default branch whose bypass list copies the same human actors (plus `DeployKey` where a release workflow pushes `main`). Humans notice nothing; the App, any PAT, any leaked bot token cannot merge or push `main`.
- Retire the transport token and its four code paths, restore `contents: write` on the App, revoke and remove ambient host credentials, inject the credential-helper env shape into every run, extend `PublicationPolicy` to all agent runs as a refusal, fix `audited()`.
- Phased migration. Phase 0 is compliance and operator work, starting with a dated addendum to the deviation record before live state changes. Phase 1 (the code) is what closes the "agent in your own session" case.

Open questions lead with opensession's own push-to-main development model.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a08084-2be1-7755-af81-327caafcf9c0)


