### PR TITLE
Keep scoped weekly budgets visible in native model settings

### DIFF
--- a/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
+++ b/packages/clients/ios/OS1/Views/ModelSettingsMenu.swift
@@ -24,13 +24,20 @@ struct ModelSettingsMenu: View {
     /// is the whole menu; suppressed where it is nested inside one, since
     /// spend is not a model setting and the row would read as one.
     var showsUsage = true
+    var onShowWeeklyRemaining: (() -> Void)?
 
     var body: some View {
         if showsUsage {
             UsageMenuSection(usage: viewModel.usage)
         }
         if !weeklyRows.isEmpty {
-            weeklyRemainingMenu
+            if let onShowWeeklyRemaining {
+                Button(action: onShowWeeklyRemaining) {
+                    Label(Self.headerTitle(weeklyReadout), systemImage: Self.gaugeSymbol(weeklyReadout?.tone))
+                }
+            } else {
+                weeklyRemainingMenu
+            }
         }
         if let catalog {
             Menu {
@@ -151,18 +158,16 @@ struct ModelSettingsMenu: View {
                     let pinnable = row.kind == currentProvider
                     let pinned = pinnable && row.accountId == viewModel.accountId
                     Button {
-                        if let account = accounts.first(where: {
-                            $0.kind == row.kind && $0.account.id == row.accountId
-                        }) {
-                            viewModel.pinAccount(account.account)
-                        }
+                        pinAccount(for: row)
                     } label: {
-                        Text(row.label)
+                        Text(row.name)
                         Text(Self.rowDetail(row))
                         // Not hidden from accessibility: hiding the mark
                         // drops the whole row from the menu's tree on iOS 26.
                         Image(systemName: pinned ? "checkmark" : (row.isPersonal ? "person" : "person.2"))
                     }
+                    // Native menu badges reserve space independently of the name.
+                    .badge(row.scope.map { Text($0).foregroundStyle(OS1VisualStyle.textDim) })
                     .disabled(!pinnable)
                     .accessibilityLabel(Self.rowSpokenLabel(row, pinned: pinned, pinnable: pinnable))
                 }
@@ -172,11 +177,83 @@ struct ModelSettingsMenu: View {
                 }
             }
         } label: {
-            Label(
-                weeklyReadout.map { "Weekly remaining · \($0.remaining)%" } ?? "Weekly remaining",
-                systemImage: Self.gaugeSymbol(weeklyReadout?.tone)
-            )
+            Label(Self.headerTitle(weeklyReadout), systemImage: Self.gaugeSymbol(weeklyReadout?.tone))
         }
+    }
+
+    /// iOS menus ignore `.badge`, so the phone presents the same accounts in
+    /// a native sheet. Only the name yields width to the scope and pin mark.
+    var weeklyRemainingOverview: some View {
+        List {
+            Section {
+                Button {
+                    viewModel.pinAccount(nil)
+                } label: {
+                    HStack {
+                        Text("Auto")
+                        Spacer()
+                        if viewModel.accountId.isEmpty { Image(systemName: "checkmark") }
+                    }
+                }
+                .disabled(currentProvider == nil)
+                ForEach(weeklyRows) { row in
+                    let pinnable = row.kind == currentProvider
+                    let pinned = pinnable && row.accountId == viewModel.accountId
+                    Button {
+                        pinAccount(for: row)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: pinned ? "checkmark" : (row.isPersonal ? "person" : "person.2"))
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack(spacing: 8) {
+                                    Text(row.name)
+                                        .lineLimit(1)
+                                        .foregroundStyle(OS1VisualStyle.text)
+                                    if let scope = row.scope {
+                                        Text(scope)
+                                            .font(.caption.weight(.medium))
+                                            .foregroundStyle(OS1VisualStyle.textDim)
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 3)
+                                            .background(OS1VisualStyle.hover, in: Capsule())
+                                            .fixedSize()
+                                    }
+                                }
+                                Text(Self.rowDetail(row))
+                                    .font(.subheadline)
+                                    .foregroundStyle(OS1VisualStyle.textDim)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                    }
+                    .disabled(!pinnable)
+                    .accessibilityLabel(Self.rowSpokenLabel(row, pinned: pinned, pinnable: pinnable))
+                }
+            } header: {
+                Text(Self.headerTitle(weeklyReadout))
+            } footer: {
+                if currentProvider != nil {
+                    Text("Choose one to use it for this session")
+                }
+            }
+        }
+    }
+
+    private func pinAccount(for row: WeeklyRemainingRow) {
+        guard let account = accounts.first(where: {
+            $0.kind == row.kind && $0.account.id == row.accountId
+        }) else { return }
+        viewModel.pinAccount(account.account)
+    }
+
+    /// The menu row's own line. A scoped readout names its bucket beside the
+    /// number, so a full general week is not read as Fable headroom.
+    static func headerTitle(_ readout: WeeklyRemainingRow?) -> String {
+        guard let readout else { return "Weekly remaining" }
+        let scope = readout.scope.map { "\($0) " } ?? ""
+        return "Weekly remaining · \(scope)\(readout.remaining)%"
     }
 
     private var viewer: String { ServerConfig.shared.userName }
