### PR TITLE
Add sandboxed artifact and slide deck blocks

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -144,16 +144,34 @@ in the workspace pane when the session has one.
 
 ### Artifacts
 
-An ` ```artifact ` fence holds a complete HTML document or fragment;
-an ` ```svg ` fence holds an SVG. Both render in a sandboxed iframe
-(no same-origin access, no navigation, scripts only when the fence asks)
-with a toggle to the source, and expand to the lightbox.
+An ` ```artifact ` fence holds a complete HTML document or a fragment; a
+fragment is wrapped in a document that takes the app's background, text
+colour and font, so it reads as native in both themes. An ` ```svg ` fence
+holds an SVG, shown as an `<img>` inside the same frame. Both render in an
+`<iframe sandbox>` by `srcdoc`: no same-origin access, no navigation, no
+forms, no popups, and a `Content-Security-Policy` meta in the head with
+`default-src 'none'` (inline styles and `data:` images allowed), so an
+artifact cannot phone home. Scripts are off unless the info string is
+` ```artifact scripts `, which adds `allow-scripts` and inline `script-src`
+and labels the block "Scripts on". A scripted artifact reports its height
+to the page (clamped to 120 to 900px); a static one starts at 320px with a
+drag handle. The header row has a Source toggle (the original fence, whose
+copy control copies the source) and an expand button that opens the same
+sandboxed document in a full-width dialog. A fence still streaming renders
+as it arrives.
 
 ### Slides
 
-A ` ```slides ` fence is markdown split into slides on `---` lines.
-Renders as a deck with arrows, dots and swipe; each slide is ordinary
-markdown, including the other block kinds.
+A ` ```slides ` fence is markdown split into slides on lines that are
+exactly `---`. Renders as a deck in a 16:9 well: one slide at a time,
+previous/next arrows, dots, a counter, arrow keys when the deck has focus,
+and swipe on a phone. Each slide is ordinary markdown through the app's
+renderer, with two limits: a nested fence inside a slide stays a plain code
+block (neither upgraded into another block kind nor syntax highlighted,
+since the body's upgrade pass has already run), and a `---` inside such a
+fence belongs to the fence, not the deck. Nest fences by giving the deck a
+longer fence (` ````slides `). The expand button opens the deck at the
+dialog's width, on the current slide.
 
 ### Metrics
 

--- a/packages/core/opensession-server/src/frontend/AppContent.tsx
+++ b/packages/core/opensession-server/src/frontend/AppContent.tsx
@@ -24,6 +24,7 @@ import { refWebPanel } from "./components/FeedWebPane";
 import { FirstMile } from "./components/FirstMile";
 import { Goals } from "./components/Goals";
 import { IconDesk, IconSidebarLeft } from "./components/icons";
+import { BlockExpandHost } from "./components/BlockExpandDialog";
 import { MediaLightboxHost } from "./components/MediaLightbox";
 import { NavigationProvider } from "./components/NavigationProvider";
 import { NewSession } from "./components/NewSession";
@@ -1219,6 +1220,7 @@ export function AppContent({
     <UserGate>
       <RestartOverlay connected={connected} addHandler={addHandler} />
       <MediaLightboxHost />
+      <BlockExpandHost />
       <ToastHost container={settingsActive ? null : detailPaneEl} />
       <RunningCloseDialog {...runningCloseDialog} />
       <div className="app">

--- a/packages/core/opensession-server/src/frontend/components/BlockExpandDialog.tsx
+++ b/packages/core/opensession-server/src/frontend/components/BlockExpandDialog.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import {
+  registerBlockExpandHost,
+  type BlockExpandRequest,
+} from "../lib/block-expand";
+import { cn } from "../ui/cn";
+import { Modal } from "../ui/modal";
+
+/**
+ * The one dialog a markdown block opens itself large in (lib/block-expand.ts):
+ * a sandboxed artifact at the window's size, a slide deck at reading width.
+ * Hosted once in the app, beside the media lightbox, because the blocks are
+ * DOM built inside innerHTML bodies and have no React tree to render a
+ * dialog from.
+ */
+export function BlockExpandHost() {
+  const [request, setRequest] = useState<BlockExpandRequest | null>(null);
+  const [open, setOpen] = useState(false);
+  // The body node as state rather than a ref: Base UI mounts a popup's
+  // children in a later commit than the one that opens it, so an effect on
+  // a ref would run against null (see useScrolledUnder in ui/modal.tsx).
+  const [body, setBody] = useState<HTMLDivElement | null>(null);
+  useEffect(
+    () =>
+      registerBlockExpandHost((next) => {
+        setRequest(next);
+        setOpen(true);
+      }),
+    [],
+  );
+  useEffect(() => {
+    if (!body || !request) return;
+    return request.mount(body);
+  }, [body, request]);
+
+  return (
+    <Modal.Root open={open} onOpenChange={setOpen}>
+      {request && (
+        <Modal.Content
+          widthClassName="max-w-[min(1280px,96vw)]"
+          className="w-[96vw]"
+          finalFocus={false}
+        >
+          <Modal.Header title={request.title} />
+          <div
+            ref={setBody}
+            className={cn(
+              "min-h-0 min-w-0",
+              request.fill && "h-[min(820px,calc(85dvh-104px))]",
+            )}
+          />
+        </Modal.Content>
+      )}
+    </Modal.Root>
+  );
+}

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -231,10 +231,12 @@ export function IconChevronsUpDown(p: IconProps) {
   );
 }
 
+const CHEVRON_LEFT_PATH = "M13.75 6.75L8.75 12L13.75 17.25";
+
 export function IconChevronLeft(p: IconProps) {
   return (
     <Svg {...p}>
-      <path {...stroke} d="M13.75 6.75L8.75 12L13.75 17.25" />
+      <path {...stroke} d={CHEVRON_LEFT_PATH} />
     </Svg>
   );
 }
@@ -1166,6 +1168,11 @@ export function IconOctagonAlert(p: IconProps) {
       ))}
     </Svg>
   );
+}
+
+/** <IconChevronLeft> as markup. */
+export function chevronLeftIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([CHEVRON_LEFT_PATH]), size);
 }
 
 /** <IconChevronRight> as markup: the fold caret on a JSON tree row. */

--- a/packages/core/opensession-server/src/frontend/lib/artifact-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/artifact-block.ts
@@ -1,0 +1,33 @@
+/**
+ * The cheap half of an artifact block: which fences are artifacts. Building
+ * the sandboxed frame (artifact-frame.ts) is imported when a body carries
+ * one, the way a diagram's renderer is. What goes into the frame and what
+ * keeps it there is in artifact-document.ts; see that file for the sandbox
+ * and the policy.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+
+let framePromise: Promise<typeof import("./artifact-frame")> | null = null;
+function loadFrame() {
+  framePromise ??= import("./artifact-frame");
+  return framePromise;
+}
+
+/**
+ * The block keeps the fence's <pre> beside the frame for its Source view,
+ * so the copy and wrap controls stay: what they copy is the artifact's own
+ * source, which is what anyone asking for it wants.
+ */
+export const artifactUpgrader: FenceUpgrader = {
+  langs: ["artifact", "svg"],
+  keepsCodeControls: true,
+  async upgrade({ pre, source, lang, root, alive }) {
+    const m = await loadFrame().catch(() => null);
+    if (!m || !alive() || !root.contains(pre)) return false;
+    if (!source.trim()) return false;
+    const info = pre.querySelector("code")?.dataset.info ?? lang;
+    m.mountArtifactBlock(pre, source, lang, info);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/artifact-document.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/artifact-document.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ARTIFACT_DEFAULT_HEIGHT,
+  ARTIFACT_HEIGHT_MESSAGE,
+  ARTIFACT_MAX_HEIGHT,
+  ARTIFACT_MIN_HEIGHT,
+  artifactCsp,
+  artifactHtmlDocument,
+  artifactOptionsFromInfo,
+  artifactSandbox,
+  artifactSvgDocument,
+  clampArtifactHeight,
+  isCompleteHtmlDocument,
+  artifactHeightMessageSchema,
+  svgArtifactSize,
+  type ArtifactTheme,
+} from "./artifact-document";
+
+const THEME: ArtifactTheme = {
+  bg: "#1c1c1c",
+  text: "#e9e9e9",
+  link: "#6ea8fe",
+  font: "-apple-system, sans-serif",
+  scheme: "dark",
+};
+
+describe("artifact options", () => {
+  test("scripts are off unless the info string says so", () => {
+    expect(artifactOptionsFromInfo("artifact").scripts).toBe(false);
+    expect(artifactOptionsFromInfo("artifact scripts").scripts).toBe(true);
+    expect(artifactOptionsFromInfo("Artifact SCRIPTS").scripts).toBe(true);
+    expect(artifactOptionsFromInfo("artifact script").scripts).toBe(false);
+    expect(artifactOptionsFromInfo(undefined).scripts).toBe(false);
+  });
+
+  test("the sandbox never grants same-origin, navigation, forms or popups", () => {
+    expect(artifactSandbox({ scripts: false })).toBe("");
+    expect(artifactSandbox({ scripts: true })).toBe("allow-scripts");
+  });
+
+  test("the policy blocks the network and opens scripts only on request", () => {
+    const off = artifactCsp({ scripts: false });
+    expect(off).toContain("default-src 'none'");
+    expect(off).toContain("img-src data:");
+    expect(off).toContain("style-src 'unsafe-inline'");
+    expect(off).not.toContain("script-src");
+    expect(off).not.toMatch(/https?:/);
+    const on = artifactCsp({ scripts: true });
+    expect(on).toContain("script-src 'unsafe-inline'");
+    expect(on).toContain("default-src 'none'");
+    expect(on).not.toContain("connect-src");
+  });
+});
+
+describe("artifact html document", () => {
+  test("wraps a fragment in a document carrying the page's colours", () => {
+    const doc = artifactHtmlDocument("<h1>Hi</h1>", { scripts: false }, THEME);
+    expect(doc.startsWith("<!doctype html>")).toBe(true);
+    expect(doc).toContain('http-equiv="Content-Security-Policy"');
+    expect(doc).toContain("background:#1c1c1c");
+    expect(doc).toContain("color:#e9e9e9");
+    expect(doc).toContain("color-scheme:dark");
+    expect(doc).toContain("<body><h1>Hi</h1></body>");
+    expect(doc).not.toContain("<script");
+  });
+
+  test("splices the policy into a complete document's head, first", () => {
+    const doc = artifactHtmlDocument(
+      "<!DOCTYPE html><html><head><title>T</title><style>body{color:red}</style></head><body>x</body></html>",
+      { scripts: false },
+      THEME,
+    );
+    expect(isCompleteHtmlDocument(doc)).toBe(true);
+    const csp = doc.indexOf("Content-Security-Policy");
+    expect(csp).toBeGreaterThan(-1);
+    expect(csp).toBeLessThan(doc.indexOf("<title>"));
+    // The author's own rules come after the base style, so they win.
+    expect(doc.indexOf("background:#1c1c1c")).toBeLessThan(
+      doc.indexOf("body{color:red}"),
+    );
+  });
+
+  test("gives a headless <html> document a head", () => {
+    const doc = artifactHtmlDocument(
+      "<html><body>x</body></html>",
+      { scripts: false },
+      THEME,
+    );
+    expect(doc).toMatch(/<html><head><meta http-equiv/);
+  });
+
+  test("adds the height reporter only with scripts on", () => {
+    const off = artifactHtmlDocument("<p>a</p>", { scripts: false }, THEME);
+    const on = artifactHtmlDocument("<p>a</p>", { scripts: true }, THEME);
+    expect(off).not.toContain("postMessage");
+    expect(on).toContain("postMessage");
+    expect(on).toContain("ResizeObserver");
+  });
+
+  test("a theme value cannot break out of the style block", () => {
+    const doc = artifactHtmlDocument(
+      "<p>a</p>",
+      { scripts: false },
+      { ...THEME, bg: "</style><script>1</script>" },
+    );
+    expect(doc).not.toContain("<script>1</script>");
+  });
+
+  test("a streaming fragment still becomes a document", () => {
+    const doc = artifactHtmlDocument("<div><p>half", { scripts: false }, THEME);
+    expect(doc).toContain("<body><div><p>half</body>");
+  });
+});
+
+describe("svg artifact document", () => {
+  const svg =
+    '<?xml version="1.0"?>\n<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"><rect width="200" height="100"/></svg>';
+
+  test("shows the drawing as an image, never as live markup", () => {
+    const doc = artifactSvgDocument(svg, THEME);
+    expect(doc).toContain('<img src="data:image/svg+xml;charset=utf-8,');
+    expect(doc).not.toContain("<svg");
+    expect(doc).not.toContain("script-src");
+  });
+
+  test("reads the drawing's own size past an xml prolog", () => {
+    expect(svgArtifactSize(svg)).toEqual({ w: 200, h: 100 });
+    expect(svgArtifactSize("<svg><rect/></svg>")).toBeNull();
+  });
+});
+
+describe("clampArtifactHeight", () => {
+  test("keeps a reported height inside the range", () => {
+    expect(clampArtifactHeight(10)).toBe(ARTIFACT_MIN_HEIGHT);
+    expect(clampArtifactHeight(1e9)).toBe(ARTIFACT_MAX_HEIGHT);
+    expect(clampArtifactHeight(400.4)).toBe(400);
+    expect(clampArtifactHeight(Number.NaN)).toBe(ARTIFACT_DEFAULT_HEIGHT);
+  });
+});
+
+describe("artifactHeightMessageSchema", () => {
+  test("accepts only the frame's own message shape", () => {
+    const ok = artifactHeightMessageSchema.safeParse({
+      type: ARTIFACT_HEIGHT_MESSAGE,
+      height: 480,
+    });
+    expect(ok.success && ok.data.height).toBe(480);
+    for (const bad of [
+      { type: ARTIFACT_HEIGHT_MESSAGE, height: "9" },
+      { type: "other", height: 1 },
+      "hello",
+      null,
+    ])
+      expect(artifactHeightMessageSchema.safeParse(bad).success).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/artifact-document.ts
+++ b/packages/core/opensession-server/src/frontend/lib/artifact-document.ts
@@ -1,0 +1,225 @@
+/**
+ * The pure half of an ```artifact / ```svg block: what goes into the
+ * sandboxed frame's `srcdoc`, and the sandbox and CSP that keep it there.
+ *
+ * An artifact is untrusted by definition: it is whatever the agent wrote,
+ * and the frame exists so it can be anything without touching the page.
+ * Three layers hold that line, and every one of them is decided here so a
+ * test can read the strings:
+ *
+ * - The `sandbox` attribute (artifactSandbox): never `allow-same-origin`,
+ *   so the document has an opaque origin and no reach into the app's DOM,
+ *   storage or cookies; never `allow-top-navigation`, `allow-forms` or
+ *   `allow-popups`. `allow-scripts` only when the fence asked.
+ * - A `<meta http-equiv="Content-Security-Policy">` in the document head
+ *   (artifactCsp): `default-src 'none'`, so nothing inside the frame can
+ *   fetch, load or phone home; inline styles allowed; `data:` images, so a
+ *   diagram can carry its own pictures; inline scripts only with scripts on.
+ * - The document is written by `srcdoc` and the app never reads back into
+ *   it. With scripts on, the only channel out is a `postMessage` carrying
+ *   the document's height (ARTIFACT_HEIGHT_MESSAGE), which the block clamps.
+ *
+ * A fragment is wrapped in a minimal document that takes the app's own
+ * background and text colour, so a snippet reads as native in both themes;
+ * a complete document keeps its own head and gets the CSP and the base
+ * style prepended, where the author's later rules win. An SVG becomes an
+ * `<img src="data:image/svg+xml,…">` inside the same frame: an image never
+ * runs script, never loads anything external, and sizes itself.
+ */
+
+import { z } from "zod";
+import { readDiagramSvg } from "./diagram-media";
+
+export interface ArtifactOptions {
+  /** `artifact scripts` in the fence info string. */
+  scripts: boolean;
+}
+
+export interface ArtifactTheme {
+  /** The page's --bg, resolved. */
+  bg: string;
+  /** The page's --text, resolved. */
+  text: string;
+  /** The page's --link, resolved. */
+  link: string;
+  /** The page's --sans font stack. */
+  font: string;
+  scheme: "light" | "dark";
+}
+
+/** The frame's default height before anything reports one, and the range a
+ *  report or a drag is clamped to. In CSS pixels. */
+export const ARTIFACT_DEFAULT_HEIGHT = 320;
+export const ARTIFACT_MIN_HEIGHT = 120;
+export const ARTIFACT_MAX_HEIGHT = 900;
+
+/** The `type` of the height message a scripted artifact posts to its parent.
+ *  Kept obscure enough that a stray postMessage from elsewhere is not read
+ *  as one; the height itself is clamped regardless. */
+export const ARTIFACT_HEIGHT_MESSAGE = "opensession-artifact-height";
+
+/** `artifact scripts` turns scripts on. Any other word is ignored. */
+export function artifactOptionsFromInfo(
+  info: string | undefined,
+): ArtifactOptions {
+  const words = (info ?? "").trim().toLowerCase().split(/\s+/).slice(1);
+  return { scripts: words.includes("scripts") };
+}
+
+/** The frame's `sandbox` attribute. An empty string is the fully locked
+ *  sandbox, which is what a static artifact gets. */
+export function artifactSandbox(options: ArtifactOptions): string {
+  return options.scripts ? "allow-scripts" : "";
+}
+
+/** The policy written into the document head. `default-src 'none'` is the
+ *  whole point; the rest re-opens exactly what an inline document needs. */
+export function artifactCsp(options: ArtifactOptions): string {
+  const directives = [
+    "default-src 'none'",
+    "img-src data:",
+    "style-src 'unsafe-inline'",
+    "font-src data:",
+    "form-action 'none'",
+    "base-uri 'none'",
+  ];
+  if (options.scripts) directives.push("script-src 'unsafe-inline'");
+  return directives.join("; ");
+}
+
+/** The one message the app reads from inside a frame. Parse `event.data`
+ *  with this at the window listener, then clamp what it carries. */
+export const artifactHeightMessageSchema = z.object({
+  type: z.literal(ARTIFACT_HEIGHT_MESSAGE),
+  height: z.number(),
+});
+
+export function clampArtifactHeight(height: number): number {
+  if (!Number.isFinite(height)) return ARTIFACT_DEFAULT_HEIGHT;
+  return Math.min(
+    ARTIFACT_MAX_HEIGHT,
+    Math.max(ARTIFACT_MIN_HEIGHT, Math.round(height)),
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** A CSS value is written into a style attribute inside the frame; strip
+ *  anything that could close the declaration or the tag. */
+function cssValue(s: string): string {
+  return s.replace(/[<>"{};]/g, "").trim();
+}
+
+function metaCsp(options: ArtifactOptions): string {
+  return `<meta http-equiv="Content-Security-Policy" content="${artifactCsp(options)}">`;
+}
+
+/**
+ * The app's own colours as the document's base style. First in the head, so
+ * anything the author wrote after it wins; a document that never mentions
+ * its background still reads as part of the page.
+ */
+function baseStyle(theme: ArtifactTheme): string {
+  return (
+    "<style>" +
+    `:root{color-scheme:${theme.scheme};background:${cssValue(theme.bg)};color:${cssValue(theme.text)};` +
+    `font-family:${cssValue(theme.font)};font-size:15px;line-height:1.5}` +
+    "body{margin:16px}" +
+    `a{color:${cssValue(theme.link)}}` +
+    "img,svg,video,canvas{max-width:100%}" +
+    "</style>"
+  );
+}
+
+/**
+ * With scripts on the frame can measure itself. The root element's box is
+ * the content height (the root's margins never collapse with body's, so
+ * body's margin sits inside it), which lets the frame shrink as well as
+ * grow, unlike scrollHeight, which never drops below the viewport.
+ */
+function heightReporter(): string {
+  return (
+    "<script>(function(){" +
+    "var last=-1;" +
+    "function post(){var h=Math.ceil(document.documentElement.getBoundingClientRect().height);" +
+    `if(h!==last){last=h;parent.postMessage({type:${JSON.stringify(ARTIFACT_HEIGHT_MESSAGE)},height:h},"*")}}` +
+    'if(typeof ResizeObserver!=="undefined"){new ResizeObserver(post).observe(document.documentElement);' +
+    'document.addEventListener("DOMContentLoaded",function(){if(document.body)new ResizeObserver(post).observe(document.body)})}' +
+    'window.addEventListener("load",post);post();' +
+    "})()</script>"
+  );
+}
+
+/** Whether the source is already a complete document rather than a fragment. */
+export function isCompleteHtmlDocument(source: string): boolean {
+  return /^\s*(<!doctype\b|<html\b)/i.test(source);
+}
+
+const HEAD_OPEN = /<head\b[^>]*>/i;
+const HTML_OPEN = /<html\b[^>]*>/i;
+
+/**
+ * The `srcdoc` for an HTML artifact. A fragment gets a whole document
+ * around it; a complete one gets the policy and base style spliced into
+ * its head. Both work while the fence is still streaming: HTML tolerates a
+ * document that stops mid-tag.
+ */
+export function artifactHtmlDocument(
+  source: string,
+  options: ArtifactOptions,
+  theme: ArtifactTheme,
+): string {
+  const head =
+    metaCsp(options) +
+    baseStyle(theme) +
+    (options.scripts ? heightReporter() : "");
+  if (isCompleteHtmlDocument(source)) {
+    if (HEAD_OPEN.test(source))
+      return source.replace(HEAD_OPEN, (open) => `${open}${head}`);
+    if (HTML_OPEN.test(source))
+      return source.replace(HTML_OPEN, (open) => `${open}<head>${head}</head>`);
+    return `<!doctype html><html><head>${head}</head>${source.replace(/^\s*<!doctype\b[^>]*>/i, "")}`;
+  }
+  return `<!doctype html><html><head><meta charset="utf-8">${head}</head><body>${source}</body></html>`;
+}
+
+/** Strip an XML prolog, doctype and leading comments so the root <svg> is
+ *  the first tag, which is what the size reader expects. */
+function svgRoot(source: string): string {
+  return source.replace(
+    /^\s*(?:<\?xml[^>]*\?>|<!DOCTYPE[^>]*>|<!--[\s\S]*?-->)\s*/gi,
+    "",
+  );
+}
+
+/** The SVG's own size, when it declares one, so the frame can be sized to
+ *  its aspect ratio before anything loads: a static frame cannot report. */
+export function svgArtifactSize(
+  source: string,
+): { w: number; h: number } | null {
+  return readDiagramSvg(svgRoot(source))?.size ?? null;
+}
+
+/**
+ * The `srcdoc` for an SVG artifact: the drawing as an image on the app's
+ * background, at the frame's width. Scripts are never on for an SVG; an
+ * `<img>` would not run them anyway.
+ */
+export function artifactSvgDocument(
+  source: string,
+  theme: ArtifactTheme,
+): string {
+  const options: ArtifactOptions = { scripts: false };
+  const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgRoot(source))}`;
+  return (
+    `<!doctype html><html><head><meta charset="utf-8">${metaCsp(options)}${baseStyle(theme)}` +
+    "<style>body{margin:0;display:grid;place-items:center;min-height:100vh}img{display:block;width:100%;height:auto}</style>" +
+    `</head><body><img src="${escapeHtml(dataUrl)}" alt=""></body></html>`
+  );
+}

