### PR TITLE
Native PR panel: hold a merge for five seconds with Undo and a countdown

### DIFF
--- a/packages/clients/ios/OS1/ViewModels/DeferredMerge.swift
+++ b/packages/clients/ios/OS1/ViewModels/DeferredMerge.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Observation
+
+/// One merge held back for an undo window before its request goes out.
+///
+/// Mirrors the web client's `deferred-merge.ts`: the merge the person just
+/// confirmed waits five seconds, counting down in whole seconds, and Undo
+/// during that window means the request is never sent. Nothing here reports a
+/// merged state — the phase reads `.running` only once the request is on the
+/// wire, and the pull request's own state still comes from the server.
+///
+/// The clock is injected so tests drive the window without waiting it out.
+@MainActor
+@Observable
+final class DeferredMerge {
+    enum Phase: Equatable {
+        /// Nothing held.
+        case idle
+        /// Waiting out the undo window; the request has not been sent.
+        case scheduled
+        /// The request is in flight and can no longer be taken back.
+        case running
+    }
+
+    /// Mirrors the web client's `MERGE_UNDO_DELAY_MS`.
+    nonisolated static let undoWindow: Duration = .seconds(5)
+
+    private(set) var phase: Phase = .idle
+    /// Whole seconds until the request goes out, or nil outside the window.
+    /// Never reads zero: the last tick sends rather than showing "0".
+    private(set) var secondsLeft: Int?
+
+    private let clock: any Clock<Duration>
+    private var task: Task<Void, Never>?
+    /// Bumped on every schedule and cancel so a task that outlived its
+    /// schedule can never send on behalf of a newer one.
+    private var generation = 0
+
+    init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
+
+    /// Hold `send` for the window. Refused while a merge is already held or
+    /// in flight, so a double confirmation can never send twice.
+    @discardableResult
+    func schedule(
+        window: Duration = DeferredMerge.undoWindow,
+        send: @escaping @MainActor () async throws -> Void,
+        completion: @escaping @MainActor (Result<Void, any Error>) -> Void = { _ in }
+    ) -> Bool {
+        guard phase == .idle else { return false }
+        generation += 1
+        let generation = generation
+        phase = .scheduled
+        secondsLeft = Self.wholeSeconds(window)
+        task = Task { [clock] in
+            var remaining = window
+            while remaining > .zero {
+                let step = min(remaining, .seconds(1))
+                do {
+                    try await clock.sleep(for: step)
+                } catch {
+                    return
+                }
+                guard self.generation == generation, self.phase == .scheduled else { return }
+                remaining -= step
+                self.secondsLeft = remaining > .zero ? Self.wholeSeconds(remaining) : nil
+            }
+            guard self.generation == generation, self.phase == .scheduled else { return }
+            self.phase = .running
+            self.secondsLeft = nil
+            let result: Result<Void, any Error>
+            do {
+                try await send()
+                result = .success(())
+            } catch {
+                result = .failure(error)
+            }
+            guard self.generation == generation else { return }
+            self.phase = .idle
+            self.task = nil
+            completion(result)
+        }
+        return true
+    }
+
+    /// Take the merge back. True when a held request will now never be sent;
+    /// false when nothing was held or the request is already in flight.
+    @discardableResult
+    func cancel() -> Bool {
+        guard phase == .scheduled else { return false }
+        generation += 1
+        task?.cancel()
+        task = nil
+        phase = .idle
+        secondsLeft = nil
+        return true
+    }
+
+    private static func wholeSeconds(_ duration: Duration) -> Int {
+        max(1, Int((duration / .seconds(1)).rounded(.up)))
+    }
+
+    #if DEBUG
+    /// Hold the window open at one digit with no request behind it, so a
+    /// screenshot can catch the countdown. Undo clears it like any other.
+    func presentFixture(secondsLeft: Int) {
+        cancel()
+        phase = .scheduled
+        self.secondsLeft = secondsLeft
+    }
+    #endif
+}

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -235,6 +235,10 @@ struct PrPanelView: View {
     /// Merge method awaiting confirmation — merging is the one action here
     /// that can't be taken back, so it always passes through a dialog.
     @State private var pendingMerge: String?
+    /// The confirmed merge, held for its five-second undo window before the
+    /// request goes out. Owned by the panel: closing it takes the merge back,
+    /// so a request the person can no longer see never goes out.
+    @State private var deferredMerge = DeferredMerge()
     @State private var confirmingClose = false
     @State private var slackShare: PrSlackShareRequest?
     /// Which of the canvas's two pages is showing. Two, not the six tabs this
@@ -293,7 +297,17 @@ struct PrPanelView: View {
                 page = .info
             }
             #endif
+            #if DEBUG
+            // Screenshot hook: the countdown with no request behind it.
+            if ProcessInfo.processInfo.environment["OS1_SHOW_MERGE_UNDO"] == "1" {
+                deferredMerge.presentFixture(secondsLeft: 4)
+            }
+            #endif
         }
