### PR TITLE
Render media markers in place, with captions and a before/after slider

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -18,8 +18,8 @@ only carrier of information the reader needs.
 | ` ```vega-lite ` (`chart`)           | Interactive chart with tooltips, themed, expandable    | `lib/chart-fence.ts`, `lib/vega-chart.ts`, `server/charts-mcp.ts` |
 | ` ```diff `                          | Patch with whole added and removed rows washed         | `lib/shiki-engine.ts`                                             |
 | `OPENSESSION_IMAGE: /abs/path.png`   | Image in place, full column width, optional caption    | `server/transcript-media.ts`, `lib/markdown.ts`                   |
-| `OPENSESSION_VIDEO: /abs/path.mp4`   | Video player in place                                  | same                                                              |
-| `OPENSESSION_COMPARE: /a.png /b.png` | Before/after slider                                    | `lib/compare-block.ts`                                            |
+| `OPENSESSION_VIDEO: /abs/path.mp4`   | Video player in place, optional caption                | same                                                              |
+| `OPENSESSION_COMPARE: /a.png /b.png` | Before/after slider, optional caption                  | same, `lib/compare-block.ts`                                      |
 | `> [!NOTE]` … `> [!CAUTION]`         | GitHub-style callout                                   | `lib/markdown.ts`                                                 |
 | `$$ … $$`, `$ … $`, ` ```math `      | Typeset math (KaTeX)                                   | `lib/math-block.ts`                                               |
 | ` ```palette `, `` `#ff0080` ``      | Colour swatches; a hex codespan gets a swatch chip     | `lib/palette-block.ts`                                            |
@@ -44,16 +44,48 @@ validates a Vega-Lite spec and offloads large data into a session asset.
 
 ### Media in place
 
-`OPENSESSION_IMAGE:` and `OPENSESSION_VIDEO:` lines render where they are
-written, at the column's width. A line of plain text directly under a marker
-is its caption. The entry's `images[]` / `videos[]` still carry the media for
-the turn fold's strip and the lightbox gallery; the trailing thumbnail row
-under a message only shows media the body did not already place.
+`OPENSESSION_IMAGE: /abs/path.png` and `OPENSESSION_VIDEO: /abs/path.mp4`
+lines render where they are written, at the column's width (capped at 480px
+tall, 400px on a phone), and open the lightbox gallery. The path must be
+absolute and under `/tmp` or the service user's home, which is what the
+`/media` route serves. A marker may be bolded, backticked or bulleted; the
+wrapper is dropped.
+
+A caption is one line of plain text directly under the marker: no blank line
+between, at most 160 characters, not a heading, list item, quote, table row,
+fence or another marker, and followed by a blank line, another marker or the
+end of the message. Two lines of prose after a marker are prose, not a
+caption.
+
+The server rewrites the marker in the stored message (`placeMediaMarkers` in
+`server/transcript-media.ts`) into standard image syntax,
+`![caption](/media?path=...)`, with a blank line on each side. The web
+renders a paragraph that is one such image as a figure with the alt as its
+caption, and plays it when the file is a video; every other markdown client
+shows an image or a link. The entry's `images[]` / `videos[]` still list the
+media for the turn fold's strip, the lightbox gallery and the native clients,
+and `featuredMedia` names what a marker showed. The trailing thumbnail row
+under a web message only shows media the body did not already place
+(`lib/placed-media.ts`). Messages stored before the rewrite have no image in
+their body and render exactly as before.
 
 ### Before/after
 