--- a/packages/core/opensession-server/src/frontend/lib/artifact-frame.ts
+++ b/packages/core/opensession-server/src/frontend/lib/artifact-frame.ts
@@ -1,0 +1,251 @@
+/**
+ * The DOM half of an artifact block: the sandboxed frame, its header row
+ * (label, Source toggle, expand) and the height control under it. The
+ * document inside the frame and the policy on it come from
+ * artifact-document.ts, which is where the security lives; this file only
+ * puts that document into an <iframe sandbox> and never reads back out of
+ * it.
+ *
+ * Height: a scripted artifact posts its document height (the reporter in
+ * artifact-document.ts) and the frame follows it, within limits. A static
+ * one cannot report, so it starts at the default and has a grip to drag; an
+ * SVG is sized to its own aspect ratio up front. A frame the person has
+ * dragged stops following reports.
+ */
+
+import { expandIconMarkup } from "../components/icons";
+import {
+  ARTIFACT_DEFAULT_HEIGHT,
+  artifactHtmlDocument,
+  artifactOptionsFromInfo,
+  artifactSandbox,
+  artifactSvgDocument,
+  artifactHeightMessageSchema,
+  clampArtifactHeight,
+  svgArtifactSize,
+  type ArtifactTheme,
+} from "./artifact-document";
+import { openBlockExpand } from "./block-expand";
+
+const WRAP_CLASS = "md-artifact-wrap";
+const FRAME_CLASS = "md-artifact-frame";
+
+interface FrameSpec {
+  srcdoc: string;
+  sandbox: string;
+  scripts: boolean;
+  label: string;
+}
+
+/** The page's tokens, resolved, for the document's base style. The system
+ *  colours are the fallback when a token is missing: they follow the
+ *  document's color-scheme rather than pinning a colour here. */
+function readTheme(): ArtifactTheme {
+  const style = getComputedStyle(document.documentElement);
+  const token = (name: string, fallback: string) =>
+    style.getPropertyValue(name).trim() || fallback;
+  return {
+    bg: token("--bg", "Canvas"),
+    text: token("--text", "CanvasText"),
+    link: token("--link", "LinkText"),
+    font: token("--sans", "system-ui, sans-serif"),
+    scheme:
+      document.documentElement.dataset.theme === "light" ? "light" : "dark",
+  };
+}
+
+function frameSpec(source: string, lang: string, info: string): FrameSpec {
+  const theme = readTheme();
+  if (lang === "svg") {
+    return {
+      srcdoc: artifactSvgDocument(source, theme),
+      sandbox: artifactSandbox({ scripts: false }),
+      scripts: false,
+      label: "SVG",
+    };
+  }
+  const options = artifactOptionsFromInfo(info);
+  return {
+    srcdoc: artifactHtmlDocument(source, options, theme),
+    sandbox: artifactSandbox(options),
+    scripts: options.scripts,
+    label: "Artifact",
+  };
+}
+
+function createFrame(spec: FrameSpec): HTMLIFrameElement {
+  const frame = document.createElement("iframe");
+  frame.className = FRAME_CLASS;
+  frame.title = `${spec.label} preview`;
+  // The attribute is set before srcdoc so the document never loads outside
+  // the sandbox. An empty value is the fully locked sandbox.
+  frame.setAttribute("sandbox", spec.sandbox);
+  frame.referrerPolicy = "no-referrer";
+  frame.srcdoc = spec.srcdoc;
+  return frame;
+}
+
+let listening = false;
+/** One window listener for every artifact frame on the page. A message is
+ *  matched to its frame by source window; the height it carries is clamped
+ *  before it touches layout, so a hostile artifact can at most be tall. */
+function ensureHeightListener(): void {
+  if (listening) return;
+  listening = true;
+  window.addEventListener("message", (event: MessageEvent) => {
+    const message = artifactHeightMessageSchema.safeParse(event.data);
+    if (!message.success) return;
+    const height = clampArtifactHeight(message.data.height);
+    for (const frame of document.querySelectorAll<HTMLIFrameElement>(
+      `iframe.${FRAME_CLASS}`,
+    )) {
+      if (frame.contentWindow !== event.source) continue;
+      const wrap = frame.closest<HTMLElement>(`.${WRAP_CLASS}`);
+      if (
+        !wrap ||
+        wrap.dataset.sized === "manual" ||
+        frame.dataset.fill !== undefined
+      )
+        continue;
+      frame.style.height = `${height}px`;
+    }
+  });
+}
+
+function button(
+  className: string,
+  label: string,
+  html: string,
+): HTMLButtonElement {
+  const el = document.createElement("button");
+  el.type = "button";
+  el.className = className;
+  el.title = label;
+  el.setAttribute("aria-label", label);
+  el.innerHTML = html;
+  return el;
+}
+
+/** Drag or arrow the frame's height. The grip is a real button so it is in
+ *  the tab order; pointer capture keeps a drag alive over the frame. */
+function attachGrip(
+  grip: HTMLButtonElement,
+  frame: HTMLIFrameElement,
+  wrap: HTMLElement,
+): void {
+  const setHeight = (height: number) => {
+    frame.style.height = `${clampArtifactHeight(height)}px`;
+    wrap.dataset.sized = "manual";
+  };
+  let start: { y: number; height: number } | null = null;
+  grip.addEventListener("pointerdown", (e) => {
+    if (e.button !== 0) return;
+    start = { y: e.clientY, height: frame.getBoundingClientRect().height };
+    grip.setPointerCapture(e.pointerId);
+    wrap.dataset.resizing = "";
+    e.preventDefault();
+  });
+  grip.addEventListener("pointermove", (e) => {
+    if (!start) return;
+    setHeight(start.height + (e.clientY - start.y));
+  });
+  const end = () => {
+    start = null;
+    delete wrap.dataset.resizing;
+  };
+  grip.addEventListener("pointerup", end);
+  grip.addEventListener("pointercancel", end);
+  grip.addEventListener("keydown", (e) => {
+    const step = e.shiftKey ? 120 : 40;
+    const current = frame.getBoundingClientRect().height;
+    if (e.key === "ArrowDown") setHeight(current + step);
+    else if (e.key === "ArrowUp") setHeight(current - step);
+    else return;
+    e.preventDefault();
+  });
+}
+
+/**
+ * Replace `pre` with the block, keeping `pre` inside it (hidden) for the
+ * Source view and the copy control. `info` is the fence's whole info string
+ * when the renderer kept it (`artifact scripts`), else just the language.
+ */
+export function mountArtifactBlock(
+  pre: HTMLElement,
+  source: string,
+  lang: string,
+  info: string,
+): void {
+  const spec = frameSpec(source, lang, info);
+  const wrap = document.createElement("div");
+  wrap.className = WRAP_CLASS;
+  wrap.dataset.view = "preview";
+
+  const head = document.createElement("div");
+  head.className = "md-artifact-head";
+  const label = document.createElement("span");
+  label.className = "md-artifact-label";
+  label.textContent = spec.label;
+  head.append(label);
+  if (spec.scripts) {
+    const tag = document.createElement("span");
+    tag.className = "md-artifact-tag";
+    tag.textContent = "Scripts on";
+    head.append(tag);
+  }
+  const spacer = document.createElement("span");
+  spacer.className = "md-artifact-spacer";
+  const sourceToggle = document.createElement("button");
+  sourceToggle.type = "button";
+  sourceToggle.className = "md-artifact-btn";
+  sourceToggle.textContent = "Source";
+  sourceToggle.setAttribute("aria-pressed", "false");
+  sourceToggle.addEventListener("click", () => {
+    const showing = wrap.dataset.view === "source";
+    wrap.dataset.view = showing ? "preview" : "source";
+    sourceToggle.setAttribute("aria-pressed", String(!showing));
+  });
+  const expand = button(
+    "md-artifact-btn md-artifact-expand",
+    `Expand ${spec.label.toLowerCase()}`,
+    expandIconMarkup(16),
+  );
+  expand.addEventListener("click", () => {
+    openBlockExpand({
+      title: spec.label,
+      fill: true,
+      mount(host) {
+        const large = createFrame(spec);
+        large.dataset.fill = "";
+        host.append(large);
+        return () => large.remove();
+      },
+    });
+  });
+  head.append(spacer, sourceToggle, expand);
+
+  const body = document.createElement("div");
+  body.className = "md-artifact-body";
+  const frame = createFrame(spec);
+  frame.style.height = `${ARTIFACT_DEFAULT_HEIGHT}px`;
+  const grip = button("md-artifact-grip", "Resize preview", "");
+  body.append(frame, grip);
+  attachGrip(grip, frame, wrap);
+  if (spec.scripts) ensureHeightListener();
+
+  // The block takes the fence's place first, then takes the fence in: the
+  // other way round, `pre` has already left the document by the time it
+  // is asked to be replaced.
+  pre.replaceWith(wrap);
+  wrap.append(head, body, pre);
+
+  // An SVG declares its size, so the frame can take its aspect ratio at the
+  // width it landed in. Measured after mounting, which is when there is a
+  // width to measure.
+  if (lang === "svg") {
+    const size = svgArtifactSize(source);
+    const width = body.clientWidth;
+    if (size && width > 0)
+      frame.style.height = `${clampArtifactHeight((width * size.h) / size.w)}px`;
+  }
+}