+        // Out of sight is out of reach: a merge still inside its window is
+        // taken back rather than sent from a panel nobody is looking at. One
+        // already on the wire runs to its end.
+        .onDisappear { deferredMerge.cancel() }
         .sheet(item: $slackShare) { request in
             PrSlackShareSheet(request: request)
         }
@@ -363,6 +377,11 @@ struct PrPanelView: View {
                             .labelStyle(.iconOnly)
                     }
                 }
+                // The undo control lands in front of the actions menu for the
+                // window, so nothing the person just pressed moves.
+                if deferredMerge.phase == .scheduled {
+                    ToolbarItem(placement: .topTrailingCompat) { mergeUndoControl }
+                }
                 ToolbarItem(placement: .topTrailingCompat) { actionsMenu(pr) }
             }
             .sheet(isPresented: $reviewing) {
@@ -382,7 +401,7 @@ struct PrPanelView: View {
                 Button(mergeButtonLabel(pendingMerge ?? "squash")) {
                     let method = pendingMerge ?? "squash"
                     pendingMerge = nil
-                    run(.merge) { try await viewModel.mergePr(method: method) }
+                    holdMerge(method: method)
                 }
                 Button("Cancel", role: .cancel) { pendingMerge = nil }
             } message: {
@@ -935,12 +954,21 @@ struct PrPanelView: View {
                 } label: {
                     Label("Review", systemImage: "checkmark.bubble")
                 }
-                Menu {
-                    Button("Squash and merge") { pendingMerge = "squash" }
-                    Button("Create a merge commit") { pendingMerge = "merge" }
-                    Button("Rebase and merge") { pendingMerge = "rebase" }
-                } label: {
-                    Label("Merge", systemImage: "arrow.triangle.merge")
+                if deferredMerge.phase == .idle {
+                    Menu {
+                        Button("Squash and merge") { pendingMerge = "squash" }
+                        Button("Create a merge commit") { pendingMerge = "merge" }
+                        Button("Rebase and merge") { pendingMerge = "rebase" }
+                    } label: {
+                        Label("Merge", systemImage: "arrow.triangle.merge")
+                    }
+                } else {
+                    // The row keeps its place and reads as merging for the
+                    // whole window, the way the web's button does.
+                    Button {} label: {
+                        Label("Merging…", systemImage: "arrow.triangle.merge")
+                    }
+                    .disabled(true)
                 }
             }
             Section {
@@ -995,6 +1023,45 @@ struct PrPanelView: View {
             }
         }
         .disabled(busy != nil)
+    }
+
+    /// The undo affordance for the window: the undo glyph plus the seconds
+    /// left, rolling down a digit at a time. Pressing it means the request is
+    /// never sent.
+    private var mergeUndoControl: some View {
+        let seconds = deferredMerge.secondsLeft ?? 1
+        return Button {
+            if deferredMerge.cancel() { Haptics.play(.selection) }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.uturn.backward")
+                Text(verbatim: "\(seconds)")
+                    .font(.subheadline.weight(.medium))
+                    .monospacedDigit()
+                    .contentTransition(.numericText(countsDown: true))
+                    .animation(.snappy(duration: 0.3), value: seconds)
+            }
+        }
+        .accessibilityLabel(Text(verbatim: "Undo merge, \(seconds)s left"))
+        .help("Undo merge")
+    }
+
+    /// Hold the confirmed merge for its window before anything is sent. The
+    /// spinner and the panel's busy state wait for the request itself: the
+    /// window is not a merge in progress, and must not read as one.
+    private func holdMerge(method: String) {
+        guard busy == nil else { return }
+        actionError = nil
+        deferredMerge.schedule {
+            busy = .merge
+            try await viewModel.mergePr(method: method)
+        } completion: { result in
+            if case .failure(let error) = result {
+                actionError = (error as? LocalizedError)?.errorDescription
+                    ?? error.localizedDescription
+            }
+            busy = nil
+        }
     }
 
     /// Run one action, keeping its failure in the panel: the server answers a

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -1016,6 +1016,7 @@ struct PrPanelView: View {
                     } label: {
                         Label("Close pull request", systemImage: "xmark.circle")
                     }
