### PR TITLE
Native transcript: fold every review fix round together and keep its verdict

### DIFF
--- a/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
+++ b/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
@@ -92,6 +92,11 @@ struct ReviewLoop: Identifiable, Equatable {
     var blocks: [TranscriptBlock]
     /// The settled verdict, on the final loop only.
     var result: ReviewLoopResult?
+    /// How the transcript says the loop closed, once its settle notice landed
+    /// inside it. Outranked by a live `result`, which only the final loop of
+    /// an open PR carries; every earlier or merged loop keeps this durable
+    /// verdict instead of a bare round count.
+    var settled: ReviewSettledOutcome?
 
     /// What the closed row says. A live loop is always working, whatever
     /// GitHub last reported about the PR.
@@ -101,15 +106,43 @@ struct ReviewLoop: Identifiable, Equatable {
         case .passed: return "Ready to merge"
         case .failed: return "Needs changes"
         case .pending: return "Working"
-        case nil: return roundsLabel
+        case nil: return settled?.label ?? roundsLabel
         }
     }
 
     /// The loop has reached a verdict, so opening it can move that verdict
-    /// down to its own row and give the header the round count instead.
-    var isSettled: Bool { !isLive && result != nil && result?.status != .pending }
+    /// down to its own row (or to the settle notice folded inside) and give
+    /// the header the round count instead.
+    var isSettled: Bool {
+        guard !isLive else { return false }
+        if let result { return result.status != .pending }
+        return settled != nil
+    }
 
     var roundsLabel: String { "\(rounds) round\(rounds == 1 ? "" : "s")" }
+}
+
+/// How the transcript says a review loop closed: the protocol's
+/// `review-settled` notice (`notices.ts`), delivered once the PR passed review
+/// after handed-off fix rounds or the round cap sent the rest to humans. It
+/// outlives the PR: a merged or closed PR has no live verdict, and this is
+/// what the row still says.
+enum ReviewSettledOutcome: Equatable {
+    case passed
+    case capped
+
+    /// The protocol tags a passed loop as a neutral done notice and a capped
+    /// one as a warning; the tone is the outcome's only wire form.
+    init(notice: EntryNotice) {
+        self = notice.tone == "warn" ? .capped : .passed
+    }
+
+    var label: String {
+        switch self {
+        case .passed: "Review passed"
+        case .capped: "Over to humans"
+        }
+    }
 }
 
 /// The latest GitHub facts about the PR a review loop was working on, as the