--- a/packages/core/opensession-server/src/frontend/lib/block-expand.ts
+++ b/packages/core/opensession-server/src/frontend/lib/block-expand.ts
@@ -1,0 +1,38 @@
+/**
+ * Opening a markdown block large: the artifact frame and the slide deck.
+ *
+ * The blocks are DOM built inside an innerHTML body, so like the media
+ * lightbox (media-lightbox.ts) the dialog is hosted once in the app
+ * (components/BlockExpandDialog.tsx) and opened imperatively. The block
+ * hands over a `mount` that builds a fresh copy of itself into the dialog's
+ * body rather than moving its own nodes there: the inline block stays where
+ * it is, and closing the dialog only has to tear the copy down.
+ */
+
+export interface BlockExpandRequest {
+  /** The dialog's title: "Artifact", "Slides". */
+  title: string;
+  /** Build the expanded content into `host`; return its teardown. */
+  mount: (host: HTMLElement) => () => void;
+  /** Give the content the dialog's full height (a frame) rather than let it
+   *  take its own (a deck). */
+  fill?: boolean;
+}
+
+let host: ((request: BlockExpandRequest) => void) | null = null;
+
+export function registerBlockExpandHost(
+  open: (request: BlockExpandRequest) => void,
+): () => void {
+  host = open;
+  return () => {
+    if (host === open) host = null;
+  };
+}
+
+/** False when no dialog is mounted to show it. */
+export function openBlockExpand(request: BlockExpandRequest): boolean {
+  if (!host) return false;
+  host(request);
+  return true;
+}

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -16,6 +16,7 @@
  */
 
 import { ansiUpgrader } from "./ansi-block";
