### PR TITLE
Add quick-reply chips and collapsible file tree blocks

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -132,15 +132,21 @@ a hundred, or more than one ragged row in ten keeps the plain code fence.
 
 ### Quick replies
 
-A ` ```choices ` fence lists one reply per line. Each renders as a chip;
-picking one sends that text as the next message. Chips go quiet once a
-message has been sent after them.
+A ` ```choices ` fence lists one reply per line (a leading `- ` is
+tolerated), up to twelve. Each renders as a chip; picking one sends that
+text as the next message on the composer's own path, so it queues while a
+run is busy. Chips go quiet once any later user message exists, and
+wherever there is no session to send into.
 
 ### File trees
 
-A ` ```tree ` fence holds an indented tree (two spaces per level, or
-`tree` CLI box-drawing output). Directories fold; a file row opens that file
-in the workspace pane when the session has one.
+A ` ```tree ` fence holds an indented tree (two spaces or a tab per level,
+a trailing `/` marks a directory) or `tree` CLI box-drawing output
+(`├──`, `│`, `└──`, the ASCII charset too). A trailing `# note` on a line
+shows dim beside the name. Directories fold, the top two levels open. A
+file row opens that file in the Changes pane when it is one of the
+session's changed files; the app has no viewer for an arbitrary repo file,
+so any other row is a label.
 
 ### Artifacts
 

--- a/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
+++ b/packages/core/opensession-server/src/frontend/components/SessionViewer.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
   useSyncExternalStore,
+  type MouseEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "motion/react";
@@ -200,6 +201,8 @@ import {
 } from "../lib/pending-reconcile";
 import { promptOutbox, type PromptOutboxItem } from "../lib/prompt-outbox";
 import { DiffPanel, useSessionDiff } from "./DiffPanel";
+import { useTranscriptBlocks } from "../hooks/useTranscriptBlocks";
+import { revealDiffFileWhenMounted } from "../lib/diff-navigation";
 import { RepoBar } from "./RepoBar";
 import { RepoTile } from "./RepoTile";
 import { SandboxBadge } from "./SandboxBadge";
