### PR TITLE
Add agent-started idb simulator Portals

### DIFF
--- a/.agents/skills/apple-mobile/SKILL.md
+++ b/.agents/skills/apple-mobile/SKILL.md
@@ -24,6 +24,15 @@ Use `apple_mobile_doctor` and `apple_mobile_inspect_project` before any build.
 3. Run `apple_mobile_test` where the package has host-portable tests.
 4. Use `apple_mobile_build_unsigned` for a non-signing build.
 5. Inspect generated IPAs with `apple_mobile_inspect_ipa`.
+6. To show an app from a local Mac workspace, build an `iphonesimulator` `.app`
+   inside the workspace and call `opensession-portals` `start_simulator_portal`
+   with its workspace-relative `appPath`. This needs full Xcode and idb. Open
+   the returned Portal at `/`, exercise the app, and report the URL. The person
+   can pin it beside the conversation. A listening viewer may still be booting
+   its simulator; verify the screen before claiming the app works. Use the
+   returned name with `restart_portal` after rebuilding or `stop_portal` to
+   release it. Restart creates a fresh device. This does not enable hot reload.
+   See `docs/simulator-portals.md` in the Open Session repository.
 
 ## Ad-hoc or TestFlight
 

--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -52,7 +52,7 @@ touches an in-process tool:
 | [`opensession-repos`](#opensession-repos) | 5 | interactive | Needs a session id. |
 | [`opensession-memory`](#opensession-memory) | 9 | interactive | Needs a session id. |
 | [`opensession-web`](#opensession-web) | 3 | interactive, goal wake | Needs a session id. |
-| [`opensession-portals`](#opensession-portals) | 7 | interactive | Needs a session id. |
+| [`opensession-portals`](#opensession-portals) | 8 | interactive | Needs a session id. |
 | [`opensession-desktop`](#opensession-desktop) | 8 | interactive | Needs a sandboxed session. |
 | [`opensession-walkthrough`](#opensession-walkthrough) | 2 | interactive | Needs a session id. |
 | [`opensession-slack`](#opensession-slack) | 1 | interactive | Needs a session id. |
@@ -72,7 +72,7 @@ touches an in-process tool:
 | [`opensession-github`](#opensession-github) | 4 | Slack loop | – |
 | [`opensession-goal-self`](#opensession-goal-self) | 6 | goal wake | Only on a session that carries a goalId. |
 
-31 servers, 135 tools.
+31 servers, 136 tools.
 
 ## opensession-sessions
 
@@ -632,6 +632,12 @@ Supervised HTTP/WebSocket services for this session's workspace.
 - **Wired in** `packages/core/opensession-server/src/server/interactive-mcp.ts`
 - **Runs** interactive
 - **Condition** Needs a session id.
+
+### `start_simulator_portal`
+
+`mcp__opensession-portals__start_simulator_portal` · input: `appPath` (string, required), `deviceType` (string), `runtime` (string)
+
+Start this session's interactive iOS Simulator Portal on the local Mac. Requires full Xcode, an iOS Simulator runtime, idb and idb_companion on PATH, and an already-built simulator .app inside the workspace. Creates a private simulator, streams its screen and forwards taps, swipes and typing. Returns the authenticated viewer URL; the viewer reports boot or dependency errors. Repeated calls reuse the Portal. Use stop_portal/restart_portal with the returned name. Not available in Sandboxes or remote Runner workspaces. Does not build, sign, release, or enable hot reload.
 
 ### `start_portal`
 

--- a/docs/portals-and-agent-communication.md
+++ b/docs/portals-and-agent-communication.md
@@ -82,6 +82,15 @@ Both pages say nothing about the Sandbox beyond that.
 Current boundary: Portals inherit the instance's authenticated team boundary;
 there is no per-session ACL narrower than that team boundary yet.
 
+### iOS simulators
+
+On a local Mac, agents can use `start_simulator_portal` to open an already-built
+simulator `.app` through an idb-backed viewer. It uses the same authenticated
+Portal routing, with a private simulator and companion per viewer process.
+Desktop users can pin any running Portal beside the conversation; phones retain
+the full-width view. See [iOS simulator Portals](simulator-portals.md) for setup,
+agent arguments and limits.
+
 ## Agent-to-agent communication
 
 Interactive agents receive the `opensession-sessions` tools. Together they

--- a/docs/simulator-portals.md
+++ b/docs/simulator-portals.md
@@ -1,0 +1,112 @@
+# iOS simulator Portals
+
+An interactive agent can start an iOS Simulator viewer with
+`opensession-portals.start_simulator_portal`. The app runs on the Open Session
+Mac, not in the browser. The Portal carries JPEG screen frames and input over
+an authenticated WebSocket. On desktop, use **Pin beside conversation** in the
+Portals side panel. Phones use the full-width Portal view.
+
+## Host requirements
+
+This first version supports local macOS workspaces in a **source installation**
+of Open Session. Sandboxes, remote Runners and compiled-binary installs are not
+supported. It needs:
+
+- Full Xcode selected with `xcode-select`, with an installed iOS Simulator runtime.
+- `idb` and `idb_companion` on the service's PATH. See
+  [idb installation](https://github.com/facebook/idb#quick-start).
+- Working authenticated [Portal routing](portals-and-agent-communication.md),
+  including the instance's Caddy HTTPS configuration. A listening local port
+  without that route is not a shareable viewer.
+- The source installation's Bun dependencies, including the Tailwind compiler.
+
+The implementation follows idb's `--companion` Unix-socket interface,
+`video-stream --format mjpeg --fps 15 --scale-factor 0.5`, and `ui` commands.
+It requires `describe --json` to report logical screen dimensions. Pin a tested
+idb version to your Xcode/runtime combination: idb uses private Apple frameworks.
+Do not assume that every upstream release is interchangeable.
+
+Neither Xcode nor idb is installed automatically. Verify operation after a Mac
+reboot and without a monitor before relying on unattended use. This integration
+reads the simulator framebuffer through idb, not the Mac desktop via
+ScreenCaptureKit. It does not request Screen Recording or Accessibility access.
+
+## Agent workflow
+
+1. Build an unsigned **iphonesimulator** `.app` inside the session workspace.
+   A device `.app` or `.ipa` cannot be used. For an Xcode project, a typical
+   command is:
+
+   ```sh
+   xcodebuild -project MyApp.xcodeproj -scheme MyApp \
+     -configuration Debug -sdk iphonesimulator \
+     -destination 'generic/platform=iOS Simulator' \
+     -derivedDataPath .build/simulator CODE_SIGNING_ALLOWED=NO build
+   ```
+
+2. Call `start_simulator_portal`:
+
+   ```json
+   {
+     "appPath": ".build/simulator/Build/Products/Debug-iphonesimulator/MyApp.app"
+   }
+   ```
+
+   Optional `deviceType` and `runtime` select installed CoreSimulator identifiers.
+   Omit them to choose an iPhone and an available iOS runtime. `appPath` is
+   workspace-relative; paths and symlinks escaping that workspace are rejected.
+
+3. Open the returned Portal. Its default route is `/`. The viewer shows startup
+   and dependency errors, not a fake screen. A listening Portal means the viewer
+   is ready; booting the simulator can take longer.
+4. Click or drag on the screen. Focus it to send keyboard input, or use the text
+   field and **Send**, which also works on phones. **Home** presses the simulated
+   Home button. Tab retains normal browser focus navigation.
+5. After rebuilding the app, use `restart_portal` with the returned name to
+   install the updated bundle. Use `stop_portal` to release the simulator.
+
+Repeated identical starts reuse the same Portal. Its name includes a session
+hash so sessions sharing a checkout do not select the same viewer. Changing
+start arguments requires stopping it and starting it with the new arguments.
+
+## Ownership and limits
+
+- Each viewer process creates its own CoreSimulator device set and device. No
+  command accepts an existing device UDID, including the global `booted` target.
+- An owned idb companion listens on a private Unix socket, never a public gRPC
+  port. Every input command addresses that companion explicitly.
+- At most two simulator leases run on a Mac. Durable capacity records permit
+  bounded recovery of a dead owner's private device on the next start. Recovery
+  never enumerates another session's devices or databases. Invalid metadata or
+  an interrupted recovery lock fails closed and needs operator inspection under
+  `/tmp/opensession-idb-simulator-capacity`; never delete a slot until its owned
+  device set is stopped and removed.
+- Capture runs only while viewers are connected. The helper exits and deletes
+  its device after ten minutes without a viewer. Stop/restart and normal Portal
+  cleanup also release the device. Restart creates a fresh simulator and loses
+  installed app data. Forced termination can defer cleanup until the next start.
+- Up to four viewers share one screen stream and a bounded input queue. Slow
+  browsers drop frames rather than building an unbounded video buffer.
+- Portals retain the instance's authenticated team boundary. This is not a new
+  per-person permission boundary. The helper additionally checks the WebSocket
+  origin and a same-origin token; it binds only to loopback.
+- Basic taps, swipes, text, common keyboard keys and Home are supported. This is
+  not full multi-touch, audio, clipboard sync or a screen-reader representation
+  of the app. Text support follows idb's keyboard mapping.
+- Hot reload is not enabled by this tool. Swift injection or a framework's own
+  reload server can be added to the app separately. The viewer is independent
+  of how code reaches the running app.
+
+## Verification
+
+Unit tests replace the executable boundary to test device isolation, cleanup,
+capacity, paths and CLI arguments. Real HTTP/WebSocket tests exercise the viewer
+transport, origin/token checks and input validation.
+
+For browser verification without Xcode, start a Portal with the command
+`bun scripts/verify-simulator-portal.ts`. It serves the production viewer against
+an explicitly labelled test fixture, records input at `/test-inputs.json`, and
+starts **no simulator**. Append `--failure` to exercise the setup-error view.
+These tests do not qualify a real idb/Xcode combination. Before rollout, start a
+real app on the intended Mac and verify tap, drag, typing, Home, stream reconnect,
+stop, restart, two simultaneous sessions and capacity rejection of a third.

--- a/packages/core/opensession-server/src/frontend/components/PortalPane.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PortalPane.test.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { PortalTarget } from "../lib/portals";
+import { PortalPane } from "./PortalPane";
+
+const target: PortalTarget = {
+  sessionId: "session-1",
+  name: "Simulator",
+  key: "simulator",
+  port: 8080,
+  url: "https://portal.example.test/simulator",
+};
+
+const noop = () => {};
+
+test("a pinned portal has close and full-width actions around its iframe", () => {
+  const html = renderToStaticMarkup(
+    <PortalPane target={target} onClose={noop} onExpand={noop} />,
+  );
+
+  expect(html).toContain(`src="${target.url}"`);
+  expect(html).toContain('aria-label="Expand Simulator to full width"');
+  expect(html).toContain('aria-label="Close Simulator side panel"');
+  expect(html).toContain('title="Simulator portal"');
+});
+
+test("a full-width portal does not show side-panel actions", () => {
+  const html = renderToStaticMarkup(<PortalPane target={target} />);
+
+  expect(html).not.toContain("Expand Simulator to full width");
+  expect(html).not.toContain("Close Simulator side panel");
+});

--- a/packages/core/opensession-server/src/frontend/components/PortalPane.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PortalPane.tsx
@@ -2,10 +2,24 @@ import { useState } from "react";
 import type { PortalTarget } from "../lib/portals";
 import { Button } from "../ui/button";
 import { PageLoader } from "../ui/page-loader";
-import { IconArrowUpRight, IconGlobe, IconRestore } from "./icons";
+import {
+  IconArrowUpRight,
+  IconExpand,
+  IconGlobe,
+  IconRestore,
+  IconX,
+} from "./icons";
 
-/** Browser-like center pane for one service exposed by a session portal. */
-export function PortalPane({ target }: { target: PortalTarget }) {
+/** Browser-like pane for one service exposed by a session portal. */
+export function PortalPane({
+  target,
+  onExpand,
+  onClose,
+}: {
+  target: PortalTarget;
+  onExpand?: () => void;
+  onClose?: () => void;
+}) {
   const [reloadNonce, setReloadNonce] = useState(0);
   const [loading, setLoading] = useState(true);
 
@@ -34,6 +48,16 @@ export function PortalPane({ target }: { target: PortalTarget }) {
           aria-label={`Reload ${target.name}`}
           title="Reload portal"
         />
+        {onExpand ? (
+          <Button
+            variant="ghost"
+            size="md"
+            icon={<IconExpand size={16} />}
+            onClick={onExpand}
+            aria-label={`Expand ${target.name} to full width`}
+            title="Expand to full width"
+          />
+        ) : null}
         <Button
           variant="ghost"
           size="md"
@@ -48,6 +72,16 @@ export function PortalPane({ target }: { target: PortalTarget }) {
           aria-label={`Open ${target.name} in a separate browser window`}
           title="Open in browser"
         />
+        {onClose ? (
+          <Button
+            variant="ghost"
+            size="md"
+            icon={<IconX size={16} />}
+            onClick={onClose}
+            aria-label={`Close ${target.name} side panel`}
+            title="Close side panel"
+          />
+        ) : null}
       </div>
       <div className="relative min-h-0 flex-1 bg-white">
         {loading ? (

--- a/packages/core/opensession-server/src/frontend/components/PortalsPanel.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PortalsPanel.test.tsx
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { PreviewStatus } from "../lib/api";
+import { PortalsPage } from "./PortalsPanel";
+
+const status: PreviewStatus = {
+  services: [
+    {
+      name: "Simulator",
+      key: "simulator",
+      port: 8080,
+      running: true,
+      pids: [42],
+      previewUrl: "https://portal.example.test/simulator",
+    },
+  ],
+};
+
+const noop = () => {};
+
+test("a running portal can be pinned beside the conversation", () => {
+  const html = renderToStaticMarkup(
+    <PortalsPage
+      sessionId="session-1"
+      status={status}
+      onBack={noop}
+      onOpenPortal={noop}
+      onPinPortal={noop}
+    />,
+  );
+
+  expect(html).toContain('aria-label="Pin Simulator beside the conversation"');
+  expect(html).toContain('title="Pin beside conversation"');
+});
+
+test("the pin action is omitted when the host does not support a side panel", () => {
+  const html = renderToStaticMarkup(
+    <PortalsPage
+      sessionId="session-1"
+      status={status}
+      onBack={noop}
+      onOpenPortal={noop}
+    />,
+  );
+
+  expect(html).not.toContain("Pin Simulator beside the conversation");
+});

--- a/packages/core/opensession-server/src/frontend/components/PortalsPanel.tsx
+++ b/packages/core/opensession-server/src/frontend/components/PortalsPanel.tsx
@@ -10,7 +10,8 @@ import {
   INFO_SECTION_CLASS,
 } from "../lib/session-viewer-classes";
 import { cn } from "../ui/cn";
-import { IconArrowUpRight } from "./icons";
+import { Button } from "../ui/button";
+import { IconArrowUpRight, IconPin } from "./icons";
 import { PanelPageHeader } from "./PanelPageHeader";
 
 /** A plain divided list. Portal rows do not need a shared grey plate around
@@ -54,6 +55,7 @@ export function PortalsPage({
   onBack,
   hideHeader = false,
   onOpenPortal,
+  onPinPortal,
   onStartPortal,
   onPortalAction,
 }: {
@@ -63,6 +65,7 @@ export function PortalsPage({
   onBack: () => void;
   hideHeader?: boolean;
   onOpenPortal?: (target: PortalTarget) => void;
+  onPinPortal?: (target: PortalTarget) => void;
   onStartPortal?: (recipe: PreviewPortalRecipe) => Promise<void>;
   onPortalAction?: (name: string, action: "stop" | "restart") => Promise<void>;
 }) {
@@ -183,7 +186,7 @@ export function PortalsPage({
                       <div
                         key={service.key}
                         className={cn(
-                          "group flex min-h-11 min-w-0 items-center gap-1 rounded-control pr-1 transition-colors",
+                          "group flex min-h-11 min-w-0 flex-wrap items-center gap-1 rounded-control pr-1 transition-colors",
                           active ? "bg-hover" : "hover:bg-hover",
                         )}
                       >
@@ -200,13 +203,25 @@ export function PortalsPage({
                             )}
                             aria-hidden="true"
                           />
-                          <span className="min-w-0 flex-1 truncate text-label text-fg">
-                            {service.name}
-                          </span>
-                          <span className="shrink-0 truncate text-label text-faint">
-                            {statusLabel(service, target, active)}
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-label text-fg">
+                              {service.name}
+                            </span>
+                            <span className="block truncate text-supporting text-faint">
+                              {statusLabel(service, target, active)}
+                            </span>
                           </span>
                         </button>
+                        {target && onPinPortal ? (
+                          <Button
+                            variant="ghost"
+                            icon={<IconPin size={14} />}
+                            onClick={() => onPinPortal(target)}
+                            className="size-11 shrink-0 text-faint hover:text-fg"
+                            aria-label={`Pin ${service.name} beside the conversation`}
+                            title="Pin beside conversation"
+                          />
+                        ) : null}
                         {target ? (
                           <a
                             href={target.url}
@@ -220,7 +235,7 @@ export function PortalsPage({
                           </a>
                         ) : null}
                         {service.managed && onPortalAction ? (
-                          <div className="flex shrink-0 items-center opacity-0 transition-opacity phone:opacity-100 group-hover:opacity-100 focus-within:opacity-100">
+                          <div className="flex basis-full items-center justify-end gap-1 pb-1">
                             <button
                               type="button"
                               disabled={working === service.name}

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -732,6 +732,7 @@ export function SessionViewer({
   const { activePanelOpen, setActivePanelOpen } = viewState.panel;
   const { panelPage, setPanelPage } = viewState.panel;
   const { panelTerminalMounted, setPanelTerminalMounted } = viewState.panel;
+  const { pinnedPortal, setPinnedPortal } = viewState.panel;
   const { assetFiles, refreshAssets, assetPaths } = viewState.assets;
   const { selectedAssetPath, setSelectedAssetPath } = viewState.assets;
   const { overlayAssetPath, setOverlayAssetPath } = viewState.assets;
@@ -1862,6 +1863,22 @@ export function SessionViewer({
             activePortal: portalTarget,
             onBack: () => setActivePanelOpen(false),
             onOpenPortal: openPortal,
+            onPinPortal: (target) => {
+              setPinnedPortal(target);
+              setActivePanelOpen(true);
+              openSession?.(session.id);
+            },
+            pinnedPortal,
+            onClosePinnedPortal: () => {
+              setPinnedPortal(null);
+              setActivePanelOpen(false);
+            },
+            onExpandPinnedPortal: () => {
+              if (!pinnedPortal) return;
+              setPinnedPortal(null);
+              setActivePanelOpen(false);
+              openPortal?.(pinnedPortal);
+            },
             onStartPortal: startDeclaredPortal,
             onPortalAction: async (name, action) => {
               setPreviewStatus(await portalActionApi(session.id, name, action));

--- a/packages/core/opensession-server/src/frontend/components/session-viewer/SessionViewerSidePanel.tsx
+++ b/packages/core/opensession-server/src/frontend/components/session-viewer/SessionViewerSidePanel.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react";
 import { DiffPanel } from "../DiffPanel";
+import { PortalPane } from "../PortalPane";
 import { PortalsPage } from "../PortalsPanel";
 import { SidePanelHost } from "../session/SidePanelHost";
 import { WorkflowPanel } from "../WorkflowPanel";
@@ -74,6 +75,10 @@ interface PortalContent {
   onOpenPortal: PortalsProps["onOpenPortal"];
   onStartPortal: PortalsProps["onStartPortal"];
   onPortalAction: PortalsProps["onPortalAction"];
+  pinnedPortal: PortalsProps["activePortal"];
+  onPinPortal: PortalsProps["onPinPortal"];
+  onClosePinnedPortal: () => void;
+  onExpandPinnedPortal: () => void;
 }
 
 interface AgentContent {
@@ -127,6 +132,15 @@ export function SessionViewerSidePanel({
         terminalMounted={shell.terminalMounted}
         onTerminalMount={shell.onTerminalMount}
         sessionId={changes.sessionId}
+        pinned={
+          portals.pinnedPortal ? (
+            <PortalPane
+              target={portals.pinnedPortal}
+              onClose={portals.onClosePinnedPortal}
+              onExpand={portals.onExpandPinnedPortal}
+            />
+          ) : undefined
+        }
         changes={
           <>
             <section
@@ -181,6 +195,7 @@ export function SessionViewerSidePanel({
             onBack={portals.onBack}
             hideHeader
             onOpenPortal={portals.onOpenPortal}
+            onPinPortal={portals.onPinPortal}
             onStartPortal={portals.onStartPortal}
             onPortalAction={portals.onPortalAction}
           />

--- a/packages/core/opensession-server/src/frontend/components/session/SidePanelHost.test.tsx
+++ b/packages/core/opensession-server/src/frontend/components/session/SidePanelHost.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SidePanelHost } from "./SidePanelHost";
+
+const noop = () => {};
+
+test("pinned content replaces the side-panel tabs and page", () => {
+  const html = renderToStaticMarkup(
+    <SidePanelHost
+      hidden={false}
+      isPhone={false}
+      available
+      open
+      onOpenChange={noop}
+      resizeHandle={null}
+      hasWorkspace
+      page="portals"
+      onPageChange={noop}
+      livePortals={1}
+      runningAgents={0}
+      terminalMounted={false}
+      onTerminalMount={noop}
+      sessionId="session-1"
+      pinned={
+        <iframe title="Pinned portal" src="https://portal.example.test" />
+      }
+      changes={<div>Changes page</div>}
+      portals={<div>Portals page</div>}
+      agents={<div>Agents page</div>}
+    />,
+  );
+
+  expect(html).toContain('title="Pinned portal"');
+  expect(html).not.toContain("Portals page");
+  expect(html).not.toContain("Changes page");
+  expect(html).not.toContain("Terminal");
+});

--- a/packages/core/opensession-server/src/frontend/components/session/SidePanelHost.tsx
+++ b/packages/core/opensession-server/src/frontend/components/session/SidePanelHost.tsx
@@ -29,6 +29,7 @@ interface SidePanelHostProps {
   terminalMounted: boolean;
   onTerminalMount: () => void;
   sessionId: string;
+  pinned?: ReactNode;
   changes: ReactNode;
   portals: ReactNode;
   agents: ReactNode;
@@ -51,6 +52,7 @@ export function SidePanelHost({
   terminalMounted,
   onTerminalMount,
   sessionId,
+  pinned,
   changes,
   portals,
   agents,
@@ -65,7 +67,7 @@ export function SidePanelHost({
       {!isPhone && available && open ? (
         <div className={PANEL_SHELL} style={style}>
           {resizeHandle}
-          {hasWorkspace && (
+          {hasWorkspace && !pinned && (
             <div className={PANEL_TABS}>
               <button
                 type="button"
@@ -131,19 +133,20 @@ export function SidePanelHost({
             </div>
           )}
           <div className={PANEL_BODY}>
-            {page === "changes"
-              ? changes
-              : page === "portals"
-                ? portals
-                : page === "agents"
-                  ? agents
-                  : null}
+            {pinned ??
+              (page === "changes"
+                ? changes
+                : page === "portals"
+                  ? portals
+                  : page === "agents"
+                    ? agents
+                    : null)}
             {/* Keep terminals mounted while switching panel tabs so their PTYs
                 survive. Closing the panel still closes its terminals. */}
             {hasWorkspace && terminalMounted && (
               <div
                 className={
-                  page === "terminal"
+                  !pinned && page === "terminal"
                     ? "flex h-full min-h-0 flex-col"
                     : "hidden"
                 }

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionViewStateController.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionViewStateController.ts
@@ -54,6 +54,7 @@ import type { useSessionSocket } from "./useSessionSocket";
 import type { LiveTurnStore } from "../lib/live-turn-store";
 import type { TranscriptViewStore } from "../lib/transcript-view-store";
 import type { SessionPrRef } from "../lib/types";
+import type { PortalTarget } from "../lib/portals";
 import type { SessionViewerProps } from "../lib/session-viewer-bindings";
 
 type WorkspaceSummaryStyle = CSSProperties & {
@@ -304,6 +305,7 @@ export function useSessionViewStateController({
   const [panelTerminalMounted, setPanelTerminalMounted] = useState(
     () => activePanelOpen && sidePanel.page === "terminal",
   );
+  const [pinnedPortal, setPinnedPortal] = useState<PortalTarget | null>(null);
   const assets = useSessionAssets(session.id, addHandler);
   const assetPaths = useMemo(
     () => assets.files.map((file) => file.path),
@@ -437,6 +439,9 @@ export function useSessionViewStateController({
       setPanelPage,
       panelTerminalMounted,
       setPanelTerminalMounted,
+      pinnedPortal:
+        pinnedPortal?.sessionId === session.id ? pinnedPortal : null,
+      setPinnedPortal,
     },
     assets: {
       assetFiles: assets.files,

--- a/packages/core/opensession-server/src/frontend/lib/simulator-viewer.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/simulator-viewer.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { simulatorGesture, simulatorPointer } from "./simulator-viewer";
+
+test("pointer mapping ignores letterbox space at desktop and phone widths", () => {
+  const rect = { left: 100, top: 50, width: 600, height: 800 };
+  expect(
+    simulatorPointer({
+      rect,
+      width: 400,
+      height: 800,
+      clientX: 100,
+      clientY: 450,
+    }),
+  ).toBeNull();
+  expect(
+    simulatorPointer({
+      rect,
+      width: 400,
+      height: 800,
+      clientX: 400,
+      clientY: 450,
+    }),
+  ).toEqual({ x: 0.5, y: 0.5 });
+  expect(
+    simulatorPointer({
+      rect: { left: 0, top: 0, width: 300, height: 800 },
+      width: 400,
+      height: 800,
+      clientX: 150,
+      clientY: 100,
+    }),
+  ).toEqual({ x: 0.5, y: 0 });
+});
+
+test("short movement taps, larger movement swipes with a bounded duration", () => {
+  const start = { x: 0.5, y: 0.5, time: 0 };
+  expect(simulatorGesture(start, { x: 0.501, y: 0.5 }, 100)).toEqual({
+    type: "tap",
+    x: 0.501,
+    y: 0.5,
+  });
+  expect(simulatorGesture(start, { x: 0.1, y: 0.8 }, 10_000)).toEqual({
+    type: "swipe",
+    x: 0.5,
+    y: 0.5,
+    endX: 0.1,
+    endY: 0.8,
+    duration: 2,
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/simulator-viewer.ts
+++ b/packages/core/opensession-server/src/frontend/lib/simulator-viewer.ts
@@ -1,0 +1,38 @@
+import type { ViewerInput } from "../../simulator-portal/protocol";
+
+/** Account for object-contain letterboxing before mapping to device points. */
+export function simulatorPointer(input: {
+  clientX: number;
+  clientY: number;
+  rect: { left: number; top: number; width: number; height: number };
+  width: number;
+  height: number;
+}): { x: number; y: number } | null {
+  const { rect, width, height } = input;
+  const scale = Math.min(rect.width / width, rect.height / height);
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  const x =
+    (input.clientX - rect.left - (rect.width - width * scale) / 2) /
+    (width * scale);
+  const y =
+    (input.clientY - rect.top - (rect.height - height * scale) / 2) /
+    (height * scale);
+  return x >= 0 && x <= 1 && y >= 0 && y <= 1 ? { x, y } : null;
+}
+
+export function simulatorGesture(
+  start: { x: number; y: number; time: number },
+  end: { x: number; y: number },
+  now: number,
+): ViewerInput {
+  if (Math.hypot(end.x - start.x, end.y - start.y) < 0.01)
+    return { type: "tap", x: end.x, y: end.y };
+  return {
+    type: "swipe",
+    x: start.x,
+    y: start.y,
+    endX: end.x,
+    endY: end.y,
+    duration: Math.max(0.05, Math.min(2, (now - start.time) / 1_000)),
+  };
+}

--- a/packages/core/opensession-server/src/frontend/simulator/SimulatorViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/simulator/SimulatorViewer.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
+import {
+  viewerMessageSchema,
+  viewerInputSchema,
+  type ViewerInput,
+  type ViewerState,
+} from "../../simulator-portal/protocol";
+import { simulatorGesture, simulatorPointer } from "../lib/simulator-viewer";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Spinner } from "../ui/spinner";
+
+export function SimulatorViewer() {
+  const canvas = useRef<HTMLCanvasElement>(null);
+  const socket = useRef<WebSocket | null>(null);
+  const gesture = useRef<{ x: number; y: number; time: number } | null>(null);
+  const [state, setState] = useState<ViewerState>({ phase: "starting" });
+  const [connected, setConnected] = useState(false);
+  const [hasFrame, setHasFrame] = useState(false);
+  const [error, setError] = useState("");
+  const [text, setText] = useState("");
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const abort = new AbortController();
+    let disposed = false;
+    let ws: WebSocket | undefined;
+    let decoding = false;
+    async function connect() {
+      const response = await fetch("/api/bootstrap", { signal: abort.signal });
+      if (!response.ok)
+        throw new Error("Could not connect to the simulator Portal");
+      const bootstrap = z
+        .object({ token: z.string() })
+        .parse(await response.json());
+      if (disposed) return;
+      const url = new URL("/socket", location.href);
+      url.protocol = location.protocol === "https:" ? "wss:" : "ws:";
+      url.searchParams.set("token", bootstrap.token);
+      ws = new WebSocket(url);
+      socket.current = ws;
+      ws.onopen = () => {
+        setConnected(true);
+        setError("");
+      };
+      ws.onclose = () => {
+        if (!disposed) {
+          setConnected(false);
+          setHasFrame(false);
+          setError("Viewer disconnected. Reconnect to continue.");
+        }
+      };
+      ws.onerror = () => {
+        if (!disposed) setError("Could not connect to the simulator Portal");
+      };
+      ws.onmessage = async (event: MessageEvent<unknown>) => {
+        if (event.data instanceof Blob) {
+          // Never queue frame decoding behind a slow or backgrounded browser.
+          if (decoding || !canvas.current) return;
+          decoding = true;
+          try {
+            const image = await createImageBitmap(event.data);
+            const target = canvas.current;
+            if (!disposed && target) {
+              if (target.width !== image.width) target.width = image.width;
+              if (target.height !== image.height) target.height = image.height;
+              target.getContext("2d")?.drawImage(image, 0, 0);
+              setHasFrame(true);
+            }
+            image.close();
+          } catch {
+            if (!disposed) setError("Could not decode the simulator screen");
+          }
+          decoding = false;
+          return;
+        }
+        const textMessage = z.string().safeParse(event.data);
+        if (!textMessage.success) return;
+        try {
+          const message = viewerMessageSchema.parse(
+            JSON.parse(textMessage.data),
+          );
+          if (message.type === "state") setState(message.state);
+          else setError(message.message);
+        } catch {
+          setError("The simulator sent an invalid response");
+        }
+      };
+    }
+    void connect().catch((cause) => {
+      if (!disposed)
+        setError(
+          cause instanceof Error ? cause.message : "Viewer connection failed",
+        );
+    });
+    return () => {
+      disposed = true;
+      abort.abort();
+      ws?.close();
+      socket.current = null;
+    };
+  }, [attempt]);
+
+  const ready = state.phase === "ready" && connected && hasFrame;
+  function send(input: ViewerInput) {
+    if (!ready || socket.current?.readyState !== WebSocket.OPEN) return;
+    setError("");
+    socket.current.send(JSON.stringify(input));
+  }
+  function point(event: React.PointerEvent<HTMLCanvasElement>) {
+    if (state.phase !== "ready") return null;
+    return simulatorPointer({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      rect: event.currentTarget.getBoundingClientRect(),
+      width: state.width,
+      height: state.height,
+    });
+  }
+
+  return (
+    <main className="flex h-dvh min-h-0 flex-col gap-2 bg-panel p-3 text-fg [box-sizing:border-box]">
+      <header className="flex min-h-11 shrink-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h1 className="m-0 truncate text-sm font-medium">
+            {state.phase === "ready" ? state.deviceName : "iOS simulator"}
+          </h1>
+          <p className="m-0 text-xs text-dim">
+            {ready ? "Live simulator" : "Simulator Portal"}
+          </p>
+        </div>
+        <Button
+          className="min-h-11 shrink-0"
+          variant="ghost"
+          disabled={!ready}
+          onClick={() => send({ type: "home" })}
+        >
+          Home
+        </Button>
+      </header>
+      <div className="relative min-h-0 flex-1 overflow-hidden rounded-lg bg-surface">
+        <canvas
+          ref={canvas}
+          role="application"
+          aria-label="Simulator screen. Click or swipe to interact. Type when focused."
+          tabIndex={ready ? 0 : -1}
+          className="block h-full w-full touch-none object-contain outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+          onPointerDown={(event) => {
+            if (!ready || event.button !== 0 || !event.isPrimary) return;
+            const start = point(event);
+            if (!start) return;
+            event.currentTarget.focus();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            gesture.current = { ...start, time: performance.now() };
+          }}
+          onPointerUp={(event) => {
+            const start = gesture.current;
+            gesture.current = null;
+            const end = point(event);
+            if (start && end)
+              send(simulatorGesture(start, end, performance.now()));
+          }}
+          onPointerCancel={() => {
+            gesture.current = null;
+          }}
+          onKeyDown={(event) => {
+            if (
+              !ready ||
+              event.metaKey ||
+              event.ctrlKey ||
+              event.altKey ||
+              event.key === "Tab"
+            )
+              return;
+            const special = viewerInputSchema.safeParse({
+              type: "key",
+              key: event.key,
+            });
+            if (special.success) {
+              event.preventDefault();
+              send(special.data);
+            } else if (event.key.length === 1) {
+              event.preventDefault();
+              send({ type: "text", text: event.key });
+            }
+          }}
+        />
+        {!ready ? (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-surface p-4 text-center text-sm text-dim"
+            role="status"
+          >
+            {state.phase === "error" ? (
+              <p className="m-0">{state.message}</p>
+            ) : (
+              <>
+                <Spinner />
+                <p className="m-0">
+                  {state.phase === "starting"
+                    ? "Starting simulator…"
+                    : connected
+                      ? "Waiting for the screen…"
+                      : "Viewer disconnected"}
+                </p>
+              </>
+            )}
+            {state.phase === "error" ? (
+              <p className="m-0 text-xs">
+                Fix the setup, then restart this Portal.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {error ? (
+        <div role="alert" className="shrink-0 text-sm text-dim">
+          {error}
+        </div>
+      ) : null}
+      {!connected && error ? (
+        <Button
+          className="min-h-11 shrink-0"
+          onClick={() => {
+            setError("");
+            setAttempt((value) => value + 1);
+          }}
+        >
+          Reconnect
+        </Button>
+      ) : null}
+      <form
+        className="flex shrink-0 items-center gap-2 pb-[env(safe-area-inset-bottom)]"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (text) {
+            send({ type: "text", text });
+            setText("");
+          }
+        }}
+      >
+        <Input
+          className="min-h-11 min-w-0 flex-1 text-base"
+          aria-label="Text to type in the simulator"
+          placeholder="Type in simulator"
+          disabled={!ready}
+          maxLength={1_000}
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+        />
+        <Button className="min-h-11" type="submit" disabled={!ready || !text}>
+          Send
+        </Button>
+      </form>
+    </main>
+  );
+}

--- a/packages/core/opensession-server/src/frontend/simulator/main.tsx
+++ b/packages/core/opensession-server/src/frontend/simulator/main.tsx
@@ -1,0 +1,13 @@
+import { createRoot } from "react-dom/client";
+import { SimulatorViewer } from "./SimulatorViewer";
+import "../styles/base.css";
+
+const theme = matchMedia("(prefers-color-scheme: light)");
+function applyTheme() {
+  document.documentElement.dataset.theme = theme.matches ? "light" : "dark";
+  document.documentElement.style.colorScheme = theme.matches ? "light" : "dark";
+}
+applyTheme();
+theme.addEventListener("change", applyTheme);
+const root = document.getElementById("root");
+if (root) createRoot(root).render(<SimulatorViewer />);

--- a/packages/core/opensession-server/src/server/portal-host-process.ts
+++ b/packages/core/opensession-server/src/server/portal-host-process.ts
@@ -1,0 +1,35 @@
+import { spawn } from "node:child_process";
+
+/** macOS has no setsid executable. Node's detached spawn creates the same
+ * session/process group, so the supervisor can reap the complete tree. */
+export function portalHostCommand(
+  command: string,
+  platform = process.platform,
+): string[] {
+  return platform === "darwin"
+    ? ["bash", "-lc", `exec ${command}`]
+    : ["setsid", "bash", "-lc", `exec ${command}`];
+}
+
+export async function spawnPortalHost(input: {
+  command: string[];
+  cwd: string;
+  env: Record<string, string>;
+  log: number;
+}): Promise<number> {
+  const [executable, ...args] = input.command;
+  if (!executable) throw new Error("Missing Portal executable");
+  const child = spawn(executable, args, {
+    cwd: input.cwd,
+    env: { NODE_ENV: "production", ...input.env },
+    detached: process.platform === "darwin",
+    stdio: ["ignore", input.log, input.log],
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.once("spawn", resolve);
+    child.once("error", reject);
+  });
+  child.unref();
+  if (!child.pid) throw new Error("Portal process did not start");
+  return child.pid;
+}

--- a/packages/core/opensession-server/src/server/portal-supervisor.ts
+++ b/packages/core/opensession-server/src/server/portal-supervisor.ts
@@ -18,6 +18,7 @@ import {
 } from "fs";
 import { join, resolve } from "path";
 import { audit } from "./audit";
+import { portalHostCommand, spawnPortalHost } from "./portal-host-process";
 import { ensureAgentAwsCredsFile } from "./aws-creds";
 import { configuredPaths, configuredServer } from "./config";
 import {
@@ -74,6 +75,8 @@ export type PortalRecord = {
   lastAccessedAt?: string;
   sleptAt?: string;
   readyTimeoutMs?: number;
+  /** Time to release external resources, such as a private simulator device. */
+  shutdownGraceMs?: number;
   lastError?: string;
 };
 
@@ -294,7 +297,10 @@ function hostPortalOps(worktreeDir: string): PortalOps {
   };
 }
 
-type PortalProcess = Pick<PortalRecord, "pid" | "scopeUnit">;
+type PortalProcess = Pick<
+  PortalRecord,
+  "pid" | "scopeUnit" | "shutdownGraceMs"
+>;
 
 async function portalProcessAlive(
   ops: PortalOps,
@@ -455,6 +461,7 @@ async function startPortal(
     description?: string;
     defaultPath?: string;
     readyTimeoutMs?: number;
+    shutdownGraceMs?: number;
     /** Host Portals record their owner so a restarted server can reap them; Sandbox Portals die with the Sandbox. */
     ownsProcess: boolean;
     allocatePort: (records: PortalRecord[]) => Promise<number>;
@@ -522,6 +529,9 @@ async function startPortal(
       ? { defaultPath: normalizePortalPath(input.defaultPath) }
       : {}),
     ...(input.readyTimeoutMs ? { readyTimeoutMs: input.readyTimeoutMs } : {}),
+    ...(input.shutdownGraceMs
+      ? { shutdownGraceMs: Math.min(30_000, input.shutdownGraceMs) }
+      : {}),
     state: "starting",
     startedAt: new Date().toISOString(),
   };
@@ -586,8 +596,16 @@ async function terminatePortalProcess(
   const pid = processRef.pid;
   if (!pid || pid < 2 || !(await ops.pidAlive(pid))) return;
   await ops.signalGroup(pid, "SIGTERM");
-  await Bun.sleep(1_500);
-  if (await ops.pidAlive(pid)) await ops.signalGroup(pid, "SIGKILL");
+  const grace = Math.min(
+    30_000,
+    Math.max(1_500, processRef.shutdownGraceMs ?? 1_500),
+  );
+  const deadline = Date.now() + grace;
+  do {
+    await Bun.sleep(Math.min(250, Math.max(0, deadline - Date.now())));
+    if (!(await ops.pidAlive(pid))) return;
+  } while (Date.now() < deadline);
+  await ops.signalGroup(pid, "SIGKILL");
 }
 
 async function stopPortal(ops: PortalOps, name: string): Promise<PortalRecord> {
@@ -639,6 +657,7 @@ export async function startPortalService(input: {
   description?: string;
   defaultPath?: string;
   readyTimeoutMs?: number;
+  shutdownGraceMs?: number;
   /** Narrow, caller-owned additions for a trusted declared recipe. */
   env?: Record<string, string>;
 }): Promise<PortalRecord & { url: string }> {
@@ -668,7 +687,7 @@ export async function startPortalService(input: {
       launch: async ({ name, command, port, url }) => {
         mkdirSync(logDir, { recursive: true });
         const log = openSync(logPath, "w");
-        const directCommand = ["setsid", "bash", "-lc", `exec ${command}`];
+        const directCommand = portalHostCommand(command);
         const portalEnv = {
           PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
           HOME: process.env.HOME || "/tmp",
@@ -687,21 +706,18 @@ export async function startPortalService(input: {
           name,
           { env: portalEnv },
         );
-        const proc = Bun.spawn(scoped.command, {
-          cwd: input.worktreeDir,
-          // Portal commands are user-authored code. Do not hand them the Open
-          // Session service environment, which can include operator credentials.
-          env: scoped.env,
-          stdin: "ignore",
-          stdout: log,
-          stderr: log,
-        });
-        closeSync(log);
-        proc.unref();
-        return {
-          pid: proc.pid,
-          ...(scoped.unit ? { scopeUnit: scoped.unit } : {}),
-        };
+        try {
+          const pid = await spawnPortalHost({
+            command: scoped.command,
+            cwd: input.worktreeDir,
+            // Portal commands never inherit the gateway's credentials.
+            env: scoped.env,
+            log,
+          });
+          return { pid, ...(scoped.unit ? { scopeUnit: scoped.unit } : {}) };
+        } finally {
+          closeSync(log);
+        }
       },
     });
     registerHostPortal(input.worktreeDir, started, true);
@@ -1034,6 +1050,7 @@ export function wakeHostPortalRoute(
     description: found.record.description,
     defaultPath: found.record.defaultPath,
     readyTimeoutMs: found.record.readyTimeoutMs ?? 180_000,
+    shutdownGraceMs: found.record.shutdownGraceMs,
   }).finally(() => hostPortalWakes.delete(key));
   hostPortalWakes.set(key, wake);
   return wake;
@@ -1301,6 +1318,7 @@ export async function restartPortalService(input: {
     description: current.description,
     defaultPath: current.defaultPath,
     readyTimeoutMs: input.readyTimeoutMs ?? current.readyTimeoutMs,
+    shutdownGraceMs: current.shutdownGraceMs,
   });
 }
 

--- a/packages/core/opensession-server/src/server/portals-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.test.ts
@@ -31,6 +31,7 @@ function fixture(overrides: Partial<VerifiedFixture> = {}): VerifiedFixture {
 async function harness(
   verifyEditorFixture: PortalsMcpContext["verifyEditorFixture"] = async () =>
     fixture(),
+  overrides: Partial<PortalsMcpContext> = {},
 ) {
   const calls: Array<{
     path: string | null;
@@ -55,6 +56,7 @@ async function harness(
     sandbox: async () => null,
     hasSandbox: () => false,
     runner: () => undefined,
+    ...overrides,
   });
   const runtime = await createMcpRuntime({
     mcpServers: [],
@@ -280,6 +282,44 @@ describe("Portals MCP staging routes", () => {
     expect(response.content[0]).toMatchObject({
       type: "text",
       text: expect.stringContaining("/settings/tags"),
+    });
+  });
+});
+
+describe("Simulator Portal MCP", () => {
+  test("the tool is discoverable and refuses Sandbox workspaces without waking them", async () => {
+    let woke = false;
+    const { runtime } = await harness(undefined, {
+      hasSandbox: () => true,
+      sandbox: async () => {
+        woke = true;
+        return null;
+      },
+    });
+    const response = await runtime.callExact(
+      "opensession-portals_start_simulator_portal",
+      { appPath: "Build/App.app" },
+      { toolCallId: "simulator" },
+    );
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("local Mac workspace"),
+    });
+    expect(woke).toBe(false);
+  });
+
+  test("no workspace cannot create a simulator on the host", async () => {
+    const { runtime } = await harness(undefined, {
+      worktreeDir: () => undefined,
+    });
+    const response = await runtime.callExact(
+      "opensession-portals_start_simulator_portal",
+      { appPath: "App.app" },
+      { toolCallId: "simulator-no-workspace" },
+    );
+    expect(response.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("no workspace"),
     });
   });
 });

--- a/packages/core/opensession-server/src/server/portals-mcp.ts
+++ b/packages/core/opensession-server/src/server/portals-mcp.ts
@@ -34,6 +34,10 @@ import type { UnifiedSession } from "./types";
 import type { Sandbox } from "./sandbox/provider";
 import { createWorkloadIdentityEnv } from "./workload-identity";
 import { getRepo } from "./worktree";
+import {
+  simulatorPortalCommand,
+  simulatorPortalInput,
+} from "./simulator-portal-command";
 
 const verifiedEditorFixtureSchema = z.object({
   leaseId: z.string().regex(/^epfl_[A-Za-z0-9]+$/),
@@ -170,7 +174,9 @@ type PortalStartInput = {
   port?: number;
   key?: string;
   description?: string;
+  defaultPath?: string;
   readyTimeoutMs?: number;
+  shutdownGraceMs?: number;
 };
 
 async function startPortalForContext(
@@ -212,7 +218,9 @@ async function startPortalForContext(
   const service = status.services.find(
     (candidate) => candidate.key === portal.key,
   );
-  return `${portal.name} is ready at ${service?.previewUrl ?? "its authenticated Portal URL"}.`;
+  return service?.previewUrl
+    ? `${portal.name} is ready at ${service.previewUrl}.`
+    : `${portal.name} is listening on port ${portal.port}, but its authenticated Portal URL is unavailable. Configure this instance's Caddy HTTPS Portal routing, then check list_portals. Do not share the raw local port.`;
 }
 
 function isTellaEditorPath(path: string): boolean {
@@ -227,6 +235,38 @@ export function createPortalsMcpServer(ctx: PortalsMcpContext) {
     name: "opensession-portals",
     version: "1.0.0",
     tools: [
+      tool(
+        "start_simulator_portal",
+        "Start this session's interactive iOS Simulator Portal on the local Mac. Requires full Xcode, an iOS Simulator runtime, idb and idb_companion on PATH, and an already-built simulator .app inside the workspace. Creates a private simulator, streams its screen and forwards taps, swipes and typing. Returns the authenticated viewer URL; the viewer reports boot or dependency errors. Repeated calls reuse the Portal. Use stop_portal/restart_portal with the returned name. Not available in Sandboxes or remote Runner workspaces. Does not build, sign, release, or enable hot reload.",
+        simulatorPortalInput,
+        async (args) => {
+          const deadline = portalToolDeadline();
+          const dir = workspace(ctx);
+          if (dir instanceof Error) return result(dir.message);
+          if (ctx.hasSandbox() || ctx.runner()?.runner)
+            return result(
+              "Simulator Portals require a local Mac workspace, not a Sandbox or remote Runner.",
+            );
+          if (process.platform !== "darwin")
+            return result(
+              "Simulator Portals require Open Session running on macOS with full Xcode and idb installed.",
+            );
+          try {
+            const input = await simulatorPortalCommand({
+              ...args,
+              sessionId: ctx.sessionId,
+              workspaceDir: dir,
+            });
+            return result(
+              await startPortalForContext(ctx, dir, null, input, deadline),
+            );
+          } catch (error) {
+            return result(
+              `Could not start simulator Portal: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        },
+      ),
       tool(
         "start_portal",
         "Start a supervised HTTP or WebSocket service in this session workspace. Open Session allocates a port when omitted, sets PORT and PORTAL_URL, waits for it to listen, and returns its authenticated Portal URL. Never use an upstream URL: Portals expose only this session's process.",

--- a/packages/core/opensession-server/src/server/preview.ts
+++ b/packages/core/opensession-server/src/server/preview.ts
@@ -348,10 +348,15 @@ async function listenerSnapshotRaw(): Promise<string> {
     return listenerSnapshot.raw;
   }
   if (!listenerSnapshotRefresh) {
-    listenerSnapshotRefresh = $`ss -tlnpH`
-      .quiet()
-      .nothrow()
-      .text()
+    const snapshot =
+      process.platform === "darwin"
+        ? $`/usr/sbin/lsof -nP -iTCP -sTCP:LISTEN -F pn`
+            .quiet()
+            .nothrow()
+            .text()
+            .then(macListenerRows)
+        : $`ss -tlnpH`.quiet().nothrow().text();
+    listenerSnapshotRefresh = snapshot
       .then((raw) => {
         listenerSnapshot = { raw, at: Date.now() };
         return raw;
@@ -361,6 +366,20 @@ async function listenerSnapshotRaw(): Promise<string> {
       });
   }
   return await listenerSnapshotRefresh;
+}
+
+/** Normalize lsof's machine-readable fields to the same local-address and
+ * pid columns consumed by the Linux listener parser. macOS does not ship ss. */
+export function macListenerRows(raw: string): string {
+  let pid = "";
+  const rows: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (/^p\d+$/.test(line)) pid = line.slice(1);
+    else if (line.startsWith("n") && /:\d+$/.test(line)) {
+      rows.push(`LISTEN 0 0 ${line.slice(1)} *:* ${pid ? `pid=${pid}` : ""}`);
+    }
+  }
+  return rows.join("\n");
 }
 
 /** Select socket rows by the local-address column, not by a loose substring

--- a/packages/core/opensession-server/src/server/simulator-portal-command.test.ts
+++ b/packages/core/opensession-server/src/server/simulator-portal-command.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simulatorPortalCommand } from "./simulator-portal-command";
+import { portalHostCommand, spawnPortalHost } from "./portal-host-process";
+import { open } from "node:fs/promises";
+
+const roots: string[] = [];
+afterEach(async () => {
+  for (const root of roots.splice(0))
+    await rm(root, { recursive: true, force: true });
+});
+async function workspace() {
+  const root = await mkdtemp(join(tmpdir(), "simulator-portal-test-"));
+  roots.push(root);
+  await mkdir(join(root, "App's build.app"));
+  return root;
+}
+
+test("agent command quotes paths and isolates the portal name by session", async () => {
+  const workspaceDir = await workspace();
+  const first = await simulatorPortalCommand({
+    sessionId: "session-a",
+    workspaceDir,
+    appPath: "App's build.app",
+  });
+  const second = await simulatorPortalCommand({
+    sessionId: "session-b",
+    workspaceDir,
+    appPath: "App's build.app",
+  });
+  expect(first.name).not.toBe(second.name);
+  expect(first.command).toContain("'App'\\''s build.app'");
+  expect(first.command).toContain("--session");
+  expect(first.shutdownGraceMs).toBe(30_000);
+});
+
+test("absolute, traversing, symlink-escaped, and non-bundle app paths are refused", async () => {
+  const workspaceDir = await workspace();
+  const outside = await workspace();
+  await symlink(
+    join(outside, "App's build.app"),
+    join(workspaceDir, "Escape.app"),
+  );
+  for (const appPath of [
+    join(workspaceDir, "App's build.app"),
+    "Escape.app",
+    ".",
+    "missing.app",
+  ])
+    await expect(
+      simulatorPortalCommand({ sessionId: "a", workspaceDir, appPath }),
+    ).rejects.toThrow();
+});
+
+test("host Portal launch does not require the Linux setsid utility on Mac", async () => {
+  expect(portalHostCommand("bun server.ts", "darwin")).toEqual([
+    "bash",
+    "-lc",
+    "exec bun server.ts",
+  ]);
+  expect(portalHostCommand("bun server.ts", "linux")).toEqual([
+    "setsid",
+    "bash",
+    "-lc",
+    "exec bun server.ts",
+  ]);
+  const root = await workspace();
+  const log = await open(join(root, "process.log"), "w");
+  try {
+    await expect(
+      spawnPortalHost({
+        command: ["/definitely/not/a/command"],
+        cwd: root,
+        env: {},
+        log: log.fd,
+      }),
+    ).rejects.toThrow();
+    const pid = await spawnPortalHost({
+      command: [process.execPath, "-e", "process.exit(0)"],
+      cwd: root,
+      env: {},
+      log: log.fd,
+    });
+    expect(pid).toBeGreaterThan(1);
+  } finally {
+    await log.close();
+  }
+});
+
+test("Mac listener discovery normalizes IPv4, IPv6 and wildcard ports without substring matches", async () => {
+  const { macListenerRows, listenerLinesForPort } = await import("./preview");
+  const rows = macListenerRows(
+    "p12\nfcwd\nn127.0.0.1:4000\nn[::1]:4000\np13\nn*:14000\n",
+  );
+  expect(listenerLinesForPort(rows, 4000)).toHaveLength(2);
+  expect(
+    listenerLinesForPort(rows, 4000).every((line) => line.includes("pid=12")),
+  ).toBe(true);
+  expect(listenerLinesForPort(rows, 14000)).toHaveLength(1);
+});

--- a/packages/core/opensession-server/src/server/simulator-portal-command.ts
+++ b/packages/core/opensession-server/src/server/simulator-portal-command.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { realpath, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+import { shellQuoteWord } from "./sandbox/adapters/bootstrap";
+
+export const simulatorPortalInput = {
+  appPath: z
+    .string()
+    .min(1)
+    .max(2_048)
+    .describe(
+      "Workspace-relative path to an already-built iphonesimulator .app bundle, not an IPA or device build.",
+    ),
+  deviceType: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe(
+      "Installed CoreSimulator device type identifier, for example com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro. Omit to select an available iPhone.",
+    ),
+  runtime: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe(
+      "Installed iOS runtime identifier. Omit to select an available iOS runtime.",
+    ),
+};
+
+export async function simulatorPortalCommand(
+  input: z.infer<z.ZodObject<typeof simulatorPortalInput>> & {
+    sessionId: string;
+    workspaceDir: string;
+  },
+) {
+  if (isAbsolute(input.appPath) || input.appPath.includes("\0"))
+    throw new Error("appPath must be relative to this session's workspace.");
+  const workspace = await realpath(input.workspaceDir);
+  const app = await realpath(resolve(workspace, input.appPath));
+  const within = relative(workspace, app);
+  if (
+    !within ||
+    within === ".." ||
+    within.startsWith(`..${sep}`) ||
+    isAbsolute(within)
+  )
+    throw new Error("The app bundle must be inside this session's workspace.");
+  if (!app.endsWith(".app") || !(await stat(app)).isDirectory())
+    throw new Error(
+      "appPath must be an already-built simulator .app directory.",
+    );
+  const entry = resolve(import.meta.dir, "../simulator-portal/main.ts");
+  if (!(await stat(entry).catch(() => null))?.isFile())
+    throw new Error(
+      "Simulator Portals currently require a source installation of Open Session on macOS.",
+    );
+  const name = `ios-simulator-${createHash("sha256").update(input.sessionId).digest("hex").slice(0, 12)}`;
+  const args = [
+    process.execPath,
+    entry,
+    "--session",
+    input.sessionId,
+    "--workspace",
+    workspace,
+    "--app",
+    within,
+  ];
+  if (input.deviceType) args.push("--device-type", input.deviceType);
+  if (input.runtime) args.push("--runtime", input.runtime);
+  return {
+    name,
+    command: args.map(shellQuoteWord).join(" "),
+    description: "Interactive iOS simulator powered by idb",
+    defaultPath: "/",
+    readyTimeoutMs: 90_000,
+    shutdownGraceMs: 30_000,
+  };
+}

--- a/packages/core/opensession-server/src/simulator-portal/assets.ts
+++ b/packages/core/opensession-server/src/simulator-portal/assets.ts
@@ -1,0 +1,59 @@
+import { resolve, basename } from "node:path";
+
+/** Built inside the supervised viewer process, never on the gateway thread. */
+export async function buildSimulatorViewer(): Promise<Map<string, Blob>> {
+  const frontend = resolve(import.meta.dir, "../frontend");
+  const root = resolve(import.meta.dir, "../../../../..");
+  const env = {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    HOME: process.env.HOME ?? "/tmp",
+  };
+  const css = Bun.spawn(
+    [
+      resolve(root, "node_modules/.bin/tailwindcss"),
+      "-i",
+      resolve(frontend, "styles/tailwind.css"),
+      "--minify",
+    ],
+    {
+      cwd: root,
+      env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+    },
+  );
+  const [bundle, stylesheet, diagnostics, code] = await Promise.all([
+    Bun.build({
+      entrypoints: [resolve(frontend, "simulator/main.tsx")],
+      target: "browser",
+      minify: true,
+      naming: "[name].[ext]",
+      define: { "process.env.NODE_ENV": '"production"' },
+    }),
+    new Response(css.stdout).text(),
+    new Response(css.stderr).text(),
+    css.exited,
+  ]);
+  if (code !== 0)
+    throw new Error(
+      `Simulator viewer styles failed: ${diagnostics.slice(-2_000)}`,
+    );
+  if (!bundle.success)
+    throw new Error(`Simulator viewer build failed: ${bundle.logs.join("\n")}`);
+  const files = new Map<string, Blob>();
+  for (const output of bundle.outputs)
+    files.set(`/${basename(output.path)}`, output);
+  files.set("/utilities.css", new Blob([stylesheet], { type: "text/css" }));
+  files.set(
+    "/",
+    new Blob(
+      [
+        `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><title>iOS simulator</title><link rel="stylesheet" href="/main.css"><link rel="stylesheet" href="/utilities.css"></head><body><div id="root"></div><script type="module" src="/main.js"></script></body></html>`,
+      ],
+      { type: "text/html" },
+    ),
+  );
+  return files;
+}

--- a/packages/core/opensession-server/src/simulator-portal/idb.test.ts
+++ b/packages/core/opensession-server/src/simulator-portal/idb.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { openIdbSimulator, type IdbSimulatorDependencies } from "./idb";
+
+const UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+const createApp = async (): Promise<{
+  workspaceDir: string;
+  appPath: string;
+  capacityRoot: string;
+}> => {
+  const workspaceDir = await mkdtemp("/tmp/idb-backend-test-");
+  temporaryDirectories.push(workspaceDir);
+  const appPath = join(workspaceDir, "Build", "Example.app");
+  await mkdir(appPath, { recursive: true });
+  await writeFile(join(appPath, "Info.plist"), "fixture");
+  return {
+    workspaceDir,
+    appPath,
+    capacityRoot: join(workspaceDir, "capacity"),
+  };
+};
+
+const streamFrom = (chunks: string[]): ReadableStream<Uint8Array> =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(new TextEncoder().encode(chunk));
+      controller.close();
+    },
+  });
+
+type FakeProcess = {
+  stdout: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill: (signal?: number) => void;
+};
+
+const longLivedProcess = (stdout: ReadableStream<Uint8Array>): FakeProcess => {
+  let finish: ((code: number) => void) | undefined;
+  const exited = new Promise<number>((resolve) => {
+    finish = resolve;
+  });
+  return {
+    stdout,
+    exited,
+    kill() {
+      finish?.(0);
+    },
+  };
+};
+
+const fakeDependencies = (
+  capacityRoot: string,
+  describeResult: unknown = {
+    screen_dimensions: {
+      width: 1179,
+      height: 2556,
+      density: 3,
+      width_points: 393,
+      height_points: 852,
+    },
+  },
+): {
+  dependencies: IdbSimulatorDependencies;
+  commands: string[][];
+  spawned: string[][];
+} => {
+  const commands: string[][] = [];
+  const spawned: string[][] = [];
+  const dependencies: IdbSimulatorDependencies = {
+    platform: "darwin",
+    pid: process.pid,
+    capacityRoot,
+    runner: {
+      async run(argv) {
+        commands.push(argv);
+        if (argv[0] === "/usr/bin/plutil") {
+          return {
+            exitCode: 0,
+            stdout: argv.includes("CFBundleIdentifier")
+              ? "com.example.fixture\n"
+              : '["iPhoneSimulator"]\n',
+            stderr: "",
+          };
+        }
+        if (argv[0] === "/usr/bin/xcrun") {
+          return { exitCode: 0, stdout: "/usr/bin/simctl\n", stderr: "" };
+        }
+        if (argv[0] === "/usr/bin/which") {
+          return {
+            exitCode: 0,
+            stdout: `/usr/local/bin/${argv[1]}\n`,
+            stderr: "",
+          };
+        }
+        if (argv[0] === "/usr/bin/simctl" && argv[1] === "list") {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              devicetypes: [
+                {
+                  name: "iPhone 16 Pro",
+                  identifier:
+                    "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+                },
+              ],
+              runtimes: [
+                {
+                  name: "iOS 18.2",
+                  identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-2",
+                  platform: "iOS",
+                  version: "18.2",
+                  isAvailable: true,
+                },
+              ],
+            }),
+            stderr: "",
+          };
+        }
+        if (argv.includes("create")) {
+          return { exitCode: 0, stdout: `${UDID}\n`, stderr: "" };
+        }
+        if (argv.includes("describe")) {
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify(describeResult),
+            stderr: "",
+          };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      spawn(argv) {
+        spawned.push(argv);
+        if (argv[0]?.endsWith("idb_companion")) {
+          return longLivedProcess(
+            streamFrom(['diagnostic\n{"grpc_path":"/tmp/private.sock"}\n']),
+          );
+        }
+        return longLivedProcess(streamFrom([]));
+      },
+    },
+  };
+  return { dependencies, commands, spawned };
+};
+
+describe("openIdbSimulator", () => {
+  test("owns a private device and addresses only its private companion", async () => {
+    const fixture = await createApp();
+    const fake = fakeDependencies(fixture.capacityRoot);
+    const simulator = await openIdbSimulator(
+      {
+        sessionId: "session-one",
+        workspaceDir: fixture.workspaceDir,
+        appPath: fixture.appPath,
+      },
+      fake.dependencies,
+    );
+
+    expect(simulator.udid).toBe(UDID);
+    expect(simulator.dimensions).toEqual({ width: 393, height: 852 });
+    expect(simulator.density).toBe(3);
+    await simulator.input({ kind: "tap", x: 20, y: 40 });
+    await simulator.input({
+      kind: "swipe",
+      x: 10,
+      y: 20,
+      endX: 30,
+      endY: 40,
+      duration: 0.5,
+    });
+
+    const companion = fake.spawned[0] ?? [];
+    expect(companion).toContain("--device-set-path");
+    expect(companion).toContain("--grpc-domain-sock");
+    expect(companion).toContain(UDID);
+    const tapCommand = fake.commands.find((argv) => argv.includes("tap"));
+    expect(tapCommand).toEqual(
+      expect.arrayContaining([
+        "/usr/local/bin/idb",
+        "--companion",
+        "ui",
+        "tap",
+        "20",
+        "40",
+      ]),
+    );
+    expect(tapCommand?.[2]?.endsWith("/idb.sock")).toBe(true);
+    expect(fake.commands).toContainEqual(
+      expect.arrayContaining([
+        "ui",
+        "swipe",
+        "10",
+        "20",
+        "30",
+        "40",
+        "--duration",
+        "0.5",
+      ]),
+    );
+
+    await simulator.close();
+    const targetCommands = fake.commands.filter(
+      (argv) =>
+        argv[0] === "/usr/bin/simctl" &&
+        ["boot", "bootstatus", "install", "launch", "shutdown", "delete"].some(
+          (verb) => argv.includes(verb),
+        ),
+    );
+    expect(targetCommands.length).toBeGreaterThan(0);
+    for (const argv of targetCommands) {
+      expect(argv[1]).toBe("--set");
+      expect(argv).toContain(UDID);
+    }
+  });
+
+  test("streams MJPEG through the callback API", async () => {
+    const fixture = await createApp();
+    const fake = fakeDependencies(fixture.capacityRoot);
+    const videoBytes = new Uint8Array([0xff, 0xd8, 1, 2, 0xff, 0xd9]);
+    fake.dependencies.runner.spawn = (argv) => {
+      fake.spawned.push(argv);
+      if (argv[0]?.endsWith("idb_companion")) {
+        return longLivedProcess(
+          streamFrom(['{"grpc_path":"/tmp/private.sock"}\n']),
+        );
+      }
+      return longLivedProcess(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(videoBytes);
+          },
+        }),
+      );
+    };
+    const simulator = await openIdbSimulator(
+      {
+        sessionId: "video-session",
+        workspaceDir: fixture.workspaceDir,
+        appPath: fixture.appPath,
+      },
+      fake.dependencies,
+    );
+    const chunks: Uint8Array[] = [];
+    const errors: Error[] = [];
+    const stop = await simulator.startVideo(
+      (chunk) => chunks.push(chunk),
+      (error) => errors.push(error),
+    );
+    await Bun.sleep(0);
+    expect(fake.spawned.at(-1)).toEqual(
+      expect.arrayContaining(["video-stream", "--format", "mjpeg"]),
+    );
+    expect(chunks).toEqual([videoBytes]);
+    await stop();
+    expect(errors).toEqual([]);
+    await simulator.close();
+  });
+
+  test("fails and deletes its own device when logical dimensions are absent", async () => {
+    const fixture = await createApp();
+    const fake = fakeDependencies(fixture.capacityRoot, {
+      screen_dimensions: { width: 1179, height: 2556 },
+    });
+    await expect(
+      openIdbSimulator(
+        {
+          sessionId: "bad-description",
+          workspaceDir: fixture.workspaceDir,
+          appPath: fixture.appPath,
+        },
+        fake.dependencies,
+      ),
+    ).rejects.toThrow("logical dimensions and density");
+    expect(fake.commands).toContainEqual(
+      expect.arrayContaining(["shutdown", UDID]),
+    );
+    expect(fake.commands).toContainEqual(
+      expect.arrayContaining(["delete", UDID]),
+    );
+  });
+
+  test("does not steal newly-created ownerless capacity slots", async () => {
+    const fixture = await createApp();
+    await mkdir(join(fixture.capacityRoot, "slot-0"), { recursive: true });
+    await mkdir(join(fixture.capacityRoot, "slot-1"), { recursive: true });
+    const fake = fakeDependencies(fixture.capacityRoot);
+    await expect(
+      openIdbSimulator(
+        {
+          sessionId: "capacity-race",
+          workspaceDir: fixture.workspaceDir,
+          appPath: fixture.appPath,
+        },
+        fake.dependencies,
+      ),
+    ).rejects.toThrow("capacity is full");
+    expect(fake.commands.some((argv) => argv.includes("create"))).toBe(false);
+  });
+
+  test("rejects a physical-device app before creating a simulator", async () => {
+    const fixture = await createApp();
+    const fake = fakeDependencies(fixture.capacityRoot);
+    const originalRun = fake.dependencies.runner.run;
+    fake.dependencies.runner.run = async (argv, options) => {
+      if (argv.includes("CFBundleSupportedPlatforms")) {
+        fake.commands.push(argv);
+        return { exitCode: 0, stdout: '["iPhoneOS"]', stderr: "" };
+      }
+      return originalRun(argv, options);
+    };
+    await expect(
+      openIdbSimulator(
+        {
+          sessionId: "device-app",
+          workspaceDir: fixture.workspaceDir,
+          appPath: fixture.appPath,
+        },
+        fake.dependencies,
+      ),
+    ).rejects.toThrow("not a physical device");
+    expect(fake.commands.some((argv) => argv.includes("create"))).toBe(false);
+  });
+});
+
+test("two concurrent sessions use separate device sets and a third cannot exceed capacity", async () => {
+  const fixture = await createApp();
+  const fake = fakeDependencies(fixture.capacityRoot);
+  const start = (sessionId: string) =>
+    openIdbSimulator(
+      {
+        sessionId,
+        workspaceDir: fixture.workspaceDir,
+        appPath: fixture.appPath,
+      },
+      fake.dependencies,
+    );
+  const [first, second] = await Promise.all([start("first"), start("second")]);
+  try {
+    const sets = fake.commands
+      .filter((args) => args.includes("create"))
+      .map((args) => args[2]);
+    expect(new Set(sets).size).toBe(2);
+    await expect(start("third")).rejects.toThrow("capacity is full");
+    await first.input({ kind: "text", text: "--help" });
+    expect(fake.commands.at(-1)?.slice(-4)).toEqual([
+      "ui",
+      "text",
+      "--",
+      "--help",
+    ]);
+  } finally {
+    await first.close();
+    await second.close();
+  }
+  const next = await start("third");
+  await next.close();
+});
+
+test("failed stale deletion preserves the occupied slot and device set", async () => {
+  const fixture = await createApp();
+  const fake = fakeDependencies(fixture.capacityRoot);
+  const slot = join(fixture.capacityRoot, "slot-0");
+  const leaseRoot = `/tmp/osi-${crypto.randomUUID().slice(0, 8)}-${crypto.randomUUID().slice(0, 8)}`;
+  await mkdir(join(leaseRoot, "set"), { recursive: true });
+  temporaryDirectories.push(leaseRoot);
+  await mkdir(slot, { recursive: true });
+  const owner = {
+    pid: 99999999,
+    token: "old-owner",
+    leaseRoot,
+    deviceSet: join(leaseRoot, "set"),
+    udid: UDID,
+  };
+  await writeFile(join(slot, "owner.json"), JSON.stringify(owner));
+  const run = fake.dependencies.runner.run;
+  fake.dependencies.runner.run = async (args, options) => {
+    if (args[0] === "/bin/kill")
+      return { exitCode: 1, stdout: "", stderr: "no process" };
+    if (args.includes("delete"))
+      return { exitCode: 1, stdout: "", stderr: "CoreSimulator unavailable" };
+    return run(args, options);
+  };
+  await expect(
+    openIdbSimulator(
+      {
+        sessionId: "recovery",
+        workspaceDir: fixture.workspaceDir,
+        appPath: fixture.appPath,
+      },
+      fake.dependencies,
+    ),
+  ).rejects.toThrow("capacity slot was preserved");
+  expect(JSON.parse(await Bun.file(join(slot, "owner.json")).text())).toEqual(
+    owner,
+  );
+  const { stat } = await import("fs/promises");
+  expect((await stat(join(leaseRoot, "set"))).isDirectory()).toBe(true);
+  expect(fake.commands.some((args) => args.includes("create"))).toBe(false);
+});

--- a/packages/core/opensession-server/src/simulator-portal/idb.ts
+++ b/packages/core/opensession-server/src/simulator-portal/idb.ts
@@ -1,0 +1,815 @@
+import { createHash, randomUUID } from "crypto";
+import { mkdir, open, readFile, realpath, rename, rm, stat } from "fs/promises";
+import { basename, extname, isAbsolute, join, relative } from "path";
+
+export type SimulatorInput =
+  | { kind: "tap"; x: number; y: number }
+  | {
+      kind: "swipe";
+      x: number;
+      y: number;
+      endX: number;
+      endY: number;
+      duration: number;
+    }
+  | { kind: "text"; text: string }
+  | { kind: "button"; button: "HOME" }
+  | { kind: "key"; key: number };
+
+export type IdbSimulator = {
+  udid: string;
+  deviceName: string;
+  /** Logical screen size in points, matching idb UI command coordinates. */
+  dimensions: { width: number; height: number };
+  /** Video pixels per logical point. */
+  density: number;
+  startVideo: (
+    onChunk: (chunk: Uint8Array) => void,
+    onError: (error: Error) => void,
+  ) => Promise<() => Promise<void>>;
+  input: (command: SimulatorInput) => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export type OpenIdbSimulatorOptions = {
+  sessionId: string;
+  workspaceDir: string;
+  appPath: string;
+  deviceType?: string;
+  runtime?: string;
+};
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+type RunningProcess = {
+  stdout: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill: (signal?: number) => void;
+};
+type ProcessRunner = {
+  run: (argv: string[], options: { timeoutMs: number }) => Promise<RunResult>;
+  spawn: (argv: string[]) => RunningProcess;
+};
+
+/** Exported only so tests can replace the executable boundary. */
+export type IdbSimulatorDependencies = {
+  runner: ProcessRunner;
+  platform: NodeJS.Platform;
+  pid: number;
+  capacityRoot?: string;
+};
+
+const COMMAND_TIMEOUT_MS = 30_000;
+const BOOT_TIMEOUT_MS = 120_000;
+const COMPANION_READY_TIMEOUT_MS = 30_000;
+const PROCESS_STOP_TIMEOUT_MS = 5_000;
+const CAPACITY_ROOT = "/tmp/opensession-idb-simulator-capacity";
+const MAX_ACTIVE_SIMULATORS = 2;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const LEASE_ROOT = /^\/tmp\/osi-[0-9a-f]{8}-[0-9a-f]{8}$/;
+
+const environment = (): Record<string, string> => {
+  const result: Record<string, string> = {
+    PATH:
+      process.env.PATH ??
+      "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    LANG: "en_US.UTF-8",
+  };
+  for (const key of ["HOME", "TMPDIR", "USER", "LOGNAME"] as const) {
+    const value = process.env[key];
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+};
+
+const readText = async (
+  stream: ReadableStream<Uint8Array>,
+  limit: number,
+): Promise<string> => {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  while (true) {
+    const next = await reader.read();
+    if (next.done) break;
+    if (output.length < limit)
+      output += decoder.decode(next.value, { stream: true });
+  }
+  return output.slice(-limit);
+};
+
+const defaultRunner: ProcessRunner = {
+  async run(argv, options) {
+    const child = Bun.spawn(argv, {
+      env: environment(),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timer = setTimeout(() => child.kill(9), options.timeoutMs);
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      readText(child.stdout, 1_000_000),
+      readText(child.stderr, 4_000),
+    ]).finally(() => clearTimeout(timer));
+    return { exitCode, stdout, stderr };
+  },
+  spawn(argv) {
+    const child = Bun.spawn(argv, {
+      env: environment(),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    return {
+      stdout: child.stdout,
+      exited: child.exited,
+      kill: (signal) => child.kill(signal),
+    };
+  },
+};
+
+const runChecked = async (
+  runner: ProcessRunner,
+  argv: string[],
+  timeoutMs = COMMAND_TIMEOUT_MS,
+): Promise<string> => {
+  const result = await runner.run(argv, { timeoutMs });
+  if (result.exitCode !== 0) {
+    const detail =
+      result.stderr.trim() || result.stdout.trim() || `exit ${result.exitCode}`;
+    throw new Error(
+      `${basename(argv[0] ?? "command")} failed: ${detail.slice(-4_000)}`,
+    );
+  }
+  return result.stdout.trim();
+};
+
+const findExecutable = async (
+  runner: ProcessRunner,
+  name: "simctl" | "idb" | "idb_companion",
+): Promise<string> => {
+  const argv =
+    name === "simctl"
+      ? ["/usr/bin/xcrun", "--find", name]
+      : ["/usr/bin/which", name];
+  try {
+    const path = await runChecked(runner, argv);
+    if (!isAbsolute(path))
+      throw new Error(`resolved to non-absolute path ${path}`);
+    return path;
+  } catch (error) {
+    const requirement = name === "simctl" ? "Xcode with simctl" : name;
+    throw new Error(`Simulator portal requires ${requirement} on macOS`, {
+      cause: error,
+    });
+  }
+};
+
+const finite = (value: number, label: string): void => {
+  if (!Number.isFinite(value)) throw new Error(`${label} must be finite`);
+};
+
+const coordinate = (value: number, label: string): string => {
+  finite(value, label);
+  if (value < 0) throw new Error(`${label} must not be negative`);
+  return String(Math.round(value));
+};
+
+const inputArguments = (command: SimulatorInput): string[] => {
+  switch (command.kind) {
+    case "tap":
+      return [
+        "ui",
+        "tap",
+        coordinate(command.x, "tap x"),
+        coordinate(command.y, "tap y"),
+      ];
+    case "swipe": {
+      finite(command.duration, "swipe duration");
+      if (command.duration < 0)
+        throw new Error("swipe duration must not be negative");
+      return [
+        "ui",
+        "swipe",
+        coordinate(command.x, "swipe x"),
+        coordinate(command.y, "swipe y"),
+        coordinate(command.endX, "swipe endX"),
+        coordinate(command.endY, "swipe endY"),
+        "--duration",
+        String(command.duration),
+      ];
+    }
+    case "text":
+      if (command.text.length > 10_000)
+        throw new Error("text input is too long");
+      return ["ui", "text", "--", command.text];
+    case "button":
+      return ["ui", "button", command.button];
+    case "key":
+      if (!Number.isSafeInteger(command.key) || command.key < 0) {
+        throw new Error("key must be a non-negative integer");
+      }
+      return ["ui", "key", String(command.key)];
+    default: {
+      const exhaustive: never = command;
+      return exhaustive;
+    }
+  }
+};
+
+type SlotOwner = {
+  pid: number;
+  token: string;
+  leaseRoot: string;
+  deviceSet: string;
+  udid?: string;
+};
+type CapacityLease = {
+  updateUdid: (udid: string) => Promise<void>;
+  release: () => Promise<void>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const parseSlotOwner = (value: unknown): SlotOwner | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (
+    typeof value.pid !== "number" ||
+    typeof value.token !== "string" ||
+    typeof value.leaseRoot !== "string" ||
+    typeof value.deviceSet !== "string" ||
+    (value.udid !== undefined && typeof value.udid !== "string")
+  )
+    return undefined;
+  return {
+    pid: value.pid,
+    token: value.token,
+    leaseRoot: value.leaseRoot,
+    deviceSet: value.deviceSet,
+    ...(value.udid === undefined ? {} : { udid: value.udid }),
+  };
+};
+
+const readOwner = async (slot: string): Promise<SlotOwner | undefined> => {
+  try {
+    return parseSlotOwner(
+      JSON.parse(await readFile(join(slot, "owner.json"), "utf8")),
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+const processExists = async (
+  runner: ProcessRunner,
+  pid: number,
+): Promise<boolean> => {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  return (
+    (await runner.run(["/bin/kill", "-0", String(pid)], { timeoutMs: 2_000 }))
+      .exitCode === 0
+  );
+};
+
+const cleanupStale = async (
+  runner: ProcessRunner,
+  simctl: string,
+  owner: SlotOwner | undefined,
+): Promise<void> => {
+  if (
+    owner === undefined ||
+    !LEASE_ROOT.test(owner.leaseRoot) ||
+    owner.deviceSet !== join(owner.leaseRoot, "set")
+  ) {
+    throw new Error(
+      "Invalid simulator lease metadata; refusing automatic cleanup",
+    );
+  }
+  const prefix = [simctl, "--set", owner.deviceSet];
+  // A crash can happen between create and persisting the returned UDID.
+  // This set belongs exclusively to this lease, so deleting all of *this
+  // private set* also recovers that gap, never another session's devices.
+  await runner.run([...prefix, "shutdown", "all"], {
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  });
+  await runChecked(runner, [...prefix, "delete", "all"]);
+  await rm(owner.leaseRoot, { recursive: true, force: true });
+};
+
+const acquireCapacity = async (
+  runner: ProcessRunner,
+  simctl: string,
+  owner: SlotOwner,
+  capacityRoot: string,
+): Promise<CapacityLease> => {
+  await mkdir(capacityRoot, { recursive: true, mode: 0o700 });
+  for (let index = 0; index < MAX_ACTIVE_SIMULATORS; index += 1) {
+    const slot = join(capacityRoot, `slot-${index}`);
+    let recovering: string | undefined;
+    try {
+      await mkdir(slot, { mode: 0o700 });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("code" in error) ||
+        error.code !== "EEXIST"
+      )
+        throw error;
+      const previous = await readOwner(slot);
+      if (previous !== undefined && (await processExists(runner, previous.pid)))
+        continue;
+      // Missing or damaged metadata cannot prove which device set is ours.
+      // Fail closed, including the brief initial mkdir/owner-write window.
+      if (previous === undefined) continue;
+      // Keep the capacity slot occupied throughout recovery. Moving the slot
+      // away would admit another simulator before the old device was deleted.
+      const recovery = join(slot, "recovering");
+      try {
+        await mkdir(recovery, { mode: 0o700 });
+      } catch {
+        continue;
+      }
+      const current = await readOwner(slot);
+      if (
+        current?.token !== previous?.token ||
+        (current && (await processExists(runner, current.pid)))
+      ) {
+        await rm(recovery, { recursive: true, force: true });
+        continue;
+      }
+      try {
+        await cleanupStale(runner, simctl, current);
+      } catch (cause) {
+        await rm(recovery, { recursive: true, force: true });
+        throw new Error(
+          "Could not recover the previous simulator; its capacity slot was preserved",
+          { cause },
+        );
+      }
+      recovering = recovery;
+    }
+    const writeOwner = async () => {
+      const temporary = join(slot, `owner-${randomUUID()}.tmp`);
+      const file = await open(temporary, "wx", 0o600);
+      try {
+        await file.writeFile(JSON.stringify(owner));
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+      await rename(temporary, join(slot, "owner.json"));
+    };
+    await writeOwner();
+    if (recovering) await rm(recovering, { recursive: true, force: true });
+    return {
+      async updateUdid(udid) {
+        owner.udid = udid;
+        await writeOwner();
+      },
+      async release() {
+        if ((await readOwner(slot))?.token === owner.token) {
+          await rm(slot, { recursive: true, force: true });
+        }
+      },
+    };
+  }
+  throw new Error(
+    `Simulator capacity is full (${MAX_ACTIVE_SIMULATORS} active sessions)`,
+  );
+};
+
+type DeviceType = { name: string; identifier: string };
+type Runtime = { name: string; identifier: string; version?: string };
+
+const chooseConfiguration = async (
+  runner: ProcessRunner,
+  simctl: string,
+  requestedDevice: string | undefined,
+  requestedRuntime: string | undefined,
+): Promise<{
+  deviceIdentifier: string;
+  runtimeIdentifier: string;
+  deviceName: string;
+}> => {
+  const parsed: unknown = JSON.parse(
+    await runChecked(runner, [simctl, "list", "-j"]),
+  );
+  if (!isRecord(parsed)) throw new Error("simctl returned an invalid catalog");
+  const devices: DeviceType[] = (
+    Array.isArray(parsed.devicetypes) ? parsed.devicetypes : []
+  ).flatMap((item) => {
+    if (
+      !isRecord(item) ||
+      typeof item.name !== "string" ||
+      typeof item.identifier !== "string" ||
+      !item.name.startsWith("iPhone")
+    )
+      return [];
+    return [{ name: item.name, identifier: item.identifier }];
+  });
+  const runtimes: Runtime[] = (
+    Array.isArray(parsed.runtimes) ? parsed.runtimes : []
+  ).flatMap((item) => {
+    if (
+      !isRecord(item) ||
+      typeof item.name !== "string" ||
+      typeof item.identifier !== "string" ||
+      (item.platform !== "iOS" && !item.identifier.includes("iOS")) ||
+      item.isAvailable === false ||
+      item.availability === "(unavailable)"
+    )
+      return [];
+    return [
+      {
+        name: item.name,
+        identifier: item.identifier,
+        ...(typeof item.version === "string" ? { version: item.version } : {}),
+      },
+    ];
+  });
+  const device = requestedDevice
+    ? devices.find(
+        (item) =>
+          item.name === requestedDevice || item.identifier === requestedDevice,
+      )
+    : (devices.find((item) => item.name === "iPhone 16 Pro") ?? devices.at(-1));
+  const runtime = requestedRuntime
+    ? runtimes.find(
+        (item) =>
+          item.name === requestedRuntime ||
+          item.identifier === requestedRuntime,
+      )
+    : runtimes.toSorted((a, b) =>
+        (b.version ?? b.name).localeCompare(a.version ?? a.name, undefined, {
+          numeric: true,
+        }),
+      )[0];
+  if (device === undefined) {
+    throw new Error(
+      `No available iPhone device type matches ${requestedDevice ?? "the default"}`,
+    );
+  }
+  if (runtime === undefined) {
+    throw new Error(
+      `No available iOS runtime matches ${requestedRuntime ?? "the default"}`,
+    );
+  }
+  return {
+    deviceIdentifier: device.identifier,
+    runtimeIdentifier: runtime.identifier,
+    deviceName: device.name,
+  };
+};
+
+const validateApp = async (
+  runner: ProcessRunner,
+  workspaceDir: string,
+  appPath: string,
+): Promise<{ appPath: string; bundleId: string }> => {
+  const workspace = await realpath(workspaceDir);
+  const resolvedApp = await realpath(
+    isAbsolute(appPath) ? appPath : join(workspace, appPath),
+  );
+  const fromWorkspace = relative(workspace, resolvedApp);
+  if (
+    fromWorkspace === "" ||
+    fromWorkspace.startsWith("..") ||
+    isAbsolute(fromWorkspace)
+  ) {
+    throw new Error("appPath must be an .app inside workspaceDir");
+  }
+  if (
+    !(await stat(resolvedApp)).isDirectory() ||
+    extname(resolvedApp) !== ".app"
+  ) {
+    throw new Error("appPath must name an iOS Simulator .app directory");
+  }
+  const plist = await realpath(join(resolvedApp, "Info.plist"));
+  const plistRelative = relative(workspace, plist);
+  if (plistRelative.startsWith("..") || isAbsolute(plistRelative))
+    throw new Error("The app Info.plist must stay inside workspaceDir");
+  const bundleId = await runChecked(runner, [
+    "/usr/bin/plutil",
+    "-extract",
+    "CFBundleIdentifier",
+    "raw",
+    "-o",
+    "-",
+    plist,
+  ]);
+  if (!/^[A-Za-z0-9][A-Za-z0-9.-]+$/.test(bundleId)) {
+    throw new Error("The app has an invalid CFBundleIdentifier");
+  }
+  const platforms: unknown = JSON.parse(
+    await runChecked(runner, [
+      "/usr/bin/plutil",
+      "-extract",
+      "CFBundleSupportedPlatforms",
+      "json",
+      "-o",
+      "-",
+      plist,
+    ]),
+  );
+  if (
+    !Array.isArray(platforms) ||
+    !platforms.includes("iPhoneSimulator") ||
+    platforms.includes("iPhoneOS")
+  ) {
+    throw new Error(
+      "appPath must be built for the iPhone Simulator, not a physical device",
+    );
+  }
+  return { appPath: resolvedApp, bundleId };
+};
+
+const waitForCompanion = async (child: RunningProcess): Promise<void> => {
+  const reader = child.stdout.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      (async () => {
+        while (true) {
+          const next = await reader.read();
+          if (next.done)
+            throw new Error("idb_companion exited before reporting ready");
+          pending += decoder.decode(next.value, { stream: true });
+          const lines = pending.split("\n");
+          pending = lines.pop() ?? "";
+          for (const line of lines) {
+            try {
+              const report: unknown = JSON.parse(line);
+              if (isRecord(report) && typeof report.grpc_path === "string")
+                return;
+            } catch {
+              // Diagnostics can precede the JSON readiness report.
+            }
+          }
+        }
+      })(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          void reader
+            .cancel()
+            .finally(() =>
+              reject(
+                new Error(
+                  "idb_companion did not become ready within 30 seconds",
+                ),
+              ),
+            );
+        }, COMPANION_READY_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    reader.releaseLock();
+  }
+};
+
+const stopProcess = async (child: RunningProcess): Promise<void> => {
+  child.kill(15);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = await Promise.race([
+    child.exited.then(() => false),
+    new Promise<true>((resolve) => {
+      timer = setTimeout(() => resolve(true), PROCESS_STOP_TIMEOUT_MS);
+    }),
+  ]);
+  if (timer !== undefined) clearTimeout(timer);
+  if (timedOut) {
+    child.kill(9);
+    await child.exited;
+  }
+};
+
+const parseDimensions = (
+  raw: string,
+): { dimensions: { width: number; height: number }; density: number } => {
+  const description: unknown = JSON.parse(raw);
+  if (!isRecord(description) || !isRecord(description.screen_dimensions)) {
+    throw new Error("idb describe did not report simulator screen dimensions");
+  }
+  const screen = description.screen_dimensions;
+  if (
+    typeof screen.width_points !== "number" ||
+    typeof screen.height_points !== "number" ||
+    typeof screen.density !== "number" ||
+    !Number.isFinite(screen.width_points) ||
+    !Number.isFinite(screen.height_points) ||
+    !Number.isFinite(screen.density) ||
+    screen.width_points <= 0 ||
+    screen.height_points <= 0 ||
+    screen.density <= 0
+  ) {
+    throw new Error(
+      "idb describe did not report positive logical dimensions and density",
+    );
+  }
+  return {
+    dimensions: { width: screen.width_points, height: screen.height_points },
+    density: screen.density,
+  };
+};
+
+export const openIdbSimulator = async (
+  options: OpenIdbSimulatorOptions,
+  dependencies: IdbSimulatorDependencies = {
+    runner: defaultRunner,
+    platform: process.platform,
+    pid: process.pid,
+  },
+): Promise<IdbSimulator> => {
+  if (dependencies.platform !== "darwin") {
+    throw new Error(
+      "Simulator portal requires macOS with Xcode and idb installed",
+    );
+  }
+  if (options.sessionId.trim() === "") throw new Error("sessionId is required");
+
+  const app = await validateApp(
+    dependencies.runner,
+    options.workspaceDir,
+    options.appPath,
+  );
+  const [simctl, idb, companion] = await Promise.all([
+    findExecutable(dependencies.runner, "simctl"),
+    findExecutable(dependencies.runner, "idb"),
+    findExecutable(dependencies.runner, "idb_companion"),
+  ]);
+  const token = randomUUID();
+  const sessionHash = createHash("sha256")
+    .update(options.sessionId)
+    .digest("hex")
+    .slice(0, 8);
+  const leaseRoot = `/tmp/osi-${sessionHash}-${token.slice(0, 8)}`;
+  const deviceSet = join(leaseRoot, "set");
+  const socketPath = join(leaseRoot, "idb.sock");
+  await mkdir(deviceSet, { recursive: true, mode: 0o700 });
+  let capacity: CapacityLease;
+  try {
+    capacity = await acquireCapacity(
+      dependencies.runner,
+      simctl,
+      { pid: dependencies.pid, token, leaseRoot, deviceSet },
+      dependencies.capacityRoot ?? CAPACITY_ROOT,
+    );
+  } catch (error) {
+    await rm(leaseRoot, { recursive: true, force: true });
+    throw error;
+  }
+  let udid: string | undefined;
+  let companionProcess: RunningProcess | undefined;
+  let videoProcess: RunningProcess | undefined;
+  let closed = false;
+  const simctlPrefix = [simctl, "--set", deviceSet];
+
+  const cleanup = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    if (videoProcess !== undefined)
+      await stopProcess(videoProcess).catch(() => undefined);
+    if (companionProcess !== undefined)
+      await stopProcess(companionProcess).catch(() => undefined);
+    if (udid !== undefined) {
+      await dependencies.runner
+        .run([...simctlPrefix, "shutdown", udid], {
+          timeoutMs: COMMAND_TIMEOUT_MS,
+        })
+        .catch(() => undefined);
+      // Keep the durable slot if CoreSimulator refuses deletion. The next
+      // start can recover it after this owner exits instead of losing track
+      // of a still-running device and admitting another one.
+      await runChecked(dependencies.runner, [...simctlPrefix, "delete", udid]);
+    }
+    await rm(leaseRoot, { recursive: true, force: true }).catch(
+      () => undefined,
+    );
+    await capacity.release();
+  };
+
+  try {
+    const configuration = await chooseConfiguration(
+      dependencies.runner,
+      simctl,
+      options.deviceType,
+      options.runtime,
+    );
+    const uniqueName = `Open Session ${sessionHash} ${token.slice(0, 6)}`;
+    udid = await runChecked(dependencies.runner, [
+      ...simctlPrefix,
+      "create",
+      uniqueName,
+      configuration.deviceIdentifier,
+      configuration.runtimeIdentifier,
+    ]);
+    if (!UUID.test(udid))
+      throw new Error(`simctl create returned an invalid UDID: ${udid}`);
+    await capacity.updateUdid(udid);
+    await runChecked(dependencies.runner, [...simctlPrefix, "boot", udid]);
+    await runChecked(
+      dependencies.runner,
+      [...simctlPrefix, "bootstatus", udid, "-b"],
+      BOOT_TIMEOUT_MS,
+    );
+    await runChecked(dependencies.runner, [
+      ...simctlPrefix,
+      "install",
+      udid,
+      app.appPath,
+    ]);
+    await runChecked(dependencies.runner, [
+      ...simctlPrefix,
+      "launch",
+      udid,
+      app.bundleId,
+    ]);
+
+    companionProcess = dependencies.runner.spawn([
+      companion,
+      "--udid",
+      udid,
+      "--device-set-path",
+      deviceSet,
+      "--grpc-domain-sock",
+      socketPath,
+      "--log-file-path",
+      join(leaseRoot, "companion.log"),
+      "--terminate-offline",
+      "1",
+    ]);
+    await waitForCompanion(companionProcess);
+    const idbPrefix = [idb, "--companion", socketPath];
+    const measurements = parseDimensions(
+      await runChecked(dependencies.runner, [
+        ...idbPrefix,
+        "describe",
+        "--json",
+      ]),
+    );
+
+    return {
+      udid,
+      deviceName: configuration.deviceName,
+      ...measurements,
+      async startVideo(onChunk, onError) {
+        if (closed) throw new Error("Simulator is closed");
+        if (videoProcess !== undefined)
+          throw new Error("Simulator video is already running");
+        const child = dependencies.runner.spawn([
+          ...idbPrefix,
+          "video-stream",
+          "--format",
+          "mjpeg",
+          "--fps",
+          "15",
+          "--scale-factor",
+          "0.5",
+        ]);
+        videoProcess = child;
+        let stopping = false;
+        void (async () => {
+          try {
+            const reader = child.stdout.getReader();
+            while (true) {
+              const next = await reader.read();
+              if (next.done) break;
+              onChunk(next.value);
+            }
+            const exitCode = await child.exited;
+            if (!stopping && !closed) {
+              onError(new Error(`idb video-stream exited with ${exitCode}`));
+            }
+          } catch (error) {
+            if (!stopping)
+              onError(
+                error instanceof Error ? error : new Error(String(error)),
+              );
+          } finally {
+            if (videoProcess === child) videoProcess = undefined;
+          }
+        })();
+        return async () => {
+          if (videoProcess !== child) return;
+          stopping = true;
+          await stopProcess(child);
+          if (videoProcess === child) videoProcess = undefined;
+        };
+      },
+      async input(command) {
+        if (closed) throw new Error("Simulator is closed");
+        await runChecked(dependencies.runner, [
+          ...idbPrefix,
+          ...inputArguments(command),
+        ]);
+      },
+      close: cleanup,
+    };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+};

--- a/packages/core/opensession-server/src/simulator-portal/main.ts
+++ b/packages/core/opensession-server/src/simulator-portal/main.ts
@@ -1,0 +1,67 @@
+import { parseArgs } from "node:util";
+import { z } from "zod";
+import { buildSimulatorViewer } from "./assets";
+import { openIdbSimulator } from "./idb";
+import { startSimulatorViewer } from "./server";
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      session: { type: "string" },
+      workspace: { type: "string" },
+      app: { type: "string" },
+      "device-type": { type: "string" },
+      runtime: { type: "string" },
+    },
+    strict: true,
+  });
+  const input = z
+    .object({
+      session: z.string().min(1),
+      workspace: z.string().min(1),
+      app: z.string().min(1),
+      "device-type": z.string().optional(),
+      runtime: z.string().optional(),
+    })
+    .parse(values);
+  const port = z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(65535)
+    .parse(process.env.PORT);
+  const origin = z.url({ protocol: /^https?$/ }).parse(process.env.PORTAL_URL);
+  const assets = await buildSimulatorViewer();
+  const viewer = startSimulatorViewer({
+    port,
+    origin,
+    assets,
+    openSimulator: () =>
+      openIdbSimulator({
+        sessionId: input.session,
+        workspaceDir: input.workspace,
+        appPath: input.app,
+        deviceType: input["device-type"],
+        runtime: input.runtime,
+      }),
+  });
+  const stop = () => {
+    void viewer.stop().then(
+      () => process.exit(0),
+      (error) => {
+        console.error(error);
+        process.exit(1);
+      },
+    );
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+  console.log("Simulator Portal listening. The viewer reports startup status.");
+}
+
+if (import.meta.main) {
+  await main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/core/opensession-server/src/simulator-portal/mjpeg.ts
+++ b/packages/core/opensession-server/src/simulator-portal/mjpeg.ts
@@ -1,0 +1,31 @@
+const START = Buffer.from([0xff, 0xd8]);
+const END = Buffer.from([0xff, 0xd9]);
+const MAX_FRAME_BYTES = 4 * 1024 * 1024;
+
+/** idb's mjpeg format is concatenated JPEGs, not an HTTP multipart stream. */
+export function jpegFrames(onFrame: (frame: Uint8Array) => void) {
+  let pending = Buffer.alloc(0);
+  return (chunk: Uint8Array) => {
+    pending = Buffer.concat([pending, chunk]);
+    for (;;) {
+      const start = pending.indexOf(START);
+      if (start < 0) {
+        pending = pending.subarray(-1);
+        return;
+      }
+      if (start > 0) pending = pending.subarray(start);
+      const end = pending.indexOf(END, 2);
+      if (end < 0) {
+        if (pending.length > MAX_FRAME_BYTES) {
+          pending = Buffer.alloc(0);
+          throw new Error("Simulator frame exceeds the 4 MiB limit");
+        }
+        return;
+      }
+      if (end + 2 > MAX_FRAME_BYTES)
+        throw new Error("Simulator frame exceeds the 4 MiB limit");
+      onFrame(pending.subarray(0, end + 2));
+      pending = pending.subarray(end + 2);
+    }
+  };
+}

--- a/packages/core/opensession-server/src/simulator-portal/protocol.ts
+++ b/packages/core/opensession-server/src/simulator-portal/protocol.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+const coordinate = z.number().finite().min(0).max(1);
+export const viewerInputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("tap"), x: coordinate, y: coordinate }).strict(),
+  z
+    .object({
+      type: z.literal("swipe"),
+      x: coordinate,
+      y: coordinate,
+      endX: coordinate,
+      endY: coordinate,
+      duration: z.number().finite().min(0.05).max(2),
+    })
+    .strict(),
+  z
+    .object({ type: z.literal("text"), text: z.string().min(1).max(1_000) })
+    .strict(),
+  z.object({ type: z.literal("home") }).strict(),
+  z
+    .object({
+      type: z.literal("key"),
+      key: z.enum([
+        "Enter",
+        "Backspace",
+        "Tab",
+        "Escape",
+        "ArrowUp",
+        "ArrowDown",
+        "ArrowLeft",
+        "ArrowRight",
+      ]),
+    })
+    .strict(),
+]);
+export type ViewerInput = z.infer<typeof viewerInputSchema>;
+
+export const viewerStateSchema = z.discriminatedUnion("phase", [
+  z.object({ phase: z.literal("starting") }),
+  z.object({
+    phase: z.literal("ready"),
+    deviceName: z.string(),
+    width: z.number().positive(),
+    height: z.number().positive(),
+  }),
+  z.object({ phase: z.literal("error"), message: z.string() }),
+]);
+export type ViewerState = z.infer<typeof viewerStateSchema>;
+export const viewerMessageSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("state"), state: viewerStateSchema }),
+  z.object({ type: z.literal("input-error"), message: z.string() }),
+]);
+
+export const simulatorKeyCodes = {
+  Enter: 40,
+  Backspace: 42,
+  Tab: 43,
+  Escape: 41,
+  ArrowRight: 79,
+  ArrowLeft: 80,
+  ArrowDown: 81,
+  ArrowUp: 82,
+} satisfies Record<Extract<ViewerInput, { type: "key" }>["key"], number>;

--- a/packages/core/opensession-server/src/simulator-portal/server.test.ts
+++ b/packages/core/opensession-server/src/simulator-portal/server.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, expect, test } from "bun:test";
+import { z } from "zod";
+import { startSimulatorViewer, simulatorInput } from "./server";
+import type { IdbSimulator, SimulatorInput } from "./idb";
+import { jpegFrames } from "./mjpeg";
+import { viewerInputSchema } from "./protocol";
+
+const cleanup: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const stop of cleanup.splice(0).reverse()) await stop();
+});
+
+async function until(condition: () => boolean) {
+  const deadline = Date.now() + 2_000;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error("Condition timed out");
+    await Bun.sleep(5);
+  }
+}
+
+function fixture(overrides: Partial<IdbSimulator> = {}, idleMs?: number) {
+  const inputs: SimulatorInput[] = [];
+  let starts = 0;
+  let stops = 0;
+  let closed = 0;
+  let emit: (chunk: Uint8Array) => void = () => {};
+  const device: IdbSimulator = {
+    udid: "fixture",
+    deviceName: "Test device",
+    dimensions: { width: 400, height: 800 },
+    density: 3,
+    async input(command) {
+      inputs.push(command);
+    },
+    async startVideo(onChunk) {
+      starts++;
+      emit = onChunk;
+      return async () => {
+        stops++;
+      };
+    },
+    async close() {
+      closed++;
+    },
+    ...overrides,
+  };
+  const origin = "https://simulator.example.test:9000";
+  const viewer = startSimulatorViewer({
+    port: 0,
+    origin,
+    assets: new Map([["/", new Blob(["Test viewer"], { type: "text/html" })]]),
+    openSimulator: async () => device,
+    idleMs,
+  });
+  cleanup.push(() => viewer.stop());
+  const base = `http://127.0.0.1:${viewer.port}`;
+  async function connect() {
+    const { token } = z
+      .object({ token: z.string() })
+      .parse(await (await fetch(`${base}/api/bootstrap`)).json());
+    // Bun supports custom handshake headers; this checkout also includes DOM
+    // types whose WebSocket constructor exposes only browser arguments.
+    const client: unknown = Reflect.construct(WebSocket, [
+      `${base.replace("http:", "ws:")}/socket?token=${token}`,
+      { headers: { Origin: origin } } satisfies Bun.WebSocketOptions,
+    ]);
+    if (!(client instanceof WebSocket)) throw new Error("Expected a WebSocket");
+    const ws = client;
+    cleanup.push(() => ws.close());
+    const messages: Array<string | Uint8Array> = [];
+    ws.binaryType = "arraybuffer";
+    ws.addEventListener("message", (event) =>
+      messages.push(
+        typeof event.data === "string"
+          ? event.data
+          : new Uint8Array(event.data),
+      ),
+    );
+    await until(() => ws.readyState === WebSocket.OPEN && messages.length > 0);
+    return { ws, messages };
+  }
+  return {
+    viewer,
+    base,
+    origin,
+    inputs,
+    connect,
+    emit: (data: Uint8Array) => emit(data),
+    counts: () => ({ starts, stops, closed }),
+  };
+}
+
+test("JPEG stream handles chunk boundaries and concatenated frames without unbounded buffering", () => {
+  const received: Uint8Array[] = [];
+  const append = jpegFrames((frame) => received.push(frame));
+  append(Buffer.from([0, 255]));
+  append(Buffer.from([216, 1, 2, 255]));
+  append(Buffer.from([217, 255, 216, 3, 255, 217]));
+  expect(received.map((value) => [...value])).toEqual([
+    [255, 216, 1, 2, 255, 217],
+    [255, 216, 3, 255, 217],
+  ]);
+  expect(() =>
+    append(
+      Buffer.concat([Buffer.from([255, 216]), Buffer.alloc(4 * 1024 * 1024)]),
+    ),
+  ).toThrow("4 MiB");
+});
+
+test("viewer commands are validated and mapped to logical points, never raw CLI arguments", () => {
+  expect(
+    simulatorInput({ type: "tap", x: 1, y: 0.5 }, { width: 400, height: 800 }),
+  ).toEqual({ kind: "tap", x: 399, y: 400 });
+  expect(
+    simulatorInput(
+      { type: "key", key: "Backspace" },
+      { width: 400, height: 800 },
+    ),
+  ).toEqual({ kind: "key", key: 42 });
+  for (const invalid of [
+    { type: "tap", x: -1, y: 0 },
+    { type: "tap", x: Infinity, y: 0 },
+    { type: "swipe", x: 0, y: 0, endX: 1, endY: 1, duration: 60 },
+    { type: "key", key: "; rm" },
+    { type: "text", text: "x".repeat(1001) },
+    { type: "home", udid: "another-device" },
+  ])
+    expect(viewerInputSchema.safeParse(invalid).success).toBe(false);
+});
+
+test("helper rejects foreign hosts, cross-origin control, absent tokens, and mutation HTTP verbs", async () => {
+  const { base, origin } = fixture();
+  const bootstrap = await fetch(`${base}/api/bootstrap`);
+  expect(bootstrap.headers.get("cache-control")).toBe("no-store");
+  expect(bootstrap.headers.get("access-control-allow-origin")).toBeNull();
+  const { token } = z
+    .object({ token: z.string() })
+    .parse(await bootstrap.json());
+  expect(
+    (await fetch(base, { headers: { Host: "attacker.example" } })).status,
+  ).toBe(403);
+  expect((await fetch(base, { method: "POST" })).status).toBe(405);
+  expect(
+    (
+      await fetch(`${base}/socket?token=${token}`, {
+        headers: { Origin: "https://attacker.example" },
+      })
+    ).status,
+  ).toBe(403);
+  expect(
+    (await fetch(`${base}/socket`, { headers: { Origin: origin } })).status,
+  ).toBe(403);
+});
+
+test("real WebSocket transports frames/input, shares one stream, and stops capture with the last viewer", async () => {
+  const f = fixture();
+  const first = await f.connect();
+  const second = await f.connect();
+  await until(() => f.counts().starts === 1);
+  f.emit(Buffer.from([255, 216, 7, 255, 217]));
+  await until(
+    () =>
+      first.messages.some((value) => typeof value !== "string") &&
+      second.messages.some((value) => typeof value !== "string"),
+  );
+  first.ws.send(JSON.stringify({ type: "tap", x: 0.25, y: 0.75 }));
+  first.ws.send(JSON.stringify({ type: "text", text: "hello" }));
+  await until(() => f.inputs.length === 2);
+  expect(f.inputs).toEqual([
+    { kind: "tap", x: 100, y: 600 },
+    { kind: "text", text: "hello" },
+  ]);
+  first.ws.close();
+  second.ws.close();
+  await until(() => f.counts().stops === 1);
+  expect(f.counts().closed).toBe(0);
+  await f.viewer.stop();
+  expect(f.counts().closed).toBe(1);
+});
+
+test("invalid input closes the connection without controlling a simulator", async () => {
+  const f = fixture();
+  const { ws } = await f.connect();
+  ws.send(JSON.stringify({ type: "tap", x: 2, y: 0 }));
+  await until(() => ws.readyState === WebSocket.CLOSED);
+  expect(f.inputs).toEqual([]);
+});
+
+test("setup failures remain visible in the Portal rather than pretending a device is ready", async () => {
+  const viewer = startSimulatorViewer({
+    port: 0,
+    origin: "https://viewer.test",
+    assets: new Map(),
+    openSimulator: async () => {
+      throw new Error("Xcode is missing");
+    },
+  });
+  cleanup.push(() => viewer.stop());
+  await viewer.ready;
+  expect(
+    await (await fetch(`http://127.0.0.1:${viewer.port}/api/bootstrap`)).json(),
+  ).toMatchObject({ state: { phase: "error", message: "Xcode is missing" } });
+});
+
+test("a capture spawn failure releases the simulator even with an error viewer connected", async () => {
+  const f = fixture({
+    startVideo: async () => {
+      throw new Error("idb capture spawn failed");
+    },
+  });
+  await f.connect();
+  await until(() => f.counts().closed === 1);
+  expect(await (await fetch(`${f.base}/api/bootstrap`)).json()).toMatchObject({
+    state: { phase: "error", message: "idb capture spawn failed" },
+  });
+  await f.viewer.stop();
+  expect(f.counts().closed).toBe(1);
+});
+
+test("a failed capture stop still closes the device", async () => {
+  const f = fixture({
+    startVideo: async () => async () => {
+      throw new Error("capture did not stop");
+    },
+  });
+  const { ws } = await f.connect();
+  ws.close();
+  await until(() => f.counts().closed === 1);
+  await f.viewer.stop();
+  expect(f.counts().closed).toBe(1);
+});
+
+test("idle viewers release their device and listener", async () => {
+  const f = fixture({}, 20);
+  await until(() => f.counts().closed === 1);
+  await f.viewer.stop();
+  expect(f.counts().closed).toBe(1);
+});

--- a/packages/core/opensession-server/src/simulator-portal/server.ts
+++ b/packages/core/opensession-server/src/simulator-portal/server.ts
@@ -1,0 +1,284 @@
+import type { ServerWebSocket } from "bun";
+import type { IdbSimulator, SimulatorInput } from "./idb";
+import { jpegFrames } from "./mjpeg";
+import {
+  simulatorKeyCodes,
+  viewerInputSchema,
+  type ViewerInput,
+  type ViewerState,
+} from "./protocol";
+
+type ViewerSocket = ServerWebSocket<{ pending: number }>;
+
+export function simulatorInput(
+  input: ViewerInput,
+  dimensions: { width: number; height: number },
+): SimulatorInput {
+  const x = (value: number) =>
+    Math.min(
+      dimensions.width - 1,
+      Math.max(0, Math.round(value * dimensions.width)),
+    );
+  const y = (value: number) =>
+    Math.min(
+      dimensions.height - 1,
+      Math.max(0, Math.round(value * dimensions.height)),
+    );
+  switch (input.type) {
+    case "tap":
+      return { kind: "tap", x: x(input.x), y: y(input.y) };
+    case "swipe":
+      return {
+        kind: "swipe",
+        x: x(input.x),
+        y: y(input.y),
+        endX: x(input.endX),
+        endY: y(input.endY),
+        duration: input.duration,
+      };
+    case "text":
+      return { kind: "text", text: input.text };
+    case "home":
+      return { kind: "button", button: "HOME" };
+    case "key":
+      return { kind: "key", key: simulatorKeyCodes[input.key] };
+  }
+}
+
+/** The Portal proxy supplies authentication. The helper binds only loopback,
+ * accepts only its Portal origin, and gates WebSockets with a same-origin token. */
+export function startSimulatorViewer(options: {
+  port: number;
+  origin: string;
+  assets: ReadonlyMap<string, Blob>;
+  openSimulator: () => Promise<IdbSimulator>;
+  /** Testable idle deadline. Production closes a device after ten minutes without a viewer. */
+  idleMs?: number;
+}) {
+  const origin = new URL(options.origin).origin;
+  const token = crypto.randomUUID();
+  const sockets = new Set<ViewerSocket>();
+  let state: ViewerState = { phase: "starting" };
+  let simulator: IdbSimulator | undefined;
+  let closing = false;
+  let lastFrame: Uint8Array | undefined;
+  let stopVideo: (() => Promise<void>) | undefined;
+  let videoTransition = Promise.resolve();
+  let commands = Promise.resolve();
+  let pending = 0;
+  let deviceClose: Promise<void> | undefined;
+  function closeDevice(): Promise<void> {
+    return simulator ? (deviceClose ??= simulator.close()) : Promise.resolve();
+  }
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  function armIdle() {
+    clearTimeout(idleTimer);
+    if (!closing && sockets.size === 0)
+      idleTimer = setTimeout(
+        () => {
+          void stop().catch((error) =>
+            console.error("Simulator cleanup failed", error),
+          );
+        },
+        options.idleMs ?? 10 * 60_000,
+      );
+  }
+
+  function send(ws: ViewerSocket, value: unknown) {
+    if (ws.readyState === 1) ws.send(JSON.stringify(value));
+  }
+  function setState(next: ViewerState) {
+    state = next;
+    for (const ws of sockets) send(ws, { type: "state", state });
+  }
+  function fail(error: unknown) {
+    setState({
+      phase: "error",
+      message:
+        error instanceof Error ? error.message : "Simulator connection failed",
+    });
+    syncVideo();
+  }
+  function syncVideo() {
+    videoTransition = videoTransition
+      .then(async () => {
+        const shouldStream =
+          !closing && sockets.size > 0 && state.phase === "ready" && simulator;
+        if (!shouldStream) {
+          await stopVideo?.();
+          stopVideo = undefined;
+          lastFrame = undefined;
+          if (state.phase === "error") await closeDevice();
+          return;
+        }
+        if (stopVideo) return;
+        const frames = jpegFrames((frame) => {
+          lastFrame = frame;
+          for (const ws of sockets) {
+            // A slow browser drops frames rather than buffering seconds of video.
+            if (ws.readyState === 1 && ws.getBufferedAmount() < 256 * 1024)
+              ws.send(frame);
+          }
+        });
+        stopVideo = await shouldStream.startVideo((chunk) => {
+          try {
+            frames(chunk);
+          } catch (error) {
+            fail(error);
+          }
+        }, fail);
+      })
+      .catch(async (error) => {
+        const message =
+          error instanceof Error ? error.message : "Simulator stream failed";
+        setState({ phase: "error", message });
+        const stop = stopVideo;
+        stopVideo = undefined;
+        await stop?.().catch(() => {});
+        // Do not chain syncVideo from inside its own transition. Release the
+        // device here even if viewers remain connected to the error screen.
+        await closeDevice().catch((cause) => {
+          setState({
+            phase: "error",
+            message: `${message}. Cleanup failed: ${cause instanceof Error ? cause.message : "restart this Portal"}`,
+          });
+        });
+      });
+  }
+
+  const server = Bun.serve<{ pending: number }>({
+    hostname: "127.0.0.1",
+    port: options.port,
+    idleTimeout: 60,
+    fetch(request, server) {
+      const url = new URL(request.url);
+      const allowedHost =
+        url.host === new URL(origin).host ||
+        url.host === `127.0.0.1:${server.port}`;
+      if (!allowedHost)
+        return new Response("Invalid viewer host", { status: 403 });
+      if (request.method !== "GET")
+        return new Response("Method not allowed", { status: 405 });
+      if (url.pathname === "/socket") {
+        if (
+          request.headers.get("origin") !== origin ||
+          url.searchParams.get("token") !== token
+        )
+          return new Response("Viewer authorization required", { status: 403 });
+        if (sockets.size >= 4 || closing)
+          return new Response("Viewer capacity reached", { status: 503 });
+        return server.upgrade(request, { data: { pending: 0 } })
+          ? undefined
+          : new Response("WebSocket required", { status: 400 });
+      }
+      const headers = {
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
+        "Content-Security-Policy":
+          "default-src 'self'; connect-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'none'; form-action 'self'",
+      };
+      if (url.pathname === "/api/bootstrap")
+        return Response.json({ token, state }, { headers });
+      const file = options.assets.get(url.pathname);
+      return file
+        ? new Response(file, { headers })
+        : new Response("Not found", { status: 404, headers });
+    },
+    websocket: {
+      maxPayloadLength: 8_192,
+      idleTimeout: 120,
+      sendPings: true,
+      open(ws) {
+        clearTimeout(idleTimer);
+        if (closing || sockets.size >= 4) {
+          ws.close(1013, "Viewer capacity reached");
+          return;
+        }
+        sockets.add(ws);
+        send(ws, { type: "state", state });
+        if (lastFrame) ws.send(lastFrame);
+        syncVideo();
+      },
+      message(ws, message) {
+        if (typeof message !== "string")
+          return ws.close(1003, "Text commands only");
+        let json: unknown;
+        try {
+          json = JSON.parse(message);
+        } catch {
+          return ws.close(1008, "Invalid command");
+        }
+        const parsed = viewerInputSchema.safeParse(json);
+        if (!parsed.success) return ws.close(1008, "Invalid command");
+        const target = simulator;
+        if (!target || state.phase !== "ready" || closing)
+          return send(ws, {
+            type: "input-error",
+            message: "Simulator is not ready",
+          });
+        if (ws.data.pending >= 4 || pending >= 16)
+          return send(ws, {
+            type: "input-error",
+            message: "Simulator is busy. Try again.",
+          });
+        ws.data.pending++;
+        pending++;
+        commands = commands
+          .then(async () => {
+            if (closing || state.phase !== "ready" || ws.readyState !== 1)
+              return;
+            await target.input(simulatorInput(parsed.data, target.dimensions));
+          })
+          .catch((error) =>
+            send(ws, {
+              type: "input-error",
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Simulator input failed",
+            }),
+          )
+          .finally(() => {
+            ws.data.pending--;
+            pending--;
+          });
+      },
+      close(ws) {
+        sockets.delete(ws);
+        syncVideo();
+        armIdle();
+      },
+    },
+  });
+  const ready = options
+    .openSimulator()
+    .then(async (device) => {
+      simulator = device;
+      if (closing) return;
+      setState({
+        phase: "ready",
+        deviceName: device.deviceName,
+        ...device.dimensions,
+      });
+      syncVideo();
+    })
+    .catch(fail);
+  let stopped: Promise<void> | undefined;
+  function stop() {
+    return (stopped ??= (async () => {
+      closing = true;
+      clearTimeout(idleTimer);
+      for (const ws of sockets) ws.close(1001, "Simulator Portal stopped");
+      sockets.clear();
+      await server.stop(true);
+      await ready;
+      syncVideo();
+      await videoTransition;
+      await commands;
+      await closeDevice();
+    })());
+  }
+  armIdle();
+  return { port: server.port, ready, stop };
+}

--- a/scripts/verify-simulator-portal.ts
+++ b/scripts/verify-simulator-portal.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+/** UI verification fixture only. No Xcode, idb, device or app is started.
+ * Run through start_portal so the real viewer transport stays authenticated. */
+import sharp from "sharp";
+import { buildSimulatorViewer } from "../packages/core/opensession-server/src/simulator-portal/assets";
+import { startSimulatorViewer } from "../packages/core/opensession-server/src/simulator-portal/server";
+import type { SimulatorInput } from "../packages/core/opensession-server/src/simulator-portal/idb";
+
+const port = Number(process.env.PORT);
+const origin = process.env.PORTAL_URL;
+if (!Number.isInteger(port) || port < 1024 || !origin)
+  throw new Error("Start this fixture through an Open Session Portal");
+const assets = await buildSimulatorViewer();
+const inputs: SimulatorInput[] = [];
+let emit: ((frame: Uint8Array) => void) | undefined;
+async function frame() {
+  const image = `<svg xmlns="http://www.w3.org/2000/svg" width="390" height="844"><rect width="390" height="844" fill="white"/><g fill="black" font-family="sans-serif" text-anchor="middle"><text x="195" y="190" font-size="25">Simulator viewer test</text><text x="195" y="230" font-size="16">No iOS runtime is running</text><rect x="55" y="310" width="280" height="100" rx="20" fill="lightgray"/><text x="195" y="355" font-size="20">Tap or swipe here</text><text x="195" y="390" font-size="18">Inputs received: ${inputs.length}</text><text x="195" y="520" font-size="16">Keyboard and Home work too</text></g></svg>`;
+  return new Uint8Array(await sharp(Buffer.from(image)).jpeg().toBuffer());
+}
+function record() {
+  assets.set(
+    "/test-inputs.json",
+    new Blob([JSON.stringify(inputs)], { type: "application/json" }),
+  );
+}
+record();
+const viewer = startSimulatorViewer({
+  port,
+  origin,
+  assets,
+  openSimulator: async () => {
+    if (process.argv.includes("--failure"))
+      throw new Error("Test fixture: Xcode or idb is not installed");
+    return {
+      udid: "test-fixture",
+      deviceName: "Test fixture",
+      dimensions: { width: 390, height: 844 },
+      density: 1,
+      async startVideo(onFrame) {
+        emit = onFrame;
+        onFrame(await frame());
+        return async () => {
+          emit = undefined;
+        };
+      },
+      async input(command) {
+        inputs.push(command);
+        record();
+        emit?.(await frame());
+      },
+      async close() {},
+    };
+  },
+});
+const stop = () => {
+  void viewer.stop().then(() => process.exit(0));
+};
+process.once("SIGTERM", stop);
+process.once("SIGINT", stop);
+console.log("Simulator viewer test fixture, no iOS runtime is running");


### PR DESCRIPTION
## Summary

- Add `opensession-portals.start_simulator_portal` for a prebuilt workspace-local simulator app.
- Stream idb MJPEG frames and forward validated taps, swipes, text, Home and common keys through an authenticated Portal viewer.
- Own a private device set and companion per session, with two-device capacity, bounded input/video buffers, idle shutdown and conservative crash recovery.
- Let desktop users pin any Portal beside the conversation; retain the phone full-width viewer.
- Fix Mac Portal process groups and listener discovery without Linux-only setsid/ss.

## Verification

- `OPENSESSION_TEST_JOBS=4 bun run check` passed, including strict transcript snapshots.
- Module import side-effect check passed.
- Real browser fixture tests at 1440×900 DPR 2 and 390×844 DPR 3 exercised screen display, tap/swipe/text/Home, reconnect, side-panel pin/expand, phone behavior, and missing-dependency errors.
- Native command tests replace the executable boundary. No real iOS Simulator was started: this Mac has no full Xcode/idb setup.
- A live Portal launch was attempted but the deployed Mac launcher still requires setsid; authenticated Portal routing also needs host configuration. No live URL or deployment is claimed.
- No native iOS/Chrome protocol changes: the viewer has its own Portal-local WebSocket protocol.

## Limits

Local macOS source installations only. Requires Xcode, an iOS runtime, idb/idb_companion and configured Portal HTTPS routing. No auto-build, signing, release or hot reload. Restart creates a fresh simulator. Real idb/Xcode qualification remains required before rollout.

Started by Local User in [this Assistant session](http://100.81.254.102:3850/session/os-01a087f2-23a6-717d-a6ca-24f8e1edf601)
