### PR TITLE
Tie Mac organizations to local Tailscale profiles

### DIFF
--- a/packages/clients/mac/README.md
+++ b/packages/clients/mac/README.md
@@ -91,6 +91,53 @@ the first-run screen offers with `opensession.defaultServer` in `package.json`
 (or `OS1_CLOUD_URL`); a profile that already worked keeps using it and is never
 asked.
 
+## Organization networks on this Mac
+
+Use **OS → Organizations → Network on this Mac…** to associate a saved
+organization with a saved Tailscale account. Install Tailscale in Applications
+and sign in to each account in Tailscale first. The shell also recognizes the
+standard Homebrew CLI locations if the app binary is absent.
+
+The default is **Ask before switching networks**. **Switch networks automatically**
+is an explicit opt-in. **Leave Tailscale unchanged** removes the association.
+Only the profile ID and switching mode are stored alongside the organization's
+local ID in `server.json`. No Tailscale credentials or settings go to a server.
+Saving does not switch networks immediately; select the organization from the
+native menu or in-app picker to apply it, including selecting the current one
+from the native menu when it needs reconnecting.
+
+Tailscale switching affects the whole Mac. Other apps and organization windows
+may disconnect. Startup, window focus, notifications, and background reconnects
+do not switch networks. An explicit cross-organization deep link uses the normal
+switch path. Rapid selections are serialized across windows; only the latest
+selection may navigate. The shell waits for the selected Tailscale profile to
+be running and probes the destination server before changing the requesting
+window's organization. This reachability check does not replace server sign-in
+or authorization. Cancel or failure leaves that window on its old organization
+but does not automatically restore the old Tailscale profile.
+
+Network settings and switch progress are bundled local pages, so they work even
+when neither server is reachable. Only their dedicated main frames may use the
+network-settings IPC. Remotely served pages cannot list Tailscale profiles or
+change the association. Commands use fixed executable paths and exact saved
+profile IDs, without a shell, `sudo`, login, or logout.
+
+### Verification
+
+```sh
+bun test packages/clients/mac/src
+cd packages/clients/mac
+bun run verify:network
+```
+
+The Electron verification uses disposable local servers and a fake Tailscale
+client. It exercises settings, IPC rejection, account switching, route retention,
+failure recovery, and background-window isolation without changing the Mac's
+network. Set `OS1_NETWORK_PROOF_DIR` to save screenshots in a chosen directory.
+It does not test the actual device-wide switch; that requires an operator who
+can tolerate disconnecting other tailnet connections. No server deploy is needed
+for this shell-only change; it ships in the next signed Mac app release.
+
 ## Architecture
 
 - `src/main.js` — sandboxed `BrowserWindow`s that each own an organization and

--- a/packages/clients/mac/package.json
+++ b/packages/clients/mac/package.json
@@ -8,6 +8,7 @@
   "main": "src/main.js",
   "scripts": {
     "start": "electron .",
+    "verify:network": "electron scripts/verify-network.js",
     "dist": "electron-builder --mac",
     "postinstall": "sh scripts/brand-dev-electron.sh || true"
   },