@@ -1256,6 +1259,34 @@ export function SessionViewer({
     headerController.layout;
   const { desktopChangesRef, headerW, compactHeader } = headerController.layout;
   const { summaryOpen, setSummaryOpen, isPhone } = headerController.layout;
+  // Blocks a markdown body builds as plain DOM (quick replies, file trees)
+  // reach the session through the messages click handler, like assets do.
+  const transcriptBlocks = useTranscriptBlocks({
+    sessionId: session.id,
+    messagesRef,
+    entries,
+    diffRepos: diffState.repos,
+    // The isolated send: chip text only, the composer's draft left alone.
+    sendQuickReply: (text) => void handleSend(text, undefined, []),
+    openChangedFile: (path) => {
+      // The same route the workspace summary's "files changed" row takes,
+      // then the diff is scrolled to the file once the pane has mounted.
+      if (isPhone) {
+        setInfoPageOpen(true);
+        setPanelPage("changes");
+      } else {
+        setDesktopPanelPage("changes");
+        setActivePanelOpen(true);
+      }
+      revealDiffFileWhenMounted(
+        () => (isPhone ? document.body : desktopChangesRef.current),
+        path,
+      );
+    },
+  });
+  const handleTranscriptClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (!transcriptBlocks.handleClick(e)) handleMessagesClick(e);
+  };
   const { summaryHasRoom, summaryVisible } = headerController.summary;
   const { summaryStep, summaryStepStyle } = headerController.summary;
   const { focusComposerForQuote } = headerController.composer;
@@ -1675,7 +1706,7 @@ export function SessionViewer({
               repairSafetyPause,
               handleFork,
               handleMessagesScroll,
-              handleMessagesClick,
+              handleMessagesClick: handleTranscriptClick,
               cancelIndexAnchorHold,
               scrollToLatest,
               loadAllHistory,

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -591,14 +591,17 @@ export function IconTerminal(p: IconProps) {
   );
 }
 
+const FILE_PATHS = [
+  "M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z",
+  "M18 9.25H13.75V5",
+];
+
 export function IconFile(p: IconProps) {
   return (
     <Svg {...p}>
-      <path
-        {...stroke}
-        d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"
-      />
-      <path {...stroke} d="M18 9.25H13.75V5" />
+      {FILE_PATHS.map((d) => (
+        <path key={d} {...stroke} d={d} />
+      ))}
     </Svg>
   );
 }
@@ -795,13 +798,13 @@ export function IconPin(p: IconProps) {
   );
 }
 
+const FOLDER_PATH =
+  "M4.75 16.25V7.75C4.75 6.64543 5.64543 5.75 6.75 5.75H9.68934C9.88823 5.75 10.079 5.82902 10.2197 5.96967L12 7.75H17.25C18.3546 7.75 19.25 8.64543 19.25 9.75V16.25C19.25 17.3546 18.3546 18.25 17.25 18.25H6.75C5.64543 18.25 4.75 17.3546 4.75 16.25Z";
+
 export function IconFolder(p: IconProps) {
   return (
     <Svg {...p}>
-      <path
-        {...stroke}
-        d="M4.75 16.25V7.75C4.75 6.64543 5.64543 5.75 6.75 5.75H9.68934C9.88823 5.75 10.079 5.82902 10.2197 5.96967L12 7.75H17.25C18.3546 7.75 19.25 8.64543 19.25 9.75V16.25C19.25 17.3546 18.3546 18.25 17.25 18.25H6.75C5.64543 18.25 4.75 17.3546 4.75 16.25Z"
-      />
+      <path {...stroke} d={FOLDER_PATH} />
     </Svg>
   );
 }
@@ -1178,6 +1181,16 @@ export function chevronLeftIconMarkup(size = MIN_ICON_SIZE): string {
 /** <IconChevronRight> as markup: the fold caret on a JSON tree row. */
 export function chevronRightIconMarkup(size = MIN_ICON_SIZE): string {
   return iconMarkup(pathsMarkup([CHEVRON_RIGHT_PATH]), size);
+}
+
+/** <IconFile> as markup. */
+export function fileIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup(FILE_PATHS), size);
+}
+
+/** <IconFolder> as markup. */
+export function folderIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(pathsMarkup([FOLDER_PATH]), size);
 }
 
 export function IconTrash(p: IconProps) {

--- a/packages/core/opensession-server/src/frontend/hooks/useTranscriptBlocks.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useTranscriptBlocks.ts
@@ -1,0 +1,97 @@
+import { useEffect, type MouseEvent, type RefObject } from "react";
+import {
+  CHOICES_BLOCK_CLASS,
+  openChoiceEntryIds,
+  quietChoicesBlock,
+  setOpenChoiceEntries,
+} from "../lib/choices-block";
+import { matchTreePath, setOpenableTreePaths } from "../lib/tree-block";
+import type { RepoDiff, TranscriptEntry } from "../lib/types";
+import { useSessionDiffResource } from "./useApiResources";
+
+/**
+ * The session viewer's side of the blocks a markdown body builds as plain
+ * DOM (lib/choices-block.ts, lib/tree-block.ts). Those blocks cannot reach
+ * React, so, like `[data-asset-path]`, they carry a data attribute and the
+ * viewer's delegated click handler acts on it. This hook also keeps the
+ * blocks told what only the viewer knows: which entries still take a quick
+ * reply, and which files the Changes pane can show.
+ */
+export function useTranscriptBlocks({
+  sessionId,
+  messagesRef,
+  entries,
+  diffRepos,
+  sendQuickReply,
+  openChangedFile,
+}: {
+  sessionId: string;
+  messagesRef: RefObject<HTMLDivElement | null>;
+  entries: TranscriptEntry[];
+  /** The Changes pane's diff, when it is open and has loaded it. */
+  diffRepos: RepoDiff[] | null;
+  /** Send chip text as the next message, on the composer's own path. */
+  sendQuickReply: (text: string) => void;
+  /** Open one of the session's changed files in the Changes pane. */
+  openChangedFile: (path: string) => void;
+}) {
+  // The pane only fetches its diff while it is open, and a tree row has to
+  // know which files it can open before then. Same SWR key, so an open pane
+  // and this share one request; a transcript with no tree asks for nothing.
+  const hasTree = entries.some(
+    (entry) => entry.type === "assistant" && entry.content.includes("```tree"),
+  );
+  const ownDiff = useSessionDiffResource(sessionId, {
+    enabled: hasTree && !diffRepos,
+  });
+  const repos = diffRepos ?? ownDiff.data?.repos ?? [];
+  const changedPaths = repos.flatMap((repo) =>
+    repo.diff.files.map((file) => file.path),
+  );
+  const changedKey = changedPaths.join("\0");
+
+  useEffect(() => {
+    const root = messagesRef.current;
+    if (root) setOpenChoiceEntries(root, openChoiceEntryIds(entries));
+  }, [entries, messagesRef]);
+
+  useEffect(() => {
+    const root = messagesRef.current;
+    if (root)
+      setOpenableTreePaths(root, changedKey ? changedKey.split("\0") : []);
+  }, [changedKey, messagesRef]);
+
+  /** True when the click was a block's and has been handled. */
+  function handleClick(e: MouseEvent): boolean {
+    const target = e.target;
+    if (!(target instanceof Element)) return false;
+    const chip = target.closest("[data-choice]");
+    if (chip instanceof HTMLButtonElement) {
+      const block = chip.closest(`.${CHOICES_BLOCK_CLASS}`);
+      if (!block || block.hasAttribute("data-quiet")) return true;
+      // The DOM's answer is refreshed from the transcript, but a chip can be
+      // pressed between a new user message landing and that refresh; the
+      // transcript itself is what decides.
+      const eid = block.getAttribute("data-choices-eid") ?? "";
+      if (!openChoiceEntryIds(entries).has(eid)) {
+        quietChoicesBlock(block);
+        return true;
+      }
+      const text = chip.textContent?.trim();
+      if (!text) return true;
+      e.preventDefault();
+      quietChoicesBlock(block);
+      sendQuickReply(text);
+      return true;
+    }
+    const row = target.closest("[data-tree-path]");
+    if (row instanceof HTMLElement) {
+      const path = matchTreePath(row.dataset.treePath ?? "", changedPaths);
+      if (path) openChangedFile(path);
+      return true;
+    }
+    return false;
+  }
+
+  return { handleClick };
+}

--- a/packages/core/opensession-server/src/frontend/lib/choices-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/choices-block.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { openChoiceEntryIds, parseChoices } from "./choices-block";
+
+describe("parseChoices", () => {
+  it("reads one reply per line and drops list markers", () => {
+    expect(parseChoices("Merge it\n- Add a test\n* Explain\n2. Stop")).toEqual([
+      "Merge it",
+      "Add a test",
+      "Explain",
+      "Stop",
+    ]);
+  });
+
+  it("ignores blank lines, surrounding space and repeats", () => {
+    expect(parseChoices("\n  Yes  \n\nYes\nNo\n")).toEqual(["Yes", "No"]);
+  });
+
+  it("declines an empty fence, too many replies or a reply that is prose", () => {
+    expect(parseChoices("")).toBeNull();
+    expect(parseChoices("- \n-\n")).toBeNull();
+    const many = Array.from({ length: 13 }, (_, i) => `Option ${i}`).join("\n");
+    expect(parseChoices(many)).toBeNull();
+    expect(parseChoices("x".repeat(201))).toBeNull();
+  });
+});
+
+describe("openChoiceEntryIds", () => {
+  const entries = [
+    { id: "u1", type: "user" },
+    { id: "a1", type: "assistant" },
+    { id: "u2", type: "user" },
+    { id: "t1", type: "tool_use" },
+    { id: "a2", type: "assistant" },
+  ];
+
+  it("keeps only the entries after the last user message", () => {
+    const open = openChoiceEntryIds(entries);
+    expect([...open]).toEqual(["t1", "a2"]);
+    expect(open.has("a1")).toBe(false);
+  });
+
+  it("keeps everything when nobody has replied yet", () => {
+    expect([...openChoiceEntryIds(entries.slice(1, 2))]).toEqual(["a1"]);
+    expect(openChoiceEntryIds([]).size).toBe(0);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/choices-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/choices-block.ts
@@ -1,0 +1,135 @@
+/**
+ * Quick replies: a ```choices fence listing one reply per line renders as a
+ * row of chips. Picking one sends that text as the next message.
+ *
+ * The block is DOM built inside a markdown body, so it never imports React.
+ * It talks to the session around it two ways, the same way `[data-asset-path]`
+ * does: the chip carries a `data-choice` marker and the block carries the
+ * entry id it belongs to (`data-choices-eid`), and the session viewer's
+ * delegated click handler (hooks/useTranscriptBlocks.ts) does the sending.
+ * Whether the chips are still current (no later user message) is decided by
+ * the viewer from the transcript and published here per messages container,
+ * so a block upgraded later reads the same answer the viewer would give.
+ *
+ * Where there is no session to send into (an asset preview, PR prose) the
+ * chips render quiet: a chip that does nothing must not invite a click.
+ */
+
+import type { FenceUpgrader } from "./fence-upgraders";
+
+export const CHOICES_BLOCK_CLASS = "md-choices";
+export const CHOICE_CLASS = "md-choice";
+/** The transcript container a block reads its scope from (MarkdownBody uses
+ *  the same class as its lazy-upgrade root). */
+const SCOPE_SELECTOR = ".viewer-messages";
+
+const MAX_CHOICES = 12;
+const MAX_CHOICE_LENGTH = 200;
+
+/**
+ * One reply per non-empty line; a leading `- `, `* ` or `1. ` is tolerated
+ * and dropped. Null when the fence is not a usable list: empty, too many, or
+ * a line long enough to be prose rather than a reply.
+ */
+export function parseChoices(source: string): string[] | null {
+  const seen = new Set<string>();
+  const choices: string[] = [];
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const text = line.replace(/^(?:[-*+]|\d+[.)])(?:\s+|$)/, "").trim();
+    if (!text || seen.has(text)) continue;
+    if (text.length > MAX_CHOICE_LENGTH) return null;
+    seen.add(text);
+    choices.push(text);
+  }
+  if (choices.length === 0 || choices.length > MAX_CHOICES) return null;
+  return choices;
+}
+
+interface EntryLike {
+  id: string;
+  type: string;
+}
+
+/**
+ * The entries whose quick replies are still current: everything after the
+ * last user message. A block in an earlier entry has been answered, by a chip
+ * or by the composer, and goes quiet.
+ */
+export function openChoiceEntryIds(
+  entries: readonly EntryLike[],
+): ReadonlySet<string> {
+  let lastUser = -1;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.type === "user") {
+      lastUser = index;
+      break;
+    }
+  }
+  return new Set(entries.slice(lastUser + 1).map((entry) => entry.id));
+}
+
+/** Per messages container: the entry ids whose chips are still live. */
+const openEntries = new WeakMap<Element, ReadonlySet<string>>();
+
+function applyQuiet(block: Element, quiet: boolean): void {
+  if (quiet) block.setAttribute("data-quiet", "");
+  else block.removeAttribute("data-quiet");
+  for (const chip of block.querySelectorAll(`.${CHOICE_CLASS}`)) {
+    if (chip instanceof HTMLButtonElement) chip.disabled = quiet;
+  }
+}
+
+function isQuiet(block: Element): boolean {
+  const scope = block.closest(SCOPE_SELECTOR);
+  const open = scope ? openEntries.get(scope) : undefined;
+  const eid = block.getAttribute("data-choices-eid");
+  return !open || !eid || !open.has(eid);
+}
+
+/**
+ * Publish which entries still take a quick reply, and bring every mounted
+ * block under `container` in line. Called by the viewer whenever the
+ * transcript changes.
+ */
+export function setOpenChoiceEntries(
+  container: Element,
+  open: ReadonlySet<string>,
+): void {
+  openEntries.set(container, open);
+  for (const block of container.querySelectorAll(`.${CHOICES_BLOCK_CLASS}`))
+    applyQuiet(block, isQuiet(block));
+}
+
+/** Quiet one block now, e.g. right after its chip was sent, ahead of the
+ *  transcript catching up. */
+export function quietChoicesBlock(block: Element): void {
+  applyQuiet(block, true);
+}
+
+export const choicesUpgrader: FenceUpgrader = {
+  langs: ["choices"],
+  async upgrade({ pre, source, root, alive }) {
+    const choices = parseChoices(source);
+    if (!choices || !alive() || !root.contains(pre)) return false;
+    const block = document.createElement("div");
+    block.className = CHOICES_BLOCK_CLASS;
+    block.setAttribute("role", "group");
+    block.setAttribute("aria-label", "Quick replies");
+    const eid = pre.closest("[data-eid]")?.getAttribute("data-eid");
+    if (eid) block.dataset.choicesEid = eid;
+    for (const choice of choices) {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = CHOICE_CLASS;
+      chip.dataset.choice = "";
+      // Untrusted text: never markup.
+      chip.textContent = choice;
+      block.append(chip);
+    }
+    pre.replaceWith(block);
+    applyQuiet(block, isQuiet(block));
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/diff-navigation.ts
+++ b/packages/core/opensession-server/src/frontend/lib/diff-navigation.ts
@@ -29,3 +29,27 @@ export function revealDiffFile(
   if (header?.getAttribute("aria-expanded") === "false") header.click();
   header?.focus({ preventScroll: true });
 }
+
+/**
+ * Reveal a file once the diff that holds it has mounted: the Changes pane
+ * may still be opening (a side panel sliding in, a phone page appearing,
+ * the diff itself still loading) when the request is made. Polls a frame at
+ * a time for a few seconds, then gives up quietly; `root` is read each time
+ * because the pane's element may not exist yet either.
+ */
+export function revealDiffFileWhenMounted(
+  root: () => HTMLElement | null,
+  path: string,
+  attempt = 0,
+): void {
+  const el = root();
+  const mounted = el?.querySelector(`[data-diff-file="${CSS.escape(path)}"]`);
+  if (mounted) {
+    revealDiffFile(el, path);
+    return;
+  }
+  if (attempt >= 300) return;
+  requestAnimationFrame(() =>
+    revealDiffFileWhenMounted(root, path, attempt + 1),
+  );
+}

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -18,6 +18,7 @@
 import { ansiUpgrader } from "./ansi-block";
 import { artifactUpgrader } from "./artifact-block";
 import { chartUpgrader } from "./chart-fence";
+import { choicesUpgrader } from "./choices-block";
 import { jsonTreeUpgrader } from "./json-tree-block";
 import { mathUpgrader } from "./math-block";
 import { mermaidUpgrader } from "./mermaid-fence";
@@ -25,6 +26,7 @@ import { paletteUpgrader } from "./palette-block";
 import { tableUpgrader } from "./table-block";
 import { metricsUpgrader } from "./metrics-block";
 import { slidesUpgrader } from "./slides-block";
+import { treeUpgrader } from "./tree-block";
 import type { EffectiveTheme } from "./theme";
 
 export interface FenceUpgradeContext {
@@ -95,6 +97,8 @@ export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   ansiUpgrader,
   artifactUpgrader,
   slidesUpgrader,
+  choicesUpgrader,
+  treeUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/tree-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/tree-block.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+  matchTreePath,
+  parseTree,
+  treeFilePaths,
+  type TreeNode,
+} from "./tree-block";
+
+const file = (name: string, note?: string): TreeNode =>
+  note
+    ? { name, dir: false, note, children: [] }
+    : { name, dir: false, children: [] };
+const dir = (name: string, children: TreeNode[]): TreeNode => ({
+  name,
+  dir: true,
+  children,
+});
+
+describe("parseTree", () => {
+  it("reads an indented tree, two spaces per level", () => {
+    expect(
+      parseTree("src/\n  upload.ts\n  lib/\n    retry.ts\npackage.json\n"),
+    ).toEqual([
+      dir("src", [file("upload.ts"), dir("lib", [file("retry.ts")])]),
+      file("package.json"),
+    ]);
+  });
+
+  it("reads tabs and four-space indents as one level each", () => {
+    expect(parseTree("src/\n\tupload.ts\n\tlib/\n\t\tretry.ts")).toEqual([
+      dir("src", [file("upload.ts"), dir("lib", [file("retry.ts")])]),
+    ]);
+    expect(parseTree("src/\n    a.ts\n    b/\n        c.ts")).toEqual([
+      dir("src", [file("a.ts"), dir("b", [file("c.ts")])]),
+    ]);
+  });
+
+  it("reads tree CLI box drawing, including the summary line", () => {
+    const source = [
+      "acme-todo/",
+      "├── src/",
+      "│   ├── upload.ts",
+      "│   └── upload.test.ts",
+      "├── NOTES.md",
+      "└── package.json",
+      "",
+      "1 directory, 4 files",
+    ].join("\n");
+    expect(parseTree(source)).toEqual([
+      dir("acme-todo", [
+        dir("src", [file("upload.ts"), file("upload.test.ts")]),
+        file("NOTES.md"),
+        file("package.json"),
+      ]),
+    ]);
+  });
+
+  it("reads the ASCII charset and deeper nesting", () => {
+    const source = [
+      ".",
+      "|-- src",
+      "|   `-- lib",
+      "|       `-- retry.ts",
+      "`-- package.json",
+    ].join("\n");
+    expect(parseTree(source)).toEqual([
+      dir(".", [
+        dir("src", [dir("lib", [file("retry.ts")])]),
+        file("package.json"),
+      ]),
+    ]);
+  });
+
+  it("keeps a trailing # note beside the name", () => {
+    expect(parseTree("src/\n  upload.ts  # retry loop")).toEqual([
+      dir("src", [file("upload.ts", "retry loop")]),
+    ]);
+  });
+
+  it("declines anything that is not a tree", () => {
+    expect(parseTree("")).toBeNull();
+    expect(parseTree("a.ts\n    b.ts\n  c.ts")).toBeNull();
+    expect(parseTree("  indented first line")).toBeNull();
+    expect(parseTree("root/\n├── a\n  b")).toBeNull();
+    expect(parseTree("│   orphan prefix")).toBeNull();
+  });
+});
+
+describe("treeFilePaths", () => {
+  it("drops a lone root directory from the paths", () => {
+    const nodes = parseTree("acme-todo/\n  src/\n    upload.ts\n  README.md");
+    expect(treeFilePaths(nodes!)).toEqual(["src/upload.ts", "README.md"]);
+  });
+
+  it("keeps every top-level name when there are several", () => {
+    const nodes = parseTree("src/\n  upload.ts\npackage.json");
+    expect(treeFilePaths(nodes!)).toEqual(["src/upload.ts", "package.json"]);
+  });
+});
+
+describe("matchTreePath", () => {
+  const changed = ["src/upload.ts", "src/lib/retry.ts", "docs/upload.ts"];
+
+  it("prefers the exact path", () => {
+    expect(matchTreePath("src/upload.ts", changed)).toBe("src/upload.ts");
+    expect(matchTreePath("./src/upload.ts", changed)).toBe("src/upload.ts");
+  });
+
+  it("matches a tree drawn from a subdirectory by its one tail", () => {
+    expect(matchTreePath("lib/retry.ts", changed)).toBe("src/lib/retry.ts");
+    expect(matchTreePath("upload.ts", changed)).toBeUndefined();
+    expect(matchTreePath("missing.ts", changed)).toBeUndefined();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/tree-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/tree-block.ts
@@ -1,0 +1,312 @@
+/**
+ * File trees: a ```tree fence renders as a collapsible tree. The fence holds
+ * either an indented listing (two spaces or a tab per level, a trailing `/`
+ * marks a directory) or `tree` CLI output with its box-drawing connectors.
+ *
+ * DOM built inside a markdown body, no React. A file row carries
+ * `data-tree-path` (relative to the tree's root); the session viewer's
+ * delegated click handler (hooks/useTranscriptBlocks.ts) opens the file in
+ * the Changes pane when the session's diff has it. Which rows can open is
+ * published here per messages container, so the row can show it, the way
+ * quick replies learn whether they are still current (choices-block.ts).
+ * Folding is the block's own business and is wired at build time.
+ */
+
+import {
+  chevronRightIconMarkup,
+  fileIconMarkup,
+  folderIconMarkup,
+} from "../components/icons";
+import type { FenceUpgrader } from "./fence-upgraders";
+
+export const TREE_BLOCK_CLASS = "md-tree";
+export const TREE_ROW_CLASS = "md-tree-row";
+const SCOPE_SELECTOR = ".viewer-messages";
+/** Directories this deep and shallower start open (root is depth 0). */
+const OPEN_DEPTH = 1;
+const MAX_LINES = 400;
+
+export interface TreeNode {
+  name: string;
+  dir: boolean;
+  /** A trailing `# note` on the line, shown dim beside the name. */
+  note?: string;
+  children: TreeNode[];
+}
+
+interface ParsedLine {
+  depth: number;
+  name: string;
+  dir: boolean;
+  note?: string;
+}
+
+/** `├── `, `└── ` and their ASCII spellings (`|-- `, `` `-- ``). */
+const CONNECTOR = /(?:├|└|\||`)[─-]{2}\s?/;
+/** One level of a `tree` prefix: `│   `, `|   ` or four blanks. */
+const PREFIX_UNIT = /^(?:[│|] {0,3}| {4})/;
+/** A name that begins with a connector's leftovers is not a name. */
+const BOX_CHARS = /^[│├└─]/;
+const SUMMARY = /^\d+ director(?:y|ies)(?:, \d+ files?)?$/;
+
+function splitName(raw: string): Pick<ParsedLine, "name" | "dir" | "note"> {
+  let text = raw.trim();
+  let note: string | undefined;
+  const hash = text.search(/\s+#\s/);
+  if (hash > 0) {
+    note =
+      text
+        .slice(hash)
+        .replace(/^\s+#\s*/, "")
+        .trim() || undefined;
+    text = text.slice(0, hash).trim();
+  }
+  // `tree -F` marks executables and links too; only the directory mark
+  // matters here, the rest is dropped so the name reads clean.
+  const dir = text.endsWith("/");
+  const name = text.replace(/[/*@=|>]$/, "").trim();
+  return note ? { name, dir, note } : { name, dir };
+}
+
+function parseBoxLine(line: string): ParsedLine | null {
+  const at = line.search(CONNECTOR);
+  if (at < 0) {
+    // A root line: no connector, no prefix.
+    if (/^[\s│|]/.test(line)) return null;
+    return { depth: 0, ...splitName(line) };
+  }
+  let prefix = line.slice(0, at);
+  let depth = 1;
+  while (prefix.length > 0) {
+    const unit = PREFIX_UNIT.exec(prefix)?.[0] ?? "";
+    if (!unit) {
+      // A short run of blanks right before the connector is still a level.
+      if (/^ +$/.test(prefix)) depth += 1;
+      else return null;
+      break;
+    }
+    prefix = prefix.slice(unit.length);
+    depth += 1;
+  }
+  const rest = line.slice(at).replace(CONNECTOR, "");
+  const parts = splitName(rest);
+  return parts.name ? { depth, ...parts } : null;
+}
+
+function parseIndentedLine(line: string, unit: number): ParsedLine | null {
+  const lead = /^[ \t]*/.exec(line)?.[0] ?? "";
+  const spaces = lead.replace(/\t/g, " ".repeat(unit)).length;
+  if (spaces % unit !== 0) return null;
+  const parts = splitName(line.slice(lead.length));
+  if (!parts.name || BOX_CHARS.test(parts.name)) return null;
+  return { depth: spaces / unit, ...parts };
+}
+
+function indentUnit(lines: string[]): number {
+  let unit = 0;
+  for (const line of lines) {
+    const lead = /^[ \t]*/.exec(line)?.[0] ?? "";
+    if (!lead) continue;
+    const width = lead.includes("\t") ? 2 * lead.length : lead.length;
+    unit = unit === 0 ? width : Math.min(unit, width);
+  }
+  return unit || 2;
+}
+
+function nest(lines: ParsedLine[]): TreeNode[] | null {
+  const roots: TreeNode[] = [];
+  const stack: TreeNode[] = [];
+  for (const line of lines) {
+    if (line.depth > stack.length) return null;
+    stack.length = line.depth;
+    const node: TreeNode = { name: line.name, dir: line.dir, children: [] };
+    if (line.note) node.note = line.note;
+    const parent = stack[line.depth - 1];
+    if (parent) {
+      parent.dir = true;
+      parent.children.push(node);
+    } else roots.push(node);
+    stack.push(node);
+  }
+  return roots;
+}
+
+/**
+ * Both grammars, decided by whether any line carries a `tree` connector.
+ * Null for anything else: mixed forms, a level skipped, a box line whose
+ * prefix does not divide into levels, or nothing at all.
+ */
+export function parseTree(source: string): TreeNode[] | null {
+  const lines = source
+    .split("\n")
+    .map((line) => line.replace(/\s+$/, ""))
+    .filter((line) => line.trim() && !SUMMARY.test(line.trim()));
+  if (lines.length === 0 || lines.length > MAX_LINES) return null;
+  const boxed = lines.some((line) => CONNECTOR.test(line));
+  const parsed: ParsedLine[] = [];
+  const unit = indentUnit(lines);
+  for (const line of lines) {
+    const entry = boxed ? parseBoxLine(line) : parseIndentedLine(line, unit);
+    if (!entry) return null;
+    parsed.push(entry);
+  }
+  if (parsed[0]?.depth !== 0) return null;
+  return nest(parsed);
+}
+
+/** A lone top-level directory names the tree and is not part of the paths
+ *  under it; otherwise the fence itself is the root. */
+export function treeRoot(nodes: TreeNode[]): TreeNode | undefined {
+  const [lone] = nodes;
+  return nodes.length === 1 && lone?.dir ? lone : undefined;
+}
+
+/** Every file path in a tree, relative to its root. */
+export function treeFilePaths(nodes: TreeNode[]): string[] {
+  const paths: string[] = [];
+  const walk = (node: TreeNode, prefix: string) => {
+    const path = prefix ? `${prefix}/${node.name}` : node.name;
+    if (!node.dir) paths.push(path);
+    for (const child of node.children) walk(child, path);
+  };
+  const root = treeRoot(nodes);
+  for (const node of root ? root.children : nodes) walk(node, "");
+  return paths;
+}
+
+/**
+ * The session file a tree row stands for. An exact path wins; otherwise a
+ * tree rooted below the repo (`src/` drawn as the root) matches the one
+ * changed file that ends in the row's path.
+ */
+export function matchTreePath(
+  path: string,
+  candidates: readonly string[],
+): string | undefined {
+  const clean = path.replace(/^\.?\//, "");
+  if (candidates.includes(clean)) return clean;
+  const suffix = `/${clean}`;
+  const tails = candidates.filter((candidate) => candidate.endsWith(suffix));
+  return tails.length === 1 ? tails[0] : undefined;
+}
+
+/** Per messages container: the paths a tree row can open. */
+const openablePaths = new WeakMap<Element, readonly string[]>();
+
+function markOpenable(block: Element): void {
+  const scope = block.closest(SCOPE_SELECTOR);
+  const paths = (scope && openablePaths.get(scope)) || [];
+  for (const row of block.querySelectorAll("[data-tree-path]")) {
+    const path = row.getAttribute("data-tree-path") ?? "";
+    if (matchTreePath(path, paths)) row.setAttribute("data-openable", "");
+    else row.removeAttribute("data-openable");
+  }
+}
+
+/**
+ * Publish the files the session can open, and bring every mounted tree under
+ * `container` in line. Called by the viewer whenever the diff changes.
+ */
+export function setOpenableTreePaths(
+  container: Element,
+  paths: readonly string[],
+): void {
+  openablePaths.set(container, paths);
+  for (const block of container.querySelectorAll(`.${TREE_BLOCK_CLASS}`))
+    markOpenable(block);
+}
+
+function span(className: string, markup?: string): HTMLSpanElement {
+  const el = document.createElement("span");
+  el.className = className;
+  if (markup) el.innerHTML = markup;
+  return el;
+}
+
+function buildRow(node: TreeNode, depth: number, path: string): HTMLElement {
+  const row = document.createElement("button");
+  row.type = "button";
+  row.className = TREE_ROW_CLASS;
+  row.style.setProperty("--md-tree-depth", String(depth));
+  const name = span("md-tree-name");
+  // Untrusted text: never markup.
+  name.textContent = node.name;
+  if (node.dir) {
+    row.dataset.treeDir = "";
+    row.setAttribute("aria-expanded", String(depth <= OPEN_DEPTH));
+    row.setAttribute("aria-label", `${node.name} folder`);
+    row.append(
+      span("md-tree-caret", chevronRightIconMarkup(16)),
+      span("md-tree-icon", folderIconMarkup(16)),
+      name,
+    );
+  } else {
+    row.dataset.treePath = path;
+    row.setAttribute("aria-label", path);
+    row.append(
+      span("md-tree-caret"),
+      span("md-tree-icon", fileIconMarkup(16)),
+      name,
+    );
+  }
+  if (node.note) {
+    const note = span("md-tree-note");
+    note.textContent = node.note;
+    row.append(note);
+  }
+  return row;
+}
+
+function buildList(
+  nodes: TreeNode[],
+  depth: number,
+  prefix: string,
+  /** The lone root directory: drawn, but not part of the paths under it. */
+  root: TreeNode | undefined,
+): HTMLUListElement {
+  const list = document.createElement("ul");
+  list.className = "md-tree-list";
+  for (const node of nodes) {
+    const path =
+      node === root ? "" : prefix ? `${prefix}/${node.name}` : node.name;
+    const item = document.createElement("li");
+    item.append(buildRow(node, depth, path));
+    if (node.dir && node.children.length > 0) {
+      const children = buildList(node.children, depth + 1, path, undefined);
+      children.hidden = depth > OPEN_DEPTH;
+      item.append(children);
+    }
+    list.append(item);
+  }
+  return list;
+}
+
+function toggleDirectory(event: Event): void {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const row = target.closest("[data-tree-dir]");
+  if (!(row instanceof HTMLElement)) return;
+  const children = row.parentElement?.querySelector(":scope > ul");
+  if (!(children instanceof HTMLElement)) return;
+  const open = row.getAttribute("aria-expanded") !== "true";
+  row.setAttribute("aria-expanded", String(open));
+  children.hidden = !open;
+}
+
+export const treeUpgrader: FenceUpgrader = {
+  langs: ["tree"],
+  async upgrade({ pre, source, root, alive }) {
+    const nodes = parseTree(source);
+    if (!nodes || !alive() || !root.contains(pre)) return false;
+    const block = document.createElement("div");
+    block.className = TREE_BLOCK_CLASS;
+    block.setAttribute("aria-label", "File tree");
+    block.append(buildList(nodes, 0, "", treeRoot(nodes)));
+    // Folding is local to the block; a click on a file row bubbles up to the
+    // session viewer's delegated handler untouched.
+    block.addEventListener("click", toggleDirectory);
+    pre.replaceWith(block);
+    markOpenable(block);
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -39,3 +39,5 @@
 @import "./base-keyframes.css";
 @import "./blocks/palette.css";
 @import "./blocks/table.css";
+@import "./blocks/choices.css";
+@import "./blocks/tree.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/choices.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/choices.css
@@ -1,0 +1,77 @@
+/* ─────────────────────────────────────────────────────────────
+   Quick replies: a ```choices fence rendered by lib/choices-block.ts.
+
+   A wrapping row of chips. Each chip wears the surface an ask card's
+   option row wears (lib/ask-card-classes.ts: bg-control, the 12px
+   control corner, the hover wash, the accent focus ring), so a reply
+   offered by the agent reads as the same kind of thing as an answer it
+   asked for. Built as DOM inside injected markdown, which is why these
+   live here rather than as utilities on JSX.
+   ───────────────────────────────────────────────────────────── */
+.md-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0 10px;
+}
+.md-choice {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  max-width: 100%;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: calc(12px * var(--rf));
+  corner-shape: var(--cs);
+  background: var(--control-surface);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--type-label);
+  font-weight: 600;
+  line-height: 20px;
+  text-align: left;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+/* The hover wash is translucent ink laid over the control surface, not in
+   place of it: a chip sits on the page's own fill, where swapping the
+   surface for the wash would step it the wrong way in one theme. */
+.md-choice::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  corner-shape: inherit;
+  background: transparent;
+  pointer-events: none;
+  transition: background-color 120ms ease;
+}
+.md-choice:hover::before {
+  background: var(--hover);
+}
+.md-choice:active::before {
+  background: var(--hover-strong);
+}
+.md-choice:focus-visible {
+  outline: 2px solid var(--accent-ink);
+  outline-offset: 2px;
+}
+/* Answered, or nowhere to send: the chips stay as a record of what was
+   offered, at the weight of a note rather than a control. */
+.md-choices[data-quiet] .md-choice {
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--divider);
+  color: var(--text-faint);
+  cursor: default;
+}
+.md-choices[data-quiet] .md-choice::before {
+  display: none;
+}
+@media (max-width: 720px) {
+  .md-choice {
+    min-height: 44px;
+    padding: 10px 14px;
+  }
+}

--- a/packages/core/opensession-server/src/frontend/styles/blocks/tree.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/tree.css
@@ -1,0 +1,94 @@
+/* ─────────────────────────────────────────────────────────────
+   File trees: a ```tree fence rendered by lib/tree-block.ts.
+
+   The same well a diagram or chart sits in (base-markdown.css), with one
+   row per node: a caret for a directory, a glyph, the name, an optional
+   dim note. Rows are real buttons, so they take focus and the keyboard
+   for free. A file row that the session can open (data-openable, set by
+   the viewer) takes the hover wash and pointer; one it cannot stays a
+   focusable label. Built as DOM inside injected markdown, which is why
+   these live here rather than as utilities on JSX.
+   ───────────────────────────────────────────────────────────── */
+.md-tree {
+  margin: 2px 0 8px;
+  padding: 6px 4px;
+  background: var(--diagram-canvas);
+  border: 1px solid var(--border);
+  border-radius: calc(8px * var(--rf));
+  corner-shape: var(--cs);
+  overflow-x: auto;
+}
+.md-tree-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.md-tree-list li {
+  margin: 0;
+  padding: 0;
+}
+.md-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-height: 28px;
+  padding: 2px 8px 2px calc(6px + var(--md-tree-depth, 0) * 18px);
+  border: 0;
+  border-radius: calc(7px * var(--rf));
+  corner-shape: var(--cs);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: var(--type-label);
+  line-height: 20px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: default;
+}
+.md-tree-row[data-tree-dir] {
+  color: var(--text);
+  font-weight: 500;
+  cursor: pointer;
+}
+.md-tree-row[data-openable] {
+  color: var(--text);
+  cursor: pointer;
+}
+.md-tree-row[data-tree-dir]:hover,
+.md-tree-row[data-openable]:hover {
+  background: var(--hover);
+}
+.md-tree-row:focus-visible {
+  outline: 2px solid var(--accent-ink);
+  outline-offset: -2px;
+}
+.md-tree-caret,
+.md-tree-icon {
+  display: inline-flex;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-faint);
+}
+.md-tree-caret > svg {
+  transition: transform 120ms ease;
+}
+.md-tree-row[aria-expanded="true"] .md-tree-caret > svg {
+  transform: rotate(90deg);
+}
+.md-tree-name {
+  min-width: 0;
+}
+.md-tree-note {
+  margin-left: 6px;
+  color: var(--text-faint);
+  font-weight: 400;
+}
+@media (max-width: 720px) {
+  .md-tree-row {
+    min-height: 44px;
+  }
+}

--- a/packages/core/opensession-server/src/server/demo/fixtures.ts
+++ b/packages/core/opensession-server/src/server/demo/fixtures.ts
@@ -319,6 +319,28 @@ export function demoSessions(opts: {
           iso(t0 + 170_000),
           MODEL_FABLE,
         ),
+        // Blocks that talk back to the session: a file tree whose rows open
+        // the changed file, and quick replies that send as the next turn.
+        transcriptLineAssistantText(
+          "The fix touches these files:\n\n" +
+            "```tree\n" +
+            "acme-todo/\n" +
+            "├── src/\n" +
+            "│   ├── upload.ts  # retry loop\n" +
+            "│   └── upload.test.ts\n" +
+            "├── NOTES.md\n" +
+            "└── package.json\n" +
+            "```\n\n" +
+            "How do you want to proceed?\n\n" +
+            "```choices\n" +
+            "- Merge the PR\n" +
+            "- Add a test for the terminal error\n" +
+            "- Explain the fix again\n" +
+            "```",
+          "demo-pr-a4",
+          iso(t0 + 190_000),
+          MODEL_FABLE,
+        ),
       ],
     });
   }


