### PR TITLE
Native app: show merge risk apart from the review's quality score

### DIFF
--- a/packages/clients/ios/OS1/Models/Session.swift
+++ b/packages/clients/ios/OS1/Models/Session.swift
@@ -356,17 +356,64 @@ struct PrChecksSummary: Decodable, Equatable, Hashable {
 /// The automated review the PR last got (`OsReviewSummary` on the server).
 /// Every field is optional here: an older server sends none of it, and a
 /// missing verdict has to read as "no verdict" rather than as a passing one.
-struct OsReviewSummary: Decodable, Equatable, Hashable {
+///
+/// The review answers two questions and they are two fields: `confidence` is
+/// whether the change is right as written, `risk` is how careful landing it
+/// has to be. A correct migration and a sloppy CSS tweak can share a score
+/// and sit at opposite ends of risk, so neither is derived from the other.
+struct OsReviewSummary: Equatable, Hashable {
+    /// How hard a mistake would be to undo. Advisory: it never moves the
+    /// verdict, only how the row reads it.
+    enum Risk: String, Decodable, CaseIterable, Sendable {
+        case low, medium, high
+    }
+
+    /// Time to get every user back to a good state if the change is wrong.
+    enum Recovery: String, Decodable, CaseIterable, Sendable {
+        case minutes, hours, days, irreversible
+    }
+
     /// approve | comment | request_changes.
     var verdict: String?
-    /// 1-5: how safe the reviewer thought this was to merge.
+    /// 1-5: quality of the change as written.
     var confidence: Int?
+    /// Merge risk, scored apart from quality by its own diff-only pass.
+    var risk: Risk?
+    var recovery: Recovery?
+    /// Fixed-taxonomy reasons behind the risk ("migration", "no tests").
+    var riskFactors: [String]?
     var findings: Int?
     /// P0/P1 findings — what would block a merge.
     var blocking: Int?
     /// The branch has moved on since this verdict — it describes older code.
     var stale: Bool?
     var at: String?
+}
+
+extension OsReviewSummary: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case verdict, confidence, risk, recovery, riskFactors, findings, blocking, stale, at
+    }
+
+    /// Hand-written so a risk word this build does not know (a newer server
+    /// adding a level) drops to nil instead of failing the whole sessions
+    /// list: one unrecognised enum case must never take the sidebar down.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        verdict = try container.decodeIfPresent(String.self, forKey: .verdict)
+        confidence = try container.decodeIfPresent(Int.self, forKey: .confidence)
+        risk = (try? container.decodeIfPresent(String.self, forKey: .risk))
+            .flatMap { $0 }
+            .flatMap(Risk.init(rawValue:))
+        recovery = (try? container.decodeIfPresent(String.self, forKey: .recovery))
+            .flatMap { $0 }
+            .flatMap(Recovery.init(rawValue:))
+        riskFactors = try container.decodeIfPresent([String].self, forKey: .riskFactors)
+        findings = try container.decodeIfPresent(Int.self, forKey: .findings)
+        blocking = try container.decodeIfPresent(Int.self, forKey: .blocking)
+        stale = try container.decodeIfPresent(Bool.self, forKey: .stale)
+        at = try container.decodeIfPresent(String.self, forKey: .at)
+    }
 }
 
 extension Session {

--- a/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
+++ b/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
@@ -151,7 +151,9 @@ struct ReviewLoopResult: Equatable {
     enum Status: Equatable { case pending, passed, failed }
 
     var status: Status
-    /// 1-5: how safe the reviewer thought this was to merge.
+    /// 1-5: quality of the change as written. Merge risk is the review's
+    /// other axis and stays on the workspace and card surfaces; the loop's
+    /// verdict is about whether the change is right.
     var confidence: Int?
     var checksPassed: Int?
     var checksFailed: Int?

--- a/packages/clients/ios/OS1/Views/SessionRowPreview.swift
+++ b/packages/clients/ios/OS1/Views/SessionRowPreview.swift
@@ -20,7 +20,9 @@ import SwiftUI
 ///   card has 300px and a label column; a phone has neither, and a 74pt label
 ///   gutter would leave its values a dozen characters wide.
 /// - **The review is compact.** Its score leads the verdict (`4/5 · approved`),
-///   with blocking and stale context retained when present.
+///   with blocking and stale context retained when present. Merge risk is a
+///   fact of its own (`high risk`): it is scored apart from quality, so it is
+///   said apart from it, in its own ink.
 ///
 /// What deliberately did NOT come across is the web footer's centred Merge
 /// button. A context menu preview is not interactive: taps go to the menu, so
@@ -189,20 +191,29 @@ struct PrReviewCardsScreenshot: View {
                 card(
                     title: "Ready after review",
                     review: OsReviewSummary(
-                        verdict: "approve", confidence: 4, findings: 0, blocking: 0, stale: false
+                        verdict: "approve", confidence: 4, risk: .low,
+                        findings: 0, blocking: 0, stale: false
+                    )
+                )
+                card(
+                    title: "Correct, but a migration",
+                    review: OsReviewSummary(
+                        verdict: "approve", confidence: 5, risk: .high, recovery: .days,
+                        findings: 0, blocking: 0, stale: false
                     )
                 )
                 card(
                     title: "Address blocking feedback",
                     review: OsReviewSummary(
-                        verdict: "request_changes", confidence: 2,
+                        verdict: "request_changes", confidence: 2, risk: .medium,
                         findings: 2, blocking: 1, stale: false
                     )
                 )
                 card(
                     title: "Review is behind the branch",
                     review: OsReviewSummary(
-                        verdict: "comment", confidence: 3, findings: 1, blocking: 0, stale: true
+                        verdict: "comment", confidence: 3, risk: .high,
+                        findings: 1, blocking: 0, stale: true
                     )
                 )
             }
@@ -267,6 +278,9 @@ enum PrPreviewFacts {
         }
         if let osReview = session.prOsReview.flatMap(osReviewFact) {
             facts.append(osReview)
+        }
+        if let risk = session.prOsReview.flatMap(riskFact) {
+            facts.append(risk)
         }
         if let waiting = reviewersFact(session.prReviewRequested, state: state) {
             facts.append(waiting)
@@ -363,6 +377,26 @@ enum PrPreviewFacts {
             }
         }
         return PrPreviewFact(text: parts.joined(separator: " · "), tone: tone)
+    }
+
+    /// Merge risk, as its own phrase beside the verdict rather than inside
+    /// it: the verdict says whether the change is right, this says how hard
+    /// it is to undo, and one ink cannot say both. High and medium take the
+    /// warning inks; low is only a word and goes dim. A stale reading goes
+    /// faint with the verdict it came with, so old caution weighs no more
+    /// than old approval.
+    static func riskFact(_ review: OsReviewSummary) -> PrPreviewFact? {
+        guard let risk = review.risk else { return nil }
+        let tone: PrPreviewFact.Tone = if review.stale == true {
+            .faint
+        } else {
+            switch risk {
+            case .high: .red
+            case .medium: .yellow
+            case .low: .dim
+            }
+        }
+        return PrPreviewFact(text: "\(risk.rawValue) risk", tone: tone)
     }
 
     /// Who the PR is waiting on. Two names is the most that fits before the

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -357,6 +357,9 @@ struct SessionsListView: View {
                 if ProcessInfo.processInfo.environment["OS1_PR_REVIEW_CARDS_FIXTURE"] == "1" {
                     PrReviewCardsScreenshot()
                 }
+                if ProcessInfo.processInfo.environment["OS1_WORKSPACE_REVIEW_FIXTURE"] == "1" {
+                    WorkspaceReviewRowsScreenshot()
+                }
             }
             #endif
             // Session-id links in agent output (SessionLinks) are ordinary

--- a/packages/clients/ios/OS1/Views/WorkspaceReviewRows.swift
+++ b/packages/clients/ios/OS1/Views/WorkspaceReviewRows.swift
@@ -127,6 +127,7 @@ private struct AgentReviewRow: View {
 
     private var review: OsReviewSummary? { pr.osReview }
     private var score: Int? { review?.confidence }
+    private var risk: OsReviewSummary.Risk? { review?.risk }
     private var stale: Bool { review?.stale == true }
     private var actionable: Bool { pr.isOpen }
     private var active: Bool { pr.reviewActive == true || busy == .review || queued != nil }
@@ -223,11 +224,14 @@ private struct AgentReviewRow: View {
         .onChange(of: pr.osReview?.at) { _, _ in settle() }
         .sheet(isPresented: $readingReport) {
             if let report {
-                AgentReviewReport(report: report, score: score, at: review?.at)
+                AgentReviewReport(report: report, score: score, risk: risk, at: review?.at)
             }
         }
     }
 
+    /// The band is quality alone. Risk is advisory and has its own word on
+    /// the line below; a high-risk change the agent found correct still sits
+    /// on a green row, exactly as it does on the web.
     private var tone: ReviewTone {
         if active { return .blue }
         guard let score else { return .muted }
@@ -236,12 +240,27 @@ private struct AgentReviewRow: View {
         return score == 3 ? .yellow : .red
     }
 
-    /// How safe it thought the change was, then the one thing worth knowing
-    /// about that reading. The score leads because it is the answer; a run
-    /// that has no score yet simply starts at the words.
-    private var detail: String {
-        guard let score, !active else { return state }
-        return "\(score)/5 · \(state)"
+    /// How good it thought the change was, how careful landing it should be,
+    /// then the one thing worth knowing about that reading. The score leads
+    /// because it is the answer; a run that has no score yet simply starts at
+    /// the words.
+    private var detail: Text {
+        AgentReviewDetail
+            .compose(score: score, risk: risk, stale: stale, active: active, state: state)
+            .segments
+            .reduce(Text("")) { line, segment in
+                line + Text(segment.text).foregroundStyle(color(for: segment.ink))
+            }
+    }
+
+    private func color(for ink: AgentReviewDetail.Ink) -> Color {
+        switch ink {
+        case .row: tone.ink
+        case .red: OS1VisualStyle.redInk
+        case .yellow: OS1VisualStyle.yellowInk
+        case .dim: OS1VisualStyle.textDim
+        case .faint: OS1VisualStyle.textFaint
+        }
     }
 
     private var state: String {
@@ -296,6 +315,64 @@ private struct AgentReviewRow: View {
         guard let queued else { return }
         if pr.reviewActive == true || pr.osReview?.at != queued.previousAt {
             self.queued = nil
+        }
+    }
+}
+
+/// The agent row's second line, in pieces. Quality and merge risk are two
+/// axes, so the line cannot be one string in one colour: the score and the
+/// state take the row's ink, the risk word takes its own, and nothing else
+/// on the row moves with it. Pure, so the wording and the inks can be
+/// asserted without a screen.
+struct AgentReviewDetail: Equatable {
+    /// Which ink a piece is set in. `row` is whatever the band's tone gives
+    /// the line; the rest are the app's status inks, which hold contrast on
+    /// both platforms' canvases in both appearances (`StatusInkContrastTests`).
+    enum Ink: Equatable {
+        case row, red, yellow, dim, faint
+    }
+
+    struct Segment: Equatable {
+        let text: String
+        let ink: Ink
+    }
+
+    let segments: [Segment]
+
+    /// The whole line, as VoiceOver reads it: one label, the inks aside.
+    var text: String { segments.map(\.text).joined() }
+
+    static func compose(
+        score: Int?,
+        risk: OsReviewSummary.Risk?,
+        stale: Bool,
+        active: Bool,
+        state: String
+    ) -> AgentReviewDetail {
+        // A running pass is only "Reviewing…": the numbers it is about to
+        // replace would read as the answer.
+        guard !active else { return AgentReviewDetail(segments: [Segment(text: state, ink: .row)]) }
+        var segments = [Segment]()
+        if let score {
+            segments.append(Segment(text: "\(score)/5 · ", ink: .row))
+        }
+        if let risk {
+            segments.append(Segment(text: "\(risk.rawValue) risk", ink: ink(for: risk, stale: stale)))
+            segments.append(Segment(text: " · ", ink: .row))
+        }
+        segments.append(Segment(text: state, ink: .row))
+        return AgentReviewDetail(segments: segments)
+    }
+
+    /// High and medium take the warning inks; low is only a word, so it goes
+    /// dim rather than borrowing green and reading as a second verdict. A
+    /// stale reading goes faint with the rest of the verdict it belongs to.
+    static func ink(for risk: OsReviewSummary.Risk, stale: Bool) -> Ink {
+        if stale { return .faint }
+        return switch risk {
+        case .high: .red
+        case .medium: .yellow
+        case .low: .dim
         }
     }
 }
@@ -364,7 +441,7 @@ private struct ReviewerRow: View {
                 }
             },
             name: rowName,
-            detail: rowState,
+            detail: Text(rowState),
             tint: tone.ink,
             note: nil,
             error: error,
@@ -570,6 +647,7 @@ private struct ReviewerRow: View {
 private struct AgentReviewReport: View {
     let report: PrComment
     let score: Int?
+    let risk: OsReviewSummary.Risk?
     let at: String?
 
     @Environment(\.dismiss) private var dismiss
@@ -587,8 +665,12 @@ private struct AgentReviewReport: View {
             .inlineTitleBarCompat()
             .toolbar {
                 ToolbarItem(placement: .topLeadingCompat) {
-                    if let score {
-                        Text("\(score)/5")
+                    // The two numbers the row led with, so the reading opens
+                    // under the same header it was tapped from.
+                    let parts = [score.map { "\($0)/5" }, risk.map { "\($0.rawValue) risk" }]
+                        .compactMap { $0 }
+                    if !parts.isEmpty {
+                        Text(parts.joined(separator: " · "))
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(OS1VisualStyle.textDim)
                             .monospacedDigit()
@@ -617,7 +699,9 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
     @ViewBuilder let leading: Leading
     /// Nil when the state already says who it is about ("Needs your review").
     let name: String?
-    let detail: String
+    /// A `Text` rather than a string so a piece of it can carry its own ink
+    /// (the agent row's risk word) while the line stays one label.
+    let detail: Text
     let tint: Color
     let note: String?
     let error: String?
@@ -671,7 +755,7 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
                         .foregroundStyle(OS1VisualStyle.text)
                         .lineLimit(1)
                 }
-                Text(detail)
+                detail
                     .font(.caption)
                     .foregroundStyle(tint)
                     .lineLimit(2)
@@ -680,6 +764,66 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
         .contentShape(Rectangle())
     }
 }
+
+#if DEBUG
+/// Deterministic visual proof for the native screenshot harness: the agent
+/// row at each merge-risk level, plus one whose reading the branch has moved
+/// past. Same plate as the workspace sheet's Review section.
+struct WorkspaceReviewRowsScreenshot: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Agent review rows")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(OS1VisualStyle.text)
+                plate(
+                    "Low risk",
+                    OsReviewSummary(verdict: "approve", confidence: 4, risk: .low, recovery: .minutes)
+                )
+                plate(
+                    "Medium risk",
+                    OsReviewSummary(
+                        verdict: "comment", confidence: 4, risk: .medium, recovery: .hours,
+                        riskFactors: ["no tests"], findings: 1, blocking: 0
+                    )
+                )
+                plate(
+                    "High risk",
+                    OsReviewSummary(
+                        verdict: "request_changes", confidence: 2, risk: .high, recovery: .days,
+                        riskFactors: ["migration", "auth"], findings: 2, blocking: 1
+                    )
+                )
+                plate(
+                    "Stale",
+                    OsReviewSummary(verdict: "approve", confidence: 3, risk: .high, stale: true)
+                )
+                plate("No risk score", OsReviewSummary(verdict: "approve", confidence: 5))
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OS1VisualStyle.background)
+    }
+
+    private func plate(_ title: String, _ review: OsReviewSummary) -> some View {
+        var pr = PrDetails(number: 128)
+        pr.state = "OPEN"
+        pr.osReview = review
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(OS1VisualStyle.textDim)
+            AgentReviewRow(sessionId: "screenshot", pr: pr, repo: "opensession", agentName: "Agent")
+                .padding(6)
+                .background(
+                    OS1VisualStyle.raised,
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+                )
+        }
+    }
+}
+#endif
 
 /// The trailing control on a review row: a small capsule that opens a menu.
 /// Title-less while a review is waiting on you, where the row's own action

--- a/packages/clients/ios/OS1Tests/AgentReviewDetailTests.swift
+++ b/packages/clients/ios/OS1Tests/AgentReviewDetailTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import OS1
+
+/// The workspace agent row's second line: quality leads, merge risk is said
+/// beside it in its own ink, and the state closes the line.
+final class AgentReviewDetailTests: XCTestCase {
+    private func detail(
+        score: Int? = 4,
+        risk: OsReviewSummary.Risk? = nil,
+        stale: Bool = false,
+        active: Bool = false,
+        state: String = "No findings"
+    ) -> AgentReviewDetail {
+        AgentReviewDetail.compose(score: score, risk: risk, stale: stale, active: active, state: state)
+    }
+
+    func testRiskSitsBetweenScoreAndState() {
+        let line = detail(risk: .high)
+        XCTAssertEqual(line.text, "4/5 · high risk · No findings")
+        XCTAssertEqual(
+            line.segments,
+            [
+                .init(text: "4/5 · ", ink: .row),
+                .init(text: "high risk", ink: .red),
+                .init(text: " · ", ink: .row),
+                .init(text: "No findings", ink: .row),
+            ]
+        )
+    }
+
+    func testEachLevelTakesItsOwnInkAndNeverTheRows() {
+        XCTAssertEqual(AgentReviewDetail.ink(for: .high, stale: false), .red)
+        XCTAssertEqual(AgentReviewDetail.ink(for: .medium, stale: false), .yellow)
+        XCTAssertEqual(AgentReviewDetail.ink(for: .low, stale: false), .dim)
+        XCTAssertEqual(detail(risk: .medium).text, "4/5 · medium risk · No findings")
+        XCTAssertEqual(detail(risk: .low).text, "4/5 · low risk · No findings")
+    }
+
+    func testAbsentRiskReadsAsBefore() {
+        let line = detail()
+        XCTAssertEqual(line.text, "4/5 · No findings")
+        XCTAssertTrue(line.segments.allSatisfy { $0.ink == .row })
+    }
+
+    func testStaleRiskGoesFaintAndTheStateStillSaysWhy() {
+        let line = detail(score: 3, risk: .high, stale: true, state: "New commits since review")
+        XCTAssertEqual(line.text, "3/5 · high risk · New commits since review")
+        XCTAssertEqual(line.segments[1], .init(text: "high risk", ink: .faint))
+        for level in OsReviewSummary.Risk.allCases {
+            XCTAssertEqual(AgentReviewDetail.ink(for: level, stale: true), .faint)
+        }
+    }
+
+    func testRiskWithoutAScoreStartsTheLine() {
+        XCTAssertEqual(detail(score: nil, risk: .medium).text, "medium risk · No findings")
+    }
+
+    func testRunningPassSaysOnlyThatItIsRunning() {
+        let line = detail(risk: .high, active: true, state: "Reviewing…")
+        XCTAssertEqual(line.segments, [.init(text: "Reviewing…", ink: .row)])
+    }
+}

--- a/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
@@ -151,6 +151,57 @@ final class SessionRowPreviewTests: XCTestCase {
         XCTAssertNil(PrPreviewFacts.osReviewFact(OsReviewSummary(confidence: 3)))
     }
 
+    // MARK: - Merge risk, the review's other axis
+
+    func testRiskIsItsOwnFactInItsOwnInk() {
+        XCTAssertEqual(
+            PrPreviewFacts.riskFact(OsReviewSummary(verdict: "approve", risk: .high)),
+            PrPreviewFact(text: "high risk", tone: .red)
+        )
+        XCTAssertEqual(
+            PrPreviewFacts.riskFact(OsReviewSummary(verdict: "approve", risk: .medium)),
+            PrPreviewFact(text: "medium risk", tone: .yellow)
+        )
+        XCTAssertEqual(
+            PrPreviewFacts.riskFact(OsReviewSummary(verdict: "approve", risk: .low)),
+            PrPreviewFact(text: "low risk", tone: .dim)
+        )
+    }
+
+    func testRiskDoesNotEnterTheVerdictPhrase() {
+        // Quality and risk are scored apart, so a correct migration keeps its
+        // green verdict and says its risk beside it, not inside it.
+        let review = OsReviewSummary(verdict: "approve", confidence: 5, risk: .high)
+        XCTAssertEqual(
+            PrPreviewFacts.osReviewFact(review),
+            PrPreviewFact(text: "5/5 · approved", tone: .green)
+        )
+        XCTAssertEqual(
+            texts(session(osReview: review)),
+            ["Ready to merge", "5/5 · approved", "high risk"]
+        )
+    }
+
+    func testAbsentRiskAddsNothing() {
+        XCTAssertNil(PrPreviewFacts.riskFact(OsReviewSummary(verdict: "approve", confidence: 4)))
+        XCTAssertEqual(
+            texts(session(osReview: OsReviewSummary(verdict: "approve", confidence: 4))),
+            ["Ready to merge", "4/5 · approved"]
+        )
+    }
+
+    func testStaleRiskGoesFaintWithItsVerdict() {
+        let review = OsReviewSummary(verdict: "approve", confidence: 4, risk: .high, stale: true)
+        XCTAssertEqual(
+            PrPreviewFacts.riskFact(review),
+            PrPreviewFact(text: "high risk", tone: .faint)
+        )
+        XCTAssertEqual(
+            PrPreviewFacts.all(for: session(osReview: review)).map(\.tone),
+            [.green, .faint, .faint]
+        )
+    }
+
     // MARK: - Reviewers
 
     func testWaitingOnUpToTwoPeopleNamesThem() {

--- a/packages/clients/ios/OS1Tests/SessionTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionTests.swift
@@ -45,6 +45,62 @@ final class SessionTests: XCTestCase {
         XCTAssertNil(partial.safety?.explanation)
     }
 
+    // MARK: - Automated review: quality and merge risk are two fields
+
+    func testReviewRiskDecodesAtEveryLevel() throws {
+        for (word, level) in [
+            ("low", OsReviewSummary.Risk.low),
+            ("medium", .medium),
+            ("high", .high),
+        ] {
+            let session = try session(
+                #"{"id":"os-1","prOsReview":{"verdict":"approve","confidence":4,"risk":"\#(word)","findings":0,"blocking":0,"stale":false}}"#
+            )
+            XCTAssertEqual(session.prOsReview?.risk, level, word)
+            XCTAssertEqual(session.prOsReview?.confidence, 4, "quality stays its own score")
+        }
+    }
+
+    func testReviewRecoveryAndFactorsDecode() throws {
+        let session = try session(
+            #"{"id":"os-1","prOsReview":{"verdict":"approve","confidence":5,"risk":"high","recovery":"irreversible","riskFactors":["migration","auth"],"findings":0,"blocking":0}}"#
+        )
+        XCTAssertEqual(session.prOsReview?.recovery, .irreversible)
+        XCTAssertEqual(session.prOsReview?.riskFactors, ["migration", "auth"])
+        XCTAssertEqual(session.prOsReview?.stale, nil)
+    }
+
+    func testOlderServerWithoutRiskStillDecodes() throws {
+        let session = try session(
+            #"{"id":"os-1","prOsReview":{"verdict":"comment","confidence":3,"findings":1,"blocking":0,"stale":true}}"#
+        )
+        XCTAssertNil(session.prOsReview?.risk)
+        XCTAssertNil(session.prOsReview?.recovery)
+        XCTAssertNil(session.prOsReview?.riskFactors)
+        XCTAssertEqual(session.prOsReview?.confidence, 3)
+        XCTAssertEqual(session.prOsReview?.stale, true)
+    }
+
+    func testUnknownRiskWordDropsToNilRatherThanFailingTheSession() throws {
+        // A newer server adding a level must not take the sessions list down.
+        let session = try session(
+            #"{"id":"os-1","prOsReview":{"verdict":"approve","confidence":4,"risk":"critical","recovery":"weeks","findings":0,"blocking":0}}"#
+        )
+        XCTAssertEqual(session.id, "os-1")
+        XCTAssertNil(session.prOsReview?.risk)
+        XCTAssertNil(session.prOsReview?.recovery)
+        XCTAssertEqual(session.prOsReview?.verdict, "approve")
+        XCTAssertEqual(session.prOsReview?.confidence, 4)
+    }
+
+    func testStaleReviewKeepsItsRisk() throws {
+        let session = try session(
+            #"{"id":"os-1","prOsReview":{"verdict":"approve","confidence":4,"risk":"high","findings":0,"blocking":0,"stale":true}}"#
+        )
+        XCTAssertEqual(session.prOsReview?.risk, .high)
+        XCTAssertEqual(session.prOsReview?.stale, true)
+    }
+
     func testSessionAliasesAreDecodedForTranscriptLinks() throws {
         let session = try self.session(
             #"{"id":"os-current","aliasIds":["bks-original"]}"#


### PR DESCRIPTION
Ports the review-summary wire and UI changes from 47c06994 to the native Swift client (OS1 / OS1Mac).

## Why

The server's `osReview` summary now carries `risk` (low/medium/high), `recovery` (minutes/hours/days/irreversible) and `riskFactors` beside `confidence`, which scores quality only. `Models/Session.swift` dropped all three and still described confidence as merge safety, so the workspace review row and the session card never showed risk.

## What changed

- **Model** (`Session.swift`): `OsReviewSummary` gains `risk: Risk?`, `recovery: Recovery?`, `riskFactors: [String]?` with a hand-written decoder. An unknown risk or recovery word drops to `nil` instead of failing the whole sessions list.
- **Workspace review row** (`WorkspaceReviewRows.swift`): the agent row's second line becomes `4/5 · high risk · No findings`. The band and the score keep the quality tone; only the risk word takes its own ink (red for high, yellow for medium, dim for low, faint when stale). `ReviewRow.detail` is a `Text` so one line can carry two inks and still read as one VoiceOver label. Logic lives in a pure `AgentReviewDetail` so it is testable. The review sheet header repeats both numbers.
- **Session card** (`SessionRowPreview.swift`): a separate `high risk` fact on the strip via `PrPreviewFacts.riskFact`, with the same tones; the verdict phrase is unchanged.
- **Fixture**: `OS1_WORKSPACE_REVIEW_FIXTURE=1` renders the row at every level for `scripts/capture-ios.ts`; the PR-cards fixture now carries risk values.
- Colours are the existing native status inks (`greenInk`/`yellowInk`/`redInk`, `secondaryLabel`/`tertiaryLabel`), which already hold contrast on both platform canvases in both appearances; no web colour values were copied.

## Tests

- `SessionTests`: decoding at low/medium/high, recovery and factors, an older server without the fields, an unknown word, and a stale review keeping its risk.
- `SessionRowPreviewTests`: risk fact per level, absent risk, stale risk goes faint, risk never enters the verdict phrase.
- `AgentReviewDetailTests` (new): line wording and inks per level, absent, stale, no score, and a running pass.

## Verification

- `xcodebuild build` for `OS1` (iOS Simulator) and `OS1Mac`; `xcodebuild test` on `OS1Mac` for the six related suites: 120 tests, 0 failures.
- `bun run check` green.
- Simulator captures (iPhone 17 Pro, light and dark) of the workspace agent row at each risk level and the session cards are attached in the OS session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-7f9cf4a1-1d0c-7da7-938e-330c740425f7)