--- a/packages/clients/mac/scripts/verify-network.js
+++ b/packages/clients/mac/scripts/verify-network.js
@@ -1,0 +1,272 @@
+// Run with Electron, not Bun: exercises real BrowserWindows and IPC using
+// disposable organizations and an injected Tailscale client. Never changes VPN.
+const { app, BrowserWindow, Menu, dialog } = require("electron");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const http = require("node:http");
+const { setTimeout: delay } = require("node:timers/promises");
+const tailscale = require("../src/tailscale");
+
+const profiles = [
+  {
+    id: "personal",
+    account: "alex@example.test",
+    tailnet: "Personal",
+    selected: true,
+  },
+  { id: "work", account: "alex@acme.test", tailnet: "Acme", selected: false },
+];
+let ready = Promise.resolve();
+let failSwitch = false;
+const switched = [];
+tailscale.createTailscaleClient = () => ({
+  list: async () => profiles,
+  switch: async (id) => {
+    if (failSwitch) throw new Error("Fixture switch failed");
+    switched.push(id);
+    for (const profile of profiles) profile.selected = profile.id === id;
+  },
+  ready: async () => ready,
+});
+const prompts = [];
+dialog.showMessageBox = async (...args) => {
+  const options = args.at(-1);
+  prompts.push(options);
+  return { response: options.type === "error" ? 2 : 0 };
+};
+// A test instance must not claim the installed app's protocol registration.
+app.setAsDefaultProtocolClient = () => true;
+
+async function until(get, message) {
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const value = await get();
+    if (value) return value;
+    await delay(30);
+  }
+  throw new Error(`Timed out: ${message}`);
+}
+
+async function server(label) {
+  const instance = http.createServer((req, res) => {
+    if (req.url.startsWith("/api/")) {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: true, organizationName: label }));
+    } else {
+      res.setHeader("Content-Type", "text/html");
+      res.end(
+        `<!doctype html><title>${label}</title><h1>${label}</h1><p>Disposable Electron verification fixture</p>`,
+      );
+    }
+  });
+  await new Promise((resolve) => instance.listen(0, "127.0.0.1", resolve));
+  return { instance, url: `http://127.0.0.1:${instance.address().port}/` };
+}
+
+function organizationMenu() {
+  return Menu.getApplicationMenu().items[0].submenu.items.find(
+    (item) => item.label === "Organizations",
+  ).submenu;
+}
+
+async function main() {
+  const root = await fs.mkdtemp(path.join("/tmp", "os-network-verify-"));
+  const personal = await server("Personal");
+  const work = await server("Acme");
+  app.setPath("appData", root);
+  delete process.env.OS1_URL;
+  const data = path.join(root, "Open Session");
+  await fs.mkdir(data);
+  const serverFile = path.join(data, "server.json");
+  await fs.writeFile(
+    serverFile,
+    JSON.stringify({
+      activeId: "personal",
+      accounts: [
+        {
+          id: "personal",
+          label: "Personal",
+          url: personal.url,
+          lastUrl: `${personal.url}session/notes`,
+        },
+        {
+          id: "work",
+          label: "Acme",
+          url: work.url,
+          lastUrl: `${work.url}session/project`,
+        },
+      ],
+    }),
+  );
+  const stored = async () => JSON.parse(await fs.readFile(serverFile, "utf8"));
+  try {
+    require("../src/main");
+    await app.whenReady();
+    const window = await until(
+      () =>
+        BrowserWindow.getAllWindows().find(
+          (candidate) =>
+            candidate.isVisible() &&
+            candidate.webContents.getURL().startsWith(personal.url),
+        ),
+      "initial organization",
+    );
+    assert.equal(
+      await window.webContents.executeJavaScript("window.os1.network.state()"),
+      null,
+    );
+    assert.deepEqual(
+      await window.webContents.executeJavaScript(
+        'window.os1.network.save("work", {profileId:"work",mode:"automatic"})',
+      ),
+      { ok: false },
+    );
+
+    organizationMenu()
+      .items.find((item) => item.label === "Network on this Mac…")
+      .click();
+    const settings = await until(
+      () =>
+        BrowserWindow.getAllWindows().find((candidate) =>
+          candidate.webContents.getURL().endsWith("/network.html"),
+        ),
+      "network settings window",
+    );
+    await until(
+      () =>
+        settings.webContents.executeJavaScript(
+          '!document.getElementById("settings").hidden',
+        ),
+      "settings loaded",
+    );
+    const setBinding = async (id, mode) => {
+      await settings.webContents.executeJavaScript(`
+        document.getElementById("organization").value = ${JSON.stringify(id)};
+        document.getElementById("organization").dispatchEvent(new Event("change"));
+        document.getElementById("profile").value = ${JSON.stringify(id)};
+        document.getElementById("profile").dispatchEvent(new Event("change"));
+        document.getElementById("mode").value = ${JSON.stringify(mode)};
+        document.getElementById("settings").requestSubmit();
+      `);
+      await until(
+        async () =>
+          (await stored()).accounts.find((account) => account.id === id)
+            ?.network?.mode === mode,
+        "saved binding",
+      );
+    };
+    await setBinding("personal", "ask");
+    await setBinding("work", "automatic");
+    const proof = process.env.OS1_NETWORK_PROOF_DIR || root;
+    await fs.mkdir(proof, { recursive: true });
+    await until(() => settings.isVisible(), "settings visible");
+    await fs.writeFile(
+      path.join(proof, "network-settings.png"),
+      (await settings.webContents.capturePage()).toPNG(),
+    );
+    settings.close();
+    await until(() => settings.isDestroyed(), "settings closed");
+
+    let release;
+    ready = new Promise((resolve) => {
+      release = resolve;
+    });
+    organizationMenu()
+      .items.find((item) => item.label === "Acme")
+      .click();
+    const progress = await until(
+      () =>
+        BrowserWindow.getAllWindows().find((candidate) =>
+          candidate.webContents.getURL().endsWith("/network.html"),
+        ),
+      "switch progress",
+    );
+    await until(
+      () =>
+        switched.length === 1 &&
+        progress.webContents.executeJavaScript(
+          'document.getElementById("title").textContent === "Switch to Acme"',
+        ),
+      "switch started",
+    );
+    console.log("[verify] switch pending before navigation");
+    assert.equal((await stored()).activeId, "personal");
+    await until(() => progress.isVisible(), "progress visible");
+    console.log("[verify] capturing switch progress");
+    await fs.writeFile(
+      path.join(proof, "network-switch.png"),
+      (await progress.webContents.capturePage()).toPNG(),
+    );
+    console.log("[verify] captured, releasing network readiness");
+    release();
+    await until(
+      () => window.webContents.getURL() === `${work.url}session/project`,
+      "destination route",
+    );
+    assert.deepEqual(switched, ["work"]);
+    assert.equal(prompts.length, 0);
+    assert.equal(
+      (await stored()).accounts.find((account) => account.id === "personal")
+        .lastUrl,
+      `${personal.url}session/notes`,
+    );
+
+    // Ask mode and returning to the saved route.
+    organizationMenu()
+      .items.find((item) => item.label === "Personal")
+      .click();
+    await until(
+      () => window.webContents.getURL() === `${personal.url}session/notes`,
+      "return route",
+    );
+    assert.equal(
+      prompts.filter((options) => options.type === "warning").length,
+      1,
+    );
+    assert.deepEqual(switched, ["work", "personal"]);
+
+    // Focusing/reloading a background account must not trigger another switch.
+    const background = await until(
+      () =>
+        BrowserWindow.getAllWindows().find(
+          (candidate) =>
+            !candidate.isVisible() &&
+            candidate.webContents.getURL().startsWith(work.url),
+        ),
+      "background organization loaded",
+    );
+    await background.webContents.executeJavaScript(
+      'window.os1.organizations.switch("work")',
+    );
+    await delay(100);
+    assert.deepEqual(switched, ["work", "personal"]);
+
+    // A failed switch leaves the requesting window and persisted account alone.
+    failSwitch = true;
+    organizationMenu()
+      .items.find((item) => item.label === "Acme")
+      .click();
+    await until(
+      () => prompts.some((options) => options.type === "error"),
+      "failure dialog",
+    );
+    assert.equal((await stored()).activeId, "personal");
+    assert.equal(window.webContents.getURL(), `${personal.url}session/notes`);
+    console.log(`Electron network verification passed. Proof: ${proof}`);
+  } finally {
+    personal.instance.close();
+    work.instance.close();
+  }
+}
+
+main()
+  .then(() => {
+    app.quit();
+    app.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    app.quit();
+    app.exit(1);
+  });

--- a/packages/clients/mac/src/main.js
+++ b/packages/clients/mac/src/main.js
@@ -21,6 +21,10 @@ const fs = require("node:fs");
 const crypto = require("node:crypto");
 const { execFile } = require("node:child_process");
 const { NativeDictation } = require("./native-dictation");