### PR DESCRIPTION
Two more block kinds for `docs/blocks.md`, registered in `FENCE_UPGRADERS` with styles in `styles/blocks/choices.css` and `styles/blocks/tree.css`.

## Quick replies (`lib/choices-block.ts`)

A ```` ```choices ```` fence lists one reply per line (`- ` tolerated, up to twelve). Renders as a wrapping row of chips on the ask card's option surface. Picking one goes through `handleSend(text, undefined, [])`, the composer's isolated send path: same outbox, same busy-queue and steer rules, and the composer draft is left alone. Chips carry `data-choice` and the block carries `data-choices-eid` (nearest `[data-eid]`); the new `hooks/useTranscriptBlocks.ts` handles the click from the messages container's delegated `onClick`, the same route `[data-asset-path]` takes.

Whether chips are still current is decided from the transcript (`openChoiceEntryIds`: entries after the last user message) and published per messages container, so a block upgraded later reads the same answer, and every mounted block is refreshed when entries change. Quiet chips are real `disabled` buttons. Outside a session (asset preview, PR prose) they render quiet.

## File trees (`lib/tree-block.ts`)

A ```` ```tree ```` fence holds an indented tree (two spaces or a tab per level, trailing `/` marks a directory) or `tree` CLI output (`├──`, `│`, `└──`, ASCII charset too; the summary line is ignored). A trailing `# note` shows dim beside the name. `parseTree` is pure with tests and declines anything else. Directories fold with a caret, top two levels open; rows are buttons so they take focus and the keyboard.

