### PR TITLE
Forgive typos in the native sidebar search, command palette, and @ people

### DIFF
--- a/packages/clients/ios/OS1/Models/CommandPalette.swift
+++ b/packages/clients/ios/OS1/Models/CommandPalette.swift
@@ -36,20 +36,18 @@ struct CommandPaletteEntry: Identifiable, Equatable, Sendable {
 
 /// Which rows a query keeps, and in what order.
 ///
-/// Deliberately not a fuzzy subsequence matcher: on a list where most rows are
-/// sessions with long, similar titles, subsequence matching turns every query
-/// into a wall of near-misses. Every whitespace-separated token has to appear
-/// somewhere in the row, and where it appears is the score — the title's start
-/// beats a word inside it, which beats the subtitle or a keyword.
+/// Matching is the shared `FuzzyMatch`, the same rules as the web palette:
+/// every whitespace-separated term has to land somewhere in the row, exactly,
+/// within a small edit distance, or as an abbreviation of one word, so
+/// "relase" still finds Release. Where it lands is the rank: a match in the
+/// title beats one that needed the subtitle or a keyword, and within each the
+/// scorer's own order holds (the title's start over a word inside it, over a
+/// typo).
 enum CommandPaletteRanking {
-    /// A row with its searchable text folded once per call. Folding inside the
-    /// comparator would redo it for every comparison.
     private struct Candidate {
         let entry: CommandPaletteEntry
         let order: Int
-        let title: String
-        let rest: String
-        var score = 0
+        let score: Int
     }
 
     static func results(
@@ -58,37 +56,16 @@ enum CommandPaletteRanking {
         sessionLimit: Int = 40,
         contentMatches: Set<String> = []
     ) -> [CommandPaletteEntry] {
-        let tokens = fold(query).split(separator: " ").map(String.init)
         var matched: [Candidate] = []
         for (order, entry) in entries.enumerated() {
-            var candidate = Candidate(
-                entry: entry,
-                order: order,
-                title: fold(entry.title),
-                rest: fold(
-                    ([entry.subtitle].compactMap { $0 } + entry.keywords)
-                        .joined(separator: " ")
-                )
-            )
-            var total = 0
-            var matchedEveryToken = true
-            for token in tokens {
-                guard let score = score(token, in: candidate) else {
-                    matchedEveryToken = false
-                    break
-                }
-                total += score
-            }
-            if matchedEveryToken {
-                candidate.score = total
+            let score = score(entry, query: query)
+            if score > 0 {
+                matched.append(Candidate(entry: entry, order: order, score: score))
             } else if entry.kind == .session, contentMatches.contains(entry.id) {
                 // A backend transcript hit ranks after every metadata match,
                 // whose weakest score is still at least one.
-                candidate.score = 0
-            } else {
-                continue
+                matched.append(Candidate(entry: entry, order: order, score: 0))
             }
-            matched.append(candidate)
         }
 
         matched.sort { left, right in
@@ -112,28 +89,15 @@ enum CommandPaletteRanking {
         }
     }
 
-    private static func score(_ token: String, in candidate: Candidate) -> Int? {
-        if candidate.title.hasPrefix(token) { return 4 }
-        if let range = candidate.title.range(of: token) {
-            return startsWord(candidate.title, at: range.lowerBound) ? 3 : 2
-        }
-        if candidate.rest.contains(token) { return 1 }
-        return nil
-    }
-
-    private static func startsWord(_ text: String, at index: String.Index) -> Bool {
-        guard index > text.startIndex else { return true }
-        let before = text[text.index(before: index)]
-        return !before.isLetter && !before.isNumber
-    }
-
-    /// Lowercased, accent-insensitive, and with runs of whitespace collapsed,
-    /// so "Café  Deploy" and "cafe deploy" are the same haystack.
-    private static func fold(_ text: String) -> String {
-        text
-            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
-            .split(whereSeparator: \.isWhitespace)
+    /// 0 when the row does not match. A title match sits a full band above a
+    /// match that needed the subtitle or keywords, and a query whose terms are
+    /// spread across both still counts, since the row as a whole is searched.
+    private static func score(_ entry: CommandPaletteEntry, query: String) -> Int {
+        let title = FuzzyMatch.score(query, entry.title)
+        if title > 0 { return 100 + title }
+        let rest = ([entry.title, entry.subtitle].compactMap { $0 } + entry.keywords)
             .joined(separator: " ")
+        return FuzzyMatch.score(query, rest)
     }
 }
 

--- a/packages/clients/ios/OS1/Models/FuzzyMatch.swift
+++ b/packages/clients/ios/OS1/Models/FuzzyMatch.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Typo-tolerant matching for the small search surfaces: the composer's `@`
+/// palette, the Mac command palette, and the sidebar filter.
+///
+/// A port of the server's `src/shared/fuzzy-match.ts`, rule for rule, so a
+/// query ranks the same here as in the web client and in the rows the server
+/// scores for the `@` palette. Change both or neither.
+///
+/// Scores are 0 (no match) to 100 (exact). Every whitespace-separated term
+/// must land somewhere in the text: as a substring, as a word within a small
+/// edit distance (an adjacent transposition counts as one edit), or as a
+/// subsequence of one word. Accents and case are ignored.
+enum FuzzyMatch {
+    /// Score `text` against `query`. 0 means no match; higher is a better
+    /// match. An empty query matches everything at 1.
+    static func score(_ query: String, _ text: String) -> Int {
+        let q = trimmed(normalize(query))
+        if q.isEmpty { return 1 }
+        let t = normalize(text)
+        if t.isEmpty { return 0 }
+        if t == q { return 100 }
+        if t.starts(with: q) { return 90 }
+        let words = split(t)
+        if words.contains(where: { $0.starts(with: q) }) { return 80 }
+        if contains(t, q) { return 70 }
+        let terms = q.split(whereSeparator: { $0.properties.isWhitespace }).map(Array.init)
+        var total = 0
+        for term in terms {
+            let score = termScore(term, text: t, words: words)
+            if score == 0 { return 0 }
+            total += score
+        }
+        return Int((Double(total) / Double(terms.count)).rounded(.toNearestOrAwayFromZero))
+    }
+
+    /// The best score across several fields of one item. 0 means no match.
+    static func best(_ query: String, in values: [String?]) -> Int {
+        var best = 0
+        for case let value? in values where !value.isEmpty {
+            let score = score(query, value)
+            if score > best { best = score }
+            if best == 100 { break }
+        }
+        return best
+    }
+
+    // MARK: - Rules
+
+    private typealias Scalars = [Unicode.Scalar]
+
+    /// Edits a term may absorb: none for short ones, so "cat" never finds
+    /// "cut".
+    private static func editBudget(_ term: Scalars) -> Int {
+        if term.count < 4 { return 0 }
+        if term.count < 8 { return 1 }
+        return 2
+    }
+
+    private static func termScore(_ term: Scalars, text: Scalars, words: [Scalars]) -> Int {
+        if contains(text, term) { return 60 }
+        let budget = editBudget(term)
+        if budget > 0 {
+            var best = budget + 1
+            for word in words {
+                if word.count < term.count - budget { continue }
+                // Compare against the whole word and its prefix of the term's
+                // length, so "wrokspace" and "relase" both land on their
+                // intended word.
+                let d = min(
+                    editDistance(term, word, max: budget),
+                    editDistance(term, Array(word.prefix(term.count)), max: budget)
+                )
+                if d < best { best = d }
+                if best == 0 { break }
+            }
+            if best <= budget { return 50 - best * 10 }
+        }
+        // "wksp" for "workspace": abbreviations skip letters but keep their
+        // order.
+        if term.count >= 3, words.contains(where: { isSubsequence(term, of: $0) }) {
+            return 20
+        }
+        return 0
+    }
+
+    /// Optimal string alignment distance, capped at `max + 1`.
+    private static func editDistance(_ a: Scalars, _ b: Scalars, max: Int) -> Int {
+        if abs(a.count - b.count) > max { return max + 1 }
+        var prev2: [Int] = []
+        var prev = Array(0...b.count)
+        for i in 1..<(a.count + 1) {
+            var row = [i]
+            row.reserveCapacity(b.count + 1)
+            var rowMin = i
+            for j in 1..<(b.count + 1) {
+                let cost = a[i - 1] == b[j - 1] ? 0 : 1
+                var d = Swift.min(prev[j] + 1, row[j - 1] + 1, prev[j - 1] + cost)
+                if i > 1, j > 1, a[i - 1] == b[j - 2], a[i - 2] == b[j - 1],
+                   prev2[j - 2] + 1 < d {
+                    d = prev2[j - 2] + 1
+                }
+                row.append(d)
+                if d < rowMin { rowMin = d }
+            }
+            if rowMin > max { return max + 1 }
+            prev2 = prev
+            prev = row
+        }
+        return prev[b.count]
+    }
+
+    private static func isSubsequence(_ term: Scalars, of word: Scalars) -> Bool {
+        var i = 0
+        for ch in word {
+            if i < term.count, ch == term[i] { i += 1 }
+            if i == term.count { return true }
+        }
+        return i == term.count
+    }
+
+    // MARK: - Text
+
+    /// Lowercased, compatibility-decomposed, with combining marks stripped:
+    /// the same three steps as the shared TypeScript.
+    private static func normalize(_ value: String) -> Scalars {
+        value.lowercased()
+            .decomposedStringWithCompatibilityMapping
+            .unicodeScalars
+            .filter { !(0x300...0x36F).contains($0.value) }
+    }
+
+    private static func trimmed(_ value: Scalars) -> Scalars {
+        Array(
+            value
+                .drop(while: { $0.properties.isWhitespace })
+                .reversed()
+                .drop(while: { $0.properties.isWhitespace })
+                .reversed()
+        )
+    }
+
+    /// Words are runs of ASCII letters and digits, as in the shared matcher.
+    private static func split(_ value: Scalars) -> [Scalars] {
+        value.split(whereSeparator: { !isWordScalar($0) }).map(Array.init)
+    }
+
+    private static func isWordScalar(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x61...0x7A, 0x30...0x39: true
+        default: false
+        }
+    }
+
+    private static func contains(_ text: Scalars, _ needle: Scalars) -> Bool {
+        if needle.isEmpty { return true }
+        guard text.count >= needle.count else { return false }
+        for start in 0...(text.count - needle.count)
+        where text[start] == needle[0] && text[start..<(start + needle.count)].elementsEqual(needle) {
+            return true
+        }
+        return false
+    }
+}

--- a/packages/clients/ios/OS1/Models/MentionRanking.swift
+++ b/packages/clients/ios/OS1/Models/MentionRanking.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The rows the `@` palette ranks on this device. The server already scores
+/// tools, workspaces and sessions with the same matcher; people come from the
+/// roster the app holds, so their order is decided here.
+enum MentionRanking {
+    /// Teammates whose first or full name matches, best score first. Among
+    /// equal scores the signed-in person leads, then the roster's own order,
+    /// so a keystroke never reshuffles rows that scored the same.
+    static func people(
+        _ names: [String],
+        query: String,
+        current: String,
+        fullName: (String) -> String
+    ) -> [String] {
+        let current = current.lowercased()
+        let scored = names.enumerated().compactMap { offset, name -> Row? in
+            let score = FuzzyMatch.best(query, in: [name, fullName(name)])
+            guard score > 0 else { return nil }
+            return Row(
+                name: name,
+                score: score,
+                isCurrent: name.lowercased() == current,
+                offset: offset
+            )
+        }
+        return scored
+            .sorted { left, right in
+                if left.score != right.score { return left.score > right.score }
+                if left.isCurrent != right.isCurrent { return left.isCurrent }
+                return left.offset < right.offset
+            }
+            .map(\.name)
+    }
+
+    private struct Row {
+        let name: String
+        let score: Int
+        let isCurrent: Bool
+        let offset: Int
+    }
+}

--- a/packages/clients/ios/OS1/SidebarSearch.swift
+++ b/packages/clients/ios/OS1/SidebarSearch.swift
@@ -7,8 +7,9 @@ import Foundation
 /// predicate, because the match is typo-tolerant (`FuzzyMatch`) and the list
 /// can be thousands of rows with the person lens on everyone: scoring every
 /// field of every row per body evaluation would pin the main actor on each
-/// keystroke. `SessionsListView` runs `matches` in a detached task and keeps
-/// the previous answer on screen until the next one lands.
+/// keystroke. `SessionsListView` runs `matches` in a detached task, cancels
+/// it when the next keystroke supersedes it, and keeps the previous answer on
+/// screen until the next one lands.
 enum SidebarSearch {
     struct Matches: Equatable, Sendable {
         /// The query these ids answer. Empty means "not filtering", and then
@@ -27,16 +28,21 @@ enum SidebarSearch {
         }
     }
 
+    /// `nil` when the surrounding task is cancelled part way: a superseded
+    /// keystroke's scan stops at the next row instead of finishing a list of
+    /// thousands and competing with the scan that replaced it. Checked once
+    /// per row, so the cost is one flag read against a row's worth of scoring.
     static func matches(
         query: String,
         rows: [SidebarWorkspace],
         archived: [Session],
         workspaceNames: [String: String]
-    ) -> Matches {
+    ) -> Matches? {
         let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
         var out = Matches(query: query)
         guard !query.isEmpty else { return out }
         for row in rows {
+            if Task.isCancelled { return nil }
             var hit = FuzzyMatch.score(query, row.title) > 0
             for session in row.sessions
             where sessionMatches(session, query: query, workspaceNames: workspaceNames) {
@@ -45,9 +51,11 @@ enum SidebarSearch {
             }
             if hit { out.workspaceIds.insert(row.id) }
         }
-        for session in archived
-        where sessionMatches(session, query: query, workspaceNames: workspaceNames) {
-            out.sessionIds.insert(session.id)
+        for session in archived {
+            if Task.isCancelled { return nil }
+            if sessionMatches(session, query: query, workspaceNames: workspaceNames) {
+                out.sessionIds.insert(session.id)
+            }
         }
         return out
     }

--- a/packages/clients/ios/OS1/SidebarSearch.swift
+++ b/packages/clients/ios/OS1/SidebarSearch.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The sidebar filter's metadata match: which rows and sessions the typed
+/// query finds by title, repository, branch, workspace name, or id.
+///
+/// Computed once per query as a set of ids rather than inside the row
+/// predicate, because the match is typo-tolerant (`FuzzyMatch`) and the list
+/// can be thousands of rows with the person lens on everyone: scoring every
+/// field of every row per body evaluation would pin the main actor on each
+/// keystroke. `SessionsListView` runs `matches` in a detached task and keeps
+/// the previous answer on screen until the next one lands.
+enum SidebarSearch {
+    struct Matches: Equatable, Sendable {
+        /// The query these ids answer. Empty means "not filtering", and then
+        /// every row passes, which is also what the frame before the first
+        /// keystroke's answer arrives should show.
+        var query = ""
+        var workspaceIds: Set<String> = []
+        var sessionIds: Set<String> = []
+
+        func matches(_ workspace: SidebarWorkspace) -> Bool {
+            query.isEmpty || workspaceIds.contains(workspace.id)
+        }
+
+        func matches(_ session: Session) -> Bool {
+            query.isEmpty || sessionIds.contains(session.id)
+        }
+    }
+
+    static func matches(
+        query: String,
+        rows: [SidebarWorkspace],
+        archived: [Session],
+        workspaceNames: [String: String]
+    ) -> Matches {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        var out = Matches(query: query)
+        guard !query.isEmpty else { return out }
+        for row in rows {
+            var hit = FuzzyMatch.score(query, row.title) > 0
+            for session in row.sessions
+            where sessionMatches(session, query: query, workspaceNames: workspaceNames) {
+                out.sessionIds.insert(session.id)
+                hit = true
+            }
+            if hit { out.workspaceIds.insert(row.id) }
+        }
+        for session in archived
+        where sessionMatches(session, query: query, workspaceNames: workspaceNames) {
+            out.sessionIds.insert(session.id)
+        }
+        return out
+    }
+
+    /// One session's metadata against the query. The workspace name counts
+    /// for its sessions, as on the web sidebar: a workspace shows through
+    /// them. The id stays an exact substring match, since a hex id would
+    /// otherwise answer to any three-letter abbreviation.
+    static func sessionMatches(
+        _ session: Session,
+        query: String,
+        workspaceNames: [String: String] = [:]
+    ) -> Bool {
+        let workspaceName = session.workspaceName
+            ?? session.workspaceId.flatMap { workspaceNames[$0] }
+        if FuzzyMatch.best(
+            query,
+            in: [session.title, session.effectiveRepo, session.branch, workspaceName]
+        ) > 0 {
+            return true
+        }
+        return session.id.lowercased().contains(query.lowercased())
+    }
+}

--- a/packages/clients/ios/OS1/Views/ComposerMentionPalette.swift
+++ b/packages/clients/ios/OS1/Views/ComposerMentionPalette.swift
@@ -172,22 +172,17 @@ struct ComposerMentionPalette: View {
             .sorted { $0.items[0].categoryOrder < $1.items[0].categoryOrder }
     }
 
+    /// Teammates by how well they match, typos forgiven, the same way the
+    /// server ranks the tools, workspaces and sessions it sends back.
     private func people(matching query: String) -> [FileMention] {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let current = ServerConfig.shared.userName.lowercased()
-        return TeamDirectory.shared.names
-            .filter { name in
-                normalized.isEmpty
-                    || name.lowercased().contains(normalized)
-                    || TeamDirectory.shared.fullName(for: name).lowercased().contains(normalized)
-            }
-            .sorted { left, right in
-                let leftIsCurrent = left.lowercased() == current
-                let rightIsCurrent = right.lowercased() == current
-                if leftIsCurrent != rightIsCurrent { return leftIsCurrent }
-                return false
-            }
-            .map { name in
+        let directory = TeamDirectory.shared
+        return MentionRanking.people(
+            directory.names,
+            query: query,
+            current: ServerConfig.shared.userName,
+            fullName: directory.fullName(for:)
+        )
+        .map { name in
                 FileMention(
                     display: name,
                     insert: name,

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -91,6 +91,10 @@ struct SessionsListView: View {
     /// session id so workspace rows can match any conversation behind them.
     @State private var transcriptSnippets: [String: String] = [:]
     @State private var transcriptSearchRevision = 0
+    /// Which rows the typed query finds by their metadata, scored off the
+    /// main actor (`SidebarSearch`). Holds the previous answer until the next
+    /// one lands, so a keystroke narrows the list rather than blanking it.
+    @State private var metadataMatches = SidebarSearch.Matches()
     /// Non-nil opens the new-session sheet; carries the per-repo "+" preset.
     @State private var newSessionRequest: NewSessionRequest?
     /// Parked "Start an Agent" requests (`StartAgentIntent`, widgets, Siri).
@@ -419,6 +423,9 @@ struct SessionsListView: View {
             #endif
             .task(id: searchText) {
                 await updateTranscriptSearch()
+            }
+            .task(id: metadataSearchKey) {
+                await updateMetadataSearch()
             }
             .task(id: knownRepoCount) {
                 // Not for the sheet's repo picker — for the tiles in this
@@ -1666,47 +1673,74 @@ struct SessionsListView: View {
         }
     }
 
-    private func sessionMatchesMetadata(_ session: Session, query: String) -> Bool {
-        [session.title, session.effectiveRepo, session.branch, session.id]
-            .compactMap { $0 }
-            .contains { $0.lowercased().contains(query) }
+    /// What the metadata search answers: the query, and the rows it is asked
+    /// over. Nil while not searching. Arrays compare by buffer identity first,
+    /// so a body evaluation that changed nothing costs no walk; a poll that
+    /// replaced the list re-runs the search.
+    private struct MetadataSearchKey: Equatable, Sendable {
+        let query: String
+        let rows: [SidebarWorkspace]
+        let archived: [Session]
     }
 
-    private func workspaceMatchesMetadata(
-        _ workspace: SidebarWorkspace,
-        query: String
-    ) -> Bool {
-        workspace.title.lowercased().contains(query)
-            || workspace.sessions.contains { sessionMatchesMetadata($0, query: query) }
+    private var metadataSearchKey: MetadataSearchKey? {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return nil }
+        return MetadataSearchKey(
+            query: query,
+            rows: allSidebarWorkspaces,
+            archived: viewModel.archivedSessions
+        )
+    }
+
+    /// Typo-tolerant scoring of every row's fields is real work on a list of
+    /// thousands, so it runs detached and publishes one set of ids; the row
+    /// predicate then costs a set lookup on the main actor.
+    private func updateMetadataSearch() async {
+        guard let key = metadataSearchKey else {
+            metadataMatches = SidebarSearch.Matches()
+            return
+        }
+        // The name map only backs sessions an older server sent without a
+        // stamped workspace name, so it is read here rather than keyed on.
+        let workspaceNames = viewModel.workspaceNames
+        let matches = await Task.detached(priority: .userInitiated) {
+            SidebarSearch.matches(
+                query: key.query,
+                rows: key.rows,
+                archived: key.archived,
+                workspaceNames: workspaceNames
+            )
+        }.value
+        guard !Task.isCancelled else { return }
+        metadataMatches = matches
     }
 
     /// Snippets explain only transcript-only hits. A metadata match already
-    /// explains itself through the row's title, repository, or branch.
+    /// explains itself through the row's title, repository, branch, or
+    /// workspace.
     private func workspaceSearchSnippet(_ workspace: SidebarWorkspace) -> String? {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty, !workspaceMatchesMetadata(workspace, query: query) else {
-            return nil
-        }
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty, !metadataMatches.matches(workspace) else { return nil }
         return workspace.sessions.compactMap { transcriptSnippets[$0.id] }.first
     }
 
     private var archivedSearchResults: [Session] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else { return [] }
         let lens = peopleLens
         let person = person
         let agentKey = agentKey
+        let matches = metadataMatches
         return viewModel.archivedSessions.filter { session in
             lens.matches(session, person: person, agentKey: agentKey)
                 && (repoFilter == "all" || session.effectiveRepo == repoFilter)
-                && (sessionMatchesMetadata(session, query: query)
-                    || transcriptSnippets[session.id] != nil)
+                && (matches.matches(session) || transcriptSnippets[session.id] != nil)
         }
     }
 
     private func archivedSearchSnippet(_ session: Session) -> String? {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !sessionMatchesMetadata(session, query: query) else { return nil }
+        guard !metadataMatches.matches(session) else { return nil }
         return transcriptSnippets[session.id]
     }
 
@@ -1730,7 +1764,8 @@ struct SessionsListView: View {
         let agentKey = agentKey
         let lens = peopleLens
         let repo = repoFilter
-        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
+        let query = searchText.trimmingCharacters(in: .whitespaces)
+        let matches = metadataMatches
         // Rows this person has hidden drop out of the sidebar — except while
         // a session of theirs is blocked on a question (the poll consumes the
         // hide when that happens), and except while searching, which is how a
@@ -1750,7 +1785,7 @@ struct SessionsListView: View {
             }
             if repo != "all", workspace.effectiveRepo != repo { return false }
             guard !query.isEmpty else { return true }
-            if workspaceMatchesMetadata(workspace, query: query) { return true }
+            if matches.matches(workspace) { return true }
             return workspace.sessions.contains { transcriptSnippets[$0.id] != nil }
         }
     }

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -1695,7 +1695,10 @@ struct SessionsListView: View {
 
     /// Typo-tolerant scoring of every row's fields is real work on a list of
     /// thousands, so it runs detached and publishes one set of ids; the row
-    /// predicate then costs a set lookup on the main actor.
+    /// predicate then costs a set lookup on the main actor. A detached task
+    /// does not inherit the `.task(id:)` cancellation that the next keystroke
+    /// triggers, so the handle is cancelled by hand: otherwise every
+    /// superseded scan would run to the end and compete with the live one.
     private func updateMetadataSearch() async {
         guard let key = metadataSearchKey else {
             metadataMatches = SidebarSearch.Matches()
@@ -1704,15 +1707,20 @@ struct SessionsListView: View {
         // The name map only backs sessions an older server sent without a
         // stamped workspace name, so it is read here rather than keyed on.
         let workspaceNames = viewModel.workspaceNames
-        let matches = await Task.detached(priority: .userInitiated) {
+        let scan = Task.detached(priority: .userInitiated) {
             SidebarSearch.matches(
                 query: key.query,
                 rows: key.rows,
                 archived: key.archived,
                 workspaceNames: workspaceNames
             )
-        }.value
-        guard !Task.isCancelled else { return }
+        }
+        let matches = await withTaskCancellationHandler {
+            await scan.value
+        } onCancel: {
+            scan.cancel()
+        }
+        guard let matches, !Task.isCancelled else { return }
         metadataMatches = matches
     }
 

--- a/packages/clients/ios/OS1Tests/CommandPaletteTests.swift
+++ b/packages/clients/ios/OS1Tests/CommandPaletteTests.swift
@@ -129,6 +129,28 @@ final class CommandPaletteTests: XCTestCase {
         ).isEmpty)
     }
 
+    func testATypoStillFindsTheRow() {
+        let entries = [
+            session("release", "Release notes"),
+            command("workspace", "New session in this workspace")
+        ]
+        XCTAssertEqual(ids(entries, "relase"), ["release"])
+        XCTAssertEqual(ids(entries, "wrokspace"), ["workspace"])
+    }
+
+    func testAnExactTitleOutranksATypoOutranksAKeyword() {
+        let entries = [
+            session("keyword", "Something else", keywords: ["release"]),
+            session("typo", "Relase notes"),
+            session("exact", "Release notes")
+        ]
+        XCTAssertEqual(ids(entries, "release"), ["exact", "typo", "keyword"])
+    }
+
+    func testShortTermsStayStrict() {
+        XCTAssertEqual(ids([session("a", "Cut the rows")], "cat"), [])
+    }
+
     func testNoMatchesReturnsNothingRatherThanEverything() {
         let entries = [command("new", "New session"), session("a", "A conversation")]
         XCTAssertEqual(ids(entries, "zzzz"), [])

--- a/packages/clients/ios/OS1Tests/FuzzyMatchTests.swift
+++ b/packages/clients/ios/OS1Tests/FuzzyMatchTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import OS1
+
+/// Parity fixtures for the server's `shared/fuzzy-match.test.ts`: the same
+/// inputs must score the same here, so a query ranks alike in every client.
+final class FuzzyMatchTests: XCTestCase {
+    func testRanksExactPrefixWordPrefixThenSubstring() {
+        XCTAssertEqual(FuzzyMatch.score("release", "Release"), 100)
+        XCTAssertEqual(FuzzyMatch.score("rel", "Release work"), 90)
+        XCTAssertEqual(FuzzyMatch.score("work", "Release work"), 80)
+        XCTAssertEqual(FuzzyMatch.score("lease", "Release work"), 70)
+    }
+
+    func testForgivesATypoInLongerTerms() {
+        XCTAssertEqual(FuzzyMatch.score("relase", "Release work"), 40)
+        XCTAssertEqual(FuzzyMatch.score("wrokspace", "Workspace cleanup"), 40)
+        XCTAssertGreaterThan(FuzzyMatch.score("billng audit", "Billing audit"), 0)
+    }
+
+    func testAnAdjacentTranspositionIsOneEdit() {
+        // "wrokspace" is one transposition away; a plain Levenshtein would
+        // need two edits and, at a budget of two, still pass. "wrkospace"
+        // has the transposition and a second slip: still within budget.
+        XCTAssertEqual(FuzzyMatch.score("wrkospace", "workspace"), 30)
+        // Three edits is past the budget for a nine-letter term.
+        XCTAssertEqual(FuzzyMatch.score("wrkospcae", "workspace rows"), 0)
+    }
+
+    func testKeepsShortTermsStrict() {
+        XCTAssertEqual(FuzzyMatch.score("cat", "cut"), 0)
+        XCTAssertEqual(FuzzyMatch.score("api", "apple"), 0)
+    }
+
+    func testMatchesAbbreviationsInsideOneWord() {
+        XCTAssertEqual(FuzzyMatch.score("wksp", "workspace"), 20)
+    }
+
+    func testNeedsEveryTermToLandSomewhere() {
+        XCTAssertEqual(FuzzyMatch.score("release billing", "Release work"), 0)
+        XCTAssertGreaterThan(FuzzyMatch.score("work release", "Release work"), 0)
+        // The mean of the per-term scores, rounded half up as in JavaScript.
+        XCTAssertEqual(FuzzyMatch.score("relase work", "Release work"), 50)
+    }
+
+    func testIgnoresCaseAndAccentsAndAnEmptyQueryMatchesAll() {
+        XCTAssertEqual(FuzzyMatch.score("jaap", "Jääp"), 100)
+        XCTAssertEqual(FuzzyMatch.score("CAFE", "Café"), 100)
+        XCTAssertEqual(FuzzyMatch.score("", "anything"), 1)
+        XCTAssertEqual(FuzzyMatch.score("   ", "anything"), 1)
+        XCTAssertEqual(FuzzyMatch.score("x", ""), 0)
+    }
+
+    func testBestTakesTheStrongestField() {
+        XCTAssertEqual(FuzzyMatch.best("audit", in: [nil, "Billing", "audit/billing"]), 90)
+        XCTAssertEqual(FuzzyMatch.best("nothing", in: ["a", nil]), 0)
+    }
+}

--- a/packages/clients/ios/OS1Tests/MentionRankingTests.swift
+++ b/packages/clients/ios/OS1Tests/MentionRankingTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import OS1
+
+final class MentionRankingTests: XCTestCase {
+    private let roster = ["Kent", "Michiel", "Kenji", "Jaap"]
+    private let fullNames = [
+        "Kent": "Kent de Bruin",
+        "Michiel": "Michiel Roos",
+        "Kenji": "Kenji Sato",
+        "Jaap": "Jaap Visser"
+    ]
+
+    private func ranked(_ query: String, current: String = "Michiel") -> [String] {
+        MentionRanking.people(roster, query: query, current: current) { fullNames[$0] ?? $0 }
+    }
+
+    func testAnEmptyQueryKeepsTheRosterOrderWithYouFirst() {
+        XCTAssertEqual(ranked(""), ["Michiel", "Kent", "Kenji", "Jaap"])
+    }
+
+    func testScoreOutranksBeingTheSignedInPerson() {
+        XCTAssertEqual(ranked("ken", current: "Michiel"), ["Kent", "Kenji"])
+        // Equal scores: the signed-in person leads, then roster order.
+        XCTAssertEqual(ranked("ken", current: "Kenji"), ["Kenji", "Kent"])
+    }
+
+    func testAFullNameAndATypoBothFind() {
+        XCTAssertEqual(ranked("bruin"), ["Kent"])
+        XCTAssertEqual(ranked("michel"), ["Michiel"])
+        XCTAssertEqual(ranked("nobody"), [])
+    }
+}

--- a/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
+++ b/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
@@ -21,28 +21,28 @@ final class SidebarSearchTests: XCTestCase {
         SidebarWorkspace(id: id, title: title, sessions: sessions, mainSession: sessions[0])
     }
 
-    func testATypoStillFindsTheRowAndItsSession() {
+    func testATypoStillFindsTheRowAndItsSession() throws {
         let release = session("os-1", title: "Release notes")
         let other = session("os-2", title: "Billing audit")
-        let matches = SidebarSearch.matches(
+        let matches = try XCTUnwrap(SidebarSearch.matches(
             query: "relase",
             rows: [row("a", title: "Release notes", [release]), row("b", title: "Billing audit", [other])],
             archived: [],
             workspaceNames: [:]
-        )
+        ))
         XCTAssertEqual(matches.workspaceIds, ["a"])
         XCTAssertEqual(matches.sessionIds, ["os-1"])
         XCTAssertTrue(matches.matches(release))
         XCTAssertFalse(matches.matches(other))
     }
 
-    func testAWorkspaceNameCountsForItsSessions() {
+    func testAWorkspaceNameCountsForItsSessions() throws {
         // Stamped on the row by the sessions route, or looked up by id when
         // an older server leaves it off.
         let stamped = session("os-1", title: "Fix hover", workspaceId: "w1", workspaceName: "Workspace cleanup")
         let lookedUp = session("os-2", title: "Fix focus", workspaceId: "w2")
         let unrelated = session("os-3", title: "Fix focus", workspaceId: "w3")
-        let matches = SidebarSearch.matches(
+        let matches = try XCTUnwrap(SidebarSearch.matches(
             query: "wrokspace",
             rows: [
                 row("a", title: "Fix hover", [stamped]),
@@ -51,18 +51,18 @@ final class SidebarSearchTests: XCTestCase {
             ],
             archived: [],
             workspaceNames: ["w2": "Workspace polish", "w3": "Sidebar"]
-        )
+        ))
         XCTAssertEqual(matches.workspaceIds, ["a", "b"])
     }
 
-    func testArchivedSessionsAreMatchedToo() {
+    func testArchivedSessionsAreMatchedToo() throws {
         let archived = session("os-old", title: "Release checklist")
-        let matches = SidebarSearch.matches(
+        let matches = try XCTUnwrap(SidebarSearch.matches(
             query: "relase",
             rows: [],
             archived: [archived],
             workspaceNames: [:]
-        )
+        ))
         XCTAssertEqual(matches.sessionIds, ["os-old"])
     }
 
@@ -73,9 +73,30 @@ final class SidebarSearchTests: XCTestCase {
         XCTAssertFalse(SidebarSearch.sessionMatches(hex, query: "abc"))
     }
 
-    func testAnEmptyQueryPassesEverything() {
-        let matches = SidebarSearch.matches(query: "  ", rows: [], archived: [], workspaceNames: [:])
+    func testAnEmptyQueryPassesEverything() throws {
+        let matches = try XCTUnwrap(
+            SidebarSearch.matches(query: "  ", rows: [], archived: [], workspaceNames: [:])
+        )
         XCTAssertTrue(matches.query.isEmpty)
         XCTAssertTrue(matches.matches(session("os-1", title: "Anything")))
+    }
+
+    func testACancelledScanStopsInsteadOfFinishing() async {
+        // The sidebar cancels a superseded keystroke's scan; on a list of
+        // thousands it has to give up at the next row, not run to the end.
+        let rows = (0..<200).map { index in
+            row("w\(index)", title: "Release \(index)", [session("os-\(index)", title: "Release \(index)")])
+        }
+        // The scan waits at the gate until it is cancelled, so it cannot
+        // finish before the cancel lands, whatever the machine's speed.
+        let gate = AsyncStream<Void>.makeStream()
+        let scan = Task.detached {
+            for await _ in gate.stream { break }
+            return SidebarSearch.matches(query: "relase", rows: rows, archived: [], workspaceNames: [:])
+        }
+        scan.cancel()
+        gate.continuation.finish()
+        let matches = await scan.value
+        XCTAssertNil(matches)
     }
 }

--- a/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
+++ b/packages/clients/ios/OS1Tests/SidebarSearchTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import OS1
+
+final class SidebarSearchTests: XCTestCase {
+    private func session(
+        _ id: String,
+        title: String? = nil,
+        branch: String? = nil,
+        workspaceId: String? = nil,
+        workspaceName: String? = nil
+    ) -> Session {
+        var session = Session(id: id)
+        session.title = title
+        session.branch = branch
+        session.workspaceId = workspaceId
+        session.workspaceName = workspaceName
+        return session
+    }
+
+    private func row(_ id: String, title: String, _ sessions: [Session]) -> SidebarWorkspace {
+        SidebarWorkspace(id: id, title: title, sessions: sessions, mainSession: sessions[0])
+    }
+
+    func testATypoStillFindsTheRowAndItsSession() {
+        let release = session("os-1", title: "Release notes")
+        let other = session("os-2", title: "Billing audit")
+        let matches = SidebarSearch.matches(
+            query: "relase",
+            rows: [row("a", title: "Release notes", [release]), row("b", title: "Billing audit", [other])],
+            archived: [],
+            workspaceNames: [:]
+        )
+        XCTAssertEqual(matches.workspaceIds, ["a"])
+        XCTAssertEqual(matches.sessionIds, ["os-1"])
+        XCTAssertTrue(matches.matches(release))
+        XCTAssertFalse(matches.matches(other))
+    }
+
+    func testAWorkspaceNameCountsForItsSessions() {
+        // Stamped on the row by the sessions route, or looked up by id when
+        // an older server leaves it off.
+        let stamped = session("os-1", title: "Fix hover", workspaceId: "w1", workspaceName: "Workspace cleanup")
+        let lookedUp = session("os-2", title: "Fix focus", workspaceId: "w2")
+        let unrelated = session("os-3", title: "Fix focus", workspaceId: "w3")
+        let matches = SidebarSearch.matches(
+            query: "wrokspace",
+            rows: [
+                row("a", title: "Fix hover", [stamped]),
+                row("b", title: "Fix focus", [lookedUp]),
+                row("c", title: "Fix focus", [unrelated])
+            ],
+            archived: [],
+            workspaceNames: ["w2": "Workspace polish", "w3": "Sidebar"]
+        )
+        XCTAssertEqual(matches.workspaceIds, ["a", "b"])
+    }
+
+    func testArchivedSessionsAreMatchedToo() {
+        let archived = session("os-old", title: "Release checklist")
+        let matches = SidebarSearch.matches(
+            query: "relase",
+            rows: [],
+            archived: [archived],
+            workspaceNames: [:]
+        )
+        XCTAssertEqual(matches.sessionIds, ["os-old"])
+    }
+
+    func testAnIdIsAnExactSubstringOnly() {
+        let hex = session("os-4a5b3c", title: "Unrelated")
+        XCTAssertTrue(SidebarSearch.sessionMatches(hex, query: "4A5B"))
+        // "abc" is a subsequence of the id's hex, which must not count.
+        XCTAssertFalse(SidebarSearch.sessionMatches(hex, query: "abc"))
+    }
+
+    func testAnEmptyQueryPassesEverything() {
+        let matches = SidebarSearch.matches(query: "  ", rows: [], archived: [], workspaceNames: [:])
+        XCTAssertTrue(matches.query.isEmpty)
+        XCTAssertTrue(matches.matches(session("os-1", title: "Anything")))
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -18,8 +18,12 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   sharing `/api/snoozes` with the web sidebar. Activity restores Needs action,
   Recent, Yesterday, and Earlier; Status remains the dynamic lane view. Group
   by project is an independent switch for all three modes. The
-  compact toolbar search/filter finds session metadata
-  and conversation text through `/api/sessions/search`. iOS long-press actions
+  compact toolbar search/filter finds session metadata (title, repository,
+  branch, workspace name) with the web's typo-tolerant matcher
+  (`Models/FuzzyMatch.swift`, a port of `shared/fuzzy-match.ts`, scored off
+  the main actor by `SidebarSearch`) and conversation text through
+  `/api/sessions/search`. The Mac command palette and the `@` palette's people
+  rows rank by the same scorer. iOS long-press actions
   include details, rename, sharing, pull request, pin, hide, Snooze/Unsnooze,
   and Archive. Swipe right pins; swipe left offers Snooze and Archive.
   Pinned rows are lifted into a Pinned band at the top in the user's own order,


### PR DESCRIPTION
Ports the typo-tolerant matching from 5b51f4d1e (`shared/fuzzy-match.ts`) to the native Swift client. One of the 8 items from the "14 native parity gaps" report; scoped to this item only.

## What changed

- **`OS1/Models/FuzzyMatch.swift`**: a rule-for-rule port of the shared scorer. Lowercase + NFKD + strip combining marks; exact 100 / prefix 90 / word prefix 80 / substring 70; per-term edit budget (0 under 4 chars, 1 under 8, else 2) with optimal string alignment so an adjacent transposition is one edit; in-word subsequences at 20 for terms of 3+; multi-term queries need every term and average the per-term scores.
- **`OS1/SidebarSearch.swift`**: the sidebar filter scores title, repository, branch and **workspace name** (stamped `workspaceName`, or the name map for older servers). Ids stay an exact substring match, since a hex id would otherwise answer to any three-letter abbreviation. Runs in a detached task keyed on the query and the row arrays (buffer-identity equality, so an unchanged body costs nothing); the row predicate on the main actor is a set lookup. The previous answer stays on screen until the next lands, so a keystroke narrows rather than blanks.
- **Mac command palette** (`CommandPaletteRanking`): same scorer; a title match ranks a band above a subtitle/keyword match; kind, score, recency, declared order break ties as before.
- **`@` palette people** (`MentionRanking`): ranked by score, then the signed-in person, then roster order. Tools, workspaces and sessions are already ranked by the server with the same matcher.

## Parity fixtures

`FuzzyMatchTests` mirrors `fuzzy-match.test.ts`; the numbers were checked against the TypeScript with `bun`: `relase`→`Release work` 40, `wrokspace`→`Workspace cleanup` 40, `wrkospace`→`workspace` 30, `wksp`→`workspace` 20, `cat`→`cut` 0, `jaap`→`Jääp` 100. `SidebarSearchTests`, `MentionRankingTests` and three new `CommandPaletteTests` cover the surfaces.

## Verification

- `xcodebuild` OS1 (iOS Simulator) and OS1Mac: both build. OS1Mac tests: 31 pass, 0 fail (FuzzyMatch 8, SidebarSearch 5, MentionRanking 3, CommandPalette 15).
- `bun run check` passed.
- Native proof on the Mac target against the live server (17k sessions), search hook `OS1_SEARCH_QUERY=relase`:

| before (`origin/main`) | after |
| --- | --- |
| "relase" finds no Release rows | 17 rows: "Review · PR #6301 Release auto-c…", "Publish the OS 0.4.0 Mac release", "Plan audio enhancement release testing", "Rebase…" (one substitution away, as on the web) |

Screenshots are in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-445f7a5e-4d76-7b94-9c19-fc8f6360684d)