### PR TITLE
Native: move a host session into a Sandbox and open its desktop

### DIFF
--- a/packages/clients/ios/OS1/Models/SessionSandbox.swift
+++ b/packages/clients/ios/OS1/Models/SessionSandbox.swift
@@ -31,9 +31,95 @@ struct SessionSandboxStatus: Decodable, Equatable, Sendable {
     let cwd: String?
     let canPause: Bool?
     let canResume: Bool?
+    /// The provider can show this Sandbox's screen; see `SandboxDesktopLink`.
+    let canDesktop: Bool?
     let logs: Logs?
 }
 
 enum SessionSandboxAction: String, Equatable {
     case pause, resume, recreate
+}
+
+/// One viewer's link to a Sandbox desktop, from
+/// `POST /api/sessions/:id/sandbox/desktop`. The URL is a bearer secret: the
+/// server hands it out once and audits the request without it, so this value
+/// is minted when someone taps Open desktop, opened, and dropped. Never store
+/// it, and never let it into a log: the description redacts it so an
+/// interpolated or printed link cannot leak it by accident.
+struct SandboxDesktopLink: Decodable, Equatable, Sendable, CustomStringConvertible {
+    let url: String
+    /// Milliseconds since the epoch, when the provider bounds the link.
+    let expiresAt: Double?
+
+    /// The link as something the browser presentation can open. Only web
+    /// URLs qualify: a provider answering anything else is a bug, and the
+    /// system opener must not be handed a bearer link of an unknown scheme.
+    var webURL: URL? {
+        guard let parsed = URL(string: url) else { return nil }
+        switch parsed.scheme?.lowercased() {
+        case "http", "https": return parsed
+        default: return nil
+        }
+    }
+
+    var description: String { "SandboxDesktopLink(url: <redacted>)" }
+}
+
+/// Moving a session that runs on this machine into a Sandbox, which the
+/// server provisions on the session's next turn. The rules mirror the web's
+/// `MoveToSandboxMenu` so both clients offer the move to the same sessions.
+enum SandboxMove {
+    /// A code session on this machine, with a repository to clone and no
+    /// automation or Runner pinning it here. Once it carries a Sandbox the
+    /// move is done.
+    static func canMove(_ session: Session) -> Bool {
+        guard session.mode == "code",
+              let repo = session.repo, !repo.isEmpty,
+              session.automation?.isAutomation != true,
+              session.runner == nil
+        else { return false }
+        guard let provider = session.sandbox?.provider, !provider.isEmpty else { return true }
+        return provider == "local"
+    }
+
+    /// The Sandboxes the move may target: the same ready providers a new
+    /// session could choose, in the server's order.
+    static func providers(_ status: InstanceSandboxStatus?) -> [String] {
+        SandboxOffering.choices(status).filter { $0 != SandboxOffering.host && $0 != "local" }
+    }
+
+    static func label(_ provider: String) -> String {
+        SandboxOffering.label(provider)
+    }
+
+    /// What the server said to one attach request.
+    enum Outcome: Equatable {
+        /// The record now says the Sandbox is preparing.
+        case moved(SessionSandboxStatus)
+        /// Work exists only on this machine (uncommitted files, unpushed
+        /// commits). The server refused with 428 and this sentence; a person
+        /// has to accept leaving it behind before the request is repeated
+        /// with `confirm`.
+        case needsConfirmation(String)
+        case failed(String)
+    }
+
+    /// Runs one attach and classifies the answer. The 428 is surfaced exactly
+    /// once: an unconfirmed attempt turns it into `needsConfirmation`, while
+    /// a confirmed retry that still meets it reports a failure rather than
+    /// asking again.
+    static func attempt(
+        confirmed: Bool,
+        request: (_ confirm: Bool) async throws -> SessionSandboxStatus
+    ) async -> Outcome {
+        do {
+            return .moved(try await request(confirmed))
+        } catch OS1API.APIError.confirmRequired(let message) where !confirmed {
+            return .needsConfirmation(message)
+        } catch {
+            return .failed(
+                (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            )
+        }
+    }
 }

--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -35,6 +35,9 @@ enum OS1API {
         case badURL
         case http(Int)
         case server(String)
+        /// 428: the server wants a person to accept a consequence it spelled
+        /// out before it acts. Repeat the request with `confirm` to proceed.
+        case confirmRequired(String)
 
         var errorDescription: String? {
             switch self {
@@ -44,7 +47,7 @@ enum OS1API {
                 code == 401
                     ? "Not signed in (401) — check your token in Settings."
                     : "Server returned HTTP \(code)."
-            case .server(let message): message
+            case .server(let message), .confirmRequired(let message): message
             }
         }
     }
@@ -1021,6 +1024,32 @@ enum OS1API {
         return try await post("/api/sessions/\(encoded)/sandbox/\(action.rawValue)", body: body)
     }
 
+    /// Move a session that runs on this machine into a Sandbox, provisioned
+    /// on its next turn. A 428 (`APIError.confirmRequired`) means work exists
+    /// only on this machine; repeat with `confirm` to move anyway.
+    static func sandboxAttach(
+        sessionId: String,
+        provider: String,
+        confirm: Bool = false
+    ) async throws -> SessionSandboxStatus {
+        let encoded = sessionId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? sessionId
+        var body: [String: Any] = ["provider": provider]
+        if confirm { body["confirm"] = true }
+        return try await post("/api/sessions/\(encoded)/sandbox/attach", body: body)
+    }
+
+    /// Mint one viewer's link to the Sandbox desktop. Open it, then drop it:
+    /// the URL is a bearer secret the server never repeats (see
+    /// `SandboxDesktopLink`).
+    static func sandboxDesktop(sessionId: String) async throws -> SandboxDesktopLink {
+        let encoded = sessionId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? sessionId
+        return try await post("/api/sessions/\(encoded)/sandbox/desktop", body: [:])
+    }
+
     /// Archive (or unarchive) a session. Archiving an in-flight session also
     /// stops its run server-side.
     static func setArchived(sessionId: String, archived: Bool) async throws {
@@ -1238,6 +1267,18 @@ enum OS1API {
     // MARK: - Session creation
 
     private struct ServerErrorBody: Decodable { let error: String? }
+
+    /// The error a mutation's non-2xx answer becomes. A server sentence wins
+    /// over the bare status, and 428 keeps its meaning so a caller can ask
+    /// the person the question the server asked.
+    nonisolated static func responseError(status: Int, body: Data) -> APIError {
+        let message = (try? JSONDecoder().decode(ServerErrorBody.self, from: body))?.error
+        if status == 428 {
+            return .confirmRequired(message ?? APIError.http(status).localizedDescription)
+        }
+        if let message { return .server(message) }
+        return .http(status)
+    }
 
     /// Every request's non-2xx tail reports its status here, so the one that
     /// means "this token is finished" is noticed in a single place rather than
@@ -2163,11 +2204,7 @@ enum OS1API {
         let (data, response) = try await URLSession.shared.data(for: request)
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             noteStatus(http.statusCode)
-            if let serverError = try? JSONDecoder().decode(ServerErrorBody.self, from: data),
-               let message = serverError.error {
-                throw APIError.server(message)
-            }
-            throw APIError.http(http.statusCode)
+            throw responseError(status: http.statusCode, body: data)
         }
         return try await decodeDetached(T.self, from: data)
     }

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -1303,6 +1303,21 @@ final class SessionViewModel {
     /// before another notice replaces it.
     func dismissNotice() { notice = nil }
 
+    /// The session just moved into a Sandbox (`POST .../sandbox/attach`).
+    /// The record the server answered with is carried onto the row now, so
+    /// the move leaves the ⋯ menu and the workspace sheet says Preparing
+    /// before the next sessions poll agrees.
+    func noteSandboxMove(_ status: SessionSandboxStatus, provider: String) {
+        session.sandbox = SessionSandbox(
+            provider: status.provider ?? provider,
+            sandboxId: status.sandboxId,
+            workspace: status.workspace,
+            lifecycle: status.lifecycle ?? "preparing",
+            lastLifecycleError: status.lastLifecycleError
+        )
+        notice = "Moving to \(SandboxMove.label(provider)). The next message runs there."
+    }
+
     /// Record something this app just did as a transcript line of its own.
     /// A client-side action gets no entry from the server, so this is a local
     /// row — and the transcript is where it belongs: it reads in place, in the

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -1876,7 +1876,22 @@ private struct SessionActionsMenu: View {
     @State private var pendingMerge: String?
     @State private var merging = false
     @State private var mergeError: String?
+    /// The Sandboxes a move may target; nil until `/api/sandbox/status`
+    /// answers, which the submenu shows as checking.
+    @State private var moveProviders: [String]?
+    /// The provider picked from the submenu, awaiting the first confirm.
+    @State private var pendingMove: String?
+    /// The server's 428: work that exists only on this machine would stay
+    /// behind. Asked once; the retry carries `confirm`.
+    @State private var moveWarning: SandboxMoveWarning?
+    @State private var moving = false
+    @State private var moveError: String?
     @Environment(\.openURL) private var openURL
+
+    private struct SandboxMoveWarning: Equatable {
+        let provider: String
+        let message: String
+    }
 
     var body: some View {
         Menu {
@@ -1968,6 +1983,36 @@ private struct SessionActionsMenu: View {
                 )
             } label: {
                 Label("Model settings", systemImage: "slider.horizontal.3")
+            }
+            // A code session on this machine can move into a Sandbox: a rare,
+            // one-way choice that reads as a session action, not as status,
+            // so it sits here as on the web rather than on a header badge.
+            // The move waits for the agent; the server refuses it mid-turn.
+            if SandboxMove.canMove(viewModel.session) {
+                Menu {
+                    if let moveProviders {
+                        if moveProviders.isEmpty {
+                            Text("No Sandbox is ready. Connect Daytona or Box in Workspace > Sandboxes.")
+                        } else {
+                            ForEach(moveProviders, id: \.self) { provider in
+                                Button {
+                                    pendingMove = provider
+                                } label: {
+                                    Text(SandboxMove.label(provider))
+                                }
+                            }
+                        }
+                    } else {
+                        Text("Checking Sandboxes…")
+                            .task { await loadMoveProviders() }
+                    }
+                } label: {
+                    Label(
+                        moving ? "Moving to Sandbox…" : "Move to Sandbox",
+                        systemImage: "shippingbox"
+                    )
+                }
+                .disabled(viewModel.isRunning || moving)
             }
             // Everything the worktree has changed, for the edits no visible
             // tool row names — the ones made before the transcript you're
@@ -2112,6 +2157,65 @@ private struct SessionActionsMenu: View {
                 .foregroundStyle(OS1VisualStyle.text)
         }
         .accessibilityLabel("Session actions")
+        // Resolved when the menu comes on screen rather than when the
+        // submenu opens: a SwiftUI Menu builds its rows up front and has no
+        // open callback, and the status read is one small GET. Skipped for
+        // every session that cannot move.
+        .task(id: viewModel.session.id) {
+            moveProviders = nil
+            await loadMoveProviders()
+            #if DEBUG
+            // Lets the native capture tool reach the move's confirm step on a
+            // simulator that takes no taps: the same state a submenu row sets.
+            if let provider = ProcessInfo.processInfo.environment["OS1_MOVE_TO_SANDBOX"],
+               !provider.isEmpty, SandboxMove.canMove(viewModel.session) {
+                pendingMove = provider
+            }
+            #endif
+        }
+        .confirmationDialog(
+            moveConfirmationTitle(pendingMove),
+            isPresented: Binding(
+                get: { pendingMove != nil },
+                set: { if !$0 { pendingMove = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Move") {
+                if let provider = pendingMove { move(to: provider, confirmed: false) }
+            }
+            Button("Cancel", role: .cancel) { pendingMove = nil }
+        } message: {
+            Text(
+                "The Sandbox starts now, clones this branch from origin, and takes over on the next message. Portals on this machine stop."
+            )
+        }
+        .confirmationDialog(
+            moveConfirmationTitle(moveWarning?.provider, anyway: true),
+            isPresented: Binding(
+                get: { moveWarning != nil },
+                set: { if !$0 { moveWarning = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Move", role: .destructive) {
+                if let warning = moveWarning { move(to: warning.provider, confirmed: true) }
+            }
+            Button("Cancel", role: .cancel) { moveWarning = nil }
+        } message: {
+            Text(moveWarning?.message ?? "")
+        }
+        .alert(
+            "Couldn’t move to a Sandbox",
+            isPresented: Binding(
+                get: { moveError != nil },
+                set: { if !$0 { moveError = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(moveError ?? "Please try again.")
+        }
         .confirmationDialog(
             mergeConfirmationTitle,
             isPresented: Binding(
@@ -2143,6 +2247,48 @@ private struct SessionActionsMenu: View {
     private func openWorker(_ worker: Session) {
         guard let url = SessionLinks.url(for: worker.id) else { return }
         openURL(url)
+    }
+
+    private func loadMoveProviders() async {
+        guard SandboxMove.canMove(viewModel.session), moveProviders == nil else { return }
+        // A failed read offers nothing, as on the web: the row then says no
+        // Sandbox is ready rather than pretending one is.
+        let status = try? await OS1API.sandboxStatus()
+        guard !Task.isCancelled else { return }
+        moveProviders = SandboxMove.providers(status)
+    }
+
+    private func moveConfirmationTitle(_ provider: String?, anyway: Bool = false) -> String {
+        let target = provider.map(SandboxMove.label) ?? "a Sandbox"
+        return anyway ? "Move to \(target) anyway?" : "Move to \(target)?"
+    }
+
+    /// One attach request. The 428 is asked about exactly once: an
+    /// unconfirmed attempt raises the warning dialog, and the confirmed retry
+    /// either moves or reports why not.
+    private func move(to provider: String, confirmed: Bool) {
+        pendingMove = nil
+        moveWarning = nil
+        guard !moving else { return }
+        moving = true
+        let sessionId = viewModel.session.id
+        Task {
+            let outcome = await SandboxMove.attempt(confirmed: confirmed) { confirm in
+                try await OS1API.sandboxAttach(
+                    sessionId: sessionId, provider: provider, confirm: confirm
+                )
+            }
+            moving = false
+            switch outcome {
+            case .moved(let status):
+                viewModel.noteSandboxMove(status, provider: provider)
+                Haptics.play(.commit)
+            case .needsConfirmation(let message):
+                moveWarning = SandboxMoveWarning(provider: provider, message: message)
+            case .failed(let message):
+                moveError = message
+            }
+        }
     }
 
     private var addIntent: SidebarAddition.Intent? {

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -34,6 +34,15 @@ struct WorktreeInfoView: View {
     @State private var sandboxAction: SessionSandboxAction?
     @State private var sandboxError: String?
     @State private var confirmingSandboxRecreate = false
+    /// The minted desktop link while its Safari sheet is up. Nowhere else:
+    /// the URL is a bearer secret (see `SandboxDesktopLink`).
+    @State private var desktopLink: SafariLink?
+    @State private var openingDesktop = false
+    #if DEBUG
+    /// Lets the native capture tool land on one section of this long sheet
+    /// (`OS1_SCROLL_TO=sandbox`) on a simulator that takes no taps.
+    @State private var scrolledSection: String?
+    #endif
     @State private var loading = true
     @State private var loadFailed = false
     @State private var repos: [OS1API.RepoInfo] = []
@@ -66,13 +75,20 @@ struct WorktreeInfoView: View {
                     assetsSection
                     worktreeSection
                     sandboxSection
+                        .id("sandbox")
                     runnerSection
                     runSettingsSection
                     effectiveConfigSection
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 28)
+                #if DEBUG
+                .scrollTargetLayout()
+                #endif
             }
+            #if DEBUG
+            .scrollPosition(id: $scrolledSection, anchor: .top)
+            #endif
             .background(OS1VisualStyle.background)
             .navigationTitle("Workspace")
             .navigationBarTitleDisplayMode(.inline)
@@ -81,7 +97,15 @@ struct WorktreeInfoView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .task(id: loadIdentity) { await load() }
+            .task(id: loadIdentity) {
+                await load()
+                #if DEBUG
+                if let target = ProcessInfo.processInfo.environment["OS1_SCROLL_TO"], !target.isEmpty {
+                    try? await Task.sleep(for: .milliseconds(400))
+                    withAnimation(nil) { scrolledSection = target }
+                }
+                #endif
+            }
             .task(id: effectiveConfigIdentity) {
                 // Model controls update the session optimistically, then send
                 // over the socket. Let that write land before forecasting it.
@@ -124,6 +148,11 @@ struct WorktreeInfoView: View {
             } message: {
                 Text("Unpushed files that exist only inside this sandbox will be deleted.")
             }
+            // The Sandbox's screen, in Safari's own view: the providers hand
+            // out a streaming page (Box) or a noVNC page (Daytona), and
+            // SFSafariViewController carries both without the app hosting
+            // web content or ever holding the link past this sheet.
+            .sheet(item: $desktopLink) { link in SafariSheet(url: link.url) }
             .alert(
                 "Couldn't update sandbox",
                 isPresented: Binding(
@@ -374,6 +403,29 @@ struct WorktreeInfoView: View {
                     if let cwd = sandboxStatus?.cwd, !cwd.isEmpty {
                         Divider()
                         InfoRow(label: "Path", value: cwd, icon: "folder", monospaced: true)
+                    }
+                    if sandboxState == "awake", sandboxStatus?.canDesktop == true {
+                        Divider()
+                        Button {
+                            Task { await openDesktop() }
+                        } label: {
+                            HStack(spacing: 10) {
+                                if openingDesktop {
+                                    ProgressView().controlSize(.small)
+                                } else {
+                                    Image(systemName: "desktopcomputer")
+                                }
+                                Text(openingDesktop ? "Opening desktop…" : "Open desktop")
+                                Spacer()
+                            }
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(OS1VisualStyle.link)
+                            .padding(.horizontal, 12)
+                            .frame(minHeight: 48)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(openingDesktop || sandboxAction != nil)
                     }
                     if sandboxState == "awake", sandboxStatus?.canPause == true {
                         Divider()
@@ -1284,6 +1336,26 @@ struct WorktreeInfoView: View {
         sandboxLoading = true
         defer { sandboxLoading = false }
         applySandboxResult(await loadSandboxResult())
+    }
+
+    /// Mints one viewer's desktop link and opens it. Minted on the tap, never
+    /// ahead of it, because the server hands each link out once and audits
+    /// the request without it; the app keeps it only as the sheet's state
+    /// and never writes it to a log or a store.
+    private func openDesktop() async {
+        guard !openingDesktop else { return }
+        openingDesktop = true
+        defer { openingDesktop = false }
+        do {
+            let link = try await OS1API.sandboxDesktop(sessionId: currentSession.id)
+            guard let url = link.webURL else {
+                sandboxError = "The Sandbox desktop link is not a web address."
+                return
+            }
+            desktopLink = SafariLink(url: url)
+        } catch {
+            sandboxError = error.localizedDescription
+        }
     }
 
     private func performSandboxAction(_ action: SessionSandboxAction) async {

--- a/packages/clients/ios/OS1Tests/SessionSandboxTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionSandboxTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+@testable import OS1
+
+/// The Sandbox session actions the web shipped after creation and lifecycle:
+/// moving a host session into a Sandbox (with the server's 428 warning) and
+/// opening the Sandbox desktop through a one-viewer bearer link.
+final class SessionSandboxTests: XCTestCase {
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    private func status(_ json: String) throws -> SessionSandboxStatus {
+        try JSONDecoder().decode(SessionSandboxStatus.self, from: Data(json.utf8))
+    }
+
+    // MARK: Wire models
+
+    func testSandboxStatusDecodesCanDesktop() throws {
+        let awake = try status(
+            #"{"enabled":true,"provider":"daytona","sandboxId":"sb-1","status":"running","lifecycle":"awake","canPause":true,"canResume":false,"canDesktop":true}"#
+        )
+        XCTAssertEqual(awake.canDesktop, true)
+        XCTAssertEqual(awake.lifecycle, "awake")
+
+        // A server that predates the field: the button simply stays away.
+        let older = try status(#"{"enabled":true,"provider":"box","status":"running"}"#)
+        XCTAssertNil(older.canDesktop)
+    }
+
+    func testDesktopLinkDecodesWithAndWithoutExpiry() throws {
+        let bounded = try JSONDecoder().decode(
+            SandboxDesktopLink.self,
+            from: Data(#"{"url":"https://desktop.example/view?token=abc","expiresAt":1757500000000}"#.utf8)
+        )
+        XCTAssertEqual(bounded.webURL?.host, "desktop.example")
+        XCTAssertEqual(bounded.expiresAt, 1_757_500_000_000)
+
+        let open = try JSONDecoder().decode(
+            SandboxDesktopLink.self,
+            from: Data(#"{"url":"https://box.example/desktop/xyz"}"#.utf8)
+        )
+        XCTAssertNil(open.expiresAt)
+        XCTAssertEqual(open.webURL?.absoluteString, "https://box.example/desktop/xyz")
+    }
+
+    /// The link is a bearer secret. Only a web URL is handed to the browser
+    /// presentation, and nothing that prints the value can leak it.
+    func testDesktopLinkIsOpenedOnlyAsWebAndNeverDescribed() {
+        XCTAssertNil(SandboxDesktopLink(url: "vnc://sandbox:5900?token=abc", expiresAt: nil).webURL)
+        XCTAssertNil(SandboxDesktopLink(url: "", expiresAt: nil).webURL)
+        XCTAssertNil(SandboxDesktopLink(url: "not a url", expiresAt: nil).webURL)
+        XCTAssertNotNil(SandboxDesktopLink(url: "http://10.0.0.5:6080/vnc.html?token=abc", expiresAt: nil).webURL)
+
+        let link = SandboxDesktopLink(url: "https://desktop.example/view?token=secret", expiresAt: nil)
+        XCTAssertFalse(link.description.contains("secret"))
+        XCTAssertFalse("\(link)".contains("secret"))
+    }
+
+    // MARK: Eligibility
+
+    func testHostCodeSessionWithRepoCanMove() throws {
+        let host = try session(#"{"id":"s1","mode":"code","repo":"tella/opensession"}"#)
+        XCTAssertTrue(SandboxMove.canMove(host))
+
+        // A record that spells the host out as the `local` provider.
+        let local = try session(
+            #"{"id":"s2","mode":"code","repo":"tella/opensession","sandbox":{"provider":"local"}}"#
+        )
+        XCTAssertTrue(SandboxMove.canMove(local))
+    }
+
+    func testSessionsThatCannotMove() throws {
+        let cases: [(String, String)] = [
+            ("ask mode", #"{"id":"s","mode":"ask","repo":"tella/opensession"}"#),
+            ("no mode", #"{"id":"s","repo":"tella/opensession"}"#),
+            ("no repo", #"{"id":"s","mode":"code"}"#),
+            ("empty repo", #"{"id":"s","mode":"code","repo":""}"#),
+            ("automation flag", #"{"id":"s","mode":"code","repo":"r","automation":true}"#),
+            ("automation name", #"{"id":"s","mode":"code","repo":"r","automation":"triage"}"#),
+            (
+                "runner",
+                #"{"id":"s","mode":"code","repo":"r","runner":{"id":"rn-1","name":"studio","workspacePath":"/w"}}"#
+            ),
+            (
+                "already in a Sandbox",
+                #"{"id":"s","mode":"code","repo":"r","sandbox":{"provider":"daytona","sandboxId":"sb-1"}}"#
+            ),
+            (
+                "move already recorded",
+                #"{"id":"s","mode":"code","repo":"r","sandbox":{"provider":"box","lifecycle":"preparing"}}"#
+            ),
+        ]
+        for (label, json) in cases {
+            XCTAssertFalse(SandboxMove.canMove(try session(json)), label)
+        }
+    }
+
+    func testMoveTargetsAreTheReadyProviders() throws {
+        let payload = try JSONDecoder().decode(
+            InstanceSandboxStatus.self,
+            from: Data("""
+            {"enabled":true,"killSwitch":false,
+             "providers":[{"id":"daytona","configured":true,"certified":true}],
+             "connections":[{"provider":"daytona","state":"ready"},
+                            {"provider":"box","state":"ready"},
+                            {"provider":"docker","state":"needs_attention"}]}
+            """.utf8)
+        )
+        XCTAssertEqual(SandboxMove.providers(payload), ["daytona", "box"])
+        XCTAssertEqual(SandboxMove.providers(nil), [])
+        XCTAssertEqual(SandboxMove.label("daytona"), "Daytona")
+        XCTAssertEqual(SandboxMove.label("box"), "Box")
+    }
+
+    // MARK: The 428 confirmation
+
+    func testMutationErrorsKeepTheConfirmMeaningOf428() {
+        let warning = Data(
+            #"{"error":"This branch has 2 unpushed commits and 3 uncommitted files.","confirmRequired":true}"#.utf8
+        )
+        guard case .confirmRequired(let message) = OS1API.responseError(status: 428, body: warning) else {
+            return XCTFail("428 must surface as confirmRequired")
+        }
+        XCTAssertEqual(message, "This branch has 2 unpushed commits and 3 uncommitted files.")
+
+        guard case .server(let refusal) = OS1API.responseError(
+            status: 409, body: Data(#"{"error":"Wait for the agent to finish before moving this session."}"#.utf8)
+        ) else {
+            return XCTFail("a server sentence stays a server error")
+        }
+        XCTAssertEqual(refusal, "Wait for the agent to finish before moving this session.")
+
+        guard case .http(500) = OS1API.responseError(status: 500, body: Data()) else {
+            return XCTFail("no body falls back to the status")
+        }
+        // A 428 without a sentence still asks, with the generic line.
+        guard case .confirmRequired = OS1API.responseError(status: 428, body: Data("nope".utf8)) else {
+            return XCTFail("428 without a body is still a confirm")
+        }
+    }
+
+    func testUnconfirmedAttemptSurfacesTheWarningOnce() async throws {
+        let moved = try status(#"{"enabled":true,"provider":"daytona","lifecycle":"preparing"}"#)
+        var sentConfirms: [Bool] = []
+
+        // First attempt: the server wants a person to accept the loss.
+        let first = await SandboxMove.attempt(confirmed: false) { confirm in
+            sentConfirms.append(confirm)
+            throw OS1API.APIError.confirmRequired("Unpushed commits would stay here.")
+        }
+        XCTAssertEqual(first, .needsConfirmation("Unpushed commits would stay here."))
+
+        // The confirmed retry carries `confirm` and moves.
+        let second = await SandboxMove.attempt(confirmed: true) { confirm in
+            sentConfirms.append(confirm)
+            return moved
+        }
+        XCTAssertEqual(second, .moved(moved))
+        XCTAssertEqual(sentConfirms, [false, true])
+    }
+
+    func testConfirmedRetryNeverAsksAgain() async {
+        let outcome = await SandboxMove.attempt(confirmed: true) { _ in
+            throw OS1API.APIError.confirmRequired("Still unpushed.")
+        }
+        XCTAssertEqual(outcome, .failed("Still unpushed."))
+    }
+
+    func testOtherErrorsFailWithTheServersSentence() async {
+        let refused = await SandboxMove.attempt(confirmed: false) { _ in
+            throw OS1API.APIError.server("Only code sessions with a repository can move to a Sandbox.")
+        }
+        XCTAssertEqual(
+            refused, .failed("Only code sessions with a repository can move to a Sandbox.")
+        )
+
+        let plain = await SandboxMove.attempt(confirmed: false) { _ in
+            throw OS1API.APIError.http(503)
+        }
+        XCTAssertEqual(plain, .failed("Server returned HTTP 503."))
+    }
+
+    func testNoConfirmOnTheSuccessfulFirstAttempt() async throws {
+        let moved = try status(#"{"enabled":true,"provider":"box","lifecycle":"preparing","workspace":"volume"}"#)
+        var sentConfirms: [Bool] = []
+        let outcome = await SandboxMove.attempt(confirmed: false) { confirm in
+            sentConfirms.append(confirm)
+            return moved
+        }
+        XCTAssertEqual(outcome, .moved(moved))
+        XCTAssertEqual(sentConfirms, [false])
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -161,7 +161,12 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   native preview frames for visual session assets while documents and data keep
   their file rows, model/reasoning controls, and live remote
   sandbox status. Sandboxed workspaces expose explicit pause, wake, and
-  confirmed recreate controls without embedding the web client. Its Effective
+  confirmed recreate controls without embedding the web client, and an awake
+  Sandbox whose provider reports `canDesktop` offers Open desktop: the
+  one-viewer link is minted on the tap, shown in Safari's in-app view, and
+  never stored or logged. A code session on this machine has Move to Sandbox
+  in the session ⋯ menu, listing the ready providers; the server's 428 for
+  unpushed work is asked about once before the confirmed retry. Its Effective
   config section resolves the next turn's model, engine, account, MCP access,
   instructions, and permissions, with the source under every displayed value.
 - **Session panels** — on iOS, Assets, individual assets, PR, Changes, Portals,


### PR DESCRIPTION
Native parity for the Sandbox session actions from ef430bcc (attach), 94296edc (desktop) and a2db38b7 (⋯ menu placement). The native app had creation and pause/wake/recreate; it now has the two newer actions.

## Before / after

| | Before | After |
|---|---|---|
| Session ⋯ menu | No move | **Move to Sandbox** submenu listing the ready providers (Daytona, Box); disabled while the agent runs |
| 428 for unpushed work | n/a | Asked exactly once: the server's sentence as a destructive **Move** confirm, then the retry carries `confirm` |
| Workspace sheet, awake Sandbox | Pause / Wake / Recreate | + **Open desktop** when the status reports `canDesktop` |
| Desktop URL | n/a | Minted on the tap, opened in `SFSafariViewController`, held only as the sheet's state; never persisted or logged (`description` is redacted) |

## Changes

- `Models/SessionSandbox.swift`: `canDesktop`, `SandboxDesktopLink` (web URLs only, redacted description), `SandboxMove` (web's eligibility rule, ready providers, attempt classifier that surfaces the 428 once).
- `Networking/OS1API.swift`: `sandboxAttach(sessionId:provider:confirm:)`, `sandboxDesktop(sessionId:)`, `APIError.confirmRequired` via a testable `responseError(status:body:)` so a 428 keeps its meaning.
- `Views/SessionView.swift`: the submenu, the two confirm dialogs, the error alert; success posts a notice and puts the returned sandbox record on the row optimistically (`SessionViewModel.noteSandboxMove`).
- `Views/WorktreeInfoView.swift`: Open desktop row + Safari sheet.
- Two `DEBUG`-only capture hooks: `OS1_MOVE_TO_SANDBOX=<provider>`, `OS1_SCROLL_TO=sandbox`.
- `OS1Tests/SessionSandboxTests.swift`: decoding, bearer-link handling, eligibility, provider resolution, 428 mapping, ask-once flow (11 tests).

## Verification

- `OS1` and `OS1Mac` build on tella-mac-node (Xcode 26.6); `OS1Tests` selected suites: 66 tests, 0 failures. `bun run check` passes.
- Live, against a throwaway host session with one uncommitted file: submenu → Move to Daytona → server 428 shown once → confirmed retry → record became `daytona / preparing / volume`; notice "Moving to Daytona. The next message runs there." Session archived afterwards.
- Live, on an awake Box session: Open desktop minted a link and the XFCE desktop rendered inside the app's Safari view.

Simulator screenshots are in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-f720da8e-4f79-78e3-b5a5-576e19029abd)