### PR TITLE
Native app: show merge risk beside the review's quality score

### DIFF
--- a/packages/clients/ios/OS1/Models/Session.swift
+++ b/packages/clients/ios/OS1/Models/Session.swift
@@ -359,14 +359,129 @@ struct PrChecksSummary: Decodable, Equatable, Hashable {
 struct OsReviewSummary: Decodable, Equatable, Hashable {
     /// approve | comment | request_changes.
     var verdict: String?
-    /// 1-5: how safe the reviewer thought this was to merge.
+    /// 1-5: quality of the change as written. Not how safe it is to land:
+    /// that is `risk`, scored on its own.
     var confidence: Int?
+    /// How hard a mistake would be to undo, scored separately from quality.
+    var risk: MergeRisk?
+    /// Time to recover every user if the change is wrong.
+    var recovery: RecoveryTime?
+    /// Why the risk is what it is: factor ids from the server's fixed list
+    /// (`schema_migration`, `no_tests`, …), heaviest first. See
+    /// `MergeRiskFactor.label` for the words they are shown as.
+    var riskFactors: [String]?
     var findings: Int?
     /// P0/P1 findings — what would block a merge.
     var blocking: Int?
     /// The branch has moved on since this verdict — it describes older code.
     var stale: Bool?
     var at: String?
+
+    init(
+        verdict: String? = nil,
+        confidence: Int? = nil,
+        risk: MergeRisk? = nil,
+        recovery: RecoveryTime? = nil,
+        riskFactors: [String]? = nil,
+        findings: Int? = nil,
+        blocking: Int? = nil,
+        stale: Bool? = nil,
+        at: String? = nil
+    ) {
+        self.verdict = verdict
+        self.confidence = confidence
+        self.risk = risk
+        self.recovery = recovery
+        self.riskFactors = riskFactors
+        self.findings = findings
+        self.blocking = blocking
+        self.stale = stale
+        self.at = at
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case verdict, confidence, risk, recovery, riskFactors, findings, blocking, stale, at
+    }
+
+    /// A review is nested in every session row, so a word this client does not
+    /// know (a fourth risk level, a new recovery time) must cost that one field
+    /// and never the row: the sessions list decodes as a whole.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        verdict = try container.decodeIfPresent(String.self, forKey: .verdict)
+        confidence = try container.decodeIfPresent(Int.self, forKey: .confidence)
+        risk = (try? container.decodeIfPresent(MergeRisk.self, forKey: .risk)) ?? nil
+        recovery = (try? container.decodeIfPresent(RecoveryTime.self, forKey: .recovery)) ?? nil
+        riskFactors = (try? container.decodeIfPresent([String].self, forKey: .riskFactors)) ?? nil
+        findings = try container.decodeIfPresent(Int.self, forKey: .findings)
+        blocking = try container.decodeIfPresent(Int.self, forKey: .blocking)
+        stale = try container.decodeIfPresent(Bool.self, forKey: .stale)
+        at = try container.decodeIfPresent(String.self, forKey: .at)
+    }
+}
+
+/// The review's second axis. Quality asks whether the change is right as
+/// written; this asks how long every user is wrong for if it is not.
+/// Advisory: it never changes the verdict, only how carefully to land it.
+enum MergeRisk: String, Decodable, Equatable, Hashable, CaseIterable {
+    case low, medium, high
+
+    /// "high risk": the phrase every compact reading uses, so the sidebar
+    /// preview, the review row and the loop's verdict all say it one way.
+    var label: String { "\(rawValue) risk" }
+
+    /// Title case for a labelled row, where "Merge risk" already says what
+    /// the word is.
+    var word: String { rawValue.capitalized }
+
+    /// What VoiceOver says. "4/5 · high risk" spoken as written is one
+    /// number and one word with nothing telling which is which, so each axis
+    /// is named: "quality 4 of 5, merge risk high".
+    var accessibilityLabel: String { "merge risk \(rawValue)" }
+}
+
+/// How long a wrong change takes to undo for everyone.
+enum RecoveryTime: String, Decodable, Equatable, Hashable, CaseIterable {
+    case minutes, hours, days, irreversible
+
+    var label: String {
+        switch self {
+        case .minutes: "minutes to recover"
+        case .hours: "hours to recover"
+        case .days: "days to recover"
+        case .irreversible: "not recoverable"
+        }
+    }
+}
+
+/// The words behind a risk factor id. The server's `RISK_FACTOR_LABELS`
+/// (agents/github/merge-risk.ts), kept in step by hand; an id this list does
+/// not know reads as its own words rather than as an underscore.
+enum MergeRiskFactor {
+    private static let labels: [String: String] = [
+        "schema_migration": "schema migration",
+        "data_backfill": "data backfill",
+        "irreversible_delete": "irreversible delete",
+        "data_to_third_party": "data to a third party",
+        "new_external_service": "new external service",
+        "dependency_change": "dependency change",
+        "dns_or_infra": "DNS or infra",
+        "secrets_or_config": "secrets or config",
+        "auth": "auth",
+        "billing": "billing",
+        "auth_or_billing": "auth or billing",
+        "public_api_contract": "public API contract",
+        "stored_data_semantics": "stored data semantics",
+        "delivered_output": "delivered output",
+        "ci_or_deploy": "CI or deploy",
+        "wide_blast_radius": "wide blast radius",
+        "no_tests": "no tests",
+        "large_diff": "large diff",
+    ]
+
+    static func label(_ id: String) -> String {
+        labels[id] ?? id.replacingOccurrences(of: "_", with: " ")
+    }
 }
 
 extension Session {

--- a/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
+++ b/packages/clients/ios/OS1/ViewModels/TranscriptBlocks.swift
@@ -151,8 +151,11 @@ struct ReviewLoopResult: Equatable {
     enum Status: Equatable { case pending, passed, failed }
 
     var status: Status
-    /// 1-5: how safe the reviewer thought this was to merge.
+    /// 1-5: quality of the change as written.
     var confidence: Int?
+    /// How hard a mistake would be to undo. Advisory: it colours one word of
+    /// the facts and never moves the verdict, the same as on the server.
+    var risk: MergeRisk?
     var checksPassed: Int?
     var checksFailed: Int?
     /// P0/P1 findings — what would block a merge.
@@ -167,6 +170,7 @@ struct ReviewLoopResult: Equatable {
         else { return nil }
         let checks = session.prChecks
         confidence = review.confidence
+        risk = review.risk
         checksPassed = checks?.passed
         checksFailed = checks?.failed
         blocking = review.blocking
@@ -183,12 +187,19 @@ struct ReviewLoopResult: Equatable {
         status = failed ? .failed : .passed
     }
 
-    /// "2 rounds · 4/5 · 1 blocking · 3 checks passed" — the numbers behind
-    /// the verdict, in the web's order, with empty pieces dropped rather than
-    /// leaving stray separators.
+    /// "2 rounds · 4/5 · high risk · 1 blocking · 3 checks passed" — the
+    /// numbers behind the verdict, in the web's order, with empty pieces
+    /// dropped rather than leaving stray separators.
     func facts(rounds: Int) -> String {
+        factList(rounds: rounds).joined(separator: " · ")
+    }
+
+    /// The same facts one phrase at a time, so the row can give the risk its
+    /// own colour without the view re-deriving what counts as a fact.
+    func factList(rounds: Int) -> [String] {
         var parts = ["\(rounds) round\(rounds == 1 ? "" : "s")"]
         if let confidence { parts.append("\(confidence)/5") }
+        if let risk { parts.append(risk.label) }
         if let blocking, blocking > 0 { parts.append("\(blocking) blocking") }
         if let checksFailed, checksFailed > 0 {
             parts.append("\(checksFailed) check\(checksFailed == 1 ? "" : "s") failed")
@@ -196,7 +207,19 @@ struct ReviewLoopResult: Equatable {
         if let checksPassed, checksPassed > 0 {
             parts.append("\(checksPassed) checks passed")
         }
-        return parts.joined(separator: " · ")
+        return parts
+    }
+
+    /// The facts as VoiceOver should say them. "4/5" and "high risk" read
+    /// aloud in a row are a number and a word with nothing saying which
+    /// question each answers, so both axes are named.
+    func accessibilityFacts(rounds: Int) -> String {
+        factList(rounds: rounds).map { part in
+            if let confidence, part == "\(confidence)/5" { return "quality \(confidence) of 5" }
+            if let risk, part == risk.label { return risk.accessibilityLabel }
+            return part
+        }
+        .joined(separator: ", ")
     }
 }
 

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -596,6 +596,12 @@ struct PrPanelView: View {
 
     @ViewBuilder
     private func statusGroup(_ pr: PrDetails) -> some View {
+        // The agent's two readings close the card, so every row above them
+        // has to know whether it is last: the hairline is drawn by the row
+        // above the gap, not the one below it.
+        let decision = reviewBadge(pr.reviewDecision)
+        let quality = agentQualityRow(pr.osReview)
+        let risk = agentRiskRow(pr.osReview)
         infoGroup(
             "Status",
             answer: Text(stateLabel(pr)).foregroundColor(pr.summary.color)
@@ -607,18 +613,33 @@ struct PrPanelView: View {
                     "Merge",
                     value: "Conflicts with \(pr.baseRefName ?? "the base")",
                     tint: OS1VisualStyle.yellowInk,
-                    last: reviewBadge(pr.reviewDecision) == nil
+                    last: decision == nil && quality == nil && risk == nil
                 )
             } else if pr.isOpen {
                 infoRow(
                     "Merge",
                     value: "No conflicts",
                     tint: OS1VisualStyle.greenInk,
-                    last: reviewBadge(pr.reviewDecision) == nil
+                    last: decision == nil && quality == nil && risk == nil
                 )
             }
-            if let decision = reviewBadge(pr.reviewDecision) {
-                infoRow("Review", value: decision.label, tint: decision.color, last: true)
+            if let decision {
+                infoRow(
+                    "Review",
+                    value: decision.label,
+                    tint: decision.color,
+                    last: quality == nil && risk == nil
+                )
+            }
+            // Quality and merge risk are two rows, not one: the number says
+            // whether the change is right as written, the word says how
+            // carefully to land it, and a reader (or VoiceOver) should never
+            // have to work out which is which from their order.
+            if let quality {
+                infoRow("Quality", value: quality.value, tint: quality.tint, last: risk == nil)
+            }
+            if let risk {
+                infoRow("Merge risk", value: risk.value, tint: risk.tint, last: true)
             }
             if let error = actionError {
                 Text(error)
@@ -1112,6 +1133,32 @@ struct PrPanelView: View {
         Text(text)
             .font(.footnote)
             .foregroundStyle(.secondary)
+    }
+
+    /// "4/5", faint with a note once the branch has moved past the reading.
+    private func agentQualityRow(_ review: OsReviewSummary?) -> (value: String, tint: Color)? {
+        guard let score = review?.confidence else { return nil }
+        return PrPanelView.agentQualityValue(score: score, stale: review?.stale == true)
+    }
+
+    /// "High" in the level's own status ink; the same faint treatment when
+    /// stale, because a risk scored on older code is not this code's risk.
+    private func agentRiskRow(_ review: OsReviewSummary?) -> (value: String, tint: Color)? {
+        guard let risk = review?.risk else { return nil }
+        return PrPanelView.agentRiskValue(risk: risk, stale: review?.stale == true)
+    }
+
+    static func agentQualityValue(score: Int, stale: Bool) -> (value: String, tint: Color) {
+        stale
+            ? ("\(score)/5 · new commits since", OS1VisualStyle.textFaint)
+            : ("\(score)/5", OS1VisualStyle.text)
+    }
+
+    static func agentRiskValue(risk: MergeRisk, stale: Bool) -> (value: String, tint: Color) {
+        (
+            stale ? "\(risk.word) · new commits since" : risk.word,
+            risk.tone(stale: stale).color
+        )
     }
 
     private func reviewBadge(_ decision: String?) -> (label: String, color: Color)? {

--- a/packages/clients/ios/OS1/Views/ReviewLoopView.swift
+++ b/packages/clients/ios/OS1/Views/ReviewLoopView.swift
@@ -223,6 +223,26 @@ struct ReviewLoopView: View {
     }
 }
 
+#if DEBUG
+/// The verdict row over a fixture review, for the native screenshot harness.
+struct ReviewLoopResultFixture: View {
+    let review: OsReviewSummary
+
+    var body: some View {
+        var session = Session(id: "screenshot-session")
+        session.prNumber = 128
+        session.prState = "OPEN"
+        session.prChecks = PrChecksSummary(total: 3, passed: 3, failed: 0, pending: 0)
+        session.prOsReview = review
+        return Group {
+            if let result = ReviewLoopResult(session: session) {
+                ReviewLoopResultRow(result: result, rounds: 2)
+            }
+        }
+    }
+}
+#endif
+
 /// What the loop concluded, once GitHub has settled: the result first, the
 /// numbers behind it as meta.
 private struct ReviewLoopResultRow: View {
@@ -263,6 +283,7 @@ private struct ReviewLoopResultRow: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(passed ? "Review passed" : "Review failed")
+        .accessibilityValue(result.accessibilityFacts(rounds: rounds))
     }
 
     private var verdictMark: some View {
@@ -278,8 +299,20 @@ private struct ReviewLoopResultRow: View {
             .foregroundStyle(OS1VisualStyle.textDim)
     }
 
+    /// The facts are one faint run, except the risk word, which takes its
+    /// level's own ink: it is the one fact here that is advice about landing
+    /// rather than a count, and a verdict that reads "Ready to merge" still
+    /// deserves a red "high risk" beside it.
     private var facts: some View {
-        Text(result.facts(rounds: rounds))
+        result.factList(rounds: rounds)
+            .enumerated()
+            .map { index, part in
+                let text = Text(index == 0 ? part : " · \(part)")
+                guard let risk = result.risk, part == risk.label else { return text }
+                return Text(index == 0 ? "" : " · ")
+                    + Text(part).foregroundStyle(risk.tone(stale: false).color)
+            }
+            .reduce(Text(""), +)
             .font(.caption2)
             .foregroundStyle(OS1VisualStyle.textFaint)
     }

--- a/packages/clients/ios/OS1/Views/SessionRowPreview.swift
+++ b/packages/clients/ios/OS1/Views/SessionRowPreview.swift
@@ -116,6 +116,7 @@ struct SessionRowPreview: View {
                 Text(fact.text)
                     .font(.caption.weight(.medium))
                     .foregroundStyle(fact.tone.color)
+                    .accessibilityLabel(fact.accessibilityText)
                     // One line is right while a fact is a few words wide. At
                     // an accessibility size a single fact can be wider than
                     // the whole card, and one line then means the end of the
@@ -309,6 +310,14 @@ struct PrPreviewFact: Equatable {
 
     let text: String
     let tone: Tone
+    /// What VoiceOver says when the visible phrase leans on layout to be
+    /// understood. "5/5" and "high risk" sit apart on the strip and are
+    /// coloured apart, but read aloud they are one number and one word with
+    /// nothing naming the axis, so those facts spell it out: "quality 5 of
+    /// 5, approved", "merge risk high". Nil when the text already says it all.
+    var spoken: String? = nil
+
+    var accessibilityText: String { spoken ?? text }
 }
 
 extension MergeRisk {
@@ -423,15 +432,22 @@ enum PrPreviewFacts {
         default: "reviewed"
         }
         var parts = [String]()
+        var spoken = [String]()
         if let confidence = review.confidence {
             parts.append("\(confidence)/5")
+            spoken.append("quality \(confidence) of 5")
         }
         parts.append(word)
+        spoken.append(word)
         if let blocking = review.blocking, blocking > 0 {
             parts.append("\(blocking) blocking")
+            spoken.append("\(blocking) blocking")
         }
         let stale = review.stale == true
-        if stale { parts.append("stale") }
+        if stale {
+            parts.append("stale")
+            spoken.append("stale")
+        }
         let tone: PrPreviewFact.Tone = if stale {
             .faint
         } else {
@@ -441,7 +457,11 @@ enum PrPreviewFacts {
             default: .dim
             }
         }
-        return PrPreviewFact(text: parts.joined(separator: " · "), tone: tone)
+        return PrPreviewFact(
+            text: parts.joined(separator: " · "),
+            tone: tone,
+            spoken: spoken.joined(separator: ", ")
+        )
     }
 
     /// Merge risk, as its own phrase after the reading. The web folds it into
@@ -451,7 +471,11 @@ enum PrPreviewFacts {
     /// Nothing without a level: a repo can opt out of the risk pass.
     static func mergeRiskFact(_ review: OsReviewSummary) -> PrPreviewFact? {
         guard let risk = review.risk else { return nil }
-        return PrPreviewFact(text: risk.label, tone: risk.tone(stale: review.stale == true))
+        return PrPreviewFact(
+            text: risk.label,
+            tone: risk.tone(stale: review.stale == true),
+            spoken: risk.accessibilityLabel
+        )
     }
 
     /// Who the PR is waiting on. Two names is the most that fits before the

--- a/packages/clients/ios/OS1/Views/SessionRowPreview.swift
+++ b/packages/clients/ios/OS1/Views/SessionRowPreview.swift
@@ -20,7 +20,9 @@ import SwiftUI
 ///   card has 300px and a label column; a phone has neither, and a 74pt label
 ///   gutter would leave its values a dozen characters wide.
 /// - **The review is compact.** Its score leads the verdict (`4/5 · approved`),
-///   with blocking and stale context retained when present.
+///   with blocking and stale context retained when present. Merge risk is
+///   its own phrase beside it, in its own colour: a correct migration and a
+///   sloppy CSS tweak can share a score and still land very differently.
 ///
 /// What deliberately did NOT come across is the web footer's centred Merge
 /// button. A context menu preview is not interactive: taps go to the menu, so
@@ -189,20 +191,59 @@ struct PrReviewCardsScreenshot: View {
                 card(
                     title: "Ready after review",
                     review: OsReviewSummary(
-                        verdict: "approve", confidence: 4, findings: 0, blocking: 0, stale: false
+                        verdict: "approve", confidence: 4, risk: .low, recovery: .minutes,
+                        findings: 0, blocking: 0, stale: false
+                    )
+                )
+                card(
+                    title: "Right as written, hard to undo",
+                    review: OsReviewSummary(
+                        verdict: "approve", confidence: 5, risk: .high, recovery: .days,
+                        riskFactors: ["schema_migration", "no_tests"],
+                        findings: 0, blocking: 0, stale: false
                     )
                 )
                 card(
                     title: "Address blocking feedback",
                     review: OsReviewSummary(
-                        verdict: "request_changes", confidence: 2,
-                        findings: 2, blocking: 1, stale: false
+                        verdict: "request_changes", confidence: 2, risk: .medium,
+                        recovery: .hours, findings: 2, blocking: 1, stale: false
                     )
                 )
                 card(
                     title: "Review is behind the branch",
                     review: OsReviewSummary(
-                        verdict: "comment", confidence: 3, findings: 1, blocking: 0, stale: true
+                        verdict: "comment", confidence: 3, risk: .high, recovery: .days,
+                        findings: 1, blocking: 0, stale: true
+                    )
+                )
+
+                Text("Review loop verdict")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(OS1VisualStyle.text)
+                    .padding(.top, 8)
+                ReviewLoopResultFixture(
+                    review: OsReviewSummary(
+                        verdict: "approve", confidence: 5, risk: .high,
+                        findings: 0, blocking: 0, stale: false
+                    )
+                )
+
+                Text("Workspace review rows")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(OS1VisualStyle.text)
+                    .padding(.top, 8)
+                reviewRows(
+                    OsReviewSummary(
+                        verdict: "approve", confidence: 5, risk: .high, recovery: .days,
+                        riskFactors: ["schema_migration", "no_tests"],
+                        findings: 0, blocking: 0, stale: false
+                    )
+                )
+                reviewRows(
+                    OsReviewSummary(
+                        verdict: "approve", confidence: 4, risk: .high, recovery: .days,
+                        findings: 0, blocking: 0, stale: true
                     )
                 )
             }
@@ -210,6 +251,24 @@ struct PrReviewCardsScreenshot: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(OS1VisualStyle.background)
+    }
+
+    /// The workspace sheet's Review section over a fixture pull request.
+    private func reviewRows(_ review: OsReviewSummary) -> some View {
+        var pr = PrDetails(number: 128)
+        pr.title = "Drop users.legacy_id"
+        pr.state = "OPEN"
+        pr.osReview = review
+        return WorkspaceReviewRows(
+            sessionId: "screenshot-session",
+            sessions: [Session(id: "screenshot-session")],
+            pr: pr,
+            repo: "opensession"
+        )
+        .background(
+            OS1VisualStyle.raised,
+            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+        )
     }
 
     private func card(title: String, review: OsReviewSummary) -> some View {
@@ -252,6 +311,23 @@ struct PrPreviewFact: Equatable {
     let tone: Tone
 }
 
+extension MergeRisk {
+    /// The one colour a risk level takes, everywhere it is shown. The app's
+    /// own status inks rather than the web's `text-red`/`text-yellow`: high
+    /// is the red the strip uses for a failed check, medium the yellow of a
+    /// running one, and low is said in the dim ink because a low risk is not
+    /// news. A stale reading goes faint with the rest of the review: the
+    /// branch has moved on, so the level describes older code.
+    func tone(stale: Bool) -> PrPreviewFact.Tone {
+        if stale { return .faint }
+        switch self {
+        case .high: return .red
+        case .medium: return .yellow
+        case .low: return .dim
+        }
+    }
+}
+
 /// Builds the preview's fact strip. Pure, and separated from the view so the
 /// editorial calls below (which fact is redundant, when a verdict is stale)
 /// can be tested without a screen.
@@ -267,6 +343,9 @@ enum PrPreviewFacts {
         }
         if let osReview = session.prOsReview.flatMap(osReviewFact) {
             facts.append(osReview)
+        }
+        if let risk = session.prOsReview.flatMap(mergeRiskFact) {
+            facts.append(risk)
         }
         if let waiting = reviewersFact(session.prReviewRequested, state: state) {
             facts.append(waiting)
@@ -363,6 +442,16 @@ enum PrPreviewFacts {
             }
         }
         return PrPreviewFact(text: parts.joined(separator: " · "), tone: tone)
+    }
+
+    /// Merge risk, as its own phrase after the reading. The web folds it into
+    /// the review text (`4/5 · approved · high risk`); here it stands apart
+    /// because the strip colours per phrase, and a red "high risk" beside a
+    /// green "5/5 · approved" is the whole point of scoring the two apart.
+    /// Nothing without a level: a repo can opt out of the risk pass.
+    static func mergeRiskFact(_ review: OsReviewSummary) -> PrPreviewFact? {
+        guard let risk = review.risk else { return nil }
+        return PrPreviewFact(text: risk.label, tone: risk.tone(stale: review.stale == true))
     }
 
     /// Who the PR is waiting on. Two names is the most that fits before the

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -350,11 +350,23 @@ struct SessionsListView: View {
     }
     #endif
 
+    /// The native screenshot harness's PR review fixture. On the phone it
+    /// floats over the list; on the Mac it takes the detail column, because an
+    /// overlay on a `NavigationSplitView` never reaches the AppKit split view
+    /// that draws it. Always false in a release build.
+    private var presentsPrReviewCardsFixture: Bool {
+        #if DEBUG
+        ProcessInfo.processInfo.environment["OS1_PR_REVIEW_CARDS_FIXTURE"] == "1"
+        #else
+        false
+        #endif
+    }
+
     var body: some View {
         navigationContainer
-            #if DEBUG
+            #if DEBUG && os(iOS)
             .overlay {
-                if ProcessInfo.processInfo.environment["OS1_PR_REVIEW_CARDS_FIXTURE"] == "1" {
+                if presentsPrReviewCardsFixture {
                     PrReviewCardsScreenshot()
                 }
             }
@@ -599,7 +611,11 @@ struct SessionsListView: View {
         } detail: {
             // A ticket takes the detail column the way a session does — the
             // sidebar's deeper panel, not a window over it.
-            if let openTicket {
+            if presentsPrReviewCardsFixture {
+                #if DEBUG
+                PrReviewCardsScreenshot()
+                #endif
+            } else if let openTicket {
                 SupportThreadView(row: openTicket) {
                     supportQueue.forget(id: openTicket.id)
                 }

--- a/packages/clients/ios/OS1/Views/WorkspaceReviewRows.swift
+++ b/packages/clients/ios/OS1/Views/WorkspaceReviewRows.swift
@@ -127,6 +127,7 @@ private struct AgentReviewRow: View {
 
     private var review: OsReviewSummary? { pr.osReview }
     private var score: Int? { review?.confidence }
+    private var risk: MergeRisk? { review?.risk }
     private var stale: Bool { review?.stale == true }
     private var actionable: Bool { pr.isOpen }
     private var active: Bool { pr.reviewActive == true || busy == .review || queued != nil }
@@ -169,6 +170,7 @@ private struct AgentReviewRow: View {
             },
             name: agentName,
             detail: detail,
+            detailSpoken: detailSpoken,
             tint: tone.ink,
             note: note,
             error: error,
@@ -222,8 +224,8 @@ private struct AgentReviewRow: View {
         .onChange(of: pr.reviewActive) { _, _ in settle() }
         .onChange(of: pr.osReview?.at) { _, _ in settle() }
         .sheet(isPresented: $readingReport) {
-            if let report {
-                AgentReviewReport(report: report, score: score, at: review?.at)
+            if let report, let review {
+                AgentReviewReport(report: report, review: review)
             }
         }
     }
@@ -236,12 +238,32 @@ private struct AgentReviewRow: View {
         return score == 3 ? .yellow : .red
     }
 
-    /// How safe it thought the change was, then the one thing worth knowing
+    /// The quality score, the merge risk, then the one thing worth knowing
     /// about that reading. The score leads because it is the answer; a run
-    /// that has no score yet simply starts at the words.
-    private var detail: String {
-        guard let score, !active else { return state }
-        return "\(score)/5 · \(state)"
+    /// that has no score yet simply starts at the words. The risk is the
+    /// only piece in its own colour: the row's tint is the verdict's, and a
+    /// green row can still carry a red "high risk" without becoming a red row.
+    private var detail: Text {
+        guard !active else { return Text(state) }
+        var pieces: [Text] = []
+        if let score { pieces.append(Text("\(score)/5")) }
+        if let risk {
+            pieces.append(Text(risk.label).foregroundStyle(risk.tone(stale: stale).color))
+        }
+        pieces.append(Text(state))
+        return pieces.dropFirst().reduce(pieces[0]) { $0 + Text(" · ") + $1 }
+    }
+
+    /// The same reading for VoiceOver, with each axis named: "4/5 · high
+    /// risk" spoken as written is a number and a word with nothing saying
+    /// which question each answers.
+    private var detailSpoken: String {
+        guard !active else { return state }
+        var pieces: [String] = []
+        if let score { pieces.append("quality \(score) of 5") }
+        if let risk { pieces.append(risk.accessibilityLabel) }
+        pieces.append(state)
+        return pieces.joined(separator: ", ")
     }
 
     private var state: String {
@@ -364,7 +386,8 @@ private struct ReviewerRow: View {
                 }
             },
             name: rowName,
-            detail: rowState,
+            detail: Text(rowState),
+            detailSpoken: rowState,
             tint: tone.ink,
             note: nil,
             error: error,
@@ -569,18 +592,24 @@ private struct ReviewerRow: View {
 /// rendered as what it is — the comment, in the app's markdown.
 private struct AgentReviewReport: View {
     let report: PrComment
-    let score: Int?
-    let at: String?
+    let review: OsReviewSummary
 
     @Environment(\.dismiss) private var dismiss
+
+    private var score: Int? { review.confidence }
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                MarkdownBody(text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
+                VStack(alignment: .leading, spacing: 12) {
+                    if let risk = review.risk {
+                        MergeRiskLine(risk: risk, review: review)
+                    }
+                    MarkdownBody(text)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
             .background(OS1VisualStyle.chatCanvas)
             .navigationTitle("Review")
@@ -592,6 +621,7 @@ private struct AgentReviewReport: View {
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(OS1VisualStyle.textDim)
                             .monospacedDigit()
+                            .accessibilityLabel("Quality \(score) of 5")
                     }
                 }
                 ToolbarItem(placement: .topTrailingCompat) {
@@ -609,6 +639,43 @@ private struct AgentReviewReport: View {
     }
 }
 
+/// Merge risk above the write-up: the level in its ink, then how long a
+/// wrong change takes to undo and what earned the level. The comment below
+/// says the same at length; this is the one line to read before it.
+private struct MergeRiskLine: View {
+    let risk: MergeRisk
+    let review: OsReviewSummary
+
+    private var stale: Bool { review.stale == true }
+
+    /// "days to recover · schema migration, no tests", or nothing when the
+    /// server sent only the level.
+    private var evidence: String? {
+        var parts: [String] = []
+        if let recovery = review.recovery { parts.append(recovery.label) }
+        if let factors = review.riskFactors, !factors.isEmpty {
+            parts.append(factors.map(MergeRiskFactor.label).joined(separator: ", "))
+        }
+        if stale { parts.append("new commits since") }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(risk.word) merge risk")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(risk.tone(stale: stale).color)
+            if let evidence {
+                Text(evidence)
+                    .font(.caption)
+                    .foregroundStyle(OS1VisualStyle.textDim)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(risk.accessibilityLabel + (evidence.map { ", \($0)" } ?? ""))
+    }
+}
+
 // MARK: - Shared row chrome
 
 /// One review row: who, how it stands, and what you can do about it.
@@ -617,7 +684,10 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
     @ViewBuilder let leading: Leading
     /// Nil when the state already says who it is about ("Needs your review").
     let name: String?
-    let detail: String
+    let detail: Text
+    /// The detail as VoiceOver reads it, where the printed one leans on
+    /// colour or on a number's position to say what it is.
+    let detailSpoken: String
     let tint: Color
     let note: String?
     let error: String?
@@ -632,9 +702,12 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
                 if let onTap {
                     Button(action: onTap) { identity }
                         .buttonStyle(.plain)
+                        .accessibilityLabel(spoken)
                         .accessibilityHint("Opens the review")
                 } else {
                     identity
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(spoken)
                 }
                 Spacer(minLength: 8)
                 trailing
@@ -659,6 +732,10 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
         )
     }
 
+    private var spoken: String {
+        [name, detailSpoken].compactMap { $0 }.joined(separator: ", ")
+    }
+
     /// Who the row is about and where that review stands. One block, because
     /// it is one tap target when the row leads to the reading behind it.
     private var identity: some View {
@@ -671,7 +748,7 @@ private struct ReviewRow<Leading: View, Trailing: View>: View {
                         .foregroundStyle(OS1VisualStyle.text)
                         .lineLimit(1)
                 }
-                Text(detail)
+                detail
                     .font(.caption)
                     .foregroundStyle(tint)
                     .lineLimit(2)

--- a/packages/clients/ios/OS1Tests/MergeRiskTests.swift
+++ b/packages/clients/ios/OS1Tests/MergeRiskTests.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import XCTest
+@testable import OS1
+
+/// The review's second axis as the native app decodes and words it: merge
+/// risk arrives beside the 1-5 quality score and must never be mistaken for
+/// it, on screen or under VoiceOver.
+final class MergeRiskTests: XCTestCase {
+    private func review(_ json: String) throws -> OsReviewSummary {
+        try JSONDecoder().decode(OsReviewSummary.self, from: Data(json.utf8))
+    }
+
+    // MARK: - Decoding
+
+    func testRiskFieldsDecodeBesideTheQualityScore() throws {
+        let review = try review("""
+        {"verdict":"approve","confidence":5,"risk":"high","recovery":"days",
+         "riskFactors":["schema_migration","no_tests"],"findings":0,"blocking":0,
+         "stale":false,"at":"2026-09-11T08:00:00Z"}
+        """)
+        XCTAssertEqual(review.confidence, 5)
+        XCTAssertEqual(review.risk, .high)
+        XCTAssertEqual(review.recovery, .days)
+        XCTAssertEqual(review.riskFactors, ["schema_migration", "no_tests"])
+        XCTAssertEqual(review.stale, false)
+    }
+
+    func testOlderServerWithoutRiskStillDecodes() throws {
+        let review = try review(#"{"verdict":"comment","confidence":3,"findings":1,"blocking":0}"#)
+        XCTAssertEqual(review.confidence, 3)
+        XCTAssertNil(review.risk)
+        XCTAssertNil(review.recovery)
+        XCTAssertNil(review.riskFactors)
+    }
+
+    func testUnknownRiskWordsCostOnlyTheirOwnField() throws {
+        // A level or recovery time this build does not know drops to nil;
+        // the score, verdict and the session row around it all survive.
+        let review = try review("""
+        {"verdict":"approve","confidence":4,"risk":"critical","recovery":"weeks",
+         "riskFactors":"schema_migration","findings":0,"blocking":0}
+        """)
+        XCTAssertEqual(review.verdict, "approve")
+        XCTAssertEqual(review.confidence, 4)
+        XCTAssertNil(review.risk)
+        XCTAssertNil(review.recovery)
+        XCTAssertNil(review.riskFactors)
+    }
+
+    func testRiskRidesTheSessionRow() throws {
+        let json = """
+        {"id":"os-1","prNumber":7,"prState":"OPEN",
+         "prOsReview":{"verdict":"approve","confidence":5,"risk":"medium","recovery":"hours"}}
+        """
+        let session = try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+        XCTAssertEqual(session.prOsReview?.risk, .medium)
+        XCTAssertEqual(session.prOsReview?.recovery, .hours)
+    }
+
+    // MARK: - Words
+
+    func testFactorIdsReadAsTheServersLabels() {
+        XCTAssertEqual(MergeRiskFactor.label("schema_migration"), "schema migration")
+        XCTAssertEqual(MergeRiskFactor.label("dns_or_infra"), "DNS or infra")
+        XCTAssertEqual(MergeRiskFactor.label("ci_or_deploy"), "CI or deploy")
+        XCTAssertEqual(MergeRiskFactor.label("public_api_contract"), "public API contract")
+    }
+
+    func testAFactorThisBuildDoesNotKnowStillReadsAsWords() {
+        XCTAssertEqual(MergeRiskFactor.label("feature_flag_default"), "feature flag default")
+    }
+
+    func testRecoveryTimesAreSaidAsRecovery() {
+        XCTAssertEqual(RecoveryTime.minutes.label, "minutes to recover")
+        XCTAssertEqual(RecoveryTime.irreversible.label, "not recoverable")
+    }
+
+    func testTheCompactPhraseAndTheRowWordAgree() {
+        XCTAssertEqual(MergeRisk.high.label, "high risk")
+        XCTAssertEqual(MergeRisk.high.word, "High")
+    }
+
+    // MARK: - Colour
+
+    func testEachLevelTakesItsOwnStatusInk() {
+        XCTAssertEqual(MergeRisk.high.tone(stale: false), .red)
+        XCTAssertEqual(MergeRisk.medium.tone(stale: false), .yellow)
+        XCTAssertEqual(MergeRisk.low.tone(stale: false), .dim)
+    }
+
+    func testAStaleRiskGoesFaintWhateverItsLevel() {
+        for risk in MergeRisk.allCases {
+            XCTAssertEqual(risk.tone(stale: true), .faint, "\(risk)")
+        }
+    }
+
+    // MARK: - VoiceOver
+
+    func testVoiceOverNamesTheAxis() {
+        XCTAssertEqual(MergeRisk.high.accessibilityLabel, "merge risk high")
+    }
+
+    func testTheLoopVerdictSpeaksQualityAndRiskApart() throws {
+        var session = Session(id: "bks-1")
+        session.prNumber = 1
+        session.prState = "OPEN"
+        session.prChecks = PrChecksSummary(total: 3, passed: 3, failed: 0, pending: 0)
+        session.prOsReview = OsReviewSummary(
+            verdict: "approve", confidence: 5, risk: .high, findings: 0, blocking: 0, stale: false
+        )
+        let result = try XCTUnwrap(ReviewLoopResult(session: session))
+        XCTAssertEqual(result.status, .passed, "risk is advisory and never moves the verdict")
+        XCTAssertEqual(result.facts(rounds: 1), "1 round · 5/5 · high risk · 3 checks passed")
+        XCTAssertEqual(
+            result.accessibilityFacts(rounds: 1),
+            "1 round, quality 5 of 5, merge risk high, 3 checks passed"
+        )
+    }
+
+    // MARK: - The PR status card
+
+    func testTheStatusCardKeepsQualityAndRiskOnTheirOwnRows() {
+        let quality = PrPanelView.agentQualityValue(score: 5, stale: false)
+        let risk = PrPanelView.agentRiskValue(risk: .high, stale: false)
+        XCTAssertEqual(quality.value, "5/5")
+        XCTAssertEqual(risk.value, "High")
+        XCTAssertEqual(risk.tint, OS1VisualStyle.redInk)
+    }
+
+    func testTheStatusCardSaysWhenTheReadingIsBehindTheBranch() {
+        let quality = PrPanelView.agentQualityValue(score: 5, stale: true)
+        let risk = PrPanelView.agentRiskValue(risk: .high, stale: true)
+        XCTAssertEqual(quality.value, "5/5 · new commits since")
+        XCTAssertEqual(risk.value, "High · new commits since")
+        XCTAssertEqual(risk.tint, OS1VisualStyle.textFaint)
+    }
+}

--- a/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
@@ -115,18 +115,18 @@ final class SessionRowPreviewTests: XCTestCase {
             PrPreviewFacts.osReviewFact(
                 OsReviewSummary(verdict: "approve", confidence: 4)
             ),
-            PrPreviewFact(text: "4/5 · approved", tone: .green)
+            PrPreviewFact(text: "4/5 · approved", tone: .green, spoken: "quality 4 of 5, approved")
         )
     }
 
     func testVerdictStillReadsWithoutAScore() {
         XCTAssertEqual(
             PrPreviewFacts.osReviewFact(OsReviewSummary(verdict: "comment")),
-            PrPreviewFact(text: "commented", tone: .dim)
+            PrPreviewFact(text: "commented", tone: .dim, spoken: "commented")
         )
         XCTAssertEqual(
             PrPreviewFacts.osReviewFact(OsReviewSummary(verdict: "request_changes")),
-            PrPreviewFact(text: "changes requested", tone: .red)
+            PrPreviewFact(text: "changes requested", tone: .red, spoken: "changes requested")
         )
     }
 
@@ -142,7 +142,8 @@ final class SessionRowPreviewTests: XCTestCase {
             ),
             PrPreviewFact(
                 text: "2/5 · changes requested · 1 blocking · stale",
-                tone: .faint
+                tone: .faint,
+                spoken: "quality 2 of 5, changes requested, 1 blocking, stale"
             )
         )
     }
@@ -165,21 +166,40 @@ final class SessionRowPreviewTests: XCTestCase {
         XCTAssertEqual(facts.map(\.tone), [.green, .green, .red])
     }
 
+    func testTheStripNamesBothReviewAxesForVoiceOver() {
+        // Seen, the colours tell the score from the risk. Heard, "5/5" and
+        // "high risk" are a number and a word with no axis, so each fact
+        // carries a spoken form that names its own.
+        let facts = PrPreviewFacts.all(
+            for: session(
+                osReview: OsReviewSummary(verdict: "approve", confidence: 5, risk: .high)
+            )
+        )
+        XCTAssertEqual(
+            facts.map(\.accessibilityText),
+            ["Ready to merge", "quality 5 of 5, approved", "merge risk high"]
+        )
+    }
+
+    func testAFactWithoutASpokenFormReadsItsText() {
+        XCTAssertEqual(PrPreviewFact(text: "Ready to merge", tone: .green).accessibilityText, "Ready to merge")
+    }
+
     func testEachRiskLevelHasItsOwnTone() {
         XCTAssertEqual(
             PrPreviewFacts.mergeRiskFact(OsReviewSummary(risk: .medium)),
-            PrPreviewFact(text: "medium risk", tone: .yellow)
+            PrPreviewFact(text: "medium risk", tone: .yellow, spoken: "merge risk medium")
         )
         XCTAssertEqual(
             PrPreviewFacts.mergeRiskFact(OsReviewSummary(risk: .low)),
-            PrPreviewFact(text: "low risk", tone: .dim)
+            PrPreviewFact(text: "low risk", tone: .dim, spoken: "merge risk low")
         )
     }
 
     func testAStaleRiskGoesFaintWithTheRestOfTheReview() {
         XCTAssertEqual(
             PrPreviewFacts.mergeRiskFact(OsReviewSummary(verdict: "approve", risk: .high, stale: true)),
-            PrPreviewFact(text: "high risk", tone: .faint)
+            PrPreviewFact(text: "high risk", tone: .faint, spoken: "merge risk high")
         )
     }
 

--- a/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
+++ b/packages/clients/ios/OS1Tests/SessionRowPreviewTests.swift
@@ -151,6 +151,48 @@ final class SessionRowPreviewTests: XCTestCase {
         XCTAssertNil(PrPreviewFacts.osReviewFact(OsReviewSummary(confidence: 3)))
     }
 
+    // MARK: - Merge risk
+
+    func testMergeRiskIsItsOwnPhraseAfterTheReading() {
+        // A correct change that is hard to undo: the reading stays green and
+        // the risk stands beside it in red, which one shared phrase could not do.
+        let facts = PrPreviewFacts.all(
+            for: session(
+                osReview: OsReviewSummary(verdict: "approve", confidence: 5, risk: .high)
+            )
+        )
+        XCTAssertEqual(facts.map(\.text), ["Ready to merge", "5/5 · approved", "high risk"])
+        XCTAssertEqual(facts.map(\.tone), [.green, .green, .red])
+    }
+
+    func testEachRiskLevelHasItsOwnTone() {
+        XCTAssertEqual(
+            PrPreviewFacts.mergeRiskFact(OsReviewSummary(risk: .medium)),
+            PrPreviewFact(text: "medium risk", tone: .yellow)
+        )
+        XCTAssertEqual(
+            PrPreviewFacts.mergeRiskFact(OsReviewSummary(risk: .low)),
+            PrPreviewFact(text: "low risk", tone: .dim)
+        )
+    }
+
+    func testAStaleRiskGoesFaintWithTheRestOfTheReview() {
+        XCTAssertEqual(
+            PrPreviewFacts.mergeRiskFact(OsReviewSummary(verdict: "approve", risk: .high, stale: true)),
+            PrPreviewFact(text: "high risk", tone: .faint)
+        )
+    }
+
+    func testAReviewWithoutARiskPassAddsNoRiskPhrase() {
+        // Repos can opt out of the risk pass; the strip says nothing rather
+        // than "no risk", which would be a claim nobody made.
+        XCTAssertNil(PrPreviewFacts.mergeRiskFact(OsReviewSummary(verdict: "approve", confidence: 4)))
+        XCTAssertEqual(
+            texts(session(osReview: OsReviewSummary(verdict: "approve", confidence: 4))),
+            ["Ready to merge", "4/5 · approved"]
+        )
+    }
+
     // MARK: - Reviewers
 
     func testWaitingOnUpToTwoPeopleNamesThem() {


### PR DESCRIPTION
Ports the review merge-risk fields from 47c06994a to the native Swift client.

## What changed

- `OsReviewSummary` gains optional `risk`, `recovery` and `riskFactors`. Decoding stays tolerant: an unknown level or recovery word costs only that field, never the session row it rides in (`Session` decodes synthesized, so a throw here would drop the whole row).
- Risk shows as its own phrase in its own ink on every surface that already carried the 1-5 score, so the two axes cannot be read as one:
  - long-press preview strip (`SessionRowPreview`): `5/5 · approved` stays green, `high risk` sits beside it in red
  - workspace review row (`WorkspaceReviewRows`): `5/5 · high risk · No findings`, only the risk word coloured
  - report sheet: a merge-risk line above the write-up with recovery time and factors
  - review loop verdict (`ReviewLoopView`): `2 rounds · 5/5 · high risk · 3 checks passed`
  - PR status card (`PrPanel`): separate `Quality` and `Merge risk` rows
- Colours are the app's status inks (high red, medium yellow, low dim), not the web's `text-red`/`text-yellow`. A stale reading goes faint with the rest of the review and says `New commits since review`.
- VoiceOver names each axis: `quality 5 of 5, merge risk high` instead of reading `5/5 · high risk`.
- Risk is advisory: `ReviewLoopResult.status` is unchanged by it, as on the server.

## Before / after

| | Before | After |
|---|---|---|
| Preview strip | `5/5 · approved` | `5/5 · approved` `high risk` (red) |
| Review row | `5/5 · No findings` | `5/5 · high risk · No findings` |
| Loop verdict | `2 rounds · 5/5 · 3 checks passed` | `2 rounds · 5/5 · high risk · 3 checks passed` |
| PR status card | `Review: Approved` | + `Quality: 5/5`, `Merge risk: High` |
| VoiceOver | "5/5 · high risk" | "quality 5 of 5, merge risk high" |

## Verification

- `OS1` and `OS1Mac` build on the Mac node; `MergeRiskTests` (14), `SessionRowPreviewTests` (24) and `TranscriptGroupingTests` (43) pass.
- `bun run check` passes.
- Captured the Mac app with the high-risk fixture (`OS1_PR_REVIEW_CARDS_FIXTURE=1`); the fixture now takes the Mac detail column because an overlay on `NavigationSplitView` never reaches the AppKit split view.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-e27ef1e1-214c-7df8-b992-3cf262e4ca2f)