### PR TITLE
Answer the native ask card's letters from the keyboard

### DIFF
--- a/packages/clients/ios/OS1/Models/AccountShortcuts.swift
+++ b/packages/clients/ios/OS1/Models/AccountShortcuts.swift
@@ -6,6 +6,9 @@ enum AccountShortcutCommand: String, CaseIterable, Identifiable {
     case commandMenu = "command-menu"
     case newSession = "session-new"
     case newSessionInWorkspace = "session-new-sibling"
+    /// The web registry's `ask-focus`: the letters answer a question from
+    /// anywhere but a text field, and this is the way over from the composer.
+    case askFocus = "ask-focus"
 
     var id: String { rawValue }
 
@@ -14,6 +17,7 @@ enum AccountShortcutCommand: String, CaseIterable, Identifiable {
         case .commandMenu: "Command menu"
         case .newSession: "New session"
         case .newSessionInWorkspace: "New session in this workspace"
+        case .askFocus: "Answer the question"
         }
     }
 
@@ -22,6 +26,7 @@ enum AccountShortcutCommand: String, CaseIterable, Identifiable {
         case .commandMenu: "Search sessions and commands"
         case .newSession: "Start a session in any repository"
         case .newSessionInWorkspace: "Start another session in the open workspace"
+        case .askFocus: "Jump to the question the assistant is waiting on"
         }
     }
 
@@ -32,6 +37,7 @@ enum AccountShortcutCommand: String, CaseIterable, Identifiable {
         case .commandMenu: AccountShortcutChord(rawValue: "mod+k")!
         case .newSession: AccountShortcutChord(rawValue: "mod+n")!
         case .newSessionInWorkspace: AccountShortcutChord(rawValue: "mod+alt+n")!
+        case .askFocus: AccountShortcutChord(rawValue: "mod+i")!
         }
     }
 }

--- a/packages/clients/ios/OS1/Models/AskLetterShortcuts.swift
+++ b/packages/clients/ios/OS1/Models/AskLetterShortcuts.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Letter shortcuts for the live question card (`AskQuestionCard`).
+///
+/// The web card labels its options A, B, C and answers to those letters from
+/// anywhere on the page that is not a text field. This is the native reading
+/// of the same idea, kept pure on purpose: the keystroke-to-option mapping
+/// and the "does this card hear this key" decision are unit-testable without
+/// a window, and the two platforms' bridges cannot disagree about which
+/// option "B" is.
+enum AskLetterShortcuts {
+    private static let letters = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+    /// The label the card draws on an option: A for the first, B the second.
+    /// Nil past Z, where a row still answers to touch but has no key.
+    static func label(at index: Int) -> String? {
+        guard letters.indices.contains(index) else { return nil }
+        return String(letters[index])
+    }
+
+    /// The option letter a keystroke spells, or nil when it is anything else:
+    /// a chord, a held key, or a key that is not one ASCII letter. Shift
+    /// passes, since "A" and "a" name the same option.
+    static func letter(
+        typed characters: String?,
+        modifiers: AccountShortcutModifiers,
+        isRepeat: Bool
+    ) -> String? {
+        guard !isRepeat, modifiers.subtracting(.shift).isEmpty,
+              let characters, characters.count == 1
+        else { return nil }
+        let upper = characters.uppercased()
+        guard upper.count == 1, let letter = upper.first, letters.contains(letter) else {
+            return nil
+        }
+        return String(letter)
+    }
+
+    /// The row a letter names, counted the way the card labels them.
+    static func index(of letter: String) -> Int? {
+        guard letter.count == 1, let character = letter.uppercased().first else { return nil }
+        return letters.firstIndex(of: character)
+    }
+
+    /// The option a letter names on one question, or nil past the last
+    /// option and on a free-text question.
+    static func option(
+        in question: AskQuestion.Question,
+        letter: String
+    ) -> AskQuestion.Option? {
+        guard let index = index(of: letter), let options = question.options,
+              options.indices.contains(index)
+        else { return nil }
+        return options[index]
+    }
+}
+
+/// Whether one card hears one keystroke. A second window or a Desk sheet can
+/// show its own live question, and the keyboard belongs to exactly one of
+/// them; the platform bridge reads these off the card's window and the pure
+/// rule decides.
+struct AskKeyScope: Equatable, Sendable {
+    /// The card's window is the key window.
+    var windowIsKey: Bool
+    /// The app is frontmost. A local event monitor only sees the app's own
+    /// events, but a stale key window while another app is active must not
+    /// answer either.
+    var appIsActive: Bool
+    /// A text field holds the keyboard: the composer, the card's own free
+    /// text row, or a search field. Letters there are text.
+    var editingText: Bool
+    /// The card already sent its answer and is waiting to be retired.
+    var answered: Bool
+
+    /// A bare letter picks an option.
+    var hearsLetters: Bool {
+        windowIsKey && appIsActive && !editingText && !answered
+    }
+
+    /// The "Answer the question" command reaches the card. It is allowed
+    /// from a text field: the composer is the one place the letters cannot
+    /// reach, and this is the way over from it.
+    var takesFocusCommand: Bool {
+        windowIsKey && appIsActive && !answered
+    }
+}

