### PR TITLE
Typeset math in messages with KaTeX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
         "effect": "4.0.0-rc.112",
         "emoji-datasource": "^16.0.0",
         "ghostty-web": "^0.4.0",
+        "katex": "0.16.47",
         "marked": "^15.0.0",
         "mermaid": "^11.16.1",
         "modal": "0.9.0",

--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -65,8 +65,15 @@ is the body.
 
 `$$` on its own lines opens and closes a display block; `$x^2$` is inline.
 Inline math needs the opening `$` to touch the expression and the closing `$`
-to touch it too, so `$1.84` and `$5 to $10` stay prose. A ` ```math `
-fence is a display block as well.
+to touch it too, with no digit after the close, so `$1.84`, `$5 to $10` and
+`$5-$10` stay prose. It never spans a line or reaches into a code span; write
+`\$` for a literal dollar next to an expression. A one-line `$$E=mc^2$$`
+typesets in display mode where it sits. A ` ```math ` fence is a display
+block as well, and a `$$` block renders as that fence until it is typeset,
+so a block that does not parse stays readable source.
+
+KaTeX writes MathML only (no katex.css, no fonts to serve); the browser
+lays it out in its math font and the current text colour.
 
 ### Colour
 

--- a/packages/core/opensession-server/package.json
+++ b/packages/core/opensession-server/package.json
@@ -36,6 +36,7 @@
     "effect": "4.0.0-rc.112",
     "emoji-datasource": "^16.0.0",
     "ghostty-web": "^0.4.0",
+    "katex": "0.16.47",
     "marked": "^15.0.0",
     "mermaid": "^11.16.1",
     "modal": "0.9.0",

--- a/packages/core/opensession-server/src/frontend/components/MarkdownBody.tsx
+++ b/packages/core/opensession-server/src/frontend/components/MarkdownBody.tsx
@@ -6,6 +6,10 @@ import {
   type FenceUpgrader,
   finalizeFenceUpgrades,
 } from "../lib/fence-upgraders";
+import {
+  MATH_PLACEHOLDER_MARK,
+  upgradeMathPlaceholders,
+} from "../lib/math-block";
 
 // Lazy loaders live at module scope: the compiler cannot lower dynamic
 // imports inside components.