@@ -235,6 +312,34 @@ struct ModelSettingsMenu: View {
         }
         return parts.joined(separator: ", ")
     }
+
+    #if DEBUG
+    /// Accounts for a screenshot of the overview: a name long enough to
+    /// truncate, whose Fable bucket is empty while its week is nearly full.
+    /// `OS1_WEEKLY_REMAINING_FIXTURE=1` swaps these in for the live pools.
+    static func fixtureAccounts(viewer: String, now: Date = Date()) -> [PooledAccount] {
+        let iso = ISO8601DateFormatter()
+        let week = UsageWindow(utilization: 12, resetsAt: iso.string(from: now.addingTimeInterval(86400 * 3)))
+        var pool = ProviderAccount(id: "fixture-pool", name: "Michael-Tella-Engineering-Shared")
+        pool.usage = AccountUsage(
+            sevenDay: week,
+            scopedLimits: [
+                ScopedUsageLimit(label: "Fable", utilization: 100, resetsAt: week.resetsAt)
+            ]
+        )
+        var personal = ProviderAccount(id: "fixture-personal", name: "Main", owner: viewer)
+        personal.usage = AccountUsage(
+            sevenDay: UsageWindow(utilization: 45, resetsAt: week.resetsAt),
+            scopedLimits: [
+                ScopedUsageLimit(label: "Fable", utilization: 55, resetsAt: week.resetsAt)
+            ]
+        )
+        return [
+            PooledAccount(account: personal, kind: .claude),
+            PooledAccount(account: pool, kind: .claude),
+        ]
+    }
+    #endif
 
     // MARK: Model settings
 

--- a/packages/clients/ios/OS1/Views/SessionView.swift
+++ b/packages/clients/ios/OS1/Views/SessionView.swift
@@ -1007,7 +1007,15 @@ struct SessionView: View {
                 }
                 #endif
                 catalog = try? await OS1API.models(workspaceId: viewModel.session.workspaceId)
+                #if DEBUG
+                if ProcessInfo.processInfo.environment["OS1_WEEKLY_REMAINING_FIXTURE"] != nil {
+                    accounts = ModelSettingsMenu.fixtureAccounts(viewer: ServerConfig.shared.userName)
+                } else {
+                    accounts = await SettingsAPI.providerAccountPools()
+                }
+                #else
                 accounts = await SettingsAPI.providerAccountPools()