-`OPENSESSION_COMPARE: /abs/before.png /abs/after.png` renders the two images
-as one slider. Both paths obey the same media rules as `OPENSESSION_IMAGE:`.
+`OPENSESSION_COMPARE: /abs/before.png /abs/after.png` renders the two stills
+as one slider: drag the divider, tap anywhere, or use the arrow keys with the
+slider focused. Both paths obey the media rules above, both land in
+`images[]` and `featuredMedia`, and the caption rule is the same. The server
+rewrites the line into a ` ```compare ` fence:
+
+```
+before: /media?path=...
+after: /media?path=...
+caption: Retry timeline
+```
+
+`lib/compare-block.ts` upgrades the fence into the slider; a client without
+it shows the two URLs and the caption as a code block. The fence can also be
+written by hand with any http(s) or root-relative still.
 
 ### Callouts
 

--- a/packages/core/opensession-server/src/frontend/components/MediaLightbox.tsx
+++ b/packages/core/opensession-server/src/frontend/components/MediaLightbox.tsx
@@ -15,6 +15,7 @@ import {
   type LightboxState,
 } from "../lib/media-lightbox";
 import {
+  lightboxBlockMediaFor,
   lightboxDiagramFor,
   openGalleryFrom,
 } from "../lib/media-lightbox-gallery";
@@ -123,6 +124,7 @@ export function MediaLightboxHost() {
       const media =
         target.closest?.("img.md-image") ||
         target.closest?.("a.md-image-link")?.querySelector("img.md-image") ||
+        lightboxBlockMediaFor(target) ||
         lightboxDiagramFor(target);
       if (!media) return;
       e.preventDefault();

--- a/packages/core/opensession-server/src/frontend/components/MessageBubble.tsx
+++ b/packages/core/opensession-server/src/frontend/components/MessageBubble.tsx
@@ -16,6 +16,7 @@ import { assetPathForMediaSrc } from "../lib/asset-preview";
 import { fullTime, shortTime } from "../lib/time";
 import { UserAvatar } from "./UserAvatar";
 import { openGalleryFrom } from "../lib/media-lightbox-gallery";
+import { unplacedMedia } from "../lib/placed-media";
 import { IconExpand, IconFileText2, IconPencil } from "./icons";
 import { Collapsible, collapsiblePanelClasses } from "../ui/collapsible";
 import { pastedTextLineLabel } from "@tellahq/opensession-protocol/pasted-text";
@@ -880,7 +881,8 @@ export const MessageBubble = function MessageBubble({
   }
 
   // assistant — no speaker label: every left-aligned bubble is the agent, so
-  // the name row was pure noise above each answer.
+  // the name row was pure noise above each answer. The trailing row is for
+  // media the body did not already place (lib/placed-media.ts).
   return (
     <div className={cn(msgRow, enterClass)} data-eid={e.id}>
       <ClampedBody
@@ -889,8 +891,11 @@ export const MessageBubble = function MessageBubble({
         entry={e}
         sessionId={sessionId}
       />
-      <EntryImages images={e.images} sessionId={sessionId} />
-      <EntryVideos videos={e.videos} />
+      <EntryImages
+        images={unplacedMedia(e.images, e.content)}
+        sessionId={sessionId}
+      />
+      <EntryVideos videos={unplacedMedia(e.videos, e.content)} />
     </div>
   );
 };

--- a/packages/core/opensession-server/src/frontend/components/TurnBlock.tsx
+++ b/packages/core/opensession-server/src/frontend/components/TurnBlock.tsx
@@ -11,6 +11,7 @@ import {
   useToolPathRoots,
 } from "./ToolCallBlock";
 import { ClampedBody, EntryImages, EntryVideos } from "./MessageBubble";
+import { unplacedMedia } from "../lib/placed-media";
 import { IconChevronDown, IconStack } from "./icons";
 import { cn } from "../ui/cn";
 import { Fold } from "../ui/fold";
@@ -715,8 +716,11 @@ function NarrationMessage({
         entry={entry}
         sessionId={sessionId}
       />
-      <EntryImages images={entry.images} sessionId={sessionId} />
-      <EntryVideos videos={entry.videos} />
+      <EntryImages
+        images={unplacedMedia(entry.images, entry.content)}
+        sessionId={sessionId}
+      />
+      <EntryVideos videos={unplacedMedia(entry.videos, entry.content)} />
     </div>
   );
 }

--- a/packages/core/opensession-server/src/frontend/components/icons.tsx
+++ b/packages/core/opensession-server/src/frontend/components/icons.tsx
@@ -1180,6 +1180,18 @@ export function chevronRightIconMarkup(size = MIN_ICON_SIZE): string {
   return iconMarkup(pathsMarkup([CHEVRON_RIGHT_PATH]), size);
 }
 
+/** The two chevrons of IconChevronLeft and IconChevronRight pulled in to
+ *  one glyph: the grip of a before/after slider (lib/compare-block.ts). */
+export function chevronsLeftRightIconMarkup(size = MIN_ICON_SIZE): string {
+  return iconMarkup(
+    pathsMarkup([
+      "M9.25 7.75L5 12L9.25 16.25",
+      "M14.75 7.75L19 12L14.75 16.25",
+    ]),
+    size,
+  );
+}
+
 export function IconTrash(p: IconProps) {
   return (
     <Svg {...p}>

--- a/packages/core/opensession-server/src/frontend/lib/compare-block.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/compare-block.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { parseCompareFence } from "./compare-block";
+
+const before = "/media?path=%2Ftmp%2Fbefore.png";
+const after = "/media?path=%2Ftmp%2Fafter.png";
+
+describe("parseCompareFence", () => {
+  it("reads before, after and a caption", () => {
+    expect(
+      parseCompareFence(
+        `before: ${before}\nafter: ${after}\ncaption: Retry timeline\n`,
+      ),
+    ).toEqual({ before, after, caption: "Retry timeline" });
+  });
+
+  it("takes the halves in either order and without a caption", () => {
+    expect(parseCompareFence(`after: ${after}\n\nbefore: ${before}`)).toEqual({
+      before,
+      after,
+      caption: undefined,
+    });
+  });
+
+  it("accepts an http(s) still", () => {
+    expect(
+      parseCompareFence(
+        "before: https://cdn.example/a.png\nafter: https://cdn.example/b.png",
+      ),
+    ).toEqual({
+      before: "https://cdn.example/a.png",
+      after: "https://cdn.example/b.png",
+      caption: undefined,
+    });
+  });
+
+  it("keeps the fence as code when a half is missing or unreadable", () => {
+    expect(parseCompareFence(`before: ${before}`)).toBeNull();
+    expect(parseCompareFence(`before: ${before}\nafter:`)).toBeNull();
+    expect(
+      parseCompareFence(`before: ${before}\nafter: javascript:alert(1)`),
+    ).toBeNull();
+    expect(
+      parseCompareFence(`before: ${before}\nafter: ${after}\nnote: hi`),
+    ).toBeNull();
+    expect(parseCompareFence("")).toBeNull();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/compare-block.ts
+++ b/packages/core/opensession-server/src/frontend/lib/compare-block.ts
@@ -1,0 +1,152 @@
+/**
+ * The ```compare fence: two stills as one before/after slider.
+ *
+ * The server writes the fence for an `OPENSESSION_COMPARE: /a.png /b.png`
+ * line (server/transcript-media.ts placeMediaMarkers), so a client without
+ * this upgrader reads two links and a caption. Here the fence becomes a
+ * slider: the before still underneath, the after still clipped to the right
+ * of a divider, and a native range input laid over the whole thing. The
+ * input is what makes it work everywhere without a pointer handler of its
+ * own: a drag or a tap anywhere moves it, arrow keys move it, a finger moves
+ * it, and it carries the accessible name and value.
+ */
+
+import {
+  chevronsLeftRightIconMarkup,
+  expandIconMarkup,
+} from "../components/icons";
+import type { FenceUpgrader } from "./fence-upgraders";
+
+export interface CompareSpec {
+  before: string;
+  after: string;
+  caption?: string;
+}
+
+/** A root-relative path (the `/media?path=` form the server writes) or an
+ *  http(s) URL. Nothing else is a still we should load. */
+const SRC_RE = /^(?:\/|https?:\/\/)\S+$/;
+
+/**
+ * `before: <src>` and `after: <src>`, one per line, in either order, plus an
+ * optional `caption: <text>`. Anything else on a line, or a missing half,
+ * keeps the fence as code.
+ */
+export function parseCompareFence(source: string): CompareSpec | null {
+  let before: string | undefined;
+  let after: string | undefined;
+  let caption: string | undefined;
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const m = /^(before|after|caption):\s*(.*)$/i.exec(line);
+    if (!m) return null;
+    const key = m[1].toLowerCase();
+    const value = m[2].trim();
+    if (key === "caption") {
+      caption = value || undefined;
+      continue;
+    }
+    if (!SRC_RE.test(value)) return null;
+    if (key === "before") before = value;
+    else after = value;
+  }
+  return before && after ? { before, after, caption } : null;
+}
+
+/** The slider's classes (styles/blocks/compare.css). */
+export const COMPARE_CLASS = "md-compare";
+export const COMPARE_AFTER_CLASS = "md-compare-after";
+
+const DEFAULT_POSITION = 50;
+
+function valueText(position: number): string {
+  return `${Math.round(position)}% before`;
+}
+
+/** The slider as DOM. Thin on purpose: the grammar above is the tested part. */
+function buildCompare(spec: CompareSpec): HTMLElement {
+  const figure = document.createElement("figure");
+  figure.className = "md-compare-wrap";
+  const box = document.createElement("div");
+  box.className = COMPARE_CLASS;
+  box.style.setProperty("--p", String(DEFAULT_POSITION));
+
+  const before = document.createElement("img");
+  before.className = "md-compare-img md-compare-before";
+  before.src = spec.before;
+  before.alt = "Before";
+  before.loading = "lazy";
+  before.draggable = false;
+  const after = document.createElement("img");
+  after.className = `md-compare-img ${COMPARE_AFTER_CLASS}`;
+  after.src = spec.after;
+  after.alt = "After";
+  after.loading = "lazy";
+  after.draggable = false;
+
+  const labelBefore = document.createElement("span");
+  labelBefore.className = "md-compare-label md-compare-label-before";
+  labelBefore.textContent = "Before";
+  const labelAfter = document.createElement("span");
+  labelAfter.className = "md-compare-label md-compare-label-after";
+  labelAfter.textContent = "After";
+
+  const divider = document.createElement("div");
+  divider.className = "md-compare-divider";
+  divider.setAttribute("aria-hidden", "true");
+  const handle = document.createElement("span");
+  handle.className = "md-compare-handle";
+  handle.innerHTML = chevronsLeftRightIconMarkup();
+  divider.append(handle);
+
+  const range = document.createElement("input");
+  range.type = "range";
+  range.className = "md-compare-range";
+  range.min = "0";
+  range.max = "100";
+  // One percent per arrow key: fine enough to line the divider up with a
+  // detail, coarse enough that a keyboard gets across in a hundred presses
+  // rather than two hundred (Home and End jump to either end).
+  range.step = "1";
+  range.value = String(DEFAULT_POSITION);
+  range.setAttribute("aria-label", "Compare before and after");
+  range.setAttribute("aria-valuetext", valueText(DEFAULT_POSITION));
+  range.addEventListener("input", () => {
+    const position = Number(range.value);
+    box.style.setProperty("--p", String(position));
+    range.setAttribute("aria-valuetext", valueText(position));
+  });
+
+  // The stills sit under the range, so the button is the way into the
+  // lightbox (MediaLightbox.tsx opens the after still through
+  // lightboxBlockMediaFor). It comes after the input in the DOM so it wins
+  // the hit test.
+  const expand = document.createElement("button");
+  expand.type = "button";
+  expand.className = "md-diagram-expand";
+  expand.dataset.mdExpand = "compare";
+  expand.title = "Expand";
+  expand.setAttribute("aria-label", "Expand");
+  expand.innerHTML = expandIconMarkup();
+
+  box.append(before, after, labelBefore, labelAfter, divider, range, expand);
+  figure.append(box);
+  if (spec.caption) {
+    const caption = document.createElement("figcaption");
+    caption.className = "md-figcaption";
+    caption.textContent = spec.caption;
+    figure.append(caption);
+  }
+  return figure;
+}
+
+export const compareUpgrader: FenceUpgrader = {
+  langs: ["compare"],
+  async upgrade({ pre, source, root, alive }) {
+    const spec = parseCompareFence(source);
+    if (!spec || !alive() || !root.contains(pre)) return false;
+    pre.replaceWith(buildCompare(spec));
+    return true;
+  },
+};

--- a/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
+++ b/packages/core/opensession-server/src/frontend/lib/fence-upgraders.ts
@@ -18,6 +18,7 @@
 import { ansiUpgrader } from "./ansi-block";
 import { artifactUpgrader } from "./artifact-block";
 import { chartUpgrader } from "./chart-fence";
+import { compareUpgrader } from "./compare-block";
 import { jsonTreeUpgrader } from "./json-tree-block";
 import { mathUpgrader } from "./math-block";
 import { mermaidUpgrader } from "./mermaid-fence";
@@ -95,6 +96,7 @@ export const FENCE_UPGRADERS: readonly FenceUpgrader[] = [
   ansiUpgrader,
   artifactUpgrader,
   slidesUpgrader,
+  compareUpgrader,
 ];
 
 /** The upgrader that claims a fence, if any. */

--- a/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.test.ts
@@ -1512,3 +1512,45 @@ describe("renderMarkdown fence info strings", () => {
     );
   });
 });
