### PR TITLE
Fix Mac app download link

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/DownloadAppsDialog.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DownloadAppsDialog.tsx
@@ -5,6 +5,9 @@ import { Button } from "../ui/button";
 import { Modal } from "../ui/modal";
 import { IconChevronLeft } from "./icons";
 
+const MAC_DOWNLOAD_URL =
+  "https://github.com/tellahq/opensession/releases/latest/download/OpenSession-arm64.dmg";
+
 /** Apple's mark, for the Mac download. A solid glyph, not part of the stroke set. */
 function IconApple({ size = 20 }: { size?: number }) {
   return (
@@ -122,11 +125,7 @@ export function DownloadAppsBody({
           size="lg"
           icon={<IconApple size={20} />}
           className="min-h-10 w-full"
-          render={
-            <a
-              href={`${BASE_PATH}/api/packages/clients/mac/download/latest.dmg`}
-            />
-          }
+          render={<a href={MAC_DOWNLOAD_URL} />}
         >
           Download
         </Button>


### PR DESCRIPTION
## Summary
Point the in-app Mac download button to the official public DMG, matching the website. The previous instance-local proxy returns "Release installer unavailable" when release integration settings are absent.

## Verification
- `bun run check` passed before committing.
- Verified the official download URL resolves to the published DMG with HTTP 200.

Started by Jaap Frolich in [this Assistant session](http://100.81.254.102:3850/session/os-01a08ca5-4cf3-79d7-8fba-1cc5df7c8bbe)