### PR TITLE
Move the web Desk voice call to GPT-Live

### DIFF
--- a/docs/setup/integrations-misc.md
+++ b/docs/setup/integrations-misc.md
@@ -160,6 +160,26 @@ The endpoint accepts at most 25 MiB per clip. Providers are optional: if no
 hosted key works and the local binary or model is unavailable, dictation
 returns an error and the rest of the app is unaffected.
 
+### Desk voice calls
+
+The Desk overlay's voice mode (Settings → Desk voice) uses its own OpenAI
+key, stored instance-wide from that settings panel rather than from the
+environment. Two engines share it:
+
+- **Web: GPT-Live** (`src/server/desk-voice-live.ts`). The browser posts its
+  WebRTC offer to `/api/desk/voice/live`; the server creates the
+  `gpt-live-1` session, attaches a sideband WebSocket, and returns the SDP
+  answer. Reasoning and tools run through Responses delegation on
+  `gpt-5.6-terra`; every function call executes on this server as the
+  verified user and transcripts are mirrored from the sideband. The browser
+  data channel is restricted to `session.close`. Billing is per second of
+  call time plus backend tokens; the server closes a call after 3 minutes of
+  silence or 30 minutes total.
+- **iOS: GPT Realtime** (`src/server/desk-voice.ts`). The device connects to
+  OpenAI with an ephemeral secret from `/api/desk/voice/secret` and relays
+  tool calls and transcripts through `/api/desk/voice/tool` and
+  `/transcript`.
+
 ## AWS creds for runs (`AGENT_AWS_REGION`)
 
 `packages/core/opensession-server/src/server/aws-creds.ts` mints short-lived