+const { readNetworkBinding, createLatestSwitchQueue } = require("./tailscale");
+const { OrganizationNetwork } = require("./organization-network");
+const queueOrganizationSwitch = createLatestSwitchQueue();
+let organizationNetwork = null;
 const {
   accountForContext,
   isOpenSessionAppUrl,
@@ -204,6 +208,9 @@ function readStoredAccounts() {
             label: String(account.label || new URL(url).host),
             url,
             lastUrl: resumableAccountUrl(url, account.lastUrl),
+            ...(readNetworkBinding(account.network)
+              ? { network: readNetworkBinding(account.network) }
+              : {}),
           },
         ];
       });
@@ -1203,12 +1210,57 @@ function syncBackgroundAccountWindows() {
   }
 }
 
-function switchAccount(id, targetURL = null, target = activeWindow()) {
+function switchAccount(
+  id,
+  targetURL = null,
+  target = activeWindow(),
+  switchNetwork = true,
+) {
+  if (!target || target.isDestroyed()) return;
+  void queueOrganizationSwitch(async (isLatest, signal) => {
+    const account = readStoredAccounts().accounts.find(
+      (candidate) => candidate.id === id,
+    );
+    if (!account || target.isDestroyed()) return;
+    const originalId = accountForWindow(target)?.id;
+    if (originalId === id && !account.network && !targetURL) return;
+    const isCurrent = () => {
+      if (!isLatest() || target.isDestroyed()) return false;
+      const stored = readStoredAccounts();
+      const saved = stored.accounts.find((candidate) => candidate.id === id);
+      return (
+        accountForWindow(target, stored)?.id === originalId &&
+        saved?.url === account.url &&
+        JSON.stringify(saved.network) === JSON.stringify(account.network)
+      );
+    };
+    if (
+      switchNetwork &&
+      organizationNetwork &&
+      !(await organizationNetwork.prepare(account, target, isCurrent, signal))
+    )
+      return;
+    if (!isCurrent()) return;
+    // A reselected current organization may only need its VPN reconnected.
+    // Keep a loaded app's drafts and scroll position; reload the offline page.
+    if (
+      originalId === id &&
+      !targetURL &&
+      inActiveWindow(target.webContents.getURL(), target)
+    )
+      return;
+    activateAccount(id, targetURL, target);
+  }).catch((error) =>
+    console.error("[network] organization switch failed", error),
+  );
+}
+
+function activateAccount(id, targetURL, target) {
   if (!target || target.isDestroyed()) return;
   const stored = readStoredAccounts();
   const account = stored.accounts.find((candidate) => candidate.id === id);
   const current = accountForWindow(target, stored);
-  if (!account || account.id === current?.id) return;
+  if (!account) return;
 
   // Keep each organization at its exact in-app URL. Loading the account root
   // delegated this to the web app's generic cold-start fallback, which could
@@ -1279,6 +1331,16 @@ function buildAppMenu() {
                 click: () => {
                   const target = showWindow();
                   showSetup("app", target, true);
+                },
+              },
+              {
+                label: "Network on this Mac…",
+                click: () => {
+                  const target = showWindow();
+                  organizationNetwork?.showSettings(
+                    target,
+                    accountForWindow(target)?.id,
+                  );
                 },
               },
               {
@@ -1395,14 +1457,19 @@ app.whenReady().then(async () => {
     );
     const target = eventWindow(e) || activeWindow();
     if (account && account.id !== accountForWindow(target, stored)?.id)
-      switchAccount(account.id, source, target);
+      // Notification/background activity must never change device networking.
+      switchAccount(account.id, source, target, false);
     else showWindow(target);
   });
 
   const fromActiveOrganizationPicker = (e) => {
     const source = e.senderFrame?.url ?? "";
     const target = eventWindow(e);
-    return !!target && inActiveWindow(source, target);
+    return (
+      !!target &&
+      e.senderFrame === e.sender.mainFrame &&
+      inActiveWindow(source, target)
+    );
   };
   ipcMain.handle("os1:organizations-list", (e) => {
     if (!fromActiveOrganizationPicker(e)) return null;
@@ -1419,7 +1486,11 @@ app.whenReady().then(async () => {
     };
   });
   ipcMain.on("os1:organizations-switch", (e, id) => {
-    if (fromActiveOrganizationPicker(e) && typeof id === "string") {
+    if (
+      fromActiveOrganizationPicker(e) &&
+      eventWindow(e)?.isFocused() &&
+      typeof id === "string"
+    ) {
       switchAccount(id, null, eventWindow(e));
     }
   });
@@ -1598,6 +1669,11 @@ app.whenReady().then(async () => {
     return { ok: true };
   });
 
+  organizationNetwork = new OrganizationNetwork({
+    readAccounts: readStoredAccounts,
+    writeAccounts: writeStoredAccounts,
+    probe: probeServer,
+  });
   buildAppMenu();
 
   appReady = true;

--- a/packages/clients/mac/src/network-page.js
+++ b/packages/clients/mac/src/network-page.js
@@ -1,0 +1,120 @@
+const network = window.os1.network;
+const form = document.getElementById("settings");
+const organization = document.getElementById("organization");
+const profile = document.getElementById("profile");
+const mode = document.getElementById("mode");
+const status = document.getElementById("status");
+const save = document.getElementById("save");
+const refresh = document.getElementById("refresh");
+let accounts = [];
+let profiles = [];
+let loadingError = null;
+
+function showBinding() {
+  const account = accounts.find((item) => item.id === organization.value);
+  profile.replaceChildren(new Option("Leave Tailscale unchanged", ""));
+  for (const item of profiles) {
+    profile.add(
+      new Option(
+        `${item.tailnet} · ${item.account}${item.selected ? " · Active account" : ""}`,
+        item.id,
+      ),
+    );
+  }
+  if (
+    account?.network &&
+    !profiles.some((item) => item.id === account.network.profileId)
+  ) {
+    profile.add(
+      new Option("Saved account unavailable", account.network.profileId),
+    );
+  }
+  profile.value = account?.network?.profileId || "";
+  mode.value = account?.network?.mode || "ask";
+  mode.disabled = !profile.value;
+  save.disabled = !account;
+  status.textContent = loadingError || "";
+}
+
+function render(state) {
+  if (!state) return;
+  if (state.kind === "progress") {
+    document.getElementById("title").textContent = `Switch to ${state.label}`;
+    document.getElementById("description").textContent =
+      "Cancelling stops the organization switch. It does not restore the previous network.";
+    document.getElementById("close").textContent = "Cancel";
+    status.textContent = state.message;
+    return;
+  }
+  const selected = organization.value || state.accountId;
+  accounts = state.accounts;
+  profiles = state.profiles;
+  loadingError = state.error;
+  organization.replaceChildren(
+    ...accounts.map((account) => new Option(account.label, account.id)),
+  );
+  if (accounts.some((account) => account.id === selected))
+    organization.value = selected;
+  form.hidden = false;
+  showBinding();
+}
+
+async function load() {
+  refresh.disabled = true;
+  save.disabled = true;
+  try {
+    render(await network.state());
+  } catch {
+    status.textContent =
+      "Couldn't load network settings. Close this window and try again.";
+  } finally {
+    refresh.disabled = false;
+  }
+}
+
+organization.addEventListener("change", showBinding);
+profile.addEventListener("change", () => {
+  mode.disabled = !profile.value;
+});
+refresh.addEventListener("click", load);
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  save.disabled = true;
+  organization.disabled = true;
+  profile.disabled = true;
+  mode.disabled = true;
+  refresh.disabled = true;
+  const binding = profile.value
+    ? { profileId: profile.value, mode: mode.value }
+    : null;
+  try {
+    const result = await network.save(organization.value, binding);
+    if (result.ok) {
+      const account = accounts.find((item) => item.id === organization.value);
+      if (account) account.network = binding;
+      status.textContent =
+        "Saved on this Mac. Applies when you next select this organization.";
+    } else
+      status.textContent =
+        result.error || "Couldn't save this network setting.";
+  } catch {
+    status.textContent = "Couldn't save this network setting.";
+  } finally {
+    save.disabled = false;
+    organization.disabled = false;
+    profile.disabled = false;
+    mode.disabled = !profile.value;
+    refresh.disabled = false;
+  }
+});
+document
+  .getElementById("open")
+  .addEventListener("click", () => network.openTailscale());
+document
+  .getElementById("close")
+  .addEventListener("click", () => network.close());
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") network.close();
+});
+network.onState(render);
+void load();

