### PR TITLE
Native New session: set and reset the default model

### DIFF
--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -16,6 +16,53 @@ enum NativePreferences {
     private static let identityKey = "os1.preferences.identity"
     private static let bucketKey = "os1.preferences.bucket"
     static let sessionCheckoutsStorageKey = "os1.composer.sessionCheckouts"
+    static let defaultModelStorageKey = "os1.composer.defaultModel"
+
+    /// The server call behind a ui-pref write, as the menus see it. Injectable
+    /// so a test can answer late, fail, or answer for an account that is no
+    /// longer active.
+    typealias UiPrefsWrite = @MainActor (
+        _ user: String, _ prefs: [String: String?]
+    ) async throws -> [String: String]
+
+    /// Make `model` the personal default for new sessions, the way the web
+    /// menus do: this device immediately, then the same per-user `default-model`
+    /// ui-pref every client reads. Both model menus (the conversation's and the
+    /// New session composer's) go through here so they cannot drift.
+    ///
+    /// The confirmed map is applied only if it is still this account's: a
+    /// switch mid-flight leaves the new account's own hydrate in charge. And
+    /// it never repaints a newer choice made on this device while the write
+    /// was out; that choice's own confirmation reconciles it.
+    ///
+    /// Returns the write so a caller can wait for the confirmation; its value
+    /// is whether the server's map was applied.
+    @discardableResult
+    static func setDefaultModel(
+        _ model: String,
+        write: @escaping UiPrefsWrite = { user, prefs in
+            try await SettingsAPI.updateUiPrefs(user: user, prefs: prefs)
+        }
+    ) -> Task<Bool, Never> {
+        let requestContext = context()
+        let defaults = UserDefaults.standard
+        beginLocalWrite()
+        defaults.set(model, forKey: defaultModelStorageKey)
+        return Task { @MainActor in
+            defer { endLocalWrite() }
+            guard let response = try? await write(
+                requestContext.user, ["default-model": model]
+            ) else { return false }
+            var confirmed = response
+            let local = defaults.string(forKey: defaultModelStorageKey) ?? ""
+            if local != model {
+                confirmed["default-model"] = local
+            } else if confirmed["default-model"] == nil {
+                confirmed["default-model"] = model
+            }
+            return apply(confirmed, for: requestContext)
+        }
+    }
 
     static func context() -> Context {
         let config = ServerConfig.shared
@@ -109,7 +156,7 @@ enum NativePreferences {
         set(
             prefs["default-model"],
             default: "",
-            key: "os1.composer.defaultModel",
+            key: defaultModelStorageKey,
             resetMissing: changedIdentity,
             in: defaults
         )

--- a/packages/clients/ios/OS1/NativePreferences.swift
+++ b/packages/clients/ios/OS1/NativePreferences.swift
@@ -25,24 +25,47 @@ enum NativePreferences {
         _ user: String, _ prefs: [String: String?]
     ) async throws -> [String: String]
 
+    /// Writes a ui-pref patch containing `default-model`. Every native writer
+    /// of that key goes through this queue, including the Preferences screen,
+    /// so the server receives model choices in the order they were made.
+    ///
+    /// The local value changes immediately. A response for an older choice can
+    /// still update the other confirmed preferences, but cannot repaint a newer
+    /// model choice or cross into another account.
+    @discardableResult
+    static func writeDefaultModel(
+        _ model: String,
+        prefs: [String: String?],
+        write: @escaping UiPrefsWrite = { user, prefs in
+            try await SettingsAPI.updateUiPrefs(user: user, prefs: prefs)
+        }
+    ) -> Task<[String: String]?, Never> {
+        let requestContext = context()
+        let defaults = UserDefaults.standard
+        beginLocalWrite()
+        defaults.set(model, forKey: defaultModelStorageKey)
+        let previous = lastDefaultModelWrite
+        let task: Task<[String: String]?, Never> = Task { @MainActor in
+            defer { endLocalWrite() }
+            _ = await previous?.value
+            guard context() == requestContext,
+                  let response = try? await write(requestContext.user, prefs)
+            else { return nil }
+            var confirmed = response
+            let local = defaults.string(forKey: defaultModelStorageKey) ?? ""
+            confirmed["default-model"] = local == model
+                ? (confirmed["default-model"] ?? model)
+                : local
+            guard apply(confirmed, for: requestContext) else { return nil }
+            return confirmed
+        }
+        lastDefaultModelWrite = task
+        return task
+    }
+
     /// Make `model` the personal default for new sessions, the way the web
-    /// menus do: this device immediately, then the same per-user `default-model`
-    /// ui-pref every client reads. Both model menus (the conversation's and the
-    /// New session composer's) go through here so they cannot drift.
-    ///
-    /// Writes reach the server in the order they were made: each waits for
-    /// the one before it, and a choice already replaced by a newer one when
-    /// its turn comes is not sent at all. Otherwise two quick picks could
-    /// land out of order and leave the server, and so every other device, on
-    /// the older one.
-    ///
-    /// The confirmed map is applied only if it is still this account's: a
-    /// switch mid-flight leaves the new account's own hydrate in charge. And
-    /// it never repaints a newer choice made on this device while the write
-    /// was out; that choice's own write, queued behind this one, reconciles it.
-    ///
-    /// Returns the write so a caller can wait for the confirmation; its value
-    /// is whether the server's map was applied.
+    /// menus do: this device immediately, then the same per-user ui-pref every
+    /// client reads.
     @discardableResult
     static func setDefaultModel(
         _ model: String,
@@ -50,37 +73,16 @@ enum NativePreferences {
             try await SettingsAPI.updateUiPrefs(user: user, prefs: prefs)
         }
     ) -> Task<Bool, Never> {
-        let requestContext = context()
-        let defaults = UserDefaults.standard
-        beginLocalWrite()
-        defaults.set(model, forKey: defaultModelStorageKey)
-        let previous = lastDefaultModelWrite
-        let task = Task { @MainActor in
-            defer { endLocalWrite() }
-            _ = await previous?.value
-            // Superseded while queued, or the account changed: the newer
-            // choice's own write (or the new account's hydrate) speaks instead.
-            guard defaults.string(forKey: defaultModelStorageKey) == model,
-                  context() == requestContext
-            else { return false }
-            guard let response = try? await write(
-                requestContext.user, ["default-model": model]
-            ) else { return false }
-            var confirmed = response
-            let local = defaults.string(forKey: defaultModelStorageKey) ?? ""
-            if local != model {
-                confirmed["default-model"] = local
-            } else if confirmed["default-model"] == nil {
-                confirmed["default-model"] = model
-            }
-            return apply(confirmed, for: requestContext)
-        }
-        lastDefaultModelWrite = task
-        return task
+        let writeTask = writeDefaultModel(
+            model,
+            prefs: ["default-model": model],
+            write: write
+        )
+        return Task { await writeTask.value != nil }
     }
 
     /// Tail of the default-model write chain; the next write waits on it.
-    private static var lastDefaultModelWrite: Task<Bool, Never>?
+    private static var lastDefaultModelWrite: Task<[String: String]?, Never>?
 
     static func context() -> Context {
         let config = ServerConfig.shared

--- a/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
+++ b/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// `SessionView.body` re-evaluates the whole body, transcript included, every
 /// time one of them moves.
 struct ModelSettingsMenu: View {
-    @AppStorage("os1.composer.defaultModel") private var preferredModel = ""
+    @AppStorage(NativePreferences.defaultModelStorageKey) private var preferredModel = ""
 
     let viewModel: SessionViewModel
     let catalog: ModelCatalog?
@@ -292,22 +292,7 @@ struct ModelSettingsMenu: View {
     private func setAsDefault() {
         let model = currentModel
         guard !model.isEmpty, model != preferredModel else { return }
-
-        // Match the web preference: update this device immediately, then sync
-        // the same per-user key so new sessions on every client start here.
-        let requestContext = NativePreferences.context()
-        NativePreferences.beginLocalWrite()
-        preferredModel = model
-        Task {
-            defer { NativePreferences.endLocalWrite() }
-            guard let response = try? await SettingsAPI.updateUiPrefs(
-                user: requestContext.user,
-                prefs: ["default-model": model]
-            ) else { return }
-            var confirmed = response
-            if confirmed["default-model"] == nil { confirmed["default-model"] = model }
-            _ = NativePreferences.apply(confirmed, for: requestContext)
-        }
+        NativePreferences.setDefaultModel(model)
     }
 
     private func reset() {

--- a/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
+++ b/packages/clients/ios/OS1/Views/NativePersonalSettingsViews.swift
@@ -104,7 +104,7 @@ struct NotificationsSettingsView: View {
 struct PreferencesSettingsView: View {
     @AppStorage("os1.composer.defaultRepo") private var nativeDefaultRepo = ""
     @AppStorage(NativePreferences.sessionCheckoutsStorageKey) private var nativeSessionCheckouts = ""
-    @AppStorage("os1.composer.defaultModel") private var nativeDefaultModel = ""
+    @AppStorage(NativePreferences.defaultModelStorageKey) private var nativeDefaultModel = ""
     @AppStorage("os1.composer.defaultEngine") private var nativeDefaultEngine = ""
     @AppStorage("os1.composer.sendKey") private var nativeSendKey = "enter"
     @AppStorage("os1.composer.busySend") private var nativeBusySend = "queue"
@@ -167,7 +167,7 @@ struct PreferencesSettingsView: View {
             "session-checkouts": NativePreferences.validatedSessionCheckouts(
                 defaults.string(forKey: NativePreferences.sessionCheckoutsStorageKey)
             ) ?? "",
-            "default-model": defaults.string(forKey: "os1.composer.defaultModel") ?? "",
+            "default-model": defaults.string(forKey: NativePreferences.defaultModelStorageKey) ?? "",
             "default-engine": defaults.string(forKey: "os1.composer.defaultEngine") ?? "",
             "send-key": defaults.string(forKey: "os1.composer.sendKey") ?? "enter",
             "busy-send": defaults.string(forKey: "os1.composer.busySend") ?? "queue",
@@ -576,10 +576,36 @@ struct PreferencesSettingsView: View {
             }
             guard !patch.isEmpty else { saving = false; resaveNeeded = false; return }
             let requestContext = NativePreferences.context()
-            let response = try await SettingsAPI.updateUiPrefs(user: requestContext.user, prefs: patch)
+            let writesDefaultModel = patch.keys.contains("default-model")
+            let response: [String: String]
+            if writesDefaultModel {
+                guard let result = await NativePreferences.writeDefaultModel(
+                    current["default-model"] ?? "",
+                    prefs: patch
+                ).value else {
+                    self.error = "Could not save preferences."
+                    saving = false
+                    if resaveNeeded {
+                        resaveNeeded = false
+                        commit()
+                    }
+                    return
+                }
+                response = result
+            } else {
+                response = try await SettingsAPI.updateUiPrefs(
+                    user: requestContext.user,
+                    prefs: patch
+                )
+            }
             var confirmed = savedPrefs
             for (key, value) in current where patch.keys.contains(key) { confirmed[key] = value }
             confirmed.merge(response) { _, server in server }
+            if writesDefaultModel {
+                // Another model choice may have entered the queue after this
+                // response. Do not let this screen repaint that newer choice.
+                confirmed["default-model"] = nativeDefaultModel
+            }
             confirmed["session-checkouts"] = NativePreferences.validatedSessionCheckouts(
                 confirmed["session-checkouts"]
             ) ?? ""

--- a/packages/clients/ios/OS1/Views/NewSessionView.swift
+++ b/packages/clients/ios/OS1/Views/NewSessionView.swift
@@ -114,7 +114,7 @@ struct NewSessionView: View {
     @AppStorage("os1.newSession.repo") private var lastRepo = ""
     @AppStorage("os1.composer.defaultRepo") private var preferredRepo = ""
     @AppStorage(NativePreferences.sessionCheckoutsStorageKey) private var sessionCheckouts = ""
-    @AppStorage("os1.composer.defaultModel") private var preferredModel = ""
+    @AppStorage(NativePreferences.defaultModelStorageKey) private var preferredModel = ""
     @AppStorage("os1.composer.defaultEngine") private var preferredEngine = ""
 
     var body: some View {
@@ -676,6 +676,21 @@ struct NewSessionView: View {
         selectedModelOption?.fastModeSupported == true
     }
 
+    private var isPreferredDefault: Bool {
+        !effectiveModelID.isEmpty && preferredModel == effectiveModelID
+    }
+
+    /// Nothing to put back: on the workspace default model at its own default
+    /// effort, standard speed. Drives the reset row's disabled state.
+    private var isAtDefault: Bool {
+        guard let catalog else { return true }
+        let defaultModel = catalog.defaultModel ?? ""
+        let onDefaultModel =
+            model.isEmpty || defaultModel.isEmpty || model == defaultModel
+        return onDefaultModel && !fastMode
+            && effort == Self.defaultSelection(in: catalog).effort
+    }
+
     private var modelChipText: String {
         let id = model.isEmpty ? catalog?.defaultModel : model
         #if os(iOS)
@@ -898,6 +913,20 @@ struct NewSessionView: View {
                     ForEach(catalog.regular) { option in
                         modelButton(option)
                     }
+                }
+                Section {
+                    Button(action: setAsDefault) {
+                        Label(
+                            "Set as default",
+                            systemImage: isPreferredDefault ? "checkmark" : "pin"
+                        )
+                    }
+                    .disabled(effectiveModelID.isEmpty || isPreferredDefault)
+
+                    Button(action: resetToDefault) {
+                        Label("Reset to default", systemImage: "arrow.uturn.backward")
+                    }
+                    .disabled(isAtDefault)
                 }
             }
         } label: {
@@ -1146,6 +1175,36 @@ struct NewSessionView: View {
         model = routed
         defaultEffortForCurrentModel()
         if !(option.fastModeSupported == true) { fastMode = false }
+    }
+
+    /// The same personal default the conversation menu sets: this device now,
+    /// the account's `default-model` ui-pref behind it, so the next New session
+    /// on every client starts here.
+    private func setAsDefault() {
+        let model = effectiveModelID
+        guard !model.isEmpty, model != preferredModel else { return }
+        NativePreferences.setDefaultModel(model)
+    }
+
+    /// Back where a fresh composer starts before any preference: the
+    /// workspace's own default model at its default effort, standard speed.
+    /// The web's reset sends "" (follow the default); this pins the same id
+    /// so the menu keeps a checked row, and the run resolves identically.
+    private func resetToDefault() {
+        guard let catalog else { return }
+        let selection = Self.defaultSelection(in: catalog)
+        model = selection.model
+        effort = selection.effort
+        fastMode = false
+    }
+
+    /// Where reset lands: the catalog's interactive default and that model's
+    /// own default effort, resolved against the default rather than the
+    /// current model, whose effort may not exist there.
+    static func defaultSelection(in catalog: ModelCatalog) -> (model: String, effort: String) {
+        let model = catalog.defaultModel ?? ""
+        let efforts = catalog.option(for: model)?.efforts ?? []
+        return (model, efforts.contains("high") ? "high" : (efforts.first ?? ""))
     }
 
     /// "High" is the palette's default where supported; presets (dial) have

--- a/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
+++ b/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
@@ -124,7 +124,7 @@ final class DefaultModelPreferenceTests: XCTestCase {
         XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-sonnet-5")
     }
 
-    func testAChoiceReplacedWhileQueuedIsNeverSent() async {
+    func testThreeChoicesReachTheServerInSelectionOrder() async {
         let (slow, slowWrite) = gated()
         let first = NativePreferences.setDefaultModel("claude-opus-5", write: slowWrite)
         await Task.yield()
@@ -136,18 +136,47 @@ final class DefaultModelPreferenceTests: XCTestCase {
 
         slow.release(["default-model": "claude-opus-5"])
         _ = await first.value
-        // Sonnet was already replaced by Haiku when its turn came, so the
-        // server never sees it and cannot end up on it.
-        let secondApplied = await second.value
-        XCTAssertFalse(secondApplied)
-        XCTAssertTrue(middle.sent.isEmpty)
+        await settle { !middle.sent.isEmpty }
+        XCTAssertEqual(middle.sent["default-model"], "claude-sonnet-5")
+        XCTAssertTrue(last.sent.isEmpty)
 
+        middle.release(["default-model": "claude-sonnet-5"])
+        let secondApplied = await second.value
+        XCTAssertTrue(secondApplied)
         await settle { !last.sent.isEmpty }
         XCTAssertEqual(last.sent["default-model"], "claude-haiku-5")
+
         last.release(["default-model": "claude-haiku-5"])
         let thirdApplied = await third.value
         XCTAssertTrue(thirdApplied)
         XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-haiku-5")
+    }
+
+    func testPreferencesPatchAndMenuChoiceShareTheWriteQueue() async {
+        let (preferences, preferencesWrite) = gated()
+        let first = NativePreferences.writeDefaultModel(
+            "claude-sonnet-5",
+            prefs: ["default-model": "claude-sonnet-5", "send-key": "mod-enter"],
+            write: preferencesWrite
+        )
+        await Task.yield()
+        XCTAssertEqual(preferences.sent["default-model"], "claude-sonnet-5")
+
+        let (menu, menuWrite) = gated()
+        let second = NativePreferences.setDefaultModel("claude-opus-5", write: menuWrite)
+        await Task.yield()
+        XCTAssertTrue(menu.sent.isEmpty)
+
+        preferences.release(["default-model": "claude-sonnet-5", "send-key": "mod-enter"])
+        let preferencesResponse = await first.value
+        XCTAssertNotNil(preferencesResponse)
+        await settle { !menu.sent.isEmpty }
+        XCTAssertEqual(menu.sent["default-model"], "claude-opus-5")
+
+        menu.release(["default-model": "claude-opus-5", "send-key": "mod-enter"])
+        let menuApplied = await second.value
+        XCTAssertTrue(menuApplied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-opus-5")
     }
 
     func testConfirmationForAnotherAccountIsDropped() async {

--- a/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
+++ b/packages/clients/ios/OS1Tests/DefaultModelPreferenceTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import OS1
+
+/// The one "Set as default" write both model menus share: the conversation's
+/// and the New session composer's. It updates this device first, then the
+/// account's `default-model` ui-pref, and reconciles what the server sends
+/// back without stepping on a newer choice or another account.
+@MainActor
+final class DefaultModelPreferenceTests: XCTestCase {
+    private let modelKey = NativePreferences.defaultModelStorageKey
+    private let markerKey = "os1.composer.sendKey"
+    private var savedModel: String?
+    private var savedMarker: String?
+    private var savedUserName = ""
+
+    /// A write the test releases by hand, so a confirmation can land after
+    /// the world moved on.
+    private final class Gate {
+        var continuation: CheckedContinuation<[String: String], Error>?
+        var sent: [String: String?] = [:]
+        func release(_ prefs: [String: String]) { continuation?.resume(returning: prefs) }
+        func fail() {
+            continuation?.resume(throwing: URLError(.notConnectedToInternet))
+        }
+    }
+
+    private func gated() -> (Gate, NativePreferences.UiPrefsWrite) {
+        let gate = Gate()
+        let write: NativePreferences.UiPrefsWrite = { _, prefs in
+            gate.sent = prefs
+            return try await withCheckedThrowingContinuation { gate.continuation = $0 }
+        }
+        return (gate, write)
+    }
+
+    override func setUp() {
+        let defaults = UserDefaults.standard
+        savedModel = defaults.string(forKey: modelKey)
+        savedMarker = defaults.string(forKey: markerKey)
+        savedUserName = ServerConfig.shared.userName
+        ServerConfig.shared.userName = "Tester"
+        defaults.set("", forKey: modelKey)
+        defaults.set("enter", forKey: markerKey)
+        // Pin the identity so the first apply below is not a "new account"
+        // reset that would blank the key under test.
+        _ = NativePreferences.apply([:], for: NativePreferences.context())
+    }
+
+    override func tearDown() {
+        let defaults = UserDefaults.standard
+        for (key, value) in [(modelKey, savedModel), (markerKey, savedMarker)] {
+            if let value { defaults.set(value, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+        ServerConfig.shared.userName = savedUserName
+    }
+
+    func testSetUpdatesThisDeviceFirstThenWritesTheAccountPref() async {
+        let (gate, write) = gated()
+
+        let task = NativePreferences.setDefaultModel("claude-opus-5", write: write)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-opus-5")
+
+        await Task.yield()
+        XCTAssertEqual(gate.sent["default-model"], "claude-opus-5")
+        gate.release(["default-model": "claude-opus-5", "send-key": "mod-enter"])
+
+        let applied = await task.value
+        XCTAssertTrue(applied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-opus-5")
+        // The rest of the confirmed map lands too: it is the whole account map.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: markerKey), "mod-enter")
+    }
+
+    func testConfirmationWithoutTheKeyKeepsTheChoice() async {
+        let task = NativePreferences.setDefaultModel("claude-sonnet-5") { _, _ in [:] }
+        let applied = await task.value
+        XCTAssertTrue(applied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-sonnet-5")
+    }
+
+    func testFailedWriteLeavesTheOptimisticChoiceAlone() async {
+        let (gate, write) = gated()
+        let task = NativePreferences.setDefaultModel("claude-opus-5", write: write)
+        await Task.yield()
+        gate.fail()
+
+        let applied = await task.value
+        XCTAssertFalse(applied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-opus-5")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: markerKey), "enter")
+    }
+
+    func testLateConfirmationDoesNotRepaintANewerChoice() async {
+        let (slow, slowWrite) = gated()
+        let first = NativePreferences.setDefaultModel("claude-opus-5", write: slowWrite)
+        await Task.yield()
+
+        let second = NativePreferences.setDefaultModel("claude-sonnet-5") { _, prefs in
+            let sent = prefs["default-model"].flatMap { $0 } ?? ""
+            return ["default-model": sent]
+        }
+        let secondApplied = await second.value
+        XCTAssertTrue(secondApplied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-sonnet-5")
+
+        // The first write's answer arrives after the second already landed.
+        slow.release(["default-model": "claude-opus-5", "send-key": "mod-enter"])
+        let firstApplied = await first.value
+        XCTAssertTrue(firstApplied)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), "claude-sonnet-5")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: markerKey), "mod-enter")
+    }
+
+    func testConfirmationForAnotherAccountIsDropped() async {
+        let (gate, write) = gated()
+        let task = NativePreferences.setDefaultModel("claude-opus-5", write: write)
+        await Task.yield()
+
+        ServerConfig.shared.userName = "Someone Else"
+        gate.release(["default-model": "claude-opus-5", "send-key": "mod-enter"])
+
+        let applied = await task.value
+        XCTAssertFalse(applied)
+        // Nothing from the old account's map reaches the new one; its own
+        // hydrate decides what this device shows next.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: markerKey), "enter")
+    }
+
+    // MARK: Reset
+
+    private func catalog(_ json: String) throws -> ModelCatalog {
+        try JSONDecoder().decode(ModelCatalog.self, from: Data(json.utf8))
+    }
+
+    func testResetLandsOnTheWorkspaceDefaultAtItsOwnEffort() throws {
+        let catalog = try catalog(
+            """
+            {"models":[
+              {"id":"claude-opus-5","efforts":["low","medium","high"]},
+              {"id":"gpt-6-astra","efforts":["xhigh"]}
+            ],"default":"claude-opus-5"}
+            """
+        )
+        let selection = NewSessionView.defaultSelection(in: catalog)
+        XCTAssertEqual(selection.model, "claude-opus-5")
+        XCTAssertEqual(selection.effort, "high")
+    }
+
+    func testResetEffortFollowsTheDefaultModelNotTheCurrentOne() throws {
+        let catalog = try catalog(
+            """
+            {"models":[
+              {"id":"gpt-6-astra","efforts":["medium","xhigh"]},
+              {"id":"dial/opus-fable","group":"dial"}
+            ],"default":"gpt-6-astra"}
+            """
+        )
+        XCTAssertEqual(NewSessionView.defaultSelection(in: catalog).effort, "medium")
+
+        let preset = try self.catalog(
+            """
+            {"models":[{"id":"dial/opus-fable","group":"dial"}],"default":"dial/opus-fable"}
+            """
+        )
+        let selection = NewSessionView.defaultSelection(in: preset)
+        XCTAssertEqual(selection.model, "dial/opus-fable")
+        XCTAssertEqual(selection.effort, "")
+    }
+}


### PR DESCRIPTION
Port of 07549a4a ("Let new sessions set the default model") to the native app.

**Before:** the New session composer's model menu had no way to make the chosen model the personal default, and no way back to the workspace default. Only an existing conversation's menu could set it.

**After:** the New session model menu ends with `Set as default` and `Reset to default`, the same rows as the conversation menu.

- `NativePreferences.setDefaultModel` now owns the optimistic `default-model` ui-pref write. Both menus call it, so they cannot drift. It updates this device first, writes the account pref, and applies the confirmed map only when the active account is unchanged and never over a newer local choice made while the write was out.
- Reset lands on the catalog's default model at that model's own default effort (resolved against the default, not the current model), fast mode off.
- `DefaultModelPreferenceTests`: set, confirmation without the key, failed write, late confirmation, account switch mid-flight, reset selection.

Verified on tella-mac-node: `OS1` and `OS1Mac` build, `OS1Tests` (DefaultModelPreference, PreferenceHydration, ModelCatalog) pass. Simulator and macOS captures of the menu, and of the server pref flipping to the chosen model and back, are in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-bf094554-1ffe-7336-ba22-f9e965893c12)