--- a/packages/core/opensession-server/src/frontend/components/Composer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Composer.tsx
@@ -64,6 +64,7 @@ import {
   IconStopSquare,
   IconPencil,
   IconTrash,
+  IconCall,
 } from "./icons";
 import {
   composerBox,
@@ -200,6 +201,7 @@ export function Composer({
     noteMode,
     askMode,
     askExitPending,
+    call,
   },
   actions: {
     onSend,
@@ -220,6 +222,7 @@ export function Composer({
     skillsFetch,
     onNoteModeChange,
     onAskModeExit,
+    onToggleCall,
   },
   menuExtra,
   attached,
@@ -1737,6 +1740,42 @@ export function Composer({
             onActiveChange={handleDictationActive}
             disabled={disabled}
           />
+
+          {onToggleCall && (
+            <motion.div
+              layout="position"
+              transition={composerMorph}
+              layoutDependency={minimized}
+              className={cn(
+                "inline-flex shrink-0 items-center",
+                // Sits right after the dictation mic in the resting pill.
+                minimized && "order-3",
+              )}
+            >
+              <Tooltip
+                label={
+                  call?.active
+                    ? `End call${call.status ? ` (${call.status})` : ""}`
+                    : "Start a voice call"
+                }
+              >
+                <button
+                  type="button"
+                  className={cn(
+                    composerIconButtonClass,
+                    // A live call reads as the universal red handset.
+                    call?.active && "text-red hover:text-red",
+                  )}
+                  onClick={onToggleCall}
+                  disabled={disabled}
+                  aria-pressed={!!call?.active}
+                  aria-label={call?.active ? "End call" : "Start a voice call"}
+                >
+                  <IconCall size={22} />
+                </button>
+              </Tooltip>
+            </motion.div>
+          )}
 
           {busy && onStop && (
             <Tooltip

--- a/packages/core/opensession-server/src/frontend/components/Composer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/Composer.tsx
@@ -403,10 +403,22 @@ export function Composer({
       sendOptions.pastedTexts = pastedTexts.map(
         (attachment) => attachment.text,
       );
-    const consumed = handler(overrideText ?? text, sendOptions);
+    const draftAtSend = text;
+    const sentText = overrideText ?? text;
+    const consumed = handler(sentText, sendOptions);
     if (consumed instanceof Promise) {
+      // The handler answers later; the draft may have moved on by then.
+      // Clear only what was sent: a field the user has since retyped keeps
+      // its new text. (The dictation override commits to state after this
+      // call, so the field may legitimately hold either snapshot.)
       void consumed.then((result) => {
-        if (result === true) consume();
+        if (result !== true) return;
+        const now = textRef.current;
+        if (isControlled || now === draftAtSend || now === sentText) consume();
+        else
+          setPastedTexts((current) =>
+            current.filter((attachment) => !sentPastedIds.has(attachment.id)),
+          );
       });
     } else if (consumed === true) {
       consume();

--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -46,9 +46,10 @@ interface DeskConversationProps {
   model?: string;
   effort?: string;
   hideBefore?: string;
-  /** While a voice call is live, typed messages go into it instead of
-   *  starting a text run. Return false to fall through to the normal send. */
-  voiceSend?: (text: string) => boolean;
+  /** Present while a voice call is up: typed messages go into it instead of
+   * starting a text run. Resolves true once the call has taken the text;
+   * false means it did not, and the draft must survive. */
+  voiceSend?: (text: string) => Promise<boolean>;
   /** The voice call control, rendered in the composer beside dictation. */
   voiceCall?: { active: boolean; status?: string; onToggle: () => void };
   /** Drill into a session a tool call spawned (the Desk delegates constantly).
@@ -401,11 +402,12 @@ export function DeskConversation({
 
   // Returns true when the message was consumed, so the (uncontrolled) Composer
   // clears its draft; false keeps it for a retry — same contract as the
-  // session view.
+  // session view. The voice path answers asynchronously: the draft clears
+  // only once the call has acknowledged the text.
   function handleSend(
     raw: string,
     opts?: { steer?: boolean; pastedTexts?: string[] },
-  ): boolean {
+  ): boolean | Promise<boolean> {
     const content = raw.trim();
     const pastedTexts = opts?.pastedTexts ?? [];
     if (!connected) return false;
@@ -435,11 +437,33 @@ export function DeskConversation({
       ]);
       return true;
     }
-    // Live voice call: inject the typed message into it (the call mirrors its
+    // Live voice call: a text-only message goes into it (the call mirrors its
     // transcript back, so no optimistic bubble — the entry lands via append).
-    if (content && voiceSend?.(content)) {
-      followRef.current = true;
-      return true;
+    // Attachments can't ride a call, so they take the ordinary path below.
+    if (
+      voiceSend &&
+      content &&
+      images.length === 0 &&
+      files.length === 0 &&
+      pastedTexts.length === 0
+    ) {
+      return voiceSend(content).then((taken) => {
+        if (taken) {
+          followRef.current = true;
+          return true;
+        }
+        setEntries((prev) => [
+          ...prev,
+          {
+            id: randomUUID(),
+            type: "system",
+            content:
+              "The voice call didn't take that message. Try again, or end the call to send it as text.",
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        return false;
+      });
     }
     // Prefer the staged disk path (HTTP upload); fall back to inline dataUrl.
     const filePayload = files.map((f) =>

--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -49,6 +49,8 @@ interface DeskConversationProps {
   /** While a voice call is live, typed messages go into it instead of
    *  starting a text run. Return false to fall through to the normal send. */
   voiceSend?: (text: string) => boolean;
+  /** The voice call control, rendered in the composer beside dictation. */
+  voiceCall?: { active: boolean; status?: string; onToggle: () => void };
   /** Drill into a session a tool call spawned (the Desk delegates constantly).
    *  The overlay has no side pane, so this opens it in the full viewer. */
   onOpenSubagent?: (sessionId: string) => void;
@@ -72,6 +74,7 @@ export function DeskConversation({
   effort: sessionEffort,
   hideBefore,
   voiceSend,
+  voiceCall,
   onOpenSubagent,
   suggestions,
 }: DeskConversationProps) {
@@ -609,6 +612,7 @@ export function DeskConversation({
             onDictationActive={handleDictationActive}
             config={{
               draftKey: `desk:${sessionId}`,
+              call: voiceCall,
               attachmentShortcutActive: presenceActive,
               placeholder: connected
                 ? placeholder || "Ask your Desk…"
@@ -641,6 +645,7 @@ export function DeskConversation({
               mentionFetch: (query) => fetchFileMentions(query, sessionId),
               paletteFetch: (query) =>
                 fetchMentionSuggestions(query, sessionId, getCurrentUser()),
+              onToggleCall: voiceCall?.onToggle,
             }}
           />
           <FullPageFileDropOverlay active={fileDragActive} />

--- a/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
@@ -73,6 +73,15 @@ function DeskBody({
   );
 
   const voiceActive = voiceState !== "idle" && voiceState !== "error";
+  const voiceStatus: Record<DeskVoiceState, string | undefined> = {
+    idle: undefined,
+    error: undefined,
+    connecting: "Connecting…",
+    listening: "Listening",
+    thinking: "Thinking…",
+    speaking: "Speaking",
+    action: "Working…",
+  };
 
   function toggleVoice() {
     if (voiceRef.current?.active) {
@@ -164,13 +173,7 @@ function DeskBody({
           >
             {voiceState === "error"
               ? (voiceError ?? "Voice call failed")
-              : {
-                  connecting: "Connecting…",
-                  listening: "Listening",
-                  thinking: "Thinking…",
-                  speaking: "Speaking",
-                  action: "Working…",
-                }[voiceState]}
+              : voiceStatus[voiceState]}
           </span>
         )}
         <Button
@@ -223,6 +226,17 @@ function DeskBody({
             hideBefore={clearedAt}
             voiceSend={(text) =>
               voiceRef.current?.active ? voiceRef.current.sendText(text) : false
+            }
+            // The handset lives in the composer beside dictation; the header
+            // label above shows the call's state.
+            voiceCall={
+              voiceEnabled
+                ? {
+                    active: voiceActive,
+                    status: voiceStatus[voiceState],
+                    onToggle: toggleVoice,
+                  }
+                : undefined
             }
             // The Desk's job is delegating, so its transcript is full of
             // spawned workers. There's no side pane in a modal — open the

--- a/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
@@ -84,6 +84,8 @@ function DeskBody({
   };
 
   function toggleVoice() {
+    // `active` covers a start still connecting: pressing the handset again
+    // then cancels that start instead of layering a second call on it.
     if (voiceRef.current?.active) {
       voiceRef.current.stop();
       return;
@@ -224,8 +226,11 @@ function DeskBody({
             model={settings.model}
             effort={settings.effort}
             hideBefore={clearedAt}
-            voiceSend={(text) =>
-              voiceRef.current?.active ? voiceRef.current.sendText(text) : false
+            voiceSend={
+              voiceActive
+                ? (text) =>
+                    voiceRef.current?.sendText(text) ?? Promise.resolve(false)
+                : undefined
             }
             // The handset lives in the composer beside dictation; the header
             // label above shows the call's state.

--- a/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
@@ -53,9 +53,9 @@ function DeskBody({
     {},
   );
 
-  // Voice mode (Settings → Desk voice): a live GPT Realtime call layered on
-  // this same Desk session. The call mirrors its transcript into the session,
-  // so the conversation below updates live while you talk.
+  // Voice mode (Settings → Desk voice): a GPT-Live call layered on this same
+  // Desk session. The server mirrors the call's transcript into the session,
+  // so the conversation below updates while you talk.
   const [voiceEnabled, setVoiceEnabled] = useState(getDeskVoicePref);
   const [voiceState, setVoiceState] = useState<DeskVoiceState>("idle");
   const [voiceError, setVoiceError] = useState<string | null>(null);

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -71,11 +71,15 @@ const stroke = {
   strokeLinejoin: "round" as const,
 };
 
+const ARROW_UP_PATHS = ["M17.25 10.25L12 4.75L6.75 10.25", "M12 19.25V5.75"];
+const ARROW_DOWN_PATHS = ["M17.25 13.75L12 19.25L6.75 13.75", "M12 4.75v13.5"];
+
 export function IconArrowUp(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M17.25 10.25L12 4.75L6.75 10.25" />
-      <path {...stroke} d="M12 19.25V5.75" />
+      {ARROW_UP_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
     </Svg>
   );
 }
@@ -94,8 +98,9 @@ export function IconArrowUpToLine(p: IconProps) {
 export function IconArrowDown(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M17.25 13.75L12 19.25L6.75 13.75" />
-      <path {...stroke} d="M12 4.75v13.5" />
+      {ARROW_DOWN_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
     </Svg>
   );
 }
@@ -226,18 +231,22 @@ export function IconChevronsUpDown(p: IconProps) {
   );
 }
 
+const CHEVRON_LEFT_PATH = "M13.75 6.75L8.75 12L13.75 17.25";
+
 export function IconChevronLeft(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M13.75 6.75L8.75 12L13.75 17.25" />
+      <path {...stroke} d={CHEVRON_LEFT_PATH} />
     </Svg>
   );
 }
 
+const CHEVRON_RIGHT_PATH = "M10.25 6.75L15.25 12L10.25 17.25";
+
 export function IconChevronRight(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M10.25 6.75L15.25 12L10.25 17.25" />
+      <path {...stroke} d={CHEVRON_RIGHT_PATH} />
     </Svg>
   );
 }
@@ -582,14 +591,17 @@ export function IconTerminal(p: IconProps) {
   );
 }
 
+const FILE_PATHS = [
+  "M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z",
+  "M18 9.25H13.75V5",
+];
+
 export function IconFile(p: IconProps) {
   return (
     <Svg {...p}>
-      <path
-        {...stroke}
-        d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"
-      />
-      <path {...stroke} d="M18 9.25H13.75V5" />
+      {FILE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
     </Svg>
   );
 }
@@ -786,13 +798,13 @@ export function IconPin(p: IconProps) {
   );
 }
 
+const FOLDER_PATH =
+  "M4.75 16.25V7.75C4.75 6.64543 5.64543 5.75 6.75 5.75H9.68934C9.88823 5.75 10.079 5.82902 10.2197 5.96967L12 7.75H17.25C18.3546 7.75 19.25 8.64543 19.25 9.75V16.25C19.25 17.3546 18.3546 18.25 17.25 18.25H6.75C5.64543 18.25 4.75 17.3546 4.75 16.25Z";
+
 export function IconFolder(p: IconProps) {
   return (
     <Svg {...p}>
-      <path
-        {...stroke}
-        d="M4.75 16.25V7.75C4.75 6.64543 5.64543 5.75 6.75 5.75H9.68934C9.88823 5.75 10.079 5.82902 10.2197 5.96967L12 7.75H17.25C18.3546 7.75 19.25 8.64543 19.25 9.75V16.25C19.25 17.3546 18.3546 18.25 17.25 18.25H6.75C5.64543 18.25 4.75 17.3546 4.75 16.25Z"
-      />
+      <path {...stroke} d={FOLDER_PATH} />
     </Svg>
   );
 }
@@ -1041,6 +1053,156 @@ export function slidersIconMarkup(size = MIN_ICON_SIZE): string {
 /** <IconCheck> as markup. */
 export function checkIconMarkup(size = MIN_ICON_SIZE): string {
   return iconMarkup(pathsMarkup([CHECK_PATH]), size);
+}
+
+/** <IconArrowUp> as markup. */
+export function arrowUpIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup(ARROW_UP_PATHS), size);
+}
+
+/** <IconArrowDown> as markup. */
+export function arrowDownIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup(ARROW_DOWN_PATHS), size);
+}
+
+// ── Callout glyphs ─────────────────────────────────────────────────────────
+// One per GitHub admonition kind (`> [!NOTE]` … `> [!CAUTION]`), drawn by
+// lib/markdown.ts into the callout's title. Same paths as the JSX icons below.
+
+const INFO_CIRCLE_PATHS = ["M12 11.25V16.25", "M12 8.25H12.01"];
+const LIGHTBULB_PATHS = [
+  "M9.75 17.25V16.4C9.75 15.5 9.2 14.8 8.6 14.2C7.45 13.2 6.75 11.8 6.75 10.25C6.75 7.35 9.1 5 12 5C14.9 5 17.25 7.35 17.25 10.25C17.25 11.8 16.55 13.2 15.4 14.2C14.8 14.8 14.25 15.5 14.25 16.4V17.25",
+  "M9.75 17.25H14.25",
+  "M10.25 19.25H13.75",
+];
+const REPORT_PATHS = [
+  "M4.75 6.75C4.75 5.645 5.645 4.75 6.75 4.75H17.25C18.355 4.75 19.25 5.645 19.25 6.75V14.25C19.25 15.355 18.355 16.25 17.25 16.25H13L8.75 19.25V16.25H6.75C5.645 16.25 4.75 15.355 4.75 14.25V6.75Z",
+  "M12 8.25V11",
+  "M12 13.75H12.01",
+];
+const WARNING_TRIANGLE_PATHS = [
+  "M4.9 17.25L10.7 6.1C11.25 5.05 12.75 5.05 13.3 6.1L19.1 17.25C19.6 18.25 18.9 19.25 17.8 19.25H6.2C5.1 19.25 4.4 18.25 4.9 17.25Z",
+  "M12 10V13.25",
+  "M12 16H12.01",
+];
+const OCTAGON_ALERT_PATHS = [
+  "M8.65 4.75H15.35L19.25 8.65V15.35L15.35 19.25H8.65L4.75 15.35V8.65L8.65 4.75Z",
+  "M12 8.5V12.5",
+  "M12 15.5H12.01",
+];
+
+export type CalloutIconKind =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution";
+
+/** The callout title glyph for one admonition kind, as markup. */
+export function calloutIconMarkup(
+  kind: CalloutIconKind,
+  size = MIN_ICON_SIZE,
+): string {
+  switch (kind) {
+    case "note":
+      return iconMarkup(
+        `<circle cx="12" cy="12" r="7.25" ${STROKE_MARKUP}/>` +
+          pathsMarkup(INFO_CIRCLE_PATHS),
+        size,
+      );
+    case "tip":
+      return iconMarkup(pathsMarkup(LIGHTBULB_PATHS), size);
+    case "important":
+      return iconMarkup(pathsMarkup(REPORT_PATHS), size);
+    case "warning":
+      return iconMarkup(pathsMarkup(WARNING_TRIANGLE_PATHS), size);
+    case "caution":
+      return iconMarkup(pathsMarkup(OCTAGON_ALERT_PATHS), size);
+  }
+}
+
+export function IconInfoCircle(p: IconProps) {
+  return (
+    <Svg {...p}>
+      <circle {...stroke} cx="12" cy="12" r="7.25" />
+      {INFO_CIRCLE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconLightbulb(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {LIGHTBULB_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+/** A speech bubble with an exclamation mark: "this needs your attention". */
+export function IconReport(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {REPORT_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconWarningTriangle(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {WARNING_TRIANGLE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconOctagonAlert(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {OCTAGON_ALERT_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+/** <IconChevronLeft> as markup. */
+export function chevronLeftIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([CHEVRON_LEFT_PATH]), size);
+}
+
+/** <IconChevronRight> as markup: the fold caret on a JSON tree row. */
+export function chevronRightIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([CHEVRON_RIGHT_PATH]), size);
+}
+
+/** <IconFile> as markup. */
+export function fileIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup(FILE_PATHS), size);
+}
+
+/** <IconFolder> as markup. */
+export function folderIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([FOLDER_PATH]), size);
+}
+
+/** The two chevrons of IconChevronLeft and IconChevronRight pulled in to
+ *  one glyph: the grip of a before/after slider (lib/compare-block.ts). */
+export function chevronsLeftRightIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(
+    pathsMarkup([
+      "M9.25 7.75L5 12L9.25 16.25",
+      "M14.75 7.75L19 12L14.75 16.25",
+    ]),
+    size,
+  );
 }
 
 export function IconTrash(p: IconProps) {
@@ -1297,6 +1459,19 @@ export function IconPhone(p: IconProps) {
     <Svg {...p}>
       <rect {...stroke} x="8.25" y="4.75" width="7.5" height="14.5" rx="2" />
       <path {...stroke} d="M10.75 16.75H13.25" />
+    </Svg>
+  );
+}
+
+// A handset for a live call, as distinct from IconPhone's device and
+// IconMic's dictation. One continuous stroke so it stays legible at 20px.
+export function IconCall(p: IconProps) {
+  return (
+    <Svg {...p}>
+      <path
+        {...stroke}
+        d="M7.4 4.75c.5 0 .95.3 1.14.76l1.12 2.7c.17.41.1.88-.19 1.22l-1.3 1.53a11.3 11.3 0 0 0 4.87 4.87l1.53-1.3c.34-.29.81-.36 1.22-.19l2.7 1.12c.46.19.76.64.76 1.14v1.9c0 .93-.8 1.68-1.73 1.6C10.53 19.36 4.64 13.47 3.9 6.48A1.6 1.6 0 0 1 5.5 4.75h1.9Z"
+      />
     </Svg>
   );
 }

--- a/packages/core/opensession-server/src/frontend/lib/composer-types.ts
+++ b/packages/core/opensession-server/src/frontend/lib/composer-types.ts
@@ -101,6 +101,10 @@ export interface ComposerConfig {
   /** The exit is in flight: the chip says so and its close button stops taking
    * clicks. */
   askExitPending?: boolean;
+  /** State of the host's live voice call, shown by the handset beside the
+   * dictation mic (rendered only with `onToggleCall`). `status` is the
+   * call's current phase for the tooltip, e.g. "Listening". */
+  call?: { active: boolean; status?: string };
 }
 
 /** A one-shot draft handed to the composer (see `ComposerConfig.prefill`). */
@@ -158,4 +162,6 @@ export interface ComposerActions {
    * the chip renders without an exit rather than offering one that fails.
    */
   onAskModeExit?: () => void;
+  /** Starts the host's voice call, or ends it while `config.call.active`. */
+  onToggleCall?: () => void;
 }

--- a/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
@@ -1,12 +1,12 @@
-// WebRTC client for Desk voice mode, driving a live call against OpenAI's
-// Realtime API. The server hands out a short-lived client secret (never the
-// real API key) plus a model id; this module opens the peer connection
-// directly to OpenAI, mirrors the call's transcript back to the server, and
-// routes function calls through the server's tool endpoint.
+// WebRTC client for Desk voice mode on GPT-Live. The browser only carries
+// audio: it posts its SDP offer to the server, which creates the Live session
+// with the instance key and hands back the answer. Tool calls, transcript
+// mirroring, and typed text all happen server-side over the session's
+// sideband (src/server/desk-voice-live.ts); the data channel here is limited
+// to lifecycle and transcript events plus `session.close`.
 
 import { z } from "zod";
 import { BASE_PATH } from "./base";
-import { randomUUID } from "./random-uuid";
 
 export type DeskVoiceState =
   | "idle"
@@ -19,79 +19,50 @@ export type DeskVoiceState =
 
 const API = `${BASE_PATH}/api/desk/voice`;
 const IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+const ICE_GATHER_TIMEOUT_MS = 10_000;
+const SESSION_START_TIMEOUT_MS = 15_000;
+/** Time to keep the call alive after asking to hang up, waiting for
+ * `session.closed` so pending work drains and usage finalizes. */
+const CLOSE_GRACE_MS = 5_000;
+/** Assistant transcript deltas have no "done" event: after this quiet spell
+ * the call is shown as listening again. */
+const SPEAKING_SETTLE_MS = 1_500;
 
-const secretResponseSchema = z.object({
-  clientSecret: z.string(),
-  expiresAt: z.number(),
-  model: z.string(),
+const liveResponseSchema = z.object({
+  liveSessionId: z.string(),
+  sdp: z.string(),
   sessionId: z.string(),
 });
 
-type SecretResponse = z.infer<typeof secretResponseSchema>;
-
-interface TranscriptEntry {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-}
-
-type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
-
-const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.null(),
-    z.array(jsonValueSchema),
-    z.record(z.string(), jsonValueSchema),
-  ]),
-);
-
-const realtimeEventSchema = z.object({
+const liveEventSchema = z.object({
   type: z.string(),
-  call_id: z.coerce.string().optional(),
-  name: z.coerce.string().optional(),
-  arguments: z.coerce.string().optional(),
-  transcript: z.coerce.string().optional(),
-  item_id: z.coerce.string().optional(),
+  reason: z.string().optional(),
   error: z
     .object({ message: z.string().optional() })
     .optional()
     .catch(undefined),
+  message: z.string().optional(),
 });
 
-type RealtimeEvent = z.infer<typeof realtimeEventSchema>;
-
 type VoiceRequest =
-  | { user: string }
-  | { user: string; entries: TranscriptEntry[] }
-  | {
-      user: string;
-      callId: string;
-      name: string;
-      args: JsonValue;
-    };
+  | { user: string; sdp: string }
+  | { user: string; liveSessionId: string; text: string }
+  | { user: string; liveSessionId: string };
 
 const errorResponseSchema = z.object({ error: z.string().optional() });
-const transcriptResponseSchema = z.object({ ok: z.boolean() });
-const toolResponseSchema = z.object({ result: jsonValueSchema });
+const okResponseSchema = z.object({ ok: z.boolean() });
 
 async function postJson<T>(
   path: string,
   body: VoiceRequest,
   responseSchema: z.ZodType<T>,
+  init?: { keepalive?: boolean },
 ): Promise<T> {
   const res = await fetch(`${API}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    keepalive: init?.keepalive,
   });
   const data = await res.json().catch(() => null);
   if (!res.ok) {
@@ -103,6 +74,23 @@ async function postJson<T>(
   return responseSchema.parse(data);
 }
 
+function waitForIceGathering(pc: RTCPeerConnection): Promise<void> {
+  if (pc.iceGatheringState === "complete") return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      pc.removeEventListener("icegatheringstatechange", onState);
+      reject(new Error("Timed out gathering network candidates"));
+    }, ICE_GATHER_TIMEOUT_MS);
+    function onState() {
+      if (pc.iceGatheringState !== "complete") return;
+      window.clearTimeout(timer);
+      pc.removeEventListener("icegatheringstatechange", onState);
+      resolve();
+    }
+    pc.addEventListener("icegatheringstatechange", onState);
+  });
+}
+
 export class DeskVoiceClient {
   private user: string;
   private onState: (s: DeskVoiceState, detail?: string) => void;
@@ -111,13 +99,14 @@ export class DeskVoiceClient {
   private dc: RTCDataChannel | null = null;
   private micStream: MediaStream | null = null;
   private audioEl: HTMLAudioElement | null = null;
+  private liveSessionId: string | null = null;
 
   private idleTimer: number | null = null;
+  private speakingTimer: number | null = null;
+  private closeTimer: number | null = null;
   private connected = false;
-
-  // Transcript mirror POSTs are serialized so rapid finals (barge-in,
-  // fast turn-taking) can't race each other out of order at the server.
-  private transcriptQueue: Promise<void> = Promise.resolve();
+  private closing = false;
+  private started: (() => void) | null = null;
 
   private onVisibilityChange = () => {
     if (document.hidden) this.stop();
@@ -132,7 +121,7 @@ export class DeskVoiceClient {
   }
 
   get active(): boolean {
-    return this.connected;
+    return this.connected && !this.closing;
   }
 
   async start(): Promise<void> {
@@ -154,26 +143,10 @@ export class DeskVoiceClient {
       throw new Error("Microphone permission denied");
     }
 
-    let secret: SecretResponse;
-    try {
-      secret = await postJson(
-        "/secret",
-        { user: this.user },
-        secretResponseSchema,
-      );
-    } catch (e) {
-      this.teardownMedia();
-      const message = e instanceof Error ? e.message : "Failed to start call";
-      this.onState("error", message);
-      throw new Error(message);
-    }
-
     const pc = new RTCPeerConnection();
     this.pc = pc;
-
-    for (const track of this.micStream.getTracks()) {
+    for (const track of this.micStream.getTracks())
       pc.addTrack(track, this.micStream);
-    }
 
     pc.ontrack = (event) => {
       const [stream] = event.streams;
@@ -183,92 +156,101 @@ export class DeskVoiceClient {
       audio.srcObject = stream;
       this.audioEl = audio;
     };
-
     pc.onconnectionstatechange = () => {
       const state = pc.connectionState;
-      if (
-        state === "failed" ||
-        state === "disconnected" ||
-        state === "closed"
-      ) {
+      if (state === "failed" || state === "disconnected") {
         this.onState("error", "connection lost");
-        this.stop();
+        this.teardown();
       }
     };
 
+    // The data channel and its listeners exist before the offer so no
+    // early event is missed.
     const dc = pc.createDataChannel("oai-events");
     this.dc = dc;
-    dc.onopen = () => {
-      this.connected = true;
-      this.resetIdleTimer();
-      this.onState("listening");
-    };
     dc.onmessage = (event) => this.handleEvent(event.data);
+    dc.onclose = () => {
+      if (this.connected && !this.closing) this.onState("error", "call ended");
+      this.teardown();
+    };
 
     try {
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
-
-      const answerRes = await fetch(
-        `https://api.openai.com/v1/realtime/calls?model=${encodeURIComponent(secret.model)}`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${secret.clientSecret}`,
-            "Content-Type": "application/sdp",
-          },
-          body: offer.sdp,
-        },
+      await waitForIceGathering(pc);
+      const sdp = pc.localDescription?.sdp;
+      if (!sdp) throw new Error("No local offer");
+      const live = await postJson(
+        "/live",
+        { user: this.user, sdp },
+        liveResponseSchema,
       );
-      if (!answerRes.ok) {
-        throw new Error(`Realtime call failed: HTTP ${answerRes.status}`);
-      }
-      const answerSdp = await answerRes.text();
-      await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+      this.liveSessionId = live.liveSessionId;
+      await pc.setRemoteDescription({ type: "answer", sdp: live.sdp });
     } catch (e) {
-      const message = e instanceof Error ? e.message : "Failed to connect call";
+      const message = e instanceof Error ? e.message : "Failed to start call";
       this.onState("error", message);
-      this.stop();
+      this.teardown();
       throw new Error(message);
     }
 
     document.addEventListener("visibilitychange", this.onVisibilityChange);
 
-    // Wait for the data channel to actually open before resolving.
+    // The HTTP exchange started the session; it is live once the data
+    // channel delivers session.started.
     await new Promise<void>((resolve, reject) => {
-      if (dc.readyState === "open") return resolve();
-      const onOpen = () => {
-        cleanup();
+      const timer = window.setTimeout(() => {
+        this.started = null;
+        reject(new Error("Call did not start"));
+      }, SESSION_START_TIMEOUT_MS);
+      this.started = () => {
+        window.clearTimeout(timer);
+        this.started = null;
         resolve();
       };
-      const onClose = () => {
-        cleanup();
-        reject(new Error("Call closed before it opened"));
-      };
-      const cleanup = () => {
-        dc.removeEventListener("open", onOpen);
-        dc.removeEventListener("close", onClose);
-      };
-      dc.addEventListener("open", onOpen);
-      dc.addEventListener("close", onClose);
+    }).catch((e: Error) => {
+      this.onState("error", e.message);
+      this.teardown();
+      throw e;
     });
   }
 
+  /** Hang up. Asks the session to close and waits briefly for the final
+   * `session.closed` so pending backend work drains; tears down regardless. */
   stop(): void {
-    if (this.idleTimer !== null) {
-      window.clearTimeout(this.idleTimer);
-      this.idleTimer = null;
+    if (this.closing) return;
+    if (this.dc && this.dc.readyState === "open" && this.connected) {
+      this.closing = true;
+      this.onState("idle");
+      this.dc.send(JSON.stringify({ type: "session.close" }));
+      this.closeTimer = window.setTimeout(
+        () => this.teardown(),
+        CLOSE_GRACE_MS,
+      );
+      return;
     }
-    document.removeEventListener("visibilitychange", this.onVisibilityChange);
-    this.teardownMedia();
-    this.connected = false;
-    this.onState("idle");
+    // No usable data channel: ask the server to close it from its side.
+    if (this.liveSessionId && this.connected) {
+      void postJson(
+        "/live/close",
+        { user: this.user, liveSessionId: this.liveSessionId },
+        okResponseSchema,
+        { keepalive: true },
+      ).catch(() => {});
+    }
+    this.teardown();
   }
 
-  private teardownMedia() {
+  private teardown() {
+    for (const key of ["idleTimer", "speakingTimer", "closeTimer"] as const) {
+      const t = this[key];
+      if (t !== null) window.clearTimeout(t);
+      this[key] = null;
+    }
+    document.removeEventListener("visibilitychange", this.onVisibilityChange);
     if (this.dc) {
       this.dc.onmessage = null;
-      this.dc.onopen = null;
+      this.dc.onclose = null;
       this.dc.close();
       this.dc = null;
     }
@@ -287,26 +269,25 @@ export class DeskVoiceClient {
       this.audioEl.srcObject = null;
       this.audioEl = null;
     }
+    const wasConnected = this.connected;
+    this.connected = false;
+    this.closing = false;
+    this.liveSessionId = null;
+    this.started = null;
+    if (wasConnected) this.onState("idle");
   }
 
+  /** Typed text during a call: queued on the backend server-side, mirrored
+   * there as a user turn. False when there is no live call to take it. */
   sendText(text: string): boolean {
-    if (!this.dc || this.dc.readyState !== "open") return false;
+    if (!this.active || !this.liveSessionId) return false;
     this.resetIdleTimer();
-    this.dc.send(
-      JSON.stringify({
-        type: "conversation.item.create",
-        item: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text }],
-        },
-      }),
-    );
-    this.dc.send(JSON.stringify({ type: "response.create" }));
-    this.mirrorTranscript({
-      id: "voice-typed-" + randomUUID(),
-      role: "user",
-      text,
+    void postJson(
+      "/live/text",
+      { user: this.user, liveSessionId: this.liveSessionId, text },
+      okResponseSchema,
+    ).catch((e) => {
+      console.warn("desk voice typed message failed:", e);
     });
     return true;
   }
@@ -316,111 +297,54 @@ export class DeskVoiceClient {
     this.idleTimer = window.setTimeout(() => this.stop(), IDLE_TIMEOUT_MS);
   }
 
-  private mirrorTranscript(entry: TranscriptEntry) {
-    if (!entry.text.trim()) return;
-    this.transcriptQueue = this.transcriptQueue.then(async () => {
-      try {
-        await postJson(
-          "/transcript",
-          { user: this.user, entries: [entry] },
-          transcriptResponseSchema,
-        );
-      } catch (e) {
-        console.warn("desk voice transcript mirror failed:", e);
-      }
-    });
-  }
-
-  private async handleFunctionCall(event: RealtimeEvent) {
-    const callId = String(event.call_id ?? "");
-    const name = String(event.name ?? "");
-    this.onState("action", name);
-
-    let args: JsonValue = {};
-    try {
-      args = jsonValueSchema.parse(JSON.parse(event.arguments ?? "{}"));
-    } catch {
-      args = {};
-    }
-
-    let output: JsonValue;
-    try {
-      const res = await postJson(
-        "/tool",
-        {
-          user: this.user,
-          callId,
-          name,
-          args,
-        },
-        toolResponseSchema,
-      );
-      output = res.result;
-    } catch (e) {
-      output = { error: e instanceof Error ? e.message : "Tool call failed" };
-    }
-
-    if (!this.dc || this.dc.readyState !== "open") return;
-    this.dc.send(
-      JSON.stringify({
-        type: "conversation.item.create",
-        item: {
-          type: "function_call_output",
-          call_id: callId,
-          output: JSON.stringify(output),
-        },
-      }),
-    );
-    this.dc.send(JSON.stringify({ type: "response.create" }));
-  }
-
   private handleEvent(raw: string) {
-    this.resetIdleTimer();
-    let event: RealtimeEvent;
+    let event: z.infer<typeof liveEventSchema>;
     try {
-      event = realtimeEventSchema.parse(JSON.parse(raw));
+      event = liveEventSchema.parse(JSON.parse(raw));
     } catch {
       return;
     }
+    if (this.closing && event.type !== "session.closed") return;
 
     switch (event.type) {
-      case "input_audio_buffer.speech_started":
+      case "session.started":
+        this.connected = true;
+        this.resetIdleTimer();
+        this.onState("listening");
+        this.started?.();
+        break;
+      case "session.input_transcript.delta":
+        this.resetIdleTimer();
         this.onState("listening");
         break;
-      case "response.created":
+      case "session.output_transcript.delta":
+        this.resetIdleTimer();
+        this.onState("speaking");
+        if (this.speakingTimer !== null)
+          window.clearTimeout(this.speakingTimer);
+        this.speakingTimer = window.setTimeout(() => {
+          this.speakingTimer = null;
+          if (this.active) this.onState("listening");
+        }, SPEAKING_SETTLE_MS);
+        break;
+      case "session.delegation.created":
+        this.resetIdleTimer();
         this.onState("thinking");
         break;
-      case "response.output_audio_transcript.delta":
-        this.onState("speaking");
-        break;
-      case "response.done":
-        this.onState("listening");
-        break;
-      case "conversation.item.input_audio_transcription.completed": {
-        const text = String(event.transcript ?? "");
-        this.mirrorTranscript({
-          id: "voice-" + String(event.item_id ?? randomUUID()),
-          role: "user",
-          text,
-        });
+      case "session.closed": {
+        const reason = event.reason ?? "";
+        const requested =
+          this.closing ||
+          reason === "close_requested" ||
+          reason === "remote_hangup";
+        if (!requested)
+          this.onState("error", `Call ended (${reason || "unknown"})`);
+        this.teardown();
         break;
       }
-      case "response.output_audio_transcript.done": {
-        const text = String(event.transcript ?? "");
-        this.mirrorTranscript({
-          id: "voice-" + String(event.item_id ?? randomUUID()),
-          role: "assistant",
-          text,
-        });
+      case "error":
+        this.onState("error", event.error?.message ?? event.message);
         break;
-      }
-      case "response.function_call_arguments.done":
-        void this.handleFunctionCall(event);
-        break;
-      case "error": {
-        this.onState("error", event.error?.message);
-        break;
-      }
       default:
         break; // unknown event types are ignored
     }

--- a/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
@@ -106,7 +106,14 @@ export class DeskVoiceClient {
   private closeTimer: number | null = null;
   private connected = false;
   private closing = false;
-  private started: (() => void) | null = null;
+  /** `start()` is between its first await and `session.started`. */
+  private starting = false;
+  /** `stop()` came during `start()`; every later step bails out quietly. */
+  private aborted = false;
+  private startWaiter: {
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null = null;
 
   private onVisibilityChange = () => {
     if (document.hidden) this.stop();
@@ -120,15 +127,29 @@ export class DeskVoiceClient {
     this.onState = opts.onState;
   }
 
+  /** Connecting or connected, and not hanging up: the handset shows this
+   * state and `stop()` is the way out of it. */
   get active(): boolean {
-    return this.connected && !this.closing;
+    return (this.connected || this.starting) && !this.closing;
   }
 
+  /** Resolves once the call is live, or returns early without an error when
+   * `stop()` cancelled it midway. Throws on a failed start. */
   async start(): Promise<void> {
-    if (this.connected) return;
-    this.onState("connecting");
+    if (this.connected || this.starting || this.aborted) return;
+    this.starting = true;
     try {
-      this.micStream = await navigator.mediaDevices.getUserMedia({
+      await this.connect();
+    } finally {
+      this.starting = false;
+    }
+  }
+
+  private async connect(): Promise<void> {
+    this.onState("connecting");
+    let mic: MediaStream;
+    try {
+      mic = await navigator.mediaDevices.getUserMedia({
         // Explicit processing constraints: mobile browsers don't reliably
         // default to echo cancellation, and without it the phone's own
         // speaker output comes back in as user speech.
@@ -139,14 +160,21 @@ export class DeskVoiceClient {
         },
       });
     } catch {
+      if (this.aborted) return;
       this.onState("error", "Microphone permission denied");
       throw new Error("Microphone permission denied");
     }
+    if (this.aborted) {
+      // Hung up while the permission prompt was open: teardown ran before
+      // the stream existed, so release it here.
+      for (const track of mic.getTracks()) track.stop();
+      return;
+    }
+    this.micStream = mic;
 
     const pc = new RTCPeerConnection();
     this.pc = pc;
-    for (const track of this.micStream.getTracks())
-      pc.addTrack(track, this.micStream);
+    for (const track of mic.getTracks()) pc.addTrack(track, mic);
 
     pc.ontrack = (event) => {
       const [stream] = event.streams;
@@ -185,9 +213,16 @@ export class DeskVoiceClient {
         { user: this.user, sdp },
         liveResponseSchema,
       );
+      if (this.aborted) {
+        // Hung up while the server was creating the session: it exists and
+        // bills now, so close it from the server side.
+        this.closeServerSide(live.liveSessionId);
+        return;
+      }
       this.liveSessionId = live.liveSessionId;
       await pc.setRemoteDescription({ type: "answer", sdp: live.sdp });
     } catch (e) {
+      if (this.aborted) return;
       const message = e instanceof Error ? e.message : "Failed to start call";
       this.onState("error", message);
       this.teardown();
@@ -200,15 +235,23 @@ export class DeskVoiceClient {
     // channel delivers session.started.
     await new Promise<void>((resolve, reject) => {
       const timer = window.setTimeout(() => {
-        this.started = null;
+        this.startWaiter = null;
         reject(new Error("Call did not start"));
       }, SESSION_START_TIMEOUT_MS);
-      this.started = () => {
-        window.clearTimeout(timer);
-        this.started = null;
-        resolve();
+      this.startWaiter = {
+        resolve: () => {
+          window.clearTimeout(timer);
+          this.startWaiter = null;
+          resolve();
+        },
+        reject: (error) => {
+          window.clearTimeout(timer);
+          this.startWaiter = null;
+          reject(error);
+        },
       };
     }).catch((e: Error) => {
+      if (this.aborted) return;
       this.onState("error", e.message);
       this.teardown();
       throw e;
@@ -218,7 +261,18 @@ export class DeskVoiceClient {
   /** Hang up. Asks the session to close and waits briefly for the final
    * `session.closed` so pending backend work drains; tears down regardless. */
   stop(): void {
-    if (this.closing) return;
+    if (this.closing || this.aborted) return;
+    if (this.starting) {
+      // Cancel the start in progress. Whatever step is awaiting sees
+      // `aborted` and returns; a session the server already created is
+      // closed here or by that step once its id is known.
+      this.aborted = true;
+      if (this.liveSessionId) this.closeServerSide(this.liveSessionId);
+      this.startWaiter?.reject(new Error("Call cancelled"));
+      this.teardown();
+      this.onState("idle");
+      return;
+    }
     if (this.dc && this.dc.readyState === "open" && this.connected) {
       this.closing = true;
       this.onState("idle");
@@ -230,15 +284,18 @@ export class DeskVoiceClient {
       return;
     }
     // No usable data channel: ask the server to close it from its side.
-    if (this.liveSessionId && this.connected) {
-      void postJson(
-        "/live/close",
-        { user: this.user, liveSessionId: this.liveSessionId },
-        okResponseSchema,
-        { keepalive: true },
-      ).catch(() => {});
-    }
+    if (this.liveSessionId && this.connected)
+      this.closeServerSide(this.liveSessionId);
     this.teardown();
+  }
+
+  private closeServerSide(liveSessionId: string) {
+    void postJson(
+      "/live/close",
+      { user: this.user, liveSessionId },
+      okResponseSchema,
+      { keepalive: true },
+    ).catch(() => {});
   }
 
   private teardown() {
@@ -273,23 +330,28 @@ export class DeskVoiceClient {
     this.connected = false;
     this.closing = false;
     this.liveSessionId = null;
-    this.started = null;
+    this.startWaiter = null;
     if (wasConnected) this.onState("idle");
   }
 
   /** Typed text during a call: queued on the backend server-side, mirrored
-   * there as a user turn. False when there is no live call to take it. */
-  sendText(text: string): boolean {
-    if (!this.active || !this.liveSessionId) return false;
+   * there as a user turn. Resolves true only once the server has taken it;
+   * false when there is no live call or the request failed, so the caller
+   * keeps the draft instead of losing the message. */
+  async sendText(text: string): Promise<boolean> {
+    if (!this.connected || this.closing || !this.liveSessionId) return false;
     this.resetIdleTimer();
-    void postJson(
-      "/live/text",
-      { user: this.user, liveSessionId: this.liveSessionId, text },
-      okResponseSchema,
-    ).catch((e) => {
+    try {
+      const res = await postJson(
+        "/live/text",
+        { user: this.user, liveSessionId: this.liveSessionId, text },
+        okResponseSchema,
+      );
+      return res.ok;
+    } catch (e) {
       console.warn("desk voice typed message failed:", e);
-    });
-    return true;
+      return false;
+    }
   }
 
   private resetIdleTimer() {
@@ -311,7 +373,7 @@ export class DeskVoiceClient {
         this.connected = true;
         this.resetIdleTimer();
         this.onState("listening");
-        this.started?.();
+        this.startWaiter?.resolve();
         break;
       case "session.input_transcript.delta":
         this.resetIdleTimer();

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -266,6 +266,10 @@ describe("LiveResponseLoop", () => {
       "response.item.create",
       "response.create",
     ]);
+    // The continue opened another response; the loop is busy until it ends.
+    expect(l.busy).toBe(true);
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", { type: "response.completed" });
     expect(l.busy).toBe(false);
   });
 
@@ -312,9 +316,42 @@ describe("LiveResponseLoop", () => {
       "response.item.create",
       "response.create",
     ]);
+    // The continued response streams and ends with no further calls.
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", { type: "response.completed" });
+    expect(sent.length).toBe(2);
     // Idle loop: a typed message runs the backend right away.
     l.requestContinue();
     expect(sent.at(-1)?.type).toBe("response.create");
     expect(sent.length).toBe(3);
+  });
+
+  test("defers a typed-text continue while a response is still streaming", async () => {
+    const { l, sent } = loop(async () => ({}));
+    l.handle("del_1", { type: "response.created", response: { id: "resp_1" } });
+    // No function call yet, but the response has not finished: a second
+    // response.create now would collide with it.
+    expect(l.busy).toBe(true);
+    l.requestContinue();
+    expect(sent).toEqual([]);
+    l.handle("del_1", { type: "response.completed" });
+    await tick();
+    expect(sent.map((e) => e.type)).toEqual(["response.create"]);
+    // That continue opened a new response; it is busy again until it ends.
+    l.handle("del_1", { type: "response.created", response: { id: "resp_2" } });
+    expect(l.busy).toBe(true);
+    l.handle("del_1", { type: "response.completed" });
+    expect(l.busy).toBe(false);
+    expect(sent.length).toBe(1);
+  });
+
+  test("a failed response frees the loop and runs the deferred typed text", () => {
+    const { l, sent } = loop(async () => ({}));
+    l.handle("del_1", { type: "response.created" });
+    l.requestContinue();
+    expect(sent).toEqual([]);
+    l.handle("del_1", { type: "response.failed" });
+    expect(l.busy).toBe(false);
+    expect(sent.map((e) => e.type)).toEqual(["response.create"]);
   });
 });

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LIVE_CLIENT_ALLOWED_EVENTS,
+  LIVE_ROW_GAP_MS,
+  LiveResponseLoop,
+  VoiceTranscriptRows,
+  buildLiveSessionConfig,
+} from "./desk-voice-live";
+import { registerSessionControl, type SessionControl } from "./session-control";
+
+function registerStubControl(
+  tail: Array<{ type: "user" | "assistant"; content: string }> = [],
+) {
+  registerSessionControl({
+    listSessions: () => [] as ReturnType<SessionControl["listSessions"]>,
+    getSession: () => undefined,
+    transcriptTail: async () =>
+      tail.map((e, i) => ({
+        id: `e${i}`,
+        type: e.type,
+        content: e.content,
+        timestamp: "2026-09-10T09:00:00.000Z",
+      })) as Awaited<ReturnType<SessionControl["transcriptTail"]>>,
+    answerQuestion: () => false,
+    deliverToSession: async () => ({
+      status: "error" as const,
+      message: "not used",
+    }),
+    cancelSession: () => false,
+    reparentSession: async () => ({ ok: false, error: "not used" }),
+    createSession: async () => ({
+      id: "unused",
+      createdBy: "Test",
+      createdAt: "2026-09-10T09:00:00.000Z",
+    }),
+  });
+}
+
+describe("Desk voice GPT-Live session config", () => {
+  test("delegates to a Responses backend that carries the voice tool facade", async () => {
+    registerStubControl();
+    const config = await buildLiveSessionConfig("missing-test-session");
+    expect(config.model).toBe("gpt-live-1");
+    expect(config.delegation.type).toBe("responses");
+    const names = config.delegation.responses.tools.map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "list_current_work",
+        "start_session",
+        "steer_session",
+        "list_sessions",
+        "opensession-admin_list_automations",
+      ]),
+    );
+    // MCP schemas are not strict-mode compatible; every tool opts out.
+    expect(
+      config.delegation.responses.tools.every((t) => t.strict === false),
+    ).toBe(true);
+    // The voice prompt stays short; the rules live in the backend prompt.
+    expect(config.instructions.length).toBeLessThan(2000);
+    expect(config.delegation.responses.instructions).toContain("start_session");
+  });
+
+  test("locks the browser data channel down to hanging up", async () => {
+    registerStubControl();
+    const config = await buildLiveSessionConfig("missing-test-session");
+    expect(LIVE_CLIENT_ALLOWED_EVENTS).toEqual(["session.close"]);
+    expect(config.client.data_channel.allowed_client_events).toEqual([
+      "session.close",
+    ]);
+    const visible = config.client.data_channel.allowed_server_events.map(
+      (s) => s.type,
+    );
+    expect(visible).toContain("session.started");
+    expect(visible).toContain("session.closed");
+    expect(visible).not.toContain("response.event");
+  });
+
+  test("seeds the live model with the recent Desk text conversation", async () => {
+    registerStubControl([
+      { type: "user", content: "what's   running?" },
+      { type: "assistant", content: "Two sessions." },
+    ]);
+    const config = await buildLiveSessionConfig("desk-session");
+    expect(config.input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "what's running?" }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "Two sessions." }],
+      },
+    ]);
+  });
+});
+
+describe("VoiceTranscriptRows", () => {
+  function rows() {
+    const out: Array<{ id: string; role: string; text: string }> = [];
+    const r = new VoiceTranscriptRows({
+      gapMs: LIVE_ROW_GAP_MS,
+      idleMs: 60_000,
+      rowId: (role, startMs) => `${role}-${startMs}`,
+      onRow: (row) => out.push(row),
+    });
+    return { r, out };
+  }
+
+  test("joins fragments of one utterance and splits on a timeline gap", () => {
+    const { r, out } = rows();
+    r.push({ role: "user", delta: "What is", startMs: 1000, endMs: 1200 });
+    r.push({ role: "user", delta: " running?", startMs: 1200, endMs: 1800 });
+    expect(out).toEqual([]);
+    r.push({ role: "user", delta: "Also,", startMs: 5000, endMs: 5300 });
+    expect(out).toEqual([
+      { id: "user-1000", role: "user", text: "What is running?" },
+    ]);
+    r.flushAll();
+    expect(out[1]).toEqual({ id: "user-5000", role: "user", text: "Also," });
+  });
+
+  test("keeps overlapping user and assistant rows independent", () => {
+    const { r, out } = rows();
+    r.push({ role: "assistant", delta: "Sure, ", startMs: 100, endMs: 600 });
+    r.push({ role: "user", delta: "wait", startMs: 400, endMs: 700 });
+    r.push({
+      role: "assistant",
+      delta: "one moment.",
+      startMs: 600,
+      endMs: 1200,
+    });
+    r.flushAll();
+    expect(out).toEqual([
+      { id: "user-400", role: "user", text: "wait" },
+      { id: "assistant-100", role: "assistant", text: "Sure, one moment." },
+    ]);
+  });
+
+  test("drops whitespace-only rows", () => {
+    const { r, out } = rows();
+    r.push({ role: "user", delta: "  ", startMs: 0, endMs: 100 });
+    r.flushAll();
+    expect(out).toEqual([]);
+  });
+});
+
+describe("LiveResponseLoop", () => {
+  function loop(
+    runTool: (
+      callId: string,
+      name: string,
+      args: Record<string, unknown>,
+    ) => Promise<unknown>,
+  ) {
+    const sent: Array<Record<string, unknown>> = [];
+    const l = new LiveResponseLoop({ send: (e) => sent.push(e), runTool });
+    return { l, sent };
+  }
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+
+  test("answers every function call before continuing the response", async () => {
+    const ran: string[] = [];
+    const { l, sent } = loop(async (_id, name, args) => {
+      ran.push(name);
+      return { ok: true, args };
+    });
+    l.handle("del_1", { type: "response.created", response: { id: "resp_1" } });
+    l.handle("del_1", {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        call_id: "call_a",
+        name: "list_current_work",
+        arguments: "{}",
+      },
+    });
+    l.handle("del_1", {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        call_id: "call_b",
+        name: "inspect_session",
+        arguments: '{"session_id":"os-1"}',
+      },
+    });
+    l.handle("del_1", { type: "response.completed" });
+    await tick();
+    await tick();
+    expect(ran).toEqual(["list_current_work", "inspect_session"]);
+    expect(sent.map((e) => e.type)).toEqual([
+      "response.item.create",
+      "response.item.create",
+      "response.create",
+    ]);
+    const outputs = sent
+      .filter((e) => e.type === "response.item.create")
+      .map((e) => e.item as { call_id: string; output: string });
+    expect(outputs.map((o) => o.call_id).sort()).toEqual(["call_a", "call_b"]);
+    expect(JSON.parse(outputs[1].output)).toEqual({
+      ok: true,
+      args: { session_id: "os-1" },
+    });
+  });
+
+  test("waits for a slow tool even when the response completes first", async () => {
+    let release: (v: unknown) => void = () => {};
+    const { l, sent } = loop(() => new Promise((r) => (release = r)));
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", {
+      type: "response.output_item.done",
+      item: { type: "function_call", call_id: "c1", name: "start_session" },
+    });
+    l.handle("del_1", { type: "response.completed" });
+    await tick();
+    expect(sent).toEqual([]);
+    expect(l.busy).toBe(true);
+    release({ id: "os-new", started: true });
+    await tick();
+    await tick();
+    expect(sent.map((e) => e.type)).toEqual([
+      "response.item.create",
+      "response.create",
+    ]);
+    expect(l.busy).toBe(false);
+  });
+
+  test("reports a thrown tool as an error output instead of stalling", async () => {
+    const { l, sent } = loop(async () => {
+      throw new Error("boom");
+    });
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", {
+      type: "response.output_item.done",
+      item: { type: "function_call", call_id: "c1", name: "steer_session" },
+    });
+    l.handle("del_1", { type: "response.completed" });
+    await tick();
+    await tick();
+    const output = sent[0].item as { output: string };
+    expect(JSON.parse(output.output)).toEqual({ error: "boom" });
+    expect(sent[1].type).toBe("response.create");
+  });
+
+  test("does not continue a response that made no calls", async () => {
+    const { l, sent } = loop(async () => ({}));
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", { type: "response.completed" });
+    await tick();
+    expect(sent).toEqual([]);
+  });
+
+  test("defers a typed-text continue until outstanding calls are answered", async () => {
+    let release: (v: unknown) => void = () => {};
+    const { l, sent } = loop(() => new Promise((r) => (release = r)));
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", {
+      type: "response.output_item.done",
+      item: { type: "function_call", call_id: "c1", name: "list_current_work" },
+    });
+    l.requestContinue();
+    expect(sent).toEqual([]);
+    l.handle("del_1", { type: "response.completed" });
+    release({ sessions: [] });
+    await tick();
+    await tick();
+    expect(sent.map((e) => e.type)).toEqual([
+      "response.item.create",
+      "response.create",
+    ]);
+    // Idle loop: a typed message runs the backend right away.
+    l.requestContinue();
+    expect(sent.at(-1)?.type).toBe("response.create");
+    expect(sent.length).toBe(3);
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -181,6 +181,26 @@ describe("VoiceTranscriptRows", () => {
     ]);
   });
 
+  test("an interrupted reply still leads the interruption when a later fragment closes both", () => {
+    const { r, out } = rows();
+    r.push({
+      role: "assistant",
+      delta: "Sure, one moment.",
+      startMs: 100,
+      endMs: 1200,
+    });
+    r.push({ role: "user", delta: "wait", startMs: 400, endMs: 700 });
+    // Past the user's gap and past the assistant's end: both rows close, and
+    // the one that started first goes out first.
+    r.push({ role: "user", delta: "go on.", startMs: 5000, endMs: 5400 });
+    expect(out).toEqual([
+      { id: "assistant-100", role: "assistant", text: "Sure, one moment." },
+      { id: "user-400", role: "user", text: "wait" },
+    ]);
+    r.flushAll();
+    expect(out[2]).toEqual({ id: "user-5000", role: "user", text: "go on." });
+  });
+
   test("drops whitespace-only rows", () => {
     const { r, out } = rows();
     r.push({ role: "user", delta: "  ", startMs: 0, endMs: 100 });
@@ -351,7 +371,33 @@ describe("LiveResponseLoop", () => {
     l.requestContinue();
     expect(sent).toEqual([]);
     l.handle("del_1", { type: "response.failed" });
-    expect(l.busy).toBe(false);
     expect(sent.map((e) => e.type)).toEqual(["response.create"]);
+    // Busy again: that create has not been answered with response.created.
+    expect(l.busy).toBe(true);
+    l.handle("del_1", { type: "response.created" });
+    l.handle("del_1", { type: "response.completed" });
+    expect(l.busy).toBe(false);
+  });
+
+  test("back-to-back typed messages open one response at a time", () => {
+    const { l, sent } = loop(async () => ({}));
+    // Two /live/text requests before the backend has acknowledged the first
+    // response.create: the second waits rather than colliding.
+    l.requestContinue();
+    l.requestContinue();
+    expect(sent.map((e) => e.type)).toEqual(["response.create"]);
+    expect(l.busy).toBe(true);
+    l.handle("del_1", { type: "response.created", response: { id: "resp_1" } });
+    expect(l.busy).toBe(true);
+    l.handle("del_1", { type: "response.completed" });
+    // The deferred second message runs once the first response ends.
+    expect(sent.map((e) => e.type)).toEqual([
+      "response.create",
+      "response.create",
+    ]);
+    l.handle("del_1", { type: "response.created", response: { id: "resp_2" } });
+    l.handle("del_1", { type: "response.completed" });
+    expect(l.busy).toBe(false);
+    expect(sent.length).toBe(2);
   });
 });

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -122,7 +122,7 @@ describe("VoiceTranscriptRows", () => {
     expect(out[1]).toEqual({ id: "user-5000", role: "user", text: "Also," });
   });
 
-  test("keeps overlapping user and assistant rows independent", () => {
+  test("keeps overlapping user and assistant rows independent, in start order", () => {
     const { r, out } = rows();
     r.push({ role: "assistant", delta: "Sure, ", startMs: 100, endMs: 600 });
     r.push({ role: "user", delta: "wait", startMs: 400, endMs: 700 });
@@ -134,8 +134,50 @@ describe("VoiceTranscriptRows", () => {
     });
     r.flushAll();
     expect(out).toEqual([
-      { id: "user-400", role: "user", text: "wait" },
       { id: "assistant-100", role: "assistant", text: "Sure, one moment." },
+      { id: "user-400", role: "user", text: "wait" },
+    ]);
+  });
+
+  test("ends a turn when the other speaker starts after it, so user/assistant/user stays three rows in order", () => {
+    const { r, out } = rows();
+    r.push({ role: "user", delta: "What's running?", startMs: 0, endMs: 800 });
+    r.push({
+      role: "assistant",
+      delta: "Two sessions.",
+      startMs: 900,
+      endMs: 1800,
+    });
+    // Within the user's 2s gap of the first fragment, but a new turn: the
+    // assistant answered in between.
+    r.push({ role: "user", delta: "Stop one.", startMs: 1900, endMs: 2400 });
+    expect(out).toEqual([
+      { id: "user-0", role: "user", text: "What's running?" },
+      { id: "assistant-900", role: "assistant", text: "Two sessions." },
+    ]);
+    r.flushAll();
+    expect(out[2]).toEqual({
+      id: "user-1900",
+      role: "user",
+      text: "Stop one.",
+    });
+  });
+
+  test("puts a late-arriving user fragment ahead of the reply that followed it", () => {
+    const { r, out } = rows();
+    // Recognition lags playback: the reply's transcript shows up first.
+    r.push({
+      role: "assistant",
+      delta: "Two sessions.",
+      startMs: 900,
+      endMs: 1800,
+    });
+    r.push({ role: "user", delta: "What's running?", startMs: 0, endMs: 800 });
+    // The assistant's idle fires first; the question still goes out first.
+    r.flush("assistant");
+    expect(out).toEqual([
+      { id: "user-0", role: "user", text: "What's running?" },
+      { id: "assistant-900", role: "assistant", text: "Two sessions." },
     ]);
   });
 

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -1,0 +1,718 @@
+/**
+ * Desk voice mode on GPT-Live — the web Desk's voice engine.
+ *
+ * GPT-Live splits a call in two: a full-duplex voice model that only talks,
+ * and a backend it delegates to whenever the user needs real state read or
+ * changed. Here the backend is OpenAI's Responses delegation (gpt-5.6-terra)
+ * carrying the Desk's voice tool facade, and this server executes every tool
+ * call it makes. The browser never sees a credential and its data channel is
+ * locked down to transcript/lifecycle events plus `session.close`.
+ *
+ * Call lifecycle:
+ * 1. The browser posts its WebRTC SDP offer to routes/desk-voice.ts.
+ * 2. createLiveVoiceCall() builds the server-owned session config, creates
+ *    the Live session with the instance API key (the SDP exchange happens in
+ *    that same request), then attaches a sideband WebSocket to it before
+ *    handing the SDP answer back. Nothing the model does is missed.
+ * 3. The sideband receives every session event: transcript deltas are
+ *    grouped into rows and mirrored into the Desk transcript; nested
+ *    Responses events surface function calls, which run as the verified user
+ *    and are answered with `response.item.create` + `response.create`.
+ * 4. `session.closed` (or a dead sideband) finalizes the call: rows flush,
+ *    timers clear, the registry entry goes away.
+ *
+ * Typed text during a call is queued as a user message on the Responses
+ * backend, exactly as the Live docs prescribe for exact values.
+ *
+ * Module invariants: no sockets or timers at import time (everything hangs
+ * off a request), and nothing here touches the gateway thread synchronously
+ * beyond what desk-voice.ts already does for mirroring.
+ */
+
+import { ensureDeskSession } from "./desk";
+import {
+  VOICE_TOOLS,
+  executeVoiceTool,
+  listVoiceMcpTools,
+  mirrorVoiceEntries,
+  mirrorVoiceToolCall,
+  recentDeskTurns,
+  requireVoiceApiKey,
+  truncate,
+} from "./desk-voice";
+
+export const DESK_LIVE_MODEL = "gpt-live-1";
+/** Reasoning + tool selection model behind the voice. Terra is OpenAI's
+ * recommended default for Live backends; Luna is the cost-sensitive option. */
+export const DESK_LIVE_BACKEND_MODEL = "gpt-5.6-terra";
+const LIVE_SESSIONS_URL = "https://api.openai.com/v1/live/sessions";
+
+/** Session timeline gap (ms) between two fragments of the same speaker that
+ * starts a new transcript row. Rows are a record, not captions, so this is
+ * tuned toward whole utterances rather than reactive display. */
+export const LIVE_ROW_GAP_MS = 2000;
+/** Wall-clock quiet period after which an open row is mirrored anyway. */
+const LIVE_ROW_IDLE_MS = 2500;
+/** Server-side backstops: the browser has its own idle timer, but the server
+ * pays per second, so a call whose client silently vanished must not run
+ * until OpenAI's own expiry. */
+const LIVE_IDLE_CLOSE_MS = 3 * 60 * 1000;
+const LIVE_MAX_CALL_MS = 30 * 60 * 1000;
+const LIVE_ATTACH_TIMEOUT_MS = 10_000;
+/** How long to wait for `session.closed` after asking for a close before
+ * treating the call as finished anyway. */
+const LIVE_CLOSE_GRACE_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Prompts. Live wants a short voice prompt (speech, turn-taking, when to
+// delegate) and a separate backend prompt carrying the actual rules.
+
+export const LIVE_VOICE_INSTRUCTIONS = `You are the user's Desk, their standing concierge for the Open Session workspace, on a voice call. You are the same Desk they type to; this call continues that conversation.
+
+How to talk: short, natural sentences, one or two per reply. No markdown, no lists. Never read ids aloud; refer to sessions by title. If the user pauses mid-thought, wait. If they interrupt, stop and listen.
+
+You know nothing about real state yourself. Anything about sessions, todos, repos, automations, or what is running comes from the backend: delegate, say briefly that you're checking or doing it, and keep the conversation going while it works. Never guess or invent state. If the backend reports a failure, say so plainly.
+
+Delegate actions too: capturing a todo, starting a worker session, sending a message into a session. Before starting or steering a session, confirm in one line what you're about to do; don't over-confirm reads. When a result comes back, paraphrase it naturally instead of reading it out.`;
+
+export const LIVE_BACKEND_INSTRUCTIONS = `## Voice conversation context
+You are the backend for the user's Desk, their standing concierge for the Open Session workspace, during a live voice call. The voice model handles speech and delegates to you whenever the user needs real state read or changed. Transcripts can contain mistakes, unfinished phrases, and later corrections: use the latest context and verified tool results. If a needed detail is still unclear, return a question instead of guessing.
+
+## Task instructions
+- Use the tools for anything about real state: sessions, todos, repos, automations. Never invent state or a successful action.
+- You are an orchestrator, not the worker. For anything beyond a quick answer or a list edit, start a scoped worker session (start_session) with a self-contained prompt and report that you did. Use mode "code" when it should edit files or open a PR, "ask" for read-only investigation.
+- Capture todos the moment the user mentions wanting or needing to do something. Never drop a todo unprompted.
+- Run independent lookups together. Do not repeat an action that already ran.
+
+## Return the result
+Return two or three plain sentences the voice model can say aloud: the relevant facts, whether the task is done, and what comes next. Refer to sessions by title, never by id. No markdown, no lists, no raw tool output.`;
+
+/** The browser's data channel may only ask to hang up. Tool results, session
+ * updates, and typed text all travel through this server. */
+export const LIVE_CLIENT_ALLOWED_EVENTS = ["session.close"] as const;
+/** What the browser gets to see: enough for call state and captions, none of
+ * the nested backend traffic (tool arguments and results stay server-side). */
+export const LIVE_CLIENT_VISIBLE_EVENTS = [
+  "session.started",
+  "session.closed",
+  "session.input_transcript.delta",
+  "session.output_transcript.delta",
+  "session.delegation.created",
+  "error",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Session config — server-owned, so the client can't widen the tool list or
+// its own data-channel permissions.
+
+export interface LiveFunctionTool {
+  type: string;
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
+  strict?: boolean;
+}
+
+export async function buildLiveSessionConfig(
+  sessionId: string,
+  user = "Open Session",
+) {
+  const turns = await recentDeskTurns(sessionId);
+  const tools: LiveFunctionTool[] = [
+    ...VOICE_TOOLS,
+    ...((await listVoiceMcpTools(
+      user,
+      sessionId,
+    )) as unknown as LiveFunctionTool[]),
+    // Responses function tools default to strict schemas, which the MCP
+    // inventory's schemas do not satisfy; strict mode buys nothing here.
+  ].map((tool) => ({ ...tool, strict: false }));
+  return {
+    model: DESK_LIVE_MODEL,
+    instructions: LIVE_VOICE_INSTRUCTIONS,
+    ...(turns.length
+      ? {
+          input: turns.map((t) => ({
+            type: "message",
+            role: t.role,
+            content: [
+              {
+                type: t.role === "user" ? "input_text" : "text",
+                text: t.text,
+              },
+            ],
+          })),
+        }
+      : {}),
+    audio: { output: { voice: "marin" } },
+    delegation: {
+      type: "responses",
+      responses: {
+        model: DESK_LIVE_BACKEND_MODEL,
+        instructions: LIVE_BACKEND_INSTRUCTIONS,
+        tools,
+        tool_choice: "auto",
+        parallel_tool_calls: true,
+        reasoning: { effort: "low" },
+        text: { verbosity: "low" },
+      },
+    },
+    client: {
+      data_channel: {
+        allowed_client_events: [...LIVE_CLIENT_ALLOWED_EVENTS],
+        allowed_server_events: LIVE_CLIENT_VISIBLE_EVENTS.map((type) => ({
+          type,
+        })),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transcript rows. Live emits timed fragments per speaker with no turn
+// boundary, so rows are grouped by session-timeline gap and flushed on a
+// wall-clock idle. Each flushed row is one mirrored transcript entry.
+
+export type VoiceRole = "user" | "assistant";
+
+export interface TranscriptFragment {
+  role: VoiceRole;
+  delta: string;
+  startMs: number;
+  endMs: number;
+}
+
+interface OpenRow {
+  id: string;
+  text: string;
+  startMs: number;
+  endMs: number;
+}
+
+export class VoiceTranscriptRows {
+  private open: Record<VoiceRole, OpenRow | null> = {
+    user: null,
+    assistant: null,
+  };
+  private idleTimers: Record<VoiceRole, ReturnType<typeof setTimeout> | null> =
+    { user: null, assistant: null };
+
+  constructor(
+    private readonly opts: {
+      gapMs: number;
+      idleMs: number;
+      rowId: (role: VoiceRole, startMs: number) => string;
+      onRow: (row: { id: string; role: VoiceRole; text: string }) => void;
+    },
+  ) {}
+
+  push(fragment: TranscriptFragment): void {
+    const { role } = fragment;
+    const current = this.open[role];
+    if (current && fragment.startMs - current.endMs > this.opts.gapMs)
+      this.flush(role);
+    const row = this.open[role];
+    if (row) {
+      // Concatenate exactly as received: fragments carry their own spacing.
+      row.text += fragment.delta;
+      row.endMs = Math.max(row.endMs, fragment.endMs);
+    } else {
+      this.open[role] = {
+        id: this.opts.rowId(role, fragment.startMs),
+        text: fragment.delta,
+        startMs: fragment.startMs,
+        endMs: fragment.endMs,
+      };
+    }
+    this.armIdle(role);
+  }
+
+  flush(role: VoiceRole): void {
+    const timer = this.idleTimers[role];
+    if (timer) {
+      clearTimeout(timer);
+      this.idleTimers[role] = null;
+    }
+    const row = this.open[role];
+    this.open[role] = null;
+    if (row && row.text.trim())
+      this.opts.onRow({ id: row.id, role, text: row.text.trim() });
+  }
+
+  flushAll(): void {
+    this.flush("user");
+    this.flush("assistant");
+  }
+
+  private armIdle(role: VoiceRole) {
+    const existing = this.idleTimers[role];
+    if (existing) clearTimeout(existing);
+    this.idleTimers[role] = setTimeout(
+      () => this.flush(role),
+      this.opts.idleMs,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Responses delegation loop. Nested Responses events arrive wrapped in
+// `response.event`; completed function calls are read from
+// `response.output_item.done` (the only event carrying call_id + name +
+// arguments together), executed, answered with `response.item.create`, and
+// the response is continued with `response.create` once every call of that
+// response has an output and the response itself has finished streaming.
+
+export interface LiveResponseEvent {
+  type: string;
+  response?: { id?: string };
+  item?: {
+    type?: string;
+    id?: string;
+    call_id?: string;
+    name?: string;
+    arguments?: string;
+  };
+}
+
+interface DelegationState {
+  /** Function calls of the current response still awaiting an output. */
+  open: Set<string>;
+  /** Function calls seen in the current response, answered or not. */
+  calls: number;
+  finished: boolean;
+}
+
+export class LiveResponseLoop {
+  private delegations = new Map<string, DelegationState>();
+  /** A continue requested (typed text) while calls were still open. */
+  private continueWanted = false;
+
+  constructor(
+    private readonly io: {
+      send: (event: Record<string, unknown>) => void;
+      runTool: (
+        callId: string,
+        name: string,
+        args: Record<string, unknown>,
+      ) => Promise<unknown>;
+    },
+  ) {}
+
+  get busy(): boolean {
+    for (const d of this.delegations.values()) if (d.open.size) return true;
+    return false;
+  }
+
+  handle(delegationId: string, event: LiveResponseEvent): void {
+    const state = this.delegations.get(delegationId) ?? {
+      open: new Set<string>(),
+      calls: 0,
+      finished: false,
+    };
+    this.delegations.set(delegationId, state);
+    switch (event.type) {
+      case "response.created":
+        // A fresh response under this delegation (first, or the one our
+        // response.create continued). Its own calls start from zero.
+        state.open.clear();
+        state.calls = 0;
+        state.finished = false;
+        break;
+      case "response.output_item.done": {
+        const item = event.item;
+        if (item?.type !== "function_call" || !item.call_id || !item.name)
+          break;
+        const callId = item.call_id;
+        state.open.add(callId);
+        state.calls += 1;
+        void this.execute(
+          delegationId,
+          state,
+          callId,
+          item.name,
+          item.arguments,
+        );
+        break;
+      }
+      case "response.completed":
+      case "response.done":
+        state.finished = true;
+        this.maybeContinue(delegationId, state);
+        break;
+      case "response.failed":
+      case "response.incomplete":
+      case "response.cancelled":
+        state.finished = true;
+        state.open.clear();
+        this.delegations.delete(delegationId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /** Ask the backend to run (typed text): immediate when idle, otherwise
+   * deferred until the outstanding tool results have been submitted. */
+  requestContinue(): void {
+    if (this.busy) {
+      this.continueWanted = true;
+      return;
+    }
+    this.continueWanted = false;
+    this.io.send({ type: "response.create" });
+  }
+
+  private async execute(
+    delegationId: string,
+    state: DelegationState,
+    callId: string,
+    name: string,
+    rawArgs: string | undefined,
+  ) {
+    let args: Record<string, unknown> = {};
+    try {
+      const parsed: unknown = JSON.parse(rawArgs || "{}");
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed))
+        args = parsed as Record<string, unknown>;
+    } catch {}
+    let output: unknown;
+    try {
+      output = await this.io.runTool(callId, name, args);
+    } catch (e) {
+      output = { error: e instanceof Error ? e.message : String(e) };
+    }
+    if (!state.open.has(callId)) return; // response failed meanwhile
+    this.io.send({
+      type: "response.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output: JSON.stringify(output) ?? "",
+      },
+    });
+    state.open.delete(callId);
+    this.maybeContinue(delegationId, state);
+  }
+
+  private maybeContinue(delegationId: string, state: DelegationState) {
+    if (!state.finished || state.open.size) return;
+    // Nothing to answer: the response finished without tool calls. Only a
+    // deferred typed-text continue still needs a response.create.
+    if (state.calls === 0 && !this.continueWanted) {
+      this.delegations.delete(delegationId);
+      return;
+    }
+    this.continueWanted = false;
+    state.finished = false;
+    state.calls = 0;
+    this.io.send({ type: "response.create" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Call registry.
+
+interface LiveCall {
+  id: string;
+  user: string;
+  deskSessionId: string;
+  socket: WebSocket;
+  rows: VoiceTranscriptRows;
+  loop: LiveResponseLoop;
+  startedAt: number;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+  maxTimer: ReturnType<typeof setTimeout> | null;
+  closeTimer: ReturnType<typeof setTimeout> | null;
+  finalized: boolean;
+}
+
+const calls = new Map<string, LiveCall>();
+
+/** Exported for tests and diagnostics; never exposes sockets. */
+export function activeLiveCalls(): Array<{
+  id: string;
+  user: string;
+  startedAt: number;
+}> {
+  return [...calls.values()].map((c) => ({
+    id: c.id,
+    user: c.user,
+    startedAt: c.startedAt,
+  }));
+}
+
+function sendEvent(call: LiveCall, event: Record<string, unknown>): void {
+  if (call.socket.readyState !== WebSocket.OPEN) return;
+  try {
+    call.socket.send(JSON.stringify(event));
+  } catch (e) {
+    console.error(`[desk-voice-live] send failed for ${call.id}:`, e);
+  }
+}
+
+function requestClose(call: LiveCall): void {
+  if (call.finalized) return;
+  sendEvent(call, { type: "session.close" });
+  if (!call.closeTimer)
+    call.closeTimer = setTimeout(
+      () => finalize(call, "close timeout"),
+      LIVE_CLOSE_GRACE_MS,
+    );
+}
+
+function touch(call: LiveCall): void {
+  if (call.idleTimer) clearTimeout(call.idleTimer);
+  call.idleTimer = setTimeout(() => {
+    console.log(`[desk-voice-live] ${call.id} idle, closing`);
+    requestClose(call);
+  }, LIVE_IDLE_CLOSE_MS);
+}
+
+function finalize(call: LiveCall, reason: string, seconds?: number): void {
+  if (call.finalized) return;
+  call.finalized = true;
+  calls.delete(call.id);
+  for (const t of [call.idleTimer, call.maxTimer, call.closeTimer])
+    if (t) clearTimeout(t);
+  call.rows.flushAll();
+  try {
+    if (
+      call.socket.readyState === WebSocket.OPEN ||
+      call.socket.readyState === WebSocket.CONNECTING
+    )
+      call.socket.close();
+  } catch {}
+  console.log(
+    `[desk-voice-live] ${call.id} ended (${reason})${
+      seconds !== undefined ? ` after ${Math.round(seconds)}s` : ""
+    } user=${call.user}`,
+  );
+}
+
+interface LiveServerEvent {
+  type: string;
+  delta?: string;
+  start_ms?: number;
+  end_ms?: number;
+  delegation_id?: string | null;
+  event?: LiveResponseEvent;
+  reason?: string;
+  usage?: { seconds?: number };
+  error?: { message?: string; code?: string };
+  message?: string;
+  code?: string;
+}
+
+function handleSidebandEvent(call: LiveCall, event: LiveServerEvent): void {
+  switch (event.type) {
+    case "session.input_transcript.delta":
+    case "session.output_transcript.delta":
+      if (typeof event.delta === "string") {
+        call.rows.push({
+          role:
+            event.type === "session.input_transcript.delta"
+              ? "user"
+              : "assistant",
+          delta: event.delta,
+          startMs: event.start_ms ?? 0,
+          endMs: event.end_ms ?? event.start_ms ?? 0,
+        });
+        touch(call);
+      }
+      break;
+    case "session.delegation.created":
+      touch(call);
+      break;
+    case "response.event":
+      if (event.event && typeof event.delegation_id === "string")
+        call.loop.handle(event.delegation_id, event.event);
+      break;
+    case "session.closed":
+      finalize(call, event.reason ?? "closed", event.usage?.seconds);
+      break;
+    case "error":
+      console.error(
+        `[desk-voice-live] ${call.id} error: ${
+          event.error?.message ?? event.message ?? JSON.stringify(event)
+        }`,
+      );
+      break;
+    default:
+      break;
+  }
+}
+
+function attachSideband(apiKey: string, liveId: string): Promise<WebSocket> {
+  // Bun's WebSocket accepts request headers; the DOM lib signature doesn't
+  // know about them, hence the narrow cast.
+  const Ctor = WebSocket as unknown as new (
+    url: string,
+    options: { headers: Record<string, string> },
+  ) => WebSocket;
+  const socket = new Ctor(
+    `wss://api.openai.com/v1/live/sessions/${encodeURIComponent(liveId)}/attach`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+  );
+  return new Promise<WebSocket>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error("Timed out attaching to the Live session"));
+    }, LIVE_ATTACH_TIMEOUT_MS);
+    socket.onopen = () => {
+      clearTimeout(timer);
+      resolve(socket);
+    };
+    socket.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error("Could not attach to the Live session"));
+    };
+    socket.onclose = (ev) => {
+      clearTimeout(timer);
+      reject(
+        new Error(`Live session sideband closed before it opened (${ev.code})`),
+      );
+    };
+  });
+}
+
+export async function createLiveVoiceCall(
+  user: string,
+  offerSdp: string,
+): Promise<{ liveSessionId: string; sdp: string; sessionId: string }> {
+  const key = requireVoiceApiKey();
+  const { sessionId } = ensureDeskSession(user);
+
+  // One call per user: a reload or a second tab must not leave the old call
+  // (and its per-second billing) running headless.
+  for (const existing of calls.values())
+    if (existing.user === user) requestClose(existing);
+
+  const session = await buildLiveSessionConfig(sessionId, user);
+  const res = await fetch(LIVE_SESSIONS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session,
+      transport: { type: "webrtc", sdp: offerSdp },
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `OpenAI rejected the voice session (${res.status}): ${truncate(text, 300)}`,
+    );
+  }
+  const data = (await res.json()) as {
+    session?: { id?: string };
+    transport?: { sdp?: string };
+  };
+  const liveId = data.session?.id;
+  const answer = data.transport?.sdp;
+  if (!liveId || !answer)
+    throw new Error("OpenAI returned no Live session id or SDP answer");
+
+  const socket = await attachSideband(key, liveId);
+  const call: LiveCall = {
+    id: liveId,
+    user,
+    deskSessionId: sessionId,
+    socket,
+    rows: new VoiceTranscriptRows({
+      gapMs: LIVE_ROW_GAP_MS,
+      idleMs: LIVE_ROW_IDLE_MS,
+      rowId: (role, startMs) => `voice-${liveId}-${role}-${startMs}`,
+      onRow: (row) =>
+        mirrorVoiceEntries(user, [
+          { id: row.id, role: row.role, text: row.text },
+        ]),
+    }),
+    loop: new LiveResponseLoop({
+      send: (event) => sendEvent(call, event),
+      runTool: async (callId, name, args) => {
+        try {
+          const result = await executeVoiceTool(user, name, args);
+          mirrorVoiceToolCall(user, callId, name, args, result);
+          return result;
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          mirrorVoiceToolCall(user, callId, name, args, { error: message });
+          return { error: message };
+        }
+      },
+    }),
+    startedAt: Date.now(),
+    idleTimer: null,
+    maxTimer: null,
+    closeTimer: null,
+    finalized: false,
+  };
+  calls.set(liveId, call);
+  socket.onopen = null;
+  socket.onerror = (ev) => {
+    console.error(`[desk-voice-live] ${liveId} sideband error`, ev);
+  };
+  socket.onclose = () => finalize(call, "sideband closed");
+  socket.onmessage = (ev) => {
+    let event: LiveServerEvent;
+    try {
+      event = JSON.parse(String(ev.data)) as LiveServerEvent;
+    } catch {
+      return;
+    }
+    handleSidebandEvent(call, event);
+  };
+  touch(call);
+  call.maxTimer = setTimeout(() => {
+    console.log(`[desk-voice-live] ${liveId} hit the call length cap`);
+    requestClose(call);
+  }, LIVE_MAX_CALL_MS);
+  console.log(`[desk-voice-live] ${liveId} started user=${user}`);
+  return { liveSessionId: liveId, sdp: answer, sessionId };
+}
+
+function ownedCall(user: string, liveSessionId: string): LiveCall | undefined {
+  const call = calls.get(liveSessionId);
+  return call && call.user === user ? call : undefined;
+}
+
+/** Typed text during a call goes to the Responses backend as a user message
+ * and is mirrored like a spoken turn. False when the call is not live. */
+export function sendLiveVoiceText(
+  user: string,
+  liveSessionId: string,
+  text: string,
+): boolean {
+  const call = ownedCall(user, liveSessionId);
+  if (!call || call.finalized) return false;
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  sendEvent(call, {
+    type: "response.item.create",
+    item: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: trimmed }],
+    },
+  });
+  call.loop.requestContinue();
+  mirrorVoiceEntries(user, [
+    { id: `voice-typed-${crypto.randomUUID()}`, role: "user", text: trimmed },
+  ]);
+  touch(call);
+  return true;
+}
+
+/** Hang up from the server side (browser backstop when its data channel is
+ * already gone). Returns false when there is no such call for this user. */
+export function closeLiveVoiceCall(
+  user: string,
+  liveSessionId: string,
+): boolean {
+  const call = ownedCall(user, liveSessionId);
+  if (!call) return false;
+  requestClose(call);
+  return true;
+}

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -219,13 +219,17 @@ export class VoiceTranscriptRows {
 
   push(fragment: TranscriptFragment): void {
     const { role } = fragment;
+    // Every open row this fragment closes goes out first, in start order:
+    // the same speaker's row when the gap is too long, the other speaker's
+    // when it ended before this fragment began (that turn is over and belongs
+    // ahead of this one). Whichever closed, the earlier-started row leads.
+    const done: VoiceRole[] = [];
     const current = this.open[role];
     if (current && fragment.startMs - current.endMs > this.opts.gapMs)
-      this.flush(role);
-    // The other speaker's row ended before this fragment began: that turn is
-    // over and belongs ahead of this one.
+      done.push(role);
     const other = this.open[otherRole(role)];
-    if (other && other.endMs <= fragment.startMs) this.flush(otherRole(role));
+    if (other && other.endMs <= fragment.startMs) done.push(otherRole(role));
+    this.flushInStartOrder(done);
     const row = this.open[role];
     if (row) {
       // Concatenate exactly as received: fragments carry their own spacing.
@@ -242,32 +246,45 @@ export class VoiceTranscriptRows {
     this.armIdle(role);
   }
 
+  /** Flushes one speaker's row (its idle fired). A row of the other speaker
+   * that ended before this one started goes out first, whichever idle timer
+   * happened to fire. */
   flush(role: VoiceRole): void {
+    const row = this.open[role];
+    if (!row) {
+      this.clearIdle(role);
+      return;
+    }
+    const other = this.open[otherRole(role)];
+    if (other && other.endMs <= row.startMs) this.flushRow(otherRole(role));
+    this.flushRow(role);
+  }
+
+  /** Flushes every open row in start order. */
+  flushAll(): void {
+    this.flushInStartOrder(["user", "assistant"]);
+  }
+
+  private flushInStartOrder(roles: VoiceRole[]) {
+    const open = roles.filter((r) => this.open[r]);
+    open.sort((a, b) => this.open[a]!.startMs - this.open[b]!.startMs);
+    for (const role of open) this.flushRow(role);
+  }
+
+  private flushRow(role: VoiceRole) {
+    this.clearIdle(role);
+    const row = this.open[role];
+    this.open[role] = null;
+    if (row && row.text.trim())
+      this.opts.onRow({ id: row.id, role, text: row.text.trim() });
+  }
+
+  private clearIdle(role: VoiceRole) {
     const timer = this.idleTimers[role];
     if (timer) {
       clearTimeout(timer);
       this.idleTimers[role] = null;
     }
-    const row = this.open[role];
-    if (!row) return;
-    // A row of the other speaker that ended before this one started goes out
-    // first, whichever idle timer happened to fire.
-    const other = this.open[otherRole(role)];
-    if (other && other.endMs <= row.startMs) this.flush(otherRole(role));
-    this.open[role] = null;
-    if (row.text.trim())
-      this.opts.onRow({ id: row.id, role, text: row.text.trim() });
-  }
-
-  /** Flushes every open row in start order. */
-  flushAll(): void {
-    const { user, assistant } = this.open;
-    const first: VoiceRole =
-      user && assistant && assistant.startMs < user.startMs
-        ? "assistant"
-        : "user";
-    this.flush(first);
-    this.flush(otherRole(first));
   }
 
   private armIdle(role: VoiceRole) {
@@ -312,6 +329,10 @@ export class LiveResponseLoop {
   private delegations = new Map<string, DelegationState>();
   /** A continue requested (typed text) while calls were still open. */
   private continueWanted = false;
+  /** A `response.create` sent whose `response.created` has not arrived.
+   * Busy from the moment it is sent, so two typed messages in quick
+   * succession cannot both see an idle loop and open colliding responses. */
+  private createPending = false;
 
   constructor(
     private readonly io: {
@@ -329,6 +350,7 @@ export class LiveResponseLoop {
    * `response.create` issued now would reset the counters of the one in
    * flight; typed text waits for its terminal event instead. */
   get busy(): boolean {
+    if (this.createPending) return true;
     for (const d of this.delegations.values())
       if (!d.finished || d.open.size) return true;
     return false;
@@ -345,6 +367,7 @@ export class LiveResponseLoop {
       case "response.created":
         // A fresh response under this delegation (first, or the one our
         // response.create continued). Its own calls start from zero.
+        this.createPending = false;
         state.open.clear();
         state.calls = 0;
         state.finished = false;
@@ -373,6 +396,7 @@ export class LiveResponseLoop {
       case "response.failed":
       case "response.incomplete":
       case "response.cancelled":
+        this.createPending = false;
         state.finished = true;
         state.open.clear();
         this.delegations.delete(delegationId);
@@ -392,6 +416,11 @@ export class LiveResponseLoop {
       return;
     }
     this.continueWanted = false;
+    this.createResponse();
+  }
+
+  private createResponse() {
+    this.createPending = true;
     this.io.send({ type: "response.create" });
   }
 
@@ -438,7 +467,7 @@ export class LiveResponseLoop {
     this.continueWanted = false;
     state.finished = false;
     state.calls = 0;
-    this.io.send({ type: "response.create" });
+    this.createResponse();
   }
 }
 
@@ -474,12 +503,16 @@ export function activeLiveCalls(): Array<{
   }));
 }
 
-function sendEvent(call: LiveCall, event: Record<string, unknown>): void {
-  if (call.socket.readyState !== WebSocket.OPEN) return;
+/** True when the event went out on the sideband; false when the socket is
+ * not open (closing, before `onclose` finalizes the call) or send threw. */
+function sendEvent(call: LiveCall, event: Record<string, unknown>): boolean {
+  if (call.socket.readyState !== WebSocket.OPEN) return false;
   try {
     call.socket.send(JSON.stringify(event));
+    return true;
   } catch (e) {
     console.error(`[desk-voice-live] send failed for ${call.id}:`, e);
+    return false;
   }
 }
 
@@ -744,7 +777,9 @@ export function sendLiveVoiceText(
   if (!call || call.finalized) return false;
   const trimmed = text.trim();
   if (!trimmed) return false;
-  sendEvent(call, {
+  // Acknowledge only what the backend actually received: a false here keeps
+  // the browser's draft instead of mirroring a message nobody heard.
+  const sent = sendEvent(call, {
     type: "response.item.create",
     item: {
       type: "message",
@@ -752,6 +787,7 @@ export function sendLiveVoiceText(
       content: [{ type: "input_text", text: trimmed }],
     },
   });
+  if (!sent) return false;
   call.loop.requestContinue();
   mirrorVoiceEntries(user, [
     { id: `voice-typed-${crypto.randomUUID()}`, role: "user", text: trimmed },

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -172,6 +172,13 @@ export async function buildLiveSessionConfig(
 // Transcript rows. Live emits timed fragments per speaker with no turn
 // boundary, so rows are grouped by session-timeline gap and flushed on a
 // wall-clock idle. Each flushed row is one mirrored transcript entry.
+//
+// Both speakers may have a row open at once (full duplex), so ordering is
+// decided on the session timeline, not on arrival or idle order: a row is
+// flushed before any fragment or row that starts after it ended, and
+// `flushAll` goes by start time. User fragments arrive later than assistant
+// ones (speech recognition lags playback), which is why arrival order alone
+// would put the reply ahead of the question it answers.
 
 export type VoiceRole = "user" | "assistant";
 
@@ -187,6 +194,10 @@ interface OpenRow {
   text: string;
   startMs: number;
   endMs: number;
+}
+
+function otherRole(role: VoiceRole): VoiceRole {
+  return role === "user" ? "assistant" : "user";
 }
 
 export class VoiceTranscriptRows {
@@ -211,6 +222,10 @@ export class VoiceTranscriptRows {
     const current = this.open[role];
     if (current && fragment.startMs - current.endMs > this.opts.gapMs)
       this.flush(role);
+    // The other speaker's row ended before this fragment began: that turn is
+    // over and belongs ahead of this one.
+    const other = this.open[otherRole(role)];
+    if (other && other.endMs <= fragment.startMs) this.flush(otherRole(role));
     const row = this.open[role];
     if (row) {
       // Concatenate exactly as received: fragments carry their own spacing.
@@ -234,14 +249,25 @@ export class VoiceTranscriptRows {
       this.idleTimers[role] = null;
     }
     const row = this.open[role];
+    if (!row) return;
+    // A row of the other speaker that ended before this one started goes out
+    // first, whichever idle timer happened to fire.
+    const other = this.open[otherRole(role)];
+    if (other && other.endMs <= row.startMs) this.flush(otherRole(role));
     this.open[role] = null;
-    if (row && row.text.trim())
+    if (row.text.trim())
       this.opts.onRow({ id: row.id, role, text: row.text.trim() });
   }
 
+  /** Flushes every open row in start order. */
   flushAll(): void {
-    this.flush("user");
-    this.flush("assistant");
+    const { user, assistant } = this.open;
+    const first: VoiceRole =
+      user && assistant && assistant.startMs < user.startMs
+        ? "assistant"
+        : "user";
+    this.flush(first);
+    this.flush(otherRole(first));
   }
 
   private armIdle(role: VoiceRole) {
@@ -575,7 +601,29 @@ function attachSideband(apiKey: string, liveId: string): Promise<WebSocket> {
   });
 }
 
-export async function createLiveVoiceCall(
+/** Call creation in flight per user. Starts for one user run one at a time
+ * so the one-call-per-user rule holds across the awaits below: a second tab
+ * or a double press waits for the first start, then supersedes it. */
+const starting = new Map<string, Promise<unknown>>();
+
+export function createLiveVoiceCall(
+  user: string,
+  offerSdp: string,
+): Promise<{ liveSessionId: string; sdp: string; sessionId: string }> {
+  const previous = starting.get(user) ?? Promise.resolve();
+  const run = previous
+    .catch(() => {})
+    .then(() => createLiveVoiceCallNow(user, offerSdp));
+  starting.set(user, run);
+  void run
+    .catch(() => {})
+    .then(() => {
+      if (starting.get(user) === run) starting.delete(user);
+    });
+  return run;
+}
+
+async function createLiveVoiceCallNow(
   user: string,
   offerSdp: string,
 ): Promise<{ liveSessionId: string; sdp: string; sessionId: string }> {

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -324,8 +324,13 @@ export class LiveResponseLoop {
     },
   ) {}
 
+  /** A response is streaming or still owes tool outputs. Only one response
+   * runs per delegation, and this loop keeps one state per delegation, so a
+   * `response.create` issued now would reset the counters of the one in
+   * flight; typed text waits for its terminal event instead. */
   get busy(): boolean {
-    for (const d of this.delegations.values()) if (d.open.size) return true;
+    for (const d of this.delegations.values())
+      if (!d.finished || d.open.size) return true;
     return false;
   }
 
@@ -371,6 +376,8 @@ export class LiveResponseLoop {
         state.finished = true;
         state.open.clear();
         this.delegations.delete(delegationId);
+        // Typed text that waited on this response is still unanswered.
+        if (this.continueWanted) this.requestContinue();
         break;
       default:
         break;

--- a/packages/core/opensession-server/src/server/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/desk-voice.ts
@@ -1,17 +1,27 @@
 /**
- * Desk voice mode — GPT Realtime as a temporary conversational engine for the
- * standing Desk session (src/server/desk.ts). The browser talks WebRTC directly
- * to OpenAI with an ephemeral secret minted here; tool calls and transcripts
- * relay back over authenticated HTTP routes (routes/desk-voice.ts). The Desk
- * session stays the durable identity: voice turns are mirrored into its
- * transcript as they finalize, and a handoff note (consumed by run-session.ts
- * on the next text turn) bridges them into the text engine's context — the
- * transcript file and the engine's own conversation state are separate stores,
- * so without the handoff the next text turn would be amnesiac about the call.
+ * Desk voice mode — shared pieces for the standing Desk session's voice
+ * engines (src/server/desk.ts): the instance API key, the tool facade, and
+ * the transcript mirror + handoff buffer.
+ *
+ * Two engines share them:
+ * - GPT-Live (desk-voice-live.ts): the web Desk. The server creates the Live
+ *   session, holds a sideband WebSocket, executes tool calls itself, and
+ *   mirrors transcripts from the sideband. The browser only carries audio.
+ * - GPT Realtime (mintVoiceSecret below): the native iOS app. The device
+ *   talks to OpenAI directly with an ephemeral secret and relays tool calls
+ *   and transcripts back over routes/desk-voice.ts.
+ *
+ * The Desk session stays the durable identity either way: voice turns are
+ * mirrored into its transcript as they finalize, and a handoff note (consumed
+ * by run-session.ts on the next text turn) bridges them into the text engine's
+ * context — the transcript file and the engine's own conversation state are
+ * separate stores, so without the handoff the next text turn would be
+ * amnesiac about the call.
  *
  * The tool surface is a deliberately narrow facade over SessionControl and
- * todos — never the MCP inventory. The server-side session config (not the
- * client) fixes the tool list, so a client can't expand what OpenAI may call.
+ * todos plus the Desk's interactive MCP inventory. The server-side session
+ * config (not the client) fixes the tool list, so a client can't expand what
+ * OpenAI may call.
  */
 
 import {
@@ -38,7 +48,8 @@ const DIR = stateDir("desk");
 const KEY_PATH = `${DIR}/voice.json`;
 const HANDOFF_DIR = `${DIR}/voice-handoff`;
 
-/** Realtime model for Desk voice calls. */
+/** Realtime model for native (iOS) Desk voice calls. The web Desk runs on
+ * GPT-Live instead; see desk-voice-live.ts. */
 const DESK_VOICE_MODEL = "gpt-realtime";
 
 /** Semantic endpointing avoids treating a short mid-sentence pause as the end
@@ -72,6 +83,16 @@ export function voiceKeyConfigured(): boolean {
   return !!readKeyFile().openaiApiKey;
 }
 
+/** The configured key, or a thrown error pointing at Settings. */
+export function requireVoiceApiKey(): string {
+  const key = readKeyFile().openaiApiKey;
+  if (!key)
+    throw new Error(
+      "No OpenAI API key configured for Desk voice — set one in Settings → Desk voice.",
+    );
+  return key;
+}
+
 export function voiceKeyMasked(): string | undefined {
   const key = readKeyFile().openaiApiKey;
   if (!key) return undefined;
@@ -100,7 +121,7 @@ Voice discipline:
 - Capture todos the moment the user mentions wanting or needing to do something. Never drop a todo unprompted.
 - Before steering or starting sessions, a one-line confirmation of what you're about to do is enough; don't over-confirm reads.`;
 
-const VOICE_TOOLS = [
+export const VOICE_TOOLS = [
   {
     type: "function",
     name: "list_current_work",
@@ -180,7 +201,7 @@ function voiceToolName(server: string, tool: string): string {
     : `${server}_${tool}`;
 }
 
-async function listVoiceMcpTools(user: string, sessionId: string) {
+export async function listVoiceMcpTools(user: string, sessionId: string) {
   const tools: Array<Record<string, unknown>> = [];
   for (const { name: serverName, server } of await voiceMcpServers(
     user,
@@ -245,26 +266,35 @@ export async function callVoiceMcpTool(
   return { found: false };
 }
 
-function truncate(s: string, n: number): string {
+export function truncate(s: string, n: number): string {
   return s.length > n ? `${s.slice(0, n)}…` : s;
 }
 
-/** Recent Desk text-mode conversation, inlined so the voice engine picks the
- *  conversation up mid-thread instead of starting blank. */
-async function recentDeskContext(sessionId: string): Promise<string> {
+/** Recent Desk text-mode turns, compacted for a voice engine's context so the
+ *  call picks the conversation up mid-thread instead of starting blank. */
+export async function recentDeskTurns(
+  sessionId: string,
+): Promise<Array<{ role: "user" | "assistant"; text: string }>> {
   try {
     const tail = await getSessionControl().transcriptTail(sessionId, 12);
-    const lines = tail
+    return tail
       .filter((e) => (e.type === "user" || e.type === "assistant") && e.content)
-      .map(
-        (e) =>
-          `${e.type === "user" ? "User" : "Desk"}: ${truncate(e.content.replace(/\s+/g, " "), 300)}`,
-      );
-    if (!lines.length) return "";
-    return `\n\nRecent Desk conversation (text mode, continue from it):\n${lines.join("\n")}`;
+      .map((e) => ({
+        role: e.type === "user" ? ("user" as const) : ("assistant" as const),
+        text: truncate(e.content.replace(/\s+/g, " "), 300),
+      }));
   } catch {
-    return "";
+    return [];
   }
+}
+
+async function recentDeskContext(sessionId: string): Promise<string> {
+  const turns = await recentDeskTurns(sessionId);
+  if (!turns.length) return "";
+  const lines = turns.map(
+    (t) => `${t.role === "user" ? "User" : "Desk"}: ${t.text}`,
+  );
+  return `\n\nRecent Desk conversation (text mode, continue from it):\n${lines.join("\n")}`;
 }
 
 /** Server-owned Realtime session policy. Exported for contract tests so a
@@ -299,11 +329,7 @@ export async function mintVoiceSecret(user: string): Promise<{
   model: string;
   sessionId: string;
 }> {
-  const key = readKeyFile().openaiApiKey;
-  if (!key)
-    throw new Error(
-      "No OpenAI API key configured for Desk voice — set one in Settings → Desk voice.",
-    );
+  const key = requireVoiceApiKey();
   const { sessionId } = ensureDeskSession(user);
   const session = await buildVoiceSessionConfig(sessionId, user);
   const res = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
@@ -502,7 +528,7 @@ export function takeVoiceHandoff(sessionId: string): string | undefined {
       ? `Action: ${e.text}`
       : `${e.role === "user" ? "User" : "Desk"} (voice): ${e.text}`,
   );
-  return `## Voice conversation handoff\nWhile in voice mode, you (the Desk) had this spoken conversation via GPT Realtime. It is already in the visible transcript — don't repeat or re-answer it; continue with full awareness of what was said and done:\n\n${lines.join("\n")}`;
+  return `## Voice conversation handoff\nWhile in voice mode, you (the Desk) had this spoken conversation through a voice model. It is already in the visible transcript — don't repeat or re-answer it; continue with full awareness of what was said and done:\n\n${lines.join("\n")}`;
 }
 
 export function mirrorVoiceEntries(

--- a/packages/core/opensession-server/src/server/routes/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/routes/desk-voice.ts
@@ -1,9 +1,15 @@
 /**
- * Desk voice mode routes — the HTTP surface behind the overlay's mic toggle
- * (src/server/desk-voice.ts has the model). The browser holds the WebRTC leg
- * to OpenAI; these routes are the authenticated relay: secret minting (the
- * real API key never reaches the client), tool execution as the verified
- * user, and transcript mirroring into the standing Desk session.
+ * Desk voice mode routes — the HTTP surface behind the overlay's mic toggle.
+ *
+ * Web (GPT-Live, src/server/desk-voice-live.ts): `/live` exchanges the
+ * browser's WebRTC offer for an answer while the server creates the session
+ * and attaches its sideband; `/live/text` and `/live/close` steer that call.
+ * Tool calls and transcripts never pass through the browser.
+ *
+ * Native iOS (GPT Realtime, src/server/desk-voice.ts): the device holds the
+ * connection to OpenAI, so `/secret`, `/tool`, `/transcript` and `/diag` are
+ * its authenticated relay: secret minting (the real API key never reaches the
+ * client), tool execution as the verified user, transcript mirroring.
  */
 
 import type { RouteContext } from "./context";
@@ -18,6 +24,14 @@ import {
   voiceKeyConfigured,
   voiceKeyMasked,
 } from "../desk-voice";
+import {
+  closeLiveVoiceCall,
+  createLiveVoiceCall,
+  sendLiveVoiceText,
+} from "../desk-voice-live";
+
+/** An SDP offer is a few KB; anything bigger is not a browser offer. */
+const MAX_SDP_BYTES = 64 * 1024;
 
 function keyStatus(): Response {
   return Response.json({
@@ -44,6 +58,61 @@ export async function handleDeskVoiceRoutes(
       );
     setVoiceKey(body.apiKey);
     return keyStatus();
+  }
+
+  if (path === "/api/desk/voice/live" && req.method === "POST") {
+    const body = await req.json().catch(() => null);
+    if (
+      !body ||
+      typeof body.sdp !== "string" ||
+      !body.sdp.trim() ||
+      body.sdp.length > MAX_SDP_BYTES
+    )
+      return Response.json(
+        { error: "expected { sdp: string }" },
+        { status: 400 },
+      );
+    const user = requestUser(ctx, body.user);
+    if (!user) return Response.json({ error: "missing user" }, { status: 400 });
+    try {
+      return Response.json(await createLiveVoiceCall(user, body.sdp), {
+        status: 201,
+      });
+    } catch (e: any) {
+      return Response.json({ error: e?.message || String(e) }, { status: 502 });
+    }
+  }
+
+  if (path === "/api/desk/voice/live/text" && req.method === "POST") {
+    const body = await req.json().catch(() => null);
+    if (
+      !body ||
+      typeof body.liveSessionId !== "string" ||
+      typeof body.text !== "string"
+    )
+      return Response.json(
+        { error: "expected { liveSessionId, text }" },
+        { status: 400 },
+      );
+    const user = requestUser(ctx, body.user);
+    if (!user) return Response.json({ error: "missing user" }, { status: 400 });
+    if (!sendLiveVoiceText(user, body.liveSessionId, body.text))
+      return Response.json({ error: "no live call" }, { status: 404 });
+    return Response.json({ ok: true });
+  }
+
+  if (path === "/api/desk/voice/live/close" && req.method === "POST") {
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body.liveSessionId !== "string")
+      return Response.json(
+        { error: "expected { liveSessionId }" },
+        { status: 400 },
+      );
+    const user = requestUser(ctx, body.user);
+    if (!user) return Response.json({ error: "missing user" }, { status: 400 });
+    return Response.json({
+      ok: closeLiveVoiceCall(user, body.liveSessionId),
+    });
   }
 
   if (path === "/api/desk/voice/secret" && req.method === "POST") {


### PR DESCRIPTION
## What

The web Desk's voice mode now runs on OpenAI's new `gpt-live-1` (released today) instead of `gpt-realtime`, which is deprecated with a Jan 20, 2027 shutdown. The native iOS app stays on the Realtime path; nothing there changes.

## How it works

- **Browser** (`desk-voice-client.ts`): gathers ICE, posts its WebRTC SDP offer to `POST /api/desk/voice/live`, applies the answer, waits for `session.started`. The data channel is restricted server-side to `session.close` plus lifecycle and transcript events, so the browser can no longer inject tool outputs.
- **Server** (`desk-voice-live.ts`, new): creates the Live session with the instance key (the SDP exchange rides on that request), then attaches a sideband WebSocket before returning the answer so no event is missed. Reasoning and tool selection run through Responses delegation on `gpt-5.6-terra`, carrying the existing voice tool facade plus the interactive MCP inventory. Function calls surface as nested `response.output_item.done` events, execute as the verified user via the existing `executeVoiceTool`, and are answered with `response.item.create` + `response.create` once every call of that response has an output.
- **Transcripts**: Live emits timed per-speaker fragments with no turn boundary. `VoiceTranscriptRows` groups them by a 2s timeline gap and flushes on idle, then reuses the existing mirror + handoff buffer, so the next text turn still knows what was said.
- **Typed text** during a call goes to `POST /api/desk/voice/live/text` and is queued on the backend as a user message.
- **Prompts** are split the way the Live docs prescribe: a short voice prompt (speech, turn-taking, when to delegate) and the Desk's rules in the backend prompt.
- **Cost guards**: Live bills $0.05/min per second of call time, so the server closes a call after 3 minutes of silence or 30 minutes total, and a user's new call closes their previous one (a reload can no longer leave a headless call running).

- **Call button** (`Composer.tsx`): the header mic that started a call was dropped when the Desk adopted the shared composer (d1b6609a8), so the Settings toggle has been a no-op since. The composer now takes `config.call` + `actions.onToggleCall` and renders a handset beside the dictation mic, red while a call is live, on desktop and phone.

## Not in this PR

- iOS (`DeskVoiceEngine.swift`) stays on Realtime and its routes (`/secret`, `/tool`, `/transcript`, `/diag`) are untouched. Bumping it to `gpt-realtime-2.1` is a separate change.
- No live call has been placed yet: this needs the configured Desk voice key on a deployed instance. The Live event contract is implemented from the API reference; `LiveResponseLoop` and `VoiceTranscriptRows` are unit-tested, the session config is contract-tested.

## Verification

- `bun run typecheck`, `bun run lint`, `scripts/test-unit-isolated.sh` (748 files, 0 failures), `bun run test:snapshots`, `bun scripts/check-module-side-effects.ts` all pass. `bun run check` as a whole only trips on another session's gitignored `artifacts/verification/` scratch files.
- Handset verified in the isolated demo instance at 1440x900 and 390x844 (Settings → Desk voice on → Desk): `button "Start a voice call"` sits next to `button "Dictate"` in both accessibility trees.
- New tests in `desk-voice-live.test.ts` (11) cover the session config, data-channel lockdown, history seeding, row grouping, and the tool-call loop (slow tools, thrown tools, deferred typed-text continue).

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08d1f-9db1-7c52-8797-090a6ccb2339)