--- a/packages/clients/ios/OS1/OS1App.swift
+++ b/packages/clients/ios/OS1/OS1App.swift
@@ -65,6 +65,15 @@ struct OS1App: App {
                     )
                 }
                 .keyboardShortcut(shortcuts.keyboardShortcut(for: .commandMenu))
+                // The letters answer a question from anywhere but a text
+                // field. This is the way in from the one place they cannot
+                // reach, the composer, which is where the keyboard usually
+                // is when a question lands. The card in the key window takes
+                // focus; with no question waiting it does nothing.
+                Button("Answer the Question") {
+                    NotificationCenter.default.post(name: .os1AskFocus, object: nil)
+                }
+                .keyboardShortcut(shortcuts.keyboardShortcut(for: .askFocus))
             }
         }
         #endif

--- a/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
+++ b/packages/clients/ios/OS1/ViewModels/SessionViewModel.swift
@@ -211,6 +211,40 @@ final class SessionViewModel {
     private var screenshotDropTask: Task<Void, Never>?
     #endif
 
+    /// A live question with three lettered options, for the card capture and
+    /// the keyboard verification. Its id matches nothing on the server, so an
+    /// answer sent for it is ignored there and only the local receipt shows.
+    func showAskForScreenshot() {
+        holdsScreenshotFixture = true
+        pendingQuestion = AskQuestion(
+            id: "screenshot-ask",
+            questions: [
+                AskQuestion.Question(
+                    question: "Which channel should the fix ship to?",
+                    header: "Deploy",
+                    options: [
+                        AskQuestion.Option(
+                            label: "Production",
+                            description: "Roll it out to every workspace now"
+                        ),
+                        AskQuestion.Option(
+                            label: "Staging",
+                            description: "Verify on the internal instance first"
+                        ),
+                        AskQuestion.Option(
+                            label: "Hold",
+                            description: "Keep it on main until the next release"
+                        ),
+                    ],
+                    multiSelect: false
+                )
+            ]
+        )
+        isRunning = false
+        runStartedAt = nil
+        isLoadingConversation = false
+    }
+
     func showSteeredMessageForScreenshot() {
         holdsScreenshotFixture = true
         let id = "screenshot-steered-message"

--- a/packages/clients/ios/OS1/Views/AskKeyBridge.swift
+++ b/packages/clients/ios/OS1/Views/AskKeyBridge.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+#if os(macOS)
+extension Notification.Name {
+    /// The "Answer the Question" command (⌘I by default). The menu and the
+    /// command palette post it; the question card in the key window takes
+    /// focus, which is how the keyboard gets from the composer to the card.
+    static let os1AskFocus = Notification.Name("os1.askFocus")
+}
+#endif
+
+extension View {
+    /// Hardware keys for the question card from outside it.
+    ///
+    /// `onLetter` is a bare letter typed anywhere in the card's window that is
+    /// not a text field; it returns whether the letter named an option, so an
+    /// unclaimed key stays the system's. `onFocusCommand` is the "Answer the
+    /// question" chord, which is allowed from a text field.
+    ///
+    /// SwiftUI's own `keyboardShortcut` cannot carry a bare letter safely on
+    /// macOS: a key equivalent is matched before the field editor sees the
+    /// key, so "a" would answer the question instead of typing into the
+    /// composer. The Mac side is an `NSEvent` local monitor scoped to the
+    /// card's own window (`AskKeyMonitorView`), which is how this app already
+    /// reads keys out from under a focused field. On iOS the letters ride the
+    /// option rows as key equivalents instead: UIKit gives text input
+    /// priority over an unmodified key command, and the one scene is the one
+    /// window.
+    func askHardwareKeys(
+        active: Bool,
+        onLetter: @escaping (String) -> Bool,
+        onFocusCommand: @escaping () -> Void
+    ) -> some View {
+        modifier(AskHardwareKeys(
+            active: active, onLetter: onLetter, onFocusCommand: onFocusCommand
+        ))
+    }
+
+    /// The bare key equivalent an option row answers to on iOS. A no-op on
+    /// macOS, where the window monitor hears the letters instead.
+    func askLetterKeyEquivalent(_ letter: String?) -> some View {
+        modifier(AskLetterKeyEquivalent(letter: letter))
+    }
+}
+
+private struct AskHardwareKeys: ViewModifier {
+    let active: Bool
+    let onLetter: (String) -> Bool
+    let onFocusCommand: () -> Void
+
+    func body(content: Content) -> some View {
+        #if os(macOS)
+        content.background {
+            AskKeyMonitor(active: active, onLetter: onLetter, onFocusCommand: onFocusCommand)
+                .frame(width: 0, height: 0)
+        }
+        #else
+        content.background {
+            // Listed in the iPad's ⌘ HUD under this title, which is what
+            // makes it discoverable; the button itself never draws.
+            Button("Answer the question", action: onFocusCommand)
+                .keyboardShortcut("i", modifiers: .command)
+                .disabled(!active)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+        }
+        #endif
+    }
+}
+
+private struct AskLetterKeyEquivalent: ViewModifier {
+    let letter: String?
+
+    func body(content: Content) -> some View {
+        #if os(iOS)
+        if let key = letter?.lowercased().first {
+            content.keyboardShortcut(KeyEquivalent(key), modifiers: [])
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}
+
+#if os(macOS)
+private struct AskKeyMonitor: NSViewRepresentable {
+    let active: Bool
+    let onLetter: (String) -> Bool
+    let onFocusCommand: () -> Void
+
+    func makeNSView(context: Context) -> AskKeyMonitorView {
+        let view = AskKeyMonitorView()
+        apply(to: view)
+        return view
+    }
+
+    func updateNSView(_ view: AskKeyMonitorView, context: Context) {
+        apply(to: view)
+    }
+
+    static func dismantleNSView(_ view: AskKeyMonitorView, coordinator: ()) {
+        view.uninstall()
+    }
+
+    private func apply(to view: AskKeyMonitorView) {
+        view.active = active
+        view.onLetter = onLetter
+        view.onFocusCommand = onFocusCommand
+    }
+}
+
+/// A zero-sized view whose only job is to know which window the card is in.
+/// The monitor it installs sees every key-down in the app first and keeps
+/// only a bare letter aimed at this window while it is key and no text field
+/// is editing; everything else passes through untouched. The focus command
+/// is answered by the same test, so with two windows open only the one the
+/// keyboard belongs to moves.
+final class AskKeyMonitorView: NSView {
+    var active = true
+    var onLetter: (String) -> Bool = { _ in false }
+    var onFocusCommand: () -> Void = {}
+
+    private var monitor: Any?
+    private var focusObserver: NSObjectProtocol?
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            uninstall()
+        } else {
+            install()
+        }
+    }
+
+    private func install() {
+        if monitor == nil {
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                MainActor.assumeIsolated {
+                    self?.consume(event) == true ? nil : event
+                }
+            }
+        }
+        if focusObserver == nil {
+            focusObserver = NotificationCenter.default.addObserver(
+                forName: .os1AskFocus, object: nil, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.takeFocus() }
+            }
+        }
+    }
+
+    func uninstall() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+        if let focusObserver {
+            NotificationCenter.default.removeObserver(focusObserver)
+            self.focusObserver = nil
+        }
+    }
+
+    private var scope: AskKeyScope? {
+        guard let window else { return nil }
+        return AskKeyScope(
+            windowIsKey: window.isKeyWindow,
+            appIsActive: NSApp.isActive,
+            editingText: Self.isEditingText(window.firstResponder),
+            answered: !active
+        )
+    }
+
+    private func consume(_ event: NSEvent) -> Bool {
+        guard let window, event.window === window, scope?.hearsLetters == true,
+              let letter = AskLetterShortcuts.letter(
+                  typed: event.charactersIgnoringModifiers,
+                  modifiers: Self.modifiers(of: event),
+                  isRepeat: event.isARepeat
+              )
+        else { return false }
+        return onLetter(letter)
+    }
+
+    private func takeFocus() {
+        guard scope?.takesFocusCommand == true else { return }
+        // The composer's field editor holds first responder. Hand the
+        // window's focus back before SwiftUI moves its own, or the letters
+        // typed next still land in the field.
+        window?.makeFirstResponder(nil)
+        onFocusCommand()
+    }
+
+    /// SwiftUI text fields are backed by `NSTextField`, whose field editor
+    /// (an `NSTextView`, so an `NSText`) is what actually holds first
+    /// responder while editing; a `TextEditor` is an `NSTextView` outright.
+    private static func isEditingText(_ responder: NSResponder?) -> Bool {
+        responder is NSText || responder is NSTextField
+    }
+
+    private static func modifiers(of event: NSEvent) -> AccountShortcutModifiers {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        var modifiers: AccountShortcutModifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        return modifiers
+    }
+}
+#endif