@@ -106,8 +110,16 @@ export function MarkdownBody({
   }, [enhance]);
 
   useEffect(() => {
-    // marked emits <code class="language-x"> only for tagged fences.
-    if (!enhance || !visible || !html.includes('<code class="language-'))
+    // marked emits <code class="language-x"> only for tagged fences, and the
+    // .md-math placeholder only for inline math (lib/math-block.ts).
+    if (
+      !enhance ||
+      !visible ||
+      !(
+        html.includes('<code class="language-') ||
+        html.includes(MATH_PLACEHOLDER_MARK)
+      )
+    )
       return;
     const el = ref.current;
     if (!el) return;
@@ -162,6 +174,11 @@ export function MarkdownBody({
             .catch(() => false);
         }
       }
+
+      // Inline math is not a fence, so the registry never sees it; its
+      // placeholders are typeset here, in the same pass and under the same
+      // reset and cancellation as the fences.
+      await upgradeMathPlaceholders(el, isAlive);
 
       if (!fences.some((f) => f.lang && !f.done)) return;
       const m = await loadCodeHighlight().catch(() => null);

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -16,6 +16,7 @@
  */
 
 import { chartUpgrader } from "./chart-fence";
+import { mathUpgrader } from "./math-block";
 import { mermaidUpgrader } from "./mermaid-fence";
 import type { EffectiveTheme } from "./theme";
 
@@ -74,6 +75,7 @@ export interface FenceUpgrader {
 export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   mermaidUpgrader,
   chartUpgrader,
+  mathUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
@@ -1319,3 +1319,62 @@ describe("GitHub user-attachment media", () => {
     expect(html).toContain(`<a href="${proxied}"`);
   });
 });
+
+describe("renderMarkdown math", () => {
+  it("emits an inline placeholder carrying the escaped source", () => {
+    const html = renderMarkdown("The area is $\\pi r^2$ here.");
+    expect(html).toContain(
+      '<span class="md-math" data-math="\\pi r^2">$\\pi r^2$</span>',
+    );
+  });
+
+  it("typesets a one-line $$...$$ as display math", () => {
+    const html = renderMarkdown("Then $$E = mc^2$$ follows.");
+    expect(html).toContain('data-display="" data-math="E = mc^2"');
+  });
+
+  it("turns a $$ block on its own lines into a math fence", () => {
+    const html = renderMarkdown("Before\n$$\n\\sum_{i=1}^n i\n$$\nAfter");
+    expect(html).toContain(
+      '<pre><code class="language-math">\\sum_{i=1}^n i\n</code></pre>',
+    );
+    expect(html).toContain("<p>Before</p>");
+    expect(html).toContain("<p>After</p>");
+    expect(html).not.toContain("md-math");
+  });
+
+  it("leaves a ```math fence as the fence the upgrader claims", () => {
+    const html = renderMarkdown("```math\nx^2\n```");
+    expect(html).toContain('<code class="language-math">x^2\n</code>');
+  });
+
+  it("keeps prices as prose", () => {
+    for (const prose of [
+      "It costs $1.84 today.",
+      "Between $5 to $10 each.",
+      "Pay $5, $10 or $20.",
+      "A range of $5-$10.",
+      "It costs $3",
+      "Roughly $5 and up to $10 more",
+    ]) {
+      const html = renderMarkdown(prose);
+      expect(html).not.toContain("md-math");
+      expect(html).toContain("$");
+    }
+  });
+
+  it("never matches across lines or inside code", () => {
+    expect(renderMarkdown("costs $5\nand $10")).not.toContain("md-math");
+    expect(renderMarkdown("run `echo $x$`")).toContain("<code>echo $x$</code>");
+    expect(renderMarkdown("```sh\necho $x$\n```")).not.toContain("md-math");
+    const fenced = renderMarkdown("```txt\n$$\nx\n$$\n```");
+    expect(fenced).toContain('class="language-txt"');
+    expect(fenced).not.toContain("language-math");
+  });
+
+  it("escapes a dollar written as \\$", () => {
+    const html = renderMarkdown("costs \\$x\\$ now");
+    expect(html).not.toContain("md-math");
+    expect(html).toContain("$x$");
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/markdown.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.ts
@@ -1,6 +1,13 @@
 import { Marked, type Token, type TokenizerThis, type Tokens } from "marked";
 import { BASE_PATH } from "./base";
 import { sanitizeHtmlFragment } from "./html-sanitize";
+import {
+  displayMathBlockStart,
+  inlineMathStart,
+  matchDisplayMathBlock,
+  matchInlineMath,
+  mathPlaceholder,
+} from "./math-block";
 import { prStatusDisplay, type PrStatusInput } from "./pr-status";
 import { repoLabel } from "./repo-label";
 import { cleanSessionTitle } from "./session-title";
@@ -1350,6 +1357,34 @@ md.use({
   // Bare session ids in prose (not wrapped in backticks) also link. Strict
   // uuidv7 shape so it only fires on real ids.
   extensions: [
+    // Math (lib/math-block.ts). A `$$` block on its own lines becomes the
+    // same code token a ```math fence is, so the fence upgrader typesets
+    // both and a body that is never upgraded still shows readable source.
+    {
+      name: "mathBlock",
+      level: "block",
+      start: displayMathBlockStart,
+      tokenizer(src: string) {
+        const m = matchDisplayMathBlock(src);
+        if (!m) return undefined;
+        return { type: "code", raw: m.raw, lang: "math", text: m.source };
+      },
+    },
+    // `$x^2$` in prose: a placeholder carrying the escaped source, upgraded
+    // after mount. The grammar is strict about prices; see math-block.ts.
+    {
+      name: "mathInline",
+      level: "inline",
+      start: inlineMathStart,
+      tokenizer(src: string) {
+        const m = matchInlineMath(src);
+        if (!m) return undefined;
+        return { type: "mathInline", raw: m.raw, math: m };
+      },
+      renderer(token: Tokens.Generic) {
+        return mathPlaceholder(token.math);
+      },
+    },
     {
       name: "assetPath",
       level: "inline",

--- a/packages/core/opensession-server/src/frontend/lib/math-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/math-block.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import katex from "katex";
+import {
+  displayMathBlockStart,
+  inlineMathStart,
+  matchDisplayMathBlock,
+  matchInlineMath,
+  mathPlaceholder,
+  renderMathHtml,
+} from "./math-block";
+
+describe("inline math grammar", () => {
+  it("matches an expression the delimiters touch", () => {
+    expect(matchInlineMath("$x^2$ and more")).toEqual({
+      raw: "$x^2$",
+      source: "x^2",
+      display: false,
+    });
+    expect(matchInlineMath("$\\frac{a}{b}$.")?.source).toBe("\\frac{a}{b}");
+  });
+
+  it("typesets a one-line $$...$$ in display mode", () => {
+    expect(matchInlineMath("$$E = mc^2$$ rest")).toEqual({
+      raw: "$$E = mc^2$$",
+      source: "E = mc^2",
+      display: true,
+    });
+  });
+
+  it("leaves prices alone", () => {
+    for (const prose of [
+      "$1.84",
+      "$5 to $10",
+      "$5 to $10 each",
+      "$5-$10",
+      "$5, $10 and $20.",
+      "$3 costs",
+      "$ x$",
+      "$x $",
+      "$$",
+      "$",
+    ]) {
+      expect(matchInlineMath(prose)).toBeUndefined();
+    }
+  });
+
+  it("never matches across a line", () => {
+    expect(matchInlineMath("$a\nb$")).toBeUndefined();
+  });
+
+  it("points marked at a candidate opener and skips glued dollars", () => {
+    expect(inlineMathStart("see $x$")).toBe(4);
+    expect(inlineMathStart("see $$x$$")).toBe(4);
+    expect(inlineMathStart("US$5$")).toBeUndefined();
+    expect(inlineMathStart("costs \\$x$")).toBeUndefined();
+    expect(inlineMathStart("costs $ x")).toBeUndefined();
+  });
+});
+
+describe("display math block grammar", () => {
+  it("matches $$ on its own lines", () => {
+    expect(matchDisplayMathBlock("$$\n\\int_0^1 x\\,dx\n$$\nafter")).toEqual({
+      raw: "$$\n\\int_0^1 x\\,dx\n$$",
+      source: "\\int_0^1 x\\,dx",
+    });
+    expect(matchDisplayMathBlock("$$  \na\nb\n  $$")?.source).toBe("a\nb");
+  });
+
+  it("needs a closing line", () => {
+    expect(matchDisplayMathBlock("$$\nx")).toBeUndefined();
+    expect(matchDisplayMathBlock("$$ x $$")).toBeUndefined();
+    expect(matchDisplayMathBlock("$$\nx\n$$y")).toBeUndefined();
+  });
+
+  it("reports where a later block starts, only when it is complete", () => {
+    expect(displayMathBlockStart("text\n$$\nx\n$$")).toBe(5);
+    expect(displayMathBlockStart("text\n$$\nx")).toBeUndefined();
+  });
+});
+
+describe("mathPlaceholder", () => {
+  it("escapes the source into the attribute and keeps it as text", () => {
+    const html = mathPlaceholder({
+      raw: '$a<b "c"$',
+      source: 'a<b "c"',
+      display: false,
+    });
+    expect(html).toBe(
+      '<span class="md-math" data-math="a&lt;b &quot;c&quot;">$a&lt;b &quot;c&quot;$</span>',
+    );
+    expect(
+      mathPlaceholder({ raw: "$$x$$", source: "x", display: true }),
+    ).toContain('data-display=""');
+  });
+});
+
+describe("renderMathHtml", () => {
+  it("writes MathML only, in display or inline mode", () => {
+    const inline = renderMathHtml(katex, "x^2", false);
+    expect(inline).toContain("<math");
+    expect(inline).not.toContain('class="katex-html"');
+    expect(inline).not.toContain('display="block"');
+    expect(renderMathHtml(katex, "x^2", true)).toContain('display="block"');
+  });
+
+  it("declines what does not parse instead of showing red text", () => {
+    expect(renderMathHtml(katex, "\\frac{a}{", true)).toBeNull();
+    expect(renderMathHtml(katex, "   ", true)).toBeNull();
+  });
+
+  it("keeps trust off so links and images stay out", () => {
+    // With trust off KaTeX typesets the command's name instead of obeying
+    // it; the source only survives as inert text in the <annotation>.
+    const html = renderMathHtml(katex, "\\href{javascript:x}{y}", false);
+    expect(html).not.toBeNull();
+    expect(html).not.toContain("href=");
+    expect(html).not.toMatch(/<a\b/);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/math-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/math-block.ts
@@ -1,0 +1,188 @@
+/**
+ * Math in session markdown, typeset by KaTeX.
+ *
+ * Three forms reach here. A ```math fence and a `$$` block on its own lines
+ * are both display math; markdown.ts turns the `$$` block into the same
+ * `<pre><code class="language-math">` marked writes for the fence, so one
+ * upgrader handles both and either keeps a readable code block when KaTeX
+ * declines. `$x^2$` (and `$$x^2$$` on one line) is inline: markdown.ts emits
+ * the `.md-math` placeholder below with the source as its text, and
+ * `upgradeMathPlaceholders` typesets it in the same post-mount pass.
+ *
+ * The grammar that tells `$x^2$` from `$5 to $10` lives here too, as pure
+ * matchers, so it can be tested without marked.
+ *
+ * KaTeX (~270 KB minified) is `import()`ed inside the upgrade, never here:
+ * this module is imported eagerly by the fence registry. Output is MathML
+ * only, so no katex.css and no font files need serving; Chrome, Safari and
+ * Firefox all lay MathML out natively.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+
+type Katex = typeof import("katex").default;
+
+let katexPromise: Promise<Katex> | null = null;
+function loadKatex(): Promise<Katex> {
+  katexPromise ??= import("katex").then((m) => m.default);
+  return katexPromise;
+}
+
+/** The class of an inline placeholder, and the substring of a rendered
+ *  body that says one is present (MarkdownBody gates its pass on it). */
+export const MATH_PLACEHOLDER_CLASS = "md-math";
+export const MATH_PLACEHOLDER_MARK = `class="${MATH_PLACEHOLDER_CLASS}"`;
+
+export interface MathMatch {
+  /** The whole match, `$...$` or `$$...$$`. */
+  raw: string;
+  /** The TeX between the delimiters. */
+  source: string;
+  /** True for `$$...$$`, which typesets in display mode. */
+  display: boolean;
+}
+
+// The opening delimiter must touch the expression and the closing one must
+// touch it too, and no digit may follow the close. That is what keeps
+// `$1.84`, `$5 to $10`, `costs $3` and `$5-$10` prose: each is missing a
+// close, or has a space before it, or a digit after it. One line only, and
+// no `$` inside, so nothing matches across a line break or swallows a second
+// price. Code spans and fences never reach these: marked hands them to
+// the codespan and fence tokenizers as a unit first.
+const DISPLAY_INLINE_EXACT = /^\$\$(?![\s$])([^$\n]+?)(?<!\s)\$\$(?!\d)/;
+const INLINE_EXACT = /^\$(?![\s$])([^$\n]+?)(?<!\s)\$(?!\d)/;
+// A `$` that could open either form, not escaped and not glued to the word
+// before it (`US$5$`, `a$b$`), for marked's fast-forward hint.
+const INLINE_START = /(?<![\w$\\])\$(?=[^\s$]|\$[^\s$])/;
+
+/** Match `$x^2$` or `$$x^2$$` at the start of `src`. */
+export function matchInlineMath(src: string): MathMatch | undefined {
+  const display = DISPLAY_INLINE_EXACT.exec(src);
+  if (display) return { raw: display[0], source: display[1], display: true };
+  const inline = INLINE_EXACT.exec(src);
+  if (inline) return { raw: inline[0], source: inline[1], display: false };
+  return undefined;
+}
+
+/** Where the next candidate opener sits in `src`, for marked's `start`. */
+export function inlineMathStart(src: string): number | undefined {
+  const m = INLINE_START.exec(src);
+  return m ? m.index : undefined;
+}
+
+// `$$` alone on a line opens the block, `$$` alone on a line closes it. The
+// body is everything between, verbatim.
+const DISPLAY_BLOCK_EXACT = /^\$\$[ \t]*\n([\s\S]*?)\n[ \t]*\$\$[ \t]*(?=\n|$)/;
+const DISPLAY_BLOCK_START =
+  /\n(?=\$\$[ \t]*\n[\s\S]*?\n[ \t]*\$\$[ \t]*(?:\n|$))/;
+
+/** Match a `$$` display block at the start of `src`. */
+export function matchDisplayMathBlock(
+  src: string,
+): { raw: string; source: string } | undefined {
+  const m = DISPLAY_BLOCK_EXACT.exec(src);
+  return m ? { raw: m[0], source: m[1] } : undefined;
+}
+
+/** Index of the `$$` line that starts a complete block later in `src`. */
+export function displayMathBlockStart(src: string): number | undefined {
+  const m = DISPLAY_BLOCK_START.exec(src);
+  return m ? m.index + 1 : undefined;
+}
+
+function escapeAttr(v: string): string {
+  return v
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * The inline placeholder markdown.ts emits: the source is escaped into an
+ * attribute (it is untrusted prose) and repeated as the visible text, so a
+ * body that is never upgraded (a live stream, a failed load) still reads as
+ * it was written.
+ */
+export function mathPlaceholder(match: MathMatch): string {
+  const display = match.display ? ' data-display=""' : "";
+  return (
+    `<span ${MATH_PLACEHOLDER_MARK}${display} data-math="${escapeAttr(match.source)}">` +
+    `${escapeAttr(match.raw)}</span>`
+  );
+}
+
+/**
+ * KaTeX markup for `source`, or null when it does not parse. `throwOnError`
+ * is off so KaTeX never throws on bad TeX; it marks the failure with a
+ * `katex-error` span instead, and that is the signal to keep the plain
+ * source rather than show red text. `trust` stays off: the source is
+ * untrusted, and the trust option would let `\href` and `\includegraphics`
+ * through.
+ */
+export function renderMathHtml(
+  katex: Pick<Katex, "renderToString">,
+  source: string,
+  display: boolean,
+): string | null {
+  const tex = source.trim();
+  if (!tex) return null;
+  let html: string;
+  try {
+    html = katex.renderToString(tex, {
+      displayMode: display,
+      output: "mathml",
+      throwOnError: false,
+      trust: false,
+      strict: "ignore",
+    });
+  } catch {
+    return null;
+  }
+  return html.includes("katex-error") ? null : html;
+}
+
+/**
+ * Typeset every inline placeholder under `root`. Called by MarkdownBody
+ * alongside the fence loop, after the innerHTML reset that hands back the
+ * pristine placeholders. One that fails keeps its source text.
+ */
+export async function upgradeMathPlaceholders(
+  root: HTMLElement,
+  alive: () => boolean,
+): Promise<void> {
+  const spans = Array.from(
+    root.querySelectorAll<HTMLElement>(`.${MATH_PLACEHOLDER_CLASS}[data-math]`),
+  );
+  if (spans.length === 0) return;
+  const katex = await loadKatex().catch(() => null);
+  if (!katex || !alive()) return;
+  for (const span of spans) {
+    if (!root.contains(span)) continue;
+    const html = renderMathHtml(
+      katex,
+      span.dataset.math ?? "",
+      span.dataset.display !== undefined,
+    );
+    if (html === null) continue;
+    span.innerHTML = html;
+    span.dataset.rendered = "";
+  }
+}
+
+/** A ```math fence, or the `$$` block markdown.ts writes as one. Source
+ *  that does not parse keeps the plain fence. */
+export const mathUpgrader: FenceUpgrader = {
+  langs: ["math"],
+  async upgrade({ pre, source, root, alive }) {
+    const katex = await loadKatex().catch(() => null);
+    if (!katex || !alive() || !root.contains(pre)) return false;
+    const html = renderMathHtml(katex, source, true);
+    if (html === null) return false;
+    const block = document.createElement("div");
+    block.className = "md-math-block";
+    block.innerHTML = html;
+    pre.replaceWith(block);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -29,4 +29,5 @@
 @import "./base-global.css";
 @import "./base-platform.css";
 @import "./base-markdown.css";
+@import "./blocks/math.css";
 @import "./base-keyframes.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/math.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/math.css
@@ -1,0 +1,37 @@
+/* ── Math (lib/math-block.ts) ──────────────────────────────────
+   KaTeX writes MathML only, so there is no katex.css and the browser
+   lays the math out in the current text colour with its own math font.
+   A ```math fence or a `$$` block becomes .md-math-block: centred, and
+   scrolling sideways when an expression is wider than the column. Inline
+   math is the .md-math span markdown.ts emits, which keeps the written
+   source as its text until it is typeset. */
+.md-math-block {
+  margin: 2px 0 8px;
+  padding: 8px 12px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-align: center;
+  color: var(--text);
+  font-size: 1.1em;
+}
+.md-math-block .katex-display {
+  display: block;
+  margin: 0;
+}
+.md-math-block math {
+  display: block math;
+  margin: 0 auto;
+}
+.md-math {
+  color: inherit;
+}
+.md-math[data-rendered] {
+  white-space: nowrap;
+}
+/* A one-line `$$x$$` typesets in display mode inside its paragraph. */
+.md-math[data-display][data-rendered] {
+  display: block;
+  overflow-x: auto;
+  text-align: center;
+  margin: 4px 0;
+}


### PR DESCRIPTION
## What

Math in session messages, as a block kind on the fence upgrader registry (`docs/blocks.md`, section "Math"):

- `$$` on its own lines opens and closes a display block.
- A ```` ```math ```` fence is a display block too.
- `$x^2$` is inline; a one-line `$$E=mc^2$$` typesets in display mode where it sits.

## How

- `lib/math-block.ts`: the grammar (pure matchers), the inline placeholder, `renderMathHtml`, the `mathUpgrader` (langs: `math`) and `upgradeMathPlaceholders`.
- `lib/markdown.ts`: two marked extensions. The block one turns a `$$` block into the same `code` token a ```` ```math ```` fence is, so one upgrader typesets both and a block that does not parse keeps a readable code fence (un-enhanced bodies and live streams show the source). The inline one emits `<span class="md-math" data-math="…">$x^2$</span>` with the source escaped into the attribute and repeated as visible text.
- `components/MarkdownBody.tsx`: the effect's gate also accepts the placeholder mark, and one call typesets the placeholders inside the same pass, under the same innerHTML reset and cancellation as the fences. That is the whole change there.
- `styles/blocks/math.css`, imported from `base.css`: display blocks centred, sideways scroll when wide, current text colour in both themes.

### Grammar and the price problem

Inline math needs the opening `$` to touch the expression and the closing `$` to touch it too, with no digit after the close. So `$1.84`, `$5 to $10`, `costs $3`, `$5-$10` and `$5, $10 or $20` all stay prose (each is missing a close, has a space before it, or a digit after it). One line only, no `$` inside. Code spans and fences never reach the tokenizer: marked hands them over as a unit first. `\$` is the escape hatch. All of these are tested as negatives in `markdown.test.ts` and `math-block.test.ts`.

### Output mode: MathML only

`output: "mathml"`. No katex.css and no font files ship; the browser lays the math out natively in its math font and the current text colour, and the lazy chunk is the only cost. Checked in Chrome on the demo instance (screenshots below): fractions, radicals, sub/superscripts, sums with limits and integrals all lay out correctly. Caveat: a host with no OpenType MATH font (this Linux box has none) renders with a fallback serif, so large operators are a little cramped; macOS (STIX Two Math) and Windows (Cambria Math) both ship one. If that ever reads as unacceptable, the fallback is `htmlAndMathml` plus serving `katex.min.css` and its woff2 set through `frontend-build.ts`.

`throwOnError: false` and `trust: false`. KaTeX marks a parse failure with a `katex-error` span rather than throwing; that is the signal to keep the fence (display) or the source text (inline) rather than show red text.

### Bundle

`katex` 0.16.47 (already in the lockfile via mermaid, so no duplicate). Lazy chunk: 274 KB minified, 78 KB gzipped, loaded only when a body carries math.

## Proof

Demo instance, compiled bundle. Dark and light at 1440x900, phone at 390x844: inline `$t = t_0 + n \cdot c$`, a one-line `$$…$$`, a `$$` block, a ```` ```math ```` fence and a paragraph of prices, all in one assistant message.

## Not in this PR

- The PR overview and PR comment surfaces render prose with `dangerouslySetInnerHTML` directly, not through `MarkdownBody`, so inline math there shows its source (the same is already true of mermaid and chart fences there).
- The asset overlay (`AssetView.tsx`) previews `.md` files through stock `marked`, not `renderMarkdown`, so only the ```` ```math ```` fence typesets there.
- The model prompt and `show-me` skill are wired by the parent for all blocks.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)