@@ -591,6 +624,7 @@ enum TranscriptGrouping {
 
     private enum ReviewBlockRole {
         case handoff(prNumber: Int?)
+        case settled(ReviewSettledOutcome)
         case userMessage
         case other
     }
@@ -599,15 +633,42 @@ enum TranscriptGrouping {
     /// message presentation rule so only an actual person's message ends a loop.
     private static func reviewBlockRole(_ block: TranscriptBlock) -> ReviewBlockRole {
         guard case .message(let entry) = block else { return .other }
-        if entry.notice?.kind == "review-handoff" {
-            return .handoff(prNumber: handoffPrNumber(block))
+        guard let notice = entry.notice else {
+            return entry.isUser ? .userMessage : .other
         }
-        return entry.isUser && entry.notice == nil ? .userMessage : .other
+        switch notice.kind {
+        case "review-handoff": return .handoff(prNumber: handoffPrNumber(block))
+        case "review-settled": return .settled(ReviewSettledOutcome(notice: notice))
+        default: return .other
+        }
+    }
+
+    /// Whether the loop open before `index` goes on: its next round's findings
+    /// or its closing settle notice arrive before any human message, note or
+    /// walkthrough.
+    private static func reviewLoopContinues(
+        _ blocks: [TranscriptBlock], from index: Int
+    ) -> Bool {
+        for block in blocks[index...] {
+            switch block {
+            case .note, .walkthrough: return false
+            default: break
+            }
+            switch reviewBlockRole(block) {
+            case .userMessage: return false
+            case .handoff, .settled: return true
+            case .other: continue
+            }
+        }
+        return false
     }
 
     /// A review handoff and the work it triggers form one quiet phase. A real
     /// user message always ends it, so people never lose their own request in
-    /// a collapsed automation trail. Mirrors the web's `groupReviewLoops`.
+    /// a collapsed automation trail. The loop's final report stays outside as
+    /// the answer; each earlier round's report folds in once a later round or
+    /// the settle notice proves it interim. Mirrors the web's
+    /// `groupReviewLoops`.
     private static func groupReviewLoops(
         _ blocks: [TranscriptBlock],
         live: Bool,
@@ -626,6 +687,7 @@ enum TranscriptGrouping {
             var loop: [TranscriptBlock] = [first]
             var rounds = 1
             var prNumber = firstPrNumber
+            var settled: ReviewSettledOutcome?
             while index + 1 < blocks.count {
                 let next = blocks[index + 1]
                 let nextRole = reviewBlockRole(next)
@@ -636,11 +698,25 @@ enum TranscriptGrouping {
                 // A normal user message is a new conversation phase. A second
                 // review handoff belongs to this loop and starts its next round.
                 if case .userMessage = nextRole { break }
+                // A turn's final answer stays outside the fold as the loop's
+                // report, unless the loop goes on past it: the next round's
+                // findings or the settle notice make that answer an interim
+                // report. A settled loop is closed, so its wrap-up always
+                // stays outside.
+                if case .message(let entry) = next, entry.isAssistant,
+                   settled != nil || !reviewLoopContinues(blocks, from: index + 2) {
+                    break
+                }
                 index += 1
                 loop.append(next)
-                if case .handoff(let nextPrNumber) = nextRole {
+                switch nextRole {
+                case .handoff(let nextPrNumber):
                     rounds += 1
                     prNumber = prNumber ?? nextPrNumber
+                case .settled(let outcome):
+                    settled = outcome
+                case .userMessage, .other:
+                    break
                 }
             }
             grouped.append(.reviewLoop(ReviewLoop(
@@ -648,7 +724,8 @@ enum TranscriptGrouping {
                 prNumber: prNumber,
                 rounds: rounds,
                 isLive: false,
-                blocks: loop
+                blocks: loop,
+                settled: settled
             )))
             index += 1
         }

--- a/packages/clients/ios/OS1/Views/ReviewLoopView.swift
+++ b/packages/clients/ios/OS1/Views/ReviewLoopView.swift
@@ -5,9 +5,11 @@ import SwiftUI
 /// A review round arrives as a pile of ordinary rows — the handoff notice, the
 /// fix turns, the push, then the next handoff — which is the noisiest thing a
 /// phone transcript can hold, and none of it is what the reader came for.
-/// Closed, this row says what the loop concluded; opened, it shows the same
-/// icon-led step rows as any other turn, with the verdict at the end. Mirrors
-/// the web viewer's `ReviewLoopBlock`.
+/// Closed, this row says what the loop concluded: GitHub's live verdict while
+/// the PR is open, or the durable outcome the settle notice recorded ("Review
+/// passed", "Over to humans") once it is merged and the live verdict is gone.
+/// Opened, it shows the same icon-led step rows as any other turn, with the
+/// verdict at the end. Mirrors the web viewer's `ReviewLoopBlock`.
 struct ReviewLoopView: View {
     let loop: ReviewLoop
     let sessionId: String
@@ -37,12 +39,14 @@ struct ReviewLoopView: View {
                     ForEach(loop.blocks) { block in
                         // The handoff itself is what the header stands for;
                         // drawing it again inside would say the same thing
-                        // twice, one indent apart.
+                        // twice, one indent apart. The settle notice stays: it
+                        // is the loop's own last word, and the verdict row
+                        // below only exists while GitHub still has one.
                         if !isHandoff(block) {
                             row(for: block)
                         }
                     }
-                    if let result = loop.result {
+                    if let result = loop.result, result.status != .pending {
                         ReviewLoopResultRow(result: result, rounds: loop.rounds)
                     }
                 }

--- a/packages/clients/ios/OS1Tests/TranscriptGroupingTests.swift
+++ b/packages/clients/ios/OS1Tests/TranscriptGroupingTests.swift
@@ -780,6 +780,28 @@ final class TranscriptGroupingTests: XCTestCase {
         )
     }
 
+    /// The GitHub-delivered notice that closes a loop, as the server classifies
+    /// it: a done notice when the PR passed review, a warning when the round
+    /// cap handed the rest to humans.
+    private func settled(_ id: String, pr: Int, passed: Bool) -> TranscriptEntry {
+        TranscriptEntry(
+            id: id,
+            type: "user",
+            content: passed
+                ? "This session's PR #\(pr) passed review after 2 fix rounds."
+                : "This session's PR #\(pr) hit the fix round cap; the rest is for humans.",
+            notice: EntryNotice(
+                kind: "review-settled",
+                title: passed ? "PR #\(pr) review passed" : "PR #\(pr) review handed to humans",
+                tone: passed ? "info" : "warn",
+                body: "collapsed",
+                link: nil,
+                ask: nil,
+                icon: passed ? "done" : nil
+            )
+        )
+    }
+
     /// Classified operational notices can retain the legacy user wire type
     /// even though they are not a person's message.
     private func legacyStatusNotice(_ id: String) -> TranscriptEntry {
@@ -826,23 +848,25 @@ final class TranscriptGroupingTests: XCTestCase {
         ])
 
         let blocks = viewModel.displayBlocks
-        XCTAssertEqual(blocks.count, 3, "prompt, answer, and one loop for the review")
+        XCTAssertEqual(
+            blocks.map(\.id).filter { !$0.hasSuffix(":footer") },
+            ["u1", "a1", "review-loop:h1", "a2"],
+            "prompt, answer, one loop for the review, then the loop's report as the answer"
+        )
         guard let loop = firstLoop(in: blocks) else {
             return XCTFail("the handoff should open a review loop")
         }
         XCTAssertEqual(loop.prNumber, 128)
         XCTAssertEqual(loop.rounds, 1)
         XCTAssertEqual(loop.detail, "1 round", "no verdict yet, so the header counts rounds")
+        XCTAssertNil(loop.settled)
         XCTAssertTrue(
             loop.blocks.contains { if case .work = $0 { true } else { false } },
             "the fix work belongs inside the loop"
         )
-        XCTAssertTrue(
-            loop.blocks.contains { block in
-                if case .message(let entry) = block { return entry.id == "a2" }
-                return false
-            },
-            "so does the answer the fix ended with"
+        XCTAssertFalse(
+            loop.blocks.flatMap(\.entryIds).contains("a2"),
+            "the answer the fix ended with is the loop's report and stays readable outside"
         )
     }
 
@@ -855,9 +879,37 @@ final class TranscriptGroupingTests: XCTestCase {
         ])
 
         let blocks = viewModel.displayBlocks
-        XCTAssertEqual(blocks.count, 1, "both rounds read as one phase")
+        XCTAssertEqual(
+            blocks.map(\.id),
+            ["review-loop:h1", "a2"],
+            "both rounds read as one phase, closed by the last round's report"
+        )
         XCTAssertEqual(firstLoop(in: blocks)?.rounds, 2)
         XCTAssertEqual(firstLoop(in: blocks)?.detail, "2 rounds")
+        XCTAssertEqual(
+            firstLoop(in: blocks)?.blocks.flatMap(\.entryIds),
+            ["h1", "a1", "h2"],
+            "the first round's report is interim once the second round's findings follow"
+        )
+    }
+
+    func testEveryFixRoundFoldsWithTheNoticesBetweenThem() {
+        append([
+            handoff("h1", pr: 42),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Fix round 1 is addressed and pushed."),
+            TranscriptEntry(id: "recap", type: "system", content: "Session recap"),
+            legacyStatusNotice("deploy"),
+            handoff("h2", pr: 42),
+            TranscriptEntry(id: "a2", type: "assistant", content: "Fix round 2 is addressed and pushed."),
+        ])
+
+        let blocks = viewModel.displayBlocks
+        XCTAssertEqual(blocks.map(\.id), ["review-loop:h1", "a2"])
+        XCTAssertEqual(
+            firstLoop(in: blocks)?.blocks.flatMap(\.entryIds),
+            ["h1", "a1", "recap", "deploy", "h2"],
+            "the recap and an operational notice between rounds are part of the same phase"
+        )
     }
 
     func testAPromptEndsTheLoopSoNobodyLosesTheirOwnRequest() {
@@ -869,14 +921,13 @@ final class TranscriptGroupingTests: XCTestCase {
         ])
 
         let blocks = viewModel.displayBlocks
-        XCTAssertEqual(blocks.count, 3, "loop, prompt, answer")
-        guard case .reviewLoop = blocks[0] else { return XCTFail("expected a loop first") }
-        guard case .message(let prompt) = blocks[1], prompt.id == "u1" else {
+        XCTAssertEqual(blocks.map(\.id), ["review-loop:h1", "a1", "u1", "a2"], "loop, report, prompt, answer")
+        guard case .message(let prompt) = blocks[2], prompt.id == "u1" else {
             return XCTFail("the human's own request must stay outside the fold")
         }
     }
 
-    func testLegacyUserShapedStatusNoticeStaysInsideTheLoop() {
+    func testATrailingStatusNoticeSitsAfterAClosedLoop() {
         append([
             handoff("h1", pr: 128),
             TranscriptEntry(id: "a1", type: "assistant", content: "Fixed."),
@@ -884,9 +935,127 @@ final class TranscriptGroupingTests: XCTestCase {
         ])
 
         let blocks = viewModel.displayBlocks
-        XCTAssertEqual(blocks.count, 1, "an operational notice remains part of the review phase")
+        XCTAssertEqual(
+            blocks.map(\.id),
+            ["review-loop:h1", "a1", "deploy"],
+            "nothing after the report proves it interim, so the loop closed at it"
+        )
+    }
+
+    func testASettledLoopFoldsItsNoticeAndKeepsTheWrapUpOutside() {
+        append([
+            handoff("h1", pr: 42),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Fix round 1 is addressed and pushed."),
+            handoff("h2", pr: 42),
+            TranscriptEntry(id: "a2", type: "assistant", content: "Fix round 2 is addressed and pushed."),
+            settled("s1", pr: 42, passed: true),
+            TranscriptEntry(
+                id: "wrap",
+                type: "assistant",
+                content: "Where things stand: the retry path now fails fast."
+            ),
+        ])
+
+        let blocks = viewModel.displayBlocks
+        XCTAssertEqual(
+            blocks.map(\.id),
+            ["review-loop:h1", "wrap"],
+            "the cold-read wrap-up is the loop's answer and stays outside"
+        )
         guard let loop = firstLoop(in: blocks) else { return XCTFail("expected a loop") }
-        XCTAssertTrue(loop.blocks.flatMap(\.entryIds).contains("deploy"))
+        XCTAssertEqual(loop.rounds, 2)
+        XCTAssertEqual(loop.settled, .passed)
+        XCTAssertEqual(loop.detail, "Review passed")
+        XCTAssertNil(loop.result)
+        XCTAssertTrue(loop.isSettled, "opened, the header trades the verdict for the round count")
+        XCTAssertEqual(
+            loop.blocks.flatMap(\.entryIds),
+            ["h1", "a1", "h2", "a2", "s1"],
+            "every round's report and the settle notice are the loop's own"
+        )
+    }
+
+    func testACappedLoopReadsOverToHumansEvenOnceThePrIsGone() {
+        let entries = [
+            handoff("h1", pr: 42),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Round 1 pushed."),
+            handoff("h2", pr: 42),
+            TranscriptEntry(id: "a2", type: "assistant", content: "Round 2 pushed."),
+            settled("s1", pr: 42, passed: false),
+            TranscriptEntry(id: "wrap", type: "assistant", content: "Two threads need a human call."),
+        ]
+        var session = Session(id: "bks-1")
+        session.prNumber = 42
+        session.prState = "MERGED"
+        session.prOsReview = OsReviewSummary(
+            verdict: "request_changes",
+            confidence: 4,
+            findings: 2,
+            blocking: 0,
+            stale: false
+        )
+        XCTAssertNil(ReviewLoopResult(session: session), "a merged PR has no live verdict")
+
+        let blocks = TranscriptGrouping.blocks(
+            from: TranscriptGrouping.displayItems(from: entries),
+            live: false,
+            worktreeDir: nil,
+            reviewResult: ReviewLoopResult(session: session)
+        )
+        XCTAssertEqual(blocks.map(\.id), ["review-loop:h1", "wrap"])
+        guard let loop = firstLoop(in: blocks) else { return XCTFail("expected a loop") }
+        XCTAssertEqual(loop.settled, .capped)
+        XCTAssertEqual(loop.detail, "Over to humans")
+        XCTAssertTrue(loop.isSettled)
+        XCTAssertEqual(loop.roundsLabel, "2 rounds")
+    }
+
+    func testGitHubsLiveVerdictOutranksTheTranscriptsOutcome() {
+        var session = Session(id: "bks-1")
+        session.prNumber = 42
+        session.prState = "OPEN"
+        session.prChecks = PrChecksSummary(total: 1, passed: 1, failed: 0, pending: 0)
+        session.prOsReview = OsReviewSummary(
+            verdict: "approve",
+            confidence: 5,
+            findings: 0,
+            blocking: 0,
+            stale: false
+        )
+        let entries = [
+            handoff("h1", pr: 42),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Pushed."),
+            settled("s1", pr: 42, passed: true),
+            TranscriptEntry(id: "wrap", type: "assistant", content: "Ready."),
+        ]
+
+        let blocks = TranscriptGrouping.blocks(
+            from: TranscriptGrouping.displayItems(from: entries),
+            live: false,
+            worktreeDir: nil,
+            reviewResult: ReviewLoopResult(session: session)
+        )
+        guard let loop = firstLoop(in: blocks) else { return XCTFail("expected a loop") }
+        XCTAssertEqual(loop.settled, .passed)
+        XCTAssertEqual(loop.result?.status, .passed)
+        XCTAssertEqual(loop.detail, "Ready to merge", "an open PR's live verdict says more")
+    }
+
+    func testASettledLoopInARunningSessionStillReadsWorking() {
+        viewModel.handle(.sessionStatus(sessionId: "bks-1", isRunning: true))
+        append([
+            handoff("h1", pr: 42),
+            TranscriptEntry(id: "a1", type: "assistant", content: "Pushed."),
+            settled("s1", pr: 42, passed: true),
+        ])
+
+        guard let loop = firstLoop(in: viewModel.displayBlocks) else {
+            return XCTFail("expected a loop")
+        }
+        XCTAssertEqual(loop.settled, .passed)
+        XCTAssertTrue(loop.isLive, "the wrap-up is still being written")
+        XCTAssertEqual(loop.detail, "Working")
+        XCTAssertFalse(loop.isSettled)
     }
 
     func testNotesStayOutsideTheLoop() {


### PR DESCRIPTION
Ports the review-loop settlement behavior from d855d13ed to the native SwiftUI client (`OS1` / `OS1Mac`).

## Before

Two rounds of the same PR's review handoff rendered as two "Review loop" folds, with the first round's report and the recap notices sitting between them. Once the PR merged, the row fell back to a bare "2 rounds".

## After

- `TranscriptBlocks.swift`: `groupReviewLoops` looks ahead. A turn's final answer, and the notices after it, fold in when the next round's findings or the settle notice follow before any human message, note or walkthrough. The loop's own final report and the cold-read wrap-up after the settle notice stay outside the fold.
- New `ReviewSettledOutcome` (`passed` / `capped`) derived from the `review-settled` notice's tone (info / warn), held on `ReviewLoop.settled`. The closed row reads **Review passed** / **Over to humans** from the transcript even when the PR is merged and the live GitHub verdict is gone; an open PR's live `ReviewLoopResult` still outranks it.
- `ReviewLoopView.swift`: the settle notice stays drawn inside the opened fold; the live verdict row only shows a settled (non-pending) result.
- `TranscriptGroupingTests.swift`: grouping and presentation tests for multi-round loops, the notices between rounds, passed and capped settlement, a merged PR keeping its verdict, live verdict precedence, and a settled loop in a still-running session.

## Verification

- `xcodegen generate`, `OS1` (iOS simulator) and `OS1Mac` built clean on tella-mac-node; `build-for-testing` for `OS1Mac` also built the `OS1Tests` bundle.
- `xcodebuild test` could not run on the node: `testmanagerd` refuses connections there right now ("Failed to establish communication with the test runner", four attempts, including after freeing disk), which is a box problem, not a compile one. `os1-native-ci.yml` runs the same Mac test command on this PR.
- iPhone 17 Pro simulator screenshot of the demo seed's two-round, settled session (`bks-demo-review`) against an isolated demo server: one **Review loop · Review passed · PR #131** row, the wrap-up beneath it. Screenshot is attached in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-b8c7bda0-84f8-7d51-be4d-d8cd29bc1df9)