+import { artifactUpgrader } from "./artifact-block";
 import { chartUpgrader } from "./chart-fence";
 import { jsonTreeUpgrader } from "./json-tree-block";
 import { mathUpgrader } from "./math-block";
@@ -23,6 +24,7 @@ import { mermaidUpgrader } from "./mermaid-fence";
 import { paletteUpgrader } from "./palette-block";
 import { tableUpgrader } from "./table-block";
 import { metricsUpgrader } from "./metrics-block";
+import { slidesUpgrader } from "./slides-block";
 import type { EffectiveTheme } from "./theme";
 
 export interface FenceUpgradeContext {
@@ -91,6 +93,8 @@ export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   mathUpgrader,
   jsonTreeUpgrader,
   ansiUpgrader,
+  artifactUpgrader,
+  slidesUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
@@ -1496,3 +1496,19 @@ describe("renderMarkdown math", () => {
     expect(html).toContain("$x$");
   });
 });
+
+describe("renderMarkdown fence info strings", () => {
+  it("keeps the whole info string on a fence that carries more than a language", () => {
+    const html = renderMarkdown("```artifact scripts\n<b>&</b>\n```");
+    expect(html).toContain(
+      '<pre><code class="language-artifact" data-info="artifact scripts">',
+    );
+    expect(html).toContain("&lt;b&gt;&amp;&lt;/b&gt;\n</code></pre>");
+  });
+
+  it("leaves a plain language fence as marked writes it", () => {
+    expect(renderMarkdown("```ts\nlet a = 1\n```")).toBe(
+      '<pre><code class="language-ts">let a = 1\n</code></pre>\n',
+    );
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/markdown.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.ts
@@ -1299,6 +1299,20 @@ md.use({
     },
   },
   renderer: {
+    // marked keeps only the first word of a fence's info string, as the
+    // language class. A block kind that reads the rest (`artifact scripts`,
+    // lib/artifact-block.ts) finds it in data-info; a fence with nothing
+    // after its language takes marked's own output, byte for byte.
+    code(token: Tokens.Code) {
+      const info = (token.lang ?? "").trim();
+      const lang = /^\S*/.exec(info)?.[0] ?? "";
+      if (info.length === lang.length) return false;
+      const code = token.text.replace(/\n$/, "") + "\n";
+      return (
+        `<pre><code class="language-${attr(lang)}" data-info="${attr(info)}">` +
+        `${token.escaped ? code : attr(code).replace(/'/g, "&#39;")}</code></pre>\n`
+      );
+    },
     // Session content is untrusted (assistant output, tool results, pasted
     // text). marked passes raw HTML through verbatim by default, and we inject
     // the result with dangerouslySetInnerHTML — so an embedded <script> or

--- a/packages/core/opensession-server/src/frontend/lib/slides-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slides-block.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { splitSlides } from "./slides-block";
+
+describe("splitSlides", () => {
+  test("splits on lines that are exactly ---", () => {
+    expect(splitSlides("# One\n---\n# Two\n---\n# Three")).toEqual([
+      "# One",
+      "# Two",
+      "# Three",
+    ]);
+  });
+
+  test("allows trailing whitespace but not a longer rule", () => {
+    expect(splitSlides("a\n---  \nb")).toEqual(["a", "b"]);
+    expect(splitSlides("a\n----\nb")).toEqual(["a\n----\nb"]);
+    expect(splitSlides("a\n - - -\nb")).toEqual(["a\n - - -\nb"]);
+  });
+
+  test("leaves a --- inside a nested fence to that fence", () => {
+    const src = "# Diff\n```diff\n---\n+++\n```\n---\n# Next";
+    expect(splitSlides(src)).toEqual([
+      "# Diff\n```diff\n---\n+++\n```",
+      "# Next",
+    ]);
+  });
+
+  test("honours tilde fences and longer closers", () => {
+    const src = "~~~\n---\n~~~\n---\n````\n---\n```\n---\n````\n---\nend";
+    expect(splitSlides(src)).toEqual([
+      "~~~\n---\n~~~",
+      "````\n---\n```\n---\n````",
+      "end",
+    ]);
+  });
+
+  test("drops blank slides and trims the rest", () => {
+    expect(splitSlides("---\n\n  a  \n\n---\n---\nb\n---\n")).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(splitSlides("")).toEqual([]);
+    expect(splitSlides("---\n---")).toEqual([]);
+  });
+
+  test("accepts CRLF line endings", () => {
+    expect(splitSlides("a\r\n---\r\nb")).toEqual(["a", "b"]);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/slides-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slides-block.ts
@@ -1,0 +1,66 @@
+/**
+ * The cheap half of a slides block: which fences are decks, and how a deck's
+ * markdown splits into slides. Building the deck (slides-deck.ts) pulls in
+ * the markdown renderer, so it is imported when a body carries one.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Split on lines that are exactly `---` (trailing whitespace allowed). A
+ * `---` inside a nested code fence belongs to that fence, not the deck.
+ * Blank slides are dropped, so a deck that opens with `---` does not start
+ * on an empty one.
+ */
+export function splitSlides(source: string): string[] {
+  const slides: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null;
+  for (const line of source.split(/\r?\n/)) {
+    const open = FENCE_OPEN.exec(line);
+    if (fence) {
+      const closes =
+        open &&
+        open[1][0] === fence[0] &&
+        open[1].length >= fence.length &&
+        line.trim() === open[1];
+      if (closes) fence = null;
+      current.push(line);
+      continue;
+    }
+    if (open) {
+      fence = open[1];
+      current.push(line);
+      continue;
+    }
+    if (line.trimEnd() === "---") {
+      slides.push(current.join("\n"));
+      current = [];
+      continue;
+    }
+    current.push(line);
+  }
+  slides.push(current.join("\n"));
+  return slides.map((slide) => slide.trim()).filter(Boolean);
+}
+
+let deckPromise: Promise<typeof import("./slides-deck")> | null = null;
+function loadDeck() {
+  deckPromise ??= import("./slides-deck");
+  return deckPromise;
+}
+
+/** A fence with nothing in it keeps the plain code block. */
+export const slidesUpgrader: FenceUpgrader = {
+  langs: ["slides"],
+  async upgrade({ pre, source, root, alive }) {
+    const slides = splitSlides(source);
+    if (slides.length === 0) return false;
+    const m = await loadDeck().catch(() => null);
+    if (!m || !alive() || !root.contains(pre)) return false;
+    pre.replaceWith(m.buildSlidesDeck(slides, { expandable: true }).el);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/slides-deck.ts
+++ b/packages/core/opensession-server/src/frontend/lib/slides-deck.ts
@@ -1,0 +1,177 @@
+/**
+ * The DOM half of a slides block: one slide at a time in a 16:9 well, with
+ * arrows, dots, a counter, the keyboard and a swipe. Each slide is the
+ * app's own markdown (renderMarkdown), rendered once up front; a nested
+ * fence inside a slide stays a plain code block, since the body's upgrade
+ * pass has already run by the time the deck exists.
+ *
+ * Built as DOM rather than JSX for the reason every block is: the body it
+ * sits in is an innerHTML string. Listeners live on the deck's own nodes
+ * and go with them.
+ */
+
+import {
+  chevronLeftIconMarkup,
+  chevronRightIconMarkup,
+  expandIconMarkup,
+} from "../components/icons";
+import { openBlockExpand } from "./block-expand";
+import { renderMarkdown } from "./markdown";
+
+/** How far a finger travels before it turns a page. */
+const SWIPE_DISTANCE = 40;
+/** Past this many slides the dots stop helping and only the counter shows. */
+const MAX_DOTS = 16;
+
+export interface SlidesDeck {
+  el: HTMLElement;
+  /** Show slide `index`, clamped. */
+  go(index: number): void;
+}
+
+function button(className: string, label: string, html: string) {
+  const el = document.createElement("button");
+  el.type = "button";
+  el.className = className;
+  el.title = label;
+  el.setAttribute("aria-label", label);
+  el.innerHTML = html;
+  return el;
+}
+
+export function buildSlidesDeck(
+  slides: readonly string[],
+  options: { index?: number; expandable: boolean },
+): SlidesDeck {
+  const count = slides.length;
+  let index = Math.min(Math.max(options.index ?? 0, 0), count - 1);
+
+  const wrap = document.createElement("div");
+  wrap.className = "md-slides-wrap";
+  const deck = document.createElement("div");
+  deck.className = "md-slides";
+  deck.tabIndex = 0;
+  deck.setAttribute("role", "group");
+  deck.setAttribute("aria-roledescription", "slide deck");
+  deck.setAttribute("aria-label", `Slides, ${count} in total`);
+
+  const stage = document.createElement("div");
+  stage.className = "md-slides-stage";
+  const panes = slides.map((slide, i) => {
+    const pane = document.createElement("div");
+    pane.className = "md-slide markdown";
+    pane.setAttribute("role", "group");
+    pane.setAttribute("aria-roledescription", "slide");
+    pane.setAttribute("aria-label", `Slide ${i + 1} of ${count}`);
+    pane.innerHTML = renderMarkdown(slide);
+    stage.append(pane);
+    return pane;
+  });
+
+  const nav = document.createElement("div");
+  nav.className = "md-slides-nav";
+  const prev = button(
+    "md-slides-arrow",
+    "Previous slide",
+    chevronLeftIconMarkup(18),
+  );
+  const next = button(
+    "md-slides-arrow",
+    "Next slide",
+    chevronRightIconMarkup(18),
+  );
+  const dots = document.createElement("div");
+  dots.className = "md-slides-dots";
+  const dotButtons =
+    count <= MAX_DOTS
+      ? slides.map((_, i) => {
+          const dot = button("md-slides-dot", `Go to slide ${i + 1}`, "");
+          dot.addEventListener("click", () => go(i));
+          dots.append(dot);
+          return dot;
+        })
+      : [];
+  const counter = document.createElement("span");
+  counter.className = "md-slides-count";
+  counter.setAttribute("aria-live", "polite");
+  nav.append(prev, dots, counter, next);
+  deck.append(stage, nav);
+  wrap.append(deck);
+
+  function go(to: number) {
+    index = Math.min(Math.max(to, 0), count - 1);
+    panes.forEach((pane, i) => {
+      if (i === index) pane.setAttribute("data-current", "");
+      else pane.removeAttribute("data-current");
+    });
+    dotButtons.forEach((dot, i) =>
+      dot.setAttribute("aria-current", i === index ? "true" : "false"),
+    );
+    counter.textContent = `${index + 1} / ${count}`;
+    prev.disabled = index === 0;
+    next.disabled = index === count - 1;
+    stage.scrollTop = 0;
+  }
+  prev.addEventListener("click", () => go(index - 1));
+  next.addEventListener("click", () => go(index + 1));
+
+  deck.addEventListener("keydown", (e) => {
+    if (e.target instanceof HTMLElement && e.target.closest("input, textarea"))
+      return;
+    if (e.key === "ArrowLeft") go(index - 1);
+    else if (e.key === "ArrowRight") go(index + 1);
+    else if (e.key === "Home") go(0);
+    else if (e.key === "End") go(count - 1);
+    else return;
+    e.preventDefault();
+  });
+
+  // A horizontal swipe on the stage turns the page; a mostly vertical one is
+  // the reader scrolling a tall slide and is left alone.
+  let touchStart: { x: number; y: number } | null = null;
+  stage.addEventListener(
+    "touchstart",
+    (e) => {
+      const t = e.touches[0];
+      touchStart = t ? { x: t.clientX, y: t.clientY } : null;
+    },
+    { passive: true },
+  );
+  stage.addEventListener(
+    "touchend",
+    (e) => {
+      const t = e.changedTouches[0];
+      if (!touchStart || !t) return;
+      const dx = t.clientX - touchStart.x;
+      const dy = t.clientY - touchStart.y;
+      touchStart = null;
+      if (Math.abs(dx) < SWIPE_DISTANCE || Math.abs(dx) < Math.abs(dy)) return;
+      go(dx < 0 ? index + 1 : index - 1);
+    },
+    { passive: true },
+  );
+
+  if (options.expandable) {
+    const expand = button(
+      "md-diagram-expand",
+      "Expand slides",
+      expandIconMarkup(),
+    );
+    expand.addEventListener("click", () => {
+      openBlockExpand({
+        title: "Slides",
+        mount(host) {
+          const large = buildSlidesDeck(slides, { index, expandable: false });
+          large.el.dataset.expanded = "";
+          host.append(large.el);
+          large.el.querySelector<HTMLElement>(".md-slides")?.focus();
+          return () => large.el.remove();
+        },
+      });
+    });
+    wrap.append(expand);
+  }
+
+  go(index);
+  return { el: wrap, go };
+}

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -34,6 +34,8 @@
 @import "./blocks/math.css";
 @import "./blocks/json-tree.css";
 @import "./blocks/ansi.css";
+@import "./blocks/artifact.css";
+@import "./blocks/slides.css";
 @import "./base-keyframes.css";
 @import "./blocks/palette.css";
 @import "./blocks/table.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/artifact.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/artifact.css
@@ -1,0 +1,159 @@
+/* ── ```artifact / ```svg block (lib/artifact-frame.ts) ─────────────
+   A sandboxed frame in the same well a diagram takes, with a header row
+   above it: the label, a Source toggle and expand. The fence's own <pre>
+   stays inside the block, hidden, for the Source view and the copy
+   control. That control (lib/code-copy.ts) sits in the wrapper AROUND this
+   block, top right, so the header keeps its right end clear for it.
+   Renderer-emitted markup, hence a stylesheet rather than utilities. */
+.md-artifact-wrap {
+  position: relative;
+  margin: 2px 0 8px;
+  overflow: hidden;
+  background: var(--diagram-canvas);
+  border: 1px solid var(--border);
+  border-radius: calc(8px * var(--rf));
+  corner-shape: var(--cs);
+}
+.md-artifact-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+  padding: 4px 80px 4px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  line-height: 1.2;
+  color: var(--text-dim);
+}
+.md-artifact-label {
+  font-weight: 600;
+  color: var(--text);
+}
+.md-artifact-tag {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--hover);
+  font-size: 11px;
+}
+.md-artifact-spacer {
+  flex: 1;
+}
+.md-artifact-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: calc(6px * var(--rf));
+  corner-shape: var(--cs);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.md-artifact-expand {
+  width: 26px;
+  padding: 0;
+  justify-content: center;
+}
+.md-artifact-btn:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+.md-artifact-btn[aria-pressed="true"] {
+  background: var(--hover-strong);
+  color: var(--text);
+}
+.md-artifact-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.md-artifact-body {
+  position: relative;
+}
+.md-artifact-frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  /* Only ever seen before the document paints; it takes the page colour. */
+  background: var(--bg);
+}
+/* A frame swallows pointer events, which would end a drag the moment the
+   pointer crossed into it. */
+.md-artifact-wrap[data-resizing] .md-artifact-frame {
+  pointer-events: none;
+}
+.md-artifact-grip {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 14px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: ns-resize;
+}
+.md-artifact-grip::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 36px;
+  height: 4px;
+  margin: -2px 0 0 -18px;
+  border-radius: 999px;
+  background: var(--text-dim);
+  opacity: 0.4;
+}
+.md-artifact-grip:hover::after,
+.md-artifact-grip:focus-visible::after {
+  opacity: 0.9;
+}
+.md-artifact-grip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+/* The Source view: the fence, with the well's own edge and corner. */
+.md-artifact-wrap > pre {
+  display: none;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+}
+.md-artifact-wrap[data-view="source"] > pre {
+  display: block;
+}
+.md-artifact-wrap[data-view="source"] > .md-artifact-body {
+  display: none;
+}
+/* The wrapper's unwrap toggle reaches a fence that is a direct child; this
+   one sits a level down. */
+.md-code-wrap[data-wrapped="false"] .md-artifact-wrap > pre {
+  white-space: pre;
+  overflow-wrap: normal;
+}
+/* Expanded (components/BlockExpandDialog.tsx): the frame fills the body. */
+.md-artifact-frame[data-fill] {
+  height: 100%;
+  border-radius: calc(8px * var(--rf));
+  corner-shape: var(--cs);
+  border: 1px solid var(--border);
+}
+@media (hover: none) and (pointer: coarse) {
+  .md-artifact-head {
+    min-height: 48px;
+    padding-right: 104px;
+  }
+  .md-artifact-btn {
+    height: 36px;
+    padding: 0 10px;
+  }
+  .md-artifact-expand {
+    width: 36px;
+  }
+  .md-artifact-grip {
+    height: 24px;
+  }
+}

--- a/packages/core/opensession-server/src/frontend/styles/blocks/slides.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/slides.css
@@ -1,0 +1,136 @@
+/* ── ```slides block (lib/slides-deck.ts) ───────────────────────────
+   One slide at a time in a 16:9 well on the diagram canvas, a nav row
+   under it, and the same expand control a chart carries. Renderer-emitted
+   markup, hence a stylesheet rather than utilities. */
+.md-slides-wrap {
+  position: relative;
+  margin: 2px 0 8px;
+}
+.md-slides {
+  overflow: hidden;
+  background: var(--diagram-canvas);
+  border: 1px solid var(--border);
+  border-radius: calc(8px * var(--rf));
+  corner-shape: var(--cs);
+  outline: none;
+}
+.md-slides:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.md-slides-stage {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.md-slide {
+  display: none;
+  box-sizing: border-box;
+  min-height: 100%;
+  padding: 24px 44px 24px 28px;
+}
+.md-slide[data-current] {
+  display: block;
+  /* A short settle rather than a slide: the global reduced-motion rule
+     (base-theme.css) takes it to nothing. */
+  animation: md-slide-in var(--dur) var(--ease) both;
+}
+@keyframes md-slide-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.md-slide > :first-child {
+  margin-top: 0;
+}
+.md-slide h1 {
+  font-size: 1.6em;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+.md-slide h2 {
+  font-size: 1.3em;
+}
+.md-slides-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border);
+}
+.md-slides-arrow {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.md-slides-arrow:hover:not(:disabled) {
+  background: var(--hover);
+  color: var(--text);
+}
+.md-slides-arrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.md-slides-arrow:focus-visible,
+.md-slides-dot:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.md-slides-dots {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+}
+.md-slides-dot {
+  position: relative;
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--text-dim);
+  opacity: 0.4;
+  cursor: pointer;
+}
+/* The dot stays small; the finger gets a square around it. */
+.md-slides-dot::before {
+  content: "";
+  position: absolute;
+  inset: -10px -6px;
+}
+.md-slides-dot[aria-current="true"] {
+  background: var(--text);
+  opacity: 1;
+}
+.md-slides-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+}
+/* Expanded (components/BlockExpandDialog.tsx): the deck takes the dialog's
+   width and stops short of its height, so the nav row stays in view. */
+.md-slides-wrap[data-expanded] .md-slides-stage {
+  max-height: calc(85dvh - 200px);
+}
+@media (hover: none) and (pointer: coarse) {
+  .md-slides-arrow {
+    width: 44px;
+    height: 44px;
+  }
+  .md-slide {
+    padding: 20px 40px 20px 20px;
+  }
+}


### PR DESCRIPTION
Two more block kinds for the fence upgrader registry (docs/blocks.md, "Artifacts" and "Slides").

## Artifacts

An ` ```artifact ` fence (a complete HTML document or a fragment) and an ` ```svg ` fence render in an `<iframe sandbox>` via `srcdoc`.

- **Sandbox**: `sandbox=""` (fully locked) for a static artifact; `sandbox="allow-scripts"` only for ` ```artifact scripts `. Never `allow-same-origin`, `allow-top-navigation`, `allow-forms` or `allow-popups`. `referrerpolicy=no-referrer`.
- **CSP** (`<meta http-equiv>` first in the head): `default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src data:; form-action 'none'; base-uri 'none'`, plus `script-src 'unsafe-inline'` only with scripts on. An artifact cannot fetch, navigate, submit or open anything.
- A fragment is wrapped in a document carrying the app's `--bg`, `--text`, `--link` and `--sans`, so it reads as native in both themes; a complete document gets the policy and base style spliced into its head, ahead of the author's own rules.
- An SVG becomes `<img src="data:image/svg+xml,...">` inside the same frame, never live DOM.
- Height: a scripted artifact posts its document height (`ResizeObserver` in the frame), parsed with a zod schema at the window listener and clamped to 120 to 900px. A static one starts at 320px; every frame has a drag grip (pointer and arrow keys). An SVG is sized to its own aspect ratio up front.
- Header row: label ("Artifact" / "SVG"), a "Scripts on" tag when applicable, a Source toggle (the original fence stays in the block, hidden; the copy control copies it) and an expand button.
- The only thing the app ever reads from a frame is that one height message; nothing reads back into the document.

## Slides

A ` ```slides ` fence splits on lines that are exactly `---` (a `---` inside a nested fence belongs to the fence). One slide at a time in a 16:9 well, previous/next arrows, dots (up to 16, counter always), arrow keys and Home/End when the deck has focus, touch swipe, and the same expand button a chart carries. The transition is an opacity settle on the app's `--dur`/`--ease`, which the global reduced-motion rule takes to nothing. Nested fences inside a slide stay plain code (the body's upgrade pass has already run), documented.

## Expand

One Base UI `Modal` host (`components/BlockExpandDialog.tsx`, mounted beside `MediaLightboxHost`) opened imperatively through `lib/block-expand.ts`, the way the lightbox is. A block hands over a `mount(host)` that builds a fresh copy of itself (a second sandboxed frame, or a second deck on the current slide). Chosen over a `frame` kind in the lightbox because the lightbox viewer is built around an image or SVG with pinch/zoom, region comments and a download link, none of which apply to a live iframe; the dialog is about 90 lines and touches no lightbox file.

## Renderer change

marked keeps only the first word of a fence's info string. `lib/markdown.ts` now overrides `code` only when the info string has more than one word, writing the whole string to `data-info` on the `<code>`; a plain fence keeps marked's byte-identical output, so nothing else in the app changes.

## Verification

`bun run check` passes. Visual proof through the verify-opensession demo instance with the compiled-bundle harness, desktop dark and light, phone dark, expanded artifact and expanded deck; screenshots are in the session.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)