### PR TITLE
Native: delay the transient reconnect banner by 8s of foreground time

### DIFF
--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -123,7 +123,19 @@ final class SessionViewModel {
     /// The request id currently being removed from Slack. Keeping the receipt
     /// visible while this is set makes a failed Undo recoverable.
     private(set) var undoingSlackComposeReceiptId: String?
-    private(set) var connectionState: ConnectionState = .connecting
+    /// The transport truth: sends, paging and presence gate on this. Views
+    /// read `presentedConnectionState` instead.
+    private(set) var connectionState: ConnectionState = .connecting {
+        didSet { presentConnectionState() }
+    }
+    /// What the session screen shows. A drop from a presented connection
+    /// waits out `connectionPresentationGrace` of foreground time before it
+    /// turns into a reconnect banner, so Wi-Fi blips and the socket churn of
+    /// backgrounding and returning never repaint the transcript or composer.
+    /// Recovery, an announced server restart, the first connect and a real
+    /// load failure show immediately.
+    private(set) var presentedConnectionState: ConnectionState = .connecting
+    private var connectionPresentationTask: Task<Void, Never>?
     private(set) var isLoadingConversation = true
     /// A watch that never receives transcript_init is not a loading state
     /// forever. The reader gets an explicit retry while reconnects continue.
@@ -169,6 +181,31 @@ final class SessionViewModel {
         runStartedAt = nil
         isLoadingConversation = false
     }
+
+    #if DEBUG
+    /// Screenshot fixture. `sustained` takes the socket down for good, so the
+    /// reconnect banner appears once the grace runs out; otherwise the socket
+    /// keeps dropping and rejoining, the transport spends most of the capture
+    /// reconnecting, and the presented state stays quiet throughout.
+    func dropConnectionForScreenshot(sustained: Bool) {
+        holdsScreenshotFixture = true
+        screenshotDropTask?.cancel()
+        screenshotDropTask = Task { [weak self] in
+            var dropped = false
+            repeat {
+                try? await Task.sleep(for: .seconds(3))
+                guard let self, !Task.isCancelled else { return }
+                guard self.connectionState == .connected else { continue }
+                self.socket?.disconnect()
+                self.socket = nil
+                self.scheduleReconnect("Connection lost")
+                if sustained { self.reconnectTask?.cancel() }
+                dropped = true
+            } while !(sustained && dropped)
+        }
+    }
+    private var screenshotDropTask: Task<Void, Never>?
+    #endif
 
     func showSteeredMessageForScreenshot() {
         holdsScreenshotFixture = true
@@ -307,6 +344,10 @@ final class SessionViewModel {
     private var isServerHandoffPending = false
     static let reconnectDelay: Duration = .seconds(2)
     static let handoffReconnectDelay: Duration = .milliseconds(250)
+    /// Mirrors the web client's `CONNECTION_PRESENTATION_GRACE_MS`.
+    static let connectionPresentationGrace: Duration = .seconds(8)
+    /// Injection seam so tests drive the grace period without waiting it out.
+    private let clock: any Clock<Duration>
     private var conversationLoadTask: Task<Void, Never>?
     private let conversationLoadTimeout: TimeInterval
     /// Multiple views can briefly overlap during a reversed tab transition.
@@ -506,6 +547,7 @@ final class SessionViewModel {
         socketFactory: @escaping @MainActor () -> any SessionSocket = { OS1Socket() },
         outbox: Outbox = .shared,
         conversationLoadTimeout: TimeInterval = 15,
+        clock: any Clock<Duration> = ContinuousClock(),
         prLoader: @escaping @MainActor (String) async throws -> PrDetails? = {
             try await OS1API.pr(sessionId: $0)
         },
@@ -520,6 +562,7 @@ final class SessionViewModel {
         self.socketFactory = socketFactory
         self.outbox = outbox
         self.conversationLoadTimeout = conversationLoadTimeout
+        self.clock = clock
         self.prLoader = prLoader
         self.slackComposerUndoer = slackComposerUndoer
         self.workflowLoader = workflowLoader
@@ -666,6 +709,10 @@ final class SessionViewModel {
         replySuggestions = []
         outbox.stopObserving(sessionId: session.id)
         reconnectTask?.cancel()
+        cancelConnectionPresentation()
+        #if DEBUG
+        screenshotDropTask?.cancel()
+        #endif
         conversationLoadTask?.cancel()
         resyncProbeTask?.cancel()
         creationRetryTask?.cancel()
@@ -929,6 +976,10 @@ final class SessionViewModel {
         guard !stopped else { return }
         stopTyping()
         isAway = true
+        // Time away from the foreground never counts toward the reconnect
+        // grace; `appDidBecomeActive` restarts it if the drop outlives the
+        // background.
+        cancelConnectionPresentation()
         // Coming back has to re-claim the face immediately, not wait out the
         // refresh interval below.
         lastPresenceRefresh = .distantPast
@@ -955,7 +1006,8 @@ final class SessionViewModel {
         loadPr()
         guard connectionState == .connected, let socket else {
             // Not connected (or a pre-suspension connect is stuck mid
-            // handshake): skip the backoff and reconnect right now.
+            // handshake): skip the backoff and reconnect right now. The
+            // rewrite of `connectionState` restarts the presentation grace.
             reconnectTask?.cancel()
             self.socket?.disconnect()
             self.socket = nil
@@ -1628,6 +1680,42 @@ final class SessionViewModel {
         socket = nil
         armConversationLoadDeadline()
         connect()
+    }
+
+    // MARK: - Connection presentation
+
+    /// Fold the transport state into the presented one. Only a drop from a
+    /// presented connection is deferred; every other transition is immediate.
+    private func presentConnectionState() {
+        let state = connectionState
+        let isTransientDrop: Bool
+        if case .reconnecting = state {
+            isTransientDrop = presentedConnectionState == .connected && !isServerHandoffPending
+        } else {
+            isTransientDrop = false
+        }
+        guard isTransientDrop else {
+            cancelConnectionPresentation()
+            presentedConnectionState = state
+            return
+        }
+        // A grace period already running keeps its deadline; retries inside
+        // it rewrite `connectionState` without restarting the clock.
+        guard connectionPresentationTask == nil, !isAway, !stopped else { return }
+        connectionPresentationTask = Task { [weak self] in
+            guard let clock = self?.clock else { return }
+            try? await clock.sleep(for: Self.connectionPresentationGrace)
+            guard let self, !Task.isCancelled, !self.stopped, !self.isAway else { return }
+            self.connectionPresentationTask = nil
+            if case .reconnecting = self.connectionState {
+                self.presentedConnectionState = self.connectionState
+            }
+        }
+    }
+
+    private func cancelConnectionPresentation() {
+        connectionPresentationTask?.cancel()
+        connectionPresentationTask = nil
     }
 
     private func armConversationLoadDeadline() {

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -136,6 +136,10 @@ final class SessionViewModel {
     /// load failure show immediately.
     private(set) var presentedConnectionState: ConnectionState = .connecting
     private var connectionPresentationTask: Task<Void, Never>?
+    /// Set by the first `hello`. Only a session that has actually been
+    /// connected may have a presented outage folded back into `.connected`
+    /// while backgrounded.
+    private var hasCompletedHandshake = false
     private(set) var isLoadingConversation = true
     /// A watch that never receives transcript_init is not a loading state
     /// forever. The reader gets an explicit retry while reconnects continue.
@@ -978,8 +982,20 @@ final class SessionViewModel {
         isAway = true
         // Time away from the foreground never counts toward the reconnect
         // grace; `appDidBecomeActive` restarts it if the drop outlives the
-        // background.
+        // background. An outage already on screen is folded back too, as the
+        // web client does while hidden: the return reconnects on the spot,
+        // and a banner that survived the background would flash through the
+        // handshake even when connectivity came back meanwhile. An announced
+        // server restart keeps its banner.
         cancelConnectionPresentation()
+        switch presentedConnectionState {
+        case .connecting, .reconnecting:
+            if hasCompletedHandshake, !isServerHandoffPending {
+                presentedConnectionState = .connected
+            }
+        case .connected, .failed:
+            break
+        }
         // Coming back has to re-claim the face immediately, not wait out the
         // refresh interval below.
         lastPresenceRefresh = .distantPast
@@ -1686,12 +1702,15 @@ final class SessionViewModel {
 
     /// Fold the transport state into the presented one. Only a drop from a
     /// presented connection is deferred; every other transition is immediate.
+    /// `connect()` rewrites an empty-transcript reconnect as `.connecting`, so
+    /// that counts as the same drop: what matters is what was on screen.
     private func presentConnectionState() {
         let state = connectionState
         let isTransientDrop: Bool
-        if case .reconnecting = state {
+        switch state {
+        case .connecting, .reconnecting:
             isTransientDrop = presentedConnectionState == .connected && !isServerHandoffPending
-        } else {
+        case .connected, .failed:
             isTransientDrop = false
         }
         guard isTransientDrop else {
@@ -1707,7 +1726,7 @@ final class SessionViewModel {
             try? await clock.sleep(for: Self.connectionPresentationGrace)
             guard let self, !Task.isCancelled, !self.stopped, !self.isAway else { return }
             self.connectionPresentationTask = nil
-            if case .reconnecting = self.connectionState {
+            if self.connectionState != .connected {
                 self.presentedConnectionState = self.connectionState
             }
         }
@@ -1739,6 +1758,7 @@ final class SessionViewModel {
         switch event {
         case .hello:
             isServerHandoffPending = false
+            hasCompletedHandshake = true
             connectionState = .connected
             // A replacement socket defaults to present. Restore scene focus
             // before joining the session so a background reconnect never

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -943,6 +943,11 @@ struct SessionView: View {
             // watchdog window. The zero-sized leaf owns only the side effects.
             .background { SessionSceneLifecycle(viewModel: viewModel) }
             .task {
+                #if DEBUG
+                if let drop = ProcessInfo.processInfo.environment["OS1_SHOW_CONNECTION_DROP"] {
+                    viewModel.dropConnectionForScreenshot(sustained: drop == "sustained")
+                }
+                #endif
                 #if DEBUG && os(iOS)
                 // Install screenshot fixtures before network requests so a
                 // slow catalog cannot leave the capture in the ordinary state.
@@ -1179,7 +1184,7 @@ struct SessionView: View {
             if let safety = viewModel.safety {
                 safetyNotice(safety)
             }
-            switch viewModel.connectionState {
+            switch viewModel.presentedConnectionState {
             case .connected:
                 EmptyView()
             case .connecting:
@@ -3609,7 +3614,7 @@ private struct SessionInputBar: View {
 
     private var visibleNotice: String? {
         guard let notice = viewModel.notice else { return nil }
-        if case .connected = viewModel.connectionState { return notice }
+        if case .connected = viewModel.presentedConnectionState { return notice }
         let normalized = notice.lowercased()
         return normalized.contains("connect") || normalized.contains("socket")
             ? nil

--- a/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
@@ -54,7 +54,11 @@ final class ConnectionPresentationTests: XCTestCase {
         for _ in 0..<8 { await Task.yield() }
     }
 
+    /// A grace task spawned by the call just before this one has not run yet
+    /// (the test still owns the main actor), so let it register its deadline
+    /// before the clock moves; otherwise it would sleep from the advanced time.
     private func advance(by duration: Duration) async {
+        await settle()
         clock.advance(by: duration)
         await settle()
     }

--- a/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import OS1
+
+/// `SessionViewModel.presentedConnectionState` is what the session screen
+/// paints. It lags the transport by eight seconds of foreground time on a
+/// drop and nothing else, so a Wi-Fi blip or a background round trip never
+/// flashes the orange reconnect banner. These tests drive the grace period
+/// with a manual clock, so nothing here waits on wall time.
+@MainActor
+final class ConnectionPresentationTests: XCTestCase {
+    private var clock: ManualClock!
+    private var sockets: [PresentationSocket] = []
+    private var viewModel: SessionViewModel!
+
+    override func setUp() {
+        super.setUp()
+        clock = ManualClock()
+        sockets = []
+        viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            socketFactory: { [unowned self] in
+                let socket = PresentationSocket()
+                sockets.append(socket)
+                return socket
+            },
+            clock: clock
+        )
+    }
+
+    override func tearDown() {
+        viewModel?.stop()
+        viewModel = nil
+        super.tearDown()
+    }
+
+    /// Open the session and land the handshake, so both states read connected.
+    private func connect() {
+        viewModel.start()
+        viewModel.handle(.hello(bootId: "boot-1"))
+        XCTAssertEqual(viewModel.connectionState, .connected)
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+    }
+
+    private func drop(_ reason: String? = "connection lost") async {
+        sockets.last?.onClose?(reason)
+        await settle()
+    }
+
+    /// Let tasks the view model spawned reach their next suspension point.
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private func advance(by duration: Duration) async {
+        clock.advance(by: duration)
+        await settle()
+    }
+
+    func testGraceMatchesTheWebClient() {
+        XCTAssertEqual(SessionViewModel.connectionPresentationGrace, .seconds(8))
+    }
+
+    func testRecoveryInsideTheGraceNeverPresentsReconnecting() async {
+        connect()
+        await drop()
+
+        XCTAssertEqual(viewModel.connectionState, .reconnecting("connection lost"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        await advance(by: .seconds(7))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "still inside the grace")
+
+        viewModel.handle(.hello(bootId: "boot-2"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "recovery shows at once")
+
+        await advance(by: .seconds(10))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "the old deadline was cancelled")
+    }
+
+    func testSustainedOutagePresentsReconnectingAfterTheGrace() async {
+        connect()
+        await drop()
+
+        await advance(by: .seconds(7))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        await advance(by: .seconds(1))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("connection lost"))
+
+        // Later retries and their failures repaint immediately: the banner is
+        // already up, so there is nothing left to protect.
+        await drop("timed out")
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("timed out"))
+
+        viewModel.handle(.hello(bootId: "boot-2"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+    }
+
+    func testBackgroundTimeDoesNotCountTowardTheGrace() async {
+        connect()
+        await drop()
+        await advance(by: .seconds(5))
+
+        viewModel.appDidEnterBackground()
+        await advance(by: .seconds(60))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "nothing counts while away")
+
+        // Returning reconnects straight away and starts a fresh grace.
+        viewModel.appDidBecomeActive()
+        await settle()
+        XCTAssertEqual(viewModel.connectionState, .reconnecting(nil))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        await advance(by: .seconds(7))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "the five seconds before backgrounding were discarded")
+
+        await advance(by: .seconds(1))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+    }
+
+    func testDropWhileBackgroundedWaitsForTheForeground() async {
+        connect()
+        viewModel.appDidEnterBackground()
+        await drop()
+        await advance(by: .seconds(30))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        viewModel.appDidBecomeActive()
+        await advance(by: .seconds(8))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+    }
+
+    func testAnnouncedServerRestartPresentsImmediately() async {
+        connect()
+        viewModel.handle(.serverRestarting)
+        await drop("server restarting")
+
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("server restarting"))
+
+        viewModel.handle(.hello(bootId: "boot-2"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+    }
+
+    func testInitialConnectAndLoadFailurePresentImmediately() async {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("os1-presentation-tests-\(UUID().uuidString)", isDirectory: true)
+        let outbox = Outbox(directory: directory, monitorNetwork: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let socket = PresentationSocket()
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            socketFactory: { socket },
+            outbox: outbox,
+            conversationLoadTimeout: 0.01,
+            clock: clock
+        )
+        defer { viewModel.stop() }
+
+        viewModel.start()
+        XCTAssertEqual(viewModel.presentedConnectionState, .connecting)
+
+        try? await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(viewModel.presentedConnectionState, .failed("Couldn't load conversation"))
+
+        viewModel.retryConversationLoad()
+        XCTAssertEqual(viewModel.presentedConnectionState, .connecting, "a retry clears the failure at once")
+    }
+
+    func testTeardownCancelsThePendingPresentation() async {
+        connect()
+        await drop()
+        viewModel.stop()
+
+        await advance(by: .seconds(20))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "a stopped model never repaints")
+        XCTAssertEqual(clock.pendingSleepers, 0, "the grace task was cancelled, not left sleeping")
+    }
+}
+
+/// A `Clock` that only moves when a test says so.
+final class ManualClock: Clock, @unchecked Sendable {
+    struct Instant: InstantProtocol {
+        var offset: Duration
+
+        func advanced(by duration: Duration) -> Instant { Instant(offset: offset + duration) }
+        func duration(to other: Instant) -> Duration { other.offset - offset }
+        static func < (lhs: Instant, rhs: Instant) -> Bool { lhs.offset < rhs.offset }
+    }
+
+    private struct Sleeper {
+        let id: UUID
+        let deadline: Instant
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let lock = NSLock()
+    private var current = Instant(offset: .zero)
+    private var sleepers: [Sleeper] = []
+
+    var now: Instant {
+        lock.lock(); defer { lock.unlock() }
+        return current
+    }
+
+    var minimumResolution: Duration { .zero }
+
+    var pendingSleepers: Int {
+        lock.lock(); defer { lock.unlock() }
+        return sleepers.count
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        current = current.advanced(by: duration)
+        let due = sleepers.filter { $0.deadline <= current }
+        sleepers.removeAll { $0.deadline <= current }
+        lock.unlock()
+        for sleeper in due { sleeper.continuation.resume() }
+    }
+
+    func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if deadline <= current {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                sleepers.append(Sleeper(id: id, deadline: deadline, continuation: continuation))
+                lock.unlock()
+            }
+        } onCancel: {
+            lock.lock()
+            let cancelled = sleepers.filter { $0.id == id }
+            sleepers.removeAll { $0.id == id }
+            lock.unlock()
+            for sleeper in cancelled { sleeper.continuation.resume(throwing: CancellationError()) }
+        }
+    }
+}
+
+/// The smallest socket that lets the view model connect, drop and rejoin.
+private final class PresentationSocket: SessionSocket {
+    var onEvent: ((ServerEvent) -> Void)?
+    var onClose: ((String?) -> Void)?
+
+    func setMutationRejectedHandler(_ handler: @escaping (String) -> Void) {}
+    func connect() {}
+    func disconnect() {}
+    func watch(sessionId: String, resume: TranscriptResumeCursor?) {}
+    func setAway(_ away: Bool) {}
+    func setTyping(sessionId: String, typing: Bool) {}
+    func loadHistory(sessionId: String, beforeOffset: Int, beforeRev: String?) {}
+    func loadHistory(sessionId: String, beforeSeq: Int, limit: Int?) {}
+    func loadWholeHistory(sessionId: String) {}
+    func prompt(
+        sessionId: String, content: String, user: String,
+        images: [String]?, effort: String?, fastMode: Bool?, busyMode: String?
+    ) {}
+    func steerQueued(sessionId: String, queueId: String) {}
+    func deleteQueued(sessionId: String, queueId: String) {}
+    func interruptQueued(sessionId: String, queueId: String) {}
+    func takeQueued(sessionId: String, queueId: String) {}
+    func takeSteered(sessionId: String, queueId: String) {}
+    func reorderQueued(sessionId: String, order: [String]) {}
+    func cancelWatchedRun() {}
+    func answer(sessionId: String, questionId: String, answers: [String: String]?) {}
+}

--- a/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
@@ -33,10 +33,13 @@ final class ConnectionPresentationTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Open the session and land the handshake, so both states read connected.
-    private func connect() {
+    /// Open the session, land the handshake and a transcript, so both states
+    /// read connected. The transcript matters: `connect()` rewrites a
+    /// reconnect on an empty transcript as `.connecting`.
+    private func connect(entries: [TranscriptEntry] = [TranscriptEntry(id: "e1", type: "assistant", content: "hi")]) {
         viewModel.start()
         viewModel.handle(.hello(bootId: "boot-1"))
+        viewModel.handle(.transcriptInit(sessionId: "bks-1", entries: entries, cursor: .empty))
         XCTAssertEqual(viewModel.connectionState, .connected)
         XCTAssertEqual(viewModel.presentedConnectionState, .connected)
     }
@@ -118,6 +121,25 @@ final class ConnectionPresentationTests: XCTestCase {
         XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
     }
 
+    func testEmptyTranscriptChurnIsDeferredToo() async {
+        connect(entries: [])
+        viewModel.appDidEnterBackground()
+        await drop()
+        viewModel.appDidBecomeActive()
+        await settle()
+        XCTAssertEqual(viewModel.connectionState, .connecting, "an empty transcript reconnects as connecting")
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "still a drop from a presented connection")
+
+        viewModel.handle(.hello(bootId: "boot-2"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        await drop()
+        viewModel.appDidEnterBackground()
+        viewModel.appDidBecomeActive()
+        await advance(by: .seconds(8))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connecting, "the grace presents whatever the transport says")
+    }
+
     func testDropWhileBackgroundedWaitsForTheForeground() async {
         connect()
         viewModel.appDidEnterBackground()
@@ -127,6 +149,63 @@ final class ConnectionPresentationTests: XCTestCase {
 
         viewModel.appDidBecomeActive()
         await advance(by: .seconds(8))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+    }
+
+    func testPresentedOutageIsFoldedBackWhileBackgrounded() async {
+        connect()
+        await drop()
+        await advance(by: .seconds(9))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+
+        // Like the web client while hidden, the outage comes off screen.
+        viewModel.appDidEnterBackground()
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        // Connectivity came back meanwhile: the foreground handshake must not
+        // flash the banner it had before.
+        viewModel.appDidBecomeActive()
+        await settle()
+        XCTAssertEqual(viewModel.connectionState, .reconnecting(nil))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "no flash through the handshake")
+        viewModel.handle(.hello(bootId: "boot-2"))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+    }
+
+    func testOutageThatOutlivesTheBackgroundGetsAFreshGrace() async {
+        connect()
+        await drop()
+        await advance(by: .seconds(9))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+
+        viewModel.appDidEnterBackground()
+        viewModel.appDidBecomeActive()
+        await settle()
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected)
+
+        await advance(by: .seconds(7))
+        XCTAssertEqual(viewModel.presentedConnectionState, .connected, "the earlier outage does not count")
+        await advance(by: .seconds(1))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+    }
+
+    func testAnnouncedServerRestartKeepsItsBannerWhileBackgrounded() async {
+        connect()
+        viewModel.handle(.serverRestarting)
+        await drop("server restarting")
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("server restarting"))
+
+        viewModel.appDidEnterBackground()
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("server restarting"))
+    }
+
+    func testNeverConnectedReconnectIsNotFoldedBack() async {
+        viewModel.start()
+        await drop()
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil), "a drop before the handshake shows at once")
+
+        // Nothing was ever on screen to fold back to.
+        viewModel.appDidEnterBackground()
         XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
     }
 

--- a/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
+++ b/packages/clients/ios/OS1Tests/ConnectionPresentationTests.swift
@@ -160,7 +160,7 @@ final class ConnectionPresentationTests: XCTestCase {
         connect()
         await drop()
         await advance(by: .seconds(9))
-        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("connection lost"))
 
         // Like the web client while hidden, the outage comes off screen.
         viewModel.appDidEnterBackground()
@@ -180,7 +180,7 @@ final class ConnectionPresentationTests: XCTestCase {
         connect()
         await drop()
         await advance(by: .seconds(9))
-        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("connection lost"))
 
         viewModel.appDidEnterBackground()
         viewModel.appDidBecomeActive()
@@ -206,11 +206,11 @@ final class ConnectionPresentationTests: XCTestCase {
     func testNeverConnectedReconnectIsNotFoldedBack() async {
         viewModel.start()
         await drop()
-        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil), "a drop before the handshake shows at once")
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("connection lost"), "a drop before the handshake shows at once")
 
         // Nothing was ever on screen to fold back to.
         viewModel.appDidEnterBackground()
-        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting(nil))
+        XCTAssertEqual(viewModel.presentedConnectionState, .reconnecting("connection lost"))
     }
 
     func testAnnouncedServerRestartPresentsImmediately() async {

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -321,8 +321,11 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   no inbound frame arrives for 30s. The server never initiates pings. An
   announced server restart uses a 250ms retry cadence until the replacement
   handshake arrives; ordinary outages retain the calmer 2s backoff. The UI
-  shows a reconnect banner and keeps an optimistic local echo of prompts until
-  the server's copy arrives.
+  shows a reconnect banner only after a drop outlives 8s of foreground time
+  (`SessionViewModel.presentedConnectionState`; recovery, an announced
+  restart and a real load failure show at once, and background time does not
+  count), and keeps an optimistic local echo of prompts until the server's
+  copy arrives.
 - **Settings** — native SwiftUI Tools, Personal, and Workspace administration,
   plus multi-organization server/GitHub/token configuration and a connection
   test. The top-bar logo on iOS and the row above Feed on macOS switch servers


### PR DESCRIPTION
Ports the web client's connection-presentation rule (c8675f570) to the native session screen.

**Before:** every socket close flipped `connectionState` to `.reconnecting` and the transcript banner and composer painted the orange "Reconnecting…" notice at once, so a Wi-Fi blip or the background/foreground socket churn flashed a warning that was gone two seconds later.

**After:** `SessionViewModel` keeps `connectionState` as the transport truth (sends, paging, presence still gate on it) and adds `presentedConnectionState`, which `SessionView` reads for the banner and the composer notice. A drop from a presented connection (`.reconnecting`, or the `.connecting` rewrite `connect()` makes on an empty transcript) waits out `connectionPresentationGrace` (8s) of foreground time before it shows; recovery, an announced `server_restarting`, the first connect and a real load failure show immediately. `appDidEnterBackground` cancels the grace and folds an ordinary presented outage back to `.connected`, as the web hook does while hidden, so the foreground reconnect never flashes a stale banner through the handshake; `appDidBecomeActive` starts a fresh grace if the drop outlives the background.

**Tests** (`OS1Tests/ConnectionPresentationTests.swift`, driven by an injected `Clock`, no wall-clock waits): recovery inside 8s, sustained outage, background pause and resume, drop while backgrounded, presented outage folded back on background (with and without recovery), announced restart kept across the background, never-connected reconnect not folded back, empty-transcript churn, initial connect and load failure, cancellation on teardown.

**Verification:** OS1 and OS1Mac build on the Mac node (`build-for-testing` for the test target too). The Mac tests could not execute there: the box's `testmanagerd` refuses every test runner today (`Failed to establish communication with the test runner`, also failing for unrelated trees), so the Mac tests run in the Native client CI job. Simulator screenshots of the quiet transient state and the sustained banner are in the session.

A `DEBUG`-only `OS1_SHOW_CONNECTION_DROP=transient|sustained` launch env drives the screenshots.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-d68a6bda-3cad-7489-b934-b2c69489b10c)
