### PR TITLE
Let native new sessions set the default model

### DIFF
--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -78,13 +78,21 @@ enum NativePreferences {
     /// never leaves, and a confirmation that arrives after a newer tap keeps
     /// the newer value locally until that tap's own write confirms it.
     ///
+    /// An account or server switch while a write is queued or on the wire
+    /// ends it: the PUT is skipped (it would leave on the new connection with
+    /// the old user), its confirmation is dropped, and once the last pending
+    /// write has released the hydration guard the active account is
+    /// rehydrated, replacing the optimistic value the old account left in
+    /// AppStorage.
+    ///
     /// Returns whether the server's confirmation was applied.
     @discardableResult
     static func setDefaultModel(
         _ model: String,
         write: @escaping (Context, [String: String?]) async throws -> [String: String] = { context, prefs in
             try await SettingsAPI.updateUiPrefs(user: context.user, prefs: prefs)
-        }
+        },
+        rehydrate: @escaping @MainActor () async -> Void = { await hydrate() }
     ) async -> Bool {
         let defaults = UserDefaults.standard
         guard !model.isEmpty, model != defaults.string(forKey: defaultModelStorageKey) else {
@@ -98,24 +106,52 @@ enum NativePreferences {
 
         let previous = lastDefaultModelWrite
         let mine = Task<Bool, Never> { @MainActor in
-            defer { endLocalWrite() }
             _ = await previous?.value
-            // A newer tap is queued behind this one; its write carries the
-            // value that should win, so this one must not reach the server.
-            guard serial == defaultModelWriteSerial else { return false }
-            guard let response = try? await write(requestContext, [defaultModelPrefKey: model]) else {
-                return false
+            let applied = await sendDefaultModel(
+                model,
+                serial: serial,
+                for: requestContext,
+                write: write
+            )
+            endLocalWrite()
+            // The account changed while this write was pending. Its hydration
+            // ran into the guard and skipped, so the old account's optimistic
+            // value is still in AppStorage; fetch the active map now that the
+            // guard is down. A write still queued behind this one does it
+            // instead, either by applying the new account's own confirmation
+            // or by rehydrating here when it is stale too.
+            if pendingLocalWrites == 0, context() != requestContext {
+                await rehydrate()
             }
-            var confirmed = response
-            if serial != defaultModelWriteSerial {
-                confirmed[defaultModelPrefKey] = defaults.string(forKey: defaultModelStorageKey) ?? model
-            } else if confirmed[defaultModelPrefKey] == nil {
-                confirmed[defaultModelPrefKey] = model
-            }
-            return apply(confirmed, for: requestContext)
+            return applied
         }
         lastDefaultModelWrite = mine
         return await mine.value
+    }
+
+    private static func sendDefaultModel(
+        _ model: String,
+        serial: Int,
+        for requestContext: Context,
+        write: (Context, [String: String?]) async throws -> [String: String]
+    ) async -> Bool {
+        // A newer tap is queued behind this one; its write carries the value
+        // that should win, so this one must not reach the server. An account
+        // switch while queued ends it too: `SettingsAPI` resolves server and
+        // token from the connection that is current when the PUT leaves, so
+        // the old account's pick would land on the new account or server.
+        guard serial == defaultModelWriteSerial, context() == requestContext else { return false }
+        guard let response = try? await write(requestContext, [defaultModelPrefKey: model]) else {
+            return false
+        }
+        var confirmed = response
+        if serial != defaultModelWriteSerial {
+            confirmed[defaultModelPrefKey] =
+                UserDefaults.standard.string(forKey: defaultModelStorageKey) ?? model
+        } else if confirmed[defaultModelPrefKey] == nil {
+            confirmed[defaultModelPrefKey] = model
+        }
+        return apply(confirmed, for: requestContext)
     }
 
     @discardableResult

--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -16,6 +16,10 @@ enum NativePreferences {
     /// Counts default-model writes so a confirmation that comes back after a
     /// newer pick left can tell it is describing an older state of the key.
     private static var defaultModelWriteSerial = 0
+    /// The write currently on the wire, or queued behind it. `/api/ui-prefs`
+    /// keeps whichever PUT arrives last, so writes leave one at a time in tap
+    /// order and the newest pick is always the last one the server sees.
+    private static var lastDefaultModelWrite: Task<Bool, Never>?
     private static let identityKey = "os1.preferences.identity"
     private static let bucketKey = "os1.preferences.bucket"
     static let sessionCheckoutsStorageKey = "os1.composer.sessionCheckouts"
@@ -69,13 +73,16 @@ enum NativePreferences {
     /// immediately so every open picker's checkmark moves at once; the
     /// confirmed map then goes through `apply`, which drops it if the account
     /// changed while the write was out. A newer pick made meanwhile wins over
-    /// this write's confirmation, so two quick taps never settle on the first.
+    /// this write, on the server and on this device: writes go out one at a
+    /// time in tap order, a queued write that a newer tap already replaced
+    /// never leaves, and a confirmation that arrives after a newer tap keeps
+    /// the newer value locally until that tap's own write confirms it.
     ///
     /// Returns whether the server's confirmation was applied.
     @discardableResult
     static func setDefaultModel(
         _ model: String,
-        write: (Context, [String: String?]) async throws -> [String: String] = { context, prefs in
+        write: @escaping (Context, [String: String?]) async throws -> [String: String] = { context, prefs in
             try await SettingsAPI.updateUiPrefs(user: context.user, prefs: prefs)
         }
     ) async -> Bool {
@@ -87,19 +94,28 @@ enum NativePreferences {
         defaultModelWriteSerial += 1
         let serial = defaultModelWriteSerial
         beginLocalWrite()
-        defer { endLocalWrite() }
         defaults.set(model, forKey: defaultModelStorageKey)
 
-        guard let response = try? await write(requestContext, [defaultModelPrefKey: model]) else {
-            return false
+        let previous = lastDefaultModelWrite
+        let mine = Task<Bool, Never> { @MainActor in
+            defer { endLocalWrite() }
+            _ = await previous?.value
+            // A newer tap is queued behind this one; its write carries the
+            // value that should win, so this one must not reach the server.
+            guard serial == defaultModelWriteSerial else { return false }
+            guard let response = try? await write(requestContext, [defaultModelPrefKey: model]) else {
+                return false
+            }
+            var confirmed = response
+            if serial != defaultModelWriteSerial {
+                confirmed[defaultModelPrefKey] = defaults.string(forKey: defaultModelStorageKey) ?? model
+            } else if confirmed[defaultModelPrefKey] == nil {
+                confirmed[defaultModelPrefKey] = model
+            }
+            return apply(confirmed, for: requestContext)
         }
-        var confirmed = response
-        if serial != defaultModelWriteSerial {
-            confirmed[defaultModelPrefKey] = defaults.string(forKey: defaultModelStorageKey) ?? model
-        } else if confirmed[defaultModelPrefKey] == nil {
-            confirmed[defaultModelPrefKey] = model
-        }
-        return apply(confirmed, for: requestContext)
+        lastDefaultModelWrite = mine
+        return await mine.value
     }
 
     @discardableResult

--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -13,9 +13,14 @@ enum NativePreferences {
 
     private static var generation = 0
     private static var pendingLocalWrites = 0
+    /// Counts default-model writes so a confirmation that comes back after a
+    /// newer pick left can tell it is describing an older state of the key.
+    private static var defaultModelWriteSerial = 0
     private static let identityKey = "os1.preferences.identity"
     private static let bucketKey = "os1.preferences.bucket"
     static let sessionCheckoutsStorageKey = "os1.composer.sessionCheckouts"
+    static let defaultModelStorageKey = "os1.composer.defaultModel"
+    static let defaultModelPrefKey = "default-model"
 
     static func context() -> Context {
         let config = ServerConfig.shared
@@ -57,6 +62,44 @@ enum NativePreferences {
     static func endLocalWrite() {
         pendingLocalWrites = max(0, pendingLocalWrites - 1)
         generation += 1
+    }
+
+    /// Pin `model` as the account's default for new sessions, the same
+    /// `default-model` ui-pref the web composer writes. This device updates
+    /// immediately so every open picker's checkmark moves at once; the
+    /// confirmed map then goes through `apply`, which drops it if the account
+    /// changed while the write was out. A newer pick made meanwhile wins over
+    /// this write's confirmation, so two quick taps never settle on the first.
+    ///
+    /// Returns whether the server's confirmation was applied.
+    @discardableResult
+    static func setDefaultModel(
+        _ model: String,
+        write: (Context, [String: String?]) async throws -> [String: String] = { context, prefs in
+            try await SettingsAPI.updateUiPrefs(user: context.user, prefs: prefs)
+        }
+    ) async -> Bool {
+        let defaults = UserDefaults.standard
+        guard !model.isEmpty, model != defaults.string(forKey: defaultModelStorageKey) else {
+            return false
+        }
+        let requestContext = context()
+        defaultModelWriteSerial += 1
+        let serial = defaultModelWriteSerial
+        beginLocalWrite()
+        defer { endLocalWrite() }
+        defaults.set(model, forKey: defaultModelStorageKey)
+
+        guard let response = try? await write(requestContext, [defaultModelPrefKey: model]) else {
+            return false
+        }
+        var confirmed = response
+        if serial != defaultModelWriteSerial {
+            confirmed[defaultModelPrefKey] = defaults.string(forKey: defaultModelStorageKey) ?? model
+        } else if confirmed[defaultModelPrefKey] == nil {
+            confirmed[defaultModelPrefKey] = model
+        }
+        return apply(confirmed, for: requestContext)
     }
 
     @discardableResult
@@ -107,9 +150,9 @@ enum NativePreferences {
             in: defaults
         )
         set(
-            prefs["default-model"],
+            prefs[defaultModelPrefKey],
             default: "",
-            key: "os1.composer.defaultModel",
+            key: defaultModelStorageKey,
             resetMissing: changedIdentity,
             in: defaults
         )

--- a/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
+++ b/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// `SessionView.body` re-evaluates the whole body, transcript included, every
 /// time one of them moves.
 struct ModelSettingsMenu: View {
-    @AppStorage("os1.composer.defaultModel") private var preferredModel = ""
+    @AppStorage(NativePreferences.defaultModelStorageKey) private var preferredModel = ""
 
     let viewModel: SessionViewModel
     let catalog: ModelCatalog?
@@ -172,24 +172,10 @@ struct ModelSettingsMenu: View {
     }
 
     private func setAsDefault() {
+        // Same write as the new-session picker: this device first, then the
+        // per-user key so new sessions on every client start here.
         let model = currentModel
-        guard !model.isEmpty, model != preferredModel else { return }
-
-        // Match the web preference: update this device immediately, then sync
-        // the same per-user key so new sessions on every client start here.
-        let requestContext = NativePreferences.context()
-        NativePreferences.beginLocalWrite()
-        preferredModel = model
-        Task {
-            defer { NativePreferences.endLocalWrite() }
-            guard let response = try? await SettingsAPI.updateUiPrefs(
-                user: requestContext.user,
-                prefs: ["default-model": model]
-            ) else { return }
-            var confirmed = response
-            if confirmed["default-model"] == nil { confirmed["default-model"] = model }
-            _ = NativePreferences.apply(confirmed, for: requestContext)
-        }
+        Task { await NativePreferences.setDefaultModel(model) }
     }
 
     private func reset() {

--- a/packages/clients/ios/OS1/Views/NewSessionView.swift
+++ b/packages/clients/ios/OS1/Views/NewSessionView.swift
@@ -114,7 +114,7 @@ struct NewSessionView: View {
     @AppStorage("os1.newSession.repo") private var lastRepo = ""
     @AppStorage("os1.composer.defaultRepo") private var preferredRepo = ""
     @AppStorage(NativePreferences.sessionCheckoutsStorageKey) private var sessionCheckouts = ""
-    @AppStorage("os1.composer.defaultModel") private var preferredModel = ""
+    @AppStorage(NativePreferences.defaultModelStorageKey) private var preferredModel = ""
     @AppStorage("os1.composer.defaultEngine") private var preferredEngine = ""
 
     var body: some View {
@@ -899,6 +899,26 @@ struct NewSessionView: View {
                         modelButton(option)
                     }
                 }
+                // Same tail as the session menu and the web composer: pin the
+                // current model for every client's new sessions, or put this
+                // composer back where a fresh one starts.
+                Section {
+                    Button {
+                        let model = effectiveModelID
+                        Task { await NativePreferences.setDefaultModel(model) }
+                    } label: {
+                        Label(
+                            "Set as default",
+                            systemImage: isPreferredDefault ? "checkmark" : "pin"
+                        )
+                    }
+                    .disabled(effectiveModelID.isEmpty || isPreferredDefault)
+
+                    Button(action: resetToDefault) {
+                        Label("Reset to default", systemImage: "arrow.uturn.backward")
+                    }
+                    .disabled(isAtDefault)
+                }
             }
         } label: {
             chipLabel(
@@ -1123,20 +1143,42 @@ struct NewSessionView: View {
         sandboxStatus = try? await sandboxFetch
         if let fetched = try? await modelsFetch {
             catalog = fetched
-            let livePreferred = livePrefs?["default-model"] ?? preferredModel
-            let liveEngine = livePrefs?["default-engine"] ?? preferredEngine
-            preferredModel = livePreferred
-            preferredEngine = liveEngine
-            if model.isEmpty {
-                let start = fetched.option(for: livePreferred) != nil
-                    ? livePreferred
-                    : (fetched.defaultModel ?? "")
-                // Start on their default engine too. It then stays with the
-                // composer: selectModel recomposes onto currentEngine.
-                model = fetched.preferredID(start, engine: liveEngine)
-            }
+            preferredModel = livePrefs?[NativePreferences.defaultModelPrefKey] ?? preferredModel
+            preferredEngine = livePrefs?["default-engine"] ?? preferredEngine
+            if model.isEmpty { model = startingModelID }
             defaultEffortForCurrentModel()
         }
+    }
+
+    /// Where a fresh composer starts: the account's default model when this
+    /// instance offers it, else the instance's own, on the account's default
+    /// engine. It then stays with the composer: selectModel recomposes onto
+    /// currentEngine.
+    private var startingModelID: String {
+        guard let catalog else { return "" }
+        let start = catalog.option(for: preferredModel) != nil
+            ? preferredModel
+            : (catalog.defaultModel ?? "")
+        return catalog.preferredID(start, engine: preferredEngine)
+    }
+
+    private var isPreferredDefault: Bool {
+        !effectiveModelID.isEmpty && preferredModel == effectiveModelID
+    }
+
+    /// Nothing to put back: on the starting model, its own default effort, and
+    /// standard speed. Drives the reset row's disabled state.
+    private var isAtDefault: Bool {
+        let start = startingModelID
+        let onStartingModel = start.isEmpty || effectiveModelID == start
+        return onStartingModel && effort == defaultEffort(for: availableEfforts) && !fastMode
+    }
+
+    private func resetToDefault() {
+        let start = startingModelID
+        if !start.isEmpty { model = start }
+        effort = defaultEffort(for: availableEfforts)
+        fastMode = false
     }
 
     private func selectModel(_ option: ModelOption) {
@@ -1151,12 +1193,13 @@ struct NewSessionView: View {
     /// "High" is the palette's default where supported; presets (dial) have
     /// no effort dimension so the chip hides.
     private func defaultEffortForCurrentModel() {
-        let efforts = availableEfforts
-        if efforts.isEmpty {
-            effort = ""
-        } else if !efforts.contains(effort) {
-            effort = efforts.contains("high") ? "high" : efforts[0]
+        if !availableEfforts.contains(effort) {
+            effort = defaultEffort(for: availableEfforts)
         }
+    }
+
+    private func defaultEffort(for efforts: [String]) -> String {
+        efforts.contains("high") ? "high" : (efforts.first ?? "")
     }
 
     /// Match the web palette's two-axis create: a universal Ask starts with no

--- a/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
+++ b/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
@@ -82,17 +82,59 @@ final class DefaultModelPreferenceTests: XCTestCase {
         XCTAssertEqual(writes, 0)
     }
 
-    func testConfirmationForAnotherAccountIsDropped() async {
+    func testConfirmationForAnotherAccountIsDroppedAndTheActiveAccountRehydrates() async {
+        var rehydrated = 0
         let applied = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { _, _ in
             // The account switched while the PUT was out: its answer describes
             // Account A, and Account B's own hydration owns the cache now.
-            ServerConfig.shared.userName = "Account B"
-            ServerConfig.shared.githubLogin = "account-b"
+            self.switchToAccountB()
             return ["default-model": "pi/openai/gpt-6-astra", "default-repo": "repo-a"]
+        } rehydrate: {
+            rehydrated += 1
         }
 
         XCTAssertFalse(applied)
         XCTAssertEqual(UserDefaults.standard.string(forKey: repoKey), "repo-before")
+        XCTAssertEqual(rehydrated, 1, "Account B's hydration skipped during the write, so it runs again now")
+    }
+
+    func testAWriteQueuedForASwitchedAccountNeverLeavesAndTheActiveAccountRehydrates() async {
+        let wire = Wire()
+        var rehydrated = 0
+
+        let first = Task { @MainActor in
+            await NativePreferences.setDefaultModel(
+                "pi/openai/gpt-5.6-sol",
+                write: wire.write(holdingFirst: true)
+            ) { rehydrated += 1 }
+        }
+        await wire.waitUntilHeld()
+        let second = Task { @MainActor in
+            await NativePreferences.setDefaultModel(
+                "pi/openai/gpt-6-astra",
+                write: wire.write()
+            ) { rehydrated += 1 }
+        }
+        await wire.settle()
+        // Account A's second pick is waiting behind the stalled first write
+        // when the user switches to Account B.
+        switchToAccountB()
+        wire.release?.resume()
+
+        let applied = await [first.value, second.value]
+
+        XCTAssertEqual(applied, [false, false])
+        XCTAssertEqual(
+            wire.sent,
+            ["pi/openai/gpt-5.6-sol"],
+            "the queued PUT would carry A's user on B's connection, so it is skipped"
+        )
+        XCTAssertEqual(rehydrated, 1, "one rehydration, after the last pending write released the guard")
+    }
+
+    private func switchToAccountB() {
+        ServerConfig.shared.userName = "Account B"
+        ServerConfig.shared.githubLogin = "account-b"
     }
 
     /// A PUT that stalls until the test releases it, recording every write's

--- a/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
+++ b/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
@@ -95,34 +95,93 @@ final class DefaultModelPreferenceTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: repoKey), "repo-before")
     }
 
-    func testNewerLocalPickOutlivesAnOlderConfirmation() async {
-        final class Gate: @unchecked Sendable { var release: CheckedContinuation<Void, Never>? }
-        let gate = Gate()
+    /// A PUT that stalls until the test releases it, recording every write's
+    /// model so the order the server would see them in can be asserted.
+    @MainActor
+    private final class Wire {
+        var sent: [String] = []
+        var release: CheckedContinuation<Void, Never>?
 
-        let first = Task { @MainActor in
-            await NativePreferences.setDefaultModel("pi/openai/gpt-5.6-sol") { _, _ in
-                await withCheckedContinuation { gate.release = $0 }
-                return ["default-model": "pi/openai/gpt-5.6-sol"]
+        func write(holdingFirst: Bool = false) -> (NativePreferences.Context, [String: String?]) async throws -> [String: String] {
+            { [self] _, prefs in
+                let model = prefs["default-model"].flatMap { $0 } ?? ""
+                let isFirst = sent.isEmpty
+                sent.append(model)
+                if holdingFirst, isFirst {
+                    await withCheckedContinuation { release = $0 }
+                }
+                return ["default-model": model]
             }
         }
-        while gate.release == nil { await Task.yield() }
+
+        func waitUntilHeld() async {
+            while release == nil { await Task.yield() }
+        }
+
+        func settle() async {
+            for _ in 0..<50 { await Task.yield() }
+        }
+    }
+
+    func testANewerPickWaitsForTheOlderWriteAndReachesTheServerLast() async {
+        let wire = Wire()
+
+        let first = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/openai/gpt-5.6-sol", write: wire.write(holdingFirst: true))
+        }
+        await wire.waitUntilHeld()
         XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "pi/openai/gpt-5.6-sol")
 
-        let second = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { _, prefs in
-            var confirmed: [String: String] = [:]
-            for (key, value) in prefs { confirmed[key] = value }
-            return confirmed
+        let second = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra", write: wire.write())
         }
-        XCTAssertTrue(second)
-
-        gate.release?.resume()
-        let firstApplied = await first.value
-
-        XCTAssertTrue(firstApplied, "the late answer still carries the rest of the map")
+        await wire.settle()
         XCTAssertEqual(
             UserDefaults.standard.string(forKey: modelKey),
             "pi/openai/gpt-6-astra",
-            "the pick made while the first write was out is the one that stays"
+            "this device shows the newer pick right away"
         )
+        XCTAssertEqual(wire.sent, ["pi/openai/gpt-5.6-sol"], "the second PUT waits behind the first")
+
+        wire.release?.resume()
+        let firstApplied = await first.value
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: modelKey),
+            "pi/openai/gpt-6-astra",
+            "the older confirmation does not flip this device back"
+        )
+        let secondApplied = await second.value
+
+        XCTAssertTrue(firstApplied, "the late answer still carries the rest of the map")
+        XCTAssertTrue(secondApplied)
+        XCTAssertEqual(
+            wire.sent,
+            ["pi/openai/gpt-5.6-sol", "pi/openai/gpt-6-astra"],
+            "the server sees the newer pick last, so its last-write merge keeps it"
+        )
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "pi/openai/gpt-6-astra")
+    }
+
+    func testAQueuedPickThatWasAlreadyReplacedNeverReachesTheServer() async {
+        let wire = Wire()
+
+        let first = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/openai/gpt-5.6-sol", write: wire.write(holdingFirst: true))
+        }
+        await wire.waitUntilHeld()
+        let second = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra", write: wire.write())
+        }
+        let third = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/anthropic/claude-nova-6", write: wire.write())
+        }
+        await wire.settle()
+        wire.release?.resume()
+
+        let applied = await [first.value, second.value, third.value]
+
+        XCTAssertEqual(applied, [true, false, true], "the replaced middle pick is skipped, not sent")
+        XCTAssertEqual(wire.sent, ["pi/openai/gpt-5.6-sol", "pi/anthropic/claude-nova-6"])
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "pi/anthropic/claude-nova-6")
     }
 }

--- a/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
+++ b/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import OS1
+
+/// The "Set as default" write shared by the new-session picker and the
+/// session model menu: optimistic on this device, confirmed through the
+/// account's `default-model` ui-pref, and reconciled without clobbering a
+/// newer account or a newer local pick.
+@MainActor
+final class DefaultModelPreferenceTests: XCTestCase {
+    private let modelKey = NativePreferences.defaultModelStorageKey
+    private let repoKey = "os1.composer.defaultRepo"
+    private var savedModel: String?
+    private var savedRepo: String?
+    private var savedUser = ""
+    private var savedLogin = ""
+
+    override func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        savedModel = defaults.string(forKey: modelKey)
+        savedRepo = defaults.string(forKey: repoKey)
+        savedUser = ServerConfig.shared.userName
+        savedLogin = ServerConfig.shared.githubLogin
+        ServerConfig.shared.userName = "Account A"
+        ServerConfig.shared.githubLogin = "account-a"
+        defaults.removeObject(forKey: modelKey)
+        defaults.set("repo-before", forKey: repoKey)
+    }
+
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        ServerConfig.shared.userName = savedUser
+        ServerConfig.shared.githubLogin = savedLogin
+        for (key, value) in [(modelKey, savedModel), (repoKey, savedRepo)] {
+            if let value { defaults.set(value, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+        super.tearDown()
+    }
+
+    func testSetAsDefaultWritesTheWebKeyAfterUpdatingThisDevice() async {
+        final class Box: @unchecked Sendable {
+            var user = ""
+            var prefs: [String: String?] = [:]
+            var localAtWrite: String?
+        }
+        let box = Box()
+
+        let applied = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { context, prefs in
+            box.user = context.user
+            box.prefs = prefs
+            box.localAtWrite = UserDefaults.standard.string(forKey: self.modelKey)
+            return ["default-model": "pi/openai/gpt-6-astra", "default-repo": "repo-confirmed"]
+        }
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(box.user, "Account A")
+        XCTAssertEqual(box.prefs, ["default-model": "pi/openai/gpt-6-astra"])
+        XCTAssertEqual(box.localAtWrite, "pi/openai/gpt-6-astra", "this device updates before the PUT leaves")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "pi/openai/gpt-6-astra")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: repoKey),
+            "repo-confirmed",
+            "the confirmed map is the whole preference set"
+        )
+    }
+
+    func testNothingIsWrittenWhenTheModelIsAlreadyTheDefault() async {
+        UserDefaults.standard.set("pi/openai/gpt-6-astra", forKey: modelKey)
+        var writes = 0
+
+        let applied = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { _, _ in
+            writes += 1
+            return [:]
+        }
+        let appliedEmpty = await NativePreferences.setDefaultModel("") { _, _ in
+            writes += 1
+            return [:]
+        }
+
+        XCTAssertFalse(applied)
+        XCTAssertFalse(appliedEmpty)
+        XCTAssertEqual(writes, 0)
+    }
+
+    func testConfirmationForAnotherAccountIsDropped() async {
+        let applied = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { _, _ in
+            // The account switched while the PUT was out: its answer describes
+            // Account A, and Account B's own hydration owns the cache now.
+            ServerConfig.shared.userName = "Account B"
+            ServerConfig.shared.githubLogin = "account-b"
+            return ["default-model": "pi/openai/gpt-6-astra", "default-repo": "repo-a"]
+        }
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: repoKey), "repo-before")
+    }
+
+    func testNewerLocalPickOutlivesAnOlderConfirmation() async {
+        final class Gate: @unchecked Sendable { var release: CheckedContinuation<Void, Never>? }
+        let gate = Gate()
+
+        let first = Task { @MainActor in
+            await NativePreferences.setDefaultModel("pi/openai/gpt-5.6-sol") { _, _ in
+                await withCheckedContinuation { gate.release = $0 }
+                return ["default-model": "pi/openai/gpt-5.6-sol"]
+            }
+        }
+        while gate.release == nil { await Task.yield() }
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "pi/openai/gpt-5.6-sol")
+
+        let second = await NativePreferences.setDefaultModel("pi/openai/gpt-6-astra") { _, prefs in
+            var confirmed: [String: String] = [:]
+            for (key, value) in prefs { confirmed[key] = value }
+            return confirmed
+        }
+        XCTAssertTrue(second)
+
+        gate.release?.resume()
+        let firstApplied = await first.value
+
+        XCTAssertTrue(firstApplied, "the late answer still carries the rest of the map")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: modelKey),
+            "pi/openai/gpt-6-astra",
+            "the pick made while the first write was out is the one that stays"
+        )
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -330,6 +330,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   passive WebSockets remain connected for inactive accounts
   while the app is active so mentions can badge the picker. Cross-device
   composer and session preferences refresh at launch and when the app foregrounds.
+  The new-session model picker and a session's model menu both carry **Set as
+  default**, which writes the account's `default-model` ui-pref the web
+  composer shares, so new sessions on every client start on that model.
   On macOS, custom account keyboard bindings drive the supported app commands and
   their command-menu hints; iOS keeps its system shortcut and widget guide.
   Infrastructure → **Runners** lists the machines this instance trusts, read


### PR DESCRIPTION
Port of 07549a4ac (web) to the native composer.

## Before

The New session model picker on iOS/macOS could only pick a model for this composer. Pinning it as the cross-device default was only possible from an existing session's model menu.

## After

The New session picker gets the same tail as the session menu and the web composer:

- **Set as default** pins the current model as the account's `default-model` ui-pref (checkmark and disabled once it is the default).
- **Reset to default** puts the composer back on the starting model, its default effort and standard speed (disabled while already there).

The write moves into `NativePreferences.setDefaultModel`, shared by both menus:

1. AppStorage updates optimistically (every open picker's checkmark moves at once).
2. `SettingsAPI.updateUiPrefs` writes the same `default-model` key the web writes.
3. The confirmed map reconciles through `NativePreferences.apply`, which drops it if the account changed while the write was out. A newer pick made meanwhile wins over the older confirmation.

## Tests

`OS1Tests/DefaultModelPreferenceTests`: preference write shape and optimistic order, no-op when already default, confirmation dropped after an account switch, newer local pick outlives an older confirmation.

## Verification

- `xcodegen generate`, OS1 (iOS Simulator) and OS1Mac builds green.
- Mac tests: `DefaultModelPreferenceTests` + `PreferenceHydrationTests`, 18/18 pass. The Mac node had no GUI login session today (`testmanagerd` unreachable), so the bundle was run with `xcrun xctest` against the `build-for-testing` output instead of `xcodebuild test`.
- `bun run check` green.
- Simulator: tapped Set as default on Fable 5.1; the Automation user's `default-model` ui-pref changed on the server (restored afterwards), and the reopened menu shows the checked, disabled row.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-331fea54-8f6d-7984-aaa9-ced96fc96e81)