### PR TITLE
Render large json fences as a tree and ansi fences with their colours

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -95,15 +95,26 @@ since `#123` in a codespan is usually an issue number or an anchor.
 
 ### JSON tree
 
-A ` ```json ` fence that parses and is large enough to be worth
-folding renders as a collapsible tree with a toggle back to the raw text.
-Small JSON stays highlighted code.
+A ` ```json ` fence that parses to an object or array and is large enough
+to be worth folding (more than 30 lines, or more than 1500 characters)
+renders as a collapsible tree: keys and typed values in shiki's inks, the
+root and its children open, anything deeper folded behind its count, and a
+Tree / Raw toggle in the header that swaps to the highlighted text. Copy
+still copies the JSON text. Small JSON, a bare scalar, and JSON that does
+not parse (still streaming, comments, trailing commas) stay highlighted
+code; `jsonc` and `json5` are not trees.
 
 ### Terminal output
 
-` ```ansi ` and ` ```terminal ` fences render ANSI SGR colours and
-styles. A `bash` or `console` fence that carries escape codes renders them
-too.
+` ```ansi ` and ` ```terminal ` fences render ANSI SGR sequences
+(`ESC[...m`: bold, dim, italic, underline, strikethrough, inverse, the 16
+colours and their bright forms, 256-colour and 24-bit) as styled text; every
+other escape (cursor movement, erase, OSC) is stripped. Write the real escape
+byte, or in an `ansi`/`terminal` fence its usual spellings (`\x1b[`, `\e[`,
+`\033[`, `\u001b[`), which are decoded when the fence holds no real one. A
+`bash`, `sh`, `zsh`, `shell`, `console`, `text` or `log` fence that carries
+a real escape byte renders the same way. Copy copies the text without its
+escape codes.
 
 ### Tables
 

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -239,10 +239,12 @@ export function IconChevronLeft(p: IconProps) {
   );
 }
 
+const CHEVRON_RIGHT_PATH = "M10.25 6.75L15.25 12L10.25 17.25";
+
 export function IconChevronRight(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M10.25 6.75L15.25 12L10.25 17.25" />
+      <path {...stroke} d={CHEVRON_RIGHT_PATH} />
     </Svg>
   );
 }
@@ -1164,6 +1166,11 @@ export function IconOctagonAlert(p: IconProps) {
       ))}
     </Svg>
   );