A file row carries `data-tree-path` relative to the tree root (a lone root directory drops out of the path). The delegated handler opens the Changes pane (side panel on desktop, info page on phone) and reveals that file's diff when it is one of the session's changed files; `matchTreePath` takes an exact path or the one changed file that ends in it. Rows that can open are marked `data-openable` and take the hover wash; the rest stay labels. **Limit:** the app has no viewer for an arbitrary repo file, only diffs of changed files, so that is as far as opening goes. Since the pane only fetches its diff while open, the hook fetches it on the same SWR key whenever the transcript carries a tree fence.

No extension-to-icon helper exists in the app, so files get the shared `IconFile` glyph and directories `IconFolder` (markup helpers added beside the JSX icons).

## Also

- One assistant message added to the demo's `bks-demo-pr` transcript with both fences.
- `revealDiffFileWhenMounted` in `lib/diff-navigation.ts` polls for the diff to mount before revealing.
- Found while verifying, not fixed here: `bks-demo-pr` shows "No transcript available" on `origin/main` too. The demo writes every jsonl to `.claude/projects/-demo-engine/`, but that session's transcript is looked up under the directory derived from its `worktreeDir`; symlinking that directory to `-demo-engine` makes the transcript appear. The other demo sessions are unaffected.

Verified with `bun run check` and the compiled-bundle harness at desktop (dark, light) and 390px (dark, light), plus a chip click (sent bubble, chips quiet) and a tree row click (Changes pane opens with the diff) on both widths.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)