### PR TITLE
iOS: archived pickers side by side, ask chip after the title

### DIFF
--- a/packages/clients/ios/OS1/ArchivedPresentation.swift
+++ b/packages/clients/ios/OS1/ArchivedPresentation.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// What the Archived screen says about a row and its lenses, as values: the
+/// chip trailing a title, and the word each picker wears. Mirrors the web's
+/// `Archived.tsx` (`originChip` and the picker labels) so both clients name
+/// the same things the same way, and sits apart from the view so a test can
+/// read it without a screen.
+enum ArchivedPresentation {
+    /// The chip naming where a session came from. Rendered only when it says
+    /// something: an automation's name is worth a chip, so is a session that
+    /// arrived from Slack or Linear, or one that ran read-only. A code session
+    /// started here is the default and gets none. The product's own name on
+    /// every row would be a column of noise dressed as data.
+    struct OriginChip: Equatable {
+        enum Tone: Equatable {
+            /// The plain pill: an automation, or an origin with no hue of its own.
+            case neutral
+            /// Green, because that is what ask means across the product.
+            case ask
+        }
+
+        let label: String
+        let tone: Tone
+    }
+
+    /// The source ids that mean "started here", including the pre-rename one
+    /// older servers and archived rows still send.
+    private static let ownSources: Set<String> = ["opensession", "backstage"]
+
+    static func originChip(for session: Session) -> OriginChip? {
+        if let name = session.automation?.name {
+            return OriginChip(label: name, tone: .neutral)
+        }
+        if session.mode == "ask" {
+            return OriginChip(label: "ask", tone: .ask)
+        }
+        if let source = session.source, !source.isEmpty, !ownSources.contains(source) {
+            return OriginChip(label: source, tone: .neutral)
+        }
+        return nil
+    }
+
+    /// What the Owner picker wears for a selection: the two fixed lenses by
+    /// name, a teammate by the roster's spelling, and a key the roster no
+    /// longer answers to as itself rather than as nothing.
+    static func ownerLabel(_ owner: String, owners: [ArchivedOwners.Owner]) -> String {
+        switch owner {
+        case ArchivedOwners.mine: "My archived"
+        case ArchivedOwners.everyone: "Everyone"
+        default: owners.first { $0.key == owner }?.label ?? owner
+        }
+    }
+
+    static let allRepositories = "all"
+
+    static func repositoryLabel(_ repo: String) -> String {
+        repo == allRepositories ? "All repos" : RepoTile.label(for: repo)
+    }
+
+    struct Reason: Identifiable {
+        let key: String
+        let label: String
+
+        var id: String { key }
+    }
+
+    /// The Reason lens, in the order the menu lists it.
+    static let reasons: [Reason] = [
+        Reason(key: "all", label: "All"),
+        Reason(key: "auto", label: "Auto-archived"),
+        Reason(key: "manual", label: "Manual"),
+    ]
+
+    static func reasonLabel(_ reason: String) -> String {
+        reasons.first { $0.key == reason }?.label ?? reason
+    }
+}

--- a/packages/clients/ios/OS1/ArchivedPresentation.swift
+++ b/packages/clients/ios/OS1/ArchivedPresentation.swift
@@ -51,10 +51,40 @@ enum ArchivedPresentation {
         }
     }
 
+    /// The owners the picker lists: those with rows here, plus the selected
+    /// one after its last row was restored, so the selection keeps its mark
+    /// and the way back stays in the same menu.
+    static func ownerOptions(
+        _ owners: [ArchivedOwners.Owner], selected owner: String
+    ) -> [ArchivedOwners.Owner] {
+        if owner == ArchivedOwners.mine || owner == ArchivedOwners.everyone
+            || owners.contains(where: { $0.key == owner }) {
+            return owners
+        }
+        return owners + [ArchivedOwners.Owner(key: owner, label: owner)]
+    }
+
     static let allRepositories = "all"
 
     static func repositoryLabel(_ repo: String) -> String {
         repo == allRepositories ? "All repos" : RepoTile.label(for: repo)
+    }
+
+    /// The repository picker leaves once there is nothing to choose between,
+    /// but never while it holds a choice. Restoring the selected repository's
+    /// last row would otherwise take the only way back to "All repos" with
+    /// it and strand the sheet on "No matches".
+    static func showsRepositoryPicker(repositories: [String], selected repo: String) -> Bool {
+        repositories.count > 1 || repo != allRepositories
+    }
+
+    /// The repositories the picker lists: those with rows here, plus the
+    /// selected one after its rows have gone.
+    static func repositoryOptions(_ repositories: [String], selected repo: String) -> [String] {
+        if repo == allRepositories || repositories.contains(repo) {
+            return repositories
+        }
+        return (repositories + [repo]).sorted()
     }
 
     struct Reason: Identifiable {
@@ -73,5 +103,13 @@ enum ArchivedPresentation {
 
     static func reasonLabel(_ reason: String) -> String {
         reasons.first { $0.key == reason }?.label ?? reason
+    }
+
+    /// The Reason menu exists once something was auto-archived, and stays
+    /// while a reason other than All is selected: restoring the last
+    /// auto-archived row under "Auto-archived" must leave the control that
+    /// can widen the lens again.
+    static func showsReasonMenu(hasAutoArchived: Bool, selected reason: String) -> Bool {
+        hasAutoArchived || reason != "all"
     }
 }

--- a/packages/clients/ios/OS1/Views/OS1VisualStyle.swift
+++ b/packages/clients/ios/OS1/Views/OS1VisualStyle.swift
@@ -357,6 +357,29 @@ enum OS1VisualStyle {
             : NSColor(red: 0.035, green: 0.412, blue: 0.855, alpha: 0.10)
     })
     #endif