+}
+
+/** <IconChevronRight> as markup: the fold caret on a JSON tree row. */
+export function chevronRightIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([CHEVRON_RIGHT_PATH]), size);
 }
 
 export function IconTrash(p: IconProps) {

--- a/packages/core/opensession-server/src/frontend/lib/ansi-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/ansi-block.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ansiUpgrader,
+  applySgr,
+  baseColorName,
+  claimsAnsi,
+  color256,
+  parseAnsi,
+  renderAnsiHtml,
+  terminalSource,
+} from "./ansi-block";
+
+const ESC = "\u001b";
+
+const text = (input: string) =>
+  parseAnsi(input)
+    .map((s) => s.text)
+    .join("");
+
+describe("claimsAnsi", () => {
+  it("always claims an explicit ansi or terminal fence", () => {
+    expect(claimsAnsi("ansi", "plain")).toBe(true);
+    expect(claimsAnsi("terminal", "plain")).toBe(true);
+  });
+
+  it("claims a shell or text fence only when it carries a real escape", () => {
+    expect(claimsAnsi("bash", `${ESC}[32mok${ESC}[0m`)).toBe(true);
+    expect(claimsAnsi("console", `${ESC}[1m`)).toBe(true);
+    expect(claimsAnsi("text", `${ESC}[K`)).toBe(true);
+    expect(claimsAnsi("bash", "echo '\\x1b[32m'")).toBe(false);
+    expect(claimsAnsi("bash", "ls -la")).toBe(false);
+    expect(claimsAnsi("json", `${ESC}[31m`)).toBe(false);
+  });
+
+  it("is what the registered upgrader claims with", () => {
+    expect(ansiUpgrader.claims).toBe(claimsAnsi);
+    expect(ansiUpgrader.keepsCodeControls).toBe(true);
+    expect(ansiUpgrader.langs).toEqual(["ansi", "terminal"]);
+  });
+});
+
+describe("terminalSource", () => {
+  it("decodes spelled escapes in an explicit fence that has no real ones", () => {
+    expect(
+      terminalSource("ansi", "\\x1b[31mred\\e[0m \\033[1mb\\u001b[m"),
+    ).toBe(`${ESC}[31mred${ESC}[0m ${ESC}[1mb${ESC}[m`);
+  });
+
+  it("leaves a fence with real escapes, or a shell fence, alone", () => {
+    const real = `${ESC}[31m\\x1b[0m`;
+    expect(terminalSource("ansi", real)).toBe(real);
+    expect(terminalSource("bash", "echo '\\x1b[31m'")).toBe("echo '\\x1b[31m'");
+  });
+
+  it("only decodes a spelling that opens a CSI", () => {
+    expect(terminalSource("terminal", "path\\extra \\e is fine")).toBe(
+      "path\\extra \\e is fine",
+    );
+  });
+});
+
+describe("parseAnsi", () => {
+  it("returns plain text as one unstyled span", () => {
+    expect(parseAnsi("hello\nworld")).toEqual([
+      {
+        text: "hello\nworld",
+        style: expect.objectContaining({ bold: false, fg: null, bg: null }),
+      },
+    ]);
+    expect(parseAnsi("")).toEqual([]);
+  });
+
+  it("splits on SGR changes and resets", () => {
+    const spans = parseAnsi(`a ${ESC}[1;31mb${ESC}[0m c`);
+    expect(spans.map((s) => s.text)).toEqual(["a ", "b", " c"]);
+    expect(spans[1]!.style.bold).toBe(true);
+    expect(spans[1]!.style.fg).toEqual({ kind: "base", index: 1 });
+    expect(spans[2]!.style.bold).toBe(false);
+    expect(spans[2]!.style.fg).toBeNull();
+  });
+
+  it("treats an empty parameter list as a reset", () => {
+    const spans = parseAnsi(`${ESC}[32mgreen${ESC}[mplain`);
+    expect(spans[1]!.style.fg).toBeNull();
+  });
+
+  it("reads bright, 256-colour and 24-bit colours", () => {
+    const spans = parseAnsi(
+      `${ESC}[91ma${ESC}[38;5;208mb${ESC}[48;2;10;20;30mc${ESC}[38:2::1:2:3md`,
+    );
+    expect(spans[0]!.style.fg).toEqual({ kind: "base", index: 9 });
+    expect(spans[1]!.style.fg).toEqual({ kind: "rgb", r: 255, g: 135, b: 0 });
+    expect(spans[2]!.style.bg).toEqual({ kind: "rgb", r: 10, g: 20, b: 30 });
+    expect(spans[3]!.style.fg).toEqual({ kind: "rgb", r: 1, g: 2, b: 3 });
+    // The colour set before the background stays in force.
+    expect(spans[2]!.style.fg).toEqual({ kind: "rgb", r: 255, g: 135, b: 0 });
+  });
+
+  it("turns individual attributes back off", () => {
+    const spans = parseAnsi(
+      `${ESC}[1;2;3;4;7;9mx${ESC}[22;23;24;27;29my${ESC}[44mz${ESC}[49;39mw`,
+    );
+    expect(spans[0]!.style).toMatchObject({
+      bold: true,
+      dim: true,
+      italic: true,
+      underline: true,
+      inverse: true,
+      strike: true,
+    });
+    expect(spans[1]!.style).toMatchObject({
+      bold: false,
+      dim: false,
+      italic: false,
+      underline: false,
+      inverse: false,
+      strike: false,
+    });
+    expect(spans[2]!.style.bg).toEqual({ kind: "base", index: 4 });
+    expect(spans[3]!.style.bg).toBeNull();
+  });
+
+  it("strips every other escape", () => {
+    expect(
+      text(
+        `${ESC}[2J${ESC}[H${ESC}[?25lline${ESC}[K${ESC}[1A${ESC}]0;title${ESC}\\ ` +
+          `${ESC}]8;;https://x${"\u0007"}link${ESC}(B${ESC}7 end${ESC}`,
+      ),
+    ).toBe("line link end");
+  });
+
+  it("ignores a malformed colour instead of misreading what follows", () => {
+    const spans = parseAnsi(`${ESC}[38;5;999mx${ESC}[38;2;1mz`);
+    expect(spans[0]!.style.fg).toBeNull();
+    expect(spans[1]!.style.fg).toBeNull();
+    expect(text(`${ESC}[38;9mafter`)).toBe("after");
+  });
+});
+
+describe("applySgr and color256", () => {
+  it("maps the cube and the grey ramp", () => {
+    expect(color256(0)).toEqual({ kind: "base", index: 0 });
+    expect(color256(15)).toEqual({ kind: "base", index: 15 });
+    expect(color256(16)).toEqual({ kind: "rgb", r: 0, g: 0, b: 0 });
+    expect(color256(231)).toEqual({ kind: "rgb", r: 255, g: 255, b: 255 });
+    expect(color256(232)).toEqual({ kind: "rgb", r: 8, g: 8, b: 8 });
+    expect(color256(255)).toEqual({ kind: "rgb", r: 238, g: 238, b: 238 });
+    expect(color256(256)).toBeNull();
+    expect(color256(-1)).toBeNull();
+  });
+
+  it("does not mutate the style it is given", () => {
+    const base = applySgr("", {
+      bold: false,
+      dim: false,
+      italic: false,
+      underline: false,
+      strike: false,
+      inverse: false,
+      hidden: false,
+      fg: null,
+      bg: null,
+    });
+    const next = applySgr("1;31", base);
+    expect(base.bold).toBe(false);
+    expect(next.bold).toBe(true);
+  });
+
+  it("names the sixteen base colours", () => {
+    expect(baseColorName(0)).toBe("black");
+    expect(baseColorName(1)).toBe("red");
+    expect(baseColorName(7)).toBe("white");
+    expect(baseColorName(8)).toBe("bright-black");
+    expect(baseColorName(15)).toBe("bright-white");
+  });
+});
+
+describe("renderAnsiHtml", () => {
+  it("escapes text and leaves unstyled runs bare", () => {
+    expect(renderAnsiHtml(parseAnsi(`<b> & "q"`))).toBe(
+      "&lt;b&gt; &amp; &quot;q&quot;",
+    );
+  });
+
+  it("writes base colours as classes and data colours as rgb()", () => {
+    expect(
+      renderAnsiHtml(parseAnsi(`${ESC}[1;4;91mhi${ESC}[0m${ESC}[38;5;208mx`)),
+    ).toBe(
+      '<span class="ansi-bold ansi-underline ansi-fg-bright-red">hi</span>' +
+        '<span style="color:rgb(255,135,0)">x</span>',
+    );
+  });
+
+  it("swaps the sides of an inverse run", () => {
+    expect(renderAnsiHtml(parseAnsi(`${ESC}[7;32mok`))).toBe(
+      '<span class="ansi-inverse ansi-bg-green">ok</span>',
+    );
+    expect(renderAnsiHtml(parseAnsi(`${ESC}[7;32;44mok`))).toBe(
+      '<span class="ansi-inverse ansi-fg-blue ansi-bg-green">ok</span>',
+    );
+  });
+
+  it("never lets escaped text reach an attribute", () => {
+    const html = renderAnsiHtml(
+      parseAnsi(`${ESC}[31m"><script>alert(1)</script>`),
+    );
+    expect(html).toBe(
+      '<span class="ansi-fg-red">&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;</span>',
+    );
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/ansi-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/ansi-block.ts
@@ -1,0 +1,339 @@
+/**
+ * ```ansi and ```terminal fences: terminal output rendered with its SGR
+ * colours and styles (`\x1b[...m`) as styled spans. A bash, sh, console or
+ * text fence that actually carries an escape byte renders the same way
+ * (`claims`). Every other escape (cursor movement, erase, OSC titles) is
+ * stripped, and everything else is escaped as text: a transcript is
+ * untrusted input.
+ *
+ * The block stays a <pre> inside the copy control's wrapper, so copy reads
+ * the text without its escape codes and the wrap toggle keeps working.
+ *
+ * The parser is a pure function over the string (see ansi-block.test.ts);
+ * the DOM part below is one element swap.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+
+/** Info-string languages that always render as terminal output. */
+export const ANSI_LANGS = ["ansi", "terminal"] as const;
+const ANSI_LANG_SET: ReadonlySet<string> = new Set(ANSI_LANGS);
+
+/** Fences that render as terminal output only when they carry an escape. */
+const ESCAPE_CLAIM_LANGS = new Set([
+  "bash",
+  "sh",
+  "shell",
+  "zsh",
+  "console",
+  "text",
+  "log",
+]);
+
+const ESC = "\u001b";
+
+/**
+ * Whether a fence of `lang` should render as terminal output. An explicit
+ * ansi/terminal fence always does; a shell or text fence only when its
+ * source holds a real escape byte followed by `[`.
+ */
+export function claimsAnsi(lang: string, source: string): boolean {
+  if (ANSI_LANG_SET.has(lang)) return true;
+  return ESCAPE_CLAIM_LANGS.has(lang) && source.includes(`${ESC}[`);
+}
+
+/**
+ * The text to parse. An explicit ansi/terminal fence written by a model
+ * usually spells the escape rather than emitting the byte (`\x1b[31m`,
+ * `\e[31m`, `\033[31m`, `\u001b[31m`), so those spellings are decoded when
+ * the fence carries no real escape at all. A shell fence is left alone: it
+ * only claimed because it has the real byte.
+ */
+export function terminalSource(lang: string, source: string): string {
+  if (!ANSI_LANG_SET.has(lang)) return source;
+  if (source.includes(ESC)) return source;
+  return source.replace(/\\(?:x1[bB]|u001[bB]|033|e)(?=\[)/g, ESC);
+}
+
+export type AnsiColor =
+  /** One of the 16 base colours, themed through `--ansi-*` tokens. */
+  | { kind: "base"; index: number }
+  /** A 256-colour or 24-bit colour: data, emitted as a literal rgb(). */
+  | { kind: "rgb"; r: number; g: number; b: number };
+
+export interface AnsiStyle {
+  bold: boolean;
+  dim: boolean;
+  italic: boolean;
+  underline: boolean;
+  strike: boolean;
+  inverse: boolean;
+  hidden: boolean;
+  fg: AnsiColor | null;
+  bg: AnsiColor | null;
+}
+
+export interface AnsiSpan {
+  text: string;
+  style: AnsiStyle;
+}
+
+const DEFAULT_STYLE: AnsiStyle = {
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  inverse: false,
+  hidden: false,
+  fg: null,
+  bg: null,
+};
+
+/** CSI: ESC [ parameter bytes, intermediate bytes, one final byte. */
+const CSI_RE = /^\u001b\[([0-?]*)([ -/]*)([@-~])/;
+/** OSC: ESC ] ... terminated by BEL or ST (ESC \). Unterminated runs to the end. */
+const OSC_RE = /^\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)?/;
+/** Charset and other two-byte escapes: ESC ( B, ESC ) 0, ESC # 8, ESC % G. */
+const TWO_BYTE_RE = /^\u001b[()*+#%][\s\S]?/;
+
+/** Index in the 256-colour cube to its rgb. 0-15 stay base colours. */
+export function color256(n: number): AnsiColor | null {
+  if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+  if (n < 16) return { kind: "base", index: n };
+  if (n < 232) {
+    const i = n - 16;
+    const level = (v: number) => (v === 0 ? 0 : 55 + v * 40);
+    return {
+      kind: "rgb",
+      r: level(Math.floor(i / 36)),
+      g: level(Math.floor(i / 6) % 6),
+      b: level(i % 6),
+    };
+  }
+  const grey = 8 + (n - 232) * 10;
+  return { kind: "rgb", r: grey, g: grey, b: grey };
+}
+
+function channel(raw: string | undefined): number | null {
+  if (raw === undefined || raw === "") return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 && n <= 255 ? n : null;
+}
+
+interface ExtendedColor {
+  /** Null when the parameters were malformed. */
+  color: AnsiColor | null;
+  /** How many parameters after the introducer were consumed. */
+  used: number;
+}
+
+/**
+ * The colour after a 38/48 introducer. `args` are the parameters that follow
+ * it: `5;n`, `2;r;g;b`, or the colon form `2::r:g:b` with an empty colour
+ * space id.
+ */
+function extendedColor(args: string[]): ExtendedColor {
+  if (args[0] === "5") {
+    const n = channel(args[1]);
+    return { color: n === null ? null : color256(n), used: 2 };
+  }
+  if (args[0] === "2") {
+    const offset = args.length >= 5 && args[1] === "" ? 2 : 1;
+    const r = channel(args[offset]);
+    const g = channel(args[offset + 1]);
+    const b = channel(args[offset + 2]);
+    const color =
+      r === null || g === null || b === null
+        ? null
+        : { kind: "rgb" as const, r, g, b };
+    return { color, used: offset + 3 };
+  }
+  return { color: null, used: 1 };
+}
+
+/** Apply one SGR parameter string (`1;31`, `38;5;208`, empty = reset). */
+export function applySgr(params: string, style: AnsiStyle): AnsiStyle {
+  const next = { ...style };
+  const parts = params === "" ? ["0"] : params.split(";");
+  for (let i = 0; i < parts.length; i++) {
+    const sub = parts[i]!.split(":");
+    const code = sub[0] === "" ? 0 : Number(sub[0]);
+    if (!Number.isInteger(code)) continue;
+    if (code === 0) Object.assign(next, DEFAULT_STYLE);
+    else if (code === 1) next.bold = true;
+    else if (code === 2) next.dim = true;
+    else if (code === 3) next.italic = true;
+    else if (code === 4) next.underline = true;
+    else if (code === 7) next.inverse = true;
+    else if (code === 8) next.hidden = true;
+    else if (code === 9) next.strike = true;
+    else if (code === 22) next.bold = next.dim = false;
+    else if (code === 23) next.italic = false;
+    else if (code === 24) next.underline = false;
+    else if (code === 27) next.inverse = false;
+    else if (code === 28) next.hidden = false;
+    else if (code === 29) next.strike = false;
+    else if (code >= 30 && code <= 37)
+      next.fg = { kind: "base", index: code - 30 };
+    else if (code === 39) next.fg = null;
+    else if (code >= 40 && code <= 47)
+      next.bg = { kind: "base", index: code - 40 };
+    else if (code === 49) next.bg = null;
+    else if (code >= 90 && code <= 97)
+      next.fg = { kind: "base", index: code - 90 + 8 };
+    else if (code >= 100 && code <= 107)
+      next.bg = { kind: "base", index: code - 100 + 8 };
+    else if (code === 38 || code === 48) {
+      // Colon form carries its arguments inside this parameter; the
+      // semicolon form spreads them over the ones that follow.
+      const inline = sub.length > 1;
+      const { color, used } = extendedColor(
+        inline ? sub.slice(1) : parts.slice(i + 1),
+      );
+      if (!inline) i += used;
+      if (code === 38) next.fg = color;
+      else next.bg = color;
+    }
+  }
+  return next;
+}
+
+/**
+ * Split terminal output into runs of text that share one style. SGR
+ * sequences change the style; every other escape is dropped.
+ */
+export function parseAnsi(input: string): AnsiSpan[] {
+  const spans: AnsiSpan[] = [];
+  let style = DEFAULT_STYLE;
+  let text = "";
+  const flush = () => {
+    if (text) spans.push({ text, style });
+    text = "";
+  };
+  let i = 0;
+  while (i < input.length) {
+    const at = input.indexOf(ESC, i);
+    if (at < 0) {
+      text += input.slice(i);
+      break;
+    }
+    text += input.slice(i, at);
+    const rest = input.slice(at);
+    const csi = CSI_RE.exec(rest);
+    if (csi) {
+      if (csi[3] === "m" && csi[2] === "") {
+        const next = applySgr(csi[1]!, style);
+        flush();
+        style = next;
+      }
+      i = at + csi[0].length;
+      continue;
+    }
+    const other = OSC_RE.exec(rest) ?? TWO_BYTE_RE.exec(rest);
+    // A lone ESC and whatever single byte follows it (ESC 7, ESC =, ...).
+    i = at + (other ? other[0].length : Math.min(2, rest.length));
+  }
+  flush();
+  return spans;
+}
+
+const BASE_NAMES = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+] as const;
+
+/** The token suffix for a base colour: `red`, `bright-red`. */
+export function baseColorName(index: number): string {
+  const name = BASE_NAMES[index % 8]!;
+  return index >= 8 ? `bright-${name}` : name;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function colorAttrs(
+  color: AnsiColor | null,
+  role: "fg" | "bg",
+  classes: string[],
+  styles: string[],
+): void {
+  if (!color) return;
+  if (color.kind === "base") {
+    classes.push(`ansi-${role}-${baseColorName(color.index)}`);
+    return;
+  }
+  const value = `rgb(${color.r},${color.g},${color.b})`;
+  styles.push(`${role === "fg" ? "color" : "background-color"}:${value}`);
+}
+
+/** One span's opening tag attributes, or null when it carries no style. */
+export function spanAttributes(style: AnsiStyle): string | null {
+  const classes: string[] = [];
+  const styles: string[] = [];
+  if (style.bold) classes.push("ansi-bold");
+  if (style.dim) classes.push("ansi-dim");
+  if (style.italic) classes.push("ansi-italic");
+  if (style.underline) classes.push("ansi-underline");
+  if (style.strike) classes.push("ansi-strike");
+  if (style.hidden) classes.push("ansi-hidden");
+  if (style.inverse) {
+    // Swap the two. The class supplies the defaults for whichever side had
+    // none; an explicit colour lands on the other side.
+    classes.push("ansi-inverse");
+    colorAttrs(style.bg, "fg", classes, styles);
+    colorAttrs(style.fg, "bg", classes, styles);
+  } else {
+    colorAttrs(style.fg, "fg", classes, styles);
+    colorAttrs(style.bg, "bg", classes, styles);
+  }
+  if (classes.length === 0 && styles.length === 0) return null;
+  let attrs = "";
+  if (classes.length) attrs += ` class="${classes.join(" ")}"`;
+  if (styles.length) attrs += ` style="${styles.join(";")}"`;
+  return attrs;
+}
+
+/** The spans as HTML for the block's <code>. Text is escaped; colours from
+ *  the data are integers, so the inline style cannot carry anything else. */
+export function renderAnsiHtml(spans: AnsiSpan[]): string {
+  let html = "";
+  for (const span of spans) {
+    const text = escapeHtml(span.text);
+    const attrs = spanAttributes(span.style);
+    html += attrs === null ? text : `<span${attrs}>${text}</span>`;
+  }
+  return html;
+}
+
+export const ansiUpgrader: FenceUpgrader = {
+  langs: [...ANSI_LANGS],
+  claims: claimsAnsi,
+  keepsCodeControls: true,
+  async upgrade({ pre, source, lang, root, alive }) {
+    const html = renderAnsiHtml(parseAnsi(terminalSource(lang, source)));
+    // Replace the fence only once the copy control's wrapper is around it
+    // (see fence-upgraders.ts): the new <pre> takes the fence's place inside
+    // that wrapper, so the controls read the escape-free text from it.
+    await Promise.resolve();
+    if (!alive() || !root.contains(pre)) return false;
+    const block = document.createElement("pre");
+    block.className = "md-ansi";
+    const code = document.createElement("code");
+    code.innerHTML = html;
+    block.append(code);
+    pre.replaceWith(block);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -15,7 +15,9 @@
  * declares the upgrader. See docs/blocks.md for the catalog and the contract.
  */
 
+import { ansiUpgrader } from "./ansi-block";
 import { chartUpgrader } from "./chart-fence";
+import { jsonTreeUpgrader } from "./json-tree-block";
 import { mathUpgrader } from "./math-block";
 import { mermaidUpgrader } from "./mermaid-fence";
 import { paletteUpgrader } from "./palette-block";
@@ -64,6 +66,11 @@ export interface FenceUpgrader {
    * (or throw) to keep the plain fence: source that does not parse, is still
    * streaming, or has the wrong shape. When returning false `ctx.pre` must
    * still be in the DOM, untouched, so shiki can highlight it.
+   *
+   * A `keepsCodeControls` block must `await` before it touches the DOM: the
+   * body attaches the copy control's wrapper in the effect that follows the
+   * one starting this pass, so a fence replaced synchronously is replaced
+   * before its wrapper exists.
    */
   upgrade(ctx: FenceUpgradeContext): Promise<boolean>;
   /**
@@ -82,6 +89,8 @@ export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   tableUpgrader,
   metricsUpgrader,
   mathUpgrader,
+  jsonTreeUpgrader,
+  ansiUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/json-tree-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/json-tree-block.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "bun:test";
+import githubDark from "@shikijs/themes/github-dark-default";
+import githubLight from "@shikijs/themes/github-light-default";
+import {
+  containerSummary,
+  JSON_TREE_COLLAPSE_DEPTH,
+  JSON_TREE_MAX_CHARS,
+  JSON_TREE_MAX_CHILDREN,
+  JSON_TREE_MIN_CHARS,
+  JSON_TREE_MIN_LINES,
+  type JsonContainer,
+  jsonAtPath,
+  jsonTreeUpgrader,
+  jsonWorthFolding,
+  parseJsonPath,
+  parseJsonTree,
+  renderJsonChildrenHtml,
+  renderJsonHeadHtml,
+  renderJsonNodeHtml,
+  renderJsonTreeHtml,
+} from "./json-tree-block";
+
+/** What JSON.stringify can write: the shape a fence's source arrives in. */
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** A container node from a JS value, the way the fence arrives. */
+function tree(value: JsonValue): JsonContainer {
+  const node = parseJsonTree(JSON.stringify(value));
+  if (!node) throw new Error("not a container");
+  return node;
+}
+
+const bigObject = Object.fromEntries(
+  Array.from({ length: 40 }, (_, i) => [`key${i}`, i]),
+);
+const bigSource = JSON.stringify(bigObject, null, 2);
+
+describe("jsonWorthFolding", () => {
+  it("folds past the line or character threshold", () => {
+    expect(jsonWorthFolding(bigSource)).toBe(true);
+    expect(bigSource.split("\n").length).toBeGreaterThan(JSON_TREE_MIN_LINES);
+    const minified = JSON.stringify(
+      Object.fromEntries(Array.from({ length: 200 }, (_, i) => [`key${i}`, i])),
+    );
+    expect(minified.split("\n").length).toBe(1);
+    expect(minified.length).toBeGreaterThan(JSON_TREE_MIN_CHARS);
+    expect(jsonWorthFolding(minified)).toBe(true);
+  });
+
+  it("leaves small JSON as highlighted code", () => {
+    expect(jsonWorthFolding('{\n  "a": 1\n}')).toBe(false);
+    const thirtyLines = `[\n${Array.from({ length: 27 }, () => "  1,").join("\n")}\n  1\n]`;
+    expect(thirtyLines.split("\n").length).toBe(JSON_TREE_MIN_LINES);
+    expect(jsonWorthFolding(thirtyLines)).toBe(false);
+    expect(jsonWorthFolding(`${thirtyLines}\n`)).toBe(false);
+  });
+
+  it("gives up on a document too big to build rows for", () => {
+    expect(jsonWorthFolding("x".repeat(JSON_TREE_MAX_CHARS + 1))).toBe(false);
+  });
+});
+
+describe("parseJsonTree", () => {
+  it("returns an object or array root as a tagged tree", () => {
+    expect(parseJsonTree('{"a":[1, "s", true, null]}')).toEqual({
+      kind: "object",
+      entries: [
+        [
+          "a",
+          {
+            kind: "array",
+            items: [
+              { kind: "number", value: 1 },
+              { kind: "string", value: "s" },
+              { kind: "boolean", value: true },
+              { kind: "null" },
+            ],
+          },
+        ],
+      ],
+    });
+    expect(parseJsonTree("[]")).toEqual({ kind: "array", items: [] });
+  });
+
+  it("keeps the document's key order", () => {
+    const node = tree({ z: 1, a: 2, m: 3 });
+    expect(node.kind === "object" && node.entries.map(([k]) => k)).toEqual([
+      "z",
+      "a",
+      "m",
+    ]);
+  });
+
+  it("declines scalars, streaming and invalid JSON", () => {
+    expect(parseJsonTree('"text"')).toBeNull();
+    expect(parseJsonTree("42")).toBeNull();
+    expect(parseJsonTree("null")).toBeNull();
+    expect(parseJsonTree('{"a": [1, 2')).toBeNull();
+    expect(parseJsonTree('{"a": 1,}')).toBeNull();
+    expect(parseJsonTree("// c\n{}")).toBeNull();
+  });
+});
+
+describe("jsonAtPath and parseJsonPath", () => {
+  const root = tree({ a: [{ b: null }, 2], "x y": { c: false }, "0": "zero" });
+
+  it("walks keys and indices by the node it is on", () => {
+    expect(jsonAtPath(root, [])).toBe(root);
+    expect(jsonAtPath(root, ["a", "0", "b"])).toEqual({ kind: "null" });
+    expect(jsonAtPath(root, ["a", "1"])).toEqual({ kind: "number", value: 2 });
+    expect(jsonAtPath(root, ["x y", "c"])).toEqual({
+      kind: "boolean",
+      value: false,
+    });
+    expect(jsonAtPath(root, ["0"])).toEqual({ kind: "string", value: "zero" });
+  });
+
+  it("returns undefined off the path rather than reading the prototype", () => {
+    expect(jsonAtPath(root, ["a", "x"])).toBeUndefined();
+    expect(jsonAtPath(root, ["nope"])).toBeUndefined();
+    expect(jsonAtPath(root, ["constructor"])).toBeUndefined();
+    expect(jsonAtPath(root, ["a", "1", "x"])).toBeUndefined();
+  });
+
+  it("round-trips a node's data-path", () => {
+    expect(parseJsonPath(JSON.stringify(["a", "0", "b"]))).toEqual([
+      "a",
+      "0",
+      "b",
+    ]);
+    expect(parseJsonPath(undefined)).toBeNull();
+    expect(parseJsonPath("{")).toBeNull();
+    expect(parseJsonPath("[0]")).toBeNull();
+  });
+});
+
+describe("renderJsonTreeHtml", () => {
+  it("renders typed leaves with their keys", () => {
+    const html = renderJsonTreeHtml(
+      tree({ name: "x", n: 1.5, ok: true, none: null, "a key": 1 }),
+    );
+    expect(html).toContain(
+      '<span class="md-json-key">name</span><span class="md-json-punct">: </span><span class="md-json-string">&quot;x&quot;</span>',
+    );
+    expect(html).toContain('<span class="md-json-number">1.5</span>');
+    expect(html).toContain('<span class="md-json-keyword">true</span>');
+    expect(html).toContain('<span class="md-json-keyword">null</span>');
+    expect(html).toContain(
+      '<span class="md-json-key">&quot;a key&quot;</span>',
+    );
+  });
+
+  it("opens the root and its children and folds deeper containers", () => {
+    const html = renderJsonTreeHtml(tree({ a: { b: { c: 1 } } }));
+    const opens = [...html.matchAll(/data-open="(true|false)"/g)].map(
+      (m) => m[1],
+    );
+    expect(opens).toEqual(["true", "true", "false"]);
+    expect(JSON_TREE_COLLAPSE_DEPTH).toBe(2);
+    // A folded node carries its path and no rows yet; its children come on
+    // the first expand.
+    expect(html).toContain(
+      'data-lazy data-path="[&quot;a&quot;,&quot;b&quot;]"',
+    );
+    expect(html).not.toContain('<span class="md-json-key">c</span>');
+    expect(html).toContain('aria-expanded="false" aria-label="Expand"');
+    expect(html).toContain('aria-expanded="true" aria-label="Collapse"');
+  });
+
+  it("renders a folded node's children on demand at the right depth", () => {
+    const root = tree({ a: { b: { c: { d: 1 } } } });
+    const b = jsonAtPath(root, ["a", "b"]);
+    if (!b || b.kind !== "object") throw new Error("expected b");
+    const html = renderJsonChildrenHtml(b, ["a", "b"], 2);
+    expect(html).toContain('data-open="false"');
+    expect(html).toContain(
+      'data-path="[&quot;a&quot;,&quot;b&quot;,&quot;c&quot;]"',
+    );
+  });
+
+  it("summarises a container by count and shows empties inline", () => {
+    expect(containerSummary(tree({}))).toBe("0 keys");
+    expect(containerSummary(tree({ a: 1 }))).toBe("1 key");
+    expect(containerSummary(tree([1, 2, 3]))).toBe("3 items");
+    const html = renderJsonTreeHtml(tree({ list: [1], empty: [], none: {} }));
+    expect(html).toContain('<span class="md-json-count">1 item</span>');
+    expect(html).toContain('<span class="md-json-punct">[]</span>');
+    expect(html).toContain('<span class="md-json-punct">{}</span>');
+    expect(html.match(/md-json-caret/g)?.length).toBe(2);
+  });
+
+  it("indexes array rows and closes with the matching bracket", () => {
+    const html = renderJsonNodeHtml(tree([1]), null, [], 0);
+    expect(html).toContain('<span class="md-json-index">0</span>');
+    expect(html).toContain(
+      '<div class="md-json-end"><span class="md-json-punct">]</span></div>',
+    );
+  });
+
+  it("escapes keys and strings as text", () => {
+    const html = renderJsonTreeHtml(tree({ "<b>": '<img src=x onerror="1">' }));
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("<b>");
+    expect(html).toContain(
+      "&quot;&lt;img src=x onerror=\\&quot;1\\&quot;&gt;&quot;",
+    );
+  });
+
+  it("caps the rows of a huge container and says so", () => {
+    const html = renderJsonChildrenHtml(
+      tree(Array.from({ length: JSON_TREE_MAX_CHILDREN + 3 }, (_, i) => i)),
+      [],
+      0,
+    );
+    expect(html.match(/<li /g)?.length).toBe(JSON_TREE_MAX_CHILDREN + 1);
+    expect(html).toContain("3 more in the raw view");
+  });
+
+  it("writes the header with the tree view pressed", () => {
+    const html = renderJsonHeadHtml(tree({ a: 1, b: 2 }));
+    expect(html).toContain('data-view="tree" aria-pressed="true">Tree<');
+    expect(html).toContain('data-view="raw" aria-pressed="false">Raw<');
+    expect(html).toContain('<span class="md-json-summary">2 keys</span>');
+  });
+});
+
+describe("registration", () => {
+  it("claims json and keeps the copy control", () => {
+    expect(jsonTreeUpgrader.langs).toEqual(["json"]);
+    expect(jsonTreeUpgrader.keepsCodeControls).toBe(true);
+  });
+});
+
+describe("json-tree.css", () => {
+  const css = Bun.file(
+    new URL("../styles/blocks/json-tree.css", import.meta.url),
+  ).text();
+
+  function token(sheet: string, scope: string, name: string): string {
+    const block =
+      scope === "light"
+        ? /html\[data-theme="light"\] \{([^}]*)\}/.exec(sheet)?.[1]
+        : /:root \{([^}]*)\}/.exec(sheet)?.[1];
+    return (
+      new RegExp(`--${name}: (#[0-9a-f]{6});`).exec(block ?? "")?.[1] ?? ""
+    );
+  }
+
+  function shikiInk(theme: typeof githubDark, scope: string): string {
+    for (const rule of theme.tokenColors ?? []) {
+      const scopes = Array.isArray(rule.scope) ? rule.scope : [rule.scope];
+      if (scopes.includes(scope) && rule.settings.foreground)
+        return rule.settings.foreground.toLowerCase();
+    }
+    throw new Error(`no ${scope} in ${theme.name}`);
+  }
+
+  it("inks the tree with shiki's JSON colours in both themes", async () => {
+    const sheet = await css;
+    for (const [scope, theme] of [
+      ["dark", githubDark],
+      ["light", githubLight],
+    ] as const) {
+      expect(token(sheet, scope, "json-key")).toBe(
+        shikiInk(theme, "support.type.property-name.json"),
+      );
+      expect(token(sheet, scope, "json-string")).toBe(
+        shikiInk(theme, "string"),
+      );
+      expect(token(sheet, scope, "json-constant")).toBe(
+        shikiInk(theme, "constant"),
+      );
+    }
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/json-tree-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/json-tree-block.ts
@@ -1,0 +1,370 @@
+/**
+ * A large ```json fence rendered as a collapsible tree, with a toggle back to
+ * the raw highlighted text. Small JSON (under the thresholds below) stays
+ * shiki-highlighted code, and JSON that does not parse (still streaming,
+ * comments, trailing commas) declines too.
+ *
+ * The block keeps the copy and wrap controls: the fence's own <pre> stays
+ * inside it, hidden while the tree shows, so the copy control (which reads
+ * the first <pre> in the wrapper) still copies the JSON text rather than
+ * the tree's labels. Switching to Raw reveals that <pre>, highlighted on
+ * first use.
+ *
+ * The fence is parsed once into a tagged tree (`JsonNode`), and the rows are
+ * built from it as an HTML string by pure functions (json-tree-block.test.ts);
+ * the DOM part is the swap, a delegated click handler and lazy rendering of
+ * a folded node's children on first expand.
+ */
+
+import { z } from "zod";
+import { chevronRightIconMarkup } from "../components/icons";
+import type { FenceUpgrader } from "./fence-upgraders";
+
+/** A fence with more lines than this is worth folding. */
+export const JSON_TREE_MIN_LINES = 30;
+/** ... or more characters than this (minified JSON is one long line). */
+export const JSON_TREE_MIN_CHARS = 1500;
+/** Past this the tree would be heavier than the wall of text it replaces. */
+export const JSON_TREE_MAX_CHARS = 200_000;
+/** Containers at this depth and deeper start folded (root is depth 0). */
+export const JSON_TREE_COLLAPSE_DEPTH = 2;
+/** Rows rendered per container; the rest are counted in one closing row. */
+export const JSON_TREE_MAX_CHILDREN = 500;
+
+export type JsonNode =
+  | { kind: "null" }
+  | { kind: "boolean"; value: boolean }
+  | { kind: "number"; value: number }
+  | { kind: "string"; value: string }
+  | { kind: "array"; items: JsonNode[] }
+  | { kind: "object"; entries: [string, JsonNode][] };
+export type JsonContainer = Extract<JsonNode, { kind: "array" | "object" }>;
+
+/** The keys (or indices, as decimal strings) from the root to a node. Which
+ *  one a step is follows from the node it is applied to. */
+export type JsonPath = string[];
+
+const jsonNodeSchema: z.ZodType<JsonNode> = z.lazy(() =>
+  z.union([
+    z.null().transform((): JsonNode => ({ kind: "null" })),
+    z.boolean().transform((value): JsonNode => ({ kind: "boolean", value })),
+    z.number().transform((value): JsonNode => ({ kind: "number", value })),
+    z.string().transform((value): JsonNode => ({ kind: "string", value })),
+    z
+      .array(jsonNodeSchema)
+      .transform((items): JsonNode => ({ kind: "array", items })),
+    z.record(z.string(), jsonNodeSchema).transform((record): JsonNode => ({
+      kind: "object",
+      entries: Object.entries(record),
+    })),
+  ]),
+);
+
+const jsonPathSchema = z.array(z.string());
+
+export function isJsonContainer(node: JsonNode): node is JsonContainer {
+  return node.kind === "array" || node.kind === "object";
+}
+
+/** Whether a fence is big enough that a tree beats reading it as text. */
+export function jsonWorthFolding(source: string): boolean {
+  const text = source.trim();
+  if (text.length > JSON_TREE_MAX_CHARS) return false;
+  if (text.length > JSON_TREE_MIN_CHARS) return true;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) if (text[i] === "\n") lines++;
+  return lines > JSON_TREE_MIN_LINES;
+}
+
+/** The fence as a tree, or null when it does not parse or is not an object
+ *  or array: a bare string or number has nothing to fold. */
+export function parseJsonTree(source: string): JsonContainer | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  const parsed = jsonNodeSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  return isJsonContainer(parsed.data) ? parsed.data : null;
+}
+
+/** The node at `path` under `root`, or undefined when the path is off. */
+export function jsonAtPath(
+  root: JsonNode,
+  path: JsonPath,
+): JsonNode | undefined {
+  let node: JsonNode | undefined = root;
+  for (const step of path) {
+    if (node === undefined) return undefined;
+    if (node.kind === "array") {
+      const index = Number(step);
+      node = Number.isInteger(index) ? node.items[index] : undefined;
+    } else if (node.kind === "object") {
+      node = node.entries.find(([key]) => key === step)?.[1];
+    } else {
+      return undefined;
+    }
+  }
+  return node;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** What sits before a row's value: its object key or array index. */
+export type RowLabel =
+  | { kind: "key"; key: string }
+  | { kind: "index"; index: number }
+  | null;
+
+function childRows(
+  node: JsonContainer,
+): { label: RowLabel; step: string; child: JsonNode }[] {
+  return node.kind === "array"
+    ? node.items.map((child, index) => ({
+        label: { kind: "index", index },
+        step: String(index),
+        child,
+      }))
+    : node.entries.map(([key, child]) => ({
+        label: { kind: "key", key },
+        step: key,
+        child,
+      }));
+}
+
+function childCount(node: JsonContainer): number {
+  return node.kind === "array" ? node.items.length : node.entries.length;
+}
+
+/** "12 keys", "1 item": the folded summary of a container. */
+export function containerSummary(node: JsonContainer): string {
+  const count = childCount(node);
+  const noun = node.kind === "array" ? "item" : "key";
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+const BARE_KEY = /^[A-Za-z_$][\w$]*$/;
+
+function labelHtml(label: RowLabel): string {
+  if (label === null) return "";
+  if (label.kind === "index")
+    return `<span class="md-json-index">${label.index}</span><span class="md-json-punct">: </span>`;
+  const text = BARE_KEY.test(label.key) ? label.key : JSON.stringify(label.key);
+  return `<span class="md-json-key">${escapeHtml(text)}</span><span class="md-json-punct">: </span>`;
+}
+
+function leafHtml(node: Exclude<JsonNode, JsonContainer>): string {
+  switch (node.kind) {
+    case "string":
+      return `<span class="md-json-string">${escapeHtml(JSON.stringify(node.value))}</span>`;
+    case "number":
+      return `<span class="md-json-number">${String(node.value)}</span>`;
+    case "boolean":
+      return `<span class="md-json-keyword">${String(node.value)}</span>`;
+    case "null":
+      return `<span class="md-json-keyword">null</span>`;
+  }
+}
+
+/** The rows for a container's children. `path` and `depth` are the
+ *  container's own. */
+export function renderJsonChildrenHtml(
+  node: JsonContainer,
+  path: JsonPath,
+  depth: number,
+): string {
+  const rows = childRows(node);
+  let html = "";
+  for (const { label, step, child } of rows.slice(0, JSON_TREE_MAX_CHILDREN)) {
+    html += renderJsonNodeHtml(child, label, [...path, step], depth + 1);
+  }
+  const rest = rows.length - JSON_TREE_MAX_CHILDREN;
+  if (rest > 0) {
+    html += `<li class="md-json-node md-json-more"><div class="md-json-row"><span class="md-json-count">${rest} more in the raw view</span></div></li>`;
+  }
+  return html;
+}
+
+/**
+ * One node as a list item. A container at or past the collapse depth starts
+ * folded with its children left unrendered (`data-lazy`), so a big document
+ * costs only the rows that are visible.
+ */
+export function renderJsonNodeHtml(
+  node: JsonNode,
+  label: RowLabel,
+  path: JsonPath,
+  depth: number,
+): string {
+  if (!isJsonContainer(node)) {
+    return `<li class="md-json-node" data-kind="${node.kind}"><div class="md-json-row">${labelHtml(label)}${leafHtml(node)}</div></li>`;
+  }
+  const [open, close] = node.kind === "array" ? ["[", "]"] : ["{", "}"];
+  if (childCount(node) === 0) {
+    return `<li class="md-json-node" data-kind="${node.kind}"><div class="md-json-row">${labelHtml(label)}<span class="md-json-punct">${open}${close}</span></div></li>`;
+  }
+  const expanded = depth < JSON_TREE_COLLAPSE_DEPTH;
+  const pathAttr = escapeHtml(JSON.stringify(path));
+  const caret =
+    `<button type="button" class="md-json-caret" aria-expanded="${expanded}"` +
+    ` aria-label="${expanded ? "Collapse" : "Expand"}">${chevronRightIconMarkup()}</button>`;
+  const summary =
+    `<span class="md-json-punct">${open}</span>` +
+    `<span class="md-json-count">${containerSummary(node)}</span>` +
+    `<span class="md-json-punct md-json-close">${close}</span>`;
+  const children = expanded
+    ? `<ul class="md-json-list">${renderJsonChildrenHtml(node, path, depth)}</ul>`
+    : "";
+  return (
+    `<li class="md-json-node" data-kind="${node.kind}" data-open="${expanded}"${expanded ? "" : " data-lazy"} data-path="${pathAttr}">` +
+    `<div class="md-json-row">${caret}${labelHtml(label)}${summary}</div>` +
+    children +
+    `<div class="md-json-end"><span class="md-json-punct">${close}</span></div>` +
+    `</li>`
+  );
+}
+
+/** The whole tree, root expanded. */
+export function renderJsonTreeHtml(root: JsonContainer): string {
+  return `<ul class="md-json-list">${renderJsonNodeHtml(root, null, [], 0)}</ul>`;
+}
+
+/** The header: the Tree / Raw toggle and the root's summary. */
+export function renderJsonHeadHtml(root: JsonContainer): string {
+  return (
+    `<div class="md-json-head">` +
+    `<div class="md-json-views" role="group" aria-label="View">` +
+    `<button type="button" class="md-json-view" data-view="tree" aria-pressed="true">Tree</button>` +
+    `<button type="button" class="md-json-view" data-view="raw" aria-pressed="false">Raw</button>` +
+    `</div>` +
+    `<span class="md-json-summary">${containerSummary(root)}</span>` +
+    `</div>`
+  );
+}
+
+/** Parse a node's `data-path` back into a path. */
+export function parseJsonPath(raw: string | undefined): JsonPath | null {
+  if (!raw) return null;
+  try {
+    const parsed = jsonPathSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+let highlightPromise: Promise<
+  typeof import("../components/CodeHighlight")
+> | null = null;
+function loadHighlight() {
+  highlightPromise ??= import("../components/CodeHighlight");
+  return highlightPromise;
+}
+
+/**
+ * Swap the block's plain <pre> for shiki's on the first switch to Raw. The
+ * body's own highlighter skipped this fence because the tree claimed it.
+ */
+async function highlightRaw(
+  block: HTMLElement,
+  source: string,
+  root: HTMLElement,
+  alive: () => boolean,
+): Promise<void> {
+  const m = await loadHighlight().catch(() => null);
+  const out = m
+    ? await m.highlightToHtml(source, "json").catch(() => null)
+    : null;
+  if (!out || !alive() || !root.contains(block)) return;
+  const tpl = document.createElement("template");
+  tpl.innerHTML = out;
+  const shikiPre = tpl.content.firstElementChild;
+  const plain = block.querySelector(":scope > pre");
+  if (!(shikiPre instanceof HTMLElement) || !plain) return;
+  shikiPre.classList.add("md-code", "md-json-raw");
+  // The well is the block's; keep only shiki's ink (see MarkdownBody).
+  shikiPre.style.backgroundColor = "";
+  plain.replaceWith(shikiPre);
+}
+
+function setView(block: HTMLElement, view: "tree" | "raw"): void {
+  block.dataset.view = view;
+  for (const button of Array.from(
+    block.querySelectorAll<HTMLElement>(":scope > .md-json-head .md-json-view"),
+  )) {
+    button.setAttribute("aria-pressed", String(button.dataset.view === view));
+  }
+}
+
+function toggleNode(
+  li: HTMLElement,
+  caret: HTMLElement,
+  root: JsonContainer,
+): void {
+  const open = li.dataset.open !== "true";
+  if (open && li.hasAttribute("data-lazy")) {
+    const path = parseJsonPath(li.dataset.path);
+    const node = path ? jsonAtPath(root, path) : undefined;
+    if (!path || node === undefined || !isJsonContainer(node)) return;
+    const list = document.createElement("ul");
+    list.className = "md-json-list";
+    list.innerHTML = renderJsonChildrenHtml(node, path, path.length);
+    li.querySelector(":scope > .md-json-row")?.after(list);
+    li.removeAttribute("data-lazy");
+  }
+  li.dataset.open = String(open);
+  caret.setAttribute("aria-expanded", String(open));
+  caret.setAttribute("aria-label", open ? "Collapse" : "Expand");
+}
+
+export const jsonTreeUpgrader: FenceUpgrader = {
+  langs: ["json"],
+  keepsCodeControls: true,
+  async upgrade({ pre, source, root, alive }) {
+    if (!jsonWorthFolding(source)) return false;
+    const tree = parseJsonTree(source);
+    if (!tree) return false;
+    // The copy control's wrapper is attached in the effect after the upgrade
+    // pass starts (see fence-upgraders.ts), so the fence has to be replaced
+    // after this pass yields, or the wrapper forms around the hidden <pre>
+    // inside the block instead of around the block.
+    await Promise.resolve();
+    if (!alive() || !root.contains(pre)) return false;
+    const block = document.createElement("div");
+    block.className = "md-json-tree md-code-well";
+    block.dataset.view = "tree";
+    block.innerHTML =
+      renderJsonHeadHtml(tree) +
+      `<div class="md-json-body">${renderJsonTreeHtml(tree)}</div>`;
+    let highlighted = false;
+    block.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target) return;
+      const viewButton = target.closest<HTMLElement>("button.md-json-view");
+      if (viewButton && block.contains(viewButton)) {
+        const view = viewButton.dataset.view === "raw" ? "raw" : "tree";
+        setView(block, view);
+        if (view === "raw" && !highlighted) {
+          highlighted = true;
+          void highlightRaw(block, source, root, alive);
+        }
+        return;
+      }
+      const caret = target.closest<HTMLElement>("button.md-json-caret");
+      const li = caret?.closest<HTMLElement>("li.md-json-node");
+      if (caret && li && block.contains(li)) toggleNode(li, caret, tree);
+    });
+    pre.classList.add("md-json-raw");
+    pre.replaceWith(block);
+    block.append(pre);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/styles/base-markdown.css
+++ b/packages/core/opensession-server/src/frontend/styles/base-markdown.css
@@ -77,7 +77,11 @@
   color: var(--text);
 }
 
-.markdown pre {
+/* `.md-code-well` is the same well on a block that replaces its fence but is
+   still code (the JSON tree, styles/blocks/json-tree.css): one surface for
+   everything that reads as pasted code. */
+.markdown pre,
+.markdown .md-code-well {
   background: #0c0c10;
   border: 1px solid var(--border);
   border-radius: calc(18px * var(--rf));

--- a/packages/core/opensession-server/src/frontend/styles/base-theme.css
+++ b/packages/core/opensession-server/src/frontend/styles/base-theme.css
@@ -974,7 +974,8 @@ html[data-theme="light"] .markdown code {
    LIGHTER than the bubble — so a pasted snippet read as raised in light and
    sunk in dark. Translucent ink instead, the same trick as --hover: one value
    that lands a fixed step below any surface it's dropped on. */
-html[data-theme="light"] .markdown pre {
+html[data-theme="light"] .markdown pre,
+html[data-theme="light"] .markdown .md-code-well {
   background: rgba(0, 0, 0, 0.055);
   border-color: rgba(0, 0, 0, 0.1);
   color: #1f2328;

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -32,6 +32,8 @@
 @import "./blocks/callout.css";
 @import "./blocks/metrics.css";
 @import "./blocks/math.css";
+@import "./blocks/json-tree.css";
+@import "./blocks/ansi.css";
 @import "./base-keyframes.css";
 @import "./blocks/palette.css";
 @import "./blocks/table.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/ansi.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/ansi.css
@@ -1,0 +1,165 @@
+/* ── Terminal output (```ansi, lib/ansi-block.ts) ─────────────────
+   A fence that keeps the code well and its controls; only the runs inside
+   carry style. The sixteen base colours are tokens so a transcript's red
+   is the app's red in both themes; 256-colour and 24-bit values are data
+   and arrive as inline rgb() from the block.
+
+   The two greys have no semantic token of their own: terminals use black
+   and bright black as dim ink, and white as slightly quieter than default,
+   so they map onto the well's own ink ramp rather than onto a page colour
+   that would vanish against the well. Bright variants lean toward the text
+   colour, which brightens them on dark and deepens them on light: what
+   "bright" has to mean for ink on a white well. */
+:root {
+  --ansi-black: var(--code-well-gutter);
+  --ansi-red: var(--red);
+  --ansi-green: var(--green);
+  --ansi-yellow: var(--yellow);
+  --ansi-blue: var(--blue);
+  --ansi-magenta: var(--purple);
+  --ansi-cyan: var(--tool-web);
+  --ansi-white: var(--code-well-ink);
+  --ansi-bright-black: var(--text-faint);
+  --ansi-bright-red: color-mix(in srgb, var(--red) 78%, var(--text));
+  --ansi-bright-green: color-mix(in srgb, var(--green) 78%, var(--text));
+  --ansi-bright-yellow: color-mix(in srgb, var(--yellow) 78%, var(--text));
+  --ansi-bright-blue: color-mix(in srgb, var(--blue) 78%, var(--text));
+  --ansi-bright-magenta: color-mix(in srgb, var(--purple) 78%, var(--text));
+  --ansi-bright-cyan: color-mix(in srgb, var(--tool-web) 78%, var(--text));
+  --ansi-bright-white: var(--text);
+}
+
+.ansi-bold {
+  font-weight: 700;
+}
+.ansi-dim {
+  opacity: 0.6;
+}
+.ansi-italic {
+  font-style: italic;
+}
+.ansi-underline {
+  text-decoration: underline;
+}
+.ansi-strike {
+  text-decoration: line-through;
+}
+.ansi-underline.ansi-strike {
+  text-decoration: underline line-through;
+}
+.ansi-hidden {
+  color: transparent;
+}
+/* Inverse video with no colour of its own: ink on the text colour. A run
+   that carries a colour lands it on the other side through the classes
+   below, which sit later and win. */
+.ansi-inverse {
+  background: var(--text);
+  color: var(--bg);
+}
+
+.ansi-fg-black {
+  color: var(--ansi-black);
+}
+.ansi-fg-red {
+  color: var(--ansi-red);
+}
+.ansi-fg-green {
+  color: var(--ansi-green);
+}
+.ansi-fg-yellow {
+  color: var(--ansi-yellow);
+}
+.ansi-fg-blue {
+  color: var(--ansi-blue);
+}
+.ansi-fg-magenta {
+  color: var(--ansi-magenta);
+}
+.ansi-fg-cyan {
+  color: var(--ansi-cyan);
+}
+.ansi-fg-white {
+  color: var(--ansi-white);
+}
+.ansi-fg-bright-black {
+  color: var(--ansi-bright-black);
+}
+.ansi-fg-bright-red {
+  color: var(--ansi-bright-red);
+}
+.ansi-fg-bright-green {
+  color: var(--ansi-bright-green);
+}
+.ansi-fg-bright-yellow {
+  color: var(--ansi-bright-yellow);
+}
+.ansi-fg-bright-blue {
+  color: var(--ansi-bright-blue);
+}
+.ansi-fg-bright-magenta {
+  color: var(--ansi-bright-magenta);
+}
+.ansi-fg-bright-cyan {
+  color: var(--ansi-bright-cyan);
+}
+.ansi-fg-bright-white {
+  color: var(--ansi-bright-white);
+}
+
+.ansi-bg-black {
+  background: var(--ansi-black);
+}
+.ansi-bg-red {
+  background: var(--ansi-red);
+}
+.ansi-bg-green {
+  background: var(--ansi-green);
+}
+.ansi-bg-yellow {
+  background: var(--ansi-yellow);
+}
+.ansi-bg-blue {
+  background: var(--ansi-blue);
+}
+.ansi-bg-magenta {
+  background: var(--ansi-magenta);
+}
+.ansi-bg-cyan {
+  background: var(--ansi-cyan);
+}
+.ansi-bg-white {
+  background: var(--ansi-white);
+}
+.ansi-bg-bright-black {
+  background: var(--ansi-bright-black);
+}
+.ansi-bg-bright-red {
+  background: var(--ansi-bright-red);
+}
+.ansi-bg-bright-green {
+  background: var(--ansi-bright-green);
+}
+.ansi-bg-bright-yellow {
+  background: var(--ansi-bright-yellow);
+}
+.ansi-bg-bright-blue {
+  background: var(--ansi-bright-blue);
+}
+.ansi-bg-bright-magenta {
+  background: var(--ansi-bright-magenta);
+}
+.ansi-bg-bright-cyan {
+  background: var(--ansi-bright-cyan);
+}
+.ansi-bg-bright-white {
+  background: var(--ansi-bright-white);
+}
+/* A coloured background needs ink that reads on it whichever theme the
+   well is in; the page colour is the one guaranteed to contrast with a
+   status colour drawn at ink strength. Only when the run set no ink. */
+.markdown
+  .md-ansi
+  [class*="ansi-bg-"]:not([class*="ansi-fg-"]):not([style*="color"]) {
+  color: var(--bg);
+}

--- a/packages/core/opensession-server/src/frontend/styles/blocks/json-tree.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/json-tree.css
@@ -1,0 +1,232 @@
+/* ── JSON tree (```json, lib/json-tree-block.ts) ─────────────────
+   The block wears the code well (`.md-code-well`, base-markdown.css) and
+   stays inside the copy control's wrapper, so the controls sit over its
+   header at the same top-right they take on a fence.
+
+   The value inks are shiki's own for JSON, github-dark-default and
+   github-light-default (`support.type.property-name.json`, `string`,
+   `constant`), pinned by json-tree-block.test.ts: a folded tree and the raw
+   text under the Raw toggle have to be the same colours or the toggle reads
+   as a theme change. They are the one place these hexes are written. */
+:root {
+  --json-key: #7ee787;
+  --json-string: #a5d6ff;
+  --json-constant: #79c0ff;
+}
+html[data-theme="light"] {
+  --json-key: #116329;
+  --json-string: #0a3069;
+  --json-constant: #0550ae;
+}
+
+.markdown .md-json-tree {
+  padding: 0;
+  white-space: normal;
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 0.9em;
+  line-height: 1.55;
+}
+/* The fence's own <pre> travels inside the block for the copy control and
+   the Raw view; while the tree shows it is out of layout entirely. Once
+   shown it is the block's content, not a second well inside the first. */
+.markdown .md-json-tree > .md-json-raw {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-size: inherit;
+}
+.md-json-tree[data-view="tree"] > .md-json-raw,
+.md-json-tree[data-view="raw"] > .md-json-body {
+  display: none;
+}
+/* The wrapper's wrap toggle reaches the nested <pre> and long string values. */
+.md-code-wrap[data-wrapped="false"] .md-json-raw,
+.md-code-wrap[data-wrapped="false"] .md-json-string {
+  white-space: pre;
+  overflow-wrap: normal;
+}
+
+/* Header: the view toggle on the left, room for the wrapper's copy and
+   settings controls on the right (their width, base-markdown.css). */
+.md-json-head {
+  --code-pad-right: 80px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 6px 10px;
+  padding-right: var(--code-pad-right);
+  border-bottom: 1px solid var(--code-well-line);
+  font-family: var(--sans);
+  font-size: var(--type-meta);
+  color: var(--text-faint);
+}
+.md-json-views {
+  display: inline-flex;
+  flex: none;
+  padding: 2px;
+  border-radius: calc(9px * var(--rf));
+  corner-shape: var(--cs);
+  background: var(--hover);
+}
+.md-json-view {
+  min-height: 24px;
+  padding: 2px 9px;
+  border: 0;
+  border-radius: calc(7px * var(--rf));
+  corner-shape: var(--cs);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--dur-micro) var(--ease),
+    color var(--dur-micro) var(--ease);
+}
+.md-json-view:hover {
+  color: var(--text);
+}
+.md-json-view[aria-pressed="true"] {
+  background: var(--segmented-knob-surface);
+  color: var(--text);
+  box-shadow: 0 0 0 1px var(--segmented-knob-edge);
+}
+.md-json-view:focus-visible,
+.md-json-caret:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.md-json-summary {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The tree. Every row leaves a caret slot on the left so keys line up
+   whether or not the row folds; nesting indents by a fixed step. */
+.md-json-body {
+  padding: 8px 12px 10px;
+  overflow-x: auto;
+}
+.markdown .md-json-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.markdown .md-json-list .md-json-list {
+  padding-left: 16px;
+}
+.markdown .md-json-node {
+  margin: 0;
+}
+.md-json-row {
+  position: relative;
+  min-height: 22px;
+  padding-left: 22px;
+  overflow-wrap: anywhere;
+}
+.md-json-end {
+  padding-left: 22px;
+}
+.md-json-caret {
+  position: absolute;
+  top: 0;
+  left: -1px;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: calc(6px * var(--rf));
+  corner-shape: var(--cs);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+/* Hover only where there is one: on touch a tapped row would keep the
+   wash after the finger lifts. */
+@media (hover: hover) {
+  .md-json-caret:hover {
+    background: var(--hover);
+    color: var(--text);
+  }
+}
+.md-json-caret svg {
+  transition: rotate var(--dur-micro) var(--ease);
+}
+.md-json-node[data-open="true"] > .md-json-row > .md-json-caret svg {
+  rotate: 90deg;
+}
+.md-json-node[data-open="false"] > .md-json-list,
+.md-json-node[data-open="false"] > .md-json-end,
+.md-json-node[data-open="true"] > .md-json-row > .md-json-count,
+.md-json-node[data-open="true"] > .md-json-row > .md-json-close {
+  display: none;
+}
+.md-json-count {
+  margin: 0 6px;
+  font-family: var(--sans);
+  font-size: var(--type-meta);
+  color: var(--text-faint);
+}
+.md-json-key {
+  color: var(--json-key);
+}
+.md-json-index {
+  color: var(--text-faint);
+}
+/* `pre` keeps the space after the colon when the row is a flex line on
+   touch, where each span is its own item and trailing space would drop. */
+.md-json-punct {
+  color: var(--text-dim);
+  white-space: pre;
+}
+.md-json-string {
+  color: var(--json-string);
+  white-space: pre-wrap;
+}
+.md-json-number,
+.md-json-keyword {
+  color: var(--json-constant);
+}
+
+/* Touch: the wrapper's controls grow to 44px (base-markdown.css), so the
+   header makes room for them; the view buttons take the same height; and
+   a folding row is a 44px target along its whole width, not only at the
+   caret. A leaf row is not a target, so it only opens up enough to read. */
+@media (hover: none) and (pointer: coarse) {
+  .md-json-head {
+    --code-pad-right: 104px;
+    min-height: 52px;
+  }
+  .md-json-view {
+    min-height: 40px;
+    padding: 2px 12px;
+  }
+  .md-json-row {
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .md-json-node[data-open] > .md-json-row {
+    min-height: 44px;
+  }
+  .md-json-end {
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+  }
+  .md-json-node[data-open] > .md-json-row > .md-json-caret {
+    inset: 0;
+    width: auto;
+    height: auto;
+    justify-items: start;
+    padding-left: 1px;
+  }
+}


### PR DESCRIPTION
Two fence upgraders in the blocks registry, both `keepsCodeControls: true`: the block replaces the `<pre>` but stays inside `.md-code-wrap`, so copy and wrap keep working and copy reads the raw source (JSON text; terminal text without escape codes), not the widget's labels.

## JSON tree (`lib/json-tree-block.ts`)

- A ```` ```json ```` fence that `JSON.parse`s to an object or array and runs past **30 lines or 1500 characters** folds into a tree; below that, a bare scalar, or JSON that does not parse yet (streaming, comments, trailing commas) declines and stays shiki code. A 200 000 character ceiling keeps the tree off giant dumps.
- Root and its children open; containers at depth 2 and deeper start folded behind their count (`3 items`, `5 keys`), rendered lazily on first expand. Containers past 500 rows say `n more in the raw view`.
- Keys, strings, numbers and keywords take shiki's own github-dark/light JSON inks (`--json-key`, `--json-string`, `--json-constant` in `blocks/json-tree.css`), pinned to the theme files by a test, so Tree and Raw read as one thing.
- `Tree` / `Raw` toggle in the block's header. Raw reveals the fence's own `<pre>` (kept hidden inside the block, which is also what the copy control reads) and highlights it on first use.
- The fence is parsed once into a tagged `JsonNode` tree (zod); row HTML comes from pure functions with tests. Touch: fold rows are 44px targets across their width; hover washes only under `(hover: hover)`.

## Terminal output (`lib/ansi-block.ts`)

- ```` ```ansi ```` and ```` ```terminal ```` fences always claim; `bash`, `sh`, `zsh`, `shell`, `console`, `text` and `log` fences claim only when they carry a real `ESC[` byte (`claims`).
- A hand-written SGR parser (pure, ~100 lines, tests): bold, dim, italic, underline, strike, inverse, hidden, their resets, 16 base + bright colours, 256-colour, 24-bit (`;` and `:` forms). Other CSI (cursor, erase, private modes), OSC (titles, hyperlinks) and two-byte escapes are stripped. Malformed colours are ignored rather than misread.
- The 16 base colours are `--ansi-*` tokens in `blocks/ansi.css`, built from the semantic tokens (`--red`, `--green`, `--yellow`, `--blue`, `--purple`, `--tool-web`, the code well's ink ramp for black/white); 256/24-bit values are emitted as literal `rgb()` from integers. Everything else is escaped as text.
- An explicit `ansi`/`terminal` fence with no real escape byte decodes the usual spellings (`\x1b[`, `\e[`, `\033[`, `[`), since models tend to write those.

## Shared files

- `fence-upgraders.ts`: two registry entries, plus a doc note that a `keepsCodeControls` block has to `await` before replacing its fence. The body's copy-control effect runs after the effect that starts the upgrade pass, so a synchronous replacement happened before the wrapper existed and the wrapper formed around the wrong `<pre>`. Both upgraders yield once (`await Promise.resolve()`), which is what put the copy button in the JSON block's header in the screenshots.
- `base-markdown.css` / `base-theme.css`: `.md-code-well` shares the `.markdown pre` well surface (dark and light) so the tree block reads as the same well as a fence.
- `icons.tsx`: `chevronRightIconMarkup` (shared path with `IconChevronRight`) for the fold caret.
- `base.css`: the two block imports. `docs/blocks.md`: the two sections updated to the grammar shipped.

Model prompt line for the parent to wire: ```` ```json ```` (large, parses) folds into a tree with a Raw toggle; ```` ```ansi ```` / ```` ```terminal ```` (or a shell fence with real escape bytes) render SGR colours and styles.

Verified with the verify-opensession demo instance and the compiled-bundle harness: desktop dark and light, phone dark, Raw view, and the copy control's text checked over CDP for both blocks. `bun run check` passes.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)