--- a/packages/clients/mac/src/network.css
+++ b/packages/clients/mac/src/network.css
@@ -1,0 +1,39 @@
+main {
+  width: 420px;
+}
+.mark {
+  width: 44px;
+  height: 44px;
+}
+h1 {
+  margin-top: 12px;
+  font-size: 22px;
+}
+form {
+  width: 100%;
+  text-align: left;
+}
+label {
+  display: block;
+  margin-top: 16px;
+  font-size: 13px;
+}
+.field {
+  width: 100%;
+  margin-top: 5px;
+  text-align: left;
+  line-height: 1.4;
+}
+.field:disabled {
+  opacity: 0.5;
+}
+.warning {
+  font-size: 12px;
+  margin-top: 14px;
+}
+.actions {
+  margin-top: 16px;
+}
+#status {
+  font-size: 12px;
+}

--- a/packages/clients/mac/src/network.html
+++ b/packages/clients/mac/src/network.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'"
+    />
+    <title>Network on this Mac</title>
+    <link rel="stylesheet" href="shell.css" />
+    <link rel="stylesheet" href="network.css" />
+    <script src="network-page.js" defer></script>
+  </head>
+  <body>
+    <main>
+      <img class="mark" src="mark.png" width="76" height="76" alt="" />
+      <h1 id="title">Network on this Mac</h1>
+      <p class="message" id="description">
+        Link an organization to a saved Tailscale account. This setting stays on
+        this Mac.
+      </p>
+      <form id="settings" hidden>
+        <label for="organization">Organization</label>
+        <select class="field" id="organization" required></select>
+        <label for="profile">Tailscale account</label>
+        <select class="field" id="profile">
+          <option value="">Leave Tailscale unchanged</option>
+        </select>
+        <label for="mode">When switching organizations</label>
+        <select class="field" id="mode">
+          <option value="ask">Ask before switching networks</option>
+          <option value="automatic">Switch networks automatically</option>
+        </select>
+        <p class="message warning">
+          Switching changes networking for the whole Mac. Other apps and
+          organization windows may disconnect.
+        </p>
+        <div class="actions">
+          <button class="button" id="save" type="submit">Save</button>
+          <button class="button ghost" id="refresh" type="button">
+            Refresh accounts
+          </button>
+        </div>
+      </form>
+      <p id="status" role="status" aria-live="polite">Loading…</p>
+      <div class="actions">
+        <button class="button ghost" id="open" type="button">
+          Open Tailscale
+        </button>
+        <button class="button ghost" id="close" type="button">Done</button>
+      </div>
+    </main>
+  </body>
+</html>

