### PR TITLE
Native app: apply session_row frames instead of waiting for the poll

### DIFF
--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -57,8 +57,13 @@ enum OS1API {
     /// answers with the whole list, which still splits correctly downstream
     /// (`prepared` sorts archived rows out either way).
     static func sessions() async throws -> [Session] {
-        try await get("/api/sessions?archived=exclude", revalidating: true)
+        try await get("/api/sessions" + liveSessionsQuery, revalidating: true)
     }
+
+    /// The live list's query. Also what the presence socket subscribes with
+    /// (`sessions_subscribe`), so the row frames the server pushes describe
+    /// the same projection the poll reads.
+    nonisolated static let liveSessionsQuery = "?archived=exclude"
 
     /// Archived sessions, as summaries.
     ///

--- a/packages/clients/ios/OS1/Networking/OS1Socket.swift
+++ b/packages/clients/ios/OS1/Networking/OS1Socket.swift
@@ -145,6 +145,16 @@ final class OS1Socket: SessionSocket {
         send(frame)
     }
 
+    /// Tell the server which sessions list this socket renders. From then on
+    /// a metadata write reaches it as `session_row` / `session_row_removed`
+    /// for that projection instead of a whole-list invalidation. The
+    /// subscription belongs to one connection, so the owner re-sends it after
+    /// every hello. `query` is the list request's query string, the same
+    /// one the poll asks for.
+    func subscribeSessions(query: String) {
+        send(["type": "sessions_subscribe", "query": query])
+    }
+
     /// Presence, not subscription: backgrounding the app keeps the watch (the
     /// transcript must keep streaming so unread counts and notifications still
     /// land) but takes our face off the session for everyone else. A client
@@ -352,7 +362,7 @@ final class OS1Socket: SessionSocket {
                 // inline to skip two executor hops per frame. Awaiting the
                 // decode before the next receive() keeps frames ordered.
                 let event: ServerEvent
-                if data.count >= 16 * 1024 {
+                if data.count >= 16 * 1024 || Self.isSessionRowFrame(data) {
                     event = await Task.detached(priority: .userInitiated) {
                         ServerEvent.parse(data)
                     }.value
@@ -369,6 +379,18 @@ final class OS1Socket: SessionSocket {
                 return
             }
         }
+    }
+
+    /// A `session_row` frame is small, but each one decodes a whole `Session`
+    /// (dozens of optional fields) and a burst of them lands while the list
+    /// is on screen, so they take the detached path like the poll's rows do.
+    /// The server serializes `type` first, which makes a prefix check enough;
+    /// a frame that misses it decodes inline, which is still correct. The
+    /// same prefix also matches `session_row_removed`, which is fine.
+    private static let sessionRowPrefix = Data(#"{"type":"session_row""#.utf8)
+
+    nonisolated private static func isSessionRowFrame(_ data: Data) -> Bool {
+        data.starts(with: sessionRowPrefix)
     }
 
     private func pingLoop() async {

--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -71,6 +71,15 @@ enum ServerEvent: Sendable {
     /// A git-host webhook changed PR, review, or check state for this branch.
     /// This frame is app-wide and therefore has no session id.
     case prUpdated(repo: String, branch: String)
+    /// One row of the sessions list changed on the server and this socket's
+    /// subscription (`sessions_subscribe`) shows it. A server snapshot of that
+    /// one session, applied in place instead of waiting for the poll.
+    case sessionRow(Session)
+    /// The same change for a row the subscription no longer shows (archived,
+    /// deleted, or filtered out by the lens).
+    case sessionRowRemoved(sessionId: String)
+    /// A bulk change with no row to send: re-read the whole list.
+    case sessionsInvalidated
     case notice(String)
     case serverError(String)
     // Shell output, for the session's terminal panel. Each frame carries the
@@ -231,6 +240,14 @@ enum ServerEvent: Sendable {
         case "pr_updated":
             guard let repo = frame.repo, let branch = frame.branch else { return .ignored }
             return .prUpdated(repo: repo, branch: branch)
+        case "session_row":
+            guard let row = frame.row, !row.id.isEmpty else { return .ignored }
+            return .sessionRow(row)
+        case "session_row_removed":
+            guard let id = frame.id ?? frame.sessionId, !id.isEmpty else { return .ignored }
+            return .sessionRowRemoved(sessionId: id)
+        case "sessions_invalidated":
+            return .sessionsInvalidated
         case "notice":
             return .notice(frame.message ?? "")
         case "error":
@@ -464,6 +481,11 @@ private struct RawFrame: Decodable {
 
     let type: String
     let sessionId: String?
+    /// `session_row_removed` names its session `id`, not `sessionId`.
+    let id: String?
+    /// `session_row` carries the list projection of one session; the same
+    /// tolerant model the list poll decodes.
+    let row: Session?
     let bootId: String?
     let entries: [TranscriptEntry]?
     let entry: TranscriptEntry?

--- a/packages/clients/ios/OS1/PresenceStore.swift
+++ b/packages/clients/ios/OS1/PresenceStore.swift
@@ -1,9 +1,24 @@
 import Foundation
 import Observation
 
+/// One change to the sessions list, pushed by the active account's socket.
+/// `SessionsListViewModel` applies these between polls.
+enum SessionListEvent: Sendable {
+    /// A server snapshot of one row the list shows.
+    case row(Session)
+    /// A row the list no longer shows: archived, deleted, or filtered out.
+    case removed(sessionId: String)
+    /// A bulk change with no row to send. Re-read the list.
+    case invalidated
+    /// The socket (re)connected and subscribed. Frames sent while it was
+    /// down are gone, so the list should re-read once.
+    case subscribed
+}
+
 /// Who on the team is focused on which session, app-wide. One passive socket
 /// stays connected for every configured account, so inactive organizations can
-/// still deliver mention events and badge the account picker.
+/// still deliver mention events and badge the account picker. The active
+/// account's socket also carries the sessions list's row frames.
 @MainActor
 @Observable
 final class PresenceStore {
@@ -11,6 +26,9 @@ final class PresenceStore {
 
     private(set) var bySession: [String: [String]] = [:]
     private(set) var connectedAccountIDs: Set<String> = []
+
+    @ObservationIgnored
+    private var sessionListObservers: [UUID: @MainActor (SessionListEvent) -> Void] = [:]
 
     private var sockets: [String: OS1Socket] = [:]
     private var connectedAccounts: [String: ServerConnection] = [:]
@@ -37,6 +55,36 @@ final class PresenceStore {
 
     func isConnected(accountID: String) -> Bool {
         connectedAccountIDs.contains(accountID)
+    }
+
+    /// Hear the active account's list changes. Returns the token to remove
+    /// the observer with; the list view model holds one while it polls.
+    @discardableResult
+    func addSessionListObserver(
+        _ handler: @escaping @MainActor (SessionListEvent) -> Void
+    ) -> UUID {
+        let token = UUID()
+        sessionListObservers[token] = handler
+        return token
+    }
+
+    func removeSessionListObserver(_ token: UUID) {
+        sessionListObservers[token] = nil
+    }
+
+    private func notifySessionList(_ event: SessionListEvent) {
+        for handler in sessionListObservers.values { handler(event) }
+    }
+
+    /// Ask the active account's socket for row frames. Only that account's
+    /// list is on screen, so only its socket subscribes; a socket that is
+    /// still connecting subscribes from its hello instead. Idempotent on the
+    /// server, so a switch back to an already subscribed account is harmless.
+    private func subscribeActiveAccount() {
+        let activeId = ServerConfig.shared.activeId
+        guard connectedAccountIDs.contains(activeId) else { return }
+        sockets[activeId]?.subscribeSessions(query: OS1API.liveSessionsQuery)
+        notifySessionList(.subscribed)
     }
 
     func viewers(of sessions: [Session]) -> [String] {
@@ -72,6 +120,9 @@ final class PresenceStore {
         for (account, connection) in connections where sockets[account.id] == nil {
             connect(account: account, connection: connection)
         }
+        // An account switch lands here with the new account's socket already
+        // up: it has to start sending row frames now, not at its next hello.
+        subscribeActiveAccount()
     }
 
     /// iOS cannot retain network execution indefinitely in the background.
@@ -122,6 +173,15 @@ final class PresenceStore {
         switch event {
         case .hello:
             connectedAccountIDs.insert(account.id)
+            if account.id == config.activeId { subscribeActiveAccount() }
+        case .sessionRow(let row):
+            if account.id == config.activeId { notifySessionList(.row(row)) }
+        case .sessionRowRemoved(let sessionId):
+            if account.id == config.activeId {
+                notifySessionList(.removed(sessionId: sessionId))
+            }
+        case .sessionsInvalidated:
+            if account.id == config.activeId { notifySessionList(.invalidated) }
         case .globalPresence(let viewing):
             let mapped = mappedPresence(viewing, me: account.userName)
             presenceByAccount[account.id] = mapped

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1124,6 +1124,28 @@ final class SessionsListViewModel {
         }
     }
 
+    /// The side effects of a poll pass, applied only once the pass has been
+    /// accepted: the list is still at the revision it snapshotted and no
+    /// later poll has published.
+    private func accept(
+        _ polled: (active: [Session], archived: [Session], resurfacedHideKeys: [String])
+    ) {
+        // A hidden row comes back while one of its sessions is blocked on a
+        // question, and the entry is consumed when it does — so a hide can
+        // never swallow work that needs you. Consuming it here (not in the
+        // row filter) keeps the mutation out of view body evaluation.
+        HideStore.shared.clear(polled.resurfacedHideKeys)
+        // Archived rows arrive on their own request, so `polled.archived`
+        // is normally empty here. It isn't against a server that predates
+        // the `archived=exclude` parameter and answers with the whole list
+        // — those rows ARE the index in that case, which is what makes an
+        // older server degrade to the old behaviour instead of to an
+        // Archived screen that is permanently empty.
+        if !polled.archived.isEmpty {
+            setServerArchived(polled.archived)
+        }
+    }
+
     /// One pass of row frames over the live list, pure so it can run off the
     /// main actor and be tested.
     ///
@@ -1333,27 +1355,34 @@ final class SessionsListViewModel {
                         hidden: hideKeys
                     )
                 }.value
-                // A hidden row comes back while one of its sessions is blocked on a
-                // question, and the entry is consumed when it does — so a hide can
-                // never swallow work that needs you. Consuming it here (not in the
-                // row filter) keeps the mutation out of view body evaluation.
-                HideStore.shared.clear(polled.resurfacedHideKeys)
-                next = mergeOptimistic(into: polled.active)
-                // Archived rows arrive on their own request, so `polled.archived`
-                // is normally empty here. It isn't against a server that predates
-                // the `archived=exclude` parameter and answers with the whole list
-                // — those rows ARE the index in that case, which is what makes an
-                // older server degrade to the old behaviour instead of to an
-                // Archived screen that is permanently empty.
-                if !polled.archived.isEmpty {
-                    setServerArchived(polled.archived)
+                // Nothing this pass produced is applied until the list is
+                // known to still be the one it snapshotted: a hide it would
+                // consume, or an archive index it would install, may already
+                // be wrong after a frame that landed while it ran, and a
+                // cleared hide is persisted to the server and cannot be
+                // taken back. The checks are repeated after grouping below.
+                guard requestConnection == OS1API.LiveActivityConnection.current() else { return }
+                guard sequence > publishedRefreshSequence else { break }
+                if snapshotRevision != sessionsRevision {
+                    if !hasLoaded || reruns < 2 {
+                        reruns += 1
+                        continue
+                    }
+                    break
                 }
+                next = mergeOptimistic(into: polled.active)
                 // Most 5s polls change nothing — skip the assignment so the whole
                 // list doesn't re-diff (grouping, sorting, row rebuilds) for a
                 // byte-identical result.
                 let shouldPublish =
                     next != sessions || refreshedWorkspaces != nil || connectionChanged || claimsChanged
-                guard shouldPublish else { break }
+                guard shouldPublish else {
+                    // The list already says what the response says; the pass
+                    // was accepted at the current revision, so what it found
+                    // to consume still holds.
+                    accept(polled)
+                    break
+                }
                 // Group before publishing, not after: the assignment wakes
                 // every observing view, so a grouping that starts afterwards
                 // always loses the race to the body that needs it.
@@ -1375,6 +1404,7 @@ final class SessionsListViewModel {
                     }
                     break
                 }
+                accept(polled)
                 SessionLinks.register(titles: grouped.titles)
                 PrLinks.register(index: grouped.prs)
                 if let renamed { workspaceNames = renamed }

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1377,9 +1377,9 @@ final class SessionsListViewModel {
                 let shouldPublish =
                     next != sessions || refreshedWorkspaces != nil || connectionChanged || claimsChanged
                 guard shouldPublish else {
-                    // The list already says what the response says; the pass
-                    // was accepted at the current revision, so what it found
-                    // to consume still holds.
+                    // The list already says what the response says, but this
+                    // accepted response must still supersede older polls.
+                    publishedRefreshSequence = sequence
                     accept(polled)
                     break
                 }

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1039,12 +1039,24 @@ final class SessionsListViewModel {
     }
 
     private func flushRowUpdates() async {
-        // A row that arrives before the first list would publish a one-row
-        // list; the poll's first answer carries it anyway.
-        guard hasLoaded else { return pendingRowUpdates.removeAll() }
         let updates = Array(pendingRowUpdates.values)
         guard !updates.isEmpty else { return }
         pendingRowUpdates.removeAll()
+        // No list to merge into yet: a flush would publish a one-row list.
+        // Frames that arrived while the first request was out are newer
+        // than its response, though, so they go to that request's replay
+        // rather than being dropped, or the response would publish a row
+        // (an archive made elsewhere, a rename) they already moved past.
+        // With no request out, the first poll's answer carries them anyway.
+        guard hasLoaded else {
+            guard !inFlightRefreshRevisions.isEmpty else { return }
+            // Nothing published, but the list's truth moved: the bump is
+            // what puts these frames after the request's start revision,
+            // and reruns a pass that snapshotted before them.
+            sessionsRevision += 1
+            recordAppliedRowUpdates(updates)
+            return
+        }
         // Snapshot the main-actor state, then merge and regroup off it: the
         // list can be thousands of rows and a frame lands mid-typing.
         let connection = OS1API.LiveActivityConnection.current()
@@ -1092,17 +1104,24 @@ final class SessionsListViewModel {
         SessionLinks.register(titles: grouped.titles)
         PrLinks.register(index: grouped.prs)
         setSessions(applied.sessions, rows: grouped.rows)
-        if !inFlightRefreshRevisions.isEmpty {
-            for update in updates {
-                appliedRowUpdates[update.id] = AppliedRowUpdate(
-                    revision: sessionsRevision, update: update
-                )
-            }
-        }
+        recordAppliedRowUpdates(updates)
         // A row that left the live list usually went to the archive. Let the
         // next archived turn refetch instead of trusting a fresh-looking
         // index for another half minute.
         if !applied.removedIds.isEmpty { archivedFetchedAt = nil }
+    }
+
+    /// Keep what a flush applied, at the current revision, for the polls
+    /// still in flight to replay over their responses. Nothing is kept when
+    /// no poll is out: `refresh` prunes on completion, and there would be
+    /// nothing to prune this for.
+    private func recordAppliedRowUpdates(_ updates: [SessionRowUpdate]) {
+        guard !inFlightRefreshRevisions.isEmpty else { return }
+        for update in updates {
+            appliedRowUpdates[update.id] = AppliedRowUpdate(
+                revision: sessionsRevision, update: update
+            )
+        }
     }
 
     /// One pass of row frames over the live list, pure so it can run off the

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1266,7 +1266,7 @@ final class SessionsListViewModel {
         return (
             applied.sessions,
             prepared.archived,
-            Array(Set(prepared.resurfacedHideKeys).union(applied.resurfacedHideKeys))
+            resurfacedHideKeys(in: applied.sessions, hidden: hideKeys)
         )
     }
 
@@ -1564,15 +1564,22 @@ final class SessionsListViewModel {
             .map { (session: $0, key: $0.lastActivityDate ?? .distantPast) }
             .sorted { $0.key > $1.key }
             .map(\.session)
+        return (active, archived, resurfacedHideKeys(in: active, hidden: hideKeys))
+    }
+
+    /// Hides are consumed by the final rows, never by a superseded poll row.
+    nonisolated private static func resurfacedHideKeys(
+        in sessions: [Session], hidden hideKeys: Set<String>
+    ) -> [String] {
         var resurfaced = Set<String>()
         if !hideKeys.isEmpty {
-            for session in active where session.lane == .needsInput && !session.isAutomation {
+            for session in sessions where session.lane == .needsInput && !session.isAutomation {
                 for key in SidebarRowKeys.candidateKeys(for: session) where hideKeys.contains(key) {
                     resurfaced.insert(key)
                 }
             }
         }
-        return (active, archived, Array(resurfaced))
+        return Array(resurfaced)
     }
 }
 

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -43,6 +43,13 @@ enum SessionRowUpdate: Sendable {
     }
 }
 
+/// A row frame the list has applied, and the `sessionsRevision` that carries
+/// it. See `SessionsListViewModel.replay(_:after:)`.
+struct AppliedRowUpdate: Sendable {
+    var revision: Int
+    var update: SessionRowUpdate
+}
+
 /// What one batch of row frames did to the live list. See
 /// `SessionsListViewModel.applyingRowUpdates`.
 struct SessionRowUpdateResult: Equatable, Sendable {
@@ -105,6 +112,19 @@ final class SessionsListViewModel {
     /// archive, a branch's PR webhook) costs one regroup instead of one each.
     @ObservationIgnored private var pendingRowUpdates: [String: SessionRowUpdate] = [:]
     @ObservationIgnored private var rowFlushTask: Task<Void, Never>?
+    /// Row frames applied while a poll was in flight, newest per session,
+    /// tagged with the list revision that carries them. A poll's response was
+    /// built before those frames, so the poll replays them over it instead
+    /// of publishing a row the frame already moved past. Kept only while a
+    /// poll is in flight; `refresh` prunes what no in-flight poll predates.
+    @ObservationIgnored private var appliedRowUpdates: [String: AppliedRowUpdate] = [:]
+    /// `sessionsRevision` at the start of each `refresh` still in flight.
+    @ObservationIgnored private var inFlightRefreshRevisions: [Int] = []
+    /// Polls are ordered by when their request went out. One that finishes
+    /// after a later-started poll already published is discarded: its rows
+    /// are older than the list.
+    @ObservationIgnored private var refreshSequence = 0
+    @ObservationIgnored private var publishedRefreshSequence = 0
 
     /// The server's archived index, kept apart from `archivedSessions` so the
     /// local overlay (a row archived on this device, one restored a moment
@@ -1072,6 +1092,13 @@ final class SessionsListViewModel {
         SessionLinks.register(titles: grouped.titles)
         PrLinks.register(index: grouped.prs)
         setSessions(applied.sessions, rows: grouped.rows)
+        if !inFlightRefreshRevisions.isEmpty {
+            for update in updates {
+                appliedRowUpdates[update.id] = AppliedRowUpdate(
+                    revision: sessionsRevision, update: update
+                )
+            }
+        }
         // A row that left the live list usually went to the archive. Let the
         // next archived turn refetch instead of trusting a fresh-looking
         // index for another half minute.
@@ -1162,6 +1189,46 @@ final class SessionsListViewModel {
         )
     }
 
+    /// The frames applied after a list revision, oldest first, so a poll
+    /// whose request went out at that revision can replay them over its
+    /// response.
+    nonisolated static func replay(
+        _ applied: [String: AppliedRowUpdate], after revision: Int
+    ) -> [SessionRowUpdate] {
+        applied.values
+            .filter { $0.revision > revision }
+            .sorted { $0.revision < $1.revision }
+            .map(\.update)
+    }
+
+    /// A poll response the way the list will hold it: `prepared`, then the
+    /// row frames that landed while the request was out replayed on top.
+    /// Pure, so it can run off the main actor and be tested.
+    nonisolated static func polled(
+        _ all: [Session],
+        replaying updates: [SessionRowUpdate],
+        optimisticIds: Set<String>,
+        hiding hiddenIds: Set<String>,
+        restoring restoredIds: Set<String>,
+        hidden hideKeys: Set<String> = []
+    ) -> (active: [Session], archived: [Session], resurfacedHideKeys: [String]) {
+        let prepared = prepared(all, hiding: hiddenIds, restoring: restoredIds, hidden: hideKeys)
+        guard !updates.isEmpty else { return prepared }
+        let applied = applyingRowUpdates(
+            updates,
+            to: prepared.active,
+            optimisticIds: optimisticIds,
+            hiding: hiddenIds,
+            restoring: restoredIds,
+            hidden: hideKeys
+        )
+        return (
+            applied.sessions,
+            prepared.archived,
+            Array(Set(prepared.resurfacedHideKeys).union(applied.resurfacedHideKeys))
+        )
+    }
+
     func refresh() async {
         // A tailnet server with the tunnel down answers nothing at all, and
         // URLSession takes a full minute to admit it. Ask why alongside the
@@ -1169,6 +1236,20 @@ final class SessionsListViewModel {
         // milliseconds, and a request that lands clears it.
         if !hasLoaded { diagnoseUnreachableServer() }
         let requestConnection = OS1API.LiveActivityConnection.current()
+        // Everything the list holds at this revision predates the response;
+        // everything published after it (a row frame, a later poll) does not,
+        // and the response must not be published over it.
+        let startRevision = sessionsRevision
+        refreshSequence += 1
+        let sequence = refreshSequence
+        inFlightRefreshRevisions.append(startRevision)
+        defer {
+            if let index = inFlightRefreshRevisions.firstIndex(of: startRevision) {
+                inFlightRefreshRevisions.remove(at: index)
+            }
+            let floor = inFlightRefreshRevisions.min() ?? sessionsRevision
+            appliedRowUpdates = appliedRowUpdates.filter { $0.value.revision > floor }
+        }
         do {
             async let workspaceRequest = try? OS1API.workspaces()
             let all = try await OS1API.sessions()
@@ -1193,47 +1274,62 @@ final class SessionsListViewModel {
                 refreshedWorkspaces = []
                 renamed = [:]
             }
-            // Snapshot the main-actor state the filter needs, then do the
-            // heavy pass (thousands of rows) off the main thread — inline it
-            // ran on the main actor every 5s poll and hitched typing.
-            let hiddenIds = Set(Array(locallyArchived.keys).filter { isLocallyArchived($0) })
-            let restoredIds = Set(Array(locallyUnarchived.keys).filter { isLocallyUnarchived($0) })
-            let hideKeys = Set(HideStore.shared.hides.keys)
-            // Claims decide which spawned workers earn a row, and they land on
-            // their own clock (`LaneStore.hydrate`) — so a set that moved has
-            // to republish the grouping even when the list itself didn't.
-            let claimed = LaneStore.shared.claims
-            let claimsChanged = claimed != claimedSessionIds
-            claimedSessionIds = claimed
-            let prepared = await Task.detached(priority: .userInitiated) {
-                Self.prepared(
-                    all,
-                    hiding: hiddenIds,
-                    restoring: restoredIds,
-                    hidden: hideKeys
-                )
-            }.value
-            // A hidden row comes back while one of its sessions is blocked on a
-            // question, and the entry is consumed when it does — so a hide can
-            // never swallow work that needs you. Consuming it here (not in the
-            // row filter) keeps the mutation out of view body evaluation.
-            HideStore.shared.clear(prepared.resurfacedHideKeys)
-            let next = mergeOptimistic(into: prepared.active)
-            // Archived rows arrive on their own request, so `prepared.archived`
-            // is normally empty here. It isn't against a server that predates
-            // the `archived=exclude` parameter and answers with the whole list
-            // — those rows ARE the index in that case, which is what makes an
-            // older server degrade to the old behaviour instead of to an
-            // Archived screen that is permanently empty.
-            if !prepared.archived.isEmpty {
-                setServerArchived(prepared.archived)
-            }
-            // Most 5s polls change nothing — skip the assignment so the whole
-            // list doesn't re-diff (grouping, sorting, row rebuilds) for a
-            // byte-identical result.
-            let shouldPublish =
-                next != sessions || refreshedWorkspaces != nil || connectionChanged || claimsChanged
-            if shouldPublish {
+            // The detached passes below run against a snapshot of the list.
+            // A row flush that publishes while they run makes the snapshot
+            // stale, so they rerun over the moved list, with that flush's
+            // frames in the replay. Two reruns cover any realistic burst; a
+            // list that will not hold still is left to the next poll.
+            var next: [Session] = []
+            var claimsChanged = false
+            for attempt in 0 ... 2 {
+                let snapshotRevision = sessionsRevision
+                let replay = Self.replay(appliedRowUpdates, after: startRevision)
+                // Snapshot the main-actor state the filter needs, then do the
+                // heavy pass (thousands of rows) off the main thread — inline it
+                // ran on the main actor every 5s poll and hitched typing.
+                let optimisticIds = Set(optimistic.keys)
+                let hiddenIds = Set(Array(locallyArchived.keys).filter { isLocallyArchived($0) })
+                let restoredIds = Set(Array(locallyUnarchived.keys).filter { isLocallyUnarchived($0) })
+                let hideKeys = Set(HideStore.shared.hides.keys)
+                // Claims decide which spawned workers earn a row, and they land on
+                // their own clock (`LaneStore.hydrate`) — so a set that moved has
+                // to republish the grouping even when the list itself didn't.
+                let claimed = LaneStore.shared.claims
+                if claimed != claimedSessionIds {
+                    claimsChanged = true
+                    claimedSessionIds = claimed
+                }
+                let polled = await Task.detached(priority: .userInitiated) {
+                    Self.polled(
+                        all,
+                        replaying: replay,
+                        optimisticIds: optimisticIds,
+                        hiding: hiddenIds,
+                        restoring: restoredIds,
+                        hidden: hideKeys
+                    )
+                }.value
+                // A hidden row comes back while one of its sessions is blocked on a
+                // question, and the entry is consumed when it does — so a hide can
+                // never swallow work that needs you. Consuming it here (not in the
+                // row filter) keeps the mutation out of view body evaluation.
+                HideStore.shared.clear(polled.resurfacedHideKeys)
+                next = mergeOptimistic(into: polled.active)
+                // Archived rows arrive on their own request, so `polled.archived`
+                // is normally empty here. It isn't against a server that predates
+                // the `archived=exclude` parameter and answers with the whole list
+                // — those rows ARE the index in that case, which is what makes an
+                // older server degrade to the old behaviour instead of to an
+                // Archived screen that is permanently empty.
+                if !polled.archived.isEmpty {
+                    setServerArchived(polled.archived)
+                }
+                // Most 5s polls change nothing — skip the assignment so the whole
+                // list doesn't re-diff (grouping, sorting, row rebuilds) for a
+                // byte-identical result.
+                let shouldPublish =
+                    next != sessions || refreshedWorkspaces != nil || connectionChanged || claimsChanged
+                guard shouldPublish else { break }
                 // Group before publishing, not after: the assignment wakes
                 // every observing view, so a grouping that starts afterwards
                 // always loses the race to the body that needs it.
@@ -1246,12 +1342,20 @@ final class SessionsListViewModel {
                     claimed: claimed
                 )
                 guard requestConnection == OS1API.LiveActivityConnection.current() else { return }
+                // A later poll already published rows newer than these.
+                guard sequence > publishedRefreshSequence else { break }
+                if snapshotRevision != sessionsRevision {
+                    if attempt < 2 { continue }
+                    break
+                }
                 SessionLinks.register(titles: grouped.titles)
                 PrLinks.register(index: grouped.prs)
                 if let renamed { workspaceNames = renamed }
                 if let refreshedWorkspaces { workspaces = refreshedWorkspaces }
                 liveActivityConnection = requestConnection
+                publishedRefreshSequence = sequence
                 setSessions(next, rows: grouped.rows)
+                break
             }
             #if os(iOS)
             // An authoritative empty first response still matters: without it

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -1296,11 +1296,16 @@ final class SessionsListViewModel {
             // The detached passes below run against a snapshot of the list.
             // A row flush that publishes while they run makes the snapshot
             // stale, so they rerun over the moved list, with that flush's
-            // frames in the replay. Two reruns cover any realistic burst; a
-            // list that will not hold still is left to the next poll.
+            // frames in the replay. Once a list is on screen, two reruns
+            // cover any realistic burst and one that will not hold still is
+            // left to the next poll. Before the first list there is nothing
+            // to leave it to: giving up would mark the load done with an
+            // empty screen and prune the frames it needed, so the first
+            // response reruns until it lands.
             var next: [Session] = []
             var claimsChanged = false
-            for attempt in 0 ... 2 {
+            var reruns = 0
+            while true {
                 let snapshotRevision = sessionsRevision
                 let replay = Self.replay(appliedRowUpdates, after: startRevision)
                 // Snapshot the main-actor state the filter needs, then do the
@@ -1364,7 +1369,10 @@ final class SessionsListViewModel {
                 // A later poll already published rows newer than these.
                 guard sequence > publishedRefreshSequence else { break }
                 if snapshotRevision != sessionsRevision {
-                    if attempt < 2 { continue }
+                    if !hasLoaded || reruns < 2 {
+                        reruns += 1
+                        continue
+                    }
                     break
                 }
                 SessionLinks.register(titles: grouped.titles)

--- a/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionsListViewModel.swift
@@ -30,8 +30,35 @@ struct WorkspaceDeletionState: Equatable {
     }
 }
 
-/// Sessions overview. The server has no push channel for list changes, so this
-/// polls `GET /api/sessions` (server caches for 2s; the web UI polls at 5s too).
+/// One row frame from the server, queued until the next coalesced apply.
+enum SessionRowUpdate: Sendable {
+    case row(Session)
+    case removed(String)
+
+    var id: String {
+        switch self {
+        case .row(let session): session.id
+        case .removed(let id): id
+        }
+    }
+}
+
+/// What one batch of row frames did to the live list. See
+/// `SessionsListViewModel.applyingRowUpdates`.
+struct SessionRowUpdateResult: Equatable, Sendable {
+    var sessions: [Session]
+    var changed: Bool
+    /// Pending creates whose server row arrived in this batch.
+    var retiredOptimisticIds: [String]
+    /// Rows this batch dropped from the live list.
+    var removedIds: [String]
+    var resurfacedHideKeys: [String]
+}
+
+/// Sessions overview. The active account's socket pushes row frames for most
+/// metadata changes (`session_row` / `session_row_removed`, applied by
+/// `applyingRowUpdates`); `GET /api/sessions` is polled underneath as the
+/// fallback that heals a missed frame and covers a server that sends none.
 @Observable
 @MainActor
 final class SessionsListViewModel {
@@ -60,6 +87,24 @@ final class SessionsListViewModel {
     private(set) var workspaceDeletion = WorkspaceDeletionState()
 
     private var pollTask: Task<Void, Never>?
+
+    /// The fallback poll's cadence. `OS1_SESSIONS_POLL_SECONDS` lengthens it
+    /// for a build under test, so that a change which shows up demonstrably
+    /// came over the socket. Nothing is persisted.
+    private static let pollInterval: Duration = {
+        if let raw = ProcessInfo.processInfo.environment["OS1_SESSIONS_POLL_SECONDS"],
+           let seconds = Double(raw), seconds > 0 {
+            return .seconds(seconds)
+        }
+        return .seconds(5)
+    }()
+
+    @ObservationIgnored private var rowObserverToken: UUID?
+    /// Row frames waiting to be applied, newest per session. The server
+    /// coalesces per session; this coalesces across them, so a burst (a bulk
+    /// archive, a branch's PR webhook) costs one regroup instead of one each.
+    @ObservationIgnored private var pendingRowUpdates: [String: SessionRowUpdate] = [:]
+    @ObservationIgnored private var rowFlushTask: Task<Void, Never>?
 
     /// The server's archived index, kept apart from `archivedSessions` so the
     /// local overlay (a row archived on this device, one restored a moment
@@ -220,43 +265,56 @@ final class SessionsListViewModel {
         workspaceNames names: [String: String],
         workspaces: [OS1API.WorkspaceSummary],
         claimed: Set<String>
-    ) async -> (rows: [SidebarWorkspace], titles: [String: String], prs: PrLinks.Index) {
+    ) async -> Grouped {
         await Task.detached(priority: .userInitiated) {
-            var titles: [String: String] = [:]
-            titles.reserveCapacity(sessions.count)
-            for session in sessions {
-                // The WORKSPACE's name, not the session's own. A reference is
-                // read as "that piece of work", and the screen it opens is
-                // titled after the workspace, so labelling the chip after one
-                // of its conversations promised a name the destination never
-                // shows. That name is often a per-run label ("Review · PR
-                // #5741 …"). The web labels its chips from the same rule
-                // (`setSessionTitles` in App.tsx). Session title is the
-                // fallback, for a workspace this client has no name for.
-                let workspace = session.workspaceName ?? ""
-                let title = workspace.isEmpty ? session.displayTitle : workspace
-                if !title.isEmpty {
-                    titles[session.id] = title
-                    for aliasId in session.aliasIds ?? [] { titles[aliasId] = title }
-                }
-            }
-            return (
-                sidebarRows(
-                    in: listedSessions(in: sessions, claimed: claimed),
-                    workspaceNames: names,
-                    workspaces: workspaces,
-                    occupiedWorkspaceIds: Set(sessions.compactMap(\.workspaceId))
-                ),
-                titles,
-                // What tints a `#5528` chip in a transcript, and what tells a
-                // bare one which repo it belongs to — the same fields the web
-                // hands `setKnownPrStates`, off the main actor for the same
-                // reason the titles are. Built from every session, including
-                // the spawned workers the rows leave out: a chip in a
-                // transcript still has to resolve.
-                PrLinks.Index.build(sessions)
-            )
+            grouped(sessions, workspaceNames: names, workspaces: workspaces, claimed: claimed)
         }.value
+    }
+
+    private typealias Grouped = (rows: [SidebarWorkspace], titles: [String: String], prs: PrLinks.Index)
+
+    /// The synchronous half of `groupedOffMain`, for a caller that is already
+    /// off the main actor (the row-frame apply).
+    nonisolated private static func grouped(
+        _ sessions: [Session],
+        workspaceNames names: [String: String],
+        workspaces: [OS1API.WorkspaceSummary],
+        claimed: Set<String>
+    ) -> Grouped {
+        var titles: [String: String] = [:]
+        titles.reserveCapacity(sessions.count)
+        for session in sessions {
+            // The WORKSPACE's name, not the session's own. A reference is
+            // read as "that piece of work", and the screen it opens is
+            // titled after the workspace, so labelling the chip after one
+            // of its conversations promised a name the destination never
+            // shows. That name is often a per-run label ("Review · PR
+            // #5741 …"). The web labels its chips from the same rule
+            // (`setSessionTitles` in App.tsx). Session title is the
+            // fallback, for a workspace this client has no name for.
+            let workspace = session.workspaceName ?? ""
+            let title = workspace.isEmpty ? session.displayTitle : workspace
+            if !title.isEmpty {
+                titles[session.id] = title
+                for aliasId in session.aliasIds ?? [] { titles[aliasId] = title }
+            }
+        }
+        return (
+            sidebarRows(
+                in: listedSessions(in: sessions, claimed: claimed),
+                workspaceNames: names,
+                workspaces: workspaces,
+                occupiedWorkspaceIds: Set(sessions.compactMap(\.workspaceId))
+            ),
+            titles,
+            // What tints a `#5528` chip in a transcript, and what tells a
+            // bare one which repo it belongs to — the same fields the web
+            // hands `setKnownPrStates`, off the main actor for the same
+            // reason the titles are. Built from every session, including
+            // the spawned workers the rows leave out: a chip in a
+            // transcript still has to resolve.
+            PrLinks.Index.build(sessions)
+        )
     }
 
     /// Honor the web sidebar's shared order, then append newly seen repositories
@@ -900,6 +958,9 @@ final class SessionsListViewModel {
 
     func startPolling() {
         stopPolling()
+        rowObserverToken = PresenceStore.shared.addSessionListObserver { [weak self] event in
+            self?.receive(event)
+        }
         pollTask = Task {
             while !Task.isCancelled {
                 await refresh()
@@ -908,7 +969,7 @@ final class SessionsListViewModel {
                 // list is never in the live one's way. `refreshArchived`
                 // throttles itself, so most turns here cost nothing.
                 Task { await self.refreshArchived() }
-                try? await Task.sleep(for: .seconds(5))
+                try? await Task.sleep(for: Self.pollInterval)
             }
         }
     }
@@ -916,6 +977,189 @@ final class SessionsListViewModel {
     func stopPolling() {
         pollTask?.cancel()
         pollTask = nil
+        if let rowObserverToken {
+            PresenceStore.shared.removeSessionListObserver(rowObserverToken)
+        }
+        rowObserverToken = nil
+        rowFlushTask?.cancel()
+        rowFlushTask = nil
+        pendingRowUpdates.removeAll()
+    }
+
+    // MARK: - Row frames
+
+    private func receive(_ event: SessionListEvent) {
+        switch event {
+        case .row(let row):
+            pendingRowUpdates[row.id] = .row(row)
+            scheduleRowFlush()
+        case .removed(let sessionId):
+            pendingRowUpdates[sessionId] = .removed(sessionId)
+            scheduleRowFlush()
+        case .invalidated, .subscribed:
+            // Nothing row-shaped to apply: re-read the list, as the web does
+            // on an invalidation and on every reconnect. Before the first
+            // list has landed the poll is already asking.
+            guard hasLoaded else { return }
+            Task { await self.refresh() }
+        }
+    }
+
+    private func scheduleRowFlush() {
+        guard rowFlushTask == nil else { return }
+        rowFlushTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(120))
+            guard let self, !Task.isCancelled else { return }
+            await self.flushRowUpdates()
+            // One flush at a time. Frames that arrived during this one wait
+            // for the next, on a list that already carries this one's result.
+            self.rowFlushTask = nil
+            if !self.pendingRowUpdates.isEmpty { self.scheduleRowFlush() }
+        }
+    }
+
+    private func flushRowUpdates() async {
+        // A row that arrives before the first list would publish a one-row
+        // list; the poll's first answer carries it anyway.
+        guard hasLoaded else { return pendingRowUpdates.removeAll() }
+        let updates = Array(pendingRowUpdates.values)
+        guard !updates.isEmpty else { return }
+        pendingRowUpdates.removeAll()
+        // Snapshot the main-actor state, then merge and regroup off it: the
+        // list can be thousands of rows and a frame lands mid-typing.
+        let connection = OS1API.LiveActivityConnection.current()
+        let revision = sessionsRevision
+        let current = sessions
+        let optimisticIds = Set(optimistic.keys)
+        let hiddenIds = Set(Array(locallyArchived.keys).filter { isLocallyArchived($0) })
+        let restoredIds = Set(Array(locallyUnarchived.keys).filter { isLocallyUnarchived($0) })
+        let hideKeys = Set(HideStore.shared.hides.keys)
+        let names = workspaceNames
+        let currentWorkspaces = workspaces
+        let claimed = claimedSessionIds
+        let (applied, grouped) = await Task.detached(priority: .userInitiated) {
+            let applied = Self.applyingRowUpdates(
+                updates,
+                to: current,
+                optimisticIds: optimisticIds,
+                hiding: hiddenIds,
+                restoring: restoredIds,
+                hidden: hideKeys
+            )
+            let grouped: Grouped? = applied.changed
+                ? Self.grouped(
+                    applied.sessions,
+                    workspaceNames: names,
+                    workspaces: currentWorkspaces,
+                    claimed: claimed
+                )
+                : nil
+            return (applied, grouped)
+        }.value
+        guard connection == OS1API.LiveActivityConnection.current() else { return }
+        // The list moved under the merge (a poll landed, a local archive).
+        // That publish is newer for everything but these rows, so replay
+        // them onto it rather than publishing this stale base over it.
+        guard revision == sessionsRevision else {
+            for update in updates where pendingRowUpdates[update.id] == nil {
+                pendingRowUpdates[update.id] = update
+            }
+            return
+        }
+        guard applied.changed, let grouped else { return }
+        for id in applied.retiredOptimisticIds { optimistic.removeValue(forKey: id) }
+        HideStore.shared.clear(applied.resurfacedHideKeys)
+        SessionLinks.register(titles: grouped.titles)
+        PrLinks.register(index: grouped.prs)
+        setSessions(applied.sessions, rows: grouped.rows)
+        // A row that left the live list usually went to the archive. Let the
+        // next archived turn refetch instead of trusting a fresh-looking
+        // index for another half minute.
+        if !applied.removedIds.isEmpty { archivedFetchedAt = nil }
+    }
+
+    /// One pass of row frames over the live list, pure so it can run off the
+    /// main actor and be tested.
+    ///
+    /// The frames are server snapshots, so they reconcile the way a poll
+    /// does, for those rows only: the same filters as `prepared` (no desk
+    /// rows, a row archived on this device stays hidden, one restored here
+    /// reads as live), a pending create retires when its own row arrives,
+    /// and the result keeps recency order with the remaining pending creates
+    /// in front, where the poll's merge leaves them.
+    nonisolated static func applyingRowUpdates(
+        _ updates: [SessionRowUpdate],
+        to sessions: [Session],
+        optimisticIds: Set<String>,
+        hiding hiddenIds: Set<String>,
+        restoring restoredIds: Set<String>,
+        hidden hideKeys: Set<String> = []
+    ) -> SessionRowUpdateResult {
+        var next = sessions
+        var changed = false
+        var retired: [String] = []
+        var removed: [String] = []
+        var resurfaced = Set<String>()
+        func drop(_ id: String) {
+            guard let index = next.firstIndex(where: { $0.id == id }) else { return }
+            next.remove(at: index)
+            removed.append(id)
+            changed = true
+        }
+        for update in updates {
+            switch update {
+            case .removed(let id):
+                // A pending create is local until the server publishes it,
+                // and a row restored here stays until the overlay expires or
+                // the server's own row arrives. The poll reconciles both.
+                if optimisticIds.contains(id) || restoredIds.contains(id) { continue }
+                drop(id)
+            case .row(var row):
+                if row.desk == true || hiddenIds.contains(row.id) {
+                    drop(row.id)
+                    continue
+                }
+                if restoredIds.contains(row.id) { row.archived = false }
+                if row.archived == true {
+                    drop(row.id)
+                    continue
+                }
+                if optimisticIds.contains(row.id) { retired.append(row.id) }
+                if let index = next.firstIndex(where: { $0.id == row.id }) {
+                    if next[index] == row { continue }
+                    next[index] = row
+                } else {
+                    next.append(row)
+                }
+                changed = true
+                if !hideKeys.isEmpty, row.lane == .needsInput, !row.isAutomation {
+                    for key in SidebarRowKeys.candidateKeys(for: row) where hideKeys.contains(key) {
+                        resurfaced.insert(key)
+                    }
+                }
+            }
+        }
+        guard changed else {
+            return SessionRowUpdateResult(
+                sessions: sessions,
+                changed: false,
+                retiredOptimisticIds: [],
+                removedIds: [],
+                resurfacedHideKeys: []
+            )
+        }
+        let pending = optimisticIds.subtracting(retired)
+        let ordered = pending.isEmpty
+            ? byRecency(next)
+            : next.filter { pending.contains($0.id) }
+                + byRecency(next.filter { !pending.contains($0.id) })
+        return SessionRowUpdateResult(
+            sessions: ordered,
+            changed: true,
+            retiredOptimisticIds: retired,
+            removedIds: removed,
+            resurfacedHideKeys: Array(resurfaced)
+        )
     }
 
     func refresh() async {

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -367,6 +367,56 @@ final class ServerEventTests: XCTestCase {
         }
     }
 
+    // MARK: - Sessions list row frames
+
+    /// A `session_row` is the list projection of one session, decoded with the
+    /// same tolerant model as the poll: unknown fields pass, and the row is
+    /// applied from the fields it does carry.
+    func testSessionRowDecodesTheListProjection() {
+        let json = #"""
+        {"type":"session_row","row":{"id":"bks-1","title":"Row frames",
+          "isRunning":true,"workspaceId":"ws-1","lastActivity":"2026-09-05T10:00:00.000Z",
+          "prState":"OPEN","somethingNewer":{"nested":[1,2]}}}
+        """#
+        guard case .sessionRow(let row) = parse(json) else {
+            return XCTFail("expected .sessionRow")
+        }
+        XCTAssertEqual(row.id, "bks-1")
+        XCTAssertEqual(row.title, "Row frames")
+        XCTAssertEqual(row.isRunning, true)
+        XCTAssertEqual(row.workspaceId, "ws-1")
+        XCTAssertEqual(row.prState, "OPEN")
+        XCTAssertNotNil(row.lastActivityDate)
+    }
+
+    /// The removal names its session `id`, unlike every per-session frame.
+    func testSessionRowRemovedAndInvalidated() {
+        guard case .sessionRowRemoved(let id) =
+            parse(#"{"type":"session_row_removed","id":"bks-1"}"#)
+        else {
+            return XCTFail("expected .sessionRowRemoved")
+        }
+        XCTAssertEqual(id, "bks-1")
+        guard case .sessionsInvalidated = parse(#"{"type":"sessions_invalidated"}"#) else {
+            return XCTFail("expected .sessionsInvalidated")
+        }
+    }
+
+    func testMalformedSessionRowFramesAreIgnored() {
+        for json in [
+            #"{"type":"session_row"}"#,
+            #"{"type":"session_row","row":null}"#,
+            #"{"type":"session_row","row":{"title":"no id"}}"#,
+            #"{"type":"session_row","row":{"id":""}}"#,
+            #"{"type":"session_row_removed"}"#,
+            #"{"type":"session_row_removed","id":""}"#,
+        ] {
+            guard case .ignored = parse(json) else {
+                return XCTFail("expected .ignored for \(json)")
+            }
+        }
+    }
+
     func testUnknownAndMalformedFramesAreIgnored() {
         guard case .ignored = parse(#"{"type":"future_frame","payload":123}"#) else {
             return XCTFail("unknown frame types must decode to .ignored")

--- a/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import OS1
+
+/// The sessions list applies `session_row` / `session_row_removed` frames
+/// between polls. These pin the merge: a frame is a server snapshot of one
+/// row, so it must land the way a poll would for that row and leave every
+/// local overlay (an archive or restore made here, a pending create) alone.
+final class SessionRowUpdateTests: XCTestCase {
+    private func sessions(_ json: String) throws -> [Session] {
+        try JSONDecoder().decode([Session].self, from: Data(json.utf8))
+    }
+
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    private func apply(
+        _ updates: [SessionRowUpdate],
+        to list: [Session],
+        optimistic: Set<String> = [],
+        hiding: Set<String> = [],
+        restoring: Set<String> = [],
+        hidden: Set<String> = []
+    ) -> SessionRowUpdateResult {
+        SessionsListViewModel.applyingRowUpdates(
+            updates,
+            to: list,
+            optimisticIds: optimistic,
+            hiding: hiding,
+            restoring: restoring,
+            hidden: hidden
+        )
+    }
+
+    private var baseline: [Session] {
+        get throws {
+            try sessions(
+                """
+                [{"id":"os-new","title":"New","lastActivity":"2026-09-05T12:00:00.000Z"},
+                 {"id":"os-mid","title":"Mid","lastActivity":"2026-09-05T11:00:00.000Z"},
+                 {"id":"os-old","title":"Old","lastActivity":"2026-09-05T10:00:00.000Z"}]
+                """
+            )
+        }
+    }
+
+    // MARK: - Rows
+
+    func testARowReplacesItsSessionAndTheListKeepsRecencyOrder() throws {
+        let row = try session(
+            #"{"id":"os-old","title":"Old, renamed","lastActivity":"2026-09-05T13:00:00.000Z"}"#
+        )
+
+        let result = try apply([.row(row)], to: baseline)
+
+        XCTAssertTrue(result.changed)
+        XCTAssertEqual(result.sessions.map(\.id), ["os-old", "os-new", "os-mid"])
+        XCTAssertEqual(result.sessions[0].title, "Old, renamed")
+        XCTAssertTrue(result.removedIds.isEmpty)
+    }
+
+    func testAnUnknownRowJoinsTheListInRecencyOrder() throws {
+        let row = try session(
+            #"{"id":"os-other","title":"Someone else's","lastActivity":"2026-09-05T11:30:00.000Z"}"#
+        )
+
+        let result = try apply([.row(row)], to: baseline)
+
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-other", "os-mid", "os-old"])
+    }
+
+    func testAnIdenticalRowChangesNothing() throws {
+        let list = try baseline
+
+        let result = apply([.row(list[1])], to: list)
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.sessions, list)
+    }
+
+    /// Newest frame per session wins, and one batch is one pass: the caller
+    /// keys pending frames by id, so a burst reaches here already reduced.
+    func testABatchAppliesEveryFrameInOnePass() throws {
+        let renamed = try session(
+            #"{"id":"os-mid","title":"Mid, renamed","lastActivity":"2026-09-05T11:00:00.000Z"}"#
+        )
+
+        let result = try apply([.row(renamed), .removed("os-old")], to: baseline)
+
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-mid"])
+        XCTAssertEqual(result.sessions[1].title, "Mid, renamed")
+        XCTAssertEqual(result.removedIds, ["os-old"])
+    }
+
+    // MARK: - Removals and archive
+
+    func testARemovalDropsTheRow() throws {
+        let result = try apply([.removed("os-mid")], to: baseline)
+
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-old"])
+        XCTAssertEqual(result.removedIds, ["os-mid"])
+    }
+
+    func testRemovingAnUnknownRowChangesNothing() throws {
+        let result = try apply([.removed("os-elsewhere")], to: baseline)
+
+        XCTAssertFalse(result.changed)
+    }
+
+    /// The server sends a removal for an archive, but a row that says
+    /// `archived` must not stay in the live list either.
+    func testAnArchivedRowLeavesTheLiveList() throws {
+        let row = try session(#"{"id":"os-mid","archived":true}"#)
+
+        let result = try apply([.row(row)], to: baseline)
+
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-old"])
+        XCTAssertEqual(result.removedIds, ["os-mid"])
+    }
+
+    func testADeskRowNeverLists() throws {
+        let row = try session(#"{"id":"os-desk","desk":true}"#)
+
+        let result = try apply([.row(row)], to: baseline)
+
+        XCTAssertFalse(result.changed)
+    }
+
+    // MARK: - Local overlays
+
+    /// A row archived on this device is hidden until the server catches up;
+    /// its own row arriving (the copy that predates the archive, or the one
+    /// after a failed archive) must not bring it back early.
+    func testALocallyArchivedRowStaysHidden() throws {
+        let row = try session(
+            #"{"id":"os-mid","title":"Mid","lastActivity":"2026-09-05T14:00:00.000Z"}"#
+        )
+        let list = try baseline.filter { $0.id != "os-mid" }
+
+        let result = apply([.row(row)], to: list, hiding: ["os-mid"])
+
+        XCTAssertFalse(result.changed)
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-old"])
+    }
+
+    /// A row restored on this device reads as live even when the server's
+    /// snapshot still says archived, and a removal for it is not believed.
+    func testALocallyRestoredRowReadsAsLive() throws {
+        let stale = try session(
+            #"{"id":"os-back","title":"Back","archived":true,"lastActivity":"2026-09-05T11:30:00.000Z"}"#
+        )
+
+        let result = try apply([.row(stale)], to: baseline, restoring: ["os-back"])
+
+        XCTAssertEqual(result.sessions.map(\.id), ["os-new", "os-back", "os-mid", "os-old"])
+        XCTAssertEqual(result.sessions[1].archived, false)
+
+        let removal = try apply([.removed("os-back")], to: result.sessions, restoring: ["os-back"])
+        XCTAssertFalse(removal.changed)
+    }
+
+    // MARK: - Pending creates
+
+    func testAPendingCreateRetiresWhenItsOwnRowArrives() throws {
+        let placeholder = try session(
+            #"{"id":"os-real","title":"Starting","isOptimisticPlaceholder":true}"#
+        )
+        let list = try [placeholder] + baseline
+        let row = try session(
+            #"{"id":"os-real","title":"Started","lastActivity":"2026-09-05T13:00:00.000Z"}"#
+        )
+
+        let result = apply([.row(row)], to: list, optimistic: ["os-real"])
+
+        XCTAssertEqual(result.retiredOptimisticIds, ["os-real"])
+        XCTAssertEqual(result.sessions.map(\.id), ["os-real", "os-new", "os-mid", "os-old"])
+        XCTAssertEqual(result.sessions[0].isOptimistic, false)
+    }
+
+    /// Other pending creates keep their place in front, whatever their date,
+    /// and a removal for one is ignored: its row is local until the server
+    /// publishes it.
+    func testOtherPendingCreatesStayInFront() throws {
+        let pending = try session(#"{"id":"pending-1","title":"Pending"}"#)
+        let list = try [pending] + baseline
+        let row = try session(
+            #"{"id":"os-old","title":"Old, touched","lastActivity":"2026-09-05T15:00:00.000Z"}"#
+        )
+
+        let result = apply(
+            [.row(row), .removed("pending-1")], to: list, optimistic: ["pending-1"]
+        )
+
+        XCTAssertEqual(result.sessions.map(\.id), ["pending-1", "os-old", "os-new", "os-mid"])
+        XCTAssertTrue(result.retiredOptimisticIds.isEmpty)
+    }
+
+    // MARK: - Hidden rows
+
+    /// A hidden row comes back when one of its sessions blocks on a question,
+    /// exactly as the poll's pass reports it.
+    func testABlockedRowResurfacesItsHide() throws {
+        let row = try session(
+            #"{"id":"os-mid","waitingForInput":true,"lastActivity":"2026-09-05T11:00:00.000Z"}"#
+        )
+        let keys = Set(SidebarRowKeys.candidateKeys(for: row))
+        XCTAssertFalse(keys.isEmpty)
+
+        let result = try apply([.row(row)], to: baseline, hidden: keys)
+
+        XCTAssertEqual(Set(result.resurfacedHideKeys), keys)
+    }
+}

--- a/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
@@ -276,6 +276,56 @@ final class SessionRowUpdateTests: XCTestCase {
         XCTAssertEqual(polled.archived.map(\.id), ["os-gone"])
     }
 
+    func testAPollReplayDoesNotResurfaceASupersededBlockedRow() throws {
+        let blocked = try session(
+            #"{"id":"os-mid","workspaceId":"ws-1","waitingForInput":true}"#
+        )
+        let unblocked = try session(
+            #"{"id":"os-mid","workspaceId":"ws-1","waitingForInput":false}"#
+        )
+        let keys = Set(SidebarRowKeys.candidateKeys(for: blocked))
+        XCTAssertFalse(keys.isEmpty)
+        XCTAssertEqual(
+            Set(SessionsListViewModel.prepared(
+                [blocked], hiding: [], restoring: [], hidden: keys
+            ).resurfacedHideKeys), keys
+        )
+
+        for update in [SessionRowUpdate.row(unblocked), .removed(blocked.id)] {
+            let polled = SessionsListViewModel.polled(
+                [blocked], replaying: [update], optimisticIds: [],
+                hiding: [], restoring: [], hidden: keys
+            )
+
+            XCTAssertFalse(polled.active.contains { $0.lane == .needsInput })
+            XCTAssertTrue(polled.resurfacedHideKeys.isEmpty)
+        }
+    }
+
+    func testAPollReplayStillResurfacesOtherBlockedRows() throws {
+        let blocked = try session(
+            #"{"id":"os-mid","workspaceId":"ws-1","waitingForInput":true}"#
+        )
+        let other = try session(
+            #"{"id":"os-other","workspaceId":"ws-1","waitingForInput":true}"#
+        )
+        let unblocked = try session(
+            #"{"id":"os-mid","workspaceId":"ws-1","waitingForInput":false}"#
+        )
+        let keys: Set<String> = ["workspace:ws-1"]
+        for (response, updates) in [
+            ([blocked, other], [SessionRowUpdate.row(unblocked)]),
+            ([unblocked], [SessionRowUpdate.row(other)]),
+        ] {
+            let polled = SessionsListViewModel.polled(
+                response, replaying: updates, optimisticIds: [],
+                hiding: [], restoring: [], hidden: keys
+            )
+
+            XCTAssertEqual(Set(polled.resurfacedHideKeys), keys)
+        }
+    }
+
     /// Nothing to replay is exactly the plain poll pass.
     func testAPollWithNothingToReplayIsThePreparedList() throws {
         let polled = try SessionsListViewModel.polled(

--- a/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowUpdateTests.swift
@@ -210,4 +210,79 @@ final class SessionRowUpdateTests: XCTestCase {
 
         XCTAssertEqual(Set(result.resurfacedHideKeys), keys)
     }
+
+    // MARK: - Poll replay
+
+    /// A poll's response was built before any frame applied while its
+    /// request was out, so only those frames replay, oldest first.
+    func testReplayPicksTheFramesAppliedAfterThePollStarted() throws {
+        let mid = try session(#"{"id":"os-mid","title":"Mid, later"}"#)
+        let old = try session(#"{"id":"os-old","title":"Old, later"}"#)
+        let applied: [String: AppliedRowUpdate] = [
+            "os-new": AppliedRowUpdate(revision: 3, update: .removed("os-new")),
+            "os-old": AppliedRowUpdate(revision: 7, update: .row(old)),
+            "os-mid": AppliedRowUpdate(revision: 5, update: .row(mid)),
+        ]
+
+        let replay = SessionsListViewModel.replay(applied, after: 3)
+
+        XCTAssertEqual(replay.map(\.id), ["os-mid", "os-old"])
+        XCTAssertTrue(SessionsListViewModel.replay(applied, after: 7).isEmpty)
+    }
+
+    /// The frames are newer than the response: a rename they carried must
+    /// not be undone by the poll, and a removal they carried stays removed.
+    func testAPollReplaysNewerFramesOverItsResponse() throws {
+        let renamed = try session(
+            #"{"id":"os-old","title":"Old, renamed","lastActivity":"2026-09-05T13:00:00.000Z"}"#
+        )
+
+        let polled = try SessionsListViewModel.polled(
+            baseline,
+            replaying: [.row(renamed), .removed("os-mid")],
+            optimisticIds: [],
+            hiding: [],
+            restoring: []
+        )
+
+        XCTAssertEqual(polled.active.map(\.id), ["os-old", "os-new"])
+        XCTAssertEqual(polled.active[0].title, "Old, renamed")
+        XCTAssertTrue(polled.archived.isEmpty)
+    }
+
+    /// The replay reconciles the way the poll does: a row archived on this
+    /// device stays hidden, and an archived row in the response still feeds
+    /// the archived index untouched.
+    func testAPollReplayKeepsTheLocalOverlays() throws {
+        let hidden = try session(
+            #"{"id":"os-new","title":"New, renamed","lastActivity":"2026-09-05T14:00:00.000Z"}"#
+        )
+        let response = try sessions(
+            """
+            [{"id":"os-new","title":"New","lastActivity":"2026-09-05T12:00:00.000Z"},
+             {"id":"os-gone","title":"Gone","archived":true,"lastActivity":"2026-09-05T11:00:00.000Z"}]
+            """
+        )
+
+        let polled = SessionsListViewModel.polled(
+            response,
+            replaying: [.row(hidden)],
+            optimisticIds: [],
+            hiding: ["os-new"],
+            restoring: []
+        )
+
+        XCTAssertTrue(polled.active.isEmpty)
+        XCTAssertEqual(polled.archived.map(\.id), ["os-gone"])
+    }
+
+    /// Nothing to replay is exactly the plain poll pass.
+    func testAPollWithNothingToReplayIsThePreparedList() throws {
+        let polled = try SessionsListViewModel.polled(
+            baseline, replaying: [], optimisticIds: [], hiding: [], restoring: []
+        )
+        let prepared = try SessionsListViewModel.prepared(baseline, hiding: [], restoring: [])
+
+        XCTAssertEqual(polled.active, prepared.active)
+    }
 }

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -561,6 +561,8 @@ OS1/
   predates any frame applied while its request was out, so the poll replays
   those frames over the response and publishes only if the list did not
   move again meanwhile (a later poll's publish, or a mid-pass flush, wins).
+  The poll's side effects (a consumed hide, an older server's archive
+  index) wait for the same acceptance, since a cleared hide is persisted.
   Before the first list has loaded, frames are kept for that replay rather
   than merged, and the first response reruns its passes until it lands
   instead of giving up on a list that keeps moving.

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -561,6 +561,8 @@ OS1/
   predates any frame applied while its request was out, so the poll replays
   those frames over the response and publishes only if the list did not
   move again meanwhile (a later poll's publish, or a mid-pass flush, wins).
+  Before the first list has loaded, frames are kept for that replay rather
+  than merged.
   `OS1_SESSIONS_POLL_SECONDS` lengthens the poll for a build under test.
 - `presence` lists everyone watching the session, one name per socket. The
   header facepile drops our own name and dedupes devices; names resolve to

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -557,7 +557,10 @@ OS1/
   pushes `session_row` (one row, the list projection) or `session_row_removed`
   (`id`) for most metadata changes, and `sessions_invalidated` only for bulk
   ones. `SessionsListViewModel` coalesces frames for ~120ms and merges them
-  off the main actor; the poll stays as the fallback.
+  off the main actor; the poll stays as the fallback. A poll's response
+  predates any frame applied while its request was out, so the poll replays
+  those frames over the response and publishes only if the list did not
+  move again meanwhile (a later poll's publish, or a mid-pass flush, wins).
   `OS1_SESSIONS_POLL_SECONDS` lengthens the poll for a build under test.
 - `presence` lists everyone watching the session, one name per socket. The
   header facepile drops our own name and dedupes devices; names resolve to

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -11,7 +11,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
 
 ## Features (v0.1)
 
-- **Sessions list:** polls `GET /api/sessions` every 5s (matching the web UI);
+- **Sessions list:** live over the presence socket (`sessions_subscribe`, then
+  `session_row` / `session_row_removed` per change) with a 5s
+  `GET /api/sessions` poll underneath as the fallback (matching the web UI);
   flat single-line workspace rows with live/PR status marks and a running-time
   ticker, larger mobile type, and the web client's warm dark palette. Inbox
   keeps Active work in stable creation order with a nearby Snoozed shelf,
@@ -488,7 +490,7 @@ OS1/
     ServerEvent.swift        WS frame parsing (unknown types -> .ignored)
     OS1Socket.swift          WebSocket: bearer auth, ping loop, typed events
   ViewModels/
-    SessionsListViewModel.swift  5s polling + memoized sidebar grouping
+    SessionsListViewModel.swift  row frames + 5s fallback poll, memoized sidebar grouping
     SessionViewModel.swift       watch/stream/prompt/ask state machine
     TranscriptBlocks.swift       Turn grouping (fold/answer/footer) + fold state
     SessionViewModelCache.swift  Bounded recently visited conversation cache
@@ -550,6 +552,13 @@ OS1/
 - Entries can arrive clamped (`contentClamped`); full content is at
   `GET /api/sessions/:id/entry/:entryId`. The assistant's **Show full message**
   action and expanded clamped tool results fetch it on demand.
+- The active account's presence socket sends `sessions_subscribe` with the
+  live list's query (`?archived=exclude`) after every hello. The server then
+  pushes `session_row` (one row, the list projection) or `session_row_removed`
+  (`id`) for most metadata changes, and `sessions_invalidated` only for bulk
+  ones. `SessionsListViewModel` coalesces frames for ~120ms and merges them
+  off the main actor; the poll stays as the fallback.
+  `OS1_SESSIONS_POLL_SECONDS` lengthens the poll for a build under test.
 - `presence` lists everyone watching the session, one name per socket. The
   header facepile drops our own name and dedupes devices; names resolve to
   GitHub pictures through `GET /api/people` (`TeamDirectory`).
@@ -564,4 +573,3 @@ OS1/
 ## Next milestones
 
 - Image attachments in assistant markdown
-- Push-style updates for the sessions list (it polls today)

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -562,7 +562,8 @@ OS1/
   those frames over the response and publishes only if the list did not
   move again meanwhile (a later poll's publish, or a mid-pass flush, wins).
   Before the first list has loaded, frames are kept for that replay rather
-  than merged.
+  than merged, and the first response reruns its passes until it lands
+  instead of giving up on a list that keeps moving.
   `OS1_SESSIONS_POLL_SECONDS` lengthens the poll for a build under test.
 - `presence` lists everyone watching the session, one name per socket. The
   header facepile drops our own name and dedupes devices; names resolve to

--- a/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
+++ b/packages/core/opensession-server/src/server/session-kernel/actor-service.test.ts
@@ -314,7 +314,7 @@ describe("session kernel actor service", () => {
     );
 
     const after = await ready();
-    expect(after.lanes[0]?.turnsCompleted).toBe(beforeByLane.get(0));
+    expect(after.lanes[0]?.turnsCompleted === beforeByLane.get(0)).toBe(true);
     const sessionLaneDeltas = after.lanes
       .slice(1)
       .map((lane) => lane.turnsCompleted - (beforeByLane.get(lane.index) ?? 0));


### PR DESCRIPTION
Brings the native Swift client up to the session-list wire behavior shipped in 7e7ff4de and 29bbe68e. The server expects a sidebar socket to send `sessions_subscribe` and answers most metadata changes with `session_row` / `session_row_removed`; at HEAD the native app ignored both and waited for its 5s poll.

## Before / after

| | Before | After |
|---|---|---|
| Subscribe | never sent | `sessions_subscribe` with `?archived=exclude` after every hello and on account switch |
| `session_row` | `.ignored` | decoded off the main actor, coalesced 120ms, merged in place |
| `session_row_removed` | `.ignored` | row dropped, archived index marked stale |
| `sessions_invalidated` | `.ignored` | list re-read |
| Archive elsewhere shows up in | up to 5s | under 1s (server coalesce 250ms + 120ms) |

## Changes

- `ServerEvent`: `.sessionRow(Session)`, `.sessionRowRemoved(sessionId:)`, `.sessionsInvalidated`; malformed frames stay `.ignored`.
- `OS1Socket`: `subscribeSessions(query:)`; row frames take the detached decode path (type-prefix match).
- `PresenceStore`: subscribes the active account's socket after hello and in `start()` (account switch / foreground), forwards that account's frames plus a `subscribed` event to observers.
- `SessionsListViewModel`: `applyingRowUpdates` is a pure off-main merge that keeps the poll's filters, local archive/restore overlays, optimistic placeholders (retire on own row, otherwise stay in front), recency order and hide resurfacing. A publish landing mid-merge requeues the frames. Poll stays as fallback; `OS1_SESSIONS_POLL_SECONDS` lengthens it for verification.

## Verification

- tella-mac-node: `xcodegen generate`, OS1 (iOS Simulator) and OS1Mac build; `ServerEventTests`, `SessionRowUpdateTests` (new, 13), `PresenceStoreTests`, `ArchivedSliceTests`, `SessionsListLensTests`: 70 pass.
- Live against os.tella.dev with `OS1_SESSIONS_POLL_SECONDS=600`: archiving a session over REST removed its row from the Mac app within 5s (1,028 -> 1,027), restoring it brought the row back (-> 1,028). Screenshots in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-8d227be9-fdf6-7406-972e-52fc6725e2f3)