### PR TITLE
Prefer Astra before Sol in the automatic fallback chain

### DIFF
--- a/packages/core/opensession-server/src/server/fake-engine.test.ts
+++ b/packages/core/opensession-server/src/server/fake-engine.test.ts
@@ -118,7 +118,7 @@ describe("fake engine through runAgent", () => {
     // turn. The switch is a timeline event, never assistant text. The walk
     // prefers the strongest AUTO candidate over the
     // configured preference when that preference ranks lower in the tier
-    // graph — sonnet's best auto hop today is gpt-5.6-sol (cross-family).
+    // graph — sonnet's best auto hop today is gpt-6-astra (cross-family).
     expect(types(events)).toEqual([
       "init",
       "model_switch",
@@ -130,10 +130,10 @@ describe("fake engine through runAgent", () => {
     // fromModel is the picker-form id (resolveConcreteModel keeps native ids
     // native); toModel is the pi-mapped hop target.
     expect(sw.fromModel).toBe("claude-sonnet-5");
-    expect(sw.toModel).toBe("pi/openai/gpt-5.6-sol");
+    expect(sw.toModel).toBe("pi/openai/gpt-6-astra");
     expect(sw.switchReason).toBe("out of credits");
     expect(fake.calls).toHaveLength(2);
-    expect(fake.calls[1].model).toBe("pi/openai/gpt-5.6-sol");
+    expect(fake.calls[1].model).toBe("pi/openai/gpt-6-astra");
     // A direct runAgent caller may have no early transcript row to name.
     // runAgent assigns one stable id to the logical turn so both model attempts
     // upsert the same user entry instead of rendering the prompt twice.
@@ -196,11 +196,11 @@ describe("fake engine through runAgent", () => {
     expect(events[1]).toMatchObject({
       type: "model_switch",
       fromModel: "pi/anthropic/claude-fable-5-1",
-      toModel: "pi/openai/gpt-5.6-sol",
+      toModel: "pi/openai/gpt-6-astra",
     });
     expect(fake.calls).toHaveLength(2);
     expect(fake.calls[0].model).toBe("pi/anthropic/claude-fable-5-1");
-    expect(fake.calls[1].model).toBe("pi/openai/gpt-5.6-sol");
+    expect(fake.calls[1].model).toBe("pi/openai/gpt-6-astra");
     expect(fake.calls[1].sessionId).toBeUndefined();
   });
 
@@ -229,14 +229,14 @@ describe("fake engine through runAgent", () => {
       "done",
     ]);
     expect(fake.calls).toHaveLength(1);
-    expect(fake.calls[0].model).toBe("pi/openai/gpt-5.6-sol");
+    expect(fake.calls[0].model).toBe("pi/openai/gpt-6-astra");
     // No source engine started, so there is no interrupted work to explain and
     // the fallback receives exactly the person's original prompt.
     expect(fake.calls[0].prompt).toBe("keep going");
     expect(events[0]).toMatchObject({
       type: "model_switch",
       fromModel: "claude-sonnet-5",
-      toModel: "pi/openai/gpt-5.6-sol",
+      toModel: "pi/openai/gpt-6-astra",
     });
   });
 
@@ -320,7 +320,7 @@ describe("fake engine through runAgent", () => {
     expect(events.find((event) => event.type === "model_switch")).toMatchObject(
       {
         fromModel: "claude-sonnet-5",
-        toModel: "pi/openai/gpt-5.6-sol",
+        toModel: "pi/openai/gpt-6-astra",
         temporaryFallback: true,
       },
     );
@@ -384,7 +384,7 @@ describe("fake engine through runAgent", () => {
     release();
     const events = await collecting;
 
-    expect(run?.model).toBe("pi/anthropic/claude-opus-5");
+    expect(run?.model).toBe("pi/openai/gpt-6-astra");
     expect(run?.selectedModel).toBe("dial/medium");
     expect(run?.transientFallback).toBe(true);
     const switchEvent = events.find((event) => event.type === "model_switch");

--- a/packages/core/opensession-server/src/server/models.test.ts
+++ b/packages/core/opensession-server/src/server/models.test.ts
@@ -174,6 +174,41 @@ describe("Pi-only model routing", () => {
     ).toSatisfy((hops) => hops.every((hop) => hop.id.startsWith("pi/")));
   });
 
+  test("falls back from Fable to Astra before configured Sol or Opus", () => {
+    for (const primary of [
+      "claude-fable-5-1",
+      "pi/anthropic/claude-fable-5-1",
+    ]) {
+      for (const preferred of ["pi/openai/gpt-5.6-sol", "claude-opus-5"]) {
+        expect(nextFallbackModel(primary, new Set(), preferred)).toEqual({
+          id: "pi/openai/gpt-6-astra",
+          mode: "auto",
+        });
+        expect(fallbackPlan(primary, preferred).slice(0, 2)).toEqual([
+          { id: "pi/openai/gpt-6-astra", mode: "auto" },
+          { id: "pi/openai/gpt-5.6-sol", mode: "auto" },
+        ]);
+      }
+    }
+  });
+
+  test("keeps Sol available when Astra is exhausted", () => {
+    expect(
+      nextFallbackModel(
+        "pi/anthropic/claude-fable-5-1",
+        new Set(["pi/openai/gpt-6-astra"]),
+        "claude-opus-5",
+      ),
+    ).toEqual({ id: "pi/openai/gpt-5.6-sol", mode: "auto" });
+  });
+
+  test("keeps automatic fallback disabled when requested", () => {
+    expect(fallbackPlan("pi/anthropic/claude-fable-5-1", "none")).toEqual([]);
+    expect(fallbackPlan("pi/anthropic/claude-fable-5-1", undefined)).toEqual(
+      [],
+    );
+  });
+
   test("crosses exhausted Haiku sessions to OpenAI", () => {
     expect(automaticFallbackModel("claude-haiku-4-5")).toBe(
       "pi/openai/gpt-5.6-luna",

--- a/packages/core/opensession-server/src/server/models.ts
+++ b/packages/core/opensession-server/src/server/models.ts
@@ -822,7 +822,7 @@ const CODEX_MODEL_ORDER = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
  * ranking — it encodes the configured rotation policy: keep a run going on
  * an equal-or-smarter model automatically, but ASK a human before dropping to a
  * dumber one. "smart→smart / medium→smart = fine (auto); smart→dumb /
- * medium→dumb = ask." Concrete edges that policy yields: Fable→Sol auto,
+ * medium→dumb = ask." Concrete edges that policy yields: Fable→Astra auto,
  * Fable→Opus auto, Opus→Sol auto, and Opus→Sonnet ask.
  *
  * Unlisted models default to tier 1 (treated as a downgrade from any premium
@@ -855,6 +855,7 @@ const FALLBACK_TIER: Record<string, number> = {
  * of, so routing another exhausted model back into it would just re-hit the cap.
  */
 const FALLBACK_DESTINATIONS = [
+  "gpt-6-astra",
   "gpt-5.6-sol",
   // Prefer Opus before the cheaper 5.6 siblings once Sol is unavailable.
   "claude-opus-5",
@@ -1270,8 +1271,8 @@ export interface FallbackHop {
  * we keep the strongest usable model. Returns null when nothing is left.
  *
  * `mode` is the tier comparison against the model we're LEAVING: equal-or-higher
- * tier ⇒ "auto" (Fable→Sol, Opus→Sol), lower ⇒ "ask" (Fable→Opus, Opus→Sonnet,
- * Sol→Opus). Fallbacks preserve an explicit Pi engine choice; legacy and
+ * tier ⇒ "auto" (Fable→Astra, Astra→Sol), lower ⇒ "ask" (Opus→Sonnet).
+ * Fallbacks preserve an explicit Pi engine choice; legacy and
  * unrouted primaries keep mapping onto Pi.
  */
 export function nextFallbackModel(
@@ -1307,7 +1308,7 @@ export function nextFallbackModel(
 
   // Auto-eligible models stay ahead of downgrades. Within a tier, use the
   // explicit destination order rather than candidate insertion order: the
-  // configured Opus fallback is added first above, but Sol must remain the
+  // configured Opus fallback is added first above, but Astra must remain the
   // first hop off Fable.
   candidates.sort((a, b) => {
     const aDown = fallbackTier(a) >= currentTier ? 0 : 1;

--- a/packages/core/opensession-server/src/server/zz-fake-run.test.ts
+++ b/packages/core/opensession-server/src/server/zz-fake-run.test.ts
@@ -304,10 +304,10 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
     const data = sessionJson(sid);
     expect(fake.calls.map((call) => call.model)).toEqual([
       "pi/openai/gpt-5.6-sol",
-      "pi/anthropic/claude-opus-5",
+      "pi/openai/gpt-6-astra",
     ]);
     expect(data.model).toBe("dial/medium");
-    expect(data.lastEngineModel).toBe("pi/anthropic/claude-opus-5");
+    expect(data.lastEngineModel).toBe("pi/openai/gpt-6-astra");
     expect(data.modelHistory).toBeUndefined();
   });
 
@@ -330,7 +330,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 
     const data = sessionJson(sid);
     expect(data.model).toBe("gpt-5.6-sol");
-    expect(data.lastEngineModel).toBe("pi/anthropic/claude-opus-5");
+    expect(data.lastEngineModel).toBe("pi/openai/gpt-6-astra");
     expect(data.modelHistory).toBeUndefined();
   });
 
@@ -352,7 +352,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
     await runSession.runSessionPromptAndDrain(sid, "keep going", "Test");
 
     const data = sessionJson(sid);
-    expect(data.model).toBe("pi/anthropic/claude-opus-5");
+    expect(data.model).toBe("pi/openai/gpt-6-astra");
     expect(data.modelHistory).toHaveLength(1);
     expect(data.modelHistory[0].by).toContain("out of credits");
   });
@@ -471,7 +471,7 @@ describe("fake-engine session runs (consumer loop end-to-end)", () => {
 
     const data = sessionJson(sid);
     expect(data.model).toBe("dial/medium");
-    expect(data.lastEngineModel).toBe("pi/openai/gpt-5.6-terra");
+    expect(data.lastEngineModel).toBe("pi/anthropic/claude-opus-5");
     expect(data.modelHistory).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Prefer GPT-6 Astra when Fable runs out of credits, with Sol retained as the next fallback.
- Apply this ordering to the shared automatic fallback chain.
- Cover configured Sol/Opus preferences, exhausted Astra, disabled fallback, and runner/session recovery.

## Verification
- `bun run check` passed.

The session PR tool targets the shared `main` branch and could not open this feature-branch PR, so it was opened through the repository bot instead.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a086ec-b1c6-7be0-97a3-b55861aac86b)
