### PR TITLE
Native app: apply session row frames and show queued pasted text

### DIFF
--- a/packages/clients/ios/OS1/Models/QueueMessage.swift
+++ b/packages/clients/ios/OS1/Models/QueueMessage.swift
@@ -23,8 +23,13 @@ struct QueueMessagePresentation: Equatable {
     let isReviewHandoff: Bool
     /// A peer session's agent-authored coordination message, not human prose.
     let isSessionMessage: Bool
+    /// The paste riding beside the text, named: "Pasted text +60 lines" for
+    /// one, "2 pasted texts" for several, nil for none. Mirrors the web's
+    /// queue row, so a queued paste reads as attached rather than lost.
+    let pastedLabel: String?
 
-    init(content: String, user: String?) {
+    init(content: String, user: String?, pastedTexts: [String] = []) {
+        pastedLabel = Self.pastedTextLabel(pastedTexts)
         isGitHub = user == "GitHub" || user == "GitHub (automation)"
         isReviewHandoff = isGitHub && Self.reviewHandoffSentinel.match(content) != nil
         let agentPrefixed = Self.agentAttribution.match(content)
@@ -96,6 +101,26 @@ struct QueueMessagePresentation: Equatable {
             return
         }
         body = Self.stripLeadingSentinels(unprefixed)
+    }
+
+    /// What the queue row says about a message's pastes. One paste is named
+    /// by its size; several are counted, since a row has no room to size each.
+    static func pastedTextLabel(_ pastedTexts: [String]) -> String? {
+        switch pastedTexts.count {
+        case 0: nil
+        case 1: "Pasted text \(lineLabel(pastedTexts[0]))"
+        default: "\(pastedTexts.count) pasted texts"
+        }
+    }
+
+    /// "+N lines", the way the transcript's paste card and the web's chip
+    /// count them (`pastedTextLineLabel`): line breaks plus one, so an empty
+    /// paste is still one line and a trailing newline still counts.
+    static func lineLabel(_ text: String) -> String {
+        // A Swift Character is a grapheme cluster, so "\r\n" is ONE newline
+        // here just as it is one separator in the web's regex.
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).count
+        return "+\(lines) \(lines == 1 ? "line" : "lines")"
     }
 
     private static func mayCarryMarker(_ content: String) -> Bool {

--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -57,8 +57,13 @@ enum OS1API {
     /// answers with the whole list, which still splits correctly downstream
     /// (`prepared` sorts archived rows out either way).
     static func sessions() async throws -> [Session] {
-        try await get("/api/sessions?archived=exclude", revalidating: true)
+        try await get("/api/sessions" + liveSessionsQuery, revalidating: true)
     }
+
+    /// The query the live list is requested with. Also what the account
+    /// socket subscribes to (`sessions_subscribe`), so the row frames the
+    /// server pushes are scoped exactly like the list they update.
+    nonisolated static let liveSessionsQuery = "?archived=exclude"
 
     /// Archived sessions, as summaries.
     ///

--- a/packages/clients/ios/OS1/Networking/OS1Socket.swift
+++ b/packages/clients/ios/OS1/Networking/OS1Socket.swift
@@ -159,6 +159,15 @@ final class OS1Socket: SessionSocket {
         send(["type": "typing", "sessionId": sessionId, "typing": typing])
     }
 
+    /// Tell the server which list projection this socket renders (the query
+    /// string the sessions list requests), so a changed row reaches it as a
+    /// `session_row` / `session_row_removed` frame instead of a whole-list
+    /// refetch. Per connection: the server forgets it with the socket, so the
+    /// owner re-sends it after every `hello`. Older servers ignore the frame.
+    func subscribeSessions(query: String) {
+        send(["type": "sessions_subscribe", "query": query])
+    }
+
     /// Page one window of earlier history (arrives as transcript_history).
     /// `beforeRev` guards against the mirror file rotating under the cursor —
     /// on mismatch the server re-sends a fresh transcript_init instead.

--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -68,6 +68,14 @@ enum ServerEvent: Sendable {
     /// A git-host webhook changed PR, review, or check state for this branch.
     /// This frame is app-wide and therefore has no session id.
     case prUpdated(repo: String, branch: String)
+    /// One session's list row changed and this socket's `sessions_subscribe`
+    /// scope shows it: a server snapshot of exactly that row, applied in
+    /// place instead of re-reading the whole list. Sent only to sockets that
+    /// subscribed; the 5s poll stays the fallback for a frame that never lands.
+    case sessionRow(Session)
+    /// The same change for a row the scope no longer shows (archived, hidden,
+    /// or deleted).
+    case sessionRowRemoved(id: String)
     case notice(String)
     case serverError(String)
     // Shell output, for the session's terminal panel. Each frame carries the
@@ -225,6 +233,12 @@ enum ServerEvent: Sendable {
         case "pr_updated":
             guard let repo = frame.repo, let branch = frame.branch else { return .ignored }
             return .prUpdated(repo: repo, branch: branch)
+        case "session_row":
+            guard let row = frame.row else { return .ignored }
+            return .sessionRow(row)
+        case "session_row_removed":
+            guard let id = frame.id else { return .ignored }
+            return .sessionRowRemoved(id: id)
         case "notice":
             return .notice(frame.message ?? "")
         case "error":
@@ -366,6 +380,10 @@ struct QueueItem: Identifiable, Equatable, Sendable {
     /// Whether file attachments ride along. The server can't fold a
     /// file-carrying message into a live run, so the chip hides Steer.
     let hasFiles: Bool
+    /// Large pastes sent beside the text (`pastedTexts` on the wire, lifted
+    /// out of the folded content by the server). The row names them so a
+    /// queued paste doesn't read as lost until the turn starts.
+    let pastedTexts: [String]
     let editable: Bool
     let hasContextSessions: Bool
     /// When the engine accepted this message as a steer (receipts only,
@@ -385,6 +403,7 @@ struct QueueItem: Identifiable, Equatable, Sendable {
         user = wire.user
         images = wire.images ?? []
         hasFiles = !(wire.files ?? []).isEmpty
+        pastedTexts = wire.pastedTexts ?? []
         editable = wire.editable ?? false
         hasContextSessions = !(wire.contextSessions ?? []).isEmpty
         steeredAt = wire.steeredAt.map { Date(timeIntervalSince1970: $0 / 1000) }
@@ -399,6 +418,7 @@ struct QueueItem: Identifiable, Equatable, Sendable {
         user: String?,
         images: [String] = [],
         hasFiles: Bool = false,
+        pastedTexts: [String] = [],
         editable: Bool = true,
         hasContextSessions: Bool = false,
         steeredAt: Date? = nil
@@ -408,6 +428,7 @@ struct QueueItem: Identifiable, Equatable, Sendable {
         self.user = user
         self.images = images
         self.hasFiles = hasFiles
+        self.pastedTexts = pastedTexts
         self.editable = editable
         self.hasContextSessions = hasContextSessions
         self.steeredAt = steeredAt
@@ -416,7 +437,8 @@ struct QueueItem: Identifiable, Equatable, Sendable {
     /// The same entry with new text — and, when the edit touched them, new
     /// attachments — for the optimistic half of an edit. `images: nil` keeps
     /// the ones it already carries, matching what the server does with an
-    /// update that names no images.
+    /// update that names no images; pasted text always rides along, since an
+    /// edit rewrites the typed message and never the paste beside it.
     func withContent(_ content: String, images: [String]? = nil) -> QueueItem {
         QueueItem(
             id: id,
@@ -424,6 +446,7 @@ struct QueueItem: Identifiable, Equatable, Sendable {
             user: user,
             images: images ?? self.images,
             hasFiles: hasFiles,
+            pastedTexts: pastedTexts,
             editable: editable,
             hasContextSessions: hasContextSessions,
             steeredAt: steeredAt
@@ -446,6 +469,7 @@ private struct RawFrame: Decodable {
         let user: String?
         let images: [String]?
         let files: [OpaqueFile]?
+        let pastedTexts: [String]?
         let editable: Bool?
         let contextSessions: [String]?
         let steeredAt: Double?
@@ -497,6 +521,10 @@ private struct RawFrame: Decodable {
     let run: WorkflowRun?
     let repo: String?
     let branch: String?
+    // session_row / session_row_removed. The row is the same shape as one
+    // element of GET /api/sessions, so it decodes as a `Session`.
+    let row: Session?
+    let id: String?
     let message: String?
     let queueId: String?
     let truncated: Bool?

--- a/packages/clients/ios/OS1/PresenceStore.swift
+++ b/packages/clients/ios/OS1/PresenceStore.swift
@@ -12,7 +12,18 @@ final class PresenceStore {
     private(set) var bySession: [String: [String]] = [:]
     private(set) var connectedAccountIDs: Set<String> = []
 
+    /// Where the active account's `session_row` / `session_row_removed`
+    /// frames go: the sessions list, which applies them in place. One slot,
+    /// because there is one list. Frames for a passive account are dropped;
+    /// its list is rebuilt from a poll when it becomes active.
+    @ObservationIgnored var onSessionRow: ((SessionRowChange) -> Void)?
+
     private var sockets: [String: OS1Socket] = [:]
+    /// Accounts whose socket has sent `sessions_subscribe` on its current
+    /// connection. Only the active account subscribes: an unscoped
+    /// subscription hears about every live row, and a passive account has
+    /// no list to spend that traffic on.
+    private var subscribedAccountIDs: Set<String> = []
     private var connectedAccounts: [String: ServerConnection] = [:]
     private var reconnectTasks: [String: Task<Void, Never>] = [:]
     private var presenceByAccount: [String: [String: [String]]] = [:]
@@ -64,6 +75,7 @@ final class PresenceStore {
             sockets.removeValue(forKey: id)?.disconnect()
             connectedAccounts[id] = nil
             connectedAccountIDs.remove(id)
+            subscribedAccountIDs.remove(id)
             reconnectTasks.removeValue(forKey: id)?.cancel()
             presenceByAccount[id] = nil
         }
@@ -72,6 +84,22 @@ final class PresenceStore {
         for (account, connection) in connections where sockets[account.id] == nil {
             connect(account: account, connection: connection)
         }
+        // Switching accounts keeps the sockets; the newly active one has to
+        // start hearing about its rows now, not on its next reconnect.
+        subscribeToSessionRows(accountID: config.activeId)
+    }
+
+    /// Send `sessions_subscribe` on the active account's socket, once per
+    /// connection. A socket that hasn't said `hello` yet subscribes when it
+    /// does; an already subscribed one is left alone.
+    private func subscribeToSessionRows(accountID: String) {
+        guard accountID == ServerConfig.shared.activeId,
+              connectedAccountIDs.contains(accountID),
+              !subscribedAccountIDs.contains(accountID),
+              let socket = sockets[accountID]
+        else { return }
+        subscribedAccountIDs.insert(accountID)
+        socket.subscribeSessions(query: OS1API.liveSessionsQuery)
     }
 
     /// iOS cannot retain network execution indefinitely in the background.
@@ -83,6 +111,7 @@ final class PresenceStore {
         sockets.removeAll()
         connectedAccounts.removeAll()
         connectedAccountIDs.removeAll()
+        subscribedAccountIDs.removeAll()
         for socket in connected { socket.disconnect() }
     }
 
@@ -122,6 +151,11 @@ final class PresenceStore {
         switch event {
         case .hello:
             connectedAccountIDs.insert(account.id)
+            subscribeToSessionRows(accountID: account.id)
+        case .sessionRow(let row):
+            if account.id == config.activeId { onSessionRow?(.row(row)) }
+        case .sessionRowRemoved(let id):
+            if account.id == config.activeId { onSessionRow?(.removed(id: id)) }
         case .globalPresence(let viewing):
             let mapped = mappedPresence(viewing, me: account.userName)
             presenceByAccount[account.id] = mapped
@@ -169,6 +203,7 @@ final class PresenceStore {
         sockets[accountID] = nil
         connectedAccounts[accountID] = nil
         connectedAccountIDs.remove(accountID)
+        subscribedAccountIDs.remove(accountID)
         reconnectTasks[accountID]?.cancel()
         reconnectTasks[accountID] = Task { [weak self] in
             try? await Task.sleep(for: .seconds(3))

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -2006,7 +2006,14 @@ final class SessionViewModel {
             removeChip(item)
             deliveringItems.removeAll { $0.id == queueId }
             deliveringSince.removeValue(forKey: queueId)
-            draft = draft.isEmpty ? item.content : draft + "\n\n" + item.content
+            // This composer has no paste chip, so a paste taken back with its
+            // message rides in the draft as text: the send folds it after the
+            // message the same way the server did, and nothing is dropped on
+            // the way through an edit.
+            let restored = ([item.content] + item.pastedTexts)
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n\n")
+            draft = draft.isEmpty ? restored : draft + "\n\n" + restored
             attachedImages.append(
                 contentsOf: item.images.compactMap(AttachedImage.init(dataURL:))
             )

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1015,18 +1015,18 @@ final class SessionsListViewModel {
             let names = workspaceNames
             let nextWorkspaces = workspaces
             let claimed = claimedSessionIds
-            let result = await Task.detached(priority: .userInitiated) {
-                () -> (next: [Session], grouped: Grouped)? in
+            let hideKeys = Set(HideStore.shared.hides.keys)
+            let pass = await Task.detached(priority: .userInitiated) {
+                () -> (result: (next: [Session], grouped: Grouped)?, resurfacedHideKeys: [String]) in
+                let resurfaced = Self.resurfacedHideKeys(in: upserts, hidden: hideKeys)
                 let next = Self.applyingRowChanges(
                     to: base, upserting: upserts, removing: removals
                 )
-                guard next != base else { return nil }
-                return (
-                    next,
-                    Self.grouped(
-                        next, workspaceNames: names, workspaces: nextWorkspaces, claimed: claimed
-                    )
+                guard next != base else { return (nil, resurfaced) }
+                let grouped = Self.grouped(
+                    next, workspaceNames: names, workspaces: nextWorkspaces, claimed: claimed
                 )
+                return ((next, grouped), resurfaced)
             }.value
             if refreshArchivedIndex { Task { await self.refreshArchived(force: true) } }
             guard revision == sessionsRevision else {
@@ -1037,7 +1037,11 @@ final class SessionsListViewModel {
                 }
                 continue
             }
-            guard let result else { continue }
+            // Same rule as the poll: a pushed row that is blocked on a
+            // question consumes the hide covering it, so answering before
+            // the next poll doesn't make the row vanish again.
+            HideStore.shared.clear(pass.resurfacedHideKeys)
+            guard let result = pass.result else { continue }
             SessionLinks.register(titles: result.grouped.titles)
             PrLinks.register(index: result.grouped.prs)
             setSessions(result.next, rows: result.grouped.rows)
@@ -1345,15 +1349,24 @@ final class SessionsListViewModel {
             .map { (session: $0, key: $0.lastActivityDate ?? .distantPast) }
             .sorted { $0.key > $1.key }
             .map(\.session)
+        return (active, archived, resurfacedHideKeys(in: active, hidden: hideKeys))
+    }
+
+    /// The hides that a blocked session consumes: any key its row can sit
+    /// under while it is waiting on a person. Automation rows don't count;
+    /// nobody is being asked anything there.
+    nonisolated static func resurfacedHideKeys(
+        in sessions: [Session],
+        hidden hideKeys: Set<String>
+    ) -> [String] {
+        guard !hideKeys.isEmpty else { return [] }
         var resurfaced = Set<String>()
-        if !hideKeys.isEmpty {
-            for session in active where session.lane == .needsInput && !session.isAutomation {
-                for key in SidebarRowKeys.candidateKeys(for: session) where hideKeys.contains(key) {
-                    resurfaced.insert(key)
-                }
+        for session in sessions where session.lane == .needsInput && !session.isAutomation {
+            for key in SidebarRowKeys.candidateKeys(for: session) where hideKeys.contains(key) {
+                resurfaced.insert(key)
             }
         }
-        return (active, archived, Array(resurfaced))
+        return Array(resurfaced)
     }
 }
 

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -30,8 +30,26 @@ struct WorkspaceDeletionState: Equatable {
     }
 }
 
-/// Sessions overview. The server has no push channel for list changes, so this
-/// polls `GET /api/sessions` (server caches for 2s; the web UI polls at 5s too).
+/// One row change pushed by the server over the account socket
+/// (`session_row` / `session_row_removed`), routed here by `PresenceStore`.
+enum SessionRowChange: Sendable {
+    /// A server snapshot of one row the subscribed list shows.
+    case row(Session)
+    /// The list no longer shows this row (archived, hidden, or deleted).
+    case removed(id: String)
+
+    var sessionId: String {
+        switch self {
+        case .row(let session): session.id
+        case .removed(let id): id
+        }
+    }
+}
+
+/// Sessions overview. Polls `GET /api/sessions` every 5s (the server caches for
+/// 2s; the web UI polls at the same rate as its fallback) and, between polls,
+/// applies the row frames the account socket subscribes to, so a change made
+/// elsewhere lands in the list at once instead of on the next tick.
 @Observable
 @MainActor
 final class SessionsListViewModel {
@@ -85,6 +103,12 @@ final class SessionsListViewModel {
     /// Bumped by every mutation of the grouping's inputs, so a detached prime
     /// can tell whether the list moved under it without an O(n) comparison.
     @ObservationIgnored private var sessionsRevision = 0
+
+    /// Row frames waiting to be applied, latest per session. A burst (a run
+    /// finishing across a workspace, a reconnect replay) is folded into one
+    /// off-main pass rather than one regroup per frame.
+    @ObservationIgnored private var pendingRowChanges: [String: SessionRowChange] = [:]
+    @ObservationIgnored private var rowFlushTask: Task<Void, Never>?
 
     /// The sidebar's rows: workspace groups, memoized.
     ///
@@ -220,43 +244,55 @@ final class SessionsListViewModel {
         workspaceNames names: [String: String],
         workspaces: [OS1API.WorkspaceSummary],
         claimed: Set<String>
-    ) async -> (rows: [SidebarWorkspace], titles: [String: String], prs: PrLinks.Index) {
+    ) async -> Grouped {
         await Task.detached(priority: .userInitiated) {
-            var titles: [String: String] = [:]
-            titles.reserveCapacity(sessions.count)
-            for session in sessions {
-                // The WORKSPACE's name, not the session's own. A reference is
-                // read as "that piece of work", and the screen it opens is
-                // titled after the workspace, so labelling the chip after one
-                // of its conversations promised a name the destination never
-                // shows. That name is often a per-run label ("Review · PR
-                // #5741 …"). The web labels its chips from the same rule
-                // (`setSessionTitles` in App.tsx). Session title is the
-                // fallback, for a workspace this client has no name for.
-                let workspace = session.workspaceName ?? ""
-                let title = workspace.isEmpty ? session.displayTitle : workspace
-                if !title.isEmpty {
-                    titles[session.id] = title
-                    for aliasId in session.aliasIds ?? [] { titles[aliasId] = title }
-                }
-            }
-            return (
-                sidebarRows(
-                    in: listedSessions(in: sessions, claimed: claimed),
-                    workspaceNames: names,
-                    workspaces: workspaces,
-                    occupiedWorkspaceIds: Set(sessions.compactMap(\.workspaceId))
-                ),
-                titles,
-                // What tints a `#5528` chip in a transcript, and what tells a
-                // bare one which repo it belongs to — the same fields the web
-                // hands `setKnownPrStates`, off the main actor for the same
-                // reason the titles are. Built from every session, including
-                // the spawned workers the rows leave out: a chip in a
-                // transcript still has to resolve.
-                PrLinks.Index.build(sessions)
-            )
+            grouped(sessions, workspaceNames: names, workspaces: workspaces, claimed: claimed)
         }.value
+    }
+
+    typealias Grouped = (rows: [SidebarWorkspace], titles: [String: String], prs: PrLinks.Index)
+
+    /// The grouping pass itself, for callers already off the main actor.
+    nonisolated private static func grouped(
+        _ sessions: [Session],
+        workspaceNames names: [String: String],
+        workspaces: [OS1API.WorkspaceSummary],
+        claimed: Set<String>
+    ) -> Grouped {
+        var titles: [String: String] = [:]
+        titles.reserveCapacity(sessions.count)
+        for session in sessions {
+            // The WORKSPACE's name, not the session's own. A reference is
+            // read as "that piece of work", and the screen it opens is
+            // titled after the workspace, so labelling the chip after one
+            // of its conversations promised a name the destination never
+            // shows. That name is often a per-run label ("Review · PR
+            // #5741 …"). The web labels its chips from the same rule
+            // (`setSessionTitles` in App.tsx). Session title is the
+            // fallback, for a workspace this client has no name for.
+            let workspace = session.workspaceName ?? ""
+            let title = workspace.isEmpty ? session.displayTitle : workspace
+            if !title.isEmpty {
+                titles[session.id] = title
+                for aliasId in session.aliasIds ?? [] { titles[aliasId] = title }
+            }
+        }
+        return (
+            sidebarRows(
+                in: listedSessions(in: sessions, claimed: claimed),
+                workspaceNames: names,
+                workspaces: workspaces,
+                occupiedWorkspaceIds: Set(sessions.compactMap(\.workspaceId))
+            ),
+            titles,
+            // What tints a `#5528` chip in a transcript, and what tells a
+            // bare one which repo it belongs to — the same fields the web
+            // hands `setKnownPrStates`, off the main actor for the same
+            // reason the titles are. Built from every session, including
+            // the spawned workers the rows leave out: a chip in a
+            // transcript still has to resolve.
+            PrLinks.Index.build(sessions)
+        )
     }
 
     /// Honor the web sidebar's shared order, then append newly seen repositories
@@ -896,10 +932,160 @@ final class SessionsListViewModel {
         hasLoaded = true
         archivedHasLoaded = true
     }
+
+    /// A loaded list without a server, for tests of the row-frame path.
+    func loadFixture(_ sessions: [Session]) {
+        hasLoaded = true
+        setSessions(sessions)
+    }
     #endif
+
+    // MARK: - Row frames
+
+    /// Apply one pushed row change. Cheap on the main actor: the change is
+    /// parked, and a short coalescing window later one detached pass merges
+    /// everything parked into the list and regroups it (`flushRowChanges`).
+    ///
+    /// Frames ahead of the first list are dropped: a one-row list flashing
+    /// up before the real one would be worse than the skeleton it replaces,
+    /// and the poll that lands moments later carries the row anyway.
+    func apply(_ change: SessionRowChange) {
+        guard hasLoaded else { return }
+        pendingRowChanges[change.sessionId] = change
+        scheduleRowFlush()
+    }
+
+    private func scheduleRowFlush() {
+        guard rowFlushTask == nil, !pendingRowChanges.isEmpty else { return }
+        rowFlushTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            await self?.flushRowChanges()
+        }
+    }
+
+    /// Merge every parked row change into the list, off the main actor, and
+    /// publish the result with its grouping in one step, the way a poll does.
+    ///
+    /// The local overlays the poll applies apply here too: a row archived on
+    /// this device stays hidden until the server's own copy says so, one
+    /// restored here stays restored, and a server row retires the optimistic
+    /// placeholder it was created from. A poll landing mid-pass bumps the
+    /// revision, and the pass is redone on top of what it published.
+    func flushRowChanges() async {
+        // Whatever is still parked when this pass gives up (the list kept
+        // moving under it) gets its own pass rather than waiting for the
+        // next frame to schedule one.
+        defer {
+            rowFlushTask = nil
+            scheduleRowFlush()
+        }
+        var attempts = 0
+        while !pendingRowChanges.isEmpty, attempts < 3 {
+            attempts += 1
+            let changes = pendingRowChanges
+            pendingRowChanges = [:]
+            var upserts: [Session] = []
+            var removals: Set<String> = []
+            var refreshArchivedIndex = false
+            for (id, change) in changes {
+                switch change {
+                case .removed:
+                    removals.insert(id)
+                case .row(var row):
+                    if row.desk == true || isLocallyArchived(id) {
+                        removals.insert(id)
+                        continue
+                    }
+                    if row.archived == true {
+                        guard isLocallyUnarchived(id) else {
+                            removals.insert(id)
+                            // The archived index runs on its own clock; a
+                            // row that just moved there shouldn't wait for it.
+                            refreshArchivedIndex = archivedHasLoaded
+                            continue
+                        }
+                        row.archived = false
+                    }
+                    optimistic.removeValue(forKey: id)
+                    upserts.append(row)
+                }
+            }
+            let base = sessions
+            let revision = sessionsRevision
+            let names = workspaceNames
+            let nextWorkspaces = workspaces
+            let claimed = claimedSessionIds
+            let result = await Task.detached(priority: .userInitiated) {
+                () -> (next: [Session], grouped: Grouped)? in
+                let next = Self.applyingRowChanges(
+                    to: base, upserting: upserts, removing: removals
+                )
+                guard next != base else { return nil }
+                return (
+                    next,
+                    Self.grouped(
+                        next, workspaceNames: names, workspaces: nextWorkspaces, claimed: claimed
+                    )
+                )
+            }.value
+            if refreshArchivedIndex { Task { await self.refreshArchived(force: true) } }
+            guard revision == sessionsRevision else {
+                // The list moved under the pass. Re-apply on top of what
+                // landed, keeping any newer frame that arrived meanwhile.
+                for (id, change) in changes where pendingRowChanges[id] == nil {
+                    pendingRowChanges[id] = change
+                }
+                continue
+            }
+            guard let result else { continue }
+            SessionLinks.register(titles: result.grouped.titles)
+            PrLinks.register(index: result.grouped.prs)
+            setSessions(result.next, rows: result.grouped.rows)
+        }
+    }
+
+    /// The live list with rows replaced, added or dropped, keeping the order
+    /// the poll publishes (newest activity first).
+    ///
+    /// An upserted row is placed by walking from the front until an older
+    /// row is found: the row that just changed is nearly always the newest,
+    /// so the walk parses one or two dates rather than every row's. A row
+    /// with no activity date sorts last, as it does in `prepared`.
+    nonisolated static func applyingRowChanges(
+        to sessions: [Session],
+        upserting upserts: [Session],
+        removing removals: Set<String>
+    ) -> [Session] {
+        let replaced = Set(upserts.map(\.id)).union(removals)
+        var next = replaced.isEmpty ? sessions : sessions.filter { !replaced.contains($0.id) }
+        for row in upserts {
+            let key = row.lastActivityDate ?? .distantPast
+            let index = next.firstIndex { ($0.lastActivityDate ?? .distantPast) < key }
+                ?? next.endIndex
+            next.insert(row, at: index)
+        }
+        return next
+    }
 
     func startPolling() {
         stopPolling()
+        PresenceStore.shared.onSessionRow = { [weak self] change in
+            self?.apply(change)
+        }
+        #if DEBUG
+        // Dev hook for proving the socket path in a screenshot: poll until
+        // the first list lands, then only row frames can move it.
+        if ProcessInfo.processInfo.environment["OS1_LIST_POLL_OFF"] == "1" {
+            pollTask = Task {
+                while !Task.isCancelled, !hasLoaded {
+                    await refresh()
+                    try? await Task.sleep(for: .seconds(5))
+                }
+                await refreshArchived()
+            }
+            return
+        }
+        #endif
         pollTask = Task {
             while !Task.isCancelled {
                 await refresh()

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -3658,7 +3658,8 @@ private struct SessionInputBar: View {
             ForEach(viewModel.queuedItems) { item in
                 let presentation = QueueMessagePresentation(
                     content: item.content,
-                    user: item.user
+                    user: item.user,
+                    pastedTexts: item.pastedTexts
                 )
                 QueuedMessageRow(
                         item: item,
@@ -3782,7 +3783,9 @@ private struct SessionInputBar: View {
         var parts: [String] = []
         parts.append(contentsOf: viewModel.deliveringItems.map { "d\($0.id)" })
         parts.append(contentsOf: viewModel.steeredItems.map { "s\($0.id)" })
-        parts.append(contentsOf: viewModel.queuedItems.map { "q\($0.id):\($0.content.count)" })
+        parts.append(contentsOf: viewModel.queuedItems.map {
+            "q\($0.id):\($0.content.count):\($0.pastedTexts.count)"
+        })
         return parts.joined(separator: "|")
     }
 
@@ -4410,7 +4413,23 @@ private struct SessionInputBar: View {
         /// tag — the queue carries agent-to-agent deliveries, not just what
         /// the person typed.
         private var message: QueueMessagePresentation {
-            QueueMessagePresentation(content: item.content, user: item.user)
+            QueueMessagePresentation(
+                content: item.content,
+                user: item.user,
+                pastedTexts: item.pastedTexts
+            )
+        }
+
+        /// A paste sent on its own has no typed text to lead the row, so its
+        /// name takes the message's place instead of leaving a blank line.
+        private var bodyText: String {
+            message.body.isEmpty ? (message.pastedLabel ?? "") : message.body
+        }
+
+        /// The paste note under the text, when there is text for it to sit
+        /// under; otherwise the body already names it.
+        private var pastedNote: String? {
+            message.body.isEmpty ? nil : message.pastedLabel
         }
 
         /// Only the states worth explaining say so. "Queued" is what the
@@ -4495,7 +4514,7 @@ private struct SessionInputBar: View {
                         }
                 }
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(message.body)
+                    Text(bodyText)
                         .font(.subheadline)
                         .lineLimit(2)
                         .foregroundStyle(OS1VisualStyle.text)
@@ -4504,8 +4523,8 @@ private struct SessionInputBar: View {
                         // phase that shows nothing says it here instead.
                         .accessibilityLabel(
                             phase == .queued
-                                ? "\(message.body), queued — delivers after this run"
-                                : message.body
+                                ? "\(bodyText), queued — delivers after this run"
+                                : bodyText
                         )
                     HStack(spacing: 5) {
                         if let label {
@@ -4527,6 +4546,12 @@ private struct SessionInputBar: View {
                             Image(systemName: "paperclip")
                                 .font(.caption2)
                                 .foregroundStyle(OS1VisualStyle.textFaint)
+                        }
+                        if let pastedNote {
+                            Text(pastedNote)
+                                .font(.caption2)
+                                .foregroundStyle(OS1VisualStyle.textFaint)
+                                .lineLimit(1)
                         }
                     }
                 }

--- a/packages/clients/ios/OS1Tests/QueueMessageTests.swift
+++ b/packages/clients/ios/OS1Tests/QueueMessageTests.swift
@@ -110,4 +110,46 @@ final class QueueMessageTests: XCTestCase {
         XCTAssertNil(message.label)
         XCTAssertEqual(message.body, "PR #42 review feedback · Runs after this turn")
     }
+
+    // MARK: - Pasted text beside a queued message
+
+    /// One paste is named by its size, the way the web's queue row and the
+    /// transcript's paste card count it: line breaks plus one.
+    func testSinglePasteIsNamedWithItsLineCount() {
+        let message = QueueMessagePresentation(
+            content: "review this",
+            user: "Alex",
+            pastedTexts: [Array(repeating: "x", count: 60).joined(separator: "\n")]
+        )
+        XCTAssertEqual(message.pastedLabel, "Pasted text +60 lines")
+        XCTAssertEqual(message.body, "review this")
+    }
+
+    func testOneLinePasteIsSingular() {
+        XCTAssertEqual(QueueMessagePresentation.lineLabel("just one"), "+1 line")
+        XCTAssertEqual(QueueMessagePresentation.lineLabel(""), "+1 line")
+        XCTAssertEqual(QueueMessagePresentation.lineLabel("a\r\nb"), "+2 lines")
+        XCTAssertEqual(QueueMessagePresentation.lineLabel("a\n"), "+2 lines")
+    }
+
+    func testSeveralPastesAreCounted() {
+        XCTAssertEqual(
+            QueueMessagePresentation.pastedTextLabel(["a", "b\nc"]),
+            "2 pasted texts"
+        )
+        XCTAssertNil(QueueMessagePresentation.pastedTextLabel([]))
+        XCTAssertNil(present("plain").pastedLabel)
+    }
+
+    /// An edit rewrites the typed text; the paste beside it is untouched.
+    func testEditedCopyKeepsItsPastes() {
+        let item = QueueItem(
+            id: "q1", content: "before", user: "Alex", pastedTexts: ["pasted block"]
+        )
+        let edited = item.withContent("after", images: ["data:image/png;base64,AA=="])
+        XCTAssertEqual(edited.content, "after")
+        XCTAssertEqual(edited.pastedTexts, ["pasted block"])
+        XCTAssertEqual(edited.images, ["data:image/png;base64,AA=="])
+        XCTAssertTrue(QueueItem(id: "local-1", content: "typed", user: "Alex").pastedTexts.isEmpty)
+    }
 }

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -375,4 +375,72 @@ final class ServerEventTests: XCTestCase {
             return XCTFail("malformed frames must decode to .ignored")
         }
     }
+
+    // MARK: - Session list row frames (sessions_subscribe)
+
+    /// `session_row` carries one list row, the same shape as an element of
+    /// GET /api/sessions, so the list can apply it in place.
+    func testSessionRowDecodesTheRow() {
+        let json = #"""
+        {"type":"session_row","row":{"id":"bks-9","title":"Renamed elsewhere",
+         "workspaceId":"ws-1","isRunning":true,"lastActivity":"2026-09-09T08:00:00.000Z"}}
+        """#
+        guard case .sessionRow(let row) = parse(json) else {
+            return XCTFail("expected .sessionRow")
+        }
+        XCTAssertEqual(row.id, "bks-9")
+        XCTAssertEqual(row.title, "Renamed elsewhere")
+        XCTAssertEqual(row.workspaceId, "ws-1")
+        XCTAssertEqual(row.isRunning, true)
+        XCTAssertEqual(row.lastActivity, "2026-09-09T08:00:00.000Z")
+    }
+
+    func testSessionRowWithoutARowIsIgnored() {
+        guard case .ignored = parse(#"{"type":"session_row"}"#) else {
+            return XCTFail("expected .ignored")
+        }
+    }
+
+    func testSessionRowRemovedDecodesTheId() {
+        guard case .sessionRowRemoved(let id) =
+            parse(#"{"type":"session_row_removed","id":"bks-9"}"#)
+        else {
+            return XCTFail("expected .sessionRowRemoved")
+        }
+        XCTAssertEqual(id, "bks-9")
+    }
+
+    func testSessionRowRemovedWithoutAnIdIsIgnored() {
+        guard case .ignored = parse(#"{"type":"session_row_removed"}"#) else {
+            return XCTFail("expected .ignored")
+        }
+    }
+
+    // MARK: - Queue rows carry their pastes
+
+    func testQueueUpdateDecodesPastedTexts() {
+        let json = #"""
+        {"type":"queue_update","sessionId":"bks-1",
+         "queued":[{"id":"q1","content":"look at this","user":"Kent",
+                    "pastedTexts":["line one\nline two\nline three"]},
+                   {"id":"q2","content":"no paste","user":"Kent"}],
+         "steered":[]}
+        """#
+        guard case .queueUpdate(_, let queued, _, _) = parse(json) else {
+            return XCTFail("expected .queueUpdate")
+        }
+        XCTAssertEqual(queued.map(\.pastedTexts), [["line one\nline two\nline three"], []])
+    }
+
+    /// The take-back reply restores the whole message, paste included.
+    func testQueuedPromptTakenDecodesPastedTexts() {
+        let json = #"""
+        {"type":"queued_prompt_taken","sessionId":"bks-1","queueId":"q1",
+         "item":{"id":"q1","content":"look at this","pastedTexts":["a","b"]}}
+        """#
+        guard case .queuedPromptTaken(_, _, let item, _) = parse(json) else {
+            return XCTFail("expected .queuedPromptTaken")
+        }
+        XCTAssertEqual(item?.pastedTexts, ["a", "b"])
+    }
 }

--- a/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import OS1
+
+/// The list applies `session_row` / `session_row_removed` frames in place
+/// between polls (`SessionsListViewModel.apply`). These pin the merge: a
+/// changed row lands where the poll would sort it, a removed one leaves, the
+/// local overlays the poll honours are honoured here too, and the grouping
+/// the views read is published in the same step as the list.
+@MainActor
+final class SessionRowUpdateTests: XCTestCase {
+    private func session(
+        _ id: String,
+        title: String? = nil,
+        at lastActivity: String? = nil,
+        workspaceId: String? = nil
+    ) -> Session {
+        var session = Session(id: id)
+        session.title = title
+        session.lastActivity = lastActivity
+        session.workspaceId = workspaceId
+        return session
+    }
+
+    /// Newest first, the order `prepared` publishes.
+    private func loaded() -> [Session] {
+        [
+            session("bks-3", title: "Three", at: "2026-09-09T08:03:00.000Z"),
+            session("bks-2", title: "Two", at: "2026-09-09T08:02:00.000Z"),
+            session("bks-1", title: "One", at: "2026-09-09T08:01:00.000Z"),
+        ]
+    }
+
+    // MARK: - The pure merge
+
+    func testReplacedRowKeepsItsPlaceWhenItsActivityDidNot() {
+        let next = SessionsListViewModel.applyingRowChanges(
+            to: loaded(),
+            upserting: [session("bks-2", title: "Two, renamed", at: "2026-09-09T08:02:00.000Z")],
+            removing: []
+        )
+        XCTAssertEqual(next.map(\.id), ["bks-3", "bks-2", "bks-1"])
+        XCTAssertEqual(next[1].title, "Two, renamed")
+    }
+
+    func testRowWithNewerActivityMovesToTheFront() {
+        let next = SessionsListViewModel.applyingRowChanges(
+            to: loaded(),
+            upserting: [session("bks-1", title: "One", at: "2026-09-09T08:10:00.000Z")],
+            removing: []
+        )
+        XCTAssertEqual(next.map(\.id), ["bks-1", "bks-3", "bks-2"])
+    }
+
+    func testUnknownRowIsInsertedByRecency() {
+        let next = SessionsListViewModel.applyingRowChanges(
+            to: loaded(),
+            upserting: [session("bks-new", at: "2026-09-09T08:02:30.000Z")],
+            removing: []
+        )
+        XCTAssertEqual(next.map(\.id), ["bks-3", "bks-new", "bks-2", "bks-1"])
+    }
+
+    func testRowWithoutActivitySortsLast() {
+        let next = SessionsListViewModel.applyingRowChanges(
+            to: loaded(), upserting: [session("bks-undated")], removing: []
+        )
+        XCTAssertEqual(next.last?.id, "bks-undated")
+    }
+
+    func testRemovalDropsTheRowAndNothingElse() {
+        let next = SessionsListViewModel.applyingRowChanges(
+            to: loaded(), upserting: [], removing: ["bks-2", "bks-never-listed"]
+        )
+        XCTAssertEqual(next.map(\.id), ["bks-3", "bks-1"])
+    }
+
+    func testNothingToApplyReturnsTheSameList() {
+        let base = loaded()
+        XCTAssertEqual(
+            SessionsListViewModel.applyingRowChanges(to: base, upserting: [], removing: []),
+            base
+        )
+    }
+
+    // MARK: - Through the view model
+
+    func testRowFrameUpdatesTheListAndItsRows() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+        XCTAssertEqual(viewModel.sidebarWorkspaces.map(\.title), ["Three", "Two", "One"])
+
+        viewModel.apply(.row(session("bks-2", title: "Two, renamed", at: "2026-09-09T08:02:00.000Z")))
+        await viewModel.flushRowChanges()
+
+        XCTAssertEqual(viewModel.sessions[1].title, "Two, renamed")
+        XCTAssertEqual(viewModel.sidebarWorkspaces.map(\.title), ["Three", "Two, renamed", "One"])
+    }
+
+    func testRemovedFrameDropsTheRow() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+
+        viewModel.apply(.removed(id: "bks-3"))
+        await viewModel.flushRowChanges()
+
+        XCTAssertEqual(viewModel.sessions.map(\.id), ["bks-2", "bks-1"])
+        XCTAssertEqual(viewModel.sidebarWorkspaces.map(\.title), ["Two", "One"])
+    }
+
+    /// The live list never shows archived or desk rows; a row frame saying
+    /// so is a removal, whatever the frame's type.
+    func testArchivedOrDeskRowFrameReadsAsRemoval() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+
+        var archived = session("bks-1", title: "One", at: "2026-09-09T08:01:00.000Z")
+        archived.archived = true
+        var desk = session("bks-2", title: "Two", at: "2026-09-09T08:02:00.000Z")
+        desk.desk = true
+        viewModel.apply(.row(archived))
+        viewModel.apply(.row(desk))
+        await viewModel.flushRowChanges()
+
+        XCTAssertEqual(viewModel.sessions.map(\.id), ["bks-3"])
+    }
+
+    /// A burst of frames for one session folds into its latest snapshot.
+    func testLatestFrameForASessionWins() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+
+        viewModel.apply(.row(session("bks-3", title: "First", at: "2026-09-09T08:03:00.000Z")))
+        viewModel.apply(.row(session("bks-3", title: "Second", at: "2026-09-09T08:03:00.000Z")))
+        await viewModel.flushRowChanges()
+
+        XCTAssertEqual(viewModel.sessions.first?.title, "Second")
+    }
+
+    /// Before the first list has landed there is nothing to merge into, and a
+    /// one-row list ahead of the real one would only flash.
+    func testFramesAheadOfTheFirstLoadAreDropped() async {
+        let viewModel = SessionsListViewModel()
+
+        viewModel.apply(.row(session("bks-1", title: "One", at: "2026-09-09T08:01:00.000Z")))
+        await viewModel.flushRowChanges()
+
+        XCTAssertTrue(viewModel.sessions.isEmpty)
+        XCTAssertFalse(viewModel.hasLoaded)
+    }
+
+    /// The server's own row retires the placeholder the create drew.
+    func testServerRowRetiresTheOptimisticPlaceholder() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+        let pending = Session.optimistic(
+            id: "bks-created",
+            title: "Created here",
+            repo: "opensession",
+            mode: "code",
+            model: nil,
+            effort: nil,
+            fastMode: false,
+            startedBy: "Alex"
+        )
+        viewModel.addOptimistic(pending)
+        XCTAssertEqual(viewModel.sessions.first?.id, "bks-created")
+        XCTAssertTrue(viewModel.sessions.first?.isOptimistic == true)
+
+        viewModel.apply(.row(session("bks-created", title: "Created here", at: "2026-09-09T09:00:00.000Z")))
+        await viewModel.flushRowChanges()
+
+        XCTAssertEqual(viewModel.sessions.first?.id, "bks-created")
+        XCTAssertFalse(viewModel.sessions.first?.isOptimistic == true)
+    }
+}

--- a/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
@@ -172,4 +172,37 @@ final class SessionRowUpdateTests: XCTestCase {
         XCTAssertEqual(viewModel.sessions.first?.id, "bks-created")
         XCTAssertFalse(viewModel.sessions.first?.isOptimistic == true)
     }
+
+    /// The poll consumes a hide when the hidden row is blocked on a question,
+    /// so the row can't disappear again once it's answered. A pushed row has
+    /// to do the same, or answering before the next poll re-hides it.
+    func testPushedRowThatNeedsInputConsumesItsHide() async {
+        let viewModel = SessionsListViewModel()
+        viewModel.loadFixture(loaded())
+        HideStore.shared.applyHydrated(
+            ["workspace:ws-2": "2026-09-09T08:00:00.000Z", "bks-1": "2026-09-09T08:00:00.000Z"],
+            persist: false
+        )
+        defer { HideStore.shared.applyHydrated([:], persist: false) }
+
+        var blocked = session("bks-2", title: "Two", at: "2026-09-09T08:02:00.000Z", workspaceId: "ws-2")
+        blocked.waitingForInput = true
+        viewModel.apply(.row(blocked))
+        viewModel.apply(.row(session("bks-1", title: "One, still idle", at: "2026-09-09T08:01:00.000Z")))
+        await viewModel.flushRowChanges()
+
+        XCTAssertNil(HideStore.shared.hides["workspace:ws-2"])
+        XCTAssertNotNil(HideStore.shared.hides["bks-1"])
+    }
+
+    func testAutomationRowThatNeedsInputKeepsItsHide() {
+        var bot = session("bks-bot", workspaceId: "ws-bot")
+        bot.waitingForInput = true
+        bot.startedBy = "nightly (automation)"
+
+        XCTAssertEqual(
+            SessionsListViewModel.resurfacedHideKeys(in: [bot], hidden: ["workspace:ws-bot", "bks-bot"]),
+            []
+        )
+    }
 }

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -551,8 +551,17 @@ OS1/
 - Presence is held while the app is active on the selected session. Reading
   without touching the screen does not make the face expire; changing sessions
   moves it, and leaving the app removes it.
+- The active account's socket (`PresenceStore`) sends
+  `{"type":"sessions_subscribe","query":"?archived=exclude"}` after every
+  `hello`, the same query the list polls with. The server answers a changed row
+  with `session_row` (a full list row) or `session_row_removed` (`id`), which
+  `SessionsListViewModel.apply` merges into the list off the main actor. The 5s
+  poll stays as the fallback for a frame lost across a reconnect.
+- Queue rows (`queue_update`, `queued_prompt_taken`) carry `pastedTexts`, the
+  large pastes the server lifted out of the message. The row names them
+  ("Pasted text +60 lines", "2 pasted texts"), and taking a message back into
+  the composer appends them to the draft, since this composer has no paste chip.
 
 ## Next milestones
 
 - Image attachments in assistant markdown
-- Push-style updates for the sessions list (it polls today)


### PR DESCRIPTION
Completes native handling for two shipped WebSocket additions that `ServerEvent.swift` previously decoded to `.ignored`.

## Session rows (7e7ff4de)

- `PresenceStore`'s active-account socket sends `sessions_subscribe` with the same query the list polls with (`?archived=exclude`), after every `hello` and when the active account changes.
- `session_row` / `session_row_removed` decode to `ServerEvent.sessionRow` / `.sessionRowRemoved` and route to `SessionsListViewModel.apply`.
- The view model parks changes (latest per session), then one detached pass merges them into the list by recency, honours the local archive/restore overlays, retires an optimistic placeholder the server now has a row for, and publishes list + grouping in one step, the same way a poll does. No regrouping on the main thread.
- The 5s poll stays as the fallback.

## Queued pasted text (f05a4cc6)

- `QueueItem` decodes `pastedTexts` and keeps it through `withContent`.
- `QueueMessagePresentation.pastedLabel`: "Pasted text +60 lines" for one paste, "2 pasted texts" for several.
- The queued row shows it under the message (or in its place for a paste sent alone). Taking a message back into the composer appends the pastes to the draft, since this composer has no paste chip.

## Tests

- `ServerEventTests`: `session_row`, `session_row_removed`, `pastedTexts` on `queue_update` and `queued_prompt_taken`.
- `SessionRowUpdateTests` (new): merge order, removal, archived/desk frames, coalescing, frames before first load, optimistic retirement.
- `QueueMessageTests`: line labels, multiple-paste label, edit keeps pastes.

## Verification

- `xcodegen generate`, OS1 (simulator) and OS1Mac builds pass.
- 997 unit tests pass in the simulator (the build node's Mac test runner, `testmanagerd`, is down, so the Mac `xcodebuild test` could not be run there; the same test sources ran hosted in the iOS app).
- Live server, 5s poll disabled: archive from the API removed the row within one flush and unarchive brought it back; a queued message with a 60-line paste reads "Pasted text +60 lines".

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-3496b6c5-e2a9-789f-ab3a-7bdc55215148)