### PR TITLE
Native: move a host session into a Sandbox

### DIFF
--- a/packages/clients/ios/OS1/Models/SandboxMove.swift
+++ b/packages/clients/ios/OS1/Models/SandboxMove.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Moving a session that runs on this machine into a Sandbox
+/// (`POST /api/sessions/:id/sandbox/attach`).
+///
+/// The rules mirror the server's `sandboxAttachRefusal` (routes/sandbox.ts)
+/// so the app never offers a move the server would answer 409 to. Kept out
+/// of the views so they can be tested against real session payloads.
+enum SandboxMove {
+    /// Why a session cannot move, in the server's order.
+    enum Refusal: Equatable {
+        /// A Sandbox already exists for it. A recorded provider without an id
+        /// is a move that has not materialized, and moving again retries it.
+        case inSandbox
+        case runner
+        case automation
+        case notCode
+        case noRepo
+    }
+
+    static func refusal(_ session: Session) -> Refusal? {
+        if let sandbox = session.sandbox,
+           let id = sandbox.sandboxId, !id.isEmpty,
+           sandbox.provider != "local" {
+            return .inSandbox
+        }
+        if let runner = session.runner, !runner.id.isEmpty { return .runner }
+        if session.automation?.isAutomation == true
+            || !(session.automationId ?? "").isEmpty {
+            return .automation
+        }
+        if session.mode != "code" { return .notCode }
+        if session.repoLess == true || (session.repo ?? "").isEmpty { return .noRepo }
+        return nil
+    }
+
+    static func canMove(_ session: Session) -> Bool {
+        refusal(session) == nil
+    }
+
+    /// Where a session may move to: the composer's own list, which is the
+    /// Ready connections, minus the host it is already on.
+    static func choices(_ status: InstanceSandboxStatus?) -> [String] {
+        SandboxOffering.choices(status).filter { $0 != SandboxOffering.host && $0 != "local" }
+    }
+}
+
+/// What the attach route answered. A 428 is not a failure: work exists only
+/// on this machine, and the person decides whether to leave it behind.
+enum SandboxAttachOutcome: Equatable {
+    case moved(SessionSandboxStatus)
+    /// The server's own sentence about the unpushed work.
+    case confirmRequired(String)
+}

