### PR TITLE
Forgive typos in native search, the Mac palette, and @ people

### DIFF
--- a/packages/clients/ios/OS1/Models/CommandPalette.swift
+++ b/packages/clients/ios/OS1/Models/CommandPalette.swift
@@ -36,11 +36,13 @@ struct CommandPaletteEntry: Identifiable, Equatable, Sendable {
 
 /// Which rows a query keeps, and in what order.
 ///
-/// Deliberately not a fuzzy subsequence matcher: on a list where most rows are
-/// sessions with long, similar titles, subsequence matching turns every query
-/// into a wall of near-misses. Every whitespace-separated token has to appear
-/// somewhere in the row, and where it appears is the score — the title's start
-/// beats a word inside it, which beats the subtitle or a keyword.
+/// Every whitespace-separated token has to land somewhere in the row, and
+/// where it lands is the score — the title's start beats a word inside it,
+/// which beats the subtitle or a keyword. A token that lands nowhere exactly
+/// may still land as a near miss (`FuzzyMatch`: a bounded edit distance or an
+/// in-word abbreviation), which ranks under every exact placement. It is not a
+/// free subsequence matcher: on a list where most rows are sessions with long,
+/// similar titles, that turns every query into a wall of near-misses.
 enum CommandPaletteRanking {
     /// A row with its searchable text folded once per call. Folding inside the
     /// comparator would redo it for every comparison.
@@ -49,7 +51,20 @@ enum CommandPaletteRanking {
         let order: Int
         let title: String
         let rest: String
+        let titleWords: [String]
+        let restWords: [String]
         var score = 0
+
+        init(entry: CommandPaletteEntry, order: Int) {
+            self.entry = entry
+            self.order = order
+            title = FuzzyMatch.fold(entry.title)
+            rest = FuzzyMatch.fold(
+                ([entry.subtitle].compactMap { $0 } + entry.keywords).joined(separator: " ")
+            )
+            titleWords = FuzzyMatch.words(of: title)
+            restWords = FuzzyMatch.words(of: rest)
+        }
     }
 
     static func results(
@@ -58,18 +73,10 @@ enum CommandPaletteRanking {
         sessionLimit: Int = 40,
         contentMatches: Set<String> = []
     ) -> [CommandPaletteEntry] {
-        let tokens = fold(query).split(separator: " ").map(String.init)
+        let tokens = FuzzyMatch.fold(query).split(separator: " ").map(String.init)
         var matched: [Candidate] = []
         for (order, entry) in entries.enumerated() {
-            var candidate = Candidate(
-                entry: entry,
-                order: order,
-                title: fold(entry.title),
-                rest: fold(
-                    ([entry.subtitle].compactMap { $0 } + entry.keywords)
-                        .joined(separator: " ")
-                )
-            )
+            var candidate = Candidate(entry: entry, order: order)
             var total = 0
             var matchedEveryToken = true
             for token in tokens {
@@ -112,12 +119,20 @@ enum CommandPaletteRanking {
         }
     }
 
+    /// Exact placements score in hundreds; a near miss scores its
+    /// `FuzzyMatch.nearMiss` (20 to 50), lifted by 25 when it is in the title.
+    /// Everything stays at least one, so a transcript-only hit's zero still
+    /// sorts last.
     private static func score(_ token: String, in candidate: Candidate) -> Int? {
-        if candidate.title.hasPrefix(token) { return 4 }
+        if candidate.title.hasPrefix(token) { return 400 }
         if let range = candidate.title.range(of: token) {
-            return startsWord(candidate.title, at: range.lowerBound) ? 3 : 2
+            return startsWord(candidate.title, at: range.lowerBound) ? 300 : 200
         }
-        if candidate.rest.contains(token) { return 1 }
+        if candidate.rest.contains(token) { return 100 }
+        let inTitle = FuzzyMatch.nearMiss(token, in: candidate.titleWords)
+        if inTitle > 0 { return inTitle + 25 }
+        let inRest = FuzzyMatch.nearMiss(token, in: candidate.restWords)
+        if inRest > 0 { return inRest }
         return nil
     }
 
@@ -125,15 +140,6 @@ enum CommandPaletteRanking {
         guard index > text.startIndex else { return true }
         let before = text[text.index(before: index)]
         return !before.isLetter && !before.isNumber
-    }
-
-    /// Lowercased, accent-insensitive, and with runs of whitespace collapsed,
-    /// so "Café  Deploy" and "cafe deploy" are the same haystack.
-    private static func fold(_ text: String) -> String {
-        text
-            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
-            .split(whereSeparator: \.isWhitespace)
-            .joined(separator: " ")
     }
 }
 

--- a/packages/clients/ios/OS1/Models/FuzzyMatch.swift
+++ b/packages/clients/ios/OS1/Models/FuzzyMatch.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Typo-tolerant matching for the small search surfaces: the sidebar search,
+/// the Mac command palette, and the composer's "@" people list. The same rules
+/// as the web client's `shared/fuzzy-match.ts`, so a query finds the same row
+/// whichever client it is typed in.
+///
+/// Scores run from 0 (no match) to 100 (exact). Every whitespace-separated term
+/// must land somewhere in the text: as a substring, as a word within a small
+/// edit distance (a transposition counts as one edit), or as a subsequence of
+/// one word ("wksp" for "workspace"). Case and accents are ignored. Short terms
+/// get no edit budget, so "cat" never finds "cut".
+enum FuzzyMatch {
+    /// Score `text` against `query`. 0 means no match; higher is better. An
+    /// empty query matches everything at 1.
+    static func score(_ query: String, in text: String) -> Int {
+        let q = fold(query)
+        if q.isEmpty { return 1 }
+        let t = fold(text)
+        if t.isEmpty { return 0 }
+        if t == q { return 100 }
+        if t.hasPrefix(q) { return 90 }
+        let words = words(of: t)
+        if words.contains(where: { $0.hasPrefix(q) }) { return 80 }
+        if t.contains(q) { return 70 }
+        let terms = q.split(separator: " ").map(String.init)
+        var total = 0
+        for term in terms {
+            let score = termScore(term, in: t, words: words)
+            if score == 0 { return 0 }
+            total += score
+        }
+        return Int((Double(total) / Double(terms.count)).rounded())
+    }
+
+    /// The best score across several fields of one item. 0 means no match.
+    static func best(_ query: String, in values: [String?]) -> Int {
+        var best = 0
+        for case let value? in values where !value.isEmpty {
+            best = max(best, score(query, in: value))
+            if best == 100 { break }
+        }
+        return best
+    }
+
+    /// Lowercased, accent-insensitive, trimmed, with runs of whitespace
+    /// collapsed to one space, so "Café  Deploy" and "cafe deploy" are the
+    /// same haystack.
+    static func fold(_ text: String) -> String {
+        text
+            .folding(options: [.diacriticInsensitive, .caseInsensitive, .widthInsensitive], locale: nil)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    /// The letter-and-digit runs of an already folded text.
+    static func words(of folded: String) -> [String] {
+        folded
+            .split { !$0.isLetter && !$0.isNumber }
+            .map(String.init)
+    }
+
+    /// How close one term comes to a word without being inside it: 50 minus 10
+    /// per edit while within the term's budget, 20 for an in-word abbreviation,
+    /// 0 for neither. Callers that rank an exact placement (a title prefix, a
+    /// keyword) above a near miss check for the substring themselves first.
+    static func nearMiss(_ term: String, in words: [String]) -> Int {
+        let budget = editBudget(term)
+        if budget > 0 {
+            let termChars = Array(term)
+            var best = budget + 1
+            for word in words {
+                if word.count < term.count - budget { continue }
+                let wordChars = Array(word)
+                // Compare against the whole word and its prefix of the term's
+                // length, so "wrokspace" and "relase" both land on their word.
+                let distance = min(
+                    editDistance(termChars, wordChars, max: budget),
+                    editDistance(termChars, Array(wordChars.prefix(termChars.count)), max: budget)
+                )
+                best = min(best, distance)
+                if best == 0 { break }
+            }
+            if best <= budget { return 50 - best * 10 }
+        }
+        if term.count >= 3, words.contains(where: { isSubsequence(term, of: $0) }) {
+            return 20
+        }
+        return 0
+    }
+
+    private static func termScore(_ term: String, in text: String, words: [String]) -> Int {
+        if text.contains(term) { return 60 }
+        return nearMiss(term, in: words)
+    }
+
+    /// Edits a term may absorb: none for short ones, one up to seven letters,
+    /// two beyond.
+    private static func editBudget(_ term: String) -> Int {
+        if term.count < 4 { return 0 }
+        if term.count < 8 { return 1 }
+        return 2
+    }
+
+    /// Optimal string alignment distance, capped at `max + 1`.
+    private static func editDistance(_ a: [Character], _ b: [Character], max: Int) -> Int {
+        if abs(a.count - b.count) > max { return max + 1 }
+        guard !a.isEmpty, !b.isEmpty else { return Swift.max(a.count, b.count) }
+        var prev2: [Int] = []
+        var prev = Array(0...b.count)
+        for i in 1...a.count {
+            var row = [i]
+            row.reserveCapacity(b.count + 1)
+            var rowMin = i
+            for j in 1...b.count {
+                let cost = a[i - 1] == b[j - 1] ? 0 : 1
+                var d = Swift.min(prev[j] + 1, row[j - 1] + 1, prev[j - 1] + cost)
+                if i > 1, j > 1, a[i - 1] == b[j - 2], a[i - 2] == b[j - 1], prev2[j - 2] + 1 < d {
+                    d = prev2[j - 2] + 1
+                }
+                row.append(d)
+                rowMin = Swift.min(rowMin, d)
+            }
+            if rowMin > max { return max + 1 }
+            prev2 = prev
+            prev = row
+        }
+        return prev[b.count]
+    }
+
+    private static func isSubsequence(_ term: String, of word: String) -> Bool {
+        var remaining = term[...]
+        for character in word {
+            guard let next = remaining.first else { return true }
+            if character == next { remaining = remaining.dropFirst() }
+        }
+        return remaining.isEmpty
+    }
+}

--- a/packages/clients/ios/OS1/SidebarSearch.swift
+++ b/packages/clients/ios/OS1/SidebarSearch.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// What the sidebar's search field matches a row on, shared by the live list
+/// and the archived results under it. The transcript hits the server returns
+/// are the caller's fallback for rows this rule does not admit.
+enum SidebarSearch {
+    /// Whether a session's metadata answers the query. The title, repository,
+    /// branch and workspace name forgive a typo; the id is pasted, not typed,
+    /// so it only matches as written.
+    static func matches(_ session: Session, workspaceName: String?, query: String) -> Bool {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if query.isEmpty { return true }
+        if FuzzyMatch.best(
+            query,
+            in: [session.title, session.effectiveRepo, session.branch, workspaceName]
+        ) > 0 {
+            return true
+        }
+        return session.id.range(of: query, options: .caseInsensitive) != nil
+    }
+
+    /// A workspace row answers through its own name or any session in it.
+    static func matches(
+        _ workspace: SidebarWorkspace,
+        workspaceNames: [String: String],
+        query: String
+    ) -> Bool {
+        FuzzyMatch.score(query, in: workspace.title) > 0
+            || workspace.sessions.contains {
+                matches($0, workspaceName: name(of: $0, in: workspaceNames), query: query)
+            }
+    }
+
+    /// The name a session's workspace goes by: the names map when it has
+    /// loaded, else the name the session itself carries.
+    static func name(of session: Session, in workspaceNames: [String: String]) -> String? {
+        session.workspaceId.flatMap { workspaceNames[$0] } ?? session.workspaceName
+    }
+}

--- a/packages/clients/ios/OS1/Views/CommandPaletteView.swift
+++ b/packages/clients/ios/OS1/Views/CommandPaletteView.swift
@@ -144,7 +144,16 @@ struct CommandPaletteView: View {
         .frame(width: 620, height: 460)
         .background(OS1VisualStyle.background)
         .onChange(of: items.map(\.id), initial: true) { model.items = items }
-        .onAppear { installKeyMonitor() }
+        .onAppear {
+            installKeyMonitor()
+            #if DEBUG
+            // Screenshot hook, paired with the host's OS1_COMMAND_PALETTE_QUERY
+            // that opens the sheet.
+            if let query = ProcessInfo.processInfo.environment["OS1_COMMAND_PALETTE_QUERY"] {
+                model.query = query
+            }
+            #endif
+        }
         .onDisappear { removeKeyMonitor() }
         .task(id: model.query) { await model.updateTranscriptSearch() }
         .task {

--- a/packages/clients/ios/OS1/Views/ComposerMentionPalette.swift
+++ b/packages/clients/ios/OS1/Views/ComposerMentionPalette.swift
@@ -173,28 +173,21 @@ struct ComposerMentionPalette: View {
     }
 
     private func people(matching query: String) -> [FileMention] {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let current = ServerConfig.shared.userName.lowercased()
-        return TeamDirectory.shared.names
-            .filter { name in
-                normalized.isEmpty
-                    || name.lowercased().contains(normalized)
-                    || TeamDirectory.shared.fullName(for: name).lowercased().contains(normalized)
-            }
-            .sorted { left, right in
-                let leftIsCurrent = left.lowercased() == current
-                let rightIsCurrent = right.lowercased() == current
-                if leftIsCurrent != rightIsCurrent { return leftIsCurrent }
-                return false
-            }
-            .map { name in
-                FileMention(
-                    display: name,
-                    insert: name,
-                    kind: "person",
-                    sub: TeamDirectory.shared.fullName(for: name)
-                )
-            }
+        let directory = TeamDirectory.shared
+        return PeopleMentionRanking.names(
+            directory.names,
+            query: query,
+            fullName: directory.fullName(for:),
+            current: ServerConfig.shared.userName
+        )
+        .map { name in
+            FileMention(
+                display: name,
+                insert: name,
+                kind: "person",
+                sub: directory.fullName(for: name)
+            )
+        }
     }
 
     private func merged(
@@ -251,5 +244,31 @@ struct ComposerMentionPalette: View {
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
+    }
+}
+
+/// Which teammates an "@" query offers, and in what order: you first, then
+/// the closest match, then the directory's own order. A typo in a name or
+/// full name is forgiven the way the web palette forgives it (`FuzzyMatch`).
+enum PeopleMentionRanking {
+    static func names(
+        _ names: [String],
+        query: String,
+        fullName: (String) -> String,
+        current: String
+    ) -> [String] {
+        let current = current.lowercased()
+        return names
+            .compactMap { name -> (name: String, score: Int)? in
+                let score = FuzzyMatch.best(query, in: [name, fullName(name)])
+                return score > 0 ? (name, score) : nil
+            }
+            .sorted { left, right in
+                let leftIsCurrent = left.name.lowercased() == current
+                let rightIsCurrent = right.name.lowercased() == current
+                if leftIsCurrent != rightIsCurrent { return leftIsCurrent }
+                return left.score > right.score
+            }
+            .map(\.name)
     }
 }

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -502,6 +502,13 @@ struct SessionsListView: View {
                     peopleFilterRaw = SidebarPersonLens.everyone
                     searchText = query
                 }
+                #if os(macOS)
+                // Screenshot hook: open the palette on a query. The rows fill
+                // in as sessions load; `CommandPaletteView` reads the query.
+                if ProcessInfo.processInfo.environment["OS1_COMMAND_PALETTE_QUERY"] != nil {
+                    showPalette = true
+                }
+                #endif
                 #endif
             }
             .onChange(of: quickCapture.request?.id) { openQuickCapture() }
@@ -1666,18 +1673,21 @@ struct SessionsListView: View {
         }
     }
 
+    /// Typo-tolerant, and a session answers to its workspace's name too, so
+    /// "relase" still finds the Release row. `SidebarSearch` holds the rule.
     private func sessionMatchesMetadata(_ session: Session, query: String) -> Bool {
-        [session.title, session.effectiveRepo, session.branch, session.id]
-            .compactMap { $0 }
-            .contains { $0.lowercased().contains(query) }
+        SidebarSearch.matches(
+            session,
+            workspaceName: SidebarSearch.name(of: session, in: viewModel.workspaceNames),
+            query: query
+        )
     }
 
     private func workspaceMatchesMetadata(
         _ workspace: SidebarWorkspace,
         query: String
     ) -> Bool {
-        workspace.title.lowercased().contains(query)
-            || workspace.sessions.contains { sessionMatchesMetadata($0, query: query) }
+        SidebarSearch.matches(workspace, workspaceNames: viewModel.workspaceNames, query: query)
     }
 
     /// Snippets explain only transcript-only hits. A metadata match already

--- a/packages/clients/ios/OS1Tests/CommandPaletteTests.swift
+++ b/packages/clients/ios/OS1Tests/CommandPaletteTests.swift
@@ -133,4 +133,42 @@ final class CommandPaletteTests: XCTestCase {
         let entries = [command("new", "New session"), session("a", "A conversation")]
         XCTAssertEqual(ids(entries, "zzzz"), [])
     }
+
+    func testATypoStillFindsTheRow() {
+        let entries = [
+            command("archived", "Archived sessions"),
+            session("release", "Release checklist", keywords: ["cut-release"])
+        ]
+        XCTAssertEqual(ids(entries, "relase"), ["release"])
+        XCTAssertEqual(ids(entries, "archvied"), ["archived"])
+        XCTAssertEqual(ids(entries, "chekclist"), ["release"])
+    }
+
+    func testAnAbbreviationFindsTheRowAShortTypoDoesNot() {
+        let entries = [command("desk", "Open the Desk"), session("cut", "Cut the timeline")]
+        XCTAssertEqual(ids(entries, "tmln"), ["cut"])
+        XCTAssertEqual(ids(entries, "cat"), [])
+    }
+
+    func testAnExactPlacementOutranksANearMiss() {
+        let entries = [
+            session("near", "Relase notes", minutesAgo: 1),
+            session("keyword", "Ship it", keywords: ["release"], minutesAgo: 2),
+            session("exact", "Release checklist", minutesAgo: 3)
+        ]
+        XCTAssertEqual(ids(entries, "release"), ["exact", "keyword", "near"])
+    }
+
+    func testANearMissStillOutranksATranscriptOnlyHit() {
+        let entries = [
+            session("content", "Unrelated recent session", minutesAgo: 1),
+            session("near", "Relase notes", minutesAgo: 20)
+        ]
+        let results = CommandPaletteRanking.results(
+            entries,
+            query: "release",
+            contentMatches: ["content"]
+        )
+        XCTAssertEqual(results.map(\.id), ["near", "content"])
+    }
 }

--- a/packages/clients/ios/OS1Tests/FuzzyMatchTests.swift
+++ b/packages/clients/ios/OS1Tests/FuzzyMatchTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OS1
+
+/// The same cases as the web client's `shared/fuzzy-match.test.ts`, so both
+/// clients answer a query the same way.
+final class FuzzyMatchTests: XCTestCase {
+    func testRanksExactPrefixWordPrefixThenSubstring() {
+        XCTAssertEqual(FuzzyMatch.score("release", in: "Release"), 100)
+        XCTAssertEqual(FuzzyMatch.score("rel", in: "Release work"), 90)
+        XCTAssertEqual(FuzzyMatch.score("work", in: "Release work"), 80)
+        XCTAssertEqual(FuzzyMatch.score("lease", in: "Release work"), 70)
+    }
+
+    func testForgivesATypoInLongerTerms() {
+        // A dropped letter.
+        XCTAssertGreaterThan(FuzzyMatch.score("relase", in: "Release work"), 0)
+        // A transposition costs one edit, not two.
+        XCTAssertGreaterThan(FuzzyMatch.score("wrokspace", in: "Workspace cleanup"), 0)
+        XCTAssertGreaterThan(FuzzyMatch.score("sidebra", in: "Fix the sidebar"), 0)
+        XCTAssertGreaterThan(FuzzyMatch.score("billng audit", in: "Billing audit"), 0)
+    }
+
+    func testKeepsShortTermsStrict() {
+        XCTAssertEqual(FuzzyMatch.score("cat", in: "cut"), 0)
+        XCTAssertEqual(FuzzyMatch.score("api", in: "apple"), 0)
+        XCTAssertEqual(FuzzyMatch.score("desk", in: "deploy"), 0)
+    }
+
+    func testMatchesAbbreviationsInsideOneWord() {
+        XCTAssertEqual(FuzzyMatch.score("wksp", in: "workspace"), 20)
+        // Not across words: letters have to come from one word.
+        XCTAssertEqual(FuzzyMatch.score("rlw", in: "release work"), 0)
+    }
+
+    func testNeedsEveryTermToLandSomewhere() {
+        XCTAssertEqual(FuzzyMatch.score("release billing", in: "Release work"), 0)
+        XCTAssertGreaterThan(FuzzyMatch.score("work release", in: "Release work"), 0)
+    }
+
+    func testIgnoresCaseAndAccentsAndAnEmptyQueryMatchesAll() {
+        XCTAssertEqual(FuzzyMatch.score("jaap", in: "Jääp"), 100)
+        XCTAssertEqual(FuzzyMatch.score("CAFE", in: "Café deploy"), 90)
+        XCTAssertEqual(FuzzyMatch.score("", in: "anything"), 1)
+        XCTAssertEqual(FuzzyMatch.score("   ", in: "anything"), 1)
+        XCTAssertEqual(FuzzyMatch.score("x", in: ""), 0)
+    }
+
+    func testBestTakesTheStrongestField() {
+        XCTAssertEqual(FuzzyMatch.best("audit", in: [nil, "Billing", "audit/billing"]), 90)
+        XCTAssertEqual(FuzzyMatch.best("nothing", in: ["a", nil]), 0)
+    }
+
+    func testNearMissScoresEditsThenAbbreviations() {
+        let words = FuzzyMatch.words(of: "release work")
+        XCTAssertEqual(FuzzyMatch.nearMiss("relase", in: words), 40)
+        XCTAssertEqual(FuzzyMatch.nearMiss("rls", in: words), 20)
+        XCTAssertEqual(FuzzyMatch.nearMiss("cat", in: words), 0)
+    }
+}

--- a/packages/clients/ios/OS1Tests/PeopleMentionRankingTests.swift
+++ b/packages/clients/ios/OS1Tests/PeopleMentionRankingTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import OS1
+
+final class PeopleMentionRankingTests: XCTestCase {
+    private let roster = ["Michiel", "Kent", "Johnny", "Jaap"]
+    private let fullNames = [
+        "Michiel": "Michiel Vos", "Kent": "Kent de Bruin", "Johnny": "Johnny Vuong", "Jaap": "Jääp Kok"
+    ]
+
+    private func names(_ query: String, current: String = "") -> [String] {
+        PeopleMentionRanking.names(
+            roster,
+            query: query,
+            fullName: { fullNames[$0] ?? "" },
+            current: current
+        )
+    }
+
+    func testAnEmptyQueryKeepsTheDirectoryOrderWithYouFirst() {
+        XCTAssertEqual(names(""), roster)
+        XCTAssertEqual(names("", current: "kent"), ["Kent", "Michiel", "Johnny", "Jaap"])
+    }
+
+    func testAPrefixOrAFullNameFindsAPerson() {
+        XCTAssertEqual(names("ke"), ["Kent"])
+        XCTAssertEqual(names("bruin"), ["Kent"])
+    }
+
+    func testATypoStillFindsAPerson() {
+        XCTAssertEqual(names("michel"), ["Michiel"])
+        XCTAssertEqual(names("jhonny"), ["Johnny"])
+    }
+
+    func testACloserMatchRanksFirstButYouStayOnTop() {
+        let roster = ["Jon", "Johnny", "John"]
+        let ranked = PeopleMentionRanking.names(
+            roster, query: "john", fullName: { _ in "" }, current: ""
+        )
+        XCTAssertEqual(ranked, ["John", "Johnny", "Jon"])
+        let mine = PeopleMentionRanking.names(
+            roster, query: "john", fullName: { _ in "" }, current: "jon"
+        )
+        XCTAssertEqual(mine, ["Jon", "John", "Johnny"])
+    }
+
+    func testAccentsDoNotMatterAndShortTermsStayStrict() {
+        XCTAssertEqual(names("jaap"), ["Jaap"])
+        XCTAssertEqual(names("kan"), [])
+    }
+}

--- a/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
+++ b/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OS1
+
+final class SidebarSearchTests: XCTestCase {
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    func testATypoStillFindsTheSession() throws {
+        let release = try session(#"{"id":"os-1","title":"Release checklist","branch":"cut-release"}"#)
+        XCTAssertTrue(SidebarSearch.matches(release, workspaceName: nil, query: "relase"))
+        XCTAssertTrue(SidebarSearch.matches(release, workspaceName: nil, query: "checklsit"))
+        XCTAssertTrue(SidebarSearch.matches(release, workspaceName: nil, query: "RELEASE"))
+        XCTAssertFalse(SidebarSearch.matches(release, workspaceName: nil, query: "billing"))
+    }
+
+    func testAShortTermStaysExact() throws {
+        let cut = try session(#"{"id":"os-1","title":"Cut the timeline"}"#)
+        XCTAssertFalse(SidebarSearch.matches(cut, workspaceName: nil, query: "cat"))
+        XCTAssertTrue(SidebarSearch.matches(cut, workspaceName: nil, query: "cut"))
+    }
+
+    func testTheWorkspaceNameCountsForItsSessions() throws {
+        let tab = try session(#"{"id":"os-1","title":"Fix the flaky test","workspaceId":"ws-1"}"#)
+        XCTAssertTrue(SidebarSearch.matches(tab, workspaceName: "Billing audit", query: "billing"))
+        XCTAssertTrue(SidebarSearch.matches(tab, workspaceName: "Billing audit", query: "billng"))
+        XCTAssertFalse(SidebarSearch.matches(tab, workspaceName: nil, query: "billing"))
+    }
+
+    func testTheNameTheSessionCarriesStandsInForTheMap() throws {
+        let tab = try session(
+            #"{"id":"os-1","title":"Fix","workspaceId":"ws-1","workspaceName":"Billing audit"}"#
+        )
+        XCTAssertEqual(SidebarSearch.name(of: tab, in: [:]), "Billing audit")
+        XCTAssertEqual(SidebarSearch.name(of: tab, in: ["ws-1": "Renamed"]), "Renamed")
+    }
+
+    func testAnIdMatchesOnlyAsWritten() throws {
+        let row = try session(#"{"id":"os-01a08a1d-e2c0","title":"Daily review"}"#)
+        XCTAssertTrue(SidebarSearch.matches(row, workspaceName: nil, query: "01a08a1d"))
+        XCTAssertFalse(SidebarSearch.matches(row, workspaceName: nil, query: "01a08a1x"))
+    }
+
+    func testAnEmptyQueryMatchesEverything() throws {
+        let row = try session(#"{"id":"os-1"}"#)
+        XCTAssertTrue(SidebarSearch.matches(row, workspaceName: nil, query: ""))
+        XCTAssertTrue(SidebarSearch.matches(row, workspaceName: nil, query: "  "))
+    }
+
+    func testAWorkspaceRowAnswersThroughItsTitleOrAnySession() throws {
+        let main = try session(#"{"id":"os-1","title":"Wire the toggle","workspaceId":"ws-1"}"#)
+        let sibling = try session(#"{"id":"os-2","title":"Write the docs","workspaceId":"ws-1"}"#)
+        let row = SidebarWorkspace(
+            id: "workspace:ws-1",
+            title: "Release checklist",
+            sessions: [main, sibling],
+            mainSession: main
+        )
+        XCTAssertTrue(SidebarSearch.matches(row, workspaceNames: [:], query: "relase"))
+        XCTAssertTrue(SidebarSearch.matches(row, workspaceNames: [:], query: "dosc"))
+        XCTAssertFalse(SidebarSearch.matches(row, workspaceNames: [:], query: "billing"))
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -18,8 +18,12 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   sharing `/api/snoozes` with the web sidebar. Activity restores Needs action,
   Recent, Yesterday, and Earlier; Status remains the dynamic lane view. Group
   by project is an independent switch for all three modes. The
-  compact toolbar search/filter finds session metadata
-  and conversation text through `/api/sessions/search`. iOS long-press actions
+  compact toolbar search/filter finds session metadata (title, repo, branch,
+  workspace name; a typo, a transposition or an in-word abbreviation still
+  lands, via `Models/FuzzyMatch.swift`, the web's `shared/fuzzy-match.ts`
+  rules) and conversation text through `/api/sessions/search`. The Mac
+  command palette and the composer's `@` people list forgive typos the same
+  way. iOS long-press actions
   include details, rename, sharing, pull request, pin, hide, Snooze/Unsnooze,
   and Archive. Swipe right pins; swipe left offers Snooze and Archive.
   Pinned rows are lifted into a Pinned band at the top in the user's own order,


### PR DESCRIPTION
Ports the web's typo-tolerant search (`shared/fuzzy-match.ts`, 5b51f4d1) to the native Swift client.

## What changed

- **`OS1/Models/FuzzyMatch.swift`** (new, Foundation-only): one matcher with the web's rules. Exact, prefix, word prefix and substring rank first; then a bounded edit distance per term (0 edits under 4 letters, 1 up to 7, 2 beyond; a transposition is one edit) and in-word abbreviations (`wksp` → workspace). Case and accents are folded; an empty query matches everything.
- **Sidebar search** (`SidebarSearch.swift`, used by `SessionsListView`): a session matches on title, repo, branch and now its **workspace name**; the id still matches only as written. Transcript-hit fallback, snippets and limits are unchanged.
- **Mac command palette** (`CommandPalette.swift`): placement ranking kept (title start > word in title > inside title > subtitle/keyword); a near miss ranks under every exact placement and still above a transcript-only hit.
- **Composer @ people** (`ComposerMentionPalette.swift`, `PeopleMentionRanking`): a typo in a name or full name still finds the person; you stay first, then the closest match.
- `OS1_COMMAND_PALETTE_QUERY` debug hook so the palette can be screenshotted.
- README note.

## Before / after

| Query | Before | After |
|---|---|---|
| `relase` (sidebar) | nothing | Release row |
| `sandbxo` (Mac palette) | nothing | "Add sandbox session actions" first |
| `michel` (@ people) | nothing | Michiel |
| `cat` vs "cut" | nothing | nothing (short terms stay strict) |

## Tests

`FuzzyMatchTests`, `SidebarSearchTests`, `PeopleMentionRankingTests`, plus four `CommandPaletteTests` cases: `relase` → Release, transpositions (`wrokspace`, `archvied`), abbreviations (`wksp`, `tmln`), short-term false positives (`cat`/`cut`, `api`/`apple`), workspace-name matching, and exact-beats-near-miss ordering.

## Verification

- `OS1` (iOS Simulator) and `OS1Mac` build on tella-mac-node; 54 tests pass (`FuzzyMatch`, `SidebarSearch`, `PeopleMentionRanking`, `CommandPalette`, `ComposerMentionContext`, `SessionsListLens`).
- Screenshots were taken on the macOS target: the box was at load 300 to 550 while sibling sessions ran simulators, and the iOS simulator rendered a blank screen. The sidebar search view is the same SwiftUI code on both platforms.
- `bun run check` passes.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-aaf93a76-3880-79c3-b8a2-42d936ead25e)