+    // The wash under the ask chip on an archived row: the web's `--green-soft`,
+    // ported as a STEP from the surface rather than as its hex. The web mixes
+    // its light green at 12% over a white page and its dark green at 14% over
+    // #1c1c1c. An archived row here sits on white and on #1c1c1e, so the
+    // surfaces nearly match, but the hue does not: light takes `greenInk`'s
+    // green, the colour the chip's own word is written in, so the pill reads
+    // as one colour, and that darker hue lands the web's luminance step below
+    // white at 11% where the web's lighter one needed 12%. Dark keeps the
+    // palette green at 13%, the web's step above its page measured from this
+    // one. `AskChipContrastTests` measures the word over both.
+    #if os(iOS)
+    static let greenSoft = Color(uiColor: UIColor { traits in
+        traits.userInterfaceStyle == .dark
+            ? UIColor(red: 0.247, green: 0.725, blue: 0.314, alpha: 0.13)
+            : UIColor(red: 0.098, green: 0.478, blue: 0.208, alpha: 0.11)
+    })
+    #else
+    static let greenSoft = Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 0.247, green: 0.725, blue: 0.314, alpha: 0.13)
+            : NSColor(red: 0.098, green: 0.478, blue: 0.208, alpha: 0.11)
+    })
+    #endif
     // A check row that wants something, on the PR panel's grouped list.
     //
     // The web tints one summary chip by the worst status it can see. A phone

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -1164,6 +1164,9 @@ struct SessionsListView: View {
                     // a scripted run would have to find and scroll to.
                     if env["OS1_OPEN_FEED"] != nil { showFeed = true }
                     if env["OS1_OPEN_TASKS"] != nil { showTasks = true }
+                    // Same reason again: Archived is a row at the foot of the
+                    // list, below whatever is live.
+                    if env["OS1_OPEN_ARCHIVED"] != nil { showArchived = true }
                     if env["OS1_OPEN_SETTINGS"] != nil {
                         showSettings = true
                     }
@@ -3914,9 +3917,25 @@ private struct ArchivedSessionsView: View {
     @State private var searchText = ""
     /// "mine", "everyone", or one teammate's canonical key — see
     /// `ArchivedOwners`.
-    @State private var owner = ArchivedOwners.mine
-    @State private var repo = "all"
+    @State private var owner = Self.initialLens("OS1_ARCHIVED_OWNER", or: ArchivedOwners.mine)
+    @State private var repo = Self.initialLens(
+        "OS1_ARCHIVED_REPO", or: ArchivedPresentation.allRepositories
+    )
     @State private var reason = "all"
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    /// The default lens unless a scripted run asks for another
+    /// (`OS1_ARCHIVED_OWNER=everyone`, `OS1_ARCHIVED_REPO=opensession`): a
+    /// picker is a tap a simulator run cannot make, and Everyone is the lens
+    /// that puts names on the rows.
+    private static func initialLens(_ variable: String, or fallback: String) -> String {
+        #if DEBUG
+        if let lens = ProcessInfo.processInfo.environment[variable], !lens.isEmpty {
+            return lens
+        }
+        #endif
+        return fallback
+    }
     /// The team roster, read in `body` so the owner options appear when it
     /// lands — it can arrive after this screen is already open.
     private var roster: [String: String] { TeamDirectory.shared.displayNames }
@@ -3940,10 +3959,15 @@ private struct ArchivedSessionsView: View {
         sessions.contains(where: isAutoArchived)
     }
 
-    private var activeFilterCount: Int {
-        (owner == ArchivedOwners.everyone ? 0 : 1)
-            + (repo == "all" ? 0 : 1) + (reason == "all" ? 0 : 1)
+    private var ownerLabel: String {
+        ArchivedPresentation.ownerLabel(owner, owners: owners)
     }
+
+    private var repositoryLabel: String {
+        ArchivedPresentation.repositoryLabel(repo)
+    }
+
+    private var showsRepositoryPicker: Bool { repositories.count > 1 }
 
     private var filteredSessions: [Session] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -3957,7 +3981,9 @@ private struct ArchivedSessionsView: View {
                     return false
                 }
             }
-            if repo != "all", session.effectiveRepo != repo { return false }
+            if repo != ArchivedPresentation.allRepositories, session.effectiveRepo != repo {
+                return false
+            }
             if reason == "auto", !isAutoArchived(session) { return false }
             if reason == "manual", isAutoArchived(session) { return false }
             guard !query.isEmpty else { return true }
@@ -3990,67 +4016,11 @@ private struct ArchivedSessionsView: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                if let loadFailure {
-                    ContentUnavailableView {
-                        Label("Couldn't load archived sessions", systemImage: "exclamationmark.triangle")
-                    } description: {
-                        Text(loadFailure)
-                    } actions: {
-                        Button("Try again", action: onRetry)
-                    }
-                    .listRowSeparator(.hidden)
-                } else if sessions.isEmpty, !loaded {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                        Text("Loading archived sessions…")
-                            .font(.footnote)
-                            .foregroundStyle(OS1VisualStyle.textDim)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 24)
-                    .listRowSeparator(.hidden)
-                } else if filteredSessions.isEmpty {
-                    ContentUnavailableView(
-                        sessions.isEmpty ? "Nothing archived" : "No matches",
-                        systemImage: sessions.isEmpty ? "archivebox" : "magnifyingglass"
-                    )
-                } else {
-                    Section {
-                        ForEach(filteredSessions) { session in
-                            HStack(spacing: 10) {
-                                RepoTile(name: session.effectiveRepo, size: 24)
-                                #if os(iOS)
-                                Button {
-                                    onOpen(session)
-                                } label: {
-                                    archivedRowLabel(session)
-                                }
-                                .buttonStyle(.plain)
-                                #else
-                                archivedRowLabel(session)
-                                #endif
-                                Button {
-                                    onRestore(session)
-                                } label: {
-                                    Image(systemName: "tray.and.arrow.up")
-                                        .font(.body)
-                                        .frame(width: 44, height: 44)
-                                }
-                                .buttonStyle(.borderless)
-                                .accessibilityLabel("Restore session")
-                            }
-                            .padding(.vertical, 2)
-                        }
-                    } header: {
-                        Text(filteredSessions.count == sessions.count
-                             ? "\(sessions.count) archived"
-                             : "\(filteredSessions.count) of \(sessions.count) archived")
-                    }
-                }
+            VStack(spacing: 0) {
+                filterBar
+                list
             }
             #if os(iOS)
-            .scrollContentBackground(.hidden)
             .background(OS1VisualStyle.background)
             #endif
             .searchable(text: $searchText, prompt: "Search archived")
@@ -4058,54 +4028,10 @@ private struct ArchivedSessionsView: View {
             .navigationTitle("Archived")
             .inlineTitleBarCompat()
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Menu {
-                        Section("Owner") {
-                            Picker("Owner", selection: $owner) {
-                                Text("My archived").tag(ArchivedOwners.mine)
-                                Text("Everyone").tag(ArchivedOwners.everyone)
-                                // Teammates who have archived something here,
-                                // busiest first. Absent on an instance of one.
-                                ForEach(owners) { person in
-                                    Text(person.label).tag(person.key)
-                                }
-                            }
-                        }
-                        if repositories.count > 1 {
-                            Section("Repository") {
-                                Picker("Repository", selection: $repo) {
-                                    Text("All repos").tag("all")
-                                    ForEach(repositories, id: \.self) { repository in
-                                        Text(RepoTile.label(for: repository)).tag(repository)
-                                    }
-                                }
-                            }
-                        }
-                        if hasAutoArchived {
-                            Section("Reason") {
-                                Picker("Reason", selection: $reason) {
-                                    Text("All").tag("all")
-                                    Text("Auto-archived").tag("auto")
-                                    Text("Manual").tag("manual")
-                                }
-                            }
-                        }
-                        if activeFilterCount > 0 {
-                            Button("Clear filters") {
-                                owner = ArchivedOwners.everyone
-                                repo = "all"
-                                reason = "all"
-                            }
-                        }
-                    } label: {
-                        Label(
-                            activeFilterCount > 0 ? "Filters (\(activeFilterCount))" : "Filters",
-                            systemImage: activeFilterCount > 0
-                                ? "line.3.horizontal.decrease.circle.fill"
-                                : "line.3.horizontal.decrease.circle"
-                        )
-                    }
-                    .accessibilityLabel("Filters, \(activeFilterCount) active")
+                // Reason stays behind a glyph: it only exists once something
+                // was auto-archived, and rarely changes.
+                if hasAutoArchived {
+                    ToolbarItem(placement: .primaryAction) { reasonMenu }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
@@ -4114,18 +4040,252 @@ private struct ArchivedSessionsView: View {
         }
     }
 
+    // No match count over the rows: the list itself shows what matched, and
+    // the pickers already say why.
+    private var list: some View {
+        List {
+            if let loadFailure {
+                ContentUnavailableView {
+                    Label("Couldn't load archived sessions", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(loadFailure)
+                } actions: {
+                    Button("Try again", action: onRetry)
+                }
+                .listRowSeparator(.hidden)
+            } else if sessions.isEmpty, !loaded {
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("Loading archived sessions…")
+                        .font(.footnote)
+                        .foregroundStyle(OS1VisualStyle.textDim)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 24)
+                .listRowSeparator(.hidden)
+            } else if filteredSessions.isEmpty {
+                ContentUnavailableView(
+                    sessions.isEmpty ? "Nothing archived" : "No matches",
+                    systemImage: sessions.isEmpty ? "archivebox" : "magnifyingglass"
+                )
+            } else {
+                Section {
+                    ForEach(filteredSessions) { session in
+                        HStack(spacing: 10) {
+                            RepoTile(name: session.effectiveRepo, size: 24)
+                            #if os(iOS)
+                            Button {
+                                onOpen(session)
+                            } label: {
+                                archivedRowLabel(session)
+                            }
+                            .buttonStyle(.plain)
+                            #else
+                            archivedRowLabel(session)
+                            #endif
+                            Button {
+                                onRestore(session)
+                            } label: {
+                                Image(systemName: "tray.and.arrow.up")
+                                    .font(.body)
+                                    .frame(width: 44, height: 44)
+                            }
+                            .buttonStyle(.borderless)
+                            .accessibilityLabel("Restore session")
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+        }
+        #if os(iOS)
+        .scrollContentBackground(.hidden)
+        .background(OS1VisualStyle.background)
+        // The grouped list's top inset was room for a section header. The
+        // pickers now stand where that header stood, so the rows start under
+        // them rather than a header's height below.
+        .contentMargins(.top, 4, for: .scrollContent)
+        #endif
+    }
+
+    /// Owner and repository as pickers side by side, each wearing its value,
+    /// so the scope reads without opening anything. The row scrolls sideways
+    /// rather than wrapping: a long name or an accessibility text size widens
+    /// the chips, and the row stays one row.
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ownerPicker
+                if showsRepositoryPicker { repositoryPicker }
+            }
+            .padding(.horizontal, 16)
+            #if os(iOS)
+            .padding(.vertical, 2)
+            #else
+            .padding(.vertical, 8)
+            #endif
+        }
+    }
+
+    private var ownerPicker: some View {
+        Menu {
+            Picker("Owner", selection: $owner) {
+                Text("My archived").tag(ArchivedOwners.mine)
+                // Teammates who have archived something here, busiest
+                // first. Absent on an instance of one.
+                ForEach(owners) { person in
+                    Text(person.label).tag(person.key)
+                }
+                Text("Everyone").tag(ArchivedOwners.everyone)
+            }
+        } label: {
+            pickerChip(ownerLabel) {
+                if owner == ArchivedOwners.everyone {
+                    Image(systemName: "person.2")
+                        .font(.caption)
+                        .foregroundStyle(OS1VisualStyle.textDim)
+                } else {
+                    UserAvatar(
+                        person: owner == ArchivedOwners.mine ? nil : ownerLabel,
+                        size: 18
+                    )
+                }
+            }
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .accessibilityLabel("Owner, \(ownerLabel)")
+    }
+
+    private var repositoryPicker: some View {
+        Menu {
+            Picker("Repository", selection: $repo) {
+                Text("All repos").tag(ArchivedPresentation.allRepositories)
+                ForEach(repositories, id: \.self) { repository in
+                    Label {
+                        Text(RepoTile.label(for: repository))
+                    } icon: {
+                        if let icon = RepoTile.menuIcon(for: repository) { icon }
+                    }
+                    .tag(repository)
+                }
+            }
+        } label: {
+            pickerChip(repositoryLabel) {
+                if repo == ArchivedPresentation.allRepositories {
+                    Image(systemName: "folder")
+                        .font(.caption)
+                        .foregroundStyle(OS1VisualStyle.textDim)
+                } else {
+                    RepoTile(name: repo, size: 18)
+                }
+            }
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .accessibilityLabel("Repository, \(repositoryLabel)")
+    }
+
+    private var reasonMenu: some View {
+        Menu {
+            Picker("Reason", selection: $reason) {
+                ForEach(ArchivedPresentation.reasons) { option in
+                    Text(option.label).tag(option.key)
+                }
+            }
+        } label: {
+            Label(
+                "Reason",
+                systemImage: reason == "all"
+                    ? "line.3.horizontal.decrease.circle"
+                    : "line.3.horizontal.decrease.circle.fill"
+            )
+        }
+        .accessibilityLabel("Reason, \(ArchivedPresentation.reasonLabel(reason))")
+    }
+
+    /// A picker's face: its value, led by the mark that stands for it and
+    /// trailed by the chevron that says it opens. Capped at the web's 150
+    /// points so one long name cannot push its neighbour off the row.
+    private func pickerChip<Icon: View>(
+        _ text: String, @ViewBuilder icon: () -> Icon
+    ) -> some View {
+        HStack(spacing: 6) {
+            icon()
+                .frame(width: 18, height: 18)
+            Text(text)
+                .lineLimit(1)
+                .frame(maxWidth: 150, alignment: .leading)
+            Image(systemName: "chevron.down")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(OS1VisualStyle.textDim)
+        }
+        .font(.subheadline.weight(.medium))
+        .foregroundStyle(OS1VisualStyle.text)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.fill.tertiary, in: Capsule())
+        #if os(iOS)
+        // The capsule keeps the row's height; the hit target grows to the 44
+        // points a thumb needs.
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+        #else
+        .contentShape(Capsule())
+        #endif
+    }
+
     private func archivedRowLabel(_ session: Session) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(session.displayTitle)
-                .font(.body.weight(.medium))
-                .foregroundStyle(OS1VisualStyle.text)
-                .lineLimit(2)
+            titleRow(for: session)
             Text(metadata(for: session))
                 .font(.footnote)
                 .foregroundStyle(OS1VisualStyle.textDim)
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+
+    /// The title, then the origin chip trailing it. The chip sits here rather
+    /// than on the line under the title so a row with nothing else to say
+    /// stays one line tall. At an accessibility text size the chip drops
+    /// below the title instead of leaving it a few characters a line.
+    @ViewBuilder
+    private func titleRow(for session: Session) -> some View {
+        let title = Text(session.displayTitle)
+            .font(.body.weight(.medium))
+            .foregroundStyle(OS1VisualStyle.text)
+            .lineLimit(2)
+        if let chip = ArchivedPresentation.originChip(for: session) {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: 4) {
+                    title
+                    originChipView(chip)
+                }
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    title
+                    originChipView(chip)
+                }
+            }
+        } else {
+            title
+        }
+    }
+
+    private func originChipView(_ chip: ArchivedPresentation.OriginChip) -> some View {
+        Text(chip.label)
+            .font(.caption2.weight(.bold))
+            .lineLimit(1)
+            .foregroundStyle(chip.tone == .ask ? OS1VisualStyle.greenInk : OS1VisualStyle.textDim)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 2)
+            .background(
+                chip.tone == .ask ? OS1VisualStyle.greenSoft : OS1VisualStyle.chipFill,
+                in: Capsule()
+            )
+            .fixedSize()
     }
 }
 

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -3967,7 +3967,13 @@ private struct ArchivedSessionsView: View {
         ArchivedPresentation.repositoryLabel(repo)
     }
 
