### PR TITLE
Render GitHub callouts and metrics cards in markdown

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -127,7 +127,9 @@ of `{label, value, delta?, unit?}` (a numeric `value` or `delta` is formatted
 for reading, `1204` as `1,204`). Renders as a row of cards: the value big and
 tabular, the label under it, the delta beside the value and coloured by its
 lead character: `+`, `▲` or `↑` is up, `-`, `▼` or `↓` is down, anything else
-is neutral. A fence that does not parse stays a code block.
+is neutral. A fence that does not parse stays a code block, as does one past
+64 metrics or 16,000 characters: a row of cards is for a handful of headline
+numbers, not a table.
 
 ## Adding a block kind
 

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -58,8 +58,10 @@ as one slider. Both paths obey the same media rules as `OPENSESSION_IMAGE:`.
 ### Callouts
 
 GitHub's admonition syntax: a blockquote whose first line is `[!NOTE]`,
-`[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]`. The rest of the quote
-is the body.
+`[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` (any case) and
+nothing else. The rest of the quote is the body, ordinary markdown. A marker
+with text after it on the same line, or anywhere but the first line, is a
+plain quote, as on GitHub.
 
 ### Math
 
@@ -120,8 +122,12 @@ markdown, including the other block kinds.
 ### Metrics
 
 A ` ```metrics ` fence lists one metric per line as
-`Label: value (delta)`, or is a JSON array of `{label, value, delta, unit}`.
-Renders as a row of cards.
+`Label: value (delta)`, the parenthesised delta optional, or is a JSON array
+of `{label, value, delta?, unit?}` (a numeric `value` or `delta` is formatted
+for reading, `1204` as `1,204`). Renders as a row of cards: the value big and
+tabular, the label under it, the delta beside the value and coloured by its
+lead character: `+`, `▲` or `↑` is up, `-`, `▼` or `↓` is down, anything else
+is neutral. A fence that does not parse stays a code block.
 
 ## Adding a block kind
 

--- a/packages/core/opensession-server/src/frontend/components/AssetView.tsx
+++ b/packages/core/opensession-server/src/frontend/components/AssetView.tsx
@@ -13,7 +13,6 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { marked } from "marked";
 import {
   deleteSessionAssetApi,
   sessionAssetDownloadUrl,
@@ -47,6 +46,7 @@ import { ResponsiveDialog } from "../ui/sheet";
 import { toast } from "../ui/toast";
 import { Tooltip } from "../ui/tooltip";
 import { MarkdownBody } from "./MarkdownBody";
+import { renderMarkdown } from "../lib/markdown";
 import { openLightbox } from "../lib/media-lightbox";
 import {
   IconArrowDown,
@@ -770,7 +770,7 @@ export function AssetPreview({
         ) : (
           <MarkdownBody
             className="markdown px-4 py-3 text-label"
-            html={marked.parse(text, { async: false })}
+            html={renderMarkdown(text)}
           />
         )
       ) : kind === "text" ? (

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -1043,6 +1043,114 @@ export function checkIconMarkup(size = MIN_ICON_SIZE): string {
   return iconMarkup(pathsMarkup([CHECK_PATH]), size);
 }
 
+// ── Callout glyphs ─────────────────────────────────────────────────────────
+// One per GitHub admonition kind (`> [!NOTE]` … `> [!CAUTION]`), drawn by
+// lib/markdown.ts into the callout's title. Same paths as the JSX icons below.
+
+const INFO_CIRCLE_PATHS = ["M12 11.25V16.25", "M12 8.25H12.01"];
+const LIGHTBULB_PATHS = [
+  "M9.75 17.25V16.4C9.75 15.5 9.2 14.8 8.6 14.2C7.45 13.2 6.75 11.8 6.75 10.25C6.75 7.35 9.1 5 12 5C14.9 5 17.25 7.35 17.25 10.25C17.25 11.8 16.55 13.2 15.4 14.2C14.8 14.8 14.25 15.5 14.25 16.4V17.25",
+  "M9.75 17.25H14.25",
+  "M10.25 19.25H13.75",
+];
+const REPORT_PATHS = [
+  "M4.75 6.75C4.75 5.645 5.645 4.75 6.75 4.75H17.25C18.355 4.75 19.25 5.645 19.25 6.75V14.25C19.25 15.355 18.355 16.25 17.25 16.25H13L8.75 19.25V16.25H6.75C5.645 16.25 4.75 15.355 4.75 14.25V6.75Z",
+  "M12 8.25V11",
+  "M12 13.75H12.01",
+];
+const WARNING_TRIANGLE_PATHS = [
+  "M4.9 17.25L10.7 6.1C11.25 5.05 12.75 5.05 13.3 6.1L19.1 17.25C19.6 18.25 18.9 19.25 17.8 19.25H6.2C5.1 19.25 4.4 18.25 4.9 17.25Z",
+  "M12 10V13.25",
+  "M12 16H12.01",
+];
+const OCTAGON_ALERT_PATHS = [
+  "M8.65 4.75H15.35L19.25 8.65V15.35L15.35 19.25H8.65L4.75 15.35V8.65L8.65 4.75Z",
+  "M12 8.5V12.5",
+  "M12 15.5H12.01",
+];
+
+export type CalloutIconKind =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution";
+
+/** The callout title glyph for one admonition kind, as markup. */
+export function calloutIconMarkup(
+  kind: CalloutIconKind,
+  size = MIN_ICON_SIZE,
+): string {
+  switch (kind) {
+    case "note":
+      return iconMarkup(
+        `<circle cx="12" cy="12" r="7.25" ${STROKE_MARKUP}/>` +
+          pathsMarkup(INFO_CIRCLE_PATHS),
+        size,
+      );
+    case "tip":
+      return iconMarkup(pathsMarkup(LIGHTBULB_PATHS), size);
+    case "important":
+      return iconMarkup(pathsMarkup(REPORT_PATHS), size);
+    case "warning":
+      return iconMarkup(pathsMarkup(WARNING_TRIANGLE_PATHS), size);
+    case "caution":
+      return iconMarkup(pathsMarkup(OCTAGON_ALERT_PATHS), size);
+  }
+}
+
+export function IconInfoCircle(p: IconProps) {
+  return (
+    <Svg {...p}>
+      <circle {...stroke} cx="12" cy="12" r="7.25" />
+      {INFO_CIRCLE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconLightbulb(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {LIGHTBULB_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+/** A speech bubble with an exclamation mark: "this needs your attention". */
+export function IconReport(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {REPORT_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconWarningTriangle(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {WARNING_TRIANGLE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
+export function IconOctagonAlert(p: IconProps) {
+  return (
+    <Svg {...p}>
+      {OCTAGON_ALERT_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
+    </Svg>
+  );
+}
+
 export function IconTrash(p: IconProps) {
   return (
     <Svg {...p}>

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -17,6 +17,7 @@
 
 import { chartUpgrader } from "./chart-fence";
 import { mermaidUpgrader } from "./mermaid-fence";
+import { metricsUpgrader } from "./metrics-block";
 import type { EffectiveTheme } from "./theme";
 
 export interface FenceUpgradeContext {
@@ -74,6 +75,7 @@ export interface FenceUpgrader {
 export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   mermaidUpgrader,
   chartUpgrader,
+  metricsUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
@@ -1212,6 +1212,90 @@ describe("renderPrCommentMarkdown bot markup", () => {
   });
 });
 
+describe("renderMarkdown callouts", () => {
+  it("renders a GitHub admonition as a titled callout", () => {
+    const html = renderMarkdown("> [!NOTE]\n> Body with **bold**.");
+    expect(html).toContain('<div class="md-callout md-callout-note">');
+    expect(html).toContain('<div class="md-callout-title"><svg');
+    expect(html).toContain("</svg>Note</div>");
+    expect(html).toContain("<p>Body with <strong>bold</strong>.</p>");
+    expect(html).not.toContain("[!NOTE]");
+    expect(html).not.toContain("<blockquote>");
+  });
+
+  it("knows every kind, in any case", () => {
+    for (const [marker, kind, title] of [
+      ["[!TIP]", "tip", "Tip"],
+      ["[!IMPORTANT]", "important", "Important"],
+      ["[!Warning]", "warning", "Warning"],
+      ["[!caution]", "caution", "Caution"],
+    ]) {
+      const html = renderMarkdown(`> ${marker}\n> Text`);
+      expect(html).toContain(`md-callout-${kind}"`);
+      expect(html).toContain(`</svg>${title}</div>`);
+      expect(html).toContain("<p>Text</p>");
+    }
+  });
+
+  it("keeps the body as ordinary markdown, lists included", () => {
+    const html = renderMarkdown(
+      "> [!WARNING]\n> First line.\n>\n> - one\n> - two\n>\n> ```ts\n> x\n> ```",
+    );
+    expect(html).toContain("<p>First line.</p>");
+    expect(html).toContain("<li>one</li>");
+    expect(html).toContain('<code class="language-ts">x');
+  });
+
+  it("renders a marker with no body as just the title", () => {
+    const html = renderMarkdown("> [!TIP]");
+    expect(html).toBe(
+      '<div class="md-callout md-callout-tip"><div class="md-callout-title">' +
+        html.slice(
+          html.indexOf("<svg"),
+          html.indexOf("</svg>") + "</svg>".length,
+        ) +
+        "Tip</div></div>\n",
+    );
+  });
+
+  it("renders a body that starts on the marker line with a list", () => {
+    const html = renderMarkdown("> [!NOTE]\n> - a\n> - b");
+    expect(html).toContain("<li>a</li>");
+    expect(html).not.toContain("<p></p>");
+  });
+
+  it("leaves ordinary blockquotes alone", () => {
+    expect(renderMarkdown("> Just a quote")).toBe(
+      "<blockquote>\n<p>Just a quote</p>\n</blockquote>\n",
+    );
+    // The marker has to be the whole first line, as on GitHub.
+    const inline = renderMarkdown("> [!NOTE] inline text\n> more");
+    expect(inline).toContain("<blockquote>");
+    expect(inline).toContain("[!NOTE] inline text");
+    expect(inline).not.toContain("md-callout");
+    // Nor is a marker anywhere but first.
+    const late = renderMarkdown("> Intro\n>\n> [!NOTE]\n> more");
+    expect(late).toContain("<blockquote>");
+    expect(late).not.toContain("md-callout");
+    // An unknown kind is prose.
+    expect(renderMarkdown("> [!DANGER]\n> x")).not.toContain("md-callout");
+  });
+
+  it("renders inside PR prose, with the sanitizer still on the body", () => {
+    const html = renderPrCommentMarkdown(
+      "> [!IMPORTANT]\n> Press <kbd>K</kbd> <script>alert(1)</script>",
+    );
+    expect(html).toContain("md-callout-important");
+    expect(html).toContain("<kbd>K</kbd>");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("escapes raw HTML in a transcript callout", () => {
+    const html = renderMarkdown("> [!CAUTION]\n> <b>x</b>");
+    expect(html).toContain("&lt;b&gt;x&lt;/b&gt;");
+  });
+});
+
 describe("renderMarkdown @-mentions", () => {
   // The roster is module state, so publish it once for this block. The
   // renderer's cache is keyed on the source text, and setKnownPeople clears

--- a/packages/core/opensession-server/src/frontend/lib/markdown.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.ts
@@ -1,4 +1,5 @@
 import { Marked, type Token, type TokenizerThis, type Tokens } from "marked";
+import { type CalloutIconKind, calloutIconMarkup } from "../components/icons";
 import { BASE_PATH } from "./base";
 import { sanitizeHtmlFragment } from "./html-sanitize";
 import { prStatusDisplay, type PrStatusInput } from "./pr-status";
@@ -1193,6 +1194,75 @@ function flattenChips(tokens: Token[] | undefined): void {
   }
 }
 
+/**
+ * GitHub's admonition syntax: a blockquote whose first line is exactly
+ * `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]`, the rest
+ * of the quote being the body (docs/blocks.md, "Callouts"). Models write
+ * these constantly, and PR bodies carry them too. The marker has to be the
+ * whole first line: `> [!NOTE] inline text` is an ordinary quote on GitHub
+ * and stays one here.
+ */
+const CALLOUT_TITLES: Record<CalloutIconKind, string> = {
+  note: "Note",
+  tip: "Tip",
+  important: "Important",
+  warning: "Warning",
+  caution: "Caution",
+};
+const CALLOUT_MARKER = /^\[!(note|tip|important|warning|caution)\](\n|$)/i;
+/** The marker's name, lowercased, to its kind. */
+const CALLOUT_KINDS = new Map<string, CalloutIconKind>([
+  ["note", "note"],
+  ["tip", "tip"],
+  ["important", "important"],
+  ["warning", "warning"],
+  ["caution", "caution"],
+]);
+
+interface Callout {
+  kind: CalloutIconKind;
+  /** The quote's block tokens with the marker line taken out. */
+  body: Token[];
+}
+
+/** The callout a blockquote is, if its first line is a marker. Never mutates
+ *  the tokens marked handed over: the rewritten paragraph is a copy. */
+function calloutOf(quote: Tokens.Blockquote): Callout | null {
+  const [first, ...rest] = quote.tokens;
+  if (first?.type !== "paragraph") return null;
+  const [lead, ...inline] = first.tokens ?? [];
+  if (lead?.type !== "text") return null;
+  const m = CALLOUT_MARKER.exec(lead.text);
+  if (!m) return null;
+  const kind = CALLOUT_KINDS.get(m[1]!.toLowerCase());
+  if (!kind) return null;
+  let after = inline;
+  if (m[2] === "") {
+    // With `breaks` on, the line end after the marker is a <br> token of its
+    // own rather than a newline in the text; it goes with the marker. A
+    // marker that ends the text token but not the line (`[!NOTE]**bold**`)
+    // is prose, not a title.
+    if (after[0]?.type === "br") after = after.slice(1);
+    else if (after.length > 0) return null;
+  }
+  const remainder = lead.text.slice(m[0].length);
+  const bodyInline: Token[] = remainder
+    ? [{ ...lead, raw: remainder, text: remainder }, ...after]
+    : after;
+  const body: Token[] = bodyInline.length
+    ? [
+        {
+          ...first,
+          raw: first.raw.replace(CALLOUT_MARKER, ""),
+          text: first.text.replace(CALLOUT_MARKER, ""),
+          tokens: bodyInline,
+        },
+        ...rest,
+      ]
+    : rest;
+  return { kind, body };
+}
+
 // An auto-linked (or <bracketed>) bare URL: marked hands the raw URL over as
 // the link text. Trailing-slash tolerant so `…/session/bks-x/` still counts.
 function isBareUrlLink(token: Tokens.Link): boolean {
@@ -1236,6 +1306,20 @@ md.use({
       return renderRawHtml === "sanitize"
         ? sanitizeHtmlFragment(raw)
         : attr(raw);
+    },
+    // A GitHub callout renders as a titled block in its kind's colour
+    // (styles/blocks/callout.css); every other blockquote falls through to
+    // marked's own renderer, untouched.
+    blockquote(token: Tokens.Blockquote) {
+      const callout = calloutOf(token);
+      if (!callout) return false;
+      const { kind, body } = callout;
+      return (
+        `<div class="md-callout md-callout-${kind}">` +
+        `<div class="md-callout-title">${calloutIconMarkup(kind, 16)}${CALLOUT_TITLES[kind]}</div>` +
+        this.parser.parse(body) +
+        `</div>\n`
+      );
     },
     link(token: Tokens.Link) {
       // `[PR #5528](https://github.com/…)` is everyday agent output, and the

--- a/packages/core/opensession-server/src/frontend/lib/metrics-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/metrics-block.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseMetrics } from "./metrics-block";
+import { MAX_METRICS, MAX_SOURCE_CHARS, parseMetrics } from "./metrics-block";
 
 describe("parseMetrics line form", () => {
   it("reads one metric per line with an optional delta", () => {
@@ -44,6 +44,19 @@ describe("parseMetrics line form", () => {
     expect(parseMetrics(": 12")).toBeNull();
     expect(parseMetrics("")).toBeNull();
     expect(parseMetrics("   \n\n")).toBeNull();
+  });
+
+  it("declines a fence with more metrics than a row can show", () => {
+    const line = (i: number) => `M${i}: ${i}`;
+    const lines = (n: number) =>
+      Array.from({ length: n }, (_, i) => line(i)).join("\n");
+    expect(parseMetrics(lines(MAX_METRICS))).toHaveLength(MAX_METRICS);
+    expect(parseMetrics(lines(MAX_METRICS + 1))).toBeNull();
+  });
+
+  it("declines a fence larger than a metrics list has reason to be", () => {
+    const padded = `A: 1 ${" ".repeat(MAX_SOURCE_CHARS)}`;
+    expect(parseMetrics(padded)).toBeNull();
   });
 });
 
@@ -92,5 +105,14 @@ describe("parseMetrics JSON form", () => {
     expect(parseMetrics("[1, 2]")).toBeNull();
     expect(parseMetrics("[{")).toBeNull();
     expect(parseMetrics('{"label":"a","value":1}')).toBeNull();
+  });
+
+  it("declines an array with more metrics than a row can show", () => {
+    const entries = (n: number) =>
+      JSON.stringify(
+        Array.from({ length: n }, (_, i) => ({ label: `M${i}`, value: i })),
+      );
+    expect(parseMetrics(entries(MAX_METRICS))).toHaveLength(MAX_METRICS);
+    expect(parseMetrics(entries(MAX_METRICS + 1))).toBeNull();
   });
 });

--- a/packages/core/opensession-server/src/frontend/lib/metrics-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/metrics-block.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { parseMetrics } from "./metrics-block";
+
+describe("parseMetrics line form", () => {
+  it("reads one metric per line with an optional delta", () => {
+    expect(
+      parseMetrics("Requests: 1,204 (+12%)\nErrors: 3 (-2)\nUptime: 99.98%"),
+    ).toEqual([
+      { label: "Requests", value: "1,204", delta: "+12%", trend: "up" },
+      { label: "Errors", value: "3", delta: "-2", trend: "down" },
+      { label: "Uptime", value: "99.98%", delta: undefined, trend: "flat" },
+    ]);
+  });
+
+  it("reads arrows and the unicode minus as a direction", () => {
+    const metrics = parseMetrics(
+      "A: 1 (▲ 4)\nB: 2 (▼ 1)\nC: 3 (↑ 2)\nD: 4 (↓ 5)\nE: 5 (−3)\nF: 6 (n/a)",
+    );
+    expect(metrics?.map((m) => m.trend)).toEqual([
+      "up",
+      "down",
+      "up",
+      "down",
+      "down",
+      "flat",
+    ]);
+  });
+
+  it("splits on the first colon so a clock value keeps its own", () => {
+    expect(parseMetrics("Uptime: 12:30:05")).toEqual([
+      { label: "Uptime", value: "12:30:05", delta: undefined, trend: "flat" },
+    ]);
+  });
+
+  it("skips blank lines and trims", () => {
+    expect(parseMetrics("\n  Users :  42  \n\n")).toEqual([
+      { label: "Users", value: "42", delta: undefined, trend: "flat" },
+    ]);
+  });
+
+  it("declines a fence with a line that is not a metric", () => {
+    expect(parseMetrics("Requests: 1,204\njust a note")).toBeNull();
+    expect(parseMetrics("Requests:")).toBeNull();
+    expect(parseMetrics(": 12")).toBeNull();
+    expect(parseMetrics("")).toBeNull();
+    expect(parseMetrics("   \n\n")).toBeNull();
+  });
+});
+
+describe("parseMetrics JSON form", () => {
+  it("reads an array of objects and formats numbers", () => {
+    expect(
+      parseMetrics(
+        '[{"label":"p95","value":340,"unit":"ms","delta":-3},' +
+          '{"label":"Revenue","value":"$4.2k","delta":"+8%"},' +
+          '{"label":"Users","value":12345.678}]',
+      ),
+    ).toEqual([
+      { label: "p95", value: "340", unit: "ms", delta: "-3", trend: "down" },
+      {
+        label: "Revenue",
+        value: "$4.2k",
+        unit: undefined,
+        delta: "+8%",
+        trend: "up",
+      },
+      {
+        label: "Users",
+        value: "12,345.68",
+        unit: undefined,
+        delta: undefined,
+        trend: "flat",
+      },
+    ]);
+  });
+
+  it("signs a numeric delta", () => {
+    const metrics = parseMetrics(
+      '[{"label":"a","value":1,"delta":2},{"label":"b","value":1,"delta":0}]',
+    );
+    expect(metrics?.map((m) => [m.delta, m.trend])).toEqual([
+      ["+2", "up"],
+      ["0", "flat"],
+    ]);
+  });
+
+  it("declines JSON that is not an array of labelled values", () => {
+    expect(parseMetrics("[]")).toBeNull();
+    expect(parseMetrics('[{"label":"a"}]')).toBeNull();
+    expect(parseMetrics('[{"value":1}]')).toBeNull();
+    expect(parseMetrics('[{"label":"a","value":"  "}]')).toBeNull();
+    expect(parseMetrics("[1, 2]")).toBeNull();
+    expect(parseMetrics("[{")).toBeNull();
+    expect(parseMetrics('{"label":"a","value":1}')).toBeNull();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/metrics-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/metrics-block.ts
@@ -1,0 +1,160 @@
+/**
+ * The ```metrics fence: a row of cards, each a big number with a small label
+ * and an optional delta (docs/blocks.md, "Metrics"). Two grammars, both
+ * parsed here without a DOM so the parser is unit-testable:
+ *
+ *   Requests: 1,204 (+12%)        one metric per line, delta in parentheses
+ *   [{"label":"p95","value":340,"unit":"ms","delta":-3}]
+ *
+ * A fence that does not parse keeps its code block, so a half-streamed or
+ * mis-shaped one is still readable.
+ */
+
+import { z } from "zod";
+import type { FenceUpgrader } from "./fence-upgraders";
+
+export type MetricTrend = "up" | "down" | "flat";
+
+export interface Metric {
+  label: string;
+  value: string;
+  unit?: string;
+  delta?: string;
+  trend: MetricTrend;
+}
+
+/** `Label: value (delta)`; the parenthesised tail is optional. */
+const METRIC_LINE = /^([^:]+?)\s*:\s*(.+?)(?:\s*\(([^()]*)\))?\s*$/;
+
+/** The direction a delta reads as, from its sign or arrow. */
+function trendOf(delta: string | undefined): MetricTrend {
+  if (!delta) return "flat";
+  const lead = delta.trim().charAt(0);
+  if (lead === "+" || lead === "▲" || lead === "↑") return "up";
+  if (lead === "-" || lead === "−" || lead === "▼" || lead === "↓")
+    return "down";
+  return "flat";
+}
+
+const number = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
+
+/** A non-blank string, trimmed; blank is rejected, not emptied. */
+const text = z
+  .string()
+  .transform((s) => s.trim())
+  .refine((s) => s.length > 0);
+
+/** A value written as a number is formatted for reading; a string is kept. */
+const value = z.union([z.number().finite().transform(number.format), text]);
+
+/** A numeric delta carries its sign, so `2` reads as `+2` beside its value. */
+const signedDelta = z
+  .number()
+  .finite()
+  .transform((n) => {
+    const magnitude = number.format(Math.abs(n));
+    return n > 0 ? `+${magnitude}` : n < 0 ? `-${magnitude}` : magnitude;
+  });
+
+const metricEntry = z.object({
+  label: text,
+  value,
+  delta: z.union([signedDelta, text]).optional(),
+  unit: text.optional(),
+});
+
+const metricsJson = z.array(metricEntry).nonempty();
+
+function metricFromLine(line: string): Metric | null {
+  const m = METRIC_LINE.exec(line);
+  if (!m) return null;
+  const label = m[1]!.trim();
+  const value = m[2]!.trim();
+  if (!label || !value) return null;
+  const delta = m[3]?.trim() || undefined;
+  return { label, value, delta, trend: trendOf(delta) };
+}
+
+/**
+ * The metrics a fence lists, or null when it is not a metrics fence after
+ * all: an empty body, a JSON body that is not an array of `{label, value}`
+ * objects, or a line that is not `Label: value (delta)`.
+ */
+export function parseMetrics(source: string): Metric[] | null {
+  const body = source.trim();
+  if (!body) return null;
+  // Anything JSON-shaped is read as JSON: a bare object is not the array the
+  // grammar asks for, and must not fall through to the line reader.
+  if (body.startsWith("[") || body.startsWith("{")) {
+    let json: unknown;
+    try {
+      json = JSON.parse(body);
+    } catch {
+      return null;
+    }
+    const parsed = metricsJson.safeParse(json);
+    if (!parsed.success) return null;
+    return parsed.data.map(({ label, value, delta, unit }) => ({
+      label,
+      value,
+      unit,
+      delta,
+      trend: trendOf(delta),
+    }));
+  }
+  const metrics: Metric[] = [];
+  for (const line of body.split("\n")) {
+    if (!line.trim()) continue;
+    const metric = metricFromLine(line);
+    if (!metric) return null;
+    metrics.push(metric);
+  }
+  return metrics.length ? metrics : null;
+}
+
+/** The card row (styles/blocks/metrics.css). Text goes in as textContent. */
+function metricsElement(metrics: readonly Metric[]): HTMLElement {
+  const row = document.createElement("div");
+  row.className = "md-metrics";
+  row.setAttribute("role", "list");
+  for (const metric of metrics) {
+    const card = document.createElement("div");
+    card.className = "md-metric";
+    card.setAttribute("role", "listitem");
+    const value = document.createElement("div");
+    value.className = "md-metric-value";
+    const figure = document.createElement("span");
+    figure.className = "md-metric-figure";
+    figure.textContent = metric.value;
+    value.append(figure);
+    if (metric.unit) {
+      const unit = document.createElement("span");
+      unit.className = "md-metric-unit";
+      unit.textContent = metric.unit;
+      value.append(unit);
+    }
+    if (metric.delta) {
+      const delta = document.createElement("span");
+      delta.className = `md-metric-delta md-metric-delta-${metric.trend}`;
+      delta.textContent = metric.delta;
+      value.append(delta);
+    }
+    const label = document.createElement("div");
+    label.className = "md-metric-label";
+    label.textContent = metric.label;
+    label.title = metric.label;
+    card.append(value, label);
+    row.append(card);
+  }
+  return row;
+}
+
+export const metricsUpgrader: FenceUpgrader = {
+  langs: ["metrics"],
+  async upgrade({ pre, source, root, alive }) {
+    const metrics = parseMetrics(source);
+    if (!metrics || !alive() || !root.contains(pre)) return false;
+    pre.replaceWith(metricsElement(metrics));
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/metrics-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/metrics-block.ts
@@ -63,7 +63,15 @@ const metricEntry = z.object({
   unit: text.optional(),
 });
 
-const metricsJson = z.array(metricEntry).nonempty();
+/**
+ * A metrics row is a handful of headline numbers, and every metric costs
+ * four DOM nodes built synchronously, so a fence past these bounds keeps its
+ * code block rather than expanding a large asset into a frozen page.
+ */
+export const MAX_SOURCE_CHARS = 16_000;
+export const MAX_METRICS = 64;
+
+const metricsJson = z.array(metricEntry).nonempty().max(MAX_METRICS);
 
 function metricFromLine(line: string): Metric | null {
   const m = METRIC_LINE.exec(line);
@@ -78,9 +86,11 @@ function metricFromLine(line: string): Metric | null {
 /**
  * The metrics a fence lists, or null when it is not a metrics fence after
  * all: an empty body, a JSON body that is not an array of `{label, value}`
- * objects, or a line that is not `Label: value (delta)`.
+ * objects, a line that is not `Label: value (delta)`, or a body past
+ * MAX_SOURCE_CHARS or MAX_METRICS.
  */
 export function parseMetrics(source: string): Metric[] | null {
+  if (source.length > MAX_SOURCE_CHARS) return null;
   const body = source.trim();
   if (!body) return null;
   // Anything JSON-shaped is read as JSON: a bare object is not the array the
@@ -106,7 +116,7 @@ export function parseMetrics(source: string): Metric[] | null {
   for (const line of body.split("\n")) {
     if (!line.trim()) continue;
     const metric = metricFromLine(line);
-    if (!metric) return null;
+    if (!metric || metrics.length === MAX_METRICS) return null;
     metrics.push(metric);
   }
   return metrics.length ? metrics : null;

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -29,4 +29,6 @@
 @import "./base-global.css";
 @import "./base-platform.css";
 @import "./base-markdown.css";
+@import "./blocks/callout.css";
+@import "./blocks/metrics.css";
 @import "./base-keyframes.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/callout.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/callout.css
@@ -1,0 +1,42 @@
+/* ── GitHub callout (`> [!NOTE]` … `> [!CAUTION]`) ──────────────────────
+   Emitted by lib/markdown.ts in place of the blockquote: a title row in the
+   kind's colour over the quote's body as ordinary markdown. Same box as
+   `.markdown blockquote`, so a callout and a quote line up; the rule down
+   the side takes the kind's colour, which is what tells them apart. */
+.md-callout {
+  --callout: var(--text-dim);
+  margin: 2px 0 8px;
+  padding: 4px 12px 5px;
+  border-left: 2px solid var(--callout);
+}
+.md-callout-note {
+  --callout: var(--blue);
+}
+.md-callout-tip {
+  --callout: var(--green);
+}
+.md-callout-important {
+  --callout: var(--purple);
+}
+.md-callout-warning {
+  --callout: var(--yellow);
+}
+.md-callout-caution {
+  --callout: var(--red);
+}
+.md-callout-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  font-size: var(--type-label);
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--callout);
+}
+.md-callout-title > svg {
+  flex: none;
+}
+.md-callout > :last-child {
+  margin-bottom: 0;
+}

--- a/packages/core/opensession-server/src/frontend/styles/blocks/metrics.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/metrics.css
@@ -1,0 +1,64 @@
+/* ── ```metrics cards (lib/metrics-block.ts) ────────────────────────────
+   A row of cards that fills the column and wraps; two across on a phone. A
+   card is a fill on the message surface with no border (frontend/AGENTS.md),
+   and the figure is tabular so a row of them lines up digit for digit. */
+.md-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+  margin: 2px 0 8px;
+}
+.md-metric {
+  min-width: 0;
+  padding: 10px 12px 9px;
+  background: var(--bg-panel);
+  border-radius: calc(14px * var(--rf));
+  corner-shape: var(--cs);
+}
+.md-metric-value {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 2px 6px;
+  color: var(--text);
+}
+.md-metric-figure {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+.md-metric-unit {
+  font-size: var(--type-label);
+  font-weight: 500;
+  color: var(--text-dim);
+  /* Hugs its figure; the delta after it keeps the row's gap. */
+  margin-left: -4px;
+}
+.md-metric-delta {
+  font-size: var(--type-label);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+}
+.md-metric-delta-up {
+  color: var(--green);
+}
+.md-metric-delta-down {
+  color: var(--red);
+}
+.md-metric-label {
+  margin-top: 2px;
+  font-size: var(--type-meta);
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .md-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
Two block kinds from `docs/blocks.md`, on top of the fence upgrader registry (e20bc207e).

## Callouts

A blockquote whose first line is exactly `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` (any case) renders as a callout: a rule and title in the kind's colour (`--blue`, `--green`, `--purple`, `--yellow`, `--red`), an icon, and the rest of the quote as ordinary markdown. Implemented as marked's `blockquote` renderer in `lib/markdown.ts`, so it applies in transcripts and in PR prose through `rawHtml: "sanitize"`. Ordinary blockquotes, a marker with text after it on the same line, or a marker anywhere but the first line stay plain quotes, as on GitHub. Icons are new markup glyphs in `components/icons.tsx` (`calloutIconMarkup`), each with its JSX twin.

## Metrics

A ```` ```metrics ```` fence: one `Label: value (delta)` per line, delta optional, or a JSON array of `{label, value, delta?, unit?}` (numbers formatted, numeric deltas signed). Renders as a grid of cards: tabular figure, unit, delta coloured up/down by its lead character (`+ ▲ ↑` / `- ▼ ↓`), label. Two across on a phone. `lib/metrics-block.ts` keeps the parser pure (zod schema for the JSON form, bun tests beside it); a fence that does not parse returns false and stays code.

## Also

- `styles/blocks/callout.css` and `styles/blocks/metrics.css`, imported from `base.css`.
- `AssetView`'s markdown preview now goes through `renderMarkdown` instead of stock `marked.parse`, so a `.md` scratch file shows callouts too and escapes raw HTML the way a transcript does. One-line swap; flagging it since it was outside the brief.
- `docs/blocks.md` Callouts and Metrics sections updated to the shipped grammar.

## Verification

`bun run check` passes. Captured through the compiled-bundle harness against the verify-opensession demo instance: transcript at 1440x900 dark and light, phone 390x844, and the `metrics.md` asset preview in both themes and on phone.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)