+                    .disabled(deferredMerge.phase != .idle)
                 }
             }
         } label: {

--- a/packages/clients/ios/OS1/Views/PrPanel.swift
+++ b/packages/clients/ios/OS1/Views/PrPanel.swift
@@ -948,12 +948,15 @@ struct PrPanelView: View {
     private func actionsMenu(_ pr: PrDetails) -> some View {
         Menu {
             if pr.isOpen {
+                // Review can merge after approving, so it waits while a
+                // merge is held or on the wire: one request per PR.
                 Button {
                     actionError = nil
                     reviewing = true
                 } label: {
                     Label("Review", systemImage: "checkmark.bubble")
                 }
+                .disabled(deferredMerge.phase != .idle)
                 if deferredMerge.phase == .idle {
                     Menu {
                         Button("Squash and merge") { pendingMerge = "squash" }

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -1010,6 +1010,15 @@ struct SessionView: View {
                    openPanel.isAvailable {
                     openPanel(.changes(sessionId: viewModel.session.id))
                 }
+                #endif
+                #if DEBUG && os(macOS)
+                // The Mac has no panel stack; the PR panel is the sheet the
+                // toolbar chip opens.
+                if ProcessInfo.processInfo.environment["OS1_OPEN_PR"] == "1" {
+                    showPrPanel = true
+                }
+                #endif
+                #if DEBUG && os(iOS)
                 if ProcessInfo.processInfo.environment["OS1_SHOW_SLACK_RECEIPT"] == "1" {
                     viewModel.resolveSlackComposer(SlackComposeReceipt(
                         requestId: "screenshot-slack-receipt",

--- a/packages/clients/ios/OS1Tests/DeferredMergeTests.swift
+++ b/packages/clients/ios/OS1Tests/DeferredMergeTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import OS1
+
+/// The five-second merge window, driven by a manual clock: nothing here waits
+/// on wall time, and every tick is a step the test takes on purpose.
+@MainActor
+final class DeferredMergeTests: XCTestCase {
+    private var clock: ManualClock!
+    private var merge: DeferredMerge!
+    private var sends = 0
+    private var results: [Result<Void, any Error>] = []
+    /// Holds one send open so the in-flight phase can be observed.
+    private var release: CheckedContinuation<Void, Never>?
+
+    override func setUp() {
+        super.setUp()
+        clock = ManualClock()
+        merge = DeferredMerge(clock: clock)
+        sends = 0
+        results = []
+    }
+
+    override func tearDown() {
+        merge?.cancel()
+        merge = nil
+        super.tearDown()
+    }
+
+    private struct SendFailed: Error {}
+
+    @discardableResult
+    private func schedule(
+        window: Duration = DeferredMerge.undoWindow,
+        failing: Bool = false
+    ) -> Bool {
+        merge.schedule(window: window) { [self] in
+            sends += 1
+            if failing { throw SendFailed() }
+        } completion: { [self] result in
+            results.append(result)
+        }
+    }
+
+    /// Let the countdown task reach its next suspension point.
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    /// One second at a time: the countdown re-arms its sleep after each tick,
+    /// so a single large jump would only land the first of them.
+    private func tick(seconds: Int) async {
+        for _ in 0..<seconds {
+            await settle()
+            clock.advance(by: .seconds(1))
+            await settle()
+        }
+    }
+
+    func testWindowMatchesTheWebClient() {
+        XCTAssertEqual(DeferredMerge.undoWindow, .seconds(5))
+    }
+
+    func testHoldsTheRequestAndCountsTheSecondsDown() async {
+        XCTAssertTrue(schedule())
+        XCTAssertEqual(merge.phase, .scheduled)
+        XCTAssertEqual(merge.secondsLeft, 5)
+        XCTAssertEqual(sends, 0)
+
+        await tick(seconds: 1)
+        XCTAssertEqual(merge.secondsLeft, 4)
+        await tick(seconds: 3)
+        XCTAssertEqual(merge.secondsLeft, 1, "the digit never reads zero")
+        XCTAssertEqual(merge.phase, .scheduled)
+        XCTAssertEqual(sends, 0, "nothing goes out inside the window")
+
+        await tick(seconds: 1)
+        XCTAssertEqual(sends, 1)
+        XCTAssertEqual(merge.phase, .idle, "settled once the request returned")
+        XCTAssertNil(merge.secondsLeft)
+        XCTAssertEqual(results.count, 1)
+        if case .failure = results.first { XCTFail("the send succeeded") }
+    }
+
+    func testUndoInsideTheWindowNeverSends() async {
+        schedule()
+        await tick(seconds: 2)
+        XCTAssertEqual(merge.secondsLeft, 3)
+
+        XCTAssertTrue(merge.cancel())
+        XCTAssertEqual(merge.phase, .idle)
+        XCTAssertNil(merge.secondsLeft)
+        XCTAssertFalse(merge.cancel(), "nothing left to take back")
+
+        await tick(seconds: 10)
+        XCTAssertEqual(sends, 0)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testOneMergeAtATime() async {
+        XCTAssertTrue(schedule())
+        XCTAssertFalse(schedule(), "a second confirmation cannot queue a second send")
+
+        await tick(seconds: 5)
+        XCTAssertEqual(sends, 1)
+    }
+
+    func testAnUndoneScheduleCannotFireForItsReplacement() async {
+        schedule()
+        await tick(seconds: 4)
+        merge.cancel()
+
+        XCTAssertTrue(schedule(window: .seconds(2)))
+        XCTAssertEqual(merge.secondsLeft, 2)
+        await tick(seconds: 1)
+        XCTAssertEqual(sends, 0, "the first schedule's last second must not send")
+        await tick(seconds: 1)
+        XCTAssertEqual(sends, 1)
+    }
+
+    func testCannotUndoOnceTheRequestIsOut() async {
+        merge.schedule(window: .seconds(1)) { [self] in
+            sends += 1
+            await withCheckedContinuation { release = $0 }
+        }
+        await tick(seconds: 1)
+        XCTAssertEqual(merge.phase, .running)
+        XCTAssertEqual(sends, 1)
+
+        XCTAssertFalse(merge.cancel(), "an in-flight request is not undoable")
+        XCTAssertEqual(merge.phase, .running)
+        XCTAssertFalse(schedule(), "and holds the slot until it settles")
+
+        release?.resume()
+        release = nil
+        await settle()
+        XCTAssertEqual(merge.phase, .idle)
+        XCTAssertEqual(sends, 1)
+    }
+
+    func testAFailedSendReportsAndFreesTheSlot() async {
+        schedule(window: .seconds(1), failing: true)
+        await tick(seconds: 1)
+
+        XCTAssertEqual(merge.phase, .idle)
+        XCTAssertEqual(results.count, 1)
+        guard case .failure(let error) = results.first else {
+            return XCTFail("expected the send's failure")
+        }
+        XCTAssertTrue(error is SendFailed)
+        XCTAssertTrue(schedule(), "a failed merge can be tried again")
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -248,7 +248,9 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   comment with a summary, plus the "squash and merge after approving"
   shortcut, `POST …/pr-review`), **Merge** (squash, merge commit or rebase,
   behind a confirmation that names what it would land on top of — conflicts,
-  failing checks, a draft, requested changes — `POST …/pr-merge`), and
+  failing checks, a draft, requested changes — then held for a five-second
+  undo window with a countdown before `POST …/pr-merge` goes out; closing the
+  panel inside the window takes it back too, see `DeferredMerge`), and
   **Close pull request** (`POST …/pr-close`). The session overflow menu also
   exposes squash, merge-commit and rebase merge actions directly, with the same
   warnings and confirmation. PR surfaces can copy the GitHub link or open an


### PR DESCRIPTION
Ports the web client's deferred merge (06e04bdaf, 9effdf0dd) to the native PR panel.

**Before:** confirming a merge method sent `POST …/pr-merge` at once.

**After:** the confirmation stays; the request is held for five seconds. The Merge row keeps its place and reads "Merging…", an Undo control (`arrow.uturn.backward` plus the whole seconds left, rolling down per tick, accessibility label "Undo merge, Ns left") lands in the toolbar in front of the actions menu. The panel's busy state and spinner wait for the request itself, so nothing reads as merged before anything was sent. Undo, or closing the panel inside the window, cancels; a request already on the wire runs to its end.

- `DeferredMerge` (`@Observable`, clock-injected): one held merge per panel, `idle → scheduled → running → idle`, refused while one is held or in flight, cancellable only while scheduled, generation-guarded so a replaced schedule can never fire.
- `DeferredMergeTests` drive it with the manual clock: countdown digits, undo never sends, one at a time, an undone schedule cannot fire for its replacement, no undo once in flight, a failed send frees the slot.
- `OS1_SHOW_MERGE_UNDO=1` (DEBUG) arms the countdown with no request behind it, for screenshots; `OS1_OPEN_PR=1` now also opens the panel on macOS.

Built `OS1` and `OS1Mac`; the 7 new tests pass on the Mac node.

**macOS finding, out of scope here:** the PR sheet on macOS renders no toolbar items at all (Done, the actions menu, and so the merge entry itself are absent, before this change too: `topTrailingCompat` maps to `.primaryAction`, which macOS sheets do not draw). The undo control shares that placement, so on the Mac the countdown cannot be reached or seen from this panel until the sheet gets its actions. Captures are in the session.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-ab52b9f3-839f-7463-ba2c-cb747cbaab16)