--- a/packages/clients/ios/OS1/Models/SandboxMove.swift
+++ b/packages/clients/ios/OS1/Models/SandboxMove.swift
@@ -9,11 +9,13 @@ import Foundation
 enum SandboxMove {
     /// Why a session cannot move, in the server's order.
     enum Refusal: Equatable {
-        /// A Sandbox is recorded for it, materialized or not. The server would
-        /// accept a second move while the first is still preparing, and then
+        /// A Sandbox exists for it, or is on its way. The server would accept
+        /// a second move while the first is still preparing, and then
         /// provision twice; the Sandbox that lands second is never recorded
-        /// or destroyed. A move that failed is retried from the Sandbox
-        /// section (Recreate), not by moving again.
+        /// or destroyed. The one recorded state that may move again is a
+        /// failed provision (`needs_attention` without an id): nothing was
+        /// made, Recreate has no id to work from, and the server permits the
+        /// retry.
         case inSandbox
         case runner
         case automation
@@ -22,8 +24,10 @@ enum SandboxMove {
     }
 
     static func refusal(_ session: Session) -> Refusal? {
-        if let provider = session.sandbox?.provider, !provider.isEmpty, provider != "local" {
-            return .inSandbox
+        if let sandbox = session.sandbox,
+           let provider = sandbox.provider, !provider.isEmpty, provider != "local" {
+            let materialized = !(sandbox.sandboxId ?? "").isEmpty
+            if materialized || sandbox.lifecycle != "needs_attention" { return .inSandbox }
         }
         if let runner = session.runner, !runner.id.isEmpty { return .runner }
         if session.automation?.isAutomation == true
@@ -37,6 +41,19 @@ enum SandboxMove {
 
     static func canMove(_ session: Session) -> Bool {
         refusal(session) == nil
+    }
+
+    /// The row's record of the Sandbox the attach route answered with, so the
+    /// open session carries the provider from the moment the server does and
+    /// `refusal` says `.inSandbox` before any refresh lands.
+    static func recorded(from status: SessionSandboxStatus) -> SessionSandbox {
+        SessionSandbox(
+            provider: status.provider,
+            sandboxId: status.sandboxId,
+            workspace: status.workspace,
+            lifecycle: status.lifecycle ?? "preparing",
+            lastLifecycleError: status.lastLifecycleError
+        )
     }
 
     /// Where a session may move to: the composer's own list, which is the

--- a/packages/clients/ios/OS1/Models/SandboxMove.swift
+++ b/packages/clients/ios/OS1/Models/SandboxMove.swift
@@ -9,8 +9,11 @@ import Foundation
 enum SandboxMove {
     /// Why a session cannot move, in the server's order.
     enum Refusal: Equatable {
-        /// A Sandbox already exists for it. A recorded provider without an id
-        /// is a move that has not materialized, and moving again retries it.
+        /// A Sandbox is recorded for it, materialized or not. The server would
+        /// accept a second move while the first is still preparing, and then
+        /// provision twice; the Sandbox that lands second is never recorded
+        /// or destroyed. A move that failed is retried from the Sandbox
+        /// section (Recreate), not by moving again.
         case inSandbox
         case runner
         case automation
@@ -19,9 +22,7 @@ enum SandboxMove {
     }
 
     static func refusal(_ session: Session) -> Refusal? {
-        if let sandbox = session.sandbox,
-           let id = sandbox.sandboxId, !id.isEmpty,
-           sandbox.provider != "local" {
+        if let provider = session.sandbox?.provider, !provider.isEmpty, provider != "local" {
             return .inSandbox
         }
         if let runner = session.runner, !runner.id.isEmpty { return .runner }

--- a/packages/clients/ios/OS1/Models/Session.swift
+++ b/packages/clients/ios/OS1/Models/Session.swift
@@ -120,6 +120,9 @@ struct Session: Identifiable, Decodable, Equatable, Hashable {
     /// (server: session-control-wiring). See `belongsInList`.
     var spawnedBy: String?
     var automation: AutomationFlag?
+    /// The automation's stable id. Older rows carry only `automation`; either
+    /// one marks a session whose Sandbox the automation decides.
+    var automationId: String?
     var attachedRepos: [AttachedRepo]?
     /// Every pull-request branch associated with this session, including
     /// attached, linked, and discovered branches. The native workspace and PR

--- a/packages/clients/ios/OS1/Networking/OS1API.swift
+++ b/packages/clients/ios/OS1/Networking/OS1API.swift
@@ -1021,6 +1021,59 @@ enum OS1API {
         return try await post("/api/sessions/\(encoded)/sandbox/\(action.rawValue)", body: body)
     }
 
+    /// Move a session that runs on this machine into a Sandbox, which the
+    /// server starts provisioning right away; the next message runs there.
+    ///
+    /// Not on the shared `post` path because its 428 is an answer, not an
+    /// error: the worktree has uncommitted files or unpushed commits that a
+    /// Sandbox's fresh clone of origin would not have, and the server says so
+    /// in a sentence for the person to read before repeating with `confirm`.
+    static func attachSandbox(
+        sessionId: String,
+        provider: String,
+        confirm: Bool = false
+    ) async throws -> SandboxAttachOutcome {
+        let config = ServerConfig.shared
+        guard let base = config.baseURL, config.isConfigured else { throw APIError.notConfigured }
+        let encoded = sessionId.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? sessionId
+        guard let url = URL(string: base.absoluteString + "/api/sessions/\(encoded)/sandbox/attach")
+        else { throw APIError.badURL }
+
+        var request = config.authorizedRequest(url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        var body: [String: Any] = ["provider": provider]
+        if confirm { body["confirm"] = true }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 200
+        return try await sandboxAttachOutcome(status: status, data: data)
+    }
+
+    /// The attach route's answer by status. Split out so the 428 contract can
+    /// be tested without a server.
+    static func sandboxAttachOutcome(status: Int, data: Data) async throws -> SandboxAttachOutcome {
+        struct Refusal: Decodable {
+            let error: String?
+            let confirmRequired: Bool?
+        }
+        let refusal = try? JSONDecoder().decode(Refusal.self, from: data)
+        if status == 428 || refusal?.confirmRequired == true {
+            return .confirmRequired(
+                refusal?.error
+                    ?? "This machine has work that was never pushed. The Sandbox clones the branch from origin."
+            )
+        }
+        guard (200..<300).contains(status) else {
+            noteStatus(status)
+            if let message = refusal?.error { throw APIError.server(message) }
+            throw APIError.http(status)
+        }
+        return .moved(try await decodeDetached(SessionSandboxStatus.self, from: data))
+    }
+
     /// Archive (or unarchive) a session. Archiving an in-flight session also
     /// stops its run server-side.
     static func setArchived(sessionId: String, archived: Bool) async throws {

--- a/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// One move of a host session into a Sandbox, from the list of places it can
+/// go to the server's answer. Owned by whichever surface offers the move (the
+/// session overflow menu, the Mac toolbar, the worktree details sheet), so
+/// each keeps its own in-flight state while the rules stay in one place.
+@MainActor
+@Observable
+final class SandboxMoveViewModel {
+    /// A 428: the server named the work that would stay behind, and waits
+    /// for an explicit "move anyway" before doing it.
+    struct Confirmation: Identifiable, Equatable {
+        let sessionId: String
+        let provider: String
+        let message: String
+        var id: String { "\(sessionId)|\(provider)" }
+    }
+
+    /// Nil until the instance has answered which Sandboxes are Ready.
+    private(set) var providers: [String]?
+    /// The provider a move is in flight to.
+    private(set) var working: String?
+    var confirmation: Confirmation?
+    var error: String?
+
+    func loadProviders() async {
+        let status = try? await OS1API.sandboxStatus()
+        providers = SandboxMove.choices(status)
+    }
+
+    /// Ask the server to move the session. Returns the new Sandbox state on
+    /// success; nil when the server wants a confirmation first (now held in
+    /// `confirmation`) or refused (held in `error`).
+    func move(
+        sessionId: String,
+        to provider: String,
+        confirm: Bool = false
+    ) async -> SessionSandboxStatus? {
+        guard working == nil else { return nil }
+        working = provider
+        error = nil
+        defer { working = nil }
+        do {
+            switch try await OS1API.attachSandbox(
+                sessionId: sessionId,
+                provider: provider,
+                confirm: confirm
+            ) {
+            case .moved(let status):
+                return status
+            case .confirmRequired(let message):
+                confirmation = Confirmation(
+                    sessionId: sessionId,
+                    provider: provider,
+                    message: message
+                )
+                return nil
+            }
+        } catch {
+            self.error = error.localizedDescription
+            return nil
+        }
+    }
+
+    /// The row the server has after a move, so the open session shows the
+    /// Sandbox preparing now rather than on the next sessions poll.
+    static func refresh(_ viewModel: SessionViewModel) async {
+        guard let fresh = try? await OS1API.session(id: viewModel.session.id) else { return }
+        viewModel.updateSessionSnapshot(fresh)
+    }
+}

--- a/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
@@ -20,6 +20,10 @@ final class SandboxMoveViewModel {
     private(set) var providers: [String]?
     /// The provider a move is in flight to.
     private(set) var working: String?
+    /// The session a move has landed for. The row records the provider too,
+    /// but a sessions poll that has not caught up yet can hand back the host
+    /// snapshot, and this keeps the rows from offering a second move then.
+    private(set) var movedSessionId: String?
     var confirmation: Confirmation?
     var error: String?
 
@@ -47,6 +51,7 @@ final class SandboxMoveViewModel {
                 confirm: confirm
             ) {
             case .moved(let status):
+                movedSessionId = sessionId
                 return status
             case .confirmRequired(let message):
                 confirmation = Confirmation(
@@ -60,6 +65,20 @@ final class SandboxMoveViewModel {
             self.error = error.localizedDescription
             return nil
         }
+    }
+
+    func hasMoved(_ sessionId: String) -> Bool {
+        movedSessionId == sessionId
+    }
+
+    /// Record the server's answer on the open session now, then take the row
+    /// the server has. The refresh is a round trip that can fail or arrive
+    /// late; the offer must be gone before it starts, not after it lands.
+    static func adopt(_ status: SessionSandboxStatus, into viewModel: SessionViewModel) {
+        var session = viewModel.session
+        session.sandbox = SandboxMove.recorded(from: status)
+        viewModel.updateSessionSnapshot(session)
+        Task { await refresh(viewModel) }
     }
 
     /// The row the server has after a move, so the open session shows the

--- a/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SandboxMoveViewModel.swift
@@ -27,6 +27,16 @@ final class SandboxMoveViewModel {
     var confirmation: Confirmation?
     var error: String?
 
+    private let attach: (String, String, Bool) async throws -> SandboxAttachOutcome
+
+    init(
+        attach: @escaping (String, String, Bool) async throws -> SandboxAttachOutcome = { id, provider, confirm in
+            try await OS1API.attachSandbox(sessionId: id, provider: provider, confirm: confirm)
+        }
+    ) {
+        self.attach = attach
+    }
+
     func loadProviders() async {
         let status = try? await OS1API.sandboxStatus()
         providers = SandboxMove.choices(status)
@@ -45,11 +55,7 @@ final class SandboxMoveViewModel {
         error = nil
         defer { working = nil }
         do {
-            switch try await OS1API.attachSandbox(
-                sessionId: sessionId,
-                provider: provider,
-                confirm: confirm
-            ) {
+            switch try await attach(sessionId, provider, confirm) {
             case .moved(let status):
                 movedSessionId = sessionId
                 return status
@@ -67,8 +73,17 @@ final class SandboxMoveViewModel {
         }
     }
 
-    func hasMoved(_ sessionId: String) -> Bool {
-        movedSessionId == sessionId
+    func hasMoved(_ session: Session) -> Bool {
+        guard movedSessionId == session.id else { return false }
+        // Only an explicit provisioning failure releases the rows. A stale
+        // host snapshot must not allow another attach while provisioning.
+        if let sandbox = session.sandbox,
+           sandbox.lifecycle == "needs_attention",
+           let provider = sandbox.provider, !provider.isEmpty, provider != "local",
+           (sandbox.sandboxId ?? "").isEmpty {
+            return false
+        }
+        return true
     }
 
     /// Record the server's answer on the open session now, then take the row

--- a/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
+++ b/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// empty states want to be: readable, not tappable.
 struct SandboxMoveMenuItems: View {
     let model: SandboxMoveViewModel
-    let sessionId: String
+    let session: Session
     /// The server refuses a move while the agent runs; the rows say so
     /// instead of disappearing.
     let isRunning: Bool
@@ -23,7 +23,7 @@ struct SandboxMoveMenuItems: View {
                 ForEach(providers, id: \.self) { provider in
                     Button {
                         Task {
-                            if let status = await model.move(sessionId: sessionId, to: provider) {
+                            if let status = await model.move(sessionId: session.id, to: provider) {
                                 onMoved(status)
                             }
                         }
@@ -33,7 +33,7 @@ struct SandboxMoveMenuItems: View {
                             systemImage: "cube"
                         )
                     }
-                    .disabled(model.working != nil || model.hasMoved(sessionId) || isRunning)
+                    .disabled(model.working != nil || model.hasMoved(session) || isRunning)
                 }
                 if isRunning {
                     Text(SandboxMoveCopy.waitForAgent)
@@ -129,7 +129,7 @@ struct SandboxMoveToolbarMenu: View {
         Menu {
             SandboxMoveMenuItems(
                 model: model,
-                sessionId: viewModel.session.id,
+                session: viewModel.session,
                 isRunning: viewModel.isRunning,
                 onMoved: adopt
             )

--- a/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
+++ b/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// The rows that move a host session into a Sandbox: one per Ready provider,
+/// after the composer's own list. Mounted inside the iOS overflow menu's
+/// "Move to Sandbox" submenu and the Mac toolbar's menu, so the two cannot
+/// drift; the worktree details sheet draws the same choices as full rows.
+///
+/// A bare `Text` in a menu is a disabled row, which is what the waiting and
+/// empty states want to be: readable, not tappable.
+struct SandboxMoveMenuItems: View {
+    let model: SandboxMoveViewModel
+    let sessionId: String
+    /// The server refuses a move while the agent runs; the rows say so
+    /// instead of disappearing.
+    let isRunning: Bool
+    let onMoved: (SessionSandboxStatus) -> Void
+
+    var body: some View {
+        if let providers = model.providers {
+            if providers.isEmpty {
+                Text(SandboxMoveCopy.noneReady)
+            } else {
+                ForEach(providers, id: \.self) { provider in
+                    Button {
+                        Task {
+                            if let status = await model.move(sessionId: sessionId, to: provider) {
+                                onMoved(status)
+                            }
+                        }
+                    } label: {
+                        Label(
+                            SandboxMoveCopy.action(provider, working: model.working == provider),
+                            systemImage: "cube"
+                        )
+                    }
+                    .disabled(model.working != nil || isRunning)
+                }
+                if isRunning {
+                    Text(SandboxMoveCopy.waitForAgent)
+                }
+            }
+        } else {
+            Text(SandboxMoveCopy.checking)
+        }
+    }
+}
+
+/// The sentences every surface shares, so a phone, a Mac and the sheet say
+/// the same thing about the same move.
+enum SandboxMoveCopy {
+    static let checking = "Checking Sandboxes…"
+    static let noneReady = "No Sandbox is ready. Connect Daytona or Box in Settings > Sandboxes."
+    static let waitForAgent = "Available once the agent finishes."
+    static let explanation =
+        "The Sandbox starts now, clones this branch from origin, and takes over on the next message. Portals on this machine stop."
+
+    static func action(_ provider: String, working: Bool) -> String {
+        let name = SandboxOffering.label(provider)
+        return working ? "Moving to \(name)…" : "Move to \(name)"
+    }
+}
+
+extension View {
+    /// The two prompts a move can raise: the server's 428 (unpushed work
+    /// stays behind; move anyway?) and a refusal. Attach to the view that
+    /// hosts the rows, since rows inside a menu cannot present anything.
+    func sandboxMovePrompts(
+        _ model: SandboxMoveViewModel,
+        onMoved: @escaping (SessionSandboxStatus) -> Void
+    ) -> some View {
+        modifier(SandboxMovePrompts(model: model, onMoved: onMoved))
+    }
+}
+
+private struct SandboxMovePrompts: ViewModifier {
+    @Bindable var model: SandboxMoveViewModel
+    let onMoved: (SessionSandboxStatus) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .confirmationDialog(
+                model.confirmation.map { "Move to \(SandboxOffering.label($0.provider)) anyway?" }
+                    ?? "Move anyway?",
+                isPresented: Binding(
+                    get: { model.confirmation != nil },
+                    set: { if !$0 { model.confirmation = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: model.confirmation
+            ) { confirmation in
+                Button("Move anyway") {
+                    Task {
+                        if let status = await model.move(
+                            sessionId: confirmation.sessionId,
+                            to: confirmation.provider,
+                            confirm: true
+                        ) {
+                            onMoved(status)
+                        }
+                    }
+                }
+                Button("Cancel", role: .cancel) { model.confirmation = nil }
+            } message: { confirmation in
+                Text(confirmation.message)
+            }
+            .alert(
+                "Couldn't move to a Sandbox",
+                isPresented: Binding(
+                    get: { model.error != nil },
+                    set: { if !$0 { model.error = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(model.error ?? "Please try again.")
+            }
+    }
+}
+
+#if os(macOS)
+/// The Mac's way in: a toolbar menu beside the model settings, shown only
+/// for a session the server would let move. The Mac has no overflow menu and
+/// no worktree details sheet, so this is where the move lives there.
+struct SandboxMoveToolbarMenu: View {
+    let viewModel: SessionViewModel
+    @State private var model = SandboxMoveViewModel()
+
+    var body: some View {
+        Menu {
+            SandboxMoveMenuItems(
+                model: model,
+                sessionId: viewModel.session.id,
+                isRunning: viewModel.isRunning,
+                onMoved: adopt
+            )
+        } label: {
+            Image(systemName: "cube")
+        }
+        .help("Move this session into a Sandbox")
+        .accessibilityLabel("Move to Sandbox")
+        .sandboxMovePrompts(model, onMoved: adopt)
+        .task(id: viewModel.session.id) {
+            await model.loadProviders()
+            #if DEBUG
+            // The capture tool cannot open a menu; `OS1_SANDBOX_MOVE=<provider>`
+            // presses the row for it, and `OS1_SANDBOX_MOVE_CONFIRM=1` the
+            // Move anyway that a worktree with unpushed work leads to.
+            let env = ProcessInfo.processInfo.environment
+            if let provider = env["OS1_SANDBOX_MOVE"], !provider.isEmpty,
+               let status = await model.move(
+                   sessionId: viewModel.session.id,
+                   to: provider,
+                   confirm: env["OS1_SANDBOX_MOVE_CONFIRM"] == "1"
+               ) {
+                adopt(status)
+            }
+            #endif
+        }
+    }
+
+    private func adopt(_ status: SessionSandboxStatus) {
+        Task { await SandboxMoveViewModel.refresh(viewModel) }
+    }
+}
+#endif

--- a/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
+++ b/packages/clients/ios/OS1/Views/SandboxMoveMenu.swift
@@ -33,7 +33,7 @@ struct SandboxMoveMenuItems: View {
                             systemImage: "cube"
                         )
                     }
-                    .disabled(model.working != nil || isRunning)
+                    .disabled(model.working != nil || model.hasMoved(sessionId) || isRunning)
                 }
                 if isRunning {
                     Text(SandboxMoveCopy.waitForAgent)
@@ -159,7 +159,7 @@ struct SandboxMoveToolbarMenu: View {
     }
 
     private func adopt(_ status: SessionSandboxStatus) {
-        Task { await SandboxMoveViewModel.refresh(viewModel) }
+        SandboxMoveViewModel.adopt(status, into: viewModel)
     }
 }
 #endif

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -882,6 +882,14 @@ struct SessionView: View {
                 modelMenu
                     .help("Model and reasoning settings")
             }
+            // Where the next turn runs. Only for a session the server would
+            // let move: a Sandbox, Runner, automation or Ask session has no
+            // such choice, and the item would only ever refuse.
+            if SandboxMove.canMove(viewModel.session) {
+                ToolbarItem(placement: .topTrailingCompat) {
+                    SandboxMoveToolbarMenu(viewModel: viewModel)
+                }
+            }
             #endif
             }
 
@@ -1902,6 +1910,7 @@ private struct SessionActionsMenu: View {
     @State private var pendingMerge: String?
     @State private var merging = false
     @State private var mergeError: String?
+    @State private var sandboxMove = SandboxMoveViewModel()
     @Environment(\.openURL) private var openURL
 
     var body: some View {
@@ -1984,6 +1993,22 @@ private struct SessionActionsMenu: View {
                 showWorktreeInfo = true
             } label: {
                 Label("Worktree details", systemImage: "info.circle")
+            }
+            // Where the next turn runs. Offered only when the server would
+            // accept the move (a code session with a repository, on this
+            // machine, not an automation's and not on a Runner); a 428 from
+            // the server becomes the confirmation below.
+            if canMoveToSandbox {
+                Menu {
+                    SandboxMoveMenuItems(
+                        model: sandboxMove,
+                        sessionId: viewModel.session.id,
+                        isRunning: viewModel.isRunning,
+                        onMoved: adoptSandboxMove
+                    )
+                } label: {
+                    Label("Move to Sandbox", systemImage: "cube")
+                }
             }
             // What the next turn runs on. It was only reachable through the
             // worktree details sheet, which is a long way to go for a setting
@@ -2138,6 +2163,13 @@ private struct SessionActionsMenu: View {
                 .foregroundStyle(OS1VisualStyle.text)
         }
         .accessibilityLabel("Session actions")
+        .sandboxMovePrompts(sandboxMove, onMoved: adoptSandboxMove)
+        .task(id: viewModel.session.id) {
+            // One read of the instance's Sandboxes per session, and none for
+            // a session that cannot move: the menu shows the rows before it
+            // is opened, so they must be known before then.
+            if canMoveToSandbox { await sandboxMove.loadProviders() }
+        }
         .confirmationDialog(
             mergeConfirmationTitle,
             isPresented: Binding(
@@ -2169,6 +2201,15 @@ private struct SessionActionsMenu: View {
     private func openWorker(_ worker: Session) {
         guard let url = SessionLinks.url(for: worker.id) else { return }
         openURL(url)
+    }
+
+    private var canMoveToSandbox: Bool {
+        SandboxMove.canMove(viewModel.session)
+    }
+
+    /// The row now says Preparing; take it before the next poll does.
+    private func adoptSandboxMove(_ status: SessionSandboxStatus) {
+        Task { await SandboxMoveViewModel.refresh(viewModel) }
     }
 
     private var addIntent: SidebarAddition.Intent? {

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -2002,7 +2002,7 @@ private struct SessionActionsMenu: View {
                 Menu {
                     SandboxMoveMenuItems(
                         model: sandboxMove,
-                        sessionId: viewModel.session.id,
+                        session: viewModel.session,
                         isRunning: viewModel.isRunning,
                         onMoved: adoptSandboxMove
                     )

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -2207,9 +2207,10 @@ private struct SessionActionsMenu: View {
         SandboxMove.canMove(viewModel.session)
     }
 
-    /// The row now says Preparing; take it before the next poll does.
+    /// The row says Preparing from this call on, so the submenu is gone
+    /// before the refresh that confirms it starts.
     private func adoptSandboxMove(_ status: SessionSandboxStatus) {
-        Task { await SandboxMoveViewModel.refresh(viewModel) }
+        SandboxMoveViewModel.adopt(status, into: viewModel)
     }
 
     private var addIntent: SidebarAddition.Intent? {

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -34,6 +34,11 @@ struct WorktreeInfoView: View {
     @State private var sandboxAction: SessionSandboxAction?
     @State private var sandboxError: String?
     @State private var confirmingSandboxRecreate = false
+    @State private var sandboxMove = SandboxMoveViewModel()
+    /// A move lands before the sessions poll carries it back; held here and
+    /// read through `currentSession` until the polled row agrees, so the
+    /// Sandbox section says Preparing the moment the server does.
+    @State private var attachedSandbox: SessionSandbox?
     @State private var loading = true
     @State private var loadFailed = false
     @State private var repos: [OS1API.RepoInfo] = []
@@ -50,6 +55,7 @@ struct WorktreeInfoView: View {
 
     var body: some View {
         NavigationStack {
+            ScrollViewReader { proxy in
             ScrollView {
                 // Ordered by what the sheet is opened to find out: what this
                 // workspace is doing and what came out of it. The worktree's
@@ -66,12 +72,24 @@ struct WorktreeInfoView: View {
                     assetsSection
                     worktreeSection
                     sandboxSection
+                        .id("sandbox")
+                    runtimeSection
+                        .id("runtime")
                     runnerSection
                     runSettingsSection
                     effectiveConfigSection
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 28)
+            }
+            #if DEBUG
+            // `OS1_SCROLL_TO=sandbox|runtime` brings a section below the fold
+            // into the capture tool's screenshot once the sheet has loaded.
+            .onChange(of: scrollToForCapture) { _, target in
+                guard let target else { return }
+                withAnimation(nil) { proxy.scrollTo(target, anchor: .top) }
+            }
+            #endif
             }
             .background(OS1VisualStyle.background)
             .navigationTitle("Workspace")
@@ -135,6 +153,7 @@ struct WorktreeInfoView: View {
             } message: {
                 Text(sandboxError ?? "Please try again.")
             }
+            .sandboxMovePrompts(sandboxMove, onMoved: adoptSandboxMove)
             .confirmationDialog(
                 "Switch repository?",
                 isPresented: Binding(
@@ -1097,6 +1116,97 @@ struct WorktreeInfoView: View {
             ?? currentEngine.capitalized
     }
 
+    /// The host counterpart of the Sandbox section: a code session that runs
+    /// on this machine, and the Ready Sandboxes it can move into. Once the
+    /// move lands the session carries a `sandbox` record and the Sandbox
+    /// section above takes over with Preparing.
+    @ViewBuilder
+    private var runtimeSection: some View {
+        if remoteSandbox == nil, SandboxMove.canMove(currentSession) {
+            InfoSection(title: "Runtime") {
+                InfoRow(label: "Runs on", value: "This machine", icon: "desktopcomputer")
+                Divider()
+                if let providers = sandboxMove.providers {
+                    if providers.isEmpty {
+                        Text(SandboxMoveCopy.noneReady)
+                            .font(.footnote)
+                            .foregroundStyle(OS1VisualStyle.textDim)
+                            .padding(12)
+                    } else {
+                        Text(SandboxMoveCopy.explanation)
+                            .font(.footnote)
+                            .foregroundStyle(OS1VisualStyle.textDim)
+                            .padding(12)
+                        ForEach(providers, id: \.self) { provider in
+                            Divider()
+                            sandboxMoveButton(provider)
+                        }
+                        if viewModel.isRunning {
+                            Divider()
+                            Text(SandboxMoveCopy.waitForAgent)
+                                .font(.footnote)
+                                .foregroundStyle(OS1VisualStyle.textDim)
+                                .padding(12)
+                        }
+                    }
+                } else {
+                    HStack(spacing: 9) {
+                        ProgressView().controlSize(.small)
+                        Text(SandboxMoveCopy.checking)
+                            .font(.subheadline)
+                            .foregroundStyle(OS1VisualStyle.textDim)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                }
+            }
+        }
+    }
+
+    private func sandboxMoveButton(_ provider: String) -> some View {
+        let working = sandboxMove.working == provider
+        return Button {
+            Task {
+                if let status = await sandboxMove.move(sessionId: currentSession.id, to: provider) {
+                    adoptSandboxMove(status)
+                }
+            }
+        } label: {
+            HStack(spacing: 10) {
+                if working {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "cube")
+                }
+                Text(SandboxMoveCopy.action(provider, working: working))
+                Spacer()
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(OS1VisualStyle.link)
+            .padding(.horizontal, 12)
+            .frame(minHeight: 48)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(sandboxMove.working != nil || viewModel.isRunning)
+    }
+
+    /// Show the Sandbox section as Preparing now: the live status is what the
+    /// server answered, and the row overlay keeps `remoteSandbox` non-nil
+    /// until the sessions poll agrees.
+    private func adoptSandboxMove(_ status: SessionSandboxStatus) {
+        sandboxStatus = status
+        sandboxError = nil
+        attachedSandbox = SessionSandbox(
+            provider: status.provider,
+            sandboxId: status.sandboxId,
+            workspace: status.workspace,
+            lifecycle: status.lifecycle ?? "preparing",
+            lastLifecycleError: status.lastLifecycleError
+        )
+        Task { await SandboxMoveViewModel.refresh(viewModel) }
+    }
+
     private var remoteSandbox: (provider: String, sandboxId: String?, workspace: String?)? {
         guard let sandbox = currentSession.sandbox,
               let provider = sandbox.provider,
@@ -1209,6 +1319,11 @@ struct WorktreeInfoView: View {
         async let sandboxResult = loadSandboxResult()
         async let reposResult = try? OS1API.repos()
         async let switchableResult = try? OS1API.repoSwitchable(sessionId: currentSession.id)
+        // Which Sandboxes a host session could move into. Not asked for a
+        // session that cannot move, or one that already has a Sandbox.
+        async let movesResult: Void = remoteSandbox == nil && SandboxMove.canMove(currentSession)
+            ? sandboxMove.loadProviders()
+            : ()
         let (nextGit, nextDiffResponse, nextAssets, nextOverview, nextSandbox) = await (
             gitResult,
             diffResult,
@@ -1216,7 +1331,7 @@ struct WorktreeInfoView: View {
             overviewResult,
             sandboxResult
         )
-        let (nextRepos, nextSwitchable) = await (reposResult, switchableResult)
+        let (nextRepos, nextSwitchable, _) = await (reposResult, switchableResult, movesResult)
         guard !Task.isCancelled else { return }
         if let nextRepos {
             repos = nextRepos
@@ -1239,8 +1354,41 @@ struct WorktreeInfoView: View {
         loading = false
         #if DEBUG
         openImageForCaptureIfRequested()
+        await moveForCaptureIfRequested()
+        if let target = ProcessInfo.processInfo.environment["OS1_SCROLL_TO"], !target.isEmpty {
+            // The rows above settle first; a lazy stack scrolled at once
+            // lands short of the section.
+            try? await Task.sleep(for: .milliseconds(400))
+            scrollToForCapture = target
+        }
         #endif
     }
+
+    #if DEBUG
+    @State private var scrollToForCapture: String?
+
+    /// Lets the native capture tool drive the real move on a simulator that
+    /// takes no taps: `OS1_SANDBOX_MOVE=<provider>` presses the row, so a
+    /// worktree with unpushed work shows the server's confirmation, and
+    /// `OS1_SANDBOX_MOVE_CONFIRM=1` with it presses Move anyway.
+    @State private var didMoveForCapture = false
+
+    private func moveForCaptureIfRequested() async {
+        let env = ProcessInfo.processInfo.environment
+        guard !didMoveForCapture,
+              let provider = env["OS1_SANDBOX_MOVE"], !provider.isEmpty,
+              remoteSandbox == nil, SandboxMove.canMove(currentSession)
+        else { return }
+        didMoveForCapture = true
+        if let status = await sandboxMove.move(
+            sessionId: currentSession.id,
+            to: provider,
+            confirm: env["OS1_SANDBOX_MOVE_CONFIRM"] == "1"
+        ) {
+            adoptSandboxMove(status)
+        }
+    }
+    #endif
 
     #if DEBUG
     private func openImageForCaptureIfRequested() {
@@ -1373,6 +1521,11 @@ struct WorktreeInfoView: View {
             session.repo = switchedRepo.repo
             session.branch = switchedRepo.branch
             session.worktreeDir = switchedRepo.worktreeDir
+        }
+        // Same for a move into a Sandbox: the row keeps saying "this machine"
+        // until the poll returns the provider the server already recorded.
+        if let attachedSandbox, session.sandbox?.provider != attachedSandbox.provider {
+            session.sandbox = attachedSandbox
         }
         return session
     }

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -1188,7 +1188,9 @@ struct WorktreeInfoView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(sandboxMove.working != nil || viewModel.isRunning)
+        .disabled(
+            sandboxMove.working != nil || sandboxMove.hasMoved(currentSession.id) || viewModel.isRunning
+        )
     }
 
     /// Show the Sandbox section as Preparing now: the live status is what the
@@ -1197,14 +1199,8 @@ struct WorktreeInfoView: View {
     private func adoptSandboxMove(_ status: SessionSandboxStatus) {
         sandboxStatus = status
         sandboxError = nil
-        attachedSandbox = SessionSandbox(
-            provider: status.provider,
-            sandboxId: status.sandboxId,
-            workspace: status.workspace,
-            lifecycle: status.lifecycle ?? "preparing",
-            lastLifecycleError: status.lastLifecycleError
-        )
-        Task { await SandboxMoveViewModel.refresh(viewModel) }
+        attachedSandbox = SandboxMove.recorded(from: status)
+        SandboxMoveViewModel.adopt(status, into: viewModel)
     }
 
     private var remoteSandbox: (provider: String, sandboxId: String?, workspace: String?)? {

--- a/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
+++ b/packages/clients/ios/OS1/Views/WorktreeInfoView.swift
@@ -1189,7 +1189,7 @@ struct WorktreeInfoView: View {
         }
         .buttonStyle(.plain)
         .disabled(
-            sandboxMove.working != nil || sandboxMove.hasMoved(currentSession.id) || viewModel.isRunning
+            sandboxMove.working != nil || sandboxMove.hasMoved(currentSession) || viewModel.isRunning
         )
     }
 

--- a/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
+++ b/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
@@ -25,13 +25,19 @@ final class SandboxMoveTests: XCTestCase {
         XCTAssertEqual(SandboxMove.refusal(moved), .inSandbox)
     }
 
-    /// A recorded provider without an id is a move that has not landed
-    /// (still preparing, or failed); moving again retries it.
-    func testPreparingSandboxMayBeMovedAgain() throws {
+    /// A recorded provider without an id is a move still preparing (or one
+    /// that failed). The server would take a second move and provision twice,
+    /// so the offer ends as soon as any provider is recorded, as on the web;
+    /// a failed Sandbox is retried from the Sandbox section.
+    func testPreparingOrFailedSandboxRefuses() throws {
         let preparing = try session(
             #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"daytona","lifecycle":"preparing"}}"#
         )
-        XCTAssertNil(SandboxMove.refusal(preparing))
+        XCTAssertEqual(SandboxMove.refusal(preparing), .inSandbox)
+        let failed = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"box","lifecycle":"needs_attention"}}"#
+        )
+        XCTAssertEqual(SandboxMove.refusal(failed), .inSandbox)
         let local = try session(
             #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"local","sandboxId":"x"}}"#
         )

--- a/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
+++ b/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
@@ -148,6 +148,40 @@ final class SandboxMoveTests: XCTestCase {
     }
 
     @MainActor
+    func testMoveLatchAllowsRetryAfterProvisioningFailureButBlocksStaleHost() async throws {
+        let preparing = try JSONDecoder().decode(SessionSandboxStatus.self, from: Data(
+            #"{"enabled":true,"provider":"daytona","lifecycle":"preparing","materialized":false}"#.utf8
+        ))
+        var requests = 0
+        let model = SandboxMoveViewModel { _, _, _ in
+            requests += 1
+            return .moved(preparing)
+        }
+        let host = try session(#"{"id":"bks-1","mode":"code","repo":"r"}"#)
+        XCTAssertFalse(model.hasMoved(host))
+        let attached = await model.move(sessionId: host.id, to: "daytona")
+        XCTAssertNotNil(attached)
+        XCTAssertNil(model.working)
+        XCTAssertTrue(model.hasMoved(host), "A stale host poll must not re-enable the rows")
+
+        var snapshot = host
+        snapshot.sandbox = SandboxMove.recorded(from: preparing)
+        XCTAssertTrue(model.hasMoved(snapshot))
+        snapshot.sandbox?.lifecycle = "needs_attention"
+        XCTAssertTrue(SandboxMove.canMove(snapshot))
+        XCTAssertFalse(model.hasMoved(snapshot), "The retained menu must allow retry after failure")
+        XCTAssertTrue(model.hasMoved(host), "Bypassing a failure must not release stale host snapshots")
+
+        snapshot.sandbox?.sandboxId = "sb-1"
+        XCTAssertTrue(model.hasMoved(snapshot), "A materialized failure uses Recreate instead")
+        let retried = await model.move(sessionId: host.id, to: "daytona")
+        XCTAssertNotNil(retried)
+        XCTAssertEqual(requests, 2)
+        snapshot.sandbox = SandboxMove.recorded(from: preparing)
+        XCTAssertTrue(model.hasMoved(snapshot))
+    }
+
+    @MainActor
     func testRefusalSurfacesTheServersMessage() async {
         let body = Data(#"{"error":"Wait for the agent to finish before moving this session."}"#.utf8)
         do {

--- a/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
+++ b/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
@@ -167,12 +167,16 @@ final class SandboxMoveTests: XCTestCase {
         var snapshot = host
         snapshot.sandbox = SandboxMove.recorded(from: preparing)
         XCTAssertTrue(model.hasMoved(snapshot))
-        snapshot.sandbox?.lifecycle = "needs_attention"
+        snapshot.sandbox = try session(
+            #"{"id":"bks-1","sandbox":{"provider":"daytona","lifecycle":"needs_attention"}}"#
+        ).sandbox
         XCTAssertTrue(SandboxMove.canMove(snapshot))
         XCTAssertFalse(model.hasMoved(snapshot), "The retained menu must allow retry after failure")
         XCTAssertTrue(model.hasMoved(host), "Bypassing a failure must not release stale host snapshots")
 
-        snapshot.sandbox?.sandboxId = "sb-1"
+        snapshot.sandbox = try session(
+            #"{"id":"bks-1","sandbox":{"provider":"daytona","lifecycle":"needs_attention","sandboxId":"sb-1"}}"#
+        ).sandbox
         XCTAssertTrue(model.hasMoved(snapshot), "A materialized failure uses Recreate instead")
         let retried = await model.move(sessionId: host.id, to: "daytona")
         XCTAssertNotNil(retried)

--- a/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
+++ b/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
@@ -25,19 +25,33 @@ final class SandboxMoveTests: XCTestCase {
         XCTAssertEqual(SandboxMove.refusal(moved), .inSandbox)
     }
 
-    /// A recorded provider without an id is a move still preparing (or one
-    /// that failed). The server would take a second move and provision twice,
-    /// so the offer ends as soon as any provider is recorded, as on the web;
-    /// a failed Sandbox is retried from the Sandbox section.
-    func testPreparingOrFailedSandboxRefuses() throws {
+    /// A recorded provider without an id is a move still preparing. The
+    /// server would take a second move and provision twice, so the offer
+    /// ends as soon as the provider is recorded; a record with no lifecycle
+    /// counts as preparing.
+    func testPreparingSandboxRefuses() throws {
         let preparing = try session(
             #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"daytona","lifecycle":"preparing"}}"#
         )
         XCTAssertEqual(SandboxMove.refusal(preparing), .inSandbox)
-        let failed = try session(
-            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"box","lifecycle":"needs_attention"}}"#
+        let unknown = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"daytona"}}"#
         )
-        XCTAssertEqual(SandboxMove.refusal(failed), .inSandbox)
+        XCTAssertEqual(SandboxMove.refusal(unknown), .inSandbox)
+    }
+
+    /// A provision that failed before making anything (`needs_attention`, no
+    /// id) has no Sandbox to recreate, and the server permits the retry; a
+    /// materialized Sandbox that needs attention is handled from its section.
+    func testFailedUnmaterializedMoveMayBeRetried() throws {
+        let failed = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"box","lifecycle":"needs_attention","lastLifecycleError":"boom"}}"#
+        )
+        XCTAssertNil(SandboxMove.refusal(failed))
+        let materializedFailure = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"box","sandboxId":"sb-2","lifecycle":"needs_attention"}}"#
+        )
+        XCTAssertEqual(SandboxMove.refusal(materializedFailure), .inSandbox)
         let local = try session(
             #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"local","sandboxId":"x"}}"#
         )
@@ -123,6 +137,13 @@ final class SandboxMoveTests: XCTestCase {
         }
         XCTAssertEqual(status.provider, "daytona")
         XCTAssertEqual(status.lifecycle, "preparing")
+        // The row built from it ends the offer at once, before any refresh.
+        var row = try session(#"{"id":"bks-1","mode":"code","repo":"opensession"}"#)
+        XCTAssertNil(SandboxMove.refusal(row))
+        row.sandbox = SandboxMove.recorded(from: status)
+        XCTAssertEqual(row.sandbox?.provider, "daytona")
+        XCTAssertEqual(row.sandbox?.lifecycle, "preparing")
+        XCTAssertEqual(SandboxMove.refusal(row), .inSandbox)
         XCTAssertNil(status.sandboxId)
     }
 

--- a/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
+++ b/packages/clients/ios/OS1Tests/SandboxMoveTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import OS1
+
+final class SandboxMoveTests: XCTestCase {
+    private func session(_ json: String) throws -> Session {
+        try JSONDecoder().decode(Session.self, from: Data(json.utf8))
+    }
+
+    private func status(_ json: String) throws -> InstanceSandboxStatus {
+        try JSONDecoder().decode(InstanceSandboxStatus.self, from: Data(json.utf8))
+    }
+
+    /// The server's own refusals (routes/sandbox.ts `sandboxAttachRefusal`),
+    /// one each, so the app never offers a move that would answer 409.
+    func testHostCodeSessionWithRepoCanMove() throws {
+        let host = try session(#"{"id":"bks-1","mode":"code","repo":"opensession"}"#)
+        XCTAssertNil(SandboxMove.refusal(host))
+        XCTAssertTrue(SandboxMove.canMove(host))
+    }
+
+    func testMaterializedSandboxRefuses() throws {
+        let moved = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"daytona","sandboxId":"sb-1"}}"#
+        )
+        XCTAssertEqual(SandboxMove.refusal(moved), .inSandbox)
+    }
+
+    /// A recorded provider without an id is a move that has not landed
+    /// (still preparing, or failed); moving again retries it.
+    func testPreparingSandboxMayBeMovedAgain() throws {
+        let preparing = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"daytona","lifecycle":"preparing"}}"#
+        )
+        XCTAssertNil(SandboxMove.refusal(preparing))
+        let local = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","sandbox":{"provider":"local","sandboxId":"x"}}"#
+        )
+        XCTAssertNil(SandboxMove.refusal(local))
+    }
+
+    func testRunnerRefuses() throws {
+        let runner = try session(
+            #"{"id":"bks-1","mode":"code","repo":"opensession","runner":{"id":"mac-1","name":"Mac","workspacePath":"/w"}}"#
+        )
+        XCTAssertEqual(SandboxMove.refusal(runner), .runner)
+    }
+
+    func testAutomationRefusesByFlagNameOrId() throws {
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code","repo":"r","automation":true}"#)),
+            .automation
+        )
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code","repo":"r","automation":"triage"}"#)),
+            .automation
+        )
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code","repo":"r","automationId":"plain-triage"}"#)),
+            .automation
+        )
+        XCTAssertNil(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code","repo":"r","automation":false}"#))
+        )
+    }
+
+    func testAskAndRepoLessSessionsRefuse() throws {
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"ask","repo":"r"}"#)),
+            .notCode
+        )
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code"}"#)),
+            .noRepo
+        )
+        XCTAssertEqual(
+            SandboxMove.refusal(try session(#"{"id":"bks-1","mode":"code","repo":"r","repoLess":true}"#)),
+            .noRepo
+        )
+    }
+
+    /// The composer's choices minus the host: a move is always away from
+    /// this machine.
+    func testChoicesAreTheReadyConnections() throws {
+        let payload = try status("""
+        {"enabled":true,"killSwitch":false,
+         "providers":[{"id":"docker","configured":true,"certified":true}],
+         "connections":[{"provider":"docker","state":"needs_attention"},
+                        {"provider":"daytona","state":"ready"},
+                        {"provider":"box","state":"ready"}]}
+        """)
+        XCTAssertEqual(SandboxMove.choices(payload), ["daytona", "box"])
+        XCTAssertEqual(SandboxMove.choices(nil), [])
+    }
+
+    /// The attach route's 428 is an answer, not a failure: the server's own
+    /// sentence about the unpushed work reaches the confirmation as written.
+    @MainActor
+    func testConfirmRequiredCarriesTheServersSentence() async throws {
+        let body = Data(
+            #"{"error":"This machine has 2 uncommitted files. The Sandbox clones the branch from origin, so push first, or move anyway and leave them here.","confirmRequired":true}"#.utf8
+        )
+        let outcome = try await OS1API.sandboxAttachOutcome(status: 428, data: body)
+        guard case .confirmRequired(let message) = outcome else {
+            return XCTFail("expected confirmRequired, got \(outcome)")
+        }
+        XCTAssertTrue(message.hasPrefix("This machine has 2 uncommitted files."))
+    }
+
+    @MainActor
+    func testMovedDecodesThePreparingSandbox() async throws {
+        let body = Data(
+            #"{"enabled":true,"provider":"daytona","workspace":"volume","status":"gone","lifecycle":"preparing","materialized":false}"#.utf8
+        )
+        let outcome = try await OS1API.sandboxAttachOutcome(status: 200, data: body)
+        guard case .moved(let status) = outcome else {
+            return XCTFail("expected moved, got \(outcome)")
+        }
+        XCTAssertEqual(status.provider, "daytona")
+        XCTAssertEqual(status.lifecycle, "preparing")
+        XCTAssertNil(status.sandboxId)
+    }
+
+    @MainActor
+    func testRefusalSurfacesTheServersMessage() async {
+        let body = Data(#"{"error":"Wait for the agent to finish before moving this session."}"#.utf8)
+        do {
+            _ = try await OS1API.sandboxAttachOutcome(status: 409, data: body)
+            XCTFail("expected a thrown refusal")
+        } catch {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Wait for the agent to finish before moving this session."
+            )
+        }
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -161,7 +161,14 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   native preview frames for visual session assets while documents and data keep
   their file rows, model/reasoning controls, and live remote
   sandbox status. Sandboxed workspaces expose explicit pause, wake, and
-  confirmed recreate controls without embedding the web client. Its Effective
+  confirmed recreate controls without embedding the web client. A code session
+  on this machine gets a Runtime section instead, with "Move to Daytona/Box"
+  for the Ready Sandboxes (`POST /api/sessions/:id/sandbox/attach`); the same
+  rows sit under Move to Sandbox in the session overflow menu and in a Mac
+  toolbar menu. The server's 428 (uncommitted files or unpushed commits that a
+  fresh clone would not have) becomes a confirmation with its own sentence and
+  a Move anyway. Runner, automation, Ask, repo-less and already-sandboxed
+  sessions never see the rows, matching the server's refusals. Its Effective
   config section resolves the next turn's model, engine, account, MCP access,
   instructions, and permissions, with the source under every displayed value.
 - **Session panels** — on iOS, Assets, individual assets, PR, Changes, Portals,
@@ -476,6 +483,8 @@ OS1/
     SettingsModels.swift     Settings payloads (tools/personal/workspace)
     WorkspaceRunner.swift    Instance Runner list + the shared status words
     SandboxOffering.swift    What run environments a new session may choose
+    SandboxMove.swift        Which sessions may move into a Sandbox later, and
+                             the attach route's 428 as an answer
     AccentTheme.swift        The app's primary colour: one table of light/dark
                              fills, a derived glyph colour, and the store the
                              Appearance picker writes

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -167,8 +167,10 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   rows sit under Move to Sandbox in the session overflow menu and in a Mac
   toolbar menu. The server's 428 (uncommitted files or unpushed commits that a
   fresh clone would not have) becomes a confirmation with its own sentence and
-  a Move anyway. Runner, automation, Ask, repo-less and already-sandboxed
-  sessions never see the rows, matching the server's refusals. Its Effective
+  a Move anyway. Runner, automation, Ask, repo-less, preparing and materialized
+  Sandbox sessions never see the rows. If provisioning fails before creating a
+  Sandbox ID, the overflow menu allows another move without reopening the
+  session; stale host snapshots still cannot enable a second move. Its Effective
   config section resolves the next turn's model, engine, account, MCP access,
   instructions, and permissions, with the source under every displayed value.
 - **Session panels** — on iOS, Assets, individual assets, PR, Changes, Portals,


### PR DESCRIPTION
Ports the existing-session Sandbox attach flow (ef430bcc3, 0d07410de) to the native app.

**API** `OS1API.attachSandbox(sessionId:provider:confirm:)` posts `{ provider, confirm? }` to `/api/sessions/:id/sandbox/attach` and answers a `SandboxAttachOutcome`: `.moved(SessionSandboxStatus)` or `.confirmRequired(message)` for the 428, which is an answer rather than an error, so the server's own sentence about the uncommitted files or unpushed commits reaches the person before a repeat with `confirm`.

**Eligibility** `SandboxMove.refusal` mirrors the web's `canMoveToSandbox`: any recorded non-local Sandbox (materialized, preparing or failed), a Runner, an automation (flag, name or `automationId`, newly decoded), a non-code or repo-less session. No surface offers a move the server would 409, and none offers a second move while the first is still preparing (the server would provision twice and orphan one). A failed Sandbox is retried from the Sandbox section's Recreate. Providers are the composer's Ready list (`/api/sandbox/status`) minus the host.

**Surfaces** (one `SandboxMoveViewModel`, the same rows)
- iOS session overflow menu: a *Move to Sandbox* submenu with *Move to Daytona / Box*, disabled while the agent runs ("Available once the agent finishes.").
- Mac toolbar: a cube menu beside model settings, shown only for a movable session.
- Worktree details sheet: a *Runtime* section ("Runs on: This machine") with the same rows.

A 428 becomes a *Move to Daytona anyway?* confirmation carrying the server's sentence and a *Move anyway*; a refusal is an alert. On success the session row is refreshed from the server and the sheet overlays the recorded provider until the poll agrees, so the Sandbox section says *Preparing* at once.

**Verification** on tella-mac-node: `OS1` (iOS Simulator) and `OS1Mac` build; the full `OS1Mac` test run passes (1075 tests, incl. the new `SandboxMoveTests` for the refusals, provider choice, 428 mapping and refusal messages). The real flow was exercised against os.tella.dev on throwaway `skills` sessions (since archived): a worktree with one uncommitted file produced the 428 with the server's sentence, *Move anyway* moved the session (`daytona`, `preparing`), and the sheet showed Preparing immediately. Daytona then reported Needs attention on that instance (ingress unreachable from the sandbox), which is the instance's Daytona setup, not this change.

DEBUG capture hooks: `OS1_SANDBOX_MOVE=<provider>`, `OS1_SANDBOX_MOVE_CONFIRM=1`, `OS1_SCROLL_TO=runtime|sandbox`.

Note: tellahq/opensession#343 (a sibling item from the same parity report) also adds a native Move to Sandbox alongside Open desktop; the two touch the same files and will conflict, so whichever lands second needs a rebase.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-33266d16-76e4-79b8-b774-a63efed031c5)