--- a/packages/clients/mac/src/organization-network.js
+++ b/packages/clients/mac/src/organization-network.js
@@ -1,0 +1,228 @@
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const { BrowserWindow, ipcMain, dialog, shell } = require("electron");
+const {
+  readNetworkBinding,
+  createTailscaleClient,
+  connectOrganizationNetwork,
+} = require("./tailscale");
+
+const page = path.join(__dirname, "network.html");
+
+class OrganizationNetwork {
+  constructor({ readAccounts, writeAccounts, probe }) {
+    this.readAccounts = readAccounts;
+    this.writeAccounts = writeAccounts;
+    this.probe = probe;
+    this.client = createTailscaleClient();
+    this.windows = new Map();
+    this.settings = null;
+
+    // No remote renderer can enumerate Tailscale accounts or edit a binding.
+    // Only the main frame of a window created by this controller is admitted.
+    const sender = (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (
+        !this.windows.has(window) ||
+        event.senderFrame !== event.sender.mainFrame
+      )
+        return null;
+      const url = new URL(event.senderFrame.url);
+      url.search = "";
+      return url.href === pathToFileURL(page).href ? window : null;
+    };
+    ipcMain.handle("os1:network-state", async (event) => {
+      const window = sender(event);
+      const state = this.windows.get(window);
+      if (!state) return null;
+      if (state.kind !== "settings") return state;
+      let profiles = [];
+      let error = null;
+      try {
+        profiles = await this.client.list();
+      } catch (cause) {
+        error = cause.message;
+      }
+      return {
+        ...state,
+        accounts: this.readAccounts().accounts.map(
+          ({ id, label, network }) => ({ id, label, network }),
+        ),
+        profiles,
+        error,
+      };
+    });
+    ipcMain.handle("os1:network-save", async (event, id, value) => {
+      const window = sender(event);
+      if (this.windows.get(window)?.kind !== "settings") return { ok: false };
+      const binding = value === null ? null : readNetworkBinding(value);
+      if (value !== null && !binding)
+        return {
+          ok: false,
+          error: "Choose a saved Tailscale account and switching mode.",
+        };
+      try {
+        if (
+          binding &&
+          !(await this.client.list()).some(
+            (profile) => profile.id === binding.profileId,
+          )
+        ) {
+          return {
+            ok: false,
+            error:
+              "That Tailscale account is no longer saved. Refresh the account list.",
+          };
+        }
+        if (window.isDestroyed()) return { ok: false };
+        // Re-read after CLI work so a route or account update is never lost.
+        const stored = this.readAccounts();
+        const account = stored.accounts.find(
+          (candidate) => candidate.id === id,
+        );
+        if (!account)
+          return { ok: false, error: "That organization is no longer saved." };
+        if (binding) account.network = binding;
+        else delete account.network;
+        if (!this.writeAccounts(stored))
+          return { ok: false, error: "Couldn't save this network setting." };
+        return { ok: true };
+      } catch (cause) {
+        return { ok: false, error: cause.message };
+      }
+    });
+    ipcMain.on("os1:network-close", (event) => sender(event)?.close());
+    ipcMain.on("os1:network-open-tailscale", (event) => {
+      if (sender(event)) void this.openTailscale();
+    });
+  }
+
+  async openTailscale() {
+    const error = await shell.openPath("/Applications/Tailscale.app");
+    if (error)
+      await dialog.showMessageBox({
+        type: "info",
+        message: "Open Tailscale",
+        detail:
+          "Open your installed Tailscale app, or install it in Applications first.",
+      });
+  }
+
+  createWindow(parent, state) {
+    const window = new BrowserWindow({
+      width: 520,
+      height: state.kind === "settings" ? 640 : 360,
+      title:
+        state.kind === "settings"
+          ? "Network on this Mac"
+          : "Switch organization",
+      parent: parent && !parent.isDestroyed() ? parent : undefined,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      show: false,
+      webPreferences: {
+        preload: path.join(__dirname, "preload.js"),
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+    this.windows.set(window, state);
+    window.webContents.on("will-navigate", (event) => event.preventDefault());
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.on("closed", () => {
+      this.windows.delete(window);
+      if (this.settings === window) this.settings = null;
+    });
+    window.once("ready-to-show", () => {
+      if (!window.isDestroyed()) window.show();
+    });
+    void window.loadFile(page);
+    return window;
+  }
+
+  showSettings(parent, accountId) {
+    if (this.settings && !this.settings.isDestroyed()) {
+      this.settings.show();
+      this.settings.focus();
+      return;
+    }
+    this.settings = this.createWindow(parent, { kind: "settings", accountId });
+  }
+
+  async prepare(account, parent, isLatest, signal) {
+    if (!readNetworkBinding(account.network)) return true;
+    const progress = this.createWindow(parent, {
+      kind: "progress",
+      label: account.label,
+      message: "Checking Tailscale…",
+    });
+    const close = () => {
+      if (!progress.isDestroyed()) progress.destroy();
+    };
+    const closed = new AbortController();
+    progress.once("closed", () => closed.abort());
+    signal.addEventListener("abort", close, { once: true });
+    const dialogSignal = AbortSignal.any([signal, closed.signal]);
+    const isCurrent = () =>
+      isLatest() && !parent.isDestroyed() && !progress.isDestroyed();
+    const status = (message) => {
+      if (!isCurrent()) return;
+      const state = { kind: "progress", label: account.label, message };
+      this.windows.set(progress, state);
+      progress.webContents.send("os1:network-state", state);
+    };
+    try {
+      while (isCurrent()) {
+        try {
+          return (
+            (await connectOrganizationNetwork({
+              account,
+              client: this.client,
+              probe: this.probe,
+              isCurrent,
+              status,
+              confirm: async (profile) => {
+                if (!isCurrent()) return false;
+                const { response } = await dialog.showMessageBox(progress, {
+                  type: "warning",
+                  signal: dialogSignal,
+                  message: `Switch Tailscale to ${profile.tailnet}?`,
+                  detail: `Use ${profile.account} for ${account.label}. This changes networking for the whole Mac. Other apps and organization windows may disconnect.`,
+                  buttons: ["Switch network", "Cancel"],
+                  defaultId: 0,
+                  cancelId: 1,
+                });
+                return response === 0;
+              },
+            })) === true && isCurrent()
+          );
+        } catch (cause) {
+          if (!isCurrent()) return false;
+          status("Couldn't connect");
+          const { response } = await dialog.showMessageBox(progress, {
+            type: "error",
+            signal: dialogSignal,
+            message: `Couldn't connect to ${account.label}`,
+            detail: `${cause.message}\n\nYour previous Tailscale account is not restored automatically.`,
+            buttons: ["Retry", "Open Tailscale", "Cancel"],
+            defaultId: 0,
+            cancelId: 2,
+          });
+          if (!isCurrent() || response === 2) return false;
+          if (response === 1) {
+            await this.openTailscale();
+            return false;
+          }
+        }
+      }
+      return false;
+    } finally {
+      signal.removeEventListener("abort", close);
+      close();
+    }
+  }
+}
+
+module.exports = { OrganizationNetwork };

--- a/packages/clients/mac/src/preload.js
+++ b/packages/clients/mac/src/preload.js
@@ -25,6 +25,18 @@ contextBridge.exposeInMainWorld("os1", {
     remove: (id) => ipcRenderer.invoke("os1:organizations-remove", id),
     manage: () => ipcRenderer.send("os1:organizations-manage"),
   },
+  // Main accepts these only from its dedicated local network settings windows.
+  network: {
+    state: () => ipcRenderer.invoke("os1:network-state"),
+    save: (id, binding) => ipcRenderer.invoke("os1:network-save", id, binding),
+    close: () => ipcRenderer.send("os1:network-close"),
+    openTailscale: () => ipcRenderer.send("os1:network-open-tailscale"),
+    onState: (cb) => {
+      const listener = (_event, state) => cb(state);
+      ipcRenderer.on("os1:network-state", listener);
+      return () => ipcRenderer.removeListener("os1:network-state", listener);
+    },
+  },
   // Electron does not connect Chromium's Web Speech API to a recognition
   // service. Stream the renderer's microphone PCM to the shell's signed native
   // helper instead, which uses Apple's on-device recognizer when available.

--- a/packages/clients/mac/src/tailscale.js
+++ b/packages/clients/mac/src/tailscale.js
@@ -1,0 +1,174 @@
+const { execFile } = require("node:child_process");
+const { promisify } = require("node:util");
+const { setTimeout: delay } = require("node:timers/promises");
+
+const exec = promisify(execFile);
+const BINARIES = [
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+  "/opt/homebrew/bin/tailscale",
+  "/usr/local/bin/tailscale",
+];
+
+function readNetworkBinding(value) {
+  if (
+    !value ||
+    typeof value.profileId !== "string" ||
+    !/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/.test(value.profileId) ||
+    !["ask", "automatic"].includes(value.mode)
+  )
+    return null;
+  return { profileId: value.profileId, mode: value.mode };
+}
+
+function parseProfiles(stdout) {
+  const profiles = JSON.parse(stdout);
+  if (
+    !Array.isArray(profiles) ||
+    !profiles.every(
+      (profile) =>
+        profile &&
+        typeof profile.id === "string" &&
+        /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/.test(profile.id) &&
+        typeof profile.account === "string" &&
+        typeof profile.tailnet === "string" &&
+        typeof profile.selected === "boolean",
+    )
+  )
+    throw new Error(
+      "Tailscale returned an unsupported account list. Update Tailscale and try again.",
+    );
+  return profiles.map(({ id, account, tailnet, selected }) => ({
+    id,
+    account,
+    tailnet,
+    selected,
+  }));
+}
+
+function createTailscaleClient({
+  run = exec,
+  wait = delay,
+  platform = process.platform,
+} = {}) {
+  let binary;
+  async function command(args, timeout = 6000) {
+    if (platform !== "darwin")
+      throw new Error("Network switching is available on macOS only.");
+    for (const candidate of binary ? [binary] : BINARIES) {
+      try {
+        const result = await run(candidate, args, {
+          timeout,
+          maxBuffer: 1024 * 1024,
+          windowsHide: true,
+        });
+        binary = candidate;
+        return result.stdout;
+      } catch (error) {
+        if (error.code === "ENOENT" && !binary) continue;
+        // Do not forward CLI stderr to remotely served pages or shell HTML.
+        throw new Error(
+          "Couldn't control Tailscale. Open Tailscale, check that it is running, and try again.",
+        );
+      }
+    }
+    throw new Error(
+      "Install Tailscale in Applications and sign in to the account you want to use.",
+    );
+  }
+  const list = async () =>
+    parseProfiles(await command(["switch", "--list", "--json"]));
+  return {
+    list,
+    async switch(profileId, isCurrent = () => true) {
+      // Only exact saved IDs can reach argv. Never accept a CLI flag or a
+      // tailnet/account name, which may match more than one saved profile.
+      if (!(await list()).some((profile) => profile.id === profileId)) {
+        throw new Error(
+          "That Tailscale account is no longer saved. Choose another in Network on this Mac.",
+        );
+      }
+      if (isCurrent()) await command(["switch", profileId], 20000);
+    },
+    async ready(profileId, isCurrent) {
+      for (let attempt = 0; attempt < 12 && isCurrent(); attempt++) {
+        const profiles = await list();
+        if (profiles.find((profile) => profile.id === profileId)?.selected) {
+          const status = JSON.parse(await command(["status", "--json"]));
+          if (status?.BackendState === "Running") return;
+        }
+        await wait(350);
+      }
+      if (isCurrent())
+        throw new Error(
+          "Tailscale isn't connected to the selected account. Connect it in Tailscale, then retry.",
+        );
+    },
+  };
+}
+
+async function connectOrganizationNetwork({
+  account,
+  client,
+  confirm,
+  probe,
+  isCurrent,
+  status,
+}) {
+  const binding = readNetworkBinding(account.network);
+  if (!binding || !isCurrent()) return;
+  status("Checking Tailscale…");
+  const profiles = await client.list();
+  if (!isCurrent()) return;
+  const profile = profiles.find(
+    (candidate) => candidate.id === binding.profileId,
+  );
+  if (!profile)
+    throw new Error(
+      "That Tailscale account is no longer saved. Choose another in Network on this Mac.",
+    );
+  if (!profile.selected) {
+    if (binding.mode === "ask" && !(await confirm(profile))) return false;
+    if (!isCurrent()) return;
+    status(`Connecting to ${profile.tailnet}…`);
+    await client.switch(profile.id, isCurrent);
+  }
+  if (!isCurrent()) return;
+  await client.ready(profile.id, isCurrent);
+  if (!isCurrent()) return;
+  status(`Connecting to ${account.label}…`);
+  const reached = await probe(account.url);
+  if (!isCurrent()) return;
+  if (!reached.ok)
+    throw new Error(
+      "Tailscale is connected, but this Open Session server isn't reachable. Check the server address and network access, then retry.",
+    );
+  return true;
+}
+
+// One device has one active Tailscale profile. Serialize across all windows;
+// skip superseded selections and never navigate after a stale async result.
+function createLatestSwitchQueue() {
+  let revision = 0;
+  let controller;
+  let pending = Promise.resolve();
+  return (run) => {
+    const mine = ++revision;
+    controller?.abort();
+    controller = new AbortController();
+    const { signal } = controller;
+    const isCurrent = () => mine === revision;
+    const result = pending.then(() =>
+      isCurrent() ? run(isCurrent, signal) : undefined,
+    );
+    pending = result.catch(() => {});
+    return result;
+  };
+}
+
+module.exports = {
+  readNetworkBinding,
+  parseProfiles,
+  createTailscaleClient,
+  connectOrganizationNetwork,
+  createLatestSwitchQueue,
+};

--- a/packages/clients/mac/src/tailscale.test.js
+++ b/packages/clients/mac/src/tailscale.test.js
@@ -1,0 +1,300 @@
+const { describe, expect, test } = require("bun:test");
+const {
+  readNetworkBinding,
+  parseProfiles,
+  createTailscaleClient,
+  connectOrganizationNetwork,
+  createLatestSwitchQueue,
+} = require("./tailscale");
+
+const profiles = [
+  {
+    id: "personal",
+    account: "person@example.test",
+    tailnet: "Personal",
+    selected: true,
+  },
+  { id: "work", account: "person@work.test", tailnet: "Work", selected: false },
+];
+const account = {
+  id: "org",
+  label: "Work",
+  url: "https://os.work.test/",
+  network: { profileId: "work", mode: "ask" },
+};
+
+function fixture(overrides = {}) {
+  const calls = [];
+  return {
+    calls,
+    options: {
+      account,
+      client: {
+        list: async () => {
+          calls.push("list");
+          return profiles;
+        },
+        switch: async (id) => {
+          calls.push(`switch:${id}`);
+        },
+        ready: async (id) => {
+          calls.push(`ready:${id}`);
+        },
+      },
+      confirm: async () => {
+        calls.push("confirm");
+        return true;
+      },
+      probe: async (url) => {
+        calls.push(`probe:${url}`);
+        return { ok: true };
+      },
+      isCurrent: () => true,
+      status: () => {},
+      ...overrides,
+    },
+  };
+}
+
+describe("local network binding", () => {
+  test("keeps only a saved profile ID and an explicit mode", () => {
+    expect(
+      readNetworkBinding({ ...account.network, token: "not-stored" }),
+    ).toEqual(account.network);
+    for (const value of [
+      null,
+      {},
+      { profileId: "--logout", mode: "ask" },
+      { profileId: "work", mode: "yes" },
+    ]) {
+      expect(readNetworkBinding(value)).toBeNull();
+    }
+  });
+  test("rejects malformed CLI data", () => {
+    expect(parseProfiles(JSON.stringify(profiles))).toEqual(profiles);
+    for (const value of [
+      null,
+      {},
+      [null],
+      [{ id: "a" }],
+      [{ ...profiles[0], selected: "yes" }],
+    ]) {
+      expect(() => parseProfiles(JSON.stringify(value))).toThrow();
+    }
+  });
+});
+
+describe("Tailscale driver", () => {
+  test("uses the app binary and exact argv, then verifies readiness", async () => {
+    const calls = [];
+    const client = createTailscaleClient({
+      platform: "darwin",
+      run: async (binary, args, options) => {
+        calls.push({ binary, args, options });
+        return {
+          stdout: JSON.stringify(
+            args[0] === "status" ? { BackendState: "Running" } : profiles,
+          ),
+        };
+      },
+    });
+    await client.switch("work");
+    await client.ready("personal", () => true);
+    expect(calls.map(({ args }) => args)).toEqual([
+      ["switch", "--list", "--json"],
+      ["switch", "work"],
+      ["switch", "--list", "--json"],
+      ["status", "--json"],
+    ]);
+    expect(
+      calls.every(
+        ({ binary, options }) =>
+          binary === "/Applications/Tailscale.app/Contents/MacOS/Tailscale" &&
+          options.timeout > 0 &&
+          !options.shell,
+      ),
+    ).toBe(true);
+  });
+  test("does not execute arbitrary or removed IDs", async () => {
+    const calls = [];
+    const client = createTailscaleClient({
+      platform: "darwin",
+      run: async (_binary, args) => {
+        calls.push(args);
+        return { stdout: JSON.stringify(profiles) };
+      },
+    });
+    await expect(client.switch("--help")).rejects.toThrow("no longer saved");
+    expect(calls).toEqual([["switch", "--list", "--json"]]);
+  });
+  test("does not switch if superseded during profile revalidation", async () => {
+    let current = true;
+    const calls = [];
+    const client = createTailscaleClient({
+      platform: "darwin",
+      run: async (_binary, args) => {
+        calls.push(args);
+        current = false;
+        return { stdout: JSON.stringify(profiles) };
+      },
+    });
+    await client.switch("work", () => current);
+    expect(calls).toEqual([["switch", "--list", "--json"]]);
+  });
+  test("only falls back for missing binaries, not daemon or permission errors", async () => {
+    const paths = [];
+    const client = createTailscaleClient({
+      platform: "darwin",
+      run: async (binary) => {
+        paths.push(binary);
+        if (paths.length === 1)
+          throw Object.assign(new Error(), { code: "ENOENT" });
+        throw new Error("permission denied");
+      },
+    });
+    await expect(client.list()).rejects.toThrow("Couldn't control Tailscale");
+    expect(paths).toHaveLength(2);
+  });
+  test("reports missing installation", async () => {
+    const client = createTailscaleClient({
+      platform: "darwin",
+      run: async () => {
+        throw Object.assign(new Error(), { code: "ENOENT" });
+      },
+    });
+    await expect(client.list()).rejects.toThrow("Install Tailscale");
+  });
+  test("selected but stopped is not ready and has a bounded retry", async () => {
+    let polls = 0;
+    const client = createTailscaleClient({
+      platform: "darwin",
+      wait: async () => {},
+      run: async (_binary, args) => {
+        if (args[0] === "status") polls++;
+        return {
+          stdout: JSON.stringify(
+            args[0] === "status" ? { BackendState: "Stopped" } : profiles,
+          ),
+        };
+      },
+    });
+    await expect(client.ready("personal", () => true)).rejects.toThrow(
+      "isn't connected",
+    );
+    expect(polls).toBe(12);
+  });
+});
+
+describe("organization switching", () => {
+  test("unmapped organizations leave Tailscale alone", async () => {
+    const { options, calls } = fixture({
+      account: { ...account, network: null },
+    });
+    await connectOrganizationNetwork(options);
+    expect(calls).toEqual([]);
+  });
+  test("asks, switches, verifies readiness, then probes the destination", async () => {
+    const { options, calls } = fixture();
+    expect(await connectOrganizationNetwork(options)).toBe(true);
+    expect(calls).toEqual([
+      "list",
+      "confirm",
+      "switch:work",
+      "ready:work",
+      "probe:https://os.work.test/",
+    ]);
+  });
+  test("automatic mode skips the confirmation", async () => {
+    const { options, calls } = fixture({
+      account: {
+        ...account,
+        network: { profileId: "work", mode: "automatic" },
+      },
+    });
+    expect(await connectOrganizationNetwork(options)).toBe(true);
+    expect(calls).not.toContain("confirm");
+  });
+  test("an already active profile is checked but not switched", async () => {
+    const { options, calls } = fixture({
+      account: { ...account, network: { profileId: "personal", mode: "ask" } },
+    });
+    expect(await connectOrganizationNetwork(options)).toBe(true);
+    expect(calls).toEqual([
+      "list",
+      "ready:personal",
+      "probe:https://os.work.test/",
+    ]);
+  });
+  test("cancelling the confirmation does not switch or probe", async () => {
+    const { options, calls } = fixture({ confirm: async () => false });
+    expect(await connectOrganizationNetwork(options)).toBe(false);
+    expect(calls).toEqual(["list"]);
+  });
+  test("a removed account fails without switching", async () => {
+    const { options, calls } = fixture({
+      account: {
+        ...account,
+        network: { profileId: "gone", mode: "automatic" },
+      },
+    });
+    await expect(connectOrganizationNetwork(options)).rejects.toThrow(
+      "no longer saved",
+    );
+    expect(calls).toEqual(["list"]);
+  });
+  test("an unreachable destination doesn't complete the organization switch", async () => {
+    const { options } = fixture({ probe: async () => ({ ok: false }) });
+    await expect(connectOrganizationNetwork(options)).rejects.toThrow(
+      "isn't reachable",
+    );
+  });
+  test("a superseded confirmation cannot switch networks", async () => {
+    let current = true;
+    const { options, calls } = fixture({
+      confirm: async () => {
+        current = false;
+        return true;
+      },
+      isCurrent: () => current,
+    });
+    await connectOrganizationNetwork(options);
+    expect(calls).toEqual(["list"]);
+  });
+  test("a superseded network command cannot probe or activate", async () => {
+    let current = true;
+    const { options, calls } = fixture({ isCurrent: () => current });
+    options.client.switch = async () => {
+      current = false;
+    };
+    expect(await connectOrganizationNetwork(options)).not.toBe(true);
+    expect(calls).toEqual(["list", "confirm"]);
+  });
+  test("serializes across windows and skips intermediate selections", async () => {
+    const queue = createLatestSwitchQueue();
+    const calls = [];
+    const started = Promise.withResolvers();
+    const finish = Promise.withResolvers();
+    const first = queue(async (isCurrent) => {
+      started.resolve();
+      calls.push("first:start");
+      await finish.promise;
+      if (isCurrent()) calls.push("first:activate");
+      calls.push("first:end");
+    });
+    await started.promise;
+    const middle = queue(async () => calls.push("middle"));
+    const last = queue(async () => calls.push("last"));
+    finish.resolve();
+    await Promise.all([first, middle, last]);
+    expect(calls).toEqual(["first:start", "first:end", "last"]);
+  });
+  test("a failed request does not poison the queue", async () => {
+    const queue = createLatestSwitchQueue();
+    await expect(
+      queue(async () => {
+        throw new Error("failed");
+      }),
+    ).rejects.toThrow("failed");
+    expect(await queue(async () => "next")).toBe("next");
+  });
+});


### PR DESCRIPTION
## Summary

- Add **OS → Organizations → Network on this Mac…** to associate each local organization with a saved Tailscale profile.
- Default to asking before switching, with an explicit automatic mode and an option to leave Tailscale unchanged. Store only the profile ID and mode locally.
- Serialize explicit organization switches across windows, verify Tailscale and server readiness before navigation, and retain organization routes. Background windows, notifications, startup, and focus changes do not switch networks.
- Restrict network-settings IPC to dedicated bundled pages. Use fixed CLI paths and validated saved profile IDs without shell execution or elevated privileges.

## Verification

- Passed `OPENSESSION_TEST_JOBS=2 bun run check`.
- Passed all 33 Mac unit tests.
- Passed the Electron integration harness with disposable servers and a fake Tailscale client, including settings persistence, IPC rejection, ask/automatic modes, route retention, failure handling, and background-window isolation.
- Passed read-only profile discovery and readiness against the installed Tailscale app.
- Captured settings and progress screenshots in the linked session. A Portal could not start because the running macOS Portal launcher requires unavailable `setsid`.

The actual device-wide network switch was not exercised on the live Mac. Cancelling or failing leaves the old organization selected but does not automatically restore the previous Tailscale profile. This ships with a Mac app release; no server deploy is required.

Started by Jaap Frolich in [this Assistant session](http://100.81.254.102:3850/session/os-01a08cb7-a892-7c2d-971f-8306df4ec778)
