### PR TITLE
Render ```palette fences as colour swatches and chip hex codespans

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -70,9 +70,19 @@ fence is a display block as well.
 
 ### Colour
 
-A ` ```palette ` fence lists one colour per line, `#hex` or any CSS
-colour, optionally followed by a name. A hex colour in a codespan
-(`` `#ff0080` ``) gets a swatch chip beside it.
+A ` ```palette ` fence lists one colour per line, with an optional
+name on either side: `#ff0080 Brand pink` or `Brand pink: #ff0080`. A
+colour is `#hex` (3, 4, 6 or 8 digits), a colour function with a flat
+argument list (`rgb()`, `hsl()`, `hwb()`, `lab()`, `lch()`, `oklab()`,
+`oklch()`, `color()`; no `color-mix()` or `calc()`), or a CSS colour
+name. A trailing `;` or `,` on the value is ignored, so lines lifted from
+a stylesheet parse. Blank lines are skipped; any other line that is not a
+colour keeps the whole fence as code. Each swatch copies its value on
+click.
+
+A codespan that is exactly a six or eight digit hex (`` `#ff0080` ``)
+gets a swatch chip before the text. Three and four digit forms do not,
+since `#123` in a codespan is usually an issue number or an anchor.
 
 ### JSON tree
 

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.test.ts
@@ -12,6 +12,7 @@ describe("fence upgrader registry", () => {
     expect(fenceUpgraderFor("mermaid")?.langs).toContain("mermaid");
     expect(fenceUpgraderFor("Vega-Lite")?.langs).toContain("vega-lite");
     expect(fenceUpgraderFor("chart")?.langs).toContain("chart");
+    expect(fenceUpgraderFor("palette")?.langs).toContain("palette");
     expect(fenceUpgraderFor("ts")).toBeUndefined();
     expect(fenceUpgraderFor(undefined)).toBeUndefined();
   });

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -17,6 +17,7 @@
 
 import { chartUpgrader } from "./chart-fence";
 import { mermaidUpgrader } from "./mermaid-fence";
+import { paletteUpgrader } from "./palette-block";
 import type { EffectiveTheme } from "./theme";
 
 export interface FenceUpgradeContext {
@@ -74,6 +75,7 @@ export interface FenceUpgrader {
 export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   mermaidUpgrader,
   chartUpgrader,
+  paletteUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
@@ -1319,3 +1319,37 @@ describe("GitHub user-attachment media", () => {
     expect(html).toContain(`<a href="${proxied}"`);
   });
 });