+                #endif
                 #if DEBUG && os(iOS)
                 if ProcessInfo.processInfo.environment["OS1_OPEN_WORKTREE_INFO"] == "1" {
                     showWorktreeInfo = true
@@ -1925,6 +1933,15 @@ private struct SessionActionsMenu: View {
     /// one list from being offered in two places at once.
     var workspaceHistory: WorkspaceSessionHistory?
 
+    private var showWeeklyRemainingAction: (() -> Void)? {
+        #if os(iOS)
+        { showWeeklyRemaining = true }
+        #else
+        nil
+        #endif
+    }
+
+    @State private var showWeeklyRemaining = false
     @State private var pendingMerge: String?
     @State private var merging = false
     @State private var mergeError: String?
@@ -2033,7 +2050,8 @@ private struct SessionActionsMenu: View {
             // the web changes from the composer.
             Menu {
                 ModelSettingsMenu(
-                    viewModel: viewModel, catalog: catalog, accounts: accounts, showsUsage: false
+                    viewModel: viewModel, catalog: catalog, accounts: accounts, showsUsage: false,
+                    onShowWeeklyRemaining: showWeeklyRemainingAction
                 )
             } label: {
                 Label("Model settings", systemImage: "slider.horizontal.3")
@@ -2187,6 +2205,18 @@ private struct SessionActionsMenu: View {
             // a session that cannot move: the menu shows the rows before it
             // is opened, so they must be known before then.
             if canMoveToSandbox { await sandboxMove.loadProviders() }
+        }
+        .sheet(isPresented: $showWeeklyRemaining) {
+            NavigationStack {
+                ModelSettingsMenu(viewModel: viewModel, catalog: catalog, accounts: accounts)
+                    .weeklyRemainingOverview
+                    .navigationTitle("Weekly remaining")
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { showWeeklyRemaining = false }
+                        }
+                    }
+            }
         }
         .confirmationDialog(
             mergeConfirmationTitle,

--- a/packages/clients/ios/OS1Tests/AccountUsageTests.swift
+++ b/packages/clients/ios/OS1Tests/AccountUsageTests.swift
@@ -338,4 +338,56 @@ final class AccountUsageTests: XCTestCase {
             "Main · Fable, yours, 8 percent left, not for this model"
         )
     }
+
+    /// The scope is the row's own badge, not a suffix on the name, so a long
+    /// account name truncates without hiding which budget the number is.
+    func testMenuRowKeepsScopeOutOfTheName() {
+        let scoped = WeeklyRemainingRow(
+            accountId: "a", kind: .claude, scope: "Fable", name: "Michael-Tella-Engineering-Shared",
+            owner: nil, remaining: 0, resetsAt: nil
+        )
+        XCTAssertEqual(scoped.name, "Michael-Tella-Engineering-Shared")
+        XCTAssertEqual(scoped.scope, "Fable")
+        XCTAssertEqual(scoped.label, "Michael-Tella-Engineering-Shared · Fable")
+        XCTAssertEqual(ModelSettingsMenu.rowDetail(scoped, now: now), "Shared · 0% left · running out")
+        // VoiceOver still hears the name and the bucket together.
+        XCTAssertEqual(
+            ModelSettingsMenu.rowSpokenLabel(scoped, pinned: true, pinnable: true, now: now),
+            "Michael-Tella-Engineering-Shared · Fable, shared, 0 percent left, used for this session"
+        )
+        let general = WeeklyRemainingRow(
+            accountId: "a", kind: .claude, scope: nil, name: "Main", owner: "Kent", remaining: 88, resetsAt: nil
+        )
+        XCTAssertNil(general.scope)
+        XCTAssertEqual(general.label, "Main")
+    }
+
+    func testMenuHeaderNamesTheScopedBucket() {
+        XCTAssertEqual(ModelSettingsMenu.headerTitle(nil), "Weekly remaining")
+        let general = WeeklyRemainingRow(
+            accountId: "a", kind: .claude, scope: nil, name: "Main", owner: "Kent", remaining: 88, resetsAt: nil
+        )
+        XCTAssertEqual(ModelSettingsMenu.headerTitle(general), "Weekly remaining · 88%")
+        let scoped = WeeklyRemainingRow(
+            accountId: "a", kind: .claude, scope: "Fable", name: "Main", owner: "Kent", remaining: 0, resetsAt: nil
+        )
+        XCTAssertEqual(ModelSettingsMenu.headerTitle(scoped), "Weekly remaining · Fable 0%")
+        let other = WeeklyRemainingRow(
+            accountId: "b", kind: .claude, scope: "Sonnet", name: "Shared", owner: nil,
+            remaining: 12, resetsAt: nil
+        )
+        XCTAssertEqual(ModelSettingsMenu.headerTitle(other), "Weekly remaining · Sonnet 12%")
+    }
+
+    #if DEBUG
+    func testWeeklyFixtureShowsAnEmptyScopedBucketBehindALongName() {
+        let rows = WeeklyRemaining.rows(ModelSettingsMenu.fixtureAccounts(viewer: "Kent", now: now), viewer: "Kent", now: now)
+        XCTAssertEqual(rows.map { [$0.name, $0.scope ?? "-", "\($0.remaining)"] }, [
+            ["Main", "-", "55"],
+            ["Main", "Fable", "45"],
+            ["Michael-Tella-Engineering-Shared", "-", "88"],
+            ["Michael-Tella-Engineering-Shared", "Fable", "0"],
+        ])
+    }
+    #endif
 }


### PR DESCRIPTION
## Change
- Name the scope beside the weekly header percentage.
- Keep bare account names separate from scope badges, using OS1VisualStyle.
- Preserve VoiceOver labels and provider/account pinning.

macOS keeps its native submenu. The iOS 26 capture showed that SwiftUI ignores `.badge` inside menus, so the iPhone weekly entry opens a native budget sheet with fixed-size scope badges instead.

## Verification
- `bun run check` passed.
- OS1 simulator and OS1Mac arm64 builds passed with Xcode 26.6.
- All 26 AccountUsageTests passed, including scoped/general headers, another model bucket, spoken wording and the depleted long-name fixture.
- Captured the iPhone sheet with `Michael-Tella-Engineering-S…`, a fully visible Fable badge and 0% left. Evidence is in this OS session. Debug reproduction: `OS1_WEEKLY_REMAINING_FIXTURE=1`, then Session actions → Model settings → Weekly remaining.

Started by Kent de Bruin in [this OS session](https://os.tella.dev/session/bks-1ab4dbda-0fa5-761b-a51d-ec495a915185)