-    private var showsRepositoryPicker: Bool { repositories.count > 1 }
+    private var showsRepositoryPicker: Bool {
+        ArchivedPresentation.showsRepositoryPicker(repositories: repositories, selected: repo)
+    }
+
+    private var showsReasonMenu: Bool {
+        ArchivedPresentation.showsReasonMenu(hasAutoArchived: hasAutoArchived, selected: reason)
+    }
 
     private var filteredSessions: [Session] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -4028,9 +4034,10 @@ private struct ArchivedSessionsView: View {
             .navigationTitle("Archived")
             .inlineTitleBarCompat()
             .toolbar {
-                // Reason stays behind a glyph: it only exists once something
-                // was auto-archived, and rarely changes.
-                if hasAutoArchived {
+                // Reason stays behind a glyph: it exists once something was
+                // auto-archived, rarely changes, and stays while it holds a
+                // choice.
+                if showsReasonMenu {
                     ToolbarItem(placement: .primaryAction) { reasonMenu }
                 }
                 ToolbarItem(placement: .confirmationAction) {
@@ -4133,7 +4140,7 @@ private struct ArchivedSessionsView: View {
                 Text("My archived").tag(ArchivedOwners.mine)
                 // Teammates who have archived something here, busiest
                 // first. Absent on an instance of one.
-                ForEach(owners) { person in
+                ForEach(ArchivedPresentation.ownerOptions(owners, selected: owner)) { person in
                     Text(person.label).tag(person.key)
                 }
                 Text("Everyone").tag(ArchivedOwners.everyone)
@@ -4161,7 +4168,9 @@ private struct ArchivedSessionsView: View {
         Menu {
             Picker("Repository", selection: $repo) {
                 Text("All repos").tag(ArchivedPresentation.allRepositories)
-                ForEach(repositories, id: \.self) { repository in
+                ForEach(
+                    ArchivedPresentation.repositoryOptions(repositories, selected: repo), id: \.self
+                ) { repository in
                     Label {
                         Text(RepoTile.label(for: repository))
                     } icon: {

--- a/packages/clients/ios/OS1Tests/ArchivedPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ArchivedPresentationTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import OS1
+
+/// What the Archived screen writes on a row and on its pickers, pinned as
+/// values. These mirror the web's `originChip` and picker labels, so a
+/// divergence between the two clients fails here rather than on a phone.
+final class ArchivedPresentationTests: XCTestCase {
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    // MARK: - The origin chip
+
+    func testAReadOnlySessionWearsTheAskChipInGreen() throws {
+        let row = try session(#"{"id":"os-1","mode":"ask","source":"opensession"}"#)
+
+        XCTAssertEqual(
+            ArchivedPresentation.originChip(for: row),
+            ArchivedPresentation.OriginChip(label: "ask", tone: .ask)
+        )
+    }
+
+    func testAnAutomationIsNamedByItsChip() throws {
+        let row = try session(#"{"id":"os-1","automation":"docs-sync","mode":"ask"}"#)
+
+        // The automation's name outranks how it ran, as on the web.
+        XCTAssertEqual(
+            ArchivedPresentation.originChip(for: row),
+            ArchivedPresentation.OriginChip(label: "docs-sync", tone: .neutral)
+        )
+    }
+
+    func testABareAutomationFlagHasNoNameToShow() throws {
+        let row = try session(#"{"id":"os-1","automation":true}"#)
+
+        XCTAssertNil(ArchivedPresentation.originChip(for: row))
+    }
+
+    func testASessionFromAnIntegrationNamesItsSource() throws {
+        for source in ["slack", "linear"] {
+            let row = try session(#"{"id":"os-1","mode":"code","source":"\#(source)"}"#)
+
+            XCTAssertEqual(
+                ArchivedPresentation.originChip(for: row),
+                ArchivedPresentation.OriginChip(label: source, tone: .neutral)
+            )
+        }
+    }
+
+    /// A code session started here is the default. The product's own name on
+    /// every row would say nothing, and older rows still carry the pre-rename id.
+    func testACodeSessionStartedHereGetsNoChip() throws {
+        for json in [
+            #"{"id":"os-1","mode":"code","source":"opensession"}"#,
+            #"{"id":"os-1","mode":"code","source":"backstage"}"#,
+            #"{"id":"os-1"}"#,
+        ] {
+            XCTAssertNil(ArchivedPresentation.originChip(for: try session(json)), json)
+        }
+    }
+
+    // MARK: - The pickers
+
+    func testTheOwnerPickerWearsItsValue() {
+        let owners = [ArchivedOwners.Owner(key: "michiel", label: "Michiel")]
+
+        XCTAssertEqual(ArchivedPresentation.ownerLabel(ArchivedOwners.mine, owners: owners), "My archived")
+        XCTAssertEqual(ArchivedPresentation.ownerLabel(ArchivedOwners.everyone, owners: owners), "Everyone")
+        XCTAssertEqual(ArchivedPresentation.ownerLabel("michiel", owners: owners), "Michiel")
+        // A key the roster no longer answers to still reads as itself.
+        XCTAssertEqual(ArchivedPresentation.ownerLabel("sam", owners: owners), "sam")
+    }
+
+    func testTheRepositoryPickerWearsItsValue() {
+        XCTAssertEqual(ArchivedPresentation.repositoryLabel(ArchivedPresentation.allRepositories), "All repos")
+        XCTAssertEqual(ArchivedPresentation.repositoryLabel("tella-fusion"), "tella-fusion")
+        XCTAssertEqual(ArchivedPresentation.repositoryLabel("backstage"), "opensession")
+    }
+
+    func testTheReasonMenuListsAllThenAutoThenManual() {
+        XCTAssertEqual(ArchivedPresentation.reasons.map(\.key), ["all", "auto", "manual"])
+        XCTAssertEqual(ArchivedPresentation.reasonLabel("auto"), "Auto-archived")
+        XCTAssertEqual(ArchivedPresentation.reasonLabel("manual"), "Manual")
+        XCTAssertEqual(ArchivedPresentation.reasonLabel("all"), "All")
+    }
+}

--- a/packages/clients/ios/OS1Tests/ArchivedPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ArchivedPresentationTests.swift
@@ -77,6 +77,61 @@ final class ArchivedPresentationTests: XCTestCase {
         XCTAssertEqual(ArchivedPresentation.repositoryLabel("backstage"), "opensession")
     }
 
+    // MARK: - A lens control stays while it holds a choice
+
+    func testTheRepositoryPickerStaysWhileItsFilterIsActive() {
+        // Nothing to choose between, nothing selected: no picker.
+        XCTAssertFalse(ArchivedPresentation.showsRepositoryPicker(
+            repositories: ["b"], selected: ArchivedPresentation.allRepositories
+        ))
+        XCTAssertTrue(ArchivedPresentation.showsRepositoryPicker(
+            repositories: ["a", "b"], selected: ArchivedPresentation.allRepositories
+        ))
+        // A's last row was restored while A was selected: the picker is the
+        // only way back to All repos, so it stays.
+        XCTAssertTrue(ArchivedPresentation.showsRepositoryPicker(repositories: ["b"], selected: "a"))
+        XCTAssertTrue(ArchivedPresentation.showsRepositoryPicker(repositories: [], selected: "a"))
+    }
+
+    func testTheRepositoryPickerKeepsListingTheSelectedRepository() {
+        XCTAssertEqual(
+            ArchivedPresentation.repositoryOptions(["b", "c"], selected: "a"), ["a", "b", "c"]
+        )
+        XCTAssertEqual(ArchivedPresentation.repositoryOptions(["a", "b"], selected: "a"), ["a", "b"])
+        XCTAssertEqual(
+            ArchivedPresentation.repositoryOptions(["b"], selected: ArchivedPresentation.allRepositories),
+            ["b"]
+        )
+    }
+
+    func testTheOwnerPickerKeepsListingTheSelectedTeammate() {
+        let owners = [ArchivedOwners.Owner(key: "michiel", label: "Michiel")]
+
+        XCTAssertEqual(
+            ArchivedPresentation.ownerOptions(owners, selected: "sam").map(\.key), ["michiel", "sam"]
+        )
+        XCTAssertEqual(
+            ArchivedPresentation.ownerOptions(owners, selected: "michiel").map(\.key), ["michiel"]
+        )
+        // The fixed lenses have their own entries and add nothing.
+        XCTAssertEqual(
+            ArchivedPresentation.ownerOptions(owners, selected: ArchivedOwners.mine).map(\.key), ["michiel"]
+        )
+        XCTAssertEqual(
+            ArchivedPresentation.ownerOptions(owners, selected: ArchivedOwners.everyone).map(\.key),
+            ["michiel"]
+        )
+    }
+
+    func testTheReasonMenuStaysWhileANarrowReasonIsSelected() {
+        XCTAssertFalse(ArchivedPresentation.showsReasonMenu(hasAutoArchived: false, selected: "all"))
+        XCTAssertTrue(ArchivedPresentation.showsReasonMenu(hasAutoArchived: true, selected: "all"))
+        // The last auto-archived row was restored under Auto-archived: the
+        // menu is the only way back to All, so it stays.
+        XCTAssertTrue(ArchivedPresentation.showsReasonMenu(hasAutoArchived: false, selected: "auto"))
+        XCTAssertTrue(ArchivedPresentation.showsReasonMenu(hasAutoArchived: false, selected: "manual"))
+    }
+
     func testTheReasonMenuListsAllThenAutoThenManual() {
         XCTAssertEqual(ArchivedPresentation.reasons.map(\.key), ["all", "auto", "manual"])
         XCTAssertEqual(ArchivedPresentation.reasonLabel("auto"), "Auto-archived")

--- a/packages/clients/ios/OS1Tests/AskChipContrastTests.swift
+++ b/packages/clients/ios/OS1Tests/AskChipContrastTests.swift
@@ -1,0 +1,101 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import XCTest
+@testable import OS1
+
+/// The ask chip on an archived row, measured rather than eyeballed.
+///
+/// `OS1VisualStyle.greenSoft` is a translucent wash, so what the chip's word
+/// actually sits on is the wash composited over the row. This pins two
+/// promises: the word clears body-text contrast on that composite in both
+/// appearances, and the wash is a visible step from the row rather than a
+/// tint only a diff would notice. The surfaces are what an archived row
+/// paints: white in light, and #1C1C1E in dark.
+final class AskChipContrastTests: XCTestCase {
+    private func luminance(_ color: NSColor) -> CGFloat {
+        guard let srgb = color.usingColorSpace(.sRGB) else {
+            XCTFail("colour is not representable in sRGB")
+            return 0
+        }
+        func channel(_ value: CGFloat) -> CGFloat {
+            value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(srgb.redComponent)
+            + 0.7152 * channel(srgb.greenComponent)
+            + 0.0722 * channel(srgb.blueComponent)
+    }
+
+    private func ratio(_ a: NSColor, _ b: NSColor) -> CGFloat {
+        let (first, second) = (luminance(a), luminance(b))
+        return (max(first, second) + 0.05) / (min(first, second) + 0.05)
+    }
+
+    private func resolve(_ color: Color, _ appearance: NSAppearance.Name) -> NSColor {
+        var resolved = NSColor.clear
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            resolved = NSColor(color).usingColorSpace(.sRGB) ?? .clear
+        }
+        return resolved
+    }
+
+    /// The wash laid over a surface, the way the row draws it.
+    private func composite(_ wash: NSColor, over surface: NSColor) -> NSColor {
+        let alpha = wash.alphaComponent
+        func mix(_ top: CGFloat, _ bottom: CGFloat) -> CGFloat {
+            alpha * top + (1 - alpha) * bottom
+        }
+        return NSColor(
+            srgbRed: mix(wash.redComponent, surface.redComponent),
+            green: mix(wash.greenComponent, surface.greenComponent),
+            blue: mix(wash.blueComponent, surface.blueComponent),
+            alpha: 1
+        )
+    }
+
+    private func gray(_ white: CGFloat) -> NSColor {
+        NSColor(srgbRed: white, green: white, blue: white, alpha: 1)
+    }
+
+    private let lightRow = NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1)
+    private let darkRow = NSColor(
+        srgbRed: 28.0 / 255.0, green: 28.0 / 255.0, blue: 30.0 / 255.0, alpha: 1
+    )
+
+    func testTheAskWordClearsBodyTextContrastOnItsChip() {
+        for (name, appearance, row) in [
+            ("light", NSAppearance.Name.aqua, lightRow),
+            ("dark", NSAppearance.Name.darkAqua, darkRow),
+        ] {
+            let chip = composite(resolve(OS1VisualStyle.greenSoft, appearance), over: row)
+            let measured = ratio(resolve(OS1VisualStyle.greenInk, appearance), chip)
+            XCTAssertGreaterThanOrEqual(
+                measured, 4.5,
+                "ask reads \(String(format: "%.2f", measured)):1 on its chip in \(name)"
+            )
+        }
+    }
+
+    /// The web's step: its light wash lands ~0.14 below white in luminance
+    /// and its dark wash ~0.015 above its page. Under those the pill is a
+    /// tint a diff would catch and an eye would not.
+    func testTheWashIsAVisibleStepFromTheRow() {
+        let light = composite(resolve(OS1VisualStyle.greenSoft, .aqua), over: lightRow)
+        XCTAssertGreaterThanOrEqual(luminance(lightRow) - luminance(light), 0.12)
+
+        let dark = composite(resolve(OS1VisualStyle.greenSoft, .darkAqua), over: darkRow)
+        XCTAssertGreaterThanOrEqual(luminance(dark) - luminance(darkRow), 0.012)
+    }
+
+    /// Light takes the ink's own hue rather than the palette's, so the pill
+    /// reads as one colour: the wash's channels stand in the same order and
+    /// proportion as the word's.
+    func testTheLightWashSharesTheInksHue() {
+        let wash = resolve(OS1VisualStyle.greenSoft, .aqua)
+        let ink = resolve(OS1VisualStyle.greenInk, .aqua)
+        XCTAssertEqual(wash.redComponent, ink.redComponent, accuracy: 0.01)
+        XCTAssertEqual(wash.greenComponent, ink.greenComponent, accuracy: 0.01)
+        XCTAssertEqual(wash.blueComponent, ink.blueComponent, accuracy: 0.01)
+    }
+}
+#endif


### PR DESCRIPTION
Brings the native Archived sheet up to the web archive as shipped in 4cb28ba03a, b9444ac971 and 0fa26c7cd2.

## Before / after

| | Before | After |
|---|---|---|
| Filters | One toolbar `Filters (n)` menu with Owner, Repository, Reason sections and Clear filters | Owner and repository pickers side by side above the list, each wearing its value (avatar / repo tile, name, chevron); Reason behind a toolbar glyph, only when something was auto-archived |
| Count | `N archived` / `N of M archived` section header | Gone. The list shows what matched, the pickers say why |
| Origin | Nothing on the row | Chip after the title: automation name, `slack` / `linear`, or `ask` in green. A code session started here gets none |

## What changed

- `ArchivedPresentation` (new): the origin-chip rule and the picker labels as plain values, mirroring the web's `originChip` and labels.
- `OS1VisualStyle.greenSoft`: the web's `--green-soft` ported as a luminance step from the row it sits on, not its hex. Light uses `greenInk`'s own hue at 11% (the web's lighter hue needed 12% for the same step); dark keeps the palette green at 13% over #1c1c1e.
- `ArchivedSessionsView`: picker row (horizontal scroll, so long names and accessibility sizes widen rather than wrap), no section header, list top inset closed, chip trailing the title (drops under it at accessibility sizes), rows combined for VoiceOver, `Owner, …` / `Repository, …` / `Reason, …` labels on the controls.
- Debug hooks `OS1_OPEN_ARCHIVED`, `OS1_ARCHIVED_OWNER`, `OS1_ARCHIVED_REPO` so a simulator capture can open the sheet on a lens.

## Tests

- `ArchivedPresentationTests`: chip precedence (automation > ask > source), no chip for `opensession` / `backstage` / none, picker labels.
- `AskChipContrastTests` (macOS): `greenInk` over the composited wash clears 4.5:1 in both appearances, the wash is a visible step from the row, and the light wash shares the ink's hue.

## Verification

- `OS1` (iOS Simulator) and `OS1Mac` build clean on tella-mac-node.
- The Mac test bundle compiles, but `xcodebuild test` could not reach `testmanagerd` on the node (`Connection init failed at lookup with error 3`) for every attempt during this session, including after retries and a direct `libXCTestBundleInject` run, so the new tests have not executed there yet. They should run in CI.
- `bun run check` passes except a `context-log.test.ts` timeout under host load, which passes in isolation.
- Simulator captures (iPhone 17 Pro): light under Everyone (two owners, two repos, automation chips) and dark under Michiel + opensession (avatar and repo tile in the pickers, green `ask` chip), attached in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-8546acbf-0bd4-7734-af64-351d8a1b53ac)