+
+describe("session media placed in the body", () => {
+  const shot = "/media?path=%2Ftmp%2Fshot.png";
+  const clip = "/media?path=%2Ftmp%2Fclip.mp4";
+
+  it("renders a paragraph that is one /media image as a captioned figure", () => {
+    const html = renderMarkdown(
+      `## Proof\n\n![The login page](${shot})\n\nDone.`,
+    );
+    expect(html).toContain(
+      `<figure class="md-figure"><a href="${shot}" target="_blank" rel="noopener noreferrer" class="md-image-link">` +
+        `<img class="md-image" src="${shot}" alt="The login page" loading="lazy" /></a>` +
+        `<figcaption class="md-figcaption">The login page</figcaption></figure>`,
+    );
+    expect(html).toContain("<p>Done.</p>");
+    expect(html).not.toContain(`<p><a href="${shot}"`);
+  });
+
+  it("leaves the caption off when the alt is empty", () => {
+    const html = renderMarkdown(`![](${shot})`);
+    expect(html).toContain('<figure class="md-figure">');
+    expect(html).not.toContain("figcaption");
+  });
+
+  it("plays a /media video in the figure with an expand button", () => {
+    const html = renderMarkdown(`![The whole flow](${clip})`);
+    expect(html).toContain(
+      `<figure class="md-figure"><div class="md-video-wrap"><video class="md-video" src="${clip}" controls playsinline preload="metadata"></video>` +
+        `<button type="button" class="md-video-expand" data-md-expand="video"`,
+    );
+    expect(html).toContain(
+      '<figcaption class="md-figcaption">The whole flow</figcaption>',
+    );
+  });
+
+  it("keeps any other image, and an image beside text, inline", () => {
+    expect(renderMarkdown("![shot](https://example.com/a.png)")).toContain(
+      '<p><a href="https://example.com/a.png"',
+    );
+    expect(renderMarkdown(`See ![x](${shot})`)).toContain("<p>See <a href");
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/markdown.ts
+++ b/packages/core/opensession-server/src/frontend/lib/markdown.ts
@@ -15,6 +15,7 @@ import { repoLabel } from "./repo-label";
 import { cleanSessionTitle } from "./session-title";
 import { INTERNAL_ORIGINS, UUIDV7, internalUrlTarget } from "./session-url";
 import { sessionAssetRawUrl } from "./api/sessions";
+import { expandIconMarkup } from "../components/icons";
 
 // Dedicated marked instance for session messages so this config doesn't leak
 // into other markdown (wiki, etc.). Two customisations:
@@ -31,6 +32,43 @@ function attr(v: string | null | undefined): string {
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+const VIDEO_HREF_RE = /\.(mp4|webm|mov|m4v)([?#]|$)/i;
+/** Media streamed by this server (routes/media.ts): the form the server
+ *  writes an OPENSESSION_IMAGE/_VIDEO line into (transcript-media.ts). */
+const SESSION_MEDIA_HREF_RE = /^\/media\?path=/;
+
+function videoMarkup(href: string, title = ""): string {
+  return `<video class="md-video" src="${attr(href)}"${title} controls playsinline preload="metadata"></video>`;
+}
+
+/**
+ * A paragraph that is nothing but one image of session media is the agent
+ * showing something where it wrote it: render it as a figure, its alt text
+ * as the caption, at the width the figure styles give it (base-markdown.css).
+ * A video gets the expand button a trailing-row player has (MessageBubble
+ * EntryVideos), opened by the delegated lightbox handler; the player's own
+ * controls take every other click. Any other image, PR prose included,
+ * keeps the plain inline rendering.
+ */
+function sessionMediaFigure(token: Tokens.Paragraph): string | null {
+  if (token.tokens.length !== 1) return null;
+  const image = token.tokens[0];
+  if (image.type !== "image" || !SESSION_MEDIA_HREF_RE.test(image.href))
+    return null;
+  const caption = String(image.text ?? "").trim();
+  const media = VIDEO_HREF_RE.test(image.href)
+    ? `<div class="md-video-wrap">${videoMarkup(image.href)}` +
+      `<button type="button" class="md-video-expand" data-md-expand="video" aria-label="Expand" title="Expand">${expandIconMarkup()}</button>` +
+      `</div>`
+    : `<a href="${attr(image.href)}" target="_blank" rel="noopener noreferrer" class="md-image-link">` +
+      `<img class="md-image" src="${attr(image.href)}" alt="${attr(caption)}" loading="lazy" />` +
+      `</a>`;
+  const figcaption = caption
+    ? `<figcaption class="md-figcaption">${attr(caption)}</figcaption>`
+    : "";
+  return `<figure class="md-figure">${media}${figcaption}</figure>\n`;
 }
 
 type AssetReferenceRegistry = {
@@ -1438,14 +1476,20 @@ md.use({
         return `<code><span class="md-color-chip" style="background:${swatch}"></span>${attr(t)}</code>`;
       return `<code>${attr(t)}</code>`;
     },
+    paragraph(token: Tokens.Paragraph) {
+      return (
+        sessionMediaFigure(token) ??
+        `<p>${this.parser.parseInline(token.tokens)}</p>\n`
+      );
+    },
     image(token: Tokens.Image) {
       const title = token.title ? ` title="${attr(token.title)}"` : "";
       // Video files pasted with image syntax would render as a broken <img>
       // linking to a new tab — play them inline instead. Clicks on .md-image
       // open the media lightbox (delegated handler in MediaLightbox.tsx); the
       // wrapping <a> stays for cmd/middle-click open-in-tab.
-      if (/\.(mp4|webm|mov|m4v)([?#]|$)/i.test(token.href ?? "")) {
-        return `<video class="md-video" src="${attr(token.href)}"${title} controls playsinline preload="metadata"></video>`;
+      if (VIDEO_HREF_RE.test(token.href ?? "")) {
+        return videoMarkup(token.href, title);
       }
       // Image syntax around a GitHub user attachment is an image (a video
       // attachment is always embedded as a bare URL) — swap in the proxy

--- a/packages/core/opensession-server/src/frontend/lib/media-lightbox-gallery.ts
+++ b/packages/core/opensession-server/src/frontend/lib/media-lightbox-gallery.ts
@@ -6,9 +6,10 @@ import {
 } from "./media-lightbox";
 
 /** Every piece of session media currently in the DOM, in document order.
- *  A chart's SVG is the one vega draws into its canvas (vega-chart.ts). */
+ *  A chart's SVG is the one vega draws into its canvas (vega-chart.ts); a
+ *  before/after slider's two stills are both here (compare-block.ts). */
 export const GALLERY_SELECTOR =
-  "img.md-image, video.md-video, .md-mermaid > svg, .md-chart-canvas > svg";
+  "img.md-image, video.md-video, .md-compare > img, .md-mermaid > svg, .md-chart-canvas > svg";
 
 /** Apple's page control keeps a small moving window for long galleries. */
 export const MAX_VISIBLE_LIGHTBOX_DOTS = 7;
@@ -57,6 +58,28 @@ export function openGalleryFrom(el: Element) {
     ),
     el,
   );
+}
+
+/**
+ * The media an expand button inside rendered markdown opens: a placed
+ * video's player (markdown.ts writes the button beside it, since the player's
+ * own controls take every click) or a before/after slider's after still
+ * (compare-block.ts, where the range input covers both stills). The button
+ * carries `data-md-expand` so the React-owned expand on a trailing-row video
+ * (MessageBubble.tsx), which has its own handler, is left alone.
+ */
+export function lightboxBlockMediaFor(target: Element): Element | null {
+  const button = target.closest?.("button[data-md-expand]");
+  if (!button) return null;
+  const kind = button.getAttribute("data-md-expand");
+  if (kind === "video")
+    return button.parentElement?.querySelector("video.md-video") ?? null;
+  if (kind === "compare")
+    return (
+      button.closest(".md-compare")?.querySelector("img.md-compare-after") ??
+      null
+    );
+  return null;
 }
 
 /**

--- a/packages/core/opensession-server/src/frontend/lib/placed-media.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/placed-media.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { placedMediaSrcs, unplacedMedia } from "./placed-media";
+
+const shot = "/media?path=%2Ftmp%2Fshot.png";
+const clip = "/media?path=%2Ftmp%2Fclip.mp4";
+const before = "/media?path=%2Ftmp%2Fbefore.png";
+const after = "/media?path=%2Ftmp%2Fafter.png";
+
+describe("placedMediaSrcs", () => {
+  it("finds placed images, videos and both halves of a compare fence", () => {
+    const content = [
+      "## Proof",
+      "",
+      `![The login page](${shot})`,
+      "",
+      `![](${clip})`,
+      "",
+      "```compare",
+      `before: ${before}`,
+      `after: ${after}`,
+      "```",
+    ].join("\n");
+    expect([...placedMediaSrcs(content)]).toEqual([shot, clip, before, after]);
+  });
+
+  it("ignores images that are not session media", () => {
+    expect(
+      placedMediaSrcs("![x](https://example.com/a.png) and /tmp/shot.png"),
+    ).toEqual(new Set());
+    expect(placedMediaSrcs(undefined)).toEqual(new Set());
+  });
+});
+
+describe("unplacedMedia", () => {
+  it("returns the same array when the body placed nothing", () => {
+    const images = [shot];
+    expect(unplacedMedia(images, "Old entry, marker stripped.")).toBe(images);
+    expect(unplacedMedia(undefined, `![](${shot})`)).toBeUndefined();
+  });
+
+  it("drops what the body already shows and keeps the rest", () => {
+    const touched = "/media?path=%2Ftmp%2Ftouched.png";
+    expect(unplacedMedia([shot, touched], `![](${shot})`)).toEqual([touched]);
+    expect(unplacedMedia([shot], `![](${shot})`)).toEqual([]);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/placed-media.ts
+++ b/packages/core/opensession-server/src/frontend/lib/placed-media.ts
@@ -1,0 +1,36 @@
+/**
+ * Which of an entry's images[]/videos[] its body already shows.
+ *
+ * The server rewrites an `OPENSESSION_IMAGE:` / `_VIDEO:` / `_COMPARE:` line
+ * into markdown where it was written (server/transcript-media.ts) and still
+ * lists the media on the entry, since the turn fold's strip, the lightbox
+ * gallery and the native clients read the lists. The thumbnail row under a
+ * web message is for what the body did NOT place: a Read's image block, a
+ * path that turned up in prose, and every entry from before the rewrite,
+ * whose body has no `/media` image at all.
+ */
+
+const PLACED_IMAGE_RE = /!\[[^\]]*\]\((\/media\?path=[^)\s]+)\)/g;
+const PLACED_COMPARE_RE =
+  /^[\t ]*(?:before|after):[\t ]*(\/media\?path=\S+)[\t ]*$/gim;
+
+/** The `/media?path=` srcs a body renders in place. */
+export function placedMediaSrcs(content: string | undefined): Set<string> {
+  const placed = new Set<string>();
+  if (!content || !content.includes("/media?path=")) return placed;
+  for (const m of content.matchAll(PLACED_IMAGE_RE)) placed.add(m[1]);
+  for (const m of content.matchAll(PLACED_COMPARE_RE)) placed.add(m[1]);
+  return placed;
+}
+
+/** `media` minus what `content` already places; the same array when nothing is. */
+export function unplacedMedia(
+  media: string[] | undefined,
+  content: string | undefined,
+): string[] | undefined {
+  if (!media?.length) return media;
+  const placed = placedMediaSrcs(content);
+  if (placed.size === 0) return media;
+  const rest = media.filter((src) => !placed.has(src));
+  return rest.length === media.length ? media : rest;
+}

--- a/packages/core/opensession-server/src/frontend/styles/base-markdown.css
+++ b/packages/core/opensession-server/src/frontend/styles/base-markdown.css
@@ -526,6 +526,38 @@ html[data-theme="light"] .composer-hl .cmp-fence {
 .md-image {
   cursor: zoom-in;
 }
+/* Session media placed where the agent wrote it (markdown.ts renders a
+   paragraph that is one `/media` image as a figure; the server wrote that
+   for an OPENSESSION_IMAGE/_VIDEO line, see transcript-media.ts). It is the
+   thing the reader was asked to look at, so it gets more room than a
+   thumbnail in the trailing row, still capped so a tall phone capture does
+   not take the whole viewport. The caption is the line the agent wrote
+   under the marker. */
+.md-figure {
+  margin: 2px 0 8px;
+}
+.md-figure .md-image-link {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+}
+.md-figure .md-image,
+.md-figure .md-video {
+  max-height: 480px;
+  margin: 0;
+}
+.md-figcaption {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--text-dim);
+}
+@media (max-width: 720px) {
+  .md-figure .md-image,
+  .md-figure .md-video {
+    max-height: 400px;
+  }
+}
 /* An <img> written as raw HTML in PR prose (html-sanitize.ts tags them). The
    block treatment above is right for a pasted screenshot and wrong here: bots
    use raw images for 16px avatars and status badges inside a table cell, where

--- a/packages/core/opensession-server/src/frontend/styles/base.css
+++ b/packages/core/opensession-server/src/frontend/styles/base.css
@@ -36,6 +36,7 @@
 @import "./blocks/ansi.css";
 @import "./blocks/artifact.css";
 @import "./blocks/slides.css";
+@import "./blocks/compare.css";
 @import "./base-keyframes.css";
 @import "./blocks/palette.css";
 @import "./blocks/table.css";

--- a/packages/core/opensession-server/src/frontend/styles/blocks/compare.css
+++ b/packages/core/opensession-server/src/frontend/styles/blocks/compare.css
@@ -1,0 +1,121 @@
+/* ```compare fence upgraded into a before/after slider (lib/compare-block.ts).
+   Renderer-emitted markup, which is why it is a stylesheet and not a utility
+   string. The before still is in flow and sizes the box, capped like a placed
+   image; the after still lies over it, clipped to the right of the divider.
+   `--p` is the divider's position in percent, set by the range input that
+   covers the whole box and is the only thing here that takes input. */
+.md-compare-wrap {
+  margin: 2px 0 8px;
+}
+.md-compare {
+  --p: 50;
+  --pos: calc(var(--p) * 1%);
+  position: relative;
+  width: fit-content;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: calc(8px * var(--rf));
+  corner-shape: var(--cs);
+  background: var(--bg-panel);
+  user-select: none;
+  -webkit-user-select: none;
+}
+.md-compare-img {
+  display: block;
+  max-width: 100%;
+  max-height: 480px;
+  height: auto;
+  pointer-events: none;
+}
+.md-compare-after {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  clip-path: inset(0 0 0 var(--pos));
+}
+.md-compare-divider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--pos);
+  width: 2px;
+  margin-left: -1px;
+  background: var(--bg);
+  pointer-events: none;
+}
+.md-compare-handle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: 0 0 0 1px var(--border);
+}
+/* The stills read through the input: it is invisible but it is the hit
+   target, so a press anywhere jumps the divider there and drags it on. The
+   thumb is a hairline so the divider sits where the finger is; a wide thumb
+   would drift from it toward the edges. */
+.md-compare-range {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  cursor: ew-resize;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  touch-action: pan-y;
+}
+.md-compare-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 2px;
+  height: 100%;
+}
+.md-compare-range::-moz-range-thumb {
+  width: 2px;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+}
+.md-compare:has(.md-compare-range:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.md-compare-label {
+  position: absolute;
+  bottom: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
+  pointer-events: none;
+}
+/* Each label fades as the divider reaches it, so it never sits on the other
+   still. Unitless maths on --p: fully shown 6 points away, gone at the edge. */
+.md-compare-label-before {
+  left: 8px;
+  opacity: clamp(0, calc((var(--p) - 10) / 6), 1);
+}
+.md-compare-label-after {
+  right: 8px;
+  opacity: clamp(0, calc((90 - var(--p)) / 6), 1);
+}
+@media (max-width: 720px) {
+  .md-compare-img {
+    max-height: 400px;
+  }
+}

--- a/packages/core/opensession-server/src/server/demo/fixtures.ts
+++ b/packages/core/opensession-server/src/server/demo/fixtures.ts
@@ -191,8 +191,11 @@ export function demoSessions(opts: {
   worktreeDir: string;
   /** The generated base repo (clean checkout on main). */
   repoDir: string;
+  /** Where the generator wrote the stills the hero session shows
+   *  (generate.ts retryStill); served by the /media route. */
+  mediaDir: string;
 }): DemoSessionFixture[] {
-  const { now, worktreeDir, repoDir } = opts;
+  const { now, worktreeDir, repoDir, mediaDir } = opts;
   const min = 60_000;
   const sessions: DemoSessionFixture[] = [];
 
@@ -317,6 +320,19 @@ export function demoSessions(opts: {
             "\n```",
           "demo-pr-a3",
           iso(t0 + 170_000),
+          MODEL_FABLE,
+        ),
+        // Media in place: an image marker with a caption and a before/after
+        // compare marker, rendered where they are written (docs/blocks.md).
+        transcriptLineAssistantText(
+          "Proof that the third attempt now runs. The retry timeline from the reruns, before and after the fix:\n\n" +
+            `OPENSESSION_COMPARE: ${mediaDir}/retry-before.png ${mediaDir}/retry-after.png\n` +
+            "Attempts per run: before on the left, after on the right\n\n" +
+            `OPENSESSION_IMAGE: ${mediaDir}/retry-after.png\n` +
+            "All three attempts run and the third one succeeds\n\n" +
+            "Both stills come from the 100-run rerun above.",
+          "demo-pr-a4",
+          iso(t0 + 180_000),
           MODEL_FABLE,
         ),
       ],

--- a/packages/core/opensession-server/src/server/demo/generate.ts
+++ b/packages/core/opensession-server/src/server/demo/generate.ts
@@ -37,6 +37,7 @@ import {
   demoPrInfo,
   demoSessions,
 } from "./fixtures";
+import { encodePng, type PngRect, type Rgb } from "./png";
 
 export interface DemoGenerateOpts {
   /**
@@ -104,6 +105,39 @@ function git(cwd: string, ...args: string[]): void {
 
 /** Real git repo (main) + worktree (DEMO_BRANCH) with a committed fix, a
  *  dirty edit and an untracked file — what the Diff panel needs to render. */
+/**
+ * A 960x540 "retry timeline" still: three attempt bars on a light card.
+ * Before the fix the third attempt never runs (an empty slot and a red
+ * failure bar); after it, all three run and the third succeeds. Fixture
+ * art, not product UI, so the colours are literal.
+ */
+function retryStill(build: "before" | "after"): Uint8Array {
+  const bg: Rgb = [244, 244, 246];
+  const card: Rgb = [255, 255, 255];
+  const ink: Rgb = [38, 38, 42];
+  const track: Rgb = [228, 228, 232];
+  const ran: Rgb = [58, 120, 240];
+  const ok: Rgb = [46, 160, 96];
+  const failed: Rgb = [220, 64, 64];
+  const rects: PngRect[] = [
+    { x: 60, y: 50, w: 840, h: 440, color: card },
+    { x: 100, y: 90, w: 260, h: 14, color: ink },
+  ];
+  const attempts = build === "before" ? [1, 1, 0] : [1, 1, 1];
+  attempts.forEach((ranIt, i) => {
+    const y = 160 + i * 100;
+    rects.push({ x: 100, y, w: 90, h: 12, color: ink });
+    rects.push({ x: 220, y: y - 12, w: 640, h: 36, color: track });
+    if (ranIt) rects.push({ x: 220, y: y - 12, w: 420, h: 36, color: ran });
+  });
+  const result =
+    build === "before"
+      ? { x: 220, y: 428, w: 640, h: 24, color: failed }
+      : { x: 640, y: 348, w: 220, h: 36, color: ok };
+  rects.push(result);
+  return encodePng(960, 540, bg, rects);
+}
+
 function buildDemoRepo(repoDir: string, worktreeDir: string): void {
   mkdirSync(repoDir, { recursive: true });
   mkdirSync(dirname(worktreeDir), { recursive: true });
@@ -212,9 +246,18 @@ export function generateDemoData(
 
   buildDemoRepo(repoDir, worktreeDir);
 
+  // The stills the hero session shows in place (OPENSESSION_IMAGE and
+  // OPENSESSION_COMPARE lines in its transcript). Real files, because the
+  // /media route streams from disk; under the sessions dir so the demo's
+  // state directory owns them.
+  const mediaDir = join(demoRoot, "media");
+  mkdirSync(mediaDir, { recursive: true });
+  writeFileSync(join(mediaDir, "retry-before.png"), retryStill("before"));
+  writeFileSync(join(mediaDir, "retry-after.png"), retryStill("after"));
+
   // Sessions + their engine transcripts (claude-shape jsonl; the server
   // lazily imports these into transcripts.db on first watch).
-  const sessions = demoSessions({ now, worktreeDir, repoDir });
+  const sessions = demoSessions({ now, worktreeDir, repoDir, mediaDir });
   for (const s of sessions) {
     writeJson(join(sessionsDir, `${s.id}.json`), s.file);
     if (s.engineSessionId && s.lines.length) {

--- a/packages/core/opensession-server/src/server/demo/png.ts
+++ b/packages/core/opensession-server/src/server/demo/png.ts
@@ -1,0 +1,97 @@
+/**
+ * A tiny PNG encoder for demo stills. The demo transcript places media with
+ * OPENSESSION_IMAGE / OPENSESSION_COMPARE lines, and the /media route streams
+ * real files, so the generator has to write real PNGs into the demo's state
+ * directory. Solid rectangles are all the demo needs, and they cost no
+ * dependency.
+ */
+
+import { deflateSync } from "node:zlib";
+
+export type Rgb = readonly [number, number, number];
+
+export interface PngRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  color: Rgb;
+}
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function chunk(type: string, data: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + data.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, data.length);
+  out.set(Buffer.from(type, "ascii"), 4);
+  out.set(data, 8);
+  view.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+  return out;
+}
+
+/** An 8-bit RGB PNG of `background` with `rects` painted over it in order. */
+export function encodePng(
+  width: number,
+  height: number,
+  background: Rgb,
+  rects: readonly PngRect[],
+): Uint8Array {
+  const stride = width * 3 + 1;
+  const raw = new Uint8Array(stride * height);
+  for (let y = 0; y < height; y++) {
+    const row = y * stride;
+    raw[row] = 0;
+    for (let x = 0; x < width; x++) {
+      const at = row + 1 + x * 3;
+      raw[at] = background[0];
+      raw[at + 1] = background[1];
+      raw[at + 2] = background[2];
+    }
+  }
+  for (const rect of rects) {
+    const x0 = Math.max(0, rect.x);
+    const y0 = Math.max(0, rect.y);
+    const x1 = Math.min(width, rect.x + rect.w);
+    const y1 = Math.min(height, rect.y + rect.h);
+    for (let y = y0; y < y1; y++) {
+      const row = y * stride;
+      for (let x = x0; x < x1; x++) {
+        const at = row + 1 + x * 3;
+        raw[at] = rect.color[0];
+        raw[at + 1] = rect.color[1];
+        raw[at + 2] = rect.color[2];
+      }
+    }
+  }
+  const header = new Uint8Array(13);
+  const view = new DataView(header.buffer);
+  view.setUint32(0, width);
+  view.setUint32(4, height);
+  header[8] = 8; // bit depth
+  header[9] = 2; // colour type: RGB
+  header[10] = 0;
+  header[11] = 0;
+  header[12] = 0;
+  const signature = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  return Buffer.concat([
+    signature,
+    chunk("IHDR", header),
+    chunk("IDAT", new Uint8Array(deflateSync(raw))),
+    chunk("IEND", new Uint8Array(0)),
+  ]);
+}

--- a/packages/core/opensession-server/src/server/jsonl-parser.test.ts
+++ b/packages/core/opensession-server/src/server/jsonl-parser.test.ts
@@ -745,7 +745,7 @@ describe("Codex rollout parsing", () => {
     ]);
   });
 
-  it("extracts and hides video markers from Codex assistant messages", () => {
+  it("places video markers in Codex assistant messages", () => {
     const path = writeCodexFixture([
       JSON.stringify({
         timestamp: TS,
@@ -761,13 +761,18 @@ describe("Codex rollout parsing", () => {
     const entries = parseTranscript(path);
     expect(entries).toHaveLength(1);
     expect(entries[0].type).toBe("assistant");
-    expect(entries[0].content).toBe("Captured the production flow.");
+    expect(entries[0].content).toBe(
+      "Captured the production flow.\n\n![](/media?path=%2Ftmp%2Fcodex-demo.mov)",
+    );
     expect(entries[0].videos).toEqual(["/media?path=%2Ftmp%2Fcodex-demo.mov"]);
+    expect(entries[0].featuredMedia).toEqual([
+      "/media?path=%2Ftmp%2Fcodex-demo.mov",
+    ]);
   });
 });
 
 describe("assistant video markers", () => {
-  it("extracts a session asset and hides the marker from assistant content", () => {
+  it("extracts a session asset and places the marker in assistant content", () => {
     const assetPath =
       "/home/ubuntu/.opensession-assets/bks-019f861d-ffe5-7000-8638-5f69fc798fac/capture/tella-production-login-recording.mov";
     const path = writeFixture([
@@ -780,7 +785,9 @@ describe("assistant video markers", () => {
     const entries = parseTranscript(path);
     expect(entries).toHaveLength(1);
     expect(entries[0].type).toBe("assistant");
-    expect(entries[0].content).toBe("Captured the production flow.");
+    expect(entries[0].content).toBe(
+      `Captured the production flow.\n\n![](/media?path=${encodeURIComponent(assetPath)})`,
+    );
     expect(entries[0].videos).toEqual([
       `/media?path=${encodeURIComponent(assetPath)}`,
     ]);
@@ -827,7 +834,7 @@ describe("markers wrapped in markdown", () => {
     ).toEqual(["/media?path=%2Ftmp%2Fmy_final_shot.png"]);
   });
 
-  it("strips the whole wrapped line from an assistant bubble", () => {
+  it("places the whole wrapped line in an assistant bubble as an image", () => {
     const path = writeFixture([
       assistantLine(
         "a-wrapped",
@@ -836,9 +843,10 @@ describe("markers wrapped in markdown", () => {
     ]);
     const [entry] = parseTranscript(path);
     expect(entry.images).toEqual(["/media?path=%2Ftmp%2Fshot.png"]);
-    expect(entry.content).not.toContain("OPENSESSION_IMAGE");
-    expect(entry.content).not.toContain("**");
-    expect(entry.content).toContain("Top is now.");
+    expect(entry.featuredMedia).toEqual(["/media?path=%2Ftmp%2Fshot.png"]);
+    expect(entry.content).toBe(
+      "Done.\n\n![](/media?path=%2Ftmp%2Fshot.png)\n\nTop is now.",
+    );
   });
 
   it("renders an emphasised bare path mention", () => {

--- a/packages/core/opensession-server/src/server/jsonl-parser.ts
+++ b/packages/core/opensession-server/src/server/jsonl-parser.ts
@@ -565,6 +565,9 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
             ...(assistant.images.length > 0
               ? { images: assistant.images }
               : {}),
+            ...(assistant.featuredMedia.length > 0
+              ? { featuredMedia: assistant.featuredMedia }
+              : {}),
           });
           textBlockCount++;
         }
@@ -595,6 +598,9 @@ function parseEntry(raw: RawJsonlEntry): TranscriptEntry[] {
           ...(raw.isReasoning ? { isReasoning: true } : {}),
           ...(assistant.videos.length > 0 ? { videos: assistant.videos } : {}),
           ...(assistant.images.length > 0 ? { images: assistant.images } : {}),
+          ...(assistant.featuredMedia.length > 0
+            ? { featuredMedia: assistant.featuredMedia }
+            : {}),
         });
       }
     }
@@ -710,6 +716,10 @@ function parseCodexEntry(raw: any): TranscriptEntry[] {
           content: assistant.content,
           timestamp: ts,
           ...(assistant.videos.length > 0 ? { videos: assistant.videos } : {}),
+          ...(assistant.images.length > 0 ? { images: assistant.images } : {}),
+          ...(assistant.featuredMedia.length > 0
+            ? { featuredMedia: assistant.featuredMedia }
+            : {}),
         },
       ];
     }

--- a/packages/core/opensession-server/src/server/transcript-media.test.ts
+++ b/packages/core/opensession-server/src/server/transcript-media.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import {
+  extractAssistantVideos,
+  extractMediaMarkers,
+  isCaptionLine,
+  mediaUrlFor,
+  placeMediaMarkers,
+  stripMediaMarkers,
+} from "./transcript-media";
+
+const shot = "/media?path=%2Ftmp%2Fshot.png";
+const before = "/media?path=%2Ftmp%2Fbefore.png";
+const after = "/media?path=%2Ftmp%2Fafter.png";
+
+describe("placeMediaMarkers", () => {
+  it("leaves text without a marker byte-identical", () => {
+    const text = "Plain prose.\n\n- a list\n- with items\n";
+    expect(placeMediaMarkers(text)).toEqual({
+      content: text,
+      images: [],
+      videos: [],
+      featuredMedia: [],
+    });
+  });
+
+  it("rewrites an image marker into image syntax where it stands", () => {
+    const placed = placeMediaMarkers(
+      "## Proof\n\nOPENSESSION_IMAGE: /tmp/shot.png\n\nDone.",
+    );
+    expect(placed.content).toBe(`## Proof\n\n![](${shot})\n\nDone.`);
+    expect(placed.images).toEqual([shot]);
+    expect(placed.videos).toEqual([]);
+    expect(placed.featuredMedia).toEqual([shot]);
+  });
+
+  it("reads through emphasis, backticks and a bullet", () => {
+    for (const line of [
+      "**OPENSESSION_IMAGE: /tmp/shot.png**",
+      "`OPENSESSION_IMAGE: /tmp/shot.png`",
+      "- OPENSESSION_IMAGE: /tmp/shot.png",
+      "__OPENSESSION_IMAGE: /tmp/shot.png__",
+    ]) {
+      expect(placeMediaMarkers(line).content).toBe(`![](${shot})`);
+    }
+  });
+
+  it("keeps a blank line on each side so the figure is its own paragraph", () => {
+    const placed = placeMediaMarkers(
+      "Look:\nOPENSESSION_IMAGE: /tmp/shot.png\nThat is the header.\nAnd the footer moved too.",
+    );
+    expect(placed.content).toBe(
+      `Look:\n\n![](${shot})\n\nThat is the header.\nAnd the footer moved too.`,
+    );
+  });
+
+  it("takes one short line directly under the marker as the caption", () => {
+    const placed = placeMediaMarkers(
+      "OPENSESSION_IMAGE: /tmp/shot.png\nThe login page after the fix\n\nNext paragraph.",
+    );
+    expect(placed.content).toBe(
+      `![The login page after the fix](${shot})\n\nNext paragraph.`,
+    );
+  });
+
+  it("takes a caption at the end of the message", () => {
+    expect(
+      placeMediaMarkers("OPENSESSION_IMAGE: /tmp/shot.png\nAfter").content,
+    ).toBe(`![After](${shot})`);
+  });
+
+  it("takes a caption that is followed by another marker", () => {
+    const placed = placeMediaMarkers(
+      "OPENSESSION_IMAGE: /tmp/before.png\nBefore\nOPENSESSION_IMAGE: /tmp/after.png\nAfter",
+    );
+    expect(placed.content).toBe(`![Before](${before})\n\n![After](${after})`);
+    expect(placed.images).toEqual([before, after]);
+  });
+
+  it("does not eat a paragraph of prose after the marker", () => {
+    const placed = placeMediaMarkers(
+      "OPENSESSION_IMAGE: /tmp/shot.png\nThis shows the fix. I also\nchanged the header.\n",
+    );
+    expect(placed.content).toBe(
+      `![](${shot})\n\nThis shows the fix. I also\nchanged the header.\n`,
+    );
+  });
+
+  it("does not take a heading, list, quote, fence or long line as a caption", () => {
+    for (const line of [
+      "## Next",
+      "- item",
+      "1. step",
+      "> quote",
+      "```",
+      "| a | b |",
+      "![x](y)",
+      "x".repeat(161),
+    ]) {
+      const placed = placeMediaMarkers(
+        `OPENSESSION_IMAGE: /tmp/shot.png\n${line}\n`,
+      );
+      expect(placed.content).toBe(`![](${shot})\n\n${line}\n`);
+    }
+  });
+
+  it("drops emphasis wrappers and brackets from the alt text", () => {
+    expect(
+      placeMediaMarkers("OPENSESSION_IMAGE: /tmp/shot.png\n**Before [1]**")
+        .content,
+    ).toBe(`![Before 1](${shot})`);
+  });
+
+  it("rewrites a video marker into image syntax on the video file", () => {
+    const placed = placeMediaMarkers(
+      "OPENSESSION_VIDEO: /tmp/clip.mp4\nThe whole flow",
+    );
+    const clip = "/media?path=%2Ftmp%2Fclip.mp4";
+    expect(placed.content).toBe(`![The whole flow](${clip})`);
+    expect(placed.videos).toEqual([clip]);
+    expect(placed.images).toEqual([]);
+    expect(placed.featuredMedia).toEqual([clip]);
+  });
+
+  it("still reads the pre-rename video marker", () => {
+    expect(placeMediaMarkers("BACKSTAGE_VIDEO: /tmp/old.mov").videos).toEqual([
+      "/media?path=%2Ftmp%2Fold.mov",
+    ]);
+  });
+
+  it("rewrites a compare marker into a compare fence with both stills", () => {
+    const placed = placeMediaMarkers(
+      "Before and after:\n\nOPENSESSION_COMPARE: /tmp/before.png /tmp/after.png\nRetry timeline\n\nDone.",
+    );
+    expect(placed.content).toBe(
+      [
+        "Before and after:",
+        "",
+        "```compare",
+        `before: ${before}`,
+        `after: ${after}`,
+        "caption: Retry timeline",
+        "```",
+        "",
+        "Done.",
+      ].join("\n"),
+    );
+    expect(placed.images).toEqual([before, after]);
+    expect(placed.featuredMedia).toEqual([before, after]);
+  });
+
+  it("writes a compare fence without a caption line when there is none", () => {
+    expect(
+      placeMediaMarkers("OPENSESSION_COMPARE: /tmp/before.png /tmp/after.png")
+        .content,
+    ).toBe(`\`\`\`compare\nbefore: ${before}\nafter: ${after}\n\`\`\``);
+  });
+
+  it("ignores a compare marker with one path", () => {
+    const text = "OPENSESSION_COMPARE: /tmp/only.png";
+    expect(placeMediaMarkers(text).content).toBe(text);
+  });
+
+  it("lists a file shown twice once", () => {
+    const placed = placeMediaMarkers(
+      "OPENSESSION_IMAGE: /tmp/shot.png\n\nOPENSESSION_IMAGE: /tmp/shot.png",
+    );
+    expect(placed.images).toEqual([shot]);
+    expect(placed.content).toBe(`![](${shot})\n\n![](${shot})`);
+  });
+});
+
+describe("isCaptionLine", () => {
+  it("wants a short plain line with nothing but a blank after it", () => {
+    expect(isCaptionLine("A caption", undefined)).toBe(true);
+    expect(isCaptionLine("A caption", "")).toBe(true);
+    expect(isCaptionLine("A caption", "   ")).toBe(true);
+    expect(isCaptionLine("A caption", "More prose")).toBe(false);
+    expect(isCaptionLine("", undefined)).toBe(false);
+    expect(isCaptionLine("OPENSESSION_IMAGE: /tmp/x.png", undefined)).toBe(
+      false,
+    );
+  });
+});
+
+describe("mediaUrlFor", () => {
+  it("encodes parentheses, which markdown link syntax cannot hold", () => {
+    expect(mediaUrlFor("/tmp/shot (1).png")).toBe(
+      "/media?path=%2Ftmp%2Fshot%20%281%29.png",
+    );
+  });
+});
+
+describe("extractAssistantVideos", () => {
+  it("returns the placed text with images, videos and featured media", () => {
+    const out = extractAssistantVideos(
+      "Done.\n\nOPENSESSION_IMAGE: /tmp/shot.png\nOPENSESSION_VIDEO: /tmp/clip.mp4\n\n",
+    );
+    expect(out.content).toBe(
+      `Done.\n\n![](${shot})\n\n![](/media?path=%2Ftmp%2Fclip.mp4)`,
+    );
+    expect(out.images).toEqual([shot]);
+    expect(out.videos).toEqual(["/media?path=%2Ftmp%2Fclip.mp4"]);
+    expect(out.featuredMedia).toEqual([shot, "/media?path=%2Ftmp%2Fclip.mp4"]);
+  });
+
+  it("leaves a plain message untouched with no featured media", () => {
+    const out = extractAssistantVideos("Nothing to see.\n");
+    expect(out.content).toBe("Nothing to see.\n");
+    expect(out.featuredMedia).toEqual([]);
+  });
+});
+
+describe("compare in the Slack grammar", () => {
+  it("reads a compare marker as two images, before first", () => {
+    expect(
+      extractMediaMarkers(
+        "OPENSESSION_VIDEO: /tmp/clip.mp4\nOPENSESSION_COMPARE: /tmp/before.png /tmp/after.png\n",
+      ),
+    ).toEqual([
+      { path: "/tmp/clip.mp4", kind: "video" },
+      { path: "/tmp/before.png", kind: "image" },
+      { path: "/tmp/after.png", kind: "image" },
+    ]);
+  });
+
+  it("strips a compare line", () => {
+    expect(
+      stripMediaMarkers("a\nOPENSESSION_COMPARE: /tmp/b.png /tmp/c.png\nd"),
+    ).toBe("a\n\nd");
+  });
+});

--- a/packages/core/opensession-server/src/server/transcript-media.ts
+++ b/packages/core/opensession-server/src/server/transcript-media.ts
@@ -81,6 +81,26 @@ const VIDEO_MARKER = markerRe("(?:OPENSESSION|BACKSTAGE)_VIDEO");
 // images): `OPENSESSION_IMAGE: <abs-path>` renders inline via the same
 // authenticated media route, landing in the entry's existing `images` field.
 const IMAGE_MARKER = markerRe("OPENSESSION_IMAGE");
+// A pair of stills shown as one before/after slider:
+// `OPENSESSION_COMPARE: <abs-before> <abs-after>`. Both halves obey the
+// image rules; the web renders the pair as a ```compare fence (see
+// placeMediaMarkers), every other client reads two paths.
+const COMPARE_MARKER = new RegExp(
+  `^${MARKER_OPEN}OPENSESSION_COMPARE:[\\t ]*(/\\S+)[\\t ]+(/\\S+?)${MARKER_CLOSE}$`,
+  "gm",
+);
+
+/**
+ * The `/media` URL a path on disk streams from (routes/media.ts). Parentheses
+ * are encoded too, which encodeURIComponent leaves alone: the same URL is
+ * written into markdown image syntax, where an unbalanced `)` would end the
+ * link early.
+ */
+export function mediaUrlFor(path: string): string {
+  return `/media?path=${encodeURIComponent(path)
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")}`;
+}
 
 function markerPaths(text: string, marker: RegExp): string[] {
   if (!text) return [];
@@ -88,9 +108,7 @@ function markerPaths(text: string, marker: RegExp): string[] {
 }
 
 function extractMarker(text: string, marker: RegExp): string[] {
-  return markerPaths(text, marker).map(
-    (path) => `/media?path=${encodeURIComponent(path)}`,
-  );
+  return markerPaths(text, marker).map(mediaUrlFor);
 }
 
 export interface MarkerMedia {
@@ -103,7 +121,8 @@ export interface MarkerMedia {
  * The marked-up media of a message, in the order it was written, as paths on
  * disk. The transcript wants `/media` URLs because it renders in a browser
  * holding a session cookie; a surface that has to hand Slack the bytes wants
- * the file. Both read the same grammar, so both read it from here.
+ * the file. Both read the same grammar, so both read it from here. A compare
+ * marker is its two stills, before first.
  */
 export function extractMediaMarkers(text: string): MarkerMedia[] {
   if (!text) return [];
@@ -112,6 +131,11 @@ export function extractMediaMarkers(text: string): MarkerMedia[] {
     found.push({ path: m[1], kind: "image", at: m.index ?? 0 });
   for (const m of text.matchAll(VIDEO_MARKER))
     found.push({ path: m[1], kind: "video", at: m.index ?? 0 });
+  for (const m of text.matchAll(COMPARE_MARKER)) {
+    const at = m.index ?? 0;
+    found.push({ path: m[1], kind: "image", at });
+    found.push({ path: m[2], kind: "image", at: at + 0.5 });
+  }
   return found
     .sort((a, b) => a.at - b.at)
     .map(({ path, kind }) => ({ path, kind }));
@@ -119,7 +143,144 @@ export function extractMediaMarkers(text: string): MarkerMedia[] {
 
 /** Drops the marker lines, leaving the prose that surrounded them. */
 export function stripMediaMarkers(text: string): string {
-  return text.replace(IMAGE_MARKER, "").replace(VIDEO_MARKER, "");
+  return text
+    .replace(IMAGE_MARKER, "")
+    .replace(VIDEO_MARKER, "")
+    .replace(COMPARE_MARKER, "");
+}
+
+// ── Media in place ──────────────────────────────────────────────────────────
+// An assistant message keeps its markers where they were written, rewritten
+// into markdown every client can render: a marker becomes standard image
+// syntax (`![caption](/media?path=...)`, which the web renders as a figure and
+// plays as a video when the file is one), a compare marker becomes a
+// ```compare fence the web upgrades into a slider and everyone else reads as
+// two links. Until 2026-09 the markers were cut out of the text and only the
+// entry's images[]/videos[] carried them, so a message that said "## Proof"
+// over three markers showed nothing under Proof and three thumbnails at the
+// very end.
+
+type MarkerLine =
+  | { kind: "image" | "video"; path: string }
+  | { kind: "compare"; before: string; after: string };
+
+/** A single line's marker, if it is one. Each regex is global, so a fresh
+ *  anchored copy is used rather than sharing lastIndex across calls. */
+function markerOf(line: string): MarkerLine | null {
+  const one = (re: RegExp) => new RegExp(re.source, "").exec(line);
+  const compare = one(COMPARE_MARKER);
+  if (compare)
+    return { kind: "compare", before: compare[1], after: compare[2] };
+  const image = one(IMAGE_MARKER);
+  if (image) return { kind: "image", path: image[1] };
+  const video = one(VIDEO_MARKER);
+  if (video) return { kind: "video", path: video[1] };
+  return null;
+}
+
+const CAPTION_MAX_LENGTH = 160;
+/** Lines that open a markdown block of their own are never a caption. */
+const BLOCK_START_RE =
+  /^(?:#{1,6}\s|>|[-*+]\s|\d+[.)]\s|```|~~~|\||<|!\[|\s{4}|\t|(?:[-*_]\s*){3,}$)/;
+
+/**
+ * The caption rule, kept tight so ordinary prose after a marker is not eaten:
+ * one line of plain text directly under the marker (no blank line between),
+ * short, not a marker or another block, and the line after it blank, another
+ * marker, or the end of the message. A two-line paragraph after a marker is
+ * prose; a one-line remark right under it is what it says about the picture.
+ */
+export function isCaptionLine(line: string, following: string | undefined) {
+  const text = line.trim();
+  if (!text || text.length > CAPTION_MAX_LENGTH) return false;
+  if (markerOf(line) || BLOCK_START_RE.test(line)) return false;
+  if (following === undefined || following.trim() === "") return true;
+  return markerOf(following) !== null;
+}
+
+/** A caption as image alt text: emphasis wrappers and bracket characters
+ *  are dropped, since the alt is plain text and a `]` would end it. */
+function altText(caption: string | undefined): string {
+  if (!caption) return "";
+  return caption
+    .replace(/^[*_]+|[*_]+$/g, "")
+    .replace(/[[\]\\]/g, "")
+    .trim();
+}
+
+function placedMarkdown(marker: MarkerLine, caption: string | undefined) {
+  if (marker.kind === "compare") {
+    return [
+      "```compare",
+      `before: ${mediaUrlFor(marker.before)}`,
+      `after: ${mediaUrlFor(marker.after)}`,
+      ...(caption ? [`caption: ${caption}`] : []),
+      "```",
+    ].join("\n");
+  }
+  return `![${altText(caption)}](${mediaUrlFor(marker.path)})`;
+}
+
+export interface PlacedMedia {
+  /** The text with every marker rewritten in place. Byte-identical to the
+   *  input when there was no marker. */
+  content: string;
+  /** `/media` URLs, in the order written. A compare marker is two images. */
+  images: string[];
+  videos: string[];
+  /** Everything a marker named: what the agent asked to be SHOWN. */
+  featuredMedia: string[];
+}
+
+/**
+ * Rewrites every marker line where it stands. A blank line is kept on each
+ * side of the rewritten form so it is a paragraph of its own: an image glued
+ * to the prose above it would be an inline image inside that paragraph, and
+ * a fence needs the blank line to open at all.
+ */
+export function placeMediaMarkers(text: string): PlacedMedia {
+  const images: string[] = [];
+  const videos: string[] = [];
+  const featuredMedia: string[] = [];
+  if (!text) return { content: text, images, videos, featuredMedia };
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let placed = false;
+  for (let i = 0; i < lines.length; i++) {
+    const marker = markerOf(lines[i]);
+    if (!marker) {
+      out.push(lines[i]);
+      continue;
+    }
+    placed = true;
+    let caption: string | undefined;
+    const next = lines[i + 1];
+    if (next !== undefined && isCaptionLine(next, lines[i + 2])) {
+      caption = next.trim();
+      i++;
+    }
+    if (marker.kind === "compare") {
+      const before = mediaUrlFor(marker.before);
+      const after = mediaUrlFor(marker.after);
+      images.push(before, after);
+      featuredMedia.push(before, after);
+    } else {
+      const url = mediaUrlFor(marker.path);
+      (marker.kind === "video" ? videos : images).push(url);
+      featuredMedia.push(url);
+    }
+    if (out.length > 0 && out[out.length - 1].trim() !== "") out.push("");
+    out.push(placedMarkdown(marker, caption));
+    const after = lines[i + 1];
+    if (after !== undefined && after.trim() !== "" && !markerOf(after))
+      out.push("");
+  }
+  return {
+    content: placed ? out.join("\n") : text,
+    images: [...new Set(images)],
+    videos: [...new Set(videos)],
+    featuredMedia: [...new Set(featuredMedia)],
+  };
 }
 
 export function extractVideoMarkers(text: string): string[] {
@@ -182,27 +343,41 @@ export function extractImplicitMedia(text: string): {
   return { images, videos };
 }
 
+/**
+ * An assistant message's media. Markers stay in the text, rewritten in place
+ * (placeMediaMarkers); the entry's images[]/videos[] still carry every one of
+ * them, plus implicit mentions, for the turn fold's strip, the lightbox
+ * gallery and the clients that read the lists rather than the markdown. The
+ * trailing thumbnail row under a web message hides what the body already
+ * placed (frontend lib/placed-media.ts). `featuredMedia` names the marker
+ * media only, the same line toolResultMedia draws.
+ *
+ * Named for the video marker it first read; every marker kind goes through
+ * it now.
+ */
 export function extractAssistantVideos(text: string): {
   content: string;
   videos: string[];
   images: string[];
+  featuredMedia: string[];
 } {
-  const videos = extractVideoMarkers(text);
-  const images = extractImageMarkers(text);
-  let content = text;
-  if (videos.length > 0) content = content.replace(VIDEO_MARKER, "");
-  if (images.length > 0) content = content.replace(IMAGE_MARKER, "");
+  const placed = placeMediaMarkers(text);
   // Implicit mentions render too (markers stay the explicit override; the
   // Set-union keeps a marker + bare mention of the same file to one embed).
-  const implicit = extractImplicitMedia(content);
-  const vset = new Set(videos);
-  const iset = new Set(images);
+  // Scanned on the rewritten text: a placed `/media?path=` URL is not a bare
+  // path, so nothing is counted twice.
+  const implicit = extractImplicitMedia(placed.content);
+  const vset = new Set(placed.videos);
+  const iset = new Set(placed.images);
   for (const v of implicit.videos) vset.add(v);
   for (const i of implicit.images) iset.add(i);
   return {
-    content: videos.length || images.length ? content.trimEnd() : text,
+    content: placed.featuredMedia.length
+      ? placed.content.trimEnd()
+      : placed.content,
     videos: [...vset],
     images: [...iset],
+    featuredMedia: placed.featuredMedia,
   };
 }
 


### PR DESCRIPTION
## What

`OPENSESSION_IMAGE:` / `OPENSESSION_VIDEO:` lines now render where the agent wrote them, with an optional one-line caption, and a new `OPENSESSION_COMPARE: /abs/before.png /abs/after.png` line renders as a before/after slider. Part of the blocks work (`docs/blocks.md`, sections "Media in place" and "Before/after").

Before this, `extractAssistantVideos` cut every marker out of the message and the frontend drew the media as a thumbnail row after the body, so "## Proof" followed by three markers showed nothing under Proof and three small thumbnails at the end.

## Design choice: the server rewrites the marker in place (option a)

`placeMediaMarkers` in `server/transcript-media.ts` rewrites each marker line in the stored message instead of stripping it:

- image or video: `![caption](/media?path=...)`, with a blank line on each side so it is a paragraph of its own;
- compare: a ` ```compare ` fence with `before:`, `after:` and optional `caption:` lines, each carrying the `/media?path=` URL.

Every markdown client gets an image, a video link or two readable URLs for free; the web upgrades them. `images[]` / `videos[]` keep listing the media, and assistant entries now carry `featuredMedia` for marker media (the same line `toolResultMedia` draws), so the turn fold strip, the workspace Screenshots panel, the social card and Slack all still see them. The Slack agent reads the raw response before parsing, and its marker grammar (`extractMediaMarkers` / `stripMediaMarkers`) learned the compare line so both stills upload.

The trailing thumbnail row under a message only shows media the body did not already place (`lib/placed-media.ts`, deduped by the `/media?path=` src). Messages stored before this change have stripped bodies and render exactly as before.

What the other clients do with the rewritten body:

- **Native (iOS/Mac)**: `TranscriptRow` draws `entry.images` / `entry.videos` in its own strips and hands the body to SwiftStreamingMarkdown. It already leaves GitHub image syntax in PR prose alone (`PrMarkdownMedia` only lifts bare video URLs), so a `![caption](/media?path=...)` line is whatever that library does with a root-relative image: at worst an alt-text line beside the strip that already shows the picture. Nothing is stripped there in this PR; if the library tries to load the relative URL, the native client should lift `/media?path=` images out of the body the way it lifts PR videos, since its strip already has them. Follow-up for the native client.
- **Chrome extension**: `sidepanel.js` renders the body as plain text and ignores `images[]`, so it now shows the `![](/media?path=...)` line where it used to show nothing for the media.

## Grammar (one line for the model prompt)

Write `OPENSESSION_IMAGE: /abs/path.png`, `OPENSESSION_VIDEO: /abs/path.mp4` or `OPENSESSION_COMPARE: /abs/before.png /abs/after.png` on its own line, optionally followed directly by one short line of plain text as the caption.

The caption rule is tight so prose is not eaten: the next line, no blank line between, at most 160 characters, not a heading, list, quote, table, fence or marker, and followed by a blank line, another marker or the end of the message. Two lines of prose after a marker stay prose.

## Frontend

- `lib/markdown.ts`: a paragraph that is exactly one `/media?path=` image renders as `<figure class="md-figure">` with the alt as `<figcaption>`; a video file gets the player plus the same expand button the trailing row has (`data-md-expand`, opened by the delegated lightbox handler). Other images, PR prose included, render as before.
- `lib/compare-block.ts` + `styles/blocks/compare.css`: the ` ```compare ` upgrader, registered in `FENCE_UPGRADERS`. Plain DOM: before still in flow, after still clipped with `clip-path`, and a native `<input type="range">` over the whole box, which gives drag, tap-to-jump, touch and arrow keys (1% per press, Home/End) with an accessible name and value text, no pointer code. Both stills are in the lightbox gallery; the expand button opens the after still.
- Figures cap at 480px tall (400px on phone) and the column's width; the old 360px thumbnail cap stays for the trailing row.
- `MessageBubble` / `TurnBlock` narration rows pass `unplacedMedia(entry.images, entry.content)` to the trailing row.

## Server

- `transcript-media.ts`: `placeMediaMarkers`, `isCaptionLine`, `mediaUrlFor` (also encodes parentheses, which markdown link syntax cannot hold), compare marker support in the Slack grammar. `extractAssistantVideos` keeps its name and now returns `featuredMedia`; the three `jsonl-parser` call sites (claude text blocks, plain text, codex `agent_message`) carry it, and codex assistant messages now carry `images` too.
- Demo: one added assistant message in `bks-demo-pr` (`demo-pr-a4`) with a compare line, an image line and captions; `demo/png.ts` writes the two 960x540 stills under the demo state dir so the `/media` route can serve them. No transcript-snapshot fixture contains a marker, so those are unchanged.

## Tests

`transcript-media.test.ts` (grammar, captions, compare, dedupe, byte-identical when no marker), `compare-block.test.ts`, `placed-media.test.ts`, figure cases in `markdown.test.ts`, updated expectations in `jsonl-parser.test.ts`. `bun run check` passes on the rebased commit (on top of 931bc7f9c).

## Proof

Verified with `verify-opensession` and the compiled-bundle harness on `/session/bks-demo-pr`, desktop 1440x900 and phone 390x844, dark and light, before and after the rebase onto the other block branches. The captures show the compare slider with labels, handle and expand button; the divider moved to 25% by 25 real ArrowLeft key presses with the focus ring on the box; the expand button opening the lightbox on "After, 2 of 3"; captions under both figures; no trailing thumbnail row; and the PR panel's Screenshots strip listing both stills through `featuredMedia`.

In this environment the demo instance's session list is empty at boot on the base commit too (the list index is primed before the demo dataset is generated, and the transcript reverse-index only picks the demo jsonl up after its 5 minute TTL), so the proof route was opened directly. Not related to this change.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/os-01a08c57-d93c-7d2a-a093-61af2625db1e)