+
+describe("renderMarkdown hex colour codespans", () => {
+  it("puts a swatch chip before a six or eight digit hex codespan", () => {
+    expect(renderMarkdown("Use `#FF0080` here.")).toContain(
+      '<code><span class="md-color-chip" style="background:#ff0080"></span>#FF0080</code>',
+    );
+    expect(renderMarkdown("`#ff0080cc`")).toContain(
+      'style="background:#ff0080cc"></span>#ff0080cc</code>',
+    );
+  });
+
+  it("leaves short hashes and anything that is not exactly a hex alone", () => {
+    for (const span of [
+      "#123",
+      "#abcd",
+      "#5528",
+      "#ff0080 brand",
+      "#ff0080;",
+      "gg0080",
+      "#ff008",
+    ]) {
+      const html = renderMarkdown(`See \`${span}\`.`);
+      expect(html).not.toContain("md-color-chip");
+      expect(html).toContain(`<code>${span}</code>`);
+    }
+  });
+
+  it("never lets raw span text reach the style attribute", () => {
+    const html = renderMarkdown('`#ff0080" onmouseover="x`');
+    expect(html).not.toContain("md-color-chip");
+    expect(html).not.toContain("style=");
+    expect(html).toContain("<code>#ff0080&quot; onmouseover=&quot;x</code>");
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/markdown.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.ts
@@ -1,6 +1,7 @@
 import { Marked, type Token, type TokenizerThis, type Tokens } from "marked";
 import { BASE_PATH } from "./base";
 import { sanitizeHtmlFragment } from "./html-sanitize";
+import { hexSwatchColor } from "./palette-block";
 import { prStatusDisplay, type PrStatusInput } from "./pr-status";
 import { repoLabel } from "./repo-label";
 import { cleanSessionTitle } from "./session-title";
@@ -1325,6 +1326,11 @@ md.use({
       if (!renderInLink && SESSION_ID_EXACT.test(t)) return sessionLink(t);
       if (!renderInLink && AUTOMATION_ID_EXACT.test(t))
         return automationChip(t);
+      // A hex colour gets a swatch chip. The style is built from the
+      // validated, lowercased hex only, never from the span's raw text.
+      const swatch = hexSwatchColor(t);
+      if (swatch)
+        return `<code><span class="md-color-chip" style="background:${swatch}"></span>${attr(t)}</code>`;
       return `<code>${attr(t)}</code>`;
     },
     image(token: Tokens.Image) {

--- a/packages/core/opensession-server/src/frontend/lib/palette-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/palette-block.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import { hexSwatchColor, isCssColor, parsePalette } from "./palette-block";
+
+describe("isCssColor", () => {
+  it("accepts every hex length a browser does", () => {
+    for (const hex of ["#f08", "#f08c", "#ff0080", "#ff0080cc", "#FF0080"])
+      expect(isCssColor(hex)).toBe(true);
+    for (const hex of ["#f", "#ff", "#ff008", "#ff00800", "#ff0080ccc"])
+      expect(isCssColor(hex)).toBe(false);
+  });
+
+  it("accepts colour functions with a flat argument list", () => {
+    for (const value of [
+      "rgb(255, 0, 128)",
+      "rgba(255 0 128 / 0.5)",
+      "hsl(330deg 100% 50%)",
+      "hwb(330 0% 0%)",
+      "oklch(0.7 0.2 340)",
+      "oklch(70% 0.2 340 / 40%)",
+      "lab(60 40 -20)",
+      "color(display-p3 1 0 0.5)",
+      "OKLCH(0.7 0.2 340)",
+    ])
+      expect(isCssColor(value)).toBe(true);
+  });
+
+  it("rejects computed colours, unknown functions and stray syntax", () => {
+    for (const value of [
+      "color-mix(in oklch, red, blue)",
+      "rgb(calc(1 + 2) 0 0)",
+      "var(--accent)",
+      "url(x)",
+      "rgb()",
+      "rgb(   )",
+      "oklch(0.7 0.2 340",
+      "#ff0080; color: red",
+      "rgb(0 0 0) }",
+    ])
+      expect(isCssColor(value)).toBe(false);
+  });
+
+  it("accepts named colours in any case, and nothing near them", () => {
+    expect(isCssColor("rebeccapurple")).toBe(true);
+    expect(isCssColor("Tomato")).toBe(true);
+    expect(isCssColor("transparent")).toBe(true);
+    expect(isCssColor("brand")).toBe(false);
+    expect(isCssColor("currentcolor")).toBe(false);
+    expect(isCssColor("")).toBe(false);
+  });
+});
+
+describe("parsePalette", () => {
+  it("reads a colour per line with the name after it", () => {
+    expect(
+      parsePalette("#ff0080 Brand pink\nrgb(0 0 0)\noklch(0.7 0.2 340) Rose"),
+    ).toEqual([
+      { value: "#ff0080", name: "Brand pink" },
+      { value: "rgb(0 0 0)", name: "" },
+      { value: "oklch(0.7 0.2 340)", name: "Rose" },
+    ]);
+  });
+
+  it("reads the name before the colour", () => {
+    expect(
+      parsePalette(
+        "Brand pink: #ff0080\nInk: rgb(20, 20, 20)\n--accent: tomato;\n",
+      ),
+    ).toEqual([
+      { value: "#ff0080", name: "Brand pink" },
+      { value: "rgb(20, 20, 20)", name: "Ink" },
+      { value: "tomato", name: "--accent" },
+    ]);
+  });
+
+  it("keeps a colon inside a trailing name", () => {
+    expect(parsePalette("#ff0080 Brand: pink")).toEqual([
+      { value: "#ff0080", name: "Brand: pink" },
+    ]);
+    // A colour name followed by a colon is a label, not a colour.
+    expect(parsePalette("Red: #f00")).toEqual([{ value: "#f00", name: "Red" }]);
+  });
+
+  it("skips blank lines and trims whitespace", () => {
+    expect(parsePalette("\n  #fff  White  \n\n#000\n")).toEqual([
+      { value: "#fff", name: "White" },
+      { value: "#000", name: "" },
+    ]);
+  });
+
+  it("declines when any line is not a colour", () => {
+    expect(parsePalette("#ff0080\nthis is prose")).toBeNull();
+    expect(parsePalette("Brand: not a colour")).toBeNull();
+    expect(parsePalette("#ff008 Brand")).toBeNull();
+    expect(parsePalette(": #fff")).toBeNull();
+    expect(parsePalette("")).toBeNull();
+    expect(parsePalette("\n\n")).toBeNull();
+  });
+});
+
+describe("hexSwatchColor", () => {
+  it("takes only a whole six or eight digit hex", () => {
+    expect(hexSwatchColor("#ff0080")).toBe("#ff0080");
+    expect(hexSwatchColor("#FF0080CC")).toBe("#ff0080cc");
+    expect(hexSwatchColor("#123")).toBeNull();
+    expect(hexSwatchColor("#1234")).toBeNull();
+    expect(hexSwatchColor("#5528")).toBeNull();
+    expect(hexSwatchColor("#ff0080 ")).toBeNull();
+    expect(hexSwatchColor("#gg0080")).toBeNull();
+    expect(hexSwatchColor("ff0080")).toBeNull();
+    expect(hexSwatchColor("#ff0080; color")).toBeNull();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/palette-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/palette-block.ts
@@ -1,0 +1,184 @@
+/**
+ * The ```palette fence: one colour per line, rendered as a row of swatches
+ * that copy their value on click. Also the one place that decides what a
+ * colour is for the swatch chip a hex codespan gets (markdown.ts).
+ *
+ * The parser is a grammar, not the browser: a value is a colour when it
+ * matches a hex form, a known colour function with a flat argument list, or
+ * a CSS colour name. It never asks `CSS.supports`, so the fence resolves the
+ * same way in a unit test and in the page, and the only thing that ever
+ * reaches a `style` attribute is a value this grammar accepted.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+import { copyToClipboard } from "./share-link";
+
+export interface PaletteEntry {
+  /** The colour as written, trimmed. What the swatch shows and copies. */
+  value: string;
+  /** Optional label, from either `#hex Name` or `Name: #hex`. */
+  name: string;
+}
+
+/** `#rgb`, `#rgba`, `#rrggbb` or `#rrggbbaa`. */
+const HEX_COLOR = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+/**
+ * A colour function with a flat argument list: numbers, percentages, angles,
+ * `none`, a colour space name, separators. No nested parentheses, so
+ * `color-mix()` and `calc()` stay out: the value is copied verbatim, and a
+ * swatch should show one colour, not a computation.
+ */
+const COLOR_FUNCTION =
+  /^(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color)\(([0-9a-z.%,/+\s-]*[0-9a-z%][0-9a-z.%,/+\s-]*)\)$/i;
+
+/** CSS Color Level 4 named colours, plus `transparent`. */
+const NAMED_COLORS = new Set(
+  (
+    "aliceblue antiquewhite aqua aquamarine azure beige bisque black " +
+    "blanchedalmond blue blueviolet brown burlywood cadetblue chartreuse " +
+    "chocolate coral cornflowerblue cornsilk crimson cyan darkblue darkcyan " +
+    "darkgoldenrod darkgray darkgreen darkgrey darkkhaki darkmagenta " +
+    "darkolivegreen darkorange darkorchid darkred darksalmon darkseagreen " +
+    "darkslateblue darkslategray darkslategrey darkturquoise darkviolet " +
+    "deeppink deepskyblue dimgray dimgrey dodgerblue firebrick floralwhite " +
+    "forestgreen fuchsia gainsboro ghostwhite gold goldenrod gray green " +
+    "greenyellow grey honeydew hotpink indianred indigo ivory khaki lavender " +
+    "lavenderblush lawngreen lemonchiffon lightblue lightcoral lightcyan " +
+    "lightgoldenrodyellow lightgray lightgreen lightgrey lightpink " +
+    "lightsalmon lightseagreen lightskyblue lightslategray lightslategrey " +
+    "lightsteelblue lightyellow lime limegreen linen magenta maroon " +
+    "mediumaquamarine mediumblue mediumorchid mediumpurple mediumseagreen " +
+    "mediumslateblue mediumspringgreen mediumturquoise mediumvioletred " +
+    "midnightblue mintcream mistyrose moccasin navajowhite navy oldlace " +
+    "olive olivedrab orange orangered orchid palegoldenrod palegreen " +
+    "paleturquoise palevioletred papayawhip peachpuff peru pink plum " +
+    "powderblue purple rebeccapurple red rosybrown royalblue saddlebrown " +
+    "salmon sandybrown seagreen seashell sienna silver skyblue slateblue " +
+    "slategray slategrey snow springgreen steelblue tan teal thistle tomato " +
+    "turquoise violet wheat white whitesmoke yellow yellowgreen transparent"
+  ).split(" "),
+);
+
+/** Whether `value` is a colour this block will paint and copy. */
+export function isCssColor(value: string): boolean {
+  return (
+    HEX_COLOR.test(value) ||
+    COLOR_FUNCTION.test(value) ||
+    NAMED_COLORS.has(value.toLowerCase())
+  );
+}
+
+/**
+ * The colour a codespan gets a swatch chip for: exactly `#rrggbb` or
+ * `#rrggbbaa`, lowercased, or null. Three and four digit forms are left out
+ * on purpose: `#123` in a codespan is far more often an issue number or a
+ * heading anchor than a colour, and a wrong chip is worse than a missing one.
+ */
+export function hexSwatchColor(text: string): string | null {
+  return /^#(?:[0-9a-f]{6}|[0-9a-f]{8})$/i.test(text)
+    ? text.toLowerCase()
+    : null;
+}
+
+/** A line's leading token: hex, `fn(...)`, or a bare word, up to whitespace
+ *  or the end. What the prefix form (`#hex Name`) reads its colour from. */
+const LEADING_TOKEN = /^(#[0-9a-f]+|[a-z]+\([^()]*\)|[a-z]+)(?=\s|$)/i;
+
+function parseLine(line: string): PaletteEntry | null {
+  const lead = LEADING_TOKEN.exec(line);
+  if (lead && isCssColor(lead[1]!)) {
+    return { value: lead[1]!, name: line.slice(lead[0].length).trim() };
+  }
+  const colon = line.indexOf(":");
+  if (colon <= 0) return null;
+  const name = line.slice(0, colon).trim();
+  // A trailing `;` or `,` is how a colour arrives when the line was lifted
+  // from a stylesheet or an object literal.
+  const value = line
+    .slice(colon + 1)
+    .trim()
+    .replace(/[;,]$/, "")
+    .trim();
+  return name && isCssColor(value) ? { value, name } : null;
+}
+
+/**
+ * Every non-blank line as a colour, or null when any line is not one: a
+ * fence with prose in it is not a palette and stays code.
+ */
+export function parsePalette(source: string): PaletteEntry[] | null {
+  const entries: PaletteEntry[] = [];
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const entry = parseLine(line);
+    if (!entry) return null;
+    entries.push(entry);
+  }
+  return entries.length ? entries : null;
+}
+
+const COPIED_LABEL = "Copied";
+const COPIED_MS = 1600;
+const flashTimers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
+
+function flashCopied(swatch: HTMLElement, valueEl: HTMLElement, value: string) {
+  const running = flashTimers.get(swatch);
+  if (running) clearTimeout(running);
+  swatch.dataset.copied = "";
+  valueEl.textContent = COPIED_LABEL;
+  flashTimers.set(
+    swatch,
+    setTimeout(() => {
+      delete swatch.dataset.copied;
+      valueEl.textContent = value;
+      flashTimers.delete(swatch);
+    }, COPIED_MS),
+  );
+}
+
+function swatchElement({ value, name }: PaletteEntry): HTMLButtonElement {
+  const swatch = document.createElement("button");
+  swatch.type = "button";
+  swatch.className = "md-palette-swatch";
+  swatch.title = `Copy ${value}`;
+  swatch.setAttribute("aria-label", `Copy ${name ? `${name} ` : ""}${value}`);
+  const tile = document.createElement("span");
+  tile.className = "md-palette-tile";
+  const fill = document.createElement("span");
+  fill.className = "md-palette-fill";
+  // `value` passed the grammar above: a hex, a flat colour function or a
+  // colour name. Nothing else ever reaches a style.
+  fill.style.background = value;
+  tile.append(fill);
+  const valueEl = document.createElement("span");
+  valueEl.className = "md-palette-value";
+  valueEl.textContent = value;
+  swatch.append(tile);
+  if (name) {
+    const nameEl = document.createElement("span");
+    nameEl.className = "md-palette-name";
+    nameEl.textContent = name;
+    swatch.append(nameEl);
+  }
+  swatch.append(valueEl);
+  swatch.addEventListener("click", () =>
+    copyToClipboard(value, () => flashCopied(swatch, valueEl, value)),
+  );
+  return swatch;
+}
+
+/** Source with a line that is not a colour keeps the plain code fence. */
+export const paletteUpgrader: FenceUpgrader = {
+  langs: ["palette"],
+  async upgrade({ pre, source, root, alive }) {
+    const entries = parsePalette(source);
+    if (!entries || !alive() || !root.contains(pre)) return false;
+    const block = document.createElement("div");
+    block.className = "md-palette";
+    block.append(...entries.map(swatchElement));
+    pre.replaceWith(block);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -30,3 +30,4 @@
 @import "./base-platform.css";
 @import "./base-markdown.css";
 @import "./base-keyframes.css";
+@import "./blocks/palette.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/palette.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/palette.css
@@ -1,0 +1,119 @@
+/* ── Colour swatches ───────────────────────────────────────────
+   A ```palette fence (lib/palette-block.ts) becomes a row of swatches, and a
+   hex codespan gets a chip before its text (markdown.ts codespan). The
+   colours themselves are the reader's, set inline from the validated value;
+   everything around them is tokens. Renderer-emitted markup is why these
+   rules live here rather than in a component utility. */
+.md-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 2px 0 8px;
+}
+.md-palette-swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  /* Fits `rebeccapurple` and `#ff0080cc` on one line at the meta size. */
+  width: 96px;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text-dim);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: calc(12px * var(--rf));
+  corner-shape: var(--cs);
+}
+.md-palette-swatch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Checkerboard under the fill so a translucent colour reads as one; the
+   hairline keeps a white or near-white tile visible on a light page. */
+.md-palette-tile {
+  position: relative;
+  display: block;
+  height: 56px;
+  overflow: hidden;
+  border-radius: calc(12px * var(--rf));
+  corner-shape: var(--cs);
+  box-shadow: inset 0 0 0 1px var(--divider);
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(45deg, var(--bg-hover) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--bg-hover) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--bg-hover) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--bg-hover) 75%);
+  background-size: 12px 12px;
+  background-position:
+    0 0,
+    0 6px,
+    6px -6px,
+    -6px 0;
+  transition: transform 140ms ease;
+}
+.md-palette-fill {
+  position: absolute;
+  inset: 0;
+}
+/* The hairline sits above the fill, so it draws on the colour's own edge. */
+.md-palette-tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  corner-shape: inherit;
+  box-shadow: inset 0 0 0 1px var(--divider);
+  pointer-events: none;
+}
+.md-palette-swatch:hover .md-palette-tile {
+  transform: translateY(-1px);
+}
+.md-palette-swatch:active .md-palette-tile {
+  transform: none;
+}
+/* Wrap rather than truncate: a phone has no hover for the full value, and
+   `oklch(0.7 0.16 200)` is the value someone wants to read off the swatch. */
+.md-palette-name,
+.md-palette-value {
+  display: block;
+  padding: 0 2px;
+  font-size: var(--type-meta);
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+.md-palette-name {
+  color: var(--text);
+}
+.md-palette-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-faint);
+}
+.md-palette-swatch[data-copied] .md-palette-value {
+  color: var(--green);
+}
+@media (max-width: 720px) {
+  .md-palette {
+    gap: 8px;
+  }
+  .md-palette-swatch {
+    width: calc((100% - 16px) / 3);
+  }
+}
+
+/* A hex codespan's chip: sits before the text, inside the code capsule. */
+.md-color-chip {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-right: 0.4em;
+  vertical-align: -0.1em;
+  border-radius: calc(4px * var(--rf));
+  corner-shape: var(--cs);
+  box-shadow: inset 0 0 0 1px var(--divider);
+}


### PR DESCRIPTION
Part of the blocks work on top of #e20bc207e (the fence upgrader registry). Web UI only.

## What

- **` ```palette ` fence** (`lib/palette-block.ts`, registered in `FENCE_UPGRADERS`): one colour per line, `#hex` (3/4/6/8 digits), a colour function with a flat argument list (`rgb()`, `hsl()`, `hwb()`, `lab()`, `lch()`, `oklab()`, `oklch()`, `color()`) or a CSS colour name, with an optional name on either side (`#ff0080 Brand pink` or `Brand pink: #ff0080`). A trailing `;` or `,` on the value is tolerated so lines lifted from a stylesheet parse. Renders as a row of swatches that wraps on a phone (three-up at 390px): rounded tile with a checkerboard under translucent colours and a hairline so white shows on light, name and value in small mono text beneath, click copies the value and shows `Copied` for 1.6s. Any non-blank line that is not a colour makes the fence decline and stay code. The parser is a pure grammar (no `CSS.supports`) with `bun:test` coverage.
- **Hex codespan chip** (`markdown.ts` `codespan`): a codespan that is exactly a 6 or 8 digit hex gets a small swatch chip before the text. 3 and 4 digit forms are deliberately not chipped, since `#123` in a codespan is usually an issue number or an anchor. The `style` attribute is built only from the validated, lowercased hex; the raw span text never reaches it (test included).
- Styles in `styles/blocks/palette.css`, imported from `base.css`; semantic tokens throughout except the swatch colours themselves. Reduced motion is covered by the global block in `base-theme.css` (the only motion is a 140ms hover lift).
- `docs/blocks.md` Colour section updated to the grammar as shipped.

Not touched, per the parent's plan: `server/run-instructions.ts`, `.agents/skills/show-me/SKILL.md`, `CONCEPTS.md`.

## Grammar, one line for the model prompt

` ```palette `: one colour per line (`#hex`, `rgb()`/`hsl()`/`oklch()`/… or a colour name), optional name before or after (`#ff0080 Brand pink` / `Brand pink: #ff0080`); a 6 or 8 digit hex in a codespan gets a swatch chip.

## Verification

- `bun run check` passes; `bun test` for `palette-block`, `markdown`, `fence-upgraders`.
- Visual proof against the isolated demo instance with the compiled-bundle harness: desktop dark and light, phone dark (palette fence, a declining fence and the codespan line in an asset preview), and the chip in a real transcript turn posted through the composer.

Note for reviewers: the asset preview (`AssetView.tsx`) renders with a bare `marked.parse`, not `renderMarkdown`, so the chip appears in transcript and PR prose but not in a previewed `.md` file. Left as is; out of scope here.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)