--- a/packages/clients/ios/OS1/Views/AskQuestionCard.swift
+++ b/packages/clients/ios/OS1/Views/AskQuestionCard.swift
@@ -11,6 +11,14 @@ import SwiftUI
 /// hairline-separated rows, and — for the free-text answer — the same
 /// accent-filled send disc the composer wears, so answering here feels like
 /// writing a message rather than filling in a form.
+///
+/// The letters are the keyboard's tap. Each option wears A, B, C, and a bare
+/// letter typed anywhere in the card's window that is not a text field picks
+/// that row and answers, exactly as a tap would. The composer is the one
+/// place the letters cannot reach (they are typing there), so the "Answer the
+/// question" command (⌘I) arms the card instead: it takes the keyboard back
+/// from the composer and rings the card, and the letters answer from there.
+/// Only the card in the key window hears any of it; see `AskKeyScope`.
 struct AskQuestionCard: View {
     let ask: AskQuestion
     let onAnswer: ([String: String]?) -> Void
@@ -20,8 +28,15 @@ struct AskQuestionCard: View {
     /// between the tap and the server retiring the card.
     @State private var chosen: String?
     @FocusState private var inputFocused: Bool
+    /// The card itself holds keyboard focus, after the focus command. This is
+    /// only what arms the card and draws the ring; the letters answer through
+    /// the window bridge whether or not the card holds focus, as long as no
+    /// text field is editing.
+    @FocusState private var cardFocused: Bool
 
     private var question: AskQuestion.Question? { ask.questions.first }
+
+    private var options: [AskQuestion.Option] { question?.options ?? [] }
 
     private var cardShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -36,9 +51,9 @@ struct AskQuestionCard: View {
             if let question {
                 prompt(question)
 
-                ForEach(question.options ?? [], id: \.label) { option in
+                ForEach(Array(options.enumerated()), id: \.element.label) { index, option in
                     hairline
-                    optionRow(option, in: question)
+                    optionRow(option, at: index, in: question)
                 }
 
                 hairline
@@ -50,6 +65,19 @@ struct AskQuestionCard: View {
         // a shade over it in dark — the one direction each appearance leaves.
         .background(OS1VisualStyle.flapSurface, in: cardShape)
         .overlay(cardShape.stroke(OS1VisualStyle.border, lineWidth: 0.5))
+        .focusRingShape(cardShape)
+        .focusable()
+        .focused($cardFocused)
+        .onKeyPress(.escape) {
+            guard cardFocused else { return .ignored }
+            cardFocused = false
+            return .handled
+        }
+        .askHardwareKeys(
+            active: chosen == nil,
+            onLetter: pressLetter,
+            onFocusCommand: focusCard
+        )
         .animation(.snappy(duration: 0.2), value: chosen)
         .animation(.snappy(duration: 0.2), value: trimmedFreeText.isEmpty)
         // Answering is the moment a stuck session starts moving again — worth
@@ -84,14 +112,17 @@ struct AskQuestionCard: View {
 
     private func optionRow(
         _ option: AskQuestion.Option,
+        at index: Int,
         in question: AskQuestion.Question
     ) -> some View {
-        Button {
-            guard chosen == nil else { return }
-            chosen = option.label
-            onAnswer([question.question: option.label])
+        let letter = AskLetterShortcuts.label(at: index)
+        return Button {
+            choose(option, in: question)
         } label: {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
+                if let letter {
+                    keyCap(letter)
+                }
                 VStack(alignment: .leading, spacing: 3) {
                     Text(option.label)
                         .font(.subheadline.weight(.medium))
@@ -117,10 +148,25 @@ struct AskQuestionCard: View {
             .padding(.vertical, 11)
         }
         .buttonStyle(AskOptionButtonStyle())
+        .askLetterKeyEquivalent(letter)
         // The unpicked rows step back once a choice is in flight, so the card
         // reads as answered rather than still waiting.
         .opacity(chosen == nil || chosen == option.label ? 1 : 0.4)
         .disabled(chosen != nil)
+        .accessibilityHint(letter.map { "Press \($0) to pick" } ?? "")
+    }
+
+    /// The letter a row answers to, drawn like a key so it reads as one.
+    private func keyCap(_ letter: String) -> some View {
+        Text(verbatim: letter)
+            .font(.caption2.weight(.semibold).monospaced())
+            .foregroundStyle(OS1VisualStyle.textDim)
+            .frame(width: 18, height: 18)
+            .background(
+                OS1VisualStyle.hover,
+                in: RoundedRectangle(cornerRadius: 5, style: .continuous)
+            )
+            .accessibilityHidden(true)
     }
 
     private func freeTextRow(_ question: AskQuestion.Question) -> some View {
@@ -170,6 +216,34 @@ struct AskQuestionCard: View {
             .frame(maxWidth: .infinity)
     }
 
+    // MARK: - Answering
+
+    /// A tap, a letter, and Return all land here: pick the row and send.
+    private func choose(_ option: AskQuestion.Option, in question: AskQuestion.Question) {
+        guard chosen == nil else { return }
+        chosen = option.label
+        cardFocused = false
+        onAnswer([question.question: option.label])
+    }
+
+    /// A letter from the window. False when it names nothing on this
+    /// question, so the keystroke stays the system's.
+    private func pressLetter(_ letter: String) -> Bool {
+        guard chosen == nil, let question,
+              let option = AskLetterShortcuts.option(in: question, letter: letter)
+        else { return false }
+        choose(option, in: question)
+        return true
+    }
+
+    /// The "Answer the question" command: take the keyboard back from the
+    /// composer and ring the card so a letter answers it.
+    private func focusCard() {
+        guard chosen == nil else { return }
+        inputFocused = false
+        cardFocused = true
+    }
+
     private func sendFreeText() {
         guard let question, chosen == nil else { return }
         let text = trimmedFreeText
@@ -177,6 +251,19 @@ struct AskQuestionCard: View {
         chosen = text
         inputFocused = false
         onAnswer([question.question: text])
+    }
+}
+
+private extension View {
+    /// The system focus ring follows the card's corners. macOS is the platform
+    /// that draws one around a focusable container; iOS has no focus-effect
+    /// shape kind and draws its own keyboard focus halo.
+    func focusRingShape(_ shape: RoundedRectangle) -> some View {
+        #if os(macOS)
+        contentShape(.focusEffect, shape)
+        #else
+        self
+        #endif
     }
 }
 

--- a/packages/clients/ios/OS1/Views/AskQuestionCard.swift
+++ b/packages/clients/ios/OS1/Views/AskQuestionCard.swift
@@ -237,11 +237,17 @@ struct AskQuestionCard: View {
     }
 
     /// The "Answer the question" command: take the keyboard back from the
-    /// composer and ring the card so a letter answers it.
+    /// composer. Focus the answer field for free-text questions, otherwise
+    /// ring the card so a letter answers it.
     private func focusCard() {
         guard chosen == nil else { return }
-        inputFocused = false
-        cardFocused = true
+        if options.isEmpty {
+            cardFocused = false
+            inputFocused = true
+        } else {
+            inputFocused = false
+            cardFocused = true
+        }
     }
 
     private func sendFreeText() {

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -950,6 +950,11 @@ struct SessionView: View {
                 if let drop = ProcessInfo.processInfo.environment["OS1_SHOW_CONNECTION_DROP"] {
                     viewModel.dropConnectionForScreenshot(sustained: drop == "sustained")
                 }
+                // Both platforms: the Mac capture is where the hardware keys
+                // get exercised.
+                if ProcessInfo.processInfo.environment["OS1_SHOW_ASK_FIXTURE"] == "1" {
+                    viewModel.showAskForScreenshot()
+                }
                 #endif
                 #if DEBUG && os(iOS)
                 // Install screenshot fixtures before network requests so a
@@ -3349,10 +3354,13 @@ private struct SessionInputBar: View {
         // Desk opens with a keyboard covering its own board.
         .onAppear {
             if viewModel.session.neverRan && autoFocusWhenNeverRan { inputFocused = true }
-            #if DEBUG && os(iOS)
+            #if DEBUG
             // Open with the keyboard up, for the same reason as the panel
             // hooks in `SessionView`: a headless capture host can tap
-            // nothing, so the focused state is only reachable this way.
+            // nothing, so the focused state is only reachable this way. On
+            // the Mac it is how the keyboard verification starts in the
+            // composer, the one place the question card's letters must not
+            // reach.
             if ProcessInfo.processInfo.environment["OS1_FOCUS_COMPOSER"] == "1" {
                 inputFocused = true
             }

--- a/packages/clients/ios/OS1/Views/SessionsListView.swift
+++ b/packages/clients/ios/OS1/Views/SessionsListView.swift
@@ -814,6 +814,30 @@ struct SessionsListView: View {
             )
         }
 
+        // Only while the open session is waiting on a question, so the row
+        // never runs to nothing. The palette is a sheet and its action runs
+        // on dismiss; posting on the next turn lets the window be key again
+        // before the card checks whether the command is aimed at it.
+        if selectedSession?.waitingForInput == true {
+            items.append(
+                CommandPaletteItem(
+                    entry: CommandPaletteEntry(
+                        id: "command:ask-focus",
+                        title: "Answer the question",
+                        subtitle: "Jump to the question the assistant is waiting on",
+                        keywords: ["ask", "question", "input", "reply"],
+                        shortcut: shortcuts.primaryBinding(for: .askFocus)?.glyphs ?? [],
+                        symbol: "questionmark.bubble"
+                    ),
+                    run: {
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .os1AskFocus, object: nil)
+                        }
+                    }
+                )
+            )
+        }
+
         items.append(
             CommandPaletteItem(
                 entry: CommandPaletteEntry(

--- a/packages/clients/ios/OS1Tests/AskLetterShortcutsTests.swift
+++ b/packages/clients/ios/OS1Tests/AskLetterShortcutsTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import OS1
+
+final class AskLetterShortcutsTests: XCTestCase {
+    private let question = AskQuestion.Question(
+        question: "Pick",
+        header: nil,
+        options: [
+            AskQuestion.Option(label: "One", description: nil),
+            AskQuestion.Option(label: "Two", description: nil),
+        ],
+        multiSelect: nil
+    )
+
+    // MARK: - Letters
+
+    func testLabelsArePositionalAndStopAtZ() {
+        XCTAssertEqual(AskLetterShortcuts.label(at: 0), "A")
+        XCTAssertEqual(AskLetterShortcuts.label(at: 2), "C")
+        XCTAssertEqual(AskLetterShortcuts.label(at: 25), "Z")
+        XCTAssertNil(AskLetterShortcuts.label(at: 26))
+        XCTAssertNil(AskLetterShortcuts.label(at: -1))
+    }
+
+    func testBareLetterNamesAnOptionInEitherCase() {
+        XCTAssertEqual(AskLetterShortcuts.letter(typed: "b", modifiers: [], isRepeat: false), "B")
+        XCTAssertEqual(AskLetterShortcuts.letter(typed: "B", modifiers: [.shift], isRepeat: false), "B")
+    }
+
+    func testChordsAndHeldKeysAreNotAnswers() {
+        for modifiers: AccountShortcutModifiers in [.command, .control, .option, [.command, .shift]] {
+            XCTAssertNil(AskLetterShortcuts.letter(typed: "b", modifiers: modifiers, isRepeat: false))
+        }
+        XCTAssertNil(AskLetterShortcuts.letter(typed: "b", modifiers: [], isRepeat: true))
+    }
+
+    func testOnlySingleAsciiLettersCount() {
+        for key in ["1", "\r", " ", "é", "ß", "ab", ""] {
+            XCTAssertNil(AskLetterShortcuts.letter(typed: key, modifiers: [], isRepeat: false), key)
+        }
+        XCTAssertNil(AskLetterShortcuts.letter(typed: nil, modifiers: [], isRepeat: false))
+    }
+
+    func testLettersMapToOptionsTheWayTheCardLabelsThem() {
+        XCTAssertEqual(AskLetterShortcuts.option(in: question, letter: "A")?.label, "One")
+        XCTAssertEqual(AskLetterShortcuts.option(in: question, letter: "b")?.label, "Two")
+    }
+
+    func testLetterPastTheLastOptionOrOnFreeTextIsNothing() {
+        XCTAssertNil(AskLetterShortcuts.option(in: question, letter: "C"))
+        let freeText = AskQuestion.Question(
+            question: "Why?", header: nil, options: nil, multiSelect: nil
+        )
+        XCTAssertNil(AskLetterShortcuts.option(in: freeText, letter: "A"))
+    }
+
+    // MARK: - Which card hears the key
+
+    func testOnlyTheKeyWindowsCardHearsLetters() {
+        let front = AskKeyScope(windowIsKey: true, appIsActive: true, editingText: false, answered: false)
+        XCTAssertTrue(front.hearsLetters)
+
+        var other = front
+        other.windowIsKey = false
+        XCTAssertFalse(other.hearsLetters, "a second window or tab keeps its keys")
+
+        var background = front
+        background.appIsActive = false
+        XCTAssertFalse(background.hearsLetters)
+    }
+
+    func testTextFieldsKeepTheirLettersButNotTheFocusCommand() {
+        let composer = AskKeyScope(windowIsKey: true, appIsActive: true, editingText: true, answered: false)
+        XCTAssertFalse(composer.hearsLetters)
+        XCTAssertTrue(composer.takesFocusCommand, "the command is the way over from the composer")
+    }
+
+    func testAnAnsweredCardIsDeaf() {
+        let done = AskKeyScope(windowIsKey: true, appIsActive: true, editingText: false, answered: true)
+        XCTAssertFalse(done.hearsLetters)
+        XCTAssertFalse(done.takesFocusCommand)
+    }
+
+    // MARK: - Focus command
+
+    func testFocusCommandHasANativeDefaultChord() {
+        let shortcuts = AccountShortcuts(rawValue: "{}")
+        XCTAssertEqual(shortcuts.primaryBinding(for: .askFocus)?.rawValue, "mod+i")
+        XCTAssertEqual(AccountShortcutCommand.askFocus.rawValue, "ask-focus")
+    }
+}

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -341,6 +341,11 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   composer and session preferences refresh at launch and when the app foregrounds.
   On macOS, custom account keyboard bindings drive the supported app commands and
   their command-menu hints; iOS keeps its system shortcut and widget guide.
+  A live question's options wear A, B, C, and a bare letter typed anywhere in
+  the key window that is not a text field answers with that row; **Answer the
+  Question** (⌘I, rebindable as the web's `ask-focus`) moves focus from the
+  composer onto the card, where the arrows and Return pick (`AskKeyBridge`,
+  `AskLetterShortcuts`).
   Infrastructure → **Runners** lists the machines this instance trusts, read
   only: each one's status, hardware, workspace roots, toolchains and what it is
   working on. Connecting, revoking and permissions stay in the web settings —

--- a/packages/clients/ios/README.md
+++ b/packages/clients/ios/README.md
@@ -345,7 +345,8 @@ Pure SwiftUI with SwiftStreamingMarkdown for CommonMark/GFM rendering. See
   the key window that is not a text field answers with that row; **Answer the
   Question** (⌘I, rebindable as the web's `ask-focus`) moves focus from the
   composer onto the card, where the arrows and Return pick (`AskKeyBridge`,
-  `AskLetterShortcuts`).
+  `AskLetterShortcuts`). For questions without options, the command focuses
+  the free-text answer field instead.
   Infrastructure → **Runners** lists the machines this instance trusts, read
   only: each one's status, hardware, workspace roots, toolchains and what it is
   working on. Connecting, revoking and permissions stay in the web settings —


### PR DESCRIPTION
Ports the ask-card hardware-key behavior from web commit 2f61ea139 to the native OS1 / OS1Mac app (`packages/clients/ios/OS1/Views/AskQuestionCard.swift`), item from the "iOS parity check" report.

## What changed

The question card labels its options A, B, C, but the native app only heard those letters through a tap. A question lands while you are reading the transcript or sitting in the composer, so the letters were dead and you reached for the pointer.

- **Letters answer from the keyboard.** Each option now wears its letter, and a bare letter typed anywhere in the card's key window that is not a text field picks that option; on the lone single-select ask it answers, exactly as a tap. Text fields keep their letters, a chord or a held key stays the system's.
- **Only the active window answers.** The rule (`AskKeyScope`) requires the card's window to be key and the app frontmost, so two windows or the Desk sheet never answer one keystroke, and an already-answered card is deaf.
- **Focused platform bridge.** SwiftUI's `keyboardShortcut` cannot carry a bare letter safely on macOS, where a key equivalent is matched before the field editor sees the key (the composer would answer instead of typing). `AskKeyBridge` scopes an `NSEvent` local monitor to the card's own window on the Mac, the same way the composer reads Shift-Return out from under a focused field, and rides the option rows as key equivalents on iOS, where text input already wins over an unmodified key command.
- **Discoverable focus command.** The composer is the one place the letters cannot reach, so a rebindable **Answer the Question** command (`mod+i`, the web's `ask-focus`) takes the keyboard back from the composer and rings the card. It is in the app menu, the iPad key HUD, and the command palette while a question is waiting.
- **Pure, tested core.** `AskLetterShortcuts` holds the keystroke-to-option mapping, the label positions, and the "which card hears this key" rule, all unit-tested without a window (`OS1Tests/AskLetterShortcutsTests.swift`, 10 tests).

## Verification

Built both `OS1` (iOS simulator) and `OS1Mac`; `AskLetterShortcutsTests` passes 10/10 on the Mac node.

macOS keyboard walkthrough against the live server (a screenshot fixture question with options A/B/C):
1. Card renders with A, B, C on the rows.
2. Typing `ab` with the composer focused lands in the composer (letters stay in the text field).
3. `Cmd+I` rings the card and takes the keyboard back from the composer.
4. Pressing `C` answers, and the card shows "Answer sent - Hold" with the check on C, while the earlier composer text is untouched.

iOS: captured the labelled card on the simulator.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-e260884c-4868-7ef2-8822-69cad88a6e6d)