### PR TITLE
Native model menu: weekly remaining per account

### DIFF
--- a/packages/clients/ios/OS1/Models/AccountUsage.swift
+++ b/packages/clients/ios/OS1/Models/AccountUsage.swift
@@ -247,3 +247,252 @@ enum AccountUsageReading {
         withFractional.date(from: value) ?? plain.date(from: value)
     }
 }
+
+// MARK: - Weekly remaining
+
+/// One account together with the pool it came from. `ProviderAccount` is the
+/// wire record and carries no provider of its own: the route it was fetched
+/// from is what says whether it is a Claude, Codex or SuperGrok account.
+struct PooledAccount: Identifiable, Equatable, Sendable {
+    var account: ProviderAccount
+    var kind: AccountKind
+
+    var id: String { "\(kind.id):\(account.id ?? account.name ?? "account")" }
+}
+
+extension AccountKind {
+    /// The pool key the server uses in `accountProvider` and `/account`
+    /// replies: "claude", "codex" or "xai".
+    init?(providerKey: String?) {
+        guard let providerKey else { return nil }
+        guard let kind = Self.allCases.first(where: { $0.brand == providerKey }) else { return nil }
+        self = kind
+    }
+}
+
+/// A limit that refills on a weekly (or billing-period) cadence: the number
+/// that decides which account to run the day on. The 5-hour window is what
+/// stops a turn; the week is what runs out.
+struct WeeklyLimit: Equatable, Sendable {
+    /// Model the cap is scoped to ("Fable"), or nil for the whole account.
+    var scope: String?
+    var utilization: Double
+    var resetsAt: String?
+}
+
+/// Colour means "this one is running out", nothing else. Same thresholds as
+/// the accounts page reads utilization: 90% used is low, 70% used is a warning.
+enum RemainingTone: Equatable, Sendable {
+    case low, warn, ok
+
+    init(remaining: Int) {
+        self = remaining <= 10 ? .low : remaining <= 30 ? .warn : .ok
+    }
+}
+
+/// One line of the weekly overview in the model menu.
+struct WeeklyRemainingRow: Identifiable, Equatable, Sendable {
+    var accountId: String
+    var kind: AccountKind
+    /// Model the cap is scoped to ("Fable"), or nil for the whole account.
+    var scope: String?
+    var name: String
+    /// The account's owner when it is a personal subscription; nil for the
+    /// shared pool.
+    var owner: String?
+    /// Whole percent left, 0-100.
+    var remaining: Int
+    var resetsAt: Date?
+
+    var id: String { "\(kind.id):\(accountId):\(scope ?? "")" }
+    /// Account name, with the model a scoped cap applies to.
+    var label: String { scope.map { "\(name) · \($0)" } ?? name }
+    var tone: RemainingTone { RemainingTone(remaining: remaining) }
+    var isPersonal: Bool { owner != nil }
+}
+
+/// The weekly budget each subscription account has left, read the way the
+/// model menu shows it. Mirrors `lib/account-limits.ts` on the web: the same
+/// rows, the same order, the same readout for the menu's own line.
+enum WeeklyRemaining {
+    private static let weekMinutes: Double = 7 * 24 * 60
+
+    /// Flatten an account's `usage` into its weekly limits. Unknown or missing
+    /// usage yields nothing rather than a row that claims "0% used".
+    static func limits(_ usage: AccountUsage?, kind: AccountKind) -> [WeeklyLimit] {
+        guard let usage else { return [] }
+        switch kind {
+        case .claude:
+            var out: [WeeklyLimit] = []
+            if let week = usage.sevenDay, let utilization = week.utilization {
+                out.append(WeeklyLimit(scope: nil, utilization: utilization, resetsAt: week.resetsAt))
+            }
+            for limit in usage.scopedLimits ?? [] {
+                guard let utilization = limit.utilization else { continue }
+                out.append(WeeklyLimit(scope: limit.label, utilization: utilization, resetsAt: limit.resetsAt))
+            }
+            return out
+        case .codex:
+            var out: [WeeklyLimit] = []
+            for bucket in usage.buckets ?? [] {
+                for window in [bucket.primary, bucket.secondary].compactMap({ $0 }) {
+                    guard let utilization = window.utilization,
+                          (window.windowDurationMins ?? 0) >= weekMinutes else { continue }
+                    out.append(WeeklyLimit(scope: bucket.label, utilization: utilization, resetsAt: window.resetsAt))
+                }
+            }
+            return out
+        case .xai:
+            // SuperGrok budgets a billing period rather than a week; it is
+            // still the number that decides whether the account has anything
+            // left to give.
+            guard let percent = usage.creditUsagePercent else { return [] }
+            return [WeeklyLimit(scope: nil, utilization: percent, resetsAt: usage.periodEnd)]
+        }
+    }
+
+    /// Can `viewer` run on this account: it sits in the shared pool, or it is
+    /// their own personal subscription. Someone else's personal account is not
+    /// theirs to spend, so its budget is noise here. Same loose name compare
+    /// as the web's `ownerMatchesPerson`.
+    static func isAvailable(_ account: ProviderAccount, to viewer: String) -> Bool {
+        guard let owner = account.owner, !owner.isEmpty else { return true }
+        return SidebarPersonLens.nameMatches(owner, key: viewer)
+    }
+
+    /// The overview: every account `viewer` can use that reports a weekly
+    /// number, one row per limit. Your own subscriptions first: they are the
+    /// ones routing spends before the pool, so they are the numbers you want
+    /// at a glance. A window whose reset already passed reads as full, as it
+    /// does everywhere else.
+    static func rows(_ accounts: [PooledAccount], viewer: String, now: Date = Date()) -> [WeeklyRemainingRow] {
+        var personal: [WeeklyRemainingRow] = []
+        var pool: [WeeklyRemainingRow] = []
+        for pooled in accounts {
+            let account = pooled.account
+            guard let accountId = account.id, !accountId.isEmpty,
+                  isAvailable(account, to: viewer) else { continue }
+            let owner = account.owner?.isEmpty == false ? account.owner : nil
+            for limit in limits(account.usage, kind: pooled.kind) {
+                let window = LimitWindow(label: "", utilization: limit.utilization, resetsAt: limit.resetsAt)
+                guard let used = AccountUsageReading.liveUtilization(window, now: now) else { continue }
+                let row = WeeklyRemainingRow(
+                    accountId: accountId,
+                    kind: pooled.kind,
+                    scope: limit.scope,
+                    name: account.name ?? account.email ?? "Account",
+                    owner: owner,
+                    remaining: max(0, min(100, Int((100 - used).rounded()))),
+                    resetsAt: limit.resetsAt.flatMap(AccountUsageReading.parse)
+                )
+                if owner != nil { personal.append(row) } else { pool.append(row) }
+            }
+        }
+        return personal + pool
+    }
+
+    /// The tightest budget among `rows`.
+    static func lowest(_ rows: [WeeklyRemainingRow]) -> WeeklyRemainingRow? {
+        rows.min { $0.remaining < $1.remaining }
+    }
+
+    /// The day a window refills, as the row prints it: "now" once the reset
+    /// has passed, otherwise the short weekday. Nil when the account does not
+    /// say.
+    static func resetDay(_ resetsAt: Date?, now: Date = Date(), locale: Locale = .current) -> String? {
+        guard let resetsAt else { return nil }
+        if resetsAt <= now { return "now" }
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEE")
+        return formatter.string(from: resetsAt)
+    }
+
+    /// The exact refill time, for the row's spoken description.
+    static func resetDetail(_ resetsAt: Date?, now: Date = Date(), locale: Locale = .current) -> String? {
+        guard let resetsAt else { return nil }
+        if resetsAt <= now { return "Resets now" }
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEE MMM d HH:mm")
+        return "Resets \(formatter.string(from: resetsAt))"
+    }
+
+    /// Which account pool a model draws on. The catalog says so for every
+    /// model it lists (`accountProvider`); a preset resolves through its lead
+    /// model. Ids the catalog does not know fall back to the server's own
+    /// prefix rules (`accountProviderForModel`).
+    static func provider(forModel model: String, catalog: ModelCatalog?) -> AccountKind? {
+        if let option = catalog?.option(for: model) {
+            if let kind = AccountKind(providerKey: option.accountProvider) { return kind }
+            if let lead = option.composition?.first, lead != model {
+                return provider(forModel: lead, catalog: catalog)
+            }
+        }
+        let tail = model.hasPrefix("pi/") ? String(model.dropFirst(3)) : model
+        let upstream = tail.split(separator: "/", maxSplits: 1).count == 2
+            ? String(tail.split(separator: "/", maxSplits: 1)[0]) : nil
+        if upstream == "anthropic" || tail.hasPrefix("claude-") { return .claude }
+        if upstream == "openai" || tail.hasPrefix("gpt-") || tail.hasPrefix("codex-") { return .codex }
+        if upstream == "xai-oauth" { return .xai }
+        return nil
+    }
+
+    private static let claudeScopedFamilies = ["fable", "opus", "sonnet", "haiku"]
+
+    /// The limit that can stop `model` on one account. A Claude model with a
+    /// dedicated weekly bucket uses that bucket instead of the general 7-day
+    /// one; every other pool reads the account-wide rows.
+    static func rows(for model: String, in rows: [WeeklyRemainingRow]) -> [WeeklyRemainingRow] {
+        guard rows.first?.kind == .claude else { return rows }
+        let normalized = model.lowercased()
+        let family = normalized.contains("mythos")
+            ? "fable"
+            : claudeScopedFamilies.first { normalized.contains($0) }
+        guard let family else { return rows.filter { $0.scope == nil } }
+        let scoped = rows.filter { $0.scope?.lowercased().contains(family) == true }
+        return scoped.isEmpty ? rows.filter { $0.scope == nil } : scoped
+    }
+
+    /// The number for the account automatic routing will use: a usable pin,
+    /// otherwise the viewer's personal subscription before the shared pool.
+    /// Within a group, the account with the most model-specific headroom,
+    /// which is close enough to the pool's least-used choice without exposing
+    /// runner state.
+    static func readout(
+        rows: [WeeklyRemainingRow],
+        accounts: [PooledAccount],
+        viewer: String,
+        kind: AccountKind?,
+        model: String,
+        accountId: String?
+    ) -> WeeklyRemainingRow? {
+        let providerRows = kind.map { kind in rows.filter { $0.kind == kind } } ?? rows
+        struct Candidate {
+            let account: ProviderAccount
+            let row: WeeklyRemainingRow
+        }
+        let candidates: [Candidate] = accounts.compactMap { pooled in
+            guard kind == nil || pooled.kind == kind,
+                  isAvailable(pooled.account, to: viewer),
+                  let id = pooled.account.id else { return nil }
+            let own = self.rows(for: model, in: providerRows.filter { $0.accountId == id })
+            return lowest(own).map { Candidate(account: pooled.account, row: $0) }
+        }
+        let available = candidates.filter { $0.account.usable != false && $0.row.remaining > 0 }
+        func best(_ choices: [Candidate]) -> WeeklyRemainingRow? {
+            choices.max { $0.row.remaining < $1.row.remaining }?.row
+        }
+        if let accountId, !accountId.isEmpty,
+           let pinned = available.first(where: { $0.account.id == accountId }) {
+            return pinned.row
+        }
+        let personal = { (list: [Candidate]) in list.filter { $0.account.owner?.isEmpty == false } }
+        let pool = { (list: [Candidate]) in list.filter { !($0.account.owner?.isEmpty == false) } }
+        return best(personal(available))
+            ?? best(pool(available))
+            ?? best(personal(candidates))
+            ?? best(pool(candidates))
+            ?? lowest(providerRows)
+    }
+}

--- a/packages/clients/ios/OS1/Models/ModelCatalog.swift
+++ b/packages/clients/ios/OS1/Models/ModelCatalog.swift
@@ -13,6 +13,12 @@ struct ModelOption: Decodable, Identifiable, Hashable, Sendable {
     /// Reasoning-effort variants this model supports (may be empty — presets).
     var efforts: [String]?
     var fastModeSupported: Bool?
+    /// The subscription pool this model spends from ("claude", "codex",
+    /// "xai"), or nil for a model without a managed account pool.
+    var accountProvider: String?
+    /// A preset's member models, lead first. The pool a preset draws on is
+    /// its lead's.
+    var composition: [String]?
 
     var displayLabel: String { label ?? id }
     var isPreset: Bool { group != nil }

--- a/packages/clients/ios/OS1/Models/Session.swift
+++ b/packages/clients/ios/OS1/Models/Session.swift
@@ -33,6 +33,9 @@ struct Session: Identifiable, Decodable, Equatable, Hashable {
     var model: String?
     var effort: String?
     var fastMode: Bool?
+    /// The provider account pinned for this conversation with `/account`;
+    /// nil = automatic (personal first, shared pool fallback).
+    var accountId: String?
     var isRunning: Bool?
     var runState: String?
     /// Present when the server fenced an ambiguous operation rather than risk

--- a/packages/clients/ios/OS1/Models/SettingsModels.swift
+++ b/packages/clients/ios/OS1/Models/SettingsModels.swift
@@ -176,7 +176,7 @@ struct ModelDefaults: Codable, Sendable {
     var autoFallback: Bool?
 }
 
-struct ProviderAccount: Codable, Sendable, Identifiable {
+struct ProviderAccount: Codable, Sendable, Identifiable, Equatable {
     var id: String?
     var name: String?
     var owner: String?

--- a/packages/clients/ios/OS1/Networking/ServerConfig.swift
+++ b/packages/clients/ios/OS1/Networking/ServerConfig.swift
@@ -87,7 +87,11 @@ final class ServerConfig {
                 id: id,
                 label: URL(string: server)?.host ?? "Development",
                 url: server,
-                userName: defaults.string(forKey: Self.legacyUserNameDefaultsKey)
+                // `OS1_USER` names the viewer for a dev launch, so a screenshot
+                // can read as a particular teammate (their personal accounts,
+                // their sidebar lens) without touching the device's defaults.
+                userName: env["OS1_USER"]
+                    ?? defaults.string(forKey: Self.legacyUserNameDefaultsKey)
                     ?? Self.placeholderUserName,
                 githubLogin: ""
             )]

--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -34,6 +34,9 @@ enum ServerEvent: Sendable {
     /// The session's model changed mid-run (a fallback, or a teammate's
     /// switch): apply it now instead of waiting for the next sessions poll.
     case modelChanged(sessionId: String, model: String, by: String?)
+    /// The session's pinned provider account changed (`/account`), here or
+    /// from another viewer; nil = back to automatic routing.
+    case subscriptionChanged(sessionId: String, accountId: String?)
     /// Everyone with this session open right now, by display name. One entry
     /// per socket, so the same person can appear twice (two devices).
     case presence(sessionId: String, viewers: [String])
@@ -136,6 +139,9 @@ enum ServerEvent: Sendable {
         case "model_changed":
             guard let id = frame.sessionId, let model = frame.model else { return .ignored }
             return .modelChanged(sessionId: id, model: model, by: frame.by)
+        case "subscription_changed":
+            guard let id = frame.sessionId else { return .ignored }
+            return .subscriptionChanged(sessionId: id, accountId: frame.accountId)
         case "presence":
             guard let id = frame.sessionId else { return .ignored }
             return .presence(sessionId: id, viewers: frame.viewers ?? [])
@@ -474,6 +480,7 @@ private struct RawFrame: Decodable {
     let safety: SessionSafetyState?
     let ready: Bool?
     let model: String?
+    let accountId: String?
     let by: String?
     let viewers: [String]?
     let users: [String]?

--- a/packages/clients/ios/OS1/Networking/SettingsAPI.swift
+++ b/packages/clients/ios/OS1/Networking/SettingsAPI.swift
@@ -346,6 +346,44 @@ enum SettingsAPI {
         return response.accounts ?? []
     }
 
+    /// Every pool at once, tagged with where it came from, for the model
+    /// menu's weekly overview. A pool that fails keeps its cached answer, so
+    /// one provider being down does not blank the other two.
+    static func providerAccountPools() async -> [PooledAccount] {
+        func attempt(_ fetch: () async throws -> [ProviderAccount]) async -> Result<[ProviderAccount], Error> {
+            do { return .success(try await fetch()) } catch { return .failure(error) }
+        }
+        async let claude = attempt(claudeAccounts)
+        async let codex = attempt(codexAccounts)
+        async let xai = attempt(xaiAccounts)
+        let fetched: [(AccountKind, Result<[ProviderAccount], Error>)] =
+            await [(.claude, claude), (.codex, codex), (.xai, xai)]
+        return fetched.flatMap { kind, result -> [PooledAccount] in
+            let accounts: [ProviderAccount]
+            switch result {
+            case .success(let fresh):
+                SettingsCache.save(providerAccountsCacheKey(kind), fresh)
+                accounts = fresh
+            case .failure:
+                accounts = SettingsCache.value(providerAccountsCacheKey(kind)) ?? []
+            }
+            return accounts.map { PooledAccount(account: $0, kind: kind) }
+        }
+    }
+
+    /// The last answer this device saw for every pool, so a menu can open
+    /// with numbers before the fetch behind it lands.
+    static func cachedProviderAccountPools() -> [PooledAccount] {
+        AccountKind.allCases.flatMap { kind in
+            (SettingsCache.value(providerAccountsCacheKey(kind)) as [ProviderAccount]? ?? [])
+                .map { PooledAccount(account: $0, kind: kind) }
+        }
+    }
+
+    /// Shared with Settings → Providers, which seeds its list from the same
+    /// entries.
+    static func providerAccountsCacheKey(_ kind: AccountKind) -> String { "\(kind.brand)-accounts" }
+
     static func createClaudeAccount(_ body: [String: Any]) async throws -> ProviderAccount {
         try await request("/api/claude-accounts", method: "POST", body: body)
     }

--- a/packages/clients/ios/OS1/OS1App.swift
+++ b/packages/clients/ios/OS1/OS1App.swift
@@ -185,8 +185,11 @@ struct RootView: View {
                 // Devices signed in before the app stored the GitHub login
                 // (pre-07-23 builds) hold a valid token but an empty login —
                 // backfill it from the server so the avatar can resolve.
+                // A dev launch that names its viewer (`OS1_USER`) keeps that
+                // name; the token's own identity would overwrite it here.
                 let authContext = NativePreferences.context()
                 if config.isConfigured, config.githubLogin.isEmpty,
+                   ProcessInfo.processInfo.environment["OS1_USER"] == nil,
                    let status = try? await OS1API.authStatus(),
                    status.authenticated == true,
                    NativePreferences.context() == authContext {

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -1930,8 +1930,13 @@ final class SessionViewModel {
         case .workspaceStatus(let id, let ready) where id == session.id:
             workspaceReadyOverride = ready
 
-        case .modelChanged(let id, let model, _) where id == session.id:
-            session.model = model
+        case .modelChanged(let id, let switched, _) where id == session.id:
+            session.model = switched
+            // The model menu reads `model`, not the snapshot: a teammate's
+            // provider switch must change which accounts it can pin in the
+            // same beat as the `subscription_changed` that follows it, or a
+            // Claude id gets sent to the Codex account command.
+            model = switched
 
         case .subscriptionChanged(let id, let pinned) where id == session.id:
             accountId = pinned ?? ""

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -264,6 +264,9 @@ final class SessionViewModel {
     var effort: String
     /// OpenAI fast-mode flag; rides every send like effort.
     var fastMode: Bool
+    /// Provider account pinned with `/account` ("" = automatic routing). The
+    /// server owns it; this follows its `subscription_changed` broadcasts.
+    private(set) var accountId: String
 
     // ── Earlier-history paging ──
     /// Older history exists server-side (transcript_init/history `truncated`).
@@ -528,6 +531,7 @@ final class SessionViewModel {
         self.model = session.model ?? ""
         self.effort = session.effort ?? ""
         self.fastMode = session.fastMode ?? false
+        self.accountId = session.accountId ?? ""
         if let composerDraft {
             self.draft = composerDraft.text
             self.attachedImages = composerDraft.images
@@ -618,6 +622,7 @@ final class SessionViewModel {
         model = session.model ?? ""
         effort = session.effort ?? ""
         fastMode = session.fastMode ?? false
+        accountId = session.accountId ?? ""
     }
 
     func start() {
@@ -1292,6 +1297,22 @@ final class SessionViewModel {
         )
     }
 
+    /// Pin one provider account for this conversation, or nil for automatic
+    /// routing, through the `/account` slash command: the server validates
+    /// the pool, persists the pin and broadcasts `subscription_changed`.
+    func pinAccount(_ account: ProviderAccount?) {
+        let next = account?.id ?? ""
+        guard next != accountId, let socket else { return }
+        accountId = next
+        // Fast mode is a subscription feature; an API key cannot carry it.
+        if account?.kind == "api_key" { fastMode = false }
+        socket.prompt(
+            sessionId: session.id,
+            content: next.isEmpty ? "/account auto" : "/account \(next)",
+            user: ServerConfig.shared.userName
+        )
+    }
+
     func answer(question: AskQuestion, answers: [String: String]?) {
         socket?.answer(sessionId: session.id, questionId: question.id, answers: answers)
         pendingQuestion = nil
@@ -1911,6 +1932,10 @@ final class SessionViewModel {
 
         case .modelChanged(let id, let model, _) where id == session.id:
             session.model = model
+
+        case .subscriptionChanged(let id, let pinned) where id == session.id:
+            accountId = pinned ?? ""
+            session.accountId = pinned
 
         case .queueUpdate(let id, let queued, let steered, let pendingIds)
             where id == session.id:

--- a/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
+++ b/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
@@ -17,6 +17,9 @@ struct ModelSettingsMenu: View {
 
     let viewModel: SessionViewModel
     let catalog: ModelCatalog?
+    /// Every subscription account the server lists, for the weekly overview.
+    /// Empty until the pools load, which only costs the Weekly remaining row.
+    var accounts: [PooledAccount] = []
     /// Conversation cost, above the choices that drive it. Carried where this
     /// is the whole menu; suppressed where it is nested inside one, since
     /// spend is not a model setting and the row would read as one.
@@ -25,6 +28,9 @@ struct ModelSettingsMenu: View {
     var body: some View {
         if showsUsage {
             UsageMenuSection(usage: viewModel.usage)
+        }
+        if !weeklyRows.isEmpty {
+            weeklyRemainingMenu
         }
         if let catalog {
             Menu {
@@ -121,6 +127,117 @@ struct ModelSettingsMenu: View {
         }
     }
 
+    // MARK: Weekly remaining
+
+    /// One line per weekly budget the viewer can spend, the way the web menu
+    /// lists them: yours first, then the pool. The menu row itself reads out
+    /// the tightest budget for the account the current model will run on. A
+    /// row for the current model's pool pins that account for this session;
+    /// a row for another pool is listed for the overview but cannot be picked.
+    private var weeklyRemainingMenu: some View {
+        Menu {
+            Section {
+                Button {
+                    viewModel.pinAccount(nil)
+                } label: {
+                    if viewModel.accountId.isEmpty {
+                        Label("Auto", systemImage: "checkmark")
+                    } else {
+                        Text("Auto")
+                    }
+                }
+                .disabled(currentProvider == nil)
+                ForEach(weeklyRows) { row in
+                    let pinnable = row.kind == currentProvider
+                    let pinned = pinnable && row.accountId == viewModel.accountId
+                    Button {
+                        if let account = accounts.first(where: {
+                            $0.kind == row.kind && $0.account.id == row.accountId
+                        }) {
+                            viewModel.pinAccount(account.account)
+                        }
+                    } label: {
+                        Text(row.label)
+                        Text(Self.rowDetail(row))
+                        // Not hidden from accessibility: hiding the mark
+                        // drops the whole row from the menu's tree on iOS 26.
+                        Image(systemName: pinned ? "checkmark" : (row.isPersonal ? "person" : "person.2"))
+                    }
+                    .disabled(!pinnable)
+                    .accessibilityLabel(Self.rowSpokenLabel(row, pinned: pinned, pinnable: pinnable))
+                }
+            } footer: {
+                if currentProvider != nil {
+                    Text("Choose one to use it for this session")
+                }
+            }
+        } label: {
+            Label(
+                weeklyReadout.map { "Weekly remaining · \($0.remaining)%" } ?? "Weekly remaining",
+                systemImage: Self.gaugeSymbol(weeklyReadout?.tone)
+            )
+        }
+    }
+
+    private var viewer: String { ServerConfig.shared.userName }
+
+    private var weeklyRows: [WeeklyRemainingRow] {
+        WeeklyRemaining.rows(accounts, viewer: viewer)
+    }
+
+    /// The pool the current model spends from, which decides which rows can
+    /// be pinned.
+    private var currentProvider: AccountKind? {
+        WeeklyRemaining.provider(forModel: currentModel, catalog: catalog)
+    }
+
+    private var weeklyReadout: WeeklyRemainingRow? {
+        WeeklyRemaining.readout(
+            rows: weeklyRows,
+            accounts: accounts,
+            viewer: viewer,
+            kind: currentProvider,
+            model: catalog?.option(for: currentModel)?.composition?.first ?? currentModel,
+            accountId: viewModel.accountId
+        )
+    }
+
+    /// The gauge fills with what is left, so an account that is running out
+    /// reads as a near-empty dial before the number is read.
+    private static func gaugeSymbol(_ tone: RemainingTone?) -> String {
+        switch tone {
+        case .low: "gauge.with.dots.needle.0percent"
+        case .warn: "gauge.with.dots.needle.33percent"
+        case .ok, nil: "gauge.with.dots.needle.67percent"
+        }
+    }
+
+    /// The row's second line: whose it is, the day it refills, what is left.
+    static func rowDetail(_ row: WeeklyRemainingRow, now: Date = Date()) -> String {
+        var parts = [row.isPersonal ? "Yours" : "Shared"]
+        if let day = WeeklyRemaining.resetDay(row.resetsAt, now: now) { parts.append(day) }
+        parts.append("\(row.remaining)% left")
+        if row.tone == .low { parts.append("running out") }
+        return parts.joined(separator: " · ")
+    }
+
+    /// What VoiceOver reads for a row: the same facts as the two lines, plus
+    /// the exact refill time and whether the row can be picked.
+    static func rowSpokenLabel(
+        _ row: WeeklyRemainingRow, pinned: Bool, pinnable: Bool, now: Date = Date()
+    ) -> String {
+        var parts = [row.label, row.isPersonal ? "yours" : "shared", "\(row.remaining) percent left"]
+        if let detail = WeeklyRemaining.resetDetail(row.resetsAt, now: now) { parts.append(detail) }
+        if pinned {
+            parts.append("used for this session")
+        } else if !pinnable {
+            parts.append("not for this model")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: Model settings
+
     /// Fast mode reads as a speed, so it sits beside Effort as a value rather
     /// than as a switch of its own. Same wording as the web menu.
     private static func speedLabel(_ fast: Bool) -> String {
@@ -161,14 +278,15 @@ struct ModelSettingsMenu: View {
         !currentModel.isEmpty && preferredModel == currentModel
     }
 
-    /// Nothing to put back: following the default model, no effort picked, and
-    /// standard speed. Drives the reset row's disabled state, so it doubles as
-    /// the answer to "am I on the defaults?".
+    /// Nothing to put back: following the default model, no effort picked,
+    /// standard speed, account on auto. Drives the reset row's disabled
+    /// state, so it doubles as the answer to "am I on the defaults?".
     private var isAtDefault: Bool {
         let defaultModel = catalog?.defaultModel ?? ""
         let onDefaultModel =
             viewModel.model.isEmpty || defaultModel.isEmpty || viewModel.model == defaultModel
         return onDefaultModel && viewModel.effort.isEmpty && !viewModel.fastMode
+            && viewModel.accountId.isEmpty
     }
 
     private func setAsDefault() {
@@ -203,5 +321,6 @@ struct ModelSettingsMenu: View {
         // already the default, which is the common case for a reset.
         viewModel.effort = ""
         viewModel.fastMode = false
+        viewModel.pinAccount(nil)
     }
 }

--- a/packages/clients/ios/OS1/Views/ProviderAccounts.swift
+++ b/packages/clients/ios/OS1/Views/ProviderAccounts.swift
@@ -36,7 +36,9 @@ struct ProviderAccountSections: View {
         )
     }
 
-    private static func cacheKey(_ kind: AccountKind) -> String { "\(kind.brand)-accounts" }
+    private static func cacheKey(_ kind: AccountKind) -> String {
+        SettingsAPI.providerAccountsCacheKey(kind)
+    }
 
     var body: some View {
         Section("Accounts") {

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -220,6 +220,9 @@ struct SessionView: View {
 
     /// Model/effort catalog for the toolbar picker; fetched on first open.
     @State private var catalog: ModelCatalog?
+    /// The subscription pools, for the model menu's weekly overview. Seeded
+    /// from the last answer this device saw so the menu opens with numbers.
+    @State private var accounts: [PooledAccount] = SettingsAPI.cachedProviderAccountPools()
     @State private var forkState = SessionForkState()
 
     /// PR details sheet — the macOS toolbar PR chip, the iOS overflow menu.
@@ -986,6 +989,7 @@ struct SessionView: View {
                 }
                 #endif
                 catalog = try? await OS1API.models(workspaceId: viewModel.session.workspaceId)
+                accounts = await SettingsAPI.providerAccountPools()
                 #if DEBUG && os(iOS)
                 if ProcessInfo.processInfo.environment["OS1_OPEN_WORKTREE_INFO"] == "1" {
                     showWorktreeInfo = true
@@ -1084,6 +1088,7 @@ struct SessionView: View {
                 workerSessions: workerSessions,
                 workspaceNames: workspaceNames,
                 catalog: catalog,
+                accounts: accounts,
                 onNewSession: onNewSession,
                 onFork: canForkSession ? { forkState.enter() } : nil,
                 onRenameWorkspace: onRenameWorkspace,
@@ -1247,7 +1252,7 @@ struct SessionView: View {
     /// `ModelSettingsMenu`, which the iOS overflow menu mounts as well.
     private var modelMenu: some View {
         Menu {
-            ModelSettingsMenu(viewModel: viewModel, catalog: catalog)
+            ModelSettingsMenu(viewModel: viewModel, catalog: catalog, accounts: accounts)
         } label: {
             Image(systemName: "slider.horizontal.3")
         }
@@ -1847,6 +1852,8 @@ private struct SessionActionsMenu: View {
     /// Model/effort catalog for the nested settings rows; nil until the first
     /// `/api/models` fetch lands, which only costs the Model row.
     let catalog: ModelCatalog?
+    /// The subscription pools behind the nested Weekly remaining row.
+    let accounts: [PooledAccount]
     let onNewSession: (() -> Void)?
     let onFork: (() -> Void)?
     let onRenameWorkspace: ((String) -> Void)?
@@ -1958,7 +1965,9 @@ private struct SessionActionsMenu: View {
             // worktree details sheet, which is a long way to go for a setting
             // the web changes from the composer.
             Menu {
-                ModelSettingsMenu(viewModel: viewModel, catalog: catalog, showsUsage: false)
+                ModelSettingsMenu(
+                    viewModel: viewModel, catalog: catalog, accounts: accounts, showsUsage: false
+                )
             } label: {
                 Label("Model settings", systemImage: "slider.horizontal.3")
             }

--- a/packages/clients/ios/OS1Tests/AccountUsageTests.swift
+++ b/packages/clients/ios/OS1Tests/AccountUsageTests.swift
@@ -138,4 +138,204 @@ final class AccountUsageTests: XCTestCase {
     private func iso(_ date: Date) -> String {
         ISO8601DateFormatter().string(from: date)
     }
+
+    // MARK: Weekly remaining
+
+    private func pooled(
+        _ id: String, _ name: String, kind: AccountKind = .claude, owner: String? = nil,
+        usable: Bool? = true, usage: AccountUsage? = nil
+    ) -> PooledAccount {
+        var account = ProviderAccount()
+        account.id = id
+        account.name = name
+        account.owner = owner
+        account.usable = usable
+        account.usage = usage
+        return PooledAccount(account: account, kind: kind)
+    }
+
+    private func claudeUsage(week: Double?, fable: Double? = nil, resets: TimeInterval = 3600 * 70) -> AccountUsage {
+        var usage = AccountUsage()
+        usage.fiveHour = UsageWindow(utilization: 60, resetsAt: iso(now.addingTimeInterval(7200)))
+        usage.sevenDay = UsageWindow(utilization: week, resetsAt: iso(now.addingTimeInterval(resets)))
+        if let fable {
+            usage.scopedLimits = [ScopedUsageLimit(label: "Fable", utilization: fable, resetsAt: iso(now.addingTimeInterval(resets + 3600)))]
+        }
+        return usage
+    }
+
+    /// The 5-hour window stops a turn; the week decides which account to run
+    /// the day on, so only the week and the per-model caps are weekly.
+    func testClaudeWeeklyLimitsAreTheSevenDayWindowAndScopedCaps() {
+        let limits = WeeklyRemaining.limits(claudeUsage(week: 97, fable: 45), kind: .claude)
+        XCTAssertEqual(limits.map(\.scope), [nil, "Fable"])
+        XCTAssertEqual(limits.map(\.utilization), [97, 45])
+    }
+
+    func testCodexWeeklyLimitsAreTheWeekLongWindows() {
+        var usage = AccountUsage()
+        usage.buckets = [
+            CodexUsageBucket(
+                id: "codex",
+                primary: UsageWindow(utilization: 20, resetsAt: nil, windowDurationMins: 300),
+                secondary: UsageWindow(utilization: 98, resetsAt: nil, windowDurationMins: 10_080)
+            ),
+            CodexUsageBucket(
+                id: "spark", label: "Spark",
+                primary: nil,
+                secondary: UsageWindow(utilization: 0, resetsAt: nil, windowDurationMins: 10_080)
+            ),
+        ]
+        let limits = WeeklyRemaining.limits(usage, kind: .codex)
+        XCTAssertEqual(limits.map(\.utilization), [98, 0])
+        XCTAssertEqual(limits.map(\.scope), [nil, "Spark"])
+    }
+
+    /// SuperGrok budgets a billing period rather than a week; it is still the
+    /// number that decides whether the account has anything left.
+    func testXaiCreditPeriodCountsAsTheWeeklyBudget() {
+        var usage = AccountUsage()
+        usage.creditUsagePercent = 12
+        usage.periodEnd = iso(now.addingTimeInterval(86400 * 9))
+        let limits = WeeklyRemaining.limits(usage, kind: .xai)
+        XCTAssertEqual(limits.map(\.utilization), [12])
+        XCTAssertTrue(WeeklyRemaining.limits(AccountUsage(), kind: .xai).isEmpty)
+        XCTAssertTrue(WeeklyRemaining.limits(nil, kind: .claude).isEmpty)
+    }
+
+    /// Yours first, then the pool, and nobody else's personal subscription.
+    func testRowsListYourAccountsThenThePoolAndNobodyElses() {
+        let usage = claudeUsage(week: 50)
+        let rows = WeeklyRemaining.rows(
+            [
+                pooled("pool", "Pool", usage: usage),
+                pooled("mine", "Mine", owner: "Kent", usage: usage),
+                pooled("mine-long", "Mine long", kind: .codex, owner: "Kent de Bruin", usage: usage),
+                pooled("theirs", "Theirs", owner: "Michiel", usage: usage),
+            ],
+            viewer: "Kent",
+            now: now
+        )
+        XCTAssertEqual(rows.map(\.accountId), ["mine", "pool"])
+        XCTAssertEqual(rows.map(\.owner), ["Kent", nil])
+    }
+
+    func testOneRowPerWeeklyLimitWithRemainingAndTone() {
+        let rows = WeeklyRemaining.rows(
+            [pooled("a", "Work", usage: claudeUsage(week: 97, fable: 45)), pooled("c", "No usage")],
+            viewer: "Kent",
+            now: now
+        )
+        XCTAssertEqual(rows.map(\.label), ["Work", "Work · Fable"])
+        XCTAssertEqual(rows.map(\.remaining), [3, 55])
+        XCTAssertEqual(rows.map(\.tone), [.low, .ok])
+        XCTAssertEqual(rows[0].resetsAt, now.addingTimeInterval(3600 * 70))
+    }
+
+    /// A window whose reset already passed reads as full, as it does everywhere else.
+    func testAPassedWeeklyResetReadsAsFull() {
+        let rows = WeeklyRemaining.rows(
+            [pooled("a", "Work", usage: claudeUsage(week: 100, resets: -3600))],
+            viewer: "Kent",
+            now: now
+        )
+        XCTAssertEqual(rows.map(\.remaining), [100])
+        XCTAssertEqual(WeeklyRemaining.resetDay(rows[0].resetsAt, now: now), "now")
+        XCTAssertEqual(WeeklyRemaining.resetDetail(rows[0].resetsAt, now: now), "Resets now")
+    }
+
+    func testResetDayIsTheWeekday() {
+        let locale = Locale(identifier: "en_US")
+        // 1_700_000_000 is a Tuesday (2023-11-14 22:13 UTC).
+        XCTAssertEqual(WeeklyRemaining.resetDay(now.addingTimeInterval(86400 * 2), now: now, locale: locale), "Thu")
+        XCTAssertNil(WeeklyRemaining.resetDay(nil, now: now))
+        XCTAssertEqual(WeeklyRemaining.resetDetail(now.addingTimeInterval(86400 * 2), now: now, locale: locale)?.hasPrefix("Resets Thu"), true)
+    }
+
+    func testTonesAndTheTightestRow() {
+        XCTAssertEqual(RemainingTone(remaining: 0), .low)
+        XCTAssertEqual(RemainingTone(remaining: 10), .low)
+        XCTAssertEqual(RemainingTone(remaining: 30), .warn)
+        XCTAssertEqual(RemainingTone(remaining: 31), .ok)
+        let rows = WeeklyRemaining.rows(
+            [pooled("a", "A", usage: claudeUsage(week: 40)), pooled("b", "B", usage: claudeUsage(week: 90))],
+            viewer: "Kent",
+            now: now
+        )
+        XCTAssertEqual(WeeklyRemaining.lowest(rows)?.accountId, "b")
+        XCTAssertNil(WeeklyRemaining.lowest([]))
+    }
+
+    /// A Claude model with its own weekly bucket is stopped by that bucket,
+    /// not by the general 7-day window.
+    func testReadoutShowsTheModelBucketOnYourOwnAccount() {
+        let accounts = [
+            pooled("pool", "Pool", usage: claudeUsage(week: 100, fable: 100)),
+            pooled("mine", "Main", owner: "Kent", usage: claudeUsage(week: 100, fable: 45)),
+        ]
+        let rows = WeeklyRemaining.rows(accounts, viewer: "Kent", now: now)
+        let readout = WeeklyRemaining.readout(
+            rows: rows, accounts: accounts, viewer: "Kent", kind: .claude,
+            model: "pi/anthropic/claude-fable-5-1", accountId: nil
+        )
+        XCTAssertEqual(readout?.accountId, "mine")
+        XCTAssertEqual(readout?.scope, "Fable")
+        XCTAssertEqual(readout?.remaining, 55)
+    }
+
+    func testReadoutUsesAUsablePin() {
+        let accounts = [
+            pooled("pool", "Pool", usage: claudeUsage(week: 80)),
+            pooled("mine", "Mine", owner: "Kent", usage: claudeUsage(week: 20)),
+        ]
+        let rows = WeeklyRemaining.rows(accounts, viewer: "Kent", now: now)
+        let readout = WeeklyRemaining.readout(
+            rows: rows, accounts: accounts, viewer: "Kent", kind: .claude,
+            model: "claude-sonnet-5", accountId: "pool"
+        )
+        XCTAssertEqual(readout?.accountId, "pool")
+    }
+
+    func testReadoutFallsBackToThePoolWhenYourModelCapIsSpent() {
+        let accounts = [
+            pooled("pool", "Pool", usage: claudeUsage(week: 10, fable: 40)),
+            pooled("mine", "Mine", owner: "Kent", usage: claudeUsage(week: 10, fable: 100)),
+        ]
+        let rows = WeeklyRemaining.rows(accounts, viewer: "Kent", now: now)
+        let readout = WeeklyRemaining.readout(
+            rows: rows, accounts: accounts, viewer: "Kent", kind: .claude,
+            model: "claude-fable-5-1", accountId: nil
+        )
+        XCTAssertEqual(readout?.accountId, "pool")
+        XCTAssertEqual(readout?.remaining, 60)
+    }
+
+    /// The catalog says which pool a model spends from; ids it does not list
+    /// follow the server's prefix rules, and a preset follows its lead model.
+    func testProviderForModel() throws {
+        let data = Data("""
+        {"models":[
+          {"id":"pi/anthropic/claude-fable-5-1","accountProvider":"claude"},
+          {"id":"pi/dial/opus-fable","group":"dial","composition":["pi/anthropic/claude-opus-5"]}
+        ],"default":"pi/anthropic/claude-fable-5-1"}
+        """.utf8)
+        let catalog = try JSONDecoder().decode(ModelCatalog.self, from: data)
+        XCTAssertEqual(WeeklyRemaining.provider(forModel: "pi/anthropic/claude-fable-5-1", catalog: catalog), .claude)
+        XCTAssertEqual(WeeklyRemaining.provider(forModel: "pi/dial/opus-fable", catalog: catalog), .claude)
+        XCTAssertEqual(WeeklyRemaining.provider(forModel: "pi/openai/gpt-5.6-sol", catalog: nil), .codex)
+        XCTAssertEqual(WeeklyRemaining.provider(forModel: "pi/xai-oauth/grok-5", catalog: nil), .xai)
+        XCTAssertNil(WeeklyRemaining.provider(forModel: "pi/google/gemini-4", catalog: nil))
+    }
+
+    func testMenuRowDetailReadsOwnershipDayAndRemaining() {
+        let row = WeeklyRemainingRow(
+            accountId: "a", kind: .claude, scope: "Fable", name: "Main", owner: "Kent",
+            remaining: 8, resetsAt: nil
+        )
+        XCTAssertEqual(ModelSettingsMenu.rowDetail(row, now: now), "Yours · 8% left · running out")
+        XCTAssertEqual(
+            ModelSettingsMenu.rowSpokenLabel(row, pinned: false, pinnable: false, now: now),
+            "Main · Fable, yours, 8 percent left, not for this model"
+        )
+    }
 }

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -375,4 +375,23 @@ final class ServerEventTests: XCTestCase {
             return XCTFail("malformed frames must decode to .ignored")
         }
     }
+
+    /// `/account` pins and clears broadcast the same frame; a cleared pin
+    /// arrives as an explicit null, which must read as "auto", not "ignored".
+    func testSubscriptionChanged() {
+        guard case .subscriptionChanged(let sessionId, let accountId) = parse(
+            #"{"type":"subscription_changed","sessionId":"bks-1","accountId":"acc-9","name":"Main","by":"Kent"}"#
+        ) else {
+            return XCTFail("expected .subscriptionChanged")
+        }
+        XCTAssertEqual(sessionId, "bks-1")
+        XCTAssertEqual(accountId, "acc-9")
+
+        guard case .subscriptionChanged(_, let cleared) = parse(
+            #"{"type":"subscription_changed","sessionId":"bks-1","accountId":null,"name":null,"by":"Kent"}"#
+        ) else {
+            return XCTFail("expected .subscriptionChanged")
+        }
+        XCTAssertNil(cleared)
+    }
 }

--- a/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
@@ -37,6 +37,54 @@ final class SessionViewModelTests: XCTestCase {
         XCTAssertEqual(SessionViewModel.handoffReconnectDelay, .milliseconds(250))
     }
 
+    /// Pinning an account rides the `/account` slash command, the same
+    /// contract the web composer uses; the server validates the pool and
+    /// broadcasts the result back.
+    func testPinningAnAccountSendsTheAccountCommand() {
+        let socket = MockSocket()
+        let viewModel = SessionViewModel(
+            session: Session(id: "bks-1"),
+            socketFactory: { socket }
+        )
+        viewModel.start(owner: UUID())
+        viewModel.fastMode = true
+
+        var apiKey = ProviderAccount()
+        apiKey.id = "acc-1"
+        apiKey.kind = "api_key"
+        viewModel.pinAccount(apiKey)
+        XCTAssertEqual(viewModel.accountId, "acc-1")
+        XCTAssertFalse(viewModel.fastMode, "an API key cannot carry fast mode")
+        XCTAssertEqual(socket.prompts.map(\.content), ["/account acc-1"])
+
+        viewModel.pinAccount(apiKey)
+        XCTAssertEqual(socket.prompts.count, 1, "re-pinning the same account is a no-op")
+
+        viewModel.pinAccount(nil)
+        XCTAssertEqual(viewModel.accountId, "")
+        XCTAssertEqual(socket.prompts.map(\.content), ["/account acc-1", "/account auto"])
+    }
+
+    /// The server's broadcast is the source of truth: another viewer's pin,
+    /// or the clear that comes with a provider switch, lands here.
+    func testSubscriptionChangedFollowsTheServer() {
+        var session = Session(id: "bks-1")
+        session.accountId = "acc-1"
+        let viewModel = SessionViewModel(session: session)
+        XCTAssertEqual(viewModel.accountId, "acc-1")
+
+        viewModel.handle(.subscriptionChanged(sessionId: "bks-1", accountId: "acc-2"))
+        XCTAssertEqual(viewModel.accountId, "acc-2")
+        XCTAssertEqual(viewModel.session.accountId, "acc-2")
+
+        viewModel.handle(.subscriptionChanged(sessionId: "bks-other", accountId: nil))
+        XCTAssertEqual(viewModel.accountId, "acc-2", "another session's frame is ignored")
+
+        viewModel.handle(.subscriptionChanged(sessionId: "bks-1", accountId: nil))
+        XCTAssertEqual(viewModel.accountId, "")
+        XCTAssertNil(viewModel.session.accountId)
+    }
+
     private func entry(
         _ id: String, _ type: String, text: String? = nil, toolUseId: String? = nil
     ) -> TranscriptEntry {

--- a/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionViewModelTests.swift
@@ -85,6 +85,27 @@ final class SessionViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.session.accountId)
     }
 
+    /// A teammate's `/model` across providers arrives as `model_changed` and
+    /// then `subscription_changed`. The menu decides which accounts can be
+    /// pinned from `model`, so it has to move with the first frame, not wait
+    /// for the next sessions poll.
+    func testModelChangedMovesTheLiveModelWithTheSnapshot() {
+        var session = Session(id: "bks-1")
+        session.model = "claude-fable-5-1"
+        session.accountId = "claude-acc"
+        let viewModel = SessionViewModel(session: session)
+        XCTAssertEqual(viewModel.model, "claude-fable-5-1")
+
+        viewModel.handle(.modelChanged(sessionId: "bks-other", model: "gpt-5", by: nil))
+        XCTAssertEqual(viewModel.model, "claude-fable-5-1", "another session's frame is ignored")
+
+        viewModel.handle(.modelChanged(sessionId: "bks-1", model: "gpt-5", by: "teammate"))
+        viewModel.handle(.subscriptionChanged(sessionId: "bks-1", accountId: nil))
+        XCTAssertEqual(viewModel.model, "gpt-5")
+        XCTAssertEqual(viewModel.session.model, "gpt-5")
+        XCTAssertEqual(viewModel.accountId, "")
+    }
+
     private func entry(
         _ id: String, _ type: String, text: String? = nil, toolUseId: String? = nil
     ) -> TranscriptEntry {

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -137,7 +137,12 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   above the composer when the keyboard opens. The actions menu carries
   worktree details, the pull request panel, Add to sidebar when needed, rename,
   share, hide or restore, and archive, matching the sidebar row's long-press
-  menu. Completed native sessions can also fork from the current transcript tip
+  menu. The model settings menu (the toolbar's slider control on macOS, nested
+  in the actions menu on iOS) opens with a Weekly remaining row: what is left
+  on the account the current model will run on, over a breakdown of every
+  subscription account you can spend, yours first and then the shared pool,
+  each with its refill day. Choosing one for the current model's pool pins it
+  for the session through `/account`. Completed native sessions can also fork from the current transcript tip
   or a message menu; the composer names the source and opens the new session
   after creation. A bounded cache keeps
   recently visited conversations loaded while their


### PR DESCRIPTION
Brings the native (iOS + macOS SwiftUI) session model menu up to the web's weekly-account view (403d93c3 through eea5326f).

## What changes

- **Weekly remaining row** in `ModelSettingsMenu`: reads out what is left on the account the current model will run on (a usable pin, else your personal subscription, else the shared pool; a Claude model with its own weekly bucket reads that bucket). Gauge symbol empties as the budget runs low.
- **Account breakdown** submenu: one line per weekly limit of every account you can spend, yours first then the shared pool, with owner mark, refill weekday, percent left and a "running out" note. Each row carries a full VoiceOver label (account, yours/shared, percent, exact reset time, pin state / "not for this model").
- **Pin for this session**: a row for the current model's pool sends `/account <id>`; Auto sends `/account auto`. The view model follows the server's `subscription_changed` broadcast, so teammates' pins and the clear on a provider switch land natively. Reset to default also clears the pin.
- **Derivation** in `AccountUsage.swift` (`WeeklyRemaining`), reusing `AccountUsage`/`ProviderAccount` as decoded today and the existing `liveUtilization` reading rule; catalog decodes `accountProvider` and preset `composition`. Tests mirror `lib/account-limits.test.ts`.
- `OS1_USER` names the viewer for a dev launch so a capture can read as a particular teammate.

## Verification

- `OS1` and `OS1Mac` schemes build (tella-mac-node, Xcode 26.6).
- Focused tests (`AccountUsageTests`, `ServerEventTests`, `SessionViewModelTests`, `ModelCatalogTests`): 119 passed. Full `OS1Tests` bundle: 991 passed, 0 failures. Both runs were hosted in the iOS simulator: the node's macOS `testmanagerd` was down for every session all morning (`Failed to establish communication with the test runner`), so the macOS-hosted suite could not run there today; CI runs it on push.
- `bun run check` passes.
- Simulator screenshots (iPhone 17 Pro, viewer Michiel) with personal and shared budgets are in the session walkthrough (`output/weekly/final-top.png`, `output/weekly/final-scrolled.png`).

Not exercised live: the session used for the capture belongs to a teammate, so the `/account` round trip is covered by the view-model tests rather than a live tap.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-9526233c-47d0-7be4-85b6-f6f0443c659c)