### PR TITLE
Re-read sidebar maps when another client writes them (native)

### DIFF
--- a/packages/clients/ios/OS1/HideStore.swift
+++ b/packages/clients/ios/OS1/HideStore.swift
@@ -25,7 +25,7 @@ final class HideStore {
     /// Sidebar row key → ISO timestamp of when this user hid it.
     private(set) var hides: [String: String] = [:]
 
-    private enum Change: Equatable {
+    enum Change: Equatable {
         case set(String)
         case remove
     }
@@ -36,18 +36,25 @@ final class HideStore {
     private var hydratedContext: NativePreferences.Context?
     private(set) var hasHydrated = false
     private var isSaving = false
+    private var hydrations = HydrationClock()
 
     init() {}
 
     /// Load this user's map from the server. Guarded like
-    /// `NativePreferences.hydrate`: a stale response (server/user switched, or
-    /// a hide landed meanwhile) is dropped.
+    /// `NativePreferences.hydrate`: a stale response (server/user switched,
+    /// a newer GET begun, or a write confirmed meanwhile) is dropped.
     func hydrate() async {
         let requestContext = NativePreferences.context()
         resetForNewContext(requestContext)
+        let ticket = beginHydration()
         guard let loaded = try? await SettingsAPI.hides(user: requestContext.user) else { return }
         guard NativePreferences.context() == requestContext else { return }
-        applyHydrated(loaded)
+        applyHydrated(loaded, ticket: ticket)
+    }
+
+    /// Marks the start of one GET. Internal so the ordering is unit-testable.
+    func beginHydration() -> HydrationClock.Ticket {
+        hydrations.begin()
     }
 
     private func resetForNewContext(_ context: NativePreferences.Context) {
@@ -64,7 +71,14 @@ final class HideStore {
     }
 
     /// Kept internal so the local-before-remote merge can be covered in tests.
-    func applyHydrated(_ loaded: [String: String], persist: Bool = true) {
+    /// With a `ticket`, the map is applied only while that GET is still the
+    /// newest and no write was confirmed since it began.
+    func applyHydrated(
+        _ loaded: [String: String],
+        ticket: HydrationClock.Ticket? = nil,
+        persist: Bool = true
+    ) {
+        if let ticket, !hydrations.isCurrent(ticket) { return }
         var merged = loaded
         for (key, change) in pendingChanges {
             switch change {
@@ -114,6 +128,17 @@ final class HideStore {
         pendingChanges[key] = change
     }
 
+    /// Reconcile one successful delta response without dropping a newer local
+    /// mutation that landed while that request was in flight. A GET still in
+    /// flight may carry the pre-write map, so it is stale from here on.
+    func applySaved(_ saved: [String: String], acknowledging captured: [String: Change]) {
+        for (key, change) in captured where pendingChanges[key] == change {
+            pendingChanges.removeValue(forKey: key)
+        }
+        hydrations.confirmWrite()
+        applyHydrated(saved, persist: false)
+    }
+
     private func save() {
         guard hasHydrated,
               !isSaving,
@@ -141,10 +166,7 @@ final class HideStore {
                   NativePreferences.context() == requestContext else { return }
             self.isSaving = false
             guard let saved else { return }
-            for (key, change) in captured where self.pendingChanges[key] == change {
-                self.pendingChanges.removeValue(forKey: key)
-            }
-            self.applyHydrated(saved, persist: false)
+            self.applySaved(saved, acknowledging: captured)
             self.save()
         }
     }

--- a/packages/clients/ios/OS1/HideStore.swift
+++ b/packages/clients/ios/OS1/HideStore.swift
@@ -57,6 +57,11 @@ final class HideStore {
         hydrations.begin()
     }
 
+    /// The clock as a write would see it when it starts. Internal for tests.
+    func hydrationMark() -> HydrationClock.Ticket {
+        hydrations.mark()
+    }
+
     private func resetForNewContext(_ context: NativePreferences.Context) {
         guard let hydratedContext else {
             self.hydratedContext = context
@@ -129,14 +134,28 @@ final class HideStore {
     }
 
     /// Reconcile one successful delta response without dropping a newer local
-    /// mutation that landed while that request was in flight. A GET still in
-    /// flight may carry the pre-write map, so it is stale from here on.
-    func applySaved(_ saved: [String: String], acknowledging captured: [String: Change]) {
+    /// mutation that landed while that request was in flight.
+    ///
+    /// The response is a whole-map snapshot taken when the server applied
+    /// the delta, and the server broadcasts `user_map_changed` before it
+    /// answers, so a re-read begun after the write started (`begunAt`) can
+    /// hold a newer map. Then the snapshot is not installed: the intents are
+    /// acknowledged, the newer map stays, and the caller re-reads; a GET
+    /// begun after the response is post-write. Returns false in that case.
+    @discardableResult
+    func applySaved(
+        _ saved: [String: String],
+        acknowledging captured: [String: Change],
+        begunAt mark: HydrationClock.Ticket? = nil
+    ) -> Bool {
         for (key, change) in captured where pendingChanges[key] == change {
             pendingChanges.removeValue(forKey: key)
         }
+        let needsHydration = mark.map { hydrations.hasHydrationBegun(since: $0) } ?? false
         hydrations.confirmWrite()
+        if needsHydration { return false }
         applyHydrated(saved, persist: false)
+        return true
     }
 
     private func save() {
@@ -154,6 +173,7 @@ final class HideStore {
             if case .remove = change { return key }
             return nil
         }
+        let mark = hydrations.mark()
         isSaving = true
         Task { [weak self] in
             let saved = try? await SettingsAPI.saveHides(
@@ -166,8 +186,9 @@ final class HideStore {
                   NativePreferences.context() == requestContext else { return }
             self.isSaving = false
             guard let saved else { return }
-            self.applySaved(saved, acknowledging: captured)
+            let applied = self.applySaved(saved, acknowledging: captured, begunAt: mark)
             self.save()
+            if !applied { await self.hydrate() }
         }
     }
 

--- a/packages/clients/ios/OS1/HydrationClock.swift
+++ b/packages/clients/ios/OS1/HydrationClock.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Orders one user-map store's GETs against each other and against its
+/// confirmed writes, so a slow response cannot overwrite a newer map.
+///
+/// The stores release the main actor while a GET is in flight, and two GETs
+/// overlap whenever a `user_map_changed` frame lands during the 30-second
+/// tick. Without ordering, the tick's response (read before the other
+/// client's write) could publish after the frame's response and drop that
+/// write until the next tick. A write this client confirmed meanwhile has the
+/// same effect: the GET may have been served the pre-write map, and the
+/// write's own response is already the fresher one. Same rule as the web
+/// `user-map`'s `hydrationVersion` and `confirmedVersions`.
+struct HydrationClock {
+    /// Handed out when a GET begins; presented again with its response.
+    struct Ticket: Equatable {
+        fileprivate let version: Int
+        fileprivate let confirmed: Int
+    }
+
+    private var version = 0
+    private var confirmed = 0
+
+    /// Start a GET. Any earlier ticket is stale from here on.
+    mutating func begin() -> Ticket {
+        version += 1
+        return Ticket(version: version, confirmed: confirmed)
+    }
+
+    /// A write's response was applied; GETs begun before it are stale.
+    mutating func confirmWrite() {
+        confirmed += 1
+    }
+
+    /// True while no newer GET has begun and no write has been confirmed
+    /// since the ticket was issued.
+    func isCurrent(_ ticket: Ticket) -> Bool {
+        ticket.version == version && ticket.confirmed == confirmed
+    }
+}

--- a/packages/clients/ios/OS1/HydrationClock.swift
+++ b/packages/clients/ios/OS1/HydrationClock.swift
@@ -3,14 +3,10 @@ import Foundation
 /// Orders one user-map store's GETs against each other and against its
 /// confirmed writes, so a slow response cannot overwrite a newer map.
 ///
-/// The stores release the main actor while a GET is in flight, and two GETs
-/// overlap whenever a `user_map_changed` frame lands during the 30-second
-/// tick. Without ordering, the tick's response (read before the other
-/// client's write) could publish after the frame's response and drop that
-/// write until the next tick. A write this client confirmed meanwhile has the
-/// same effect: the GET may have been served the pre-write map, and the
-/// write's own response is already the fresher one. Same rule as the web
-/// `user-map`'s `hydrationVersion` and `confirmedVersions`.
+/// Only the latest GET may apply. A confirmed write invalidates outstanding
+/// GETs because they may predate it. Conversely, a GET begun during a PUT
+/// may carry a newer map than the PUT response: the server broadcasts before
+/// answering the PUT. In that case the store keeps its map and re-reads.
 struct HydrationClock {
     /// Handed out when a GET begins; presented again with its response.
     struct Ticket: Equatable {
@@ -27,7 +23,13 @@ struct HydrationClock {
         return Ticket(version: version, confirmed: confirmed)
     }
 
-    /// A write's response was applied; GETs begun before it are stale.
+    /// The clock as it stands, without starting a GET. A write takes one so
+    /// its response can tell whether a re-read began meanwhile.
+    func mark() -> Ticket {
+        Ticket(version: version, confirmed: confirmed)
+    }
+
+    /// A write was acknowledged; earlier GETs must not restore pre-write state.
     mutating func confirmWrite() {
         confirmed += 1
     }
@@ -36,5 +38,11 @@ struct HydrationClock {
     /// since the ticket was issued.
     func isCurrent(_ ticket: Ticket) -> Bool {
         ticket.version == version && ticket.confirmed == confirmed
+    }
+
+    /// True once any GET has begun after `ticket` was taken, whether or not
+    /// its response has landed.
+    func hasHydrationBegun(since ticket: Ticket) -> Bool {
+        ticket.version != version
     }
 }

--- a/packages/clients/ios/OS1/LaneStore.swift
+++ b/packages/clients/ios/OS1/LaneStore.swift
@@ -19,18 +19,25 @@ final class LaneStore {
     private var hydratedContext: NativePreferences.Context?
     private(set) var hasHydrated = false
     private var isSaving = false
+    private var hydrations = HydrationClock()
 
     init() {}
 
     /// Load this user's map from the server. A response for a server/user that
-    /// has since changed is dropped, while mutations made before it landed are
-    /// replayed over it.
+    /// has since changed is dropped, as is one overtaken by a newer GET or by
+    /// a confirmed write; mutations made before it landed are replayed over it.
     func hydrate() async {
         let requestContext = NativePreferences.context()
         resetForNewContext(requestContext)
+        let ticket = beginHydration()
         guard let loaded = try? await SettingsAPI.lanes(user: requestContext.user) else { return }
         guard NativePreferences.context() == requestContext else { return }
-        applyHydrated(loaded)
+        applyHydrated(loaded, ticket: ticket)
+    }
+
+    /// Marks the start of one GET. Internal so the ordering is unit-testable.
+    func beginHydration() -> HydrationClock.Ticket {
+        hydrations.begin()
     }
 
     private func resetForNewContext(_ context: NativePreferences.Context) {
@@ -64,7 +71,14 @@ final class LaneStore {
     }
 
     /// Internal so pre-hydration mutation reconciliation is unit-testable.
-    func applyHydrated(_ loaded: [String: String], persist: Bool = true) {
+    /// With a `ticket`, the map is applied only while that GET is still the
+    /// newest and no write was confirmed since it began.
+    func applyHydrated(
+        _ loaded: [String: String],
+        ticket: HydrationClock.Ticket? = nil,
+        persist: Bool = true
+    ) {
+        if let ticket, !hydrations.isCurrent(ticket) { return }
         var merged = loaded
         for (key, value) in pendingChanges { merged[key] = value }
         hasHydrated = true
@@ -78,6 +92,7 @@ final class LaneStore {
         for (key, value) in captured where pendingChanges[key] == value {
             pendingChanges.removeValue(forKey: key)
         }
+        hydrations.confirmWrite()
         applyHydrated(saved, persist: false)
     }
 

--- a/packages/clients/ios/OS1/LaneStore.swift
+++ b/packages/clients/ios/OS1/LaneStore.swift
@@ -40,6 +40,11 @@ final class LaneStore {
         hydrations.begin()
     }
 
+    /// The clock as a write would see it when it starts. Internal for tests.
+    func hydrationMark() -> HydrationClock.Ticket {
+        hydrations.mark()
+    }
+
     private func resetForNewContext(_ context: NativePreferences.Context) {
         guard let hydratedContext else {
             self.hydratedContext = context
@@ -88,12 +93,27 @@ final class LaneStore {
 
     /// Reconcile one successful delta response without dropping a newer local
     /// mutation that landed while that request was in flight.
-    func applySaved(_ saved: [String: String], acknowledging captured: [String: String]) {
+    ///
+    /// The response is a whole-map snapshot taken when the server applied
+    /// the delta, and the server broadcasts `user_map_changed` before it
+    /// answers, so a re-read begun after the write started (`begunAt`) can
+    /// hold a newer map. Then the snapshot is not installed: the intents are
+    /// acknowledged, the newer map stays, and the caller re-reads; a GET
+    /// begun after the response is post-write. Returns false in that case.
+    @discardableResult
+    func applySaved(
+        _ saved: [String: String],
+        acknowledging captured: [String: String],
+        begunAt mark: HydrationClock.Ticket? = nil
+    ) -> Bool {
         for (key, value) in captured where pendingChanges[key] == value {
             pendingChanges.removeValue(forKey: key)
         }
+        let needsHydration = mark.map { hydrations.hasHydrationBegun(since: $0) } ?? false
         hydrations.confirmWrite()
+        if needsHydration { return false }
         applyHydrated(saved, persist: false)
+        return true
     }
 
     private func apply(_ next: [String: String]) {
@@ -109,6 +129,7 @@ final class LaneStore {
               let requestContext = hydratedContext,
               NativePreferences.context() == requestContext else { return }
         let captured = pendingChanges
+        let mark = hydrations.mark()
         isSaving = true
         Task { [weak self] in
             let saved = try? await SettingsAPI.saveLanes(
@@ -120,8 +141,9 @@ final class LaneStore {
                   NativePreferences.context() == requestContext else { return }
             self.isSaving = false
             guard let saved else { return }
-            self.applySaved(saved, acknowledging: captured)
+            let applied = self.applySaved(saved, acknowledging: captured, begunAt: mark)
             self.save()
+            if !applied { await self.hydrate() }
         }
     }
 }

--- a/packages/clients/ios/OS1/Networking/ServerEvent.swift
+++ b/packages/clients/ios/OS1/Networking/ServerEvent.swift
@@ -60,6 +60,10 @@ enum ServerEvent: Sendable {
     case askResolved(sessionId: String, questionId: String)
     case mention(user: String, mention: MentionRecord)
     case mentionsCleared(user: String, sessionId: String?)
+    /// One of this person's sidebar maps was written from any client, theirs
+    /// or another device. Sent only to that person's sockets and carries no
+    /// entries: the receiver re-reads the named map (see `UserMapSync`).
+    case userMapChanged(map: UserMapName, user: String)
     case replySuggestions(sessionId: String, suggestions: [ReplySuggestion])
     case slackComposer(sessionId: String, request: SlackComposeRequest?)
     case slackComposerResolved(sessionId: String, receipt: SlackComposeReceipt)
@@ -193,6 +197,13 @@ enum ServerEvent: Sendable {
         case "mentions_cleared":
             guard let user = frame.user else { return .ignored }
             return .mentionsCleared(user: user, sessionId: frame.sessionId)
+        case "user_map_changed":
+            // A map this build does not keep is not an error, it is a newer
+            // server: ignore the frame like any other unknown one.
+            guard let user = frame.user,
+                  let map = frame.map.flatMap(UserMapName.init(rawValue:))
+            else { return .ignored }
+            return .userMapChanged(map: map, user: user)
         case "reply_suggestions":
             guard let id = frame.sessionId else { return .ignored }
             // The server sends null to retire the row. Treat it as an empty
@@ -255,6 +266,15 @@ enum ServerEvent: Sendable {
             return .ignored
         }
     }
+}
+
+/// The per-user sidebar maps the server pushes change notices for, by the
+/// name a `user_map_changed` frame carries. Each has a native store that
+/// re-reads the same `/api/<name>` the web client does.
+enum UserMapName: String, Equatable, Sendable {
+    case lanes
+    case snoozes
+    case hides
 }
 
 /// One person and the session they are looking at, from `global_presence`.
@@ -493,6 +513,7 @@ private struct RawFrame: Decodable {
     let questionId: String?
     let questions: [AskQuestion.Question]?
     let user: String?
+    let map: String?
     let mention: MentionRecord?
     let suggestions: [ReplySuggestion]?
     let request: SlackComposeRequest?

--- a/packages/clients/ios/OS1/PresenceStore.swift
+++ b/packages/clients/ios/OS1/PresenceStore.swift
@@ -141,6 +141,12 @@ final class PresenceStore {
             if account.id == config.activeId {
                 MentionStore.shared.receiveCleared(user: user, sessionId: sessionId)
             }
+        case .userMapChanged(let map, let user):
+            // A passive account's maps are re-read when it becomes active;
+            // only the account on screen has stores to refresh.
+            if account.id == config.activeId {
+                Task { await UserMapSync.receive(map: map, user: user) }
+            }
         default:
             break
         }

--- a/packages/clients/ios/OS1/UserMapSync.swift
+++ b/packages/clients/ios/OS1/UserMapSync.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Answers a `user_map_changed` socket frame: one of this person's sidebar
+/// maps (lanes, snoozes, hides) was written from another client, so the
+/// matching store re-reads it and the sessions list refetches its rows.
+///
+/// The stores otherwise re-hydrate only at launch, on foreground, and every
+/// 30 seconds while active. A Mac window that stays in front never
+/// foregrounds, so a workspace claimed on the phone kept computing
+/// `claimed == false` there and filed the row as outside until the next tick.
+/// The frame carries no entries; the GET stays the authority, and each
+/// store's hydrate already replays pending local writes over the response.
+@MainActor
+enum UserMapSync {
+    /// Posted after a store re-read its map. The sessions list refetches on
+    /// it: lanes, snoozes and hides decide which rows the scoped list holds.
+    static let didResyncNotification = Notification.Name("os1.userMapResynced")
+
+    /// The server names the person the way it resolved them (verified sign-in
+    /// or picker name); the local picker name may differ in case or padding.
+    /// Another person's write is never ours to fetch.
+    nonisolated static func isSameUser(_ user: String, as current: String) -> Bool {
+        let wanted = user.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !wanted.isEmpty else { return false }
+        return wanted == current.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    /// Route one frame from the ACTIVE account's socket. Callers scope it to
+    /// that account already; this scopes it to the account's user.
+    static func receive(map: UserMapName, user: String) async {
+        guard isSameUser(user, as: NativePreferences.context().user) else { return }
+        switch map {
+        case .lanes: await LaneStore.shared.hydrate()
+        case .snoozes: await WorkspaceSnoozeStore.shared.hydrate()
+        case .hides: await HideStore.shared.hydrate()
+        }
+        NotificationCenter.default.post(name: didResyncNotification, object: map)
+    }
+}

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -407,6 +407,16 @@ struct SessionsListView: View {
                 await TeamDirectory.shared.ensureLoaded()
                 await loadAutomationOwners()
             }
+            // A claim, snooze or hide made on another device changes which
+            // rows the scoped list carries. The store has already re-read its
+            // map by the time this posts, so the refetch sees the new claims.
+            .task {
+                for await _ in NotificationCenter.default.notifications(
+                    named: UserMapSync.didResyncNotification
+                ) {
+                    await viewModel.refresh()
+                }
+            }
             #if DEBUG && os(iOS)
             .fullScreenCover(isPresented: .constant(presentsScreenshotSession)) {
                 NavigationStack {

--- a/packages/clients/ios/OS1/WorkspaceSnooze.swift
+++ b/packages/clients/ios/OS1/WorkspaceSnooze.swift
@@ -90,6 +90,11 @@ final class WorkspaceSnoozeStore {
         hydrations.begin()
     }
 
+    /// The clock as a write would see it when it starts. Internal for tests.
+    func hydrationMark() -> HydrationClock.Ticket {
+        hydrations.mark()
+    }
+
     /// Replay local intent over the server's map. Internal so the merge is
     /// unit-testable; `persist` is off for the write path's own response.
     /// With a `ticket`, the map is applied only while that GET is still the
@@ -151,14 +156,28 @@ final class WorkspaceSnoozeStore {
     }
 
     /// Reconcile one successful delta response without dropping a newer local
-    /// mutation that landed while that request was in flight. A GET still in
-    /// flight may carry the pre-write map, so it is stale from here on.
-    func applySaved(_ saved: [String: String], acknowledging captured: [String: Change]) {
+    /// mutation that landed while that request was in flight.
+    ///
+    /// The response is a whole-map snapshot taken when the server applied
+    /// the delta, and the server broadcasts `user_map_changed` before it
+    /// answers, so a re-read begun after the write started (`begunAt`) can
+    /// hold a newer map. Then the snapshot is not installed: the intents are
+    /// acknowledged, the newer map stays, and the caller re-reads; a GET
+    /// begun after the response is post-write. Returns false in that case.
+    @discardableResult
+    func applySaved(
+        _ saved: [String: String],
+        acknowledging captured: [String: Change],
+        begunAt mark: HydrationClock.Ticket? = nil
+    ) -> Bool {
         for (key, change) in captured where pending[key] == change {
             pending.removeValue(forKey: key)
         }
+        let needsHydration = mark.map { hydrations.hasHydrationBegun(since: $0) } ?? false
         hydrations.confirmWrite()
+        if needsHydration { return false }
         applyHydrated(saved, persist: false)
+        return true
     }
 
     private func save(context requestContext: NativePreferences.Context) {
@@ -172,6 +191,7 @@ final class WorkspaceSnoozeStore {
             if case .remove = change { return key }
             return nil
         }
+        let mark = hydrations.mark()
         isSaving = true
         Task { [weak self] in
             let saved = try? await SettingsAPI.saveSnoozes(
@@ -184,8 +204,9 @@ final class WorkspaceSnoozeStore {
                   NativePreferences.context() == requestContext else { return }
             self.isSaving = false
             guard let saved else { return }
-            self.applySaved(saved, acknowledging: captured)
+            let applied = self.applySaved(saved, acknowledging: captured, begunAt: mark)
             self.save(context: requestContext)
+            if !applied { await self.hydrate() }
         }
     }
 

--- a/packages/clients/ios/OS1/WorkspaceSnooze.swift
+++ b/packages/clients/ios/OS1/WorkspaceSnooze.swift
@@ -69,13 +69,26 @@ final class WorkspaceSnoozeStore {
     private var hasHydrated = false
     private var isSaving = false
 
-    private init() {}
+    init() {}
 
+    /// Load this user's map from the server, at launch, on foreground, and
+    /// when another client wrote it (`UserMapSync`). A response for a
+    /// server/user that has since changed is dropped.
     func hydrate() async {
         let requestContext = NativePreferences.context()
         resetIfNeeded(requestContext)
         guard let loaded = try? await SettingsAPI.snoozes(user: requestContext.user),
               NativePreferences.context() == requestContext else { return }
+        applyHydrated(loaded, context: requestContext)
+    }
+
+    /// Replay local intent over the server's map. Internal so the merge is
+    /// unit-testable; `persist` is off for the write path's own response.
+    func applyHydrated(
+        _ loaded: [String: String],
+        context requestContext: NativePreferences.Context? = nil,
+        persist: Bool = true
+    ) {
         var merged = loaded
         for (key, change) in pending {
             switch change {
@@ -83,9 +96,9 @@ final class WorkspaceSnoozeStore {
             case .remove: merged.removeValue(forKey: key)
             }
         }
-        snoozes = merged
+        if merged != snoozes { snoozes = merged }
         hasHydrated = true
-        if !pending.isEmpty { save(context: requestContext) }
+        if persist, !pending.isEmpty, let requestContext { save(context: requestContext) }
     }
 
     func value(for workspace: SidebarWorkspace, now: Date = Date()) -> String? {
@@ -151,14 +164,7 @@ final class WorkspaceSnoozeStore {
             for (key, change) in captured where self.pending[key] == change {
                 self.pending.removeValue(forKey: key)
             }
-            var merged = saved
-            for (key, change) in self.pending {
-                switch change {
-                case .set(let value): merged[key] = value
-                case .remove: merged.removeValue(forKey: key)
-                }
-            }
-            self.snoozes = merged
+            self.applyHydrated(saved, persist: false)
             self.save(context: requestContext)
         }
     }

--- a/packages/clients/ios/OS1/WorkspaceSnooze.swift
+++ b/packages/clients/ios/OS1/WorkspaceSnooze.swift
@@ -60,7 +60,7 @@ final class WorkspaceSnoozeStore {
     private(set) var snoozes: [String: String] = [:]
     private var context: NativePreferences.Context?
 
-    private enum Change: Equatable {
+    enum Change: Equatable {
         case set(String)
         case remove
     }
@@ -68,27 +68,39 @@ final class WorkspaceSnoozeStore {
     private var pending: [String: Change] = [:]
     private var hasHydrated = false
     private var isSaving = false
+    private var hydrations = HydrationClock()
 
     init() {}
 
     /// Load this user's map from the server, at launch, on foreground, and
     /// when another client wrote it (`UserMapSync`). A response for a
-    /// server/user that has since changed is dropped.
+    /// server/user that has since changed is dropped, as is one overtaken by
+    /// a newer GET or by a confirmed write.
     func hydrate() async {
         let requestContext = NativePreferences.context()
         resetIfNeeded(requestContext)
+        let ticket = beginHydration()
         guard let loaded = try? await SettingsAPI.snoozes(user: requestContext.user),
               NativePreferences.context() == requestContext else { return }
-        applyHydrated(loaded, context: requestContext)
+        applyHydrated(loaded, ticket: ticket, context: requestContext)
+    }
+
+    /// Marks the start of one GET. Internal so the ordering is unit-testable.
+    func beginHydration() -> HydrationClock.Ticket {
+        hydrations.begin()
     }
 
     /// Replay local intent over the server's map. Internal so the merge is
     /// unit-testable; `persist` is off for the write path's own response.
+    /// With a `ticket`, the map is applied only while that GET is still the
+    /// newest and no write was confirmed since it began.
     func applyHydrated(
         _ loaded: [String: String],
+        ticket: HydrationClock.Ticket? = nil,
         context requestContext: NativePreferences.Context? = nil,
         persist: Bool = true
     ) {
+        if let ticket, !hydrations.isCurrent(ticket) { return }
         var merged = loaded
         for (key, change) in pending {
             switch change {
@@ -138,6 +150,17 @@ final class WorkspaceSnoozeStore {
         [SidebarRowKeys.rowKey(for: workspace)] + workspace.sessions.map(\.id)
     }
 
+    /// Reconcile one successful delta response without dropping a newer local
+    /// mutation that landed while that request was in flight. A GET still in
+    /// flight may carry the pre-write map, so it is stale from here on.
+    func applySaved(_ saved: [String: String], acknowledging captured: [String: Change]) {
+        for (key, change) in captured where pending[key] == change {
+            pending.removeValue(forKey: key)
+        }
+        hydrations.confirmWrite()
+        applyHydrated(saved, persist: false)
+    }
+
     private func save(context requestContext: NativePreferences.Context) {
         guard hasHydrated, !isSaving, !pending.isEmpty else { return }
         let captured = pending
@@ -161,10 +184,7 @@ final class WorkspaceSnoozeStore {
                   NativePreferences.context() == requestContext else { return }
             self.isSaving = false
             guard let saved else { return }
-            for (key, change) in captured where self.pending[key] == change {
-                self.pending.removeValue(forKey: key)
-            }
-            self.applyHydrated(saved, persist: false)
+            self.applySaved(saved, acknowledging: captured)
             self.save(context: requestContext)
         }
     }

--- a/packages/clients/ios/OS1Tests/ServerEventTests.swift
+++ b/packages/clients/ios/OS1Tests/ServerEventTests.swift
@@ -29,6 +29,37 @@ final class ServerEventTests: XCTestCase {
         }
     }
 
+    func testUserMapChangedDecodesEachMap() {
+        for (wire, expected) in [
+            ("lanes", UserMapName.lanes),
+            ("snoozes", .snoozes),
+            ("hides", .hides),
+        ] {
+            let json = #"{"type":"user_map_changed","map":"\#(wire)","user":"Kent"}"#
+            guard case .userMapChanged(let map, let user) = parse(json) else {
+                return XCTFail("expected .userMapChanged for \(wire)")
+            }
+            XCTAssertEqual(map, expected)
+            XCTAssertEqual(user, "Kent")
+        }
+    }
+
+    func testUserMapChangedIgnoresMapsThisBuildDoesNotKeep() {
+        // A newer server naming a fourth map is not an error.
+        guard case .ignored = parse(
+            #"{"type":"user_map_changed","map":"pins","user":"Kent"}"#
+        ) else {
+            return XCTFail("expected .ignored for an unknown map")
+        }
+    }
+
+    func testUserMapChangedNeedsAUser() {
+        // Without a user there is nothing to scope the re-read to.
+        guard case .ignored = parse(#"{"type":"user_map_changed","map":"lanes"}"#) else {
+            return XCTFail("expected .ignored without a user")
+        }
+    }
+
     func testPresenceDecodesViewers() {
         let json = #"{"type":"presence","sessionId":"bks-1","viewers":["Kent","Michiel"]}"#
         guard case .presence(let id, let viewers) = parse(json) else {

--- a/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
+++ b/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
@@ -3,10 +3,11 @@ import XCTest
 
 /// A `user_map_changed` frame makes a store re-read its map while local
 /// writes may still be pending or in flight, and while the 30-second tick's
-/// own re-read may still be out. These pin three things: the frame is scoped
+/// own re-read may still be out. These pin the ordering rules: the frame is scoped
 /// to the account's own user, a re-read never drops a local mutation the
-/// server has not acknowledged yet, and a slower, older re-read cannot
-/// overwrite the newer one or a write confirmed since it began.
+/// server has not acknowledged yet, a slower, older re-read cannot
+/// overwrite the newer one or a write confirmed since it began, and a
+/// write's own response cannot overwrite a re-read begun after it.
 @MainActor
 final class UserMapSyncTests: XCTestCase {
     private func workspaces(_ json: String) throws -> [SidebarWorkspace] {
@@ -122,6 +123,18 @@ final class UserMapSyncTests: XCTestCase {
         XCTAssertTrue(clock.isCurrent(third))
     }
 
+    func testClockMarkSeesAGetBegunAfterItButNotAConfirmedWrite() {
+        var clock = HydrationClock()
+        let mark = clock.mark()
+        XCTAssertFalse(clock.hasHydrationBegun(since: mark))
+
+        clock.confirmWrite()
+        XCTAssertFalse(clock.hasHydrationBegun(since: mark))
+
+        _ = clock.begin()
+        XCTAssertTrue(clock.hasHydrationBegun(since: mark))
+    }
+
     /// The tick's GET read the map before the other client claimed bks-9;
     /// the frame's GET read it after. The tick's response lands last.
     func testLaneResyncIsNotOverwrittenByAnOlderGet() {
@@ -150,6 +163,68 @@ final class UserMapSyncTests: XCTestCase {
         XCTAssertEqual(store.claims, ["bks-1"])
     }
 
+    /// This Mac's PUT is answered slowly. Meanwhile another device claims
+    /// bks-9 and the frame's GET brings it in. The PUT's snapshot predates
+    /// that claim and must not replace it; the store re-reads instead.
+    func testLaneSavedSnapshotDoesNotOverwriteANewerResync() throws {
+        let store = LaneStore()
+        store.applyHydrated([:], persist: false)
+        let rows = try workspaces(#"[{"id":"bks-1"}]"#)
+        store.claim(rows.flatMap(\.sessions))
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+        store.applyHydrated(["bks-1": "mine", "bks-9": "mine"], ticket: frame, persist: false)
+
+        let applied = store.applySaved(["bks-1": "mine"], acknowledging: ["bks-1": "mine"], begunAt: put)
+
+        XCTAssertFalse(applied)
+        XCTAssertEqual(store.claims, ["bks-1", "bks-9"])
+    }
+
+    /// Same race with the frame's GET still in flight when the PUT answers:
+    /// the snapshot is skipped, the acknowledgement retires that GET,
+    /// and the acknowledged claim stays on screen meanwhile.
+    func testLaneSavedSnapshotYieldsToAResyncStillInFlight() throws {
+        let store = LaneStore()
+        store.applyHydrated([:], persist: false)
+        let rows = try workspaces(#"[{"id":"bks-1"}]"#)
+        store.claim(rows.flatMap(\.sessions))
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+
+        let applied = store.applySaved(["bks-1": "mine"], acknowledging: ["bks-1": "mine"], begunAt: put)
+        XCTAssertFalse(applied)
+        XCTAssertEqual(store.claims, ["bks-1"])
+
+        store.applyHydrated([:], ticket: frame, persist: false)
+        XCTAssertEqual(store.claims, ["bks-1"])
+
+        let fresh = store.beginHydration()
+        store.applyHydrated(["bks-1": "mine", "bks-9": "mine"], ticket: fresh, persist: false)
+        store.applyHydrated([:], ticket: frame, persist: false)
+
+        XCTAssertEqual(store.claims, ["bks-1", "bks-9"])
+    }
+
+    /// With no re-read begun since the PUT started, its snapshot is the
+    /// freshest map and lands as before.
+    func testLaneSavedSnapshotAppliesWhenNothingBeganMeanwhile() throws {
+        let store = LaneStore()
+        store.applyHydrated([:], persist: false)
+        let rows = try workspaces(#"[{"id":"bks-1"}]"#)
+        store.claim(rows.flatMap(\.sessions))
+        let put = store.hydrationMark()
+
+        let applied = store.applySaved(
+            ["bks-1": "mine", "remote": "review"],
+            acknowledging: ["bks-1": "mine"],
+            begunAt: put
+        )
+
+        XCTAssertTrue(applied)
+        XCTAssertEqual(store.claims, ["bks-1", "remote"])
+    }
+
     func testHideResyncIsNotOverwrittenByAnOlderGet() throws {
         let store = HideStore()
         let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
@@ -174,6 +249,103 @@ final class UserMapSyncTests: XCTestCase {
         store.applyHydrated(["workspace:ws-1": "2026-09-01T00:00:00Z"], ticket: tick, persist: false)
 
         XCTAssertFalse(store.isHidden(rows[0]))
+    }
+
+    func testHideSavedSnapshotDoesNotOverwriteANewerResync() throws {
+        let store = HideStore()
+        let rows = try workspaces(
+            #"[{"id":"bks-1","workspaceId":"ws-1"},{"id":"bks-2","workspaceId":"ws-2"}]"#
+        )
+        store.applyHydrated([:], persist: false)
+        store.hide(rows[0])
+        let mine = store.hides["workspace:ws-1"]!
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+        store.applyHydrated(
+            ["workspace:ws-1": mine, "workspace:ws-2": "2026-09-02T00:00:00Z"],
+            ticket: frame,
+            persist: false
+        )
+
+        let applied = store.applySaved(
+            ["workspace:ws-1": mine],
+            acknowledging: ["workspace:ws-1": .set(mine)],
+            begunAt: put
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertTrue(store.isHidden(rows[0]))
+        XCTAssertTrue(store.isHidden(rows[1]))
+    }
+
+    func testSnoozeSavedSnapshotDoesNotOverwriteANewerResync() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(
+            #"[{"id":"bks-1","workspaceId":"ws-1"},{"id":"bks-2","workspaceId":"ws-2"}]"#
+        )
+        store.applyHydrated([:], persist: false)
+        store.set(rows[0], until: WorkspaceSnooze.someDay)
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+        store.applyHydrated(
+            ["workspace:ws-1": WorkspaceSnooze.someDay, "workspace:ws-2": WorkspaceSnooze.someDay],
+            ticket: frame,
+            persist: false
+        )
+
+        let applied = store.applySaved(
+            ["workspace:ws-1": WorkspaceSnooze.someDay],
+            acknowledging: ["workspace:ws-1": .set(WorkspaceSnooze.someDay)],
+            begunAt: put
+        )
+
+        XCTAssertFalse(applied)
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+        XCTAssertTrue(store.isSnoozed(rows[1]))
+    }
+
+    func testHideSkippedSnapshotKeepsANewerLocalRestore() throws {
+        let store = HideStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.hide(rows[0])
+        let mine = try XCTUnwrap(store.hides["workspace:ws-1"])
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+        store.clear(["workspace:ws-1"])
+
+        XCTAssertFalse(store.applySaved(
+            ["workspace:ws-1": mine],
+            acknowledging: ["workspace:ws-1": .set(mine)],
+            begunAt: put
+        ))
+        store.applyHydrated(["workspace:ws-1": mine], ticket: frame, persist: false)
+        XCTAssertFalse(store.isHidden(rows[0]))
+
+        let fresh = store.beginHydration()
+        store.applyHydrated(["workspace:ws-1": mine], ticket: fresh, persist: false)
+        XCTAssertFalse(store.isHidden(rows[0]))
+    }
+
+    func testSnoozeSkippedSnapshotAcknowledgesIntentAndRetiresOutstandingGet() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.set(rows[0], until: WorkspaceSnooze.someDay)
+        let put = store.hydrationMark()
+        let frame = store.beginHydration()
+
+        XCTAssertFalse(store.applySaved(
+            ["workspace:ws-1": WorkspaceSnooze.someDay],
+            acknowledging: ["workspace:ws-1": .set(WorkspaceSnooze.someDay)],
+            begunAt: put
+        ))
+        store.applyHydrated([:], ticket: frame, persist: false)
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+
+        // Another client lifted the snooze. The acknowledged intent must not
+        // be replayed over the post-write re-read.
+        let fresh = store.beginHydration()
+        store.applyHydrated([:], ticket: fresh, persist: false)
+        XCTAssertFalse(store.isSnoozed(rows[0]))
     }
 
     func testSnoozeResyncIsNotOverwrittenByAnOlderGet() throws {

--- a/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
+++ b/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
@@ -2,9 +2,11 @@ import XCTest
 @testable import OS1
 
 /// A `user_map_changed` frame makes a store re-read its map while local
-/// writes may still be pending or in flight. These pin two things: the frame
-/// is scoped to the account's own user, and a re-read never drops a local
-/// mutation the server has not acknowledged yet.
+/// writes may still be pending or in flight, and while the 30-second tick's
+/// own re-read may still be out. These pin three things: the frame is scoped
+/// to the account's own user, a re-read never drops a local mutation the
+/// server has not acknowledged yet, and a slower, older re-read cannot
+/// overwrite the newer one or a write confirmed since it began.
 @MainActor
 final class UserMapSyncTests: XCTestCase {
     private func workspaces(_ json: String) throws -> [SidebarWorkspace] {
@@ -99,6 +101,105 @@ final class UserMapSyncTests: XCTestCase {
         store.applyHydrated([:], persist: false)
 
         store.applyHydrated(["workspace:ws-1": WorkspaceSnooze.someDay], persist: false)
+
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+    }
+
+    // MARK: Ordering
+
+    func testClockRetiresOlderTicketsAndTicketsFromBeforeAConfirmedWrite() {
+        var clock = HydrationClock()
+        let first = clock.begin()
+        XCTAssertTrue(clock.isCurrent(first))
+
+        let second = clock.begin()
+        XCTAssertFalse(clock.isCurrent(first))
+        XCTAssertTrue(clock.isCurrent(second))
+
+        clock.confirmWrite()
+        XCTAssertFalse(clock.isCurrent(second))
+        let third = clock.begin()
+        XCTAssertTrue(clock.isCurrent(third))
+    }
+
+    /// The tick's GET read the map before the other client claimed bks-9;
+    /// the frame's GET read it after. The tick's response lands last.
+    func testLaneResyncIsNotOverwrittenByAnOlderGet() {
+        let store = LaneStore()
+        let tick = store.beginHydration()
+        let frame = store.beginHydration()
+
+        store.applyHydrated(["bks-9": "mine"], ticket: frame, persist: false)
+        store.applyHydrated([:], ticket: tick, persist: false)
+
+        XCTAssertEqual(store.claims, ["bks-9"])
+    }
+
+    /// A GET begun before this client's own write was confirmed may carry the
+    /// pre-write map; the write's response is the fresher one.
+    func testLaneGetFromBeforeAConfirmedWriteIsDropped() throws {
+        let store = LaneStore()
+        store.applyHydrated([:], persist: false)
+        let tick = store.beginHydration()
+        let rows = try workspaces(#"[{"id":"bks-1"}]"#)
+        store.claim(rows.flatMap(\.sessions))
+        store.applySaved(["bks-1": "mine"], acknowledging: ["bks-1": "mine"])
+
+        store.applyHydrated([:], ticket: tick, persist: false)
+
+        XCTAssertEqual(store.claims, ["bks-1"])
+    }
+
+    func testHideResyncIsNotOverwrittenByAnOlderGet() throws {
+        let store = HideStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        let tick = store.beginHydration()
+        let frame = store.beginHydration()
+
+        store.applyHydrated(["workspace:ws-1": "2026-09-01T00:00:00Z"], ticket: frame, persist: false)
+        store.applyHydrated([:], ticket: tick, persist: false)
+
+        XCTAssertTrue(store.isHidden(rows[0]))
+    }
+
+    func testHideGetFromBeforeAConfirmedWriteIsDropped() throws {
+        let store = HideStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.applyHydrated(["workspace:ws-1": "2026-09-01T00:00:00Z"], persist: false)
+        let tick = store.beginHydration()
+        store.clear(["workspace:ws-1"])
+        store.applySaved([:], acknowledging: ["workspace:ws-1": .remove])
+
+        // The stale GET still carries the hide this client just lifted.
+        store.applyHydrated(["workspace:ws-1": "2026-09-01T00:00:00Z"], ticket: tick, persist: false)
+
+        XCTAssertFalse(store.isHidden(rows[0]))
+    }
+
+    func testSnoozeResyncIsNotOverwrittenByAnOlderGet() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        let tick = store.beginHydration()
+        let frame = store.beginHydration()
+
+        store.applyHydrated(["workspace:ws-1": WorkspaceSnooze.someDay], ticket: frame, persist: false)
+        store.applyHydrated([:], ticket: tick, persist: false)
+
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+    }
+
+    func testSnoozeGetFromBeforeAConfirmedWriteIsDropped() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.applyHydrated([:], persist: false)
+        let tick = store.beginHydration()
+        store.set(rows[0], until: WorkspaceSnooze.someDay)
+        store.applySaved(
+            ["workspace:ws-1": WorkspaceSnooze.someDay],
+            acknowledging: ["workspace:ws-1": .set(WorkspaceSnooze.someDay)]
+        )
+
+        store.applyHydrated([:], ticket: tick, persist: false)
 
         XCTAssertTrue(store.isSnoozed(rows[0]))
     }

--- a/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
+++ b/packages/clients/ios/OS1Tests/UserMapSyncTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import OS1
+
+/// A `user_map_changed` frame makes a store re-read its map while local
+/// writes may still be pending or in flight. These pin two things: the frame
+/// is scoped to the account's own user, and a re-read never drops a local
+/// mutation the server has not acknowledged yet.
+@MainActor
+final class UserMapSyncTests: XCTestCase {
+    private func workspaces(_ json: String) throws -> [SidebarWorkspace] {
+        SessionsListViewModel.sidebarWorkspaces(
+            in: try JSONDecoder().decode([Session].self, from: Data(json.utf8))
+        )
+    }
+
+    // MARK: Scoping
+
+    func testSameUserIgnoresCaseAndPadding() {
+        XCTAssertTrue(UserMapSync.isSameUser("Kent", as: "kent"))
+        XCTAssertTrue(UserMapSync.isSameUser("  kent ", as: "Kent"))
+    }
+
+    func testAnotherPersonsWriteIsNotOurs() {
+        XCTAssertFalse(UserMapSync.isSameUser("Michiel", as: "Kent"))
+        XCTAssertFalse(UserMapSync.isSameUser("", as: "Kent"))
+        XCTAssertFalse(UserMapSync.isSameUser("", as: ""))
+    }
+
+    // MARK: Reconciliation
+
+    func testLaneResyncKeepsAPendingClaimOverAnOlderServerMap() throws {
+        let store = LaneStore()
+        let rows = try workspaces(#"[{"id":"bks-1"}]"#)
+        store.claim(rows.flatMap(\.sessions))
+
+        // The other device's map predates this claim: it must survive.
+        store.applyHydrated(["bks-2": "mine"], persist: false)
+
+        XCTAssertEqual(store.claims, ["bks-1", "bks-2"])
+    }
+
+    func testLaneResyncAdoptsAClaimMadeElsewhere() {
+        let store = LaneStore()
+        store.applyHydrated([:], persist: false)
+
+        store.applyHydrated(["bks-9": "mine"], persist: false)
+
+        XCTAssertEqual(store.claims, ["bks-9"])
+    }
+
+    func testHideResyncKeepsAPendingRestoreOverAnOlderServerHide() throws {
+        let store = HideStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.applyHydrated(["workspace:ws-1": "2026-09-01T00:00:00Z"], persist: false)
+        store.clear(["workspace:ws-1"])
+
+        // The re-read still carries the hide this device just lifted.
+        store.applyHydrated(
+            ["workspace:ws-1": "2026-09-01T00:00:00Z", "workspace:ws-2": "2026-09-02T00:00:00Z"],
+            persist: false
+        )
+
+        XCTAssertFalse(store.isHidden(rows[0]))
+        XCTAssertEqual(Array(store.hides.keys), ["workspace:ws-2"])
+    }
+
+    func testHideResyncKeepsAPendingHideTheServerHasNotSeen() throws {
+        let store = HideStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.hide(rows[0])
+
+        store.applyHydrated([:], persist: false)
+
+        XCTAssertTrue(store.isHidden(rows[0]))
+    }
+
+    func testSnoozeResyncKeepsPendingSetAndRemove() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(
+            #"[{"id":"bks-1","workspaceId":"ws-1"},{"id":"bks-2","workspaceId":"ws-2"}]"#
+        )
+        store.set(rows[0], until: WorkspaceSnooze.someDay)
+        store.set(rows[1], until: nil)
+
+        // The server still has ws-2 parked and has not heard about ws-1.
+        store.applyHydrated(
+            ["workspace:ws-2": WorkspaceSnooze.someDay, "workspace:ws-3": WorkspaceSnooze.someDay],
+            persist: false
+        )
+
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+        XCTAssertFalse(store.isSnoozed(rows[1]))
+        XCTAssertEqual(store.snoozes["workspace:ws-3"], WorkspaceSnooze.someDay)
+    }
+
+    func testSnoozeResyncAdoptsASnoozeMadeElsewhere() throws {
+        let store = WorkspaceSnoozeStore()
+        let rows = try workspaces(#"[{"id":"bks-1","workspaceId":"ws-1"}]"#)
+        store.applyHydrated([:], persist: false)
+
+        store.applyHydrated(["workspace:ws-1": WorkspaceSnooze.someDay], persist: false)
+
+        XCTAssertTrue(store.isSnoozed(rows[0]))
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -38,7 +38,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   matching store re-reads it (`UserMapSync`), and the list refetches its rows.
   Each store orders its re-reads (`HydrationClock`): a slower, older GET, or
   one begun before a write this client confirmed, is dropped rather than
-  applied over the newer map.
+  applied over the newer map, and a write's own response is installed only
+  when no re-read began after the write started (the server broadcasts the
+  frame before it answers the PUT); otherwise the store re-reads.
   Unread rows
   read like the web sidebar's, off the same shared store (`/api/reads`): a row
   whose sessions carry activity past your last read goes semibold at full label

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -33,6 +33,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   row stays findable and its menu offers "Restore to my sidebar". An open
   teammate, automation, or spawned session can also be claimed from its native
   action surface with "Add to sidebar", sharing `/api/lanes` with the web.
+  A claim, snooze or hide made on another client lands here without a
+  foreground: the server's `user_map_changed` frame names the map, the
+  matching store re-reads it (`UserMapSync`), and the list refetches its rows.
   Unread rows
   read like the web sidebar's, off the same shared store (`/api/reads`): a row
   whose sessions carry activity past your last read goes semibold at full label

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -36,6 +36,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   A claim, snooze or hide made on another client lands here without a
   foreground: the server's `user_map_changed` frame names the map, the
   matching store re-reads it (`UserMapSync`), and the list refetches its rows.
+  Each store orders its re-reads (`HydrationClock`): a slower, older GET, or
+  one begun before a write this client confirmed, is dropped rather than
+  applied over the newer map.
   Unread rows
   read like the web sidebar's, off the same shared store (`/api/reads`): a row
   whose sessions carry activity past your last read goes semibold at full label


### PR DESCRIPTION
Native half of 5c11d43fd. The server sends a `user_map_changed` frame to a person's sockets when `/api/lanes`, `/api/snoozes` or `/api/hides` is written; the iOS and Mac apps decoded it to `.ignored`, so a claim, snooze or hide made on the phone or in the browser reached a Mac window only at the next foreground or the 30 s hydrate tick.

**Before**: a snooze written from another client stayed invisible in a Mac window that never lost focus until the next tick.
**After**: the store re-reads within about a second of the write and the row leaves the Active band.

## What changed

- `ServerEvent`: decodes `user_map_changed` into `.userMapChanged(map:user:)` with a `UserMapName` enum (`lanes`, `snoozes`, `hides`). An unknown map name, or a missing user, still decodes to `.ignored`.
- `UserMapSync` (new): routes the frame to `LaneStore`, `WorkspaceSnoozeStore` or `HideStore.hydrate()`, scoped to the frame's user (case and padding insensitive, same rule as `MentionStore`), then posts a notification.
- `PresenceStore`: hands the frame on only for the active account; a passive account re-reads when it becomes active anyway.
- `SessionsListView`: refetches the scoped list on that notification, after the store has re-read, so claims are current when the list regroups.
- `WorkspaceSnoozeStore`: gains the same `applyHydrated` seam the lane and hide stores have; the write path reuses it. Pending local writes survive a resync in all three stores.
- README: one paragraph on the live path.

## Tests

- `ServerEventTests`: each map name decodes, an unknown map is ignored, a missing user is ignored.
- `UserMapSyncTests`: user scoping, and per store that a pending claim / hide / restore / snooze / unsnooze survives a re-read that predates it, plus that a write made elsewhere is adopted.
- `OS1` and `OS1Mac` build; 50 tests in the touched suites pass on the Mac node.

## Live check

Mac app against `os.tella.dev` as the Automation identity, a second client writing `PUT /api/snoozes` for a visible row. The frame arrived ~1 s after the write, the store re-read held the snooze, the row left the Active band, and the unsnooze brought it back, all without backgrounding the app.

## Found on the way, not changed here

- On macOS the list is one row per session (`SidebarRowKeys.rowKey` = session id) while iOS and the web key workspace rows as `workspace:<id>`, so a `workspace:` snooze or hide from the web does nothing visible on the Mac.
- macOS never applies hides to rows: the filter in `SessionsListView` is wrapped in `#if os(iOS)`.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-8c04209f-6997-75ee-bc0d-1e6eeaafe6ed)