### PR TITLE
Desk voice: link spoken PR and session references in the transcript

### DIFF
--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -30,6 +30,8 @@
  */
 
 import { ensureDeskSession } from "./desk";
+import { VoiceReferenceLedger, linkSpokenReferences } from "./desk-voice-refs";
+import { REPOS } from "./worktree";
 import {
   VOICE_TOOLS,
   executeVoiceTool,
@@ -85,7 +87,7 @@ You are the backend for the user's Desk, their standing concierge for the Open S
 - Run independent lookups together. Do not repeat an action that already ran.
 
 ## Return the result
-Return two or three plain sentences the voice model can say aloud: the relevant facts, whether the task is done, and what comes next. Refer to sessions by title, never by id. No markdown, no lists, no raw tool output.`;
+Return two or three plain sentences the voice model can say aloud: the relevant facts, whether the task is done, and what comes next. Refer to sessions by title, never by id. State a pull request as its repo and number in digits (e.g. "tella-fusion PR 6474"). No markdown, no lists, no raw tool output.`;
 
 /** The browser's data channel may only ask to hang up. Tool results, session
  * updates, and typed text all travel through this server. */
@@ -481,6 +483,9 @@ interface LiveCall {
   socket: WebSocket;
   rows: VoiceTranscriptRows;
   loop: LiveResponseLoop;
+  /** PRs and sessions the call's tool calls surfaced, so a spoken "six four
+   * seven four" or a session named only by title gets its chip. */
+  ledger: VoiceReferenceLedger;
   startedAt: number;
   idleTimer: ReturnType<typeof setTimeout> | null;
   maxTimer: ReturnType<typeof setTimeout> | null;
@@ -703,6 +708,7 @@ async function createLiveVoiceCallNow(
     throw new Error("OpenAI returned no Live session id or SDP answer");
 
   const socket = await attachSideband(key, liveId);
+  const ledger = new VoiceReferenceLedger();
   const call: LiveCall = {
     id: liveId,
     user,
@@ -712,25 +718,36 @@ async function createLiveVoiceCallNow(
       gapMs: LIVE_ROW_GAP_MS,
       idleMs: LIVE_ROW_IDLE_MS,
       rowId: (role, startMs) => `voice-${liveId}-${role}-${startMs}`,
+      // Only what the Desk said is rewritten: a spoken PR number becomes
+      // `repo#N` and a session it started gets named, so the mirrored row
+      // renders chips. The user's words stay exactly as transcribed.
       onRow: (row) =>
         mirrorVoiceEntries(user, [
-          { id: row.id, role: row.role, text: row.text },
+          {
+            id: row.id,
+            role: row.role,
+            text:
+              row.role === "assistant"
+                ? linkSpokenReferences(row.text, ledger)
+                : row.text,
+          },
         ]),
     }),
     loop: new LiveResponseLoop({
       send: (event) => sendEvent(call, event),
       runTool: async (callId, name, args) => {
+        let result: unknown;
         try {
-          const result = await executeVoiceTool(user, name, args);
-          mirrorVoiceToolCall(user, callId, name, args, result);
-          return result;
+          result = await executeVoiceTool(user, name, args);
         } catch (e) {
-          const message = e instanceof Error ? e.message : String(e);
-          mirrorVoiceToolCall(user, callId, name, args, { error: message });
-          return { error: message };
+          result = { error: e instanceof Error ? e.message : String(e) };
         }
+        mirrorVoiceToolCall(user, callId, name, args, result);
+        ledger.collect(name, args, result, knownRepos());
+        return result;
       },
     }),
+    ledger,
     startedAt: Date.now(),
     idleTimer: null,
     maxTimer: null,
@@ -759,6 +776,12 @@ async function createLiveVoiceCallNow(
   }, LIVE_MAX_CALL_MS);
   console.log(`[desk-voice-live] ${liveId} started user=${user}`);
   return { liveSessionId: liveId, sdp: answer, sessionId };
+}
+
+/** The instance's repos, as the ledger needs them to resolve a PR mention:
+ * the id a chip links by and the GitHub name a URL in a result carries. */
+function knownRepos() {
+  return Object.values(REPOS).map((r) => ({ id: r.id, ghRepo: r.ghRepo }));
 }
 
 function ownedCall(user: string, liveSessionId: string): LiveCall | undefined {

--- a/packages/core/opensession-server/src/server/desk-voice-refs.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-refs.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LEDGER_MAX_REFS,
+  VoiceReferenceLedger,
+  linkSpokenReferences,
+  spokenNumbers,
+} from "./desk-voice-refs";
+
+const REPOS = [
+  { id: "tella-fusion", ghRepo: "tellahq/tella-fusion" },
+  { id: "opensession", ghRepo: "tellahq/opensession" },
+];
+
+const SESSION_A = "bks-b72fa30b-31dd-7f7c-b4e2-bf83fdffe513";
+const SESSION_B = "bks-91ec3036-d4e8-7a47-ace1-ad7d3ae8fcc9";
+
+/** The real Desk row that motivated this module. */
+const SPOKEN_LIST =
+  "Here are the reviewed ones. Six four seven four. Six four seven five, six four seven seven, and six four seven eight. The newer one still being reviewed is six four eight five, plus an approved allow attribute change at six four seven nine.";
+
+function ledgerWith(...prs: Array<[string, number]>) {
+  const ledger = new VoiceReferenceLedger();
+  ledger.collect(
+    "list_current_work",
+    {},
+    {
+      sessions: prs.map(([repo, number], i) => ({
+        id: `bks-0190${String(i).padStart(4, "0")}-0000-7000-8000-000000000000`,
+        title: `Work ${i}`,
+        repo,
+        prNumber: number,
+      })),
+    },
+    REPOS,
+  );
+  return ledger;
+}
+
+describe("spoken numbers", () => {
+  const values = (text: string) => spokenNumbers(text).map((n) => n.value);
+
+  test("digit by digit, with or without commas", () => {
+    expect(values("six four seven four")).toEqual([6474]);
+    expect(values("six, four, seven, four")).toEqual([6474]);
+    expect(values("six oh four")).toEqual([604]);
+    expect(values("six zero four")).toEqual([604]);
+  });
+
+  test("tens and teens", () => {
+    expect(values("sixty-four seventy-four")).toEqual([6474]);
+    expect(values("sixty four seventy four")).toEqual([6474]);
+    expect(values("ninety-two")).toEqual([92]);
+    expect(values("fifteen twelve")).toEqual([1512]);
+    expect(values("sixty-four hundred")).toEqual([6400]);
+  });
+
+  test("thousands and hundreds", () => {
+    expect(values("six thousand four hundred seventy-four")).toEqual([6474]);
+    expect(values("six thousand four hundred and seventy-four")).toEqual([
+      6400, 74,
+    ]);
+    expect(values("one hundred twenty three")).toEqual([123]);
+    expect(values("twelve thousand")).toEqual([12000]);
+  });
+
+  test("digits as typed or transcribed", () => {
+    expect(values("PR 6474 and 6475")).toEqual([6474, 6475]);
+    expect(values("64 74")).toEqual([6474]);
+  });
+
+  test("a list of digit-by-digit numbers splits at punctuation", () => {
+    expect(values(SPOKEN_LIST)).toEqual([6474, 6475, 6477, 6478, 6485, 6479]);
+  });
+
+  test("ignores what is not a spoken PR number", () => {
+    // Already qualified, an id, a decimal, a lone digit, a leading zero.
+    expect(values("tella-fusion#6474 is merged")).toEqual([]);
+    expect(values("tellahq/tella-fusion#6474 is merged")).toEqual([]);
+    expect(values("#6474 is merged")).toEqual([6474]);
+    expect(values(`session ${SESSION_B} is running`)).toEqual([]);
+    expect(values("about 1.5 seconds")).toEqual([]);
+    expect(values("three sessions are running")).toEqual([]);
+    expect(values("oh six")).toEqual([]);
+    expect(values("hundred thousand")).toEqual([]);
+    expect(values("a 123456 digit run")).toEqual([]);
+  });
+
+  test("reports the span of each number", () => {
+    const text = "Look at six four seven four, please.";
+    const [n] = spokenNumbers(text);
+    expect(text.slice(n.start, n.end)).toBe("six four seven four");
+  });
+});
+
+describe("VoiceReferenceLedger", () => {
+  test("collects PRs and sessions from list_current_work rows", () => {
+    const ledger = ledgerWith(["tella-fusion", 6474], ["opensession", 92]);
+    expect(ledger.prRefsFor(6474)).toEqual([
+      { repo: "tella-fusion", number: 6474 },
+    ]);
+    expect(ledger.prRefsFor(92)).toEqual([{ repo: "opensession", number: 92 }]);
+    expect(ledger.prRefsFor(1)).toEqual([]);
+    expect(ledger.titledSessions()).toEqual([]); // "Work 0" is too short
+  });
+
+  test("reads PR numbers off result text that names one known repo", () => {
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "opensession-search_search_history",
+      { query: "allow attribute" },
+      {
+        content: [
+          {
+            type: "text",
+            text: [
+              "tella-fusion#6479 approved allow attribute change",
+              "PR 6485 in tella-fusion is still under review",
+              "https://github.com/tellahq/opensession/pull/92 shipped",
+              "#77 mentioned with tella-fusion and opensession together",
+              "#88 mentioned with no repo at all",
+              "opensession-server#99 is not a repo name",
+            ].join("\n"),
+          },
+        ],
+      },
+      REPOS,
+    );
+    expect(ledger.prRefsFor(6479)).toEqual([
+      { repo: "tella-fusion", number: 6479 },
+    ]);
+    expect(ledger.prRefsFor(6485)).toEqual([
+      { repo: "tella-fusion", number: 6485 },
+    ]);
+    expect(ledger.prRefsFor(92)).toEqual([{ repo: "opensession", number: 92 }]);
+    expect(ledger.prRefsFor(77)).toEqual([]);
+    expect(ledger.prRefsFor(88)).toEqual([]);
+    expect(ledger.prRefsFor(99)).toEqual([]);
+  });
+
+  test("reads session ids and titles off any result", () => {
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "list_sessions",
+      {},
+      {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify([
+              { id: SESSION_A, title: "Show the transcript live" },
+            ]),
+          },
+        ],
+      },
+      REPOS,
+    );
+    // The JSON was flattened to text, so the title is not a sibling field;
+    // the id is still known.
+    expect(ledger.titledSessions()).toEqual([]);
+    ledger.collect(
+      "inspect_session",
+      { session_id: SESSION_A },
+      { id: SESSION_A, title: "Show the transcript live", repo: "opensession" },
+      REPOS,
+    );
+    expect(ledger.titledSessions()).toEqual([
+      { id: SESSION_A, title: "Show the transcript live" },
+    ]);
+  });
+
+  test("keeps started and steered sessions pending until taken once", () => {
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "start_session",
+      { prompt: "x" },
+      { id: SESSION_A, started: true, mode: "code" },
+      REPOS,
+    );
+    ledger.collect(
+      "steer_session",
+      { session_id: SESSION_B, message: "y" },
+      { status: "queued", message: "queued" },
+      REPOS,
+    );
+    // A failed start or steer names no session.
+    ledger.collect(
+      "start_session",
+      { prompt: "" },
+      { error: "start_session needs a prompt" },
+      REPOS,
+    );
+    ledger.collect(
+      "steer_session",
+      { session_id: "bks-01900000-0000-7000-8000-00000000dead", message: "z" },
+      { status: "error", message: "no such session" },
+      REPOS,
+    );
+    expect(ledger.takePending()).toEqual([SESSION_A, SESSION_B]);
+    expect(ledger.takePending()).toEqual([]);
+  });
+
+  test("is bounded and idempotent", () => {
+    const ledger = new VoiceReferenceLedger();
+    for (let round = 0; round < 3; round++)
+      for (let n = 1; n <= LEDGER_MAX_REFS + 50; n++)
+        ledger.collect(
+          "inspect_session",
+          {},
+          { id: SESSION_A, repo: "opensession", prNumber: n },
+          REPOS,
+        );
+    expect(ledger.prRefsFor(1)).toEqual([]);
+    expect(ledger.prRefsFor(LEDGER_MAX_REFS + 50)).toEqual([
+      { repo: "opensession", number: LEDGER_MAX_REFS + 50 },
+    ]);
+    expect(ledger.prRefsFor(51)).toHaveLength(1);
+  });
+});
+
+describe("linkSpokenReferences", () => {
+  test("rewrites the real Desk row into qualified PR mentions", () => {
+    const ledger = ledgerWith(
+      ["tella-fusion", 6474],
+      ["tella-fusion", 6475],
+      ["tella-fusion", 6477],
+      ["tella-fusion", 6478],
+      ["tella-fusion", 6485],
+      ["tella-fusion", 6479],
+    );
+    expect(linkSpokenReferences(SPOKEN_LIST, ledger)).toBe(
+      "Here are the reviewed ones. tella-fusion#6474. tella-fusion#6475, tella-fusion#6477, and tella-fusion#6478. The newer one still being reviewed is tella-fusion#6485, plus an approved allow attribute change at tella-fusion#6479.",
+    );
+  });
+
+  test("links only the numbers the ledger knows", () => {
+    const ledger = ledgerWith(["tella-fusion", 6474]);
+    expect(linkSpokenReferences(SPOKEN_LIST, ledger)).toBe(
+      SPOKEN_LIST.replace("Six four seven four", "tella-fusion#6474"),
+    );
+    expect(linkSpokenReferences(SPOKEN_LIST, new VoiceReferenceLedger())).toBe(
+      SPOKEN_LIST,
+    );
+  });
+
+  test("handles every spoken shape and is idempotent", () => {
+    const ledger = ledgerWith(["tella-fusion", 6474]);
+    for (const spoken of [
+      "sixty-four seventy-four",
+      "six thousand four hundred seventy-four",
+      "six, four, seven, four",
+      "PR 6474",
+      "PR #6474",
+    ]) {
+      const once = linkSpokenReferences(`Merged ${spoken} today.`, ledger);
+      expect(once).toBe(
+        spoken.startsWith("PR")
+          ? "Merged PR tella-fusion#6474 today."
+          : "Merged tella-fusion#6474 today.",
+      );
+      expect(linkSpokenReferences(once, ledger)).toBe(once);
+    }
+  });
+
+  test("leaves a number that PRs in two repos share alone", () => {
+    const ledger = ledgerWith(["tella-fusion", 92], ["opensession", 92]);
+    expect(linkSpokenReferences("Ninety-two is approved.", ledger)).toBe(
+      "Ninety-two is approved.",
+    );
+  });
+
+  test("appends the started session once, to the next assistant row", () => {
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "start_session",
+      { prompt: "x", mode: "code" },
+      { id: SESSION_A, started: true, mode: "code" },
+      REPOS,
+    );
+    const first = linkSpokenReferences(
+      "I've kicked off work to make the transcript show up as I'm speaking",
+      ledger,
+    );
+    expect(first).toBe(
+      `I've kicked off work to make the transcript show up as I'm speaking\n\nSession: ${SESSION_A}`,
+    );
+    expect(linkSpokenReferences("Anything else?", ledger)).toBe(
+      "Anything else?",
+    );
+  });
+
+  test("names a listed session whose title the row says", () => {
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "list_current_work",
+      {},
+      {
+        sessions: [
+          {
+            id: SESSION_A,
+            title: "Fix the login redirect",
+            repo: "opensession",
+          },
+          { id: SESSION_B, title: "Docs", repo: "opensession" },
+        ],
+      },
+      REPOS,
+    );
+    expect(
+      linkSpokenReferences(
+        "Fix the Login Redirect is still running, and Docs is done.",
+        ledger,
+      ),
+    ).toBe(
+      `Fix the Login Redirect is still running, and Docs is done.\n\nSession: ${SESSION_A}`,
+    );
+    // Not repeated for an id the row already carries, and several sessions
+    // share one trailer.
+    ledger.collect(
+      "start_session",
+      { prompt: "y" },
+      { id: SESSION_B, started: true, mode: "ask" },
+      REPOS,
+    );
+    expect(
+      linkSpokenReferences(`Fix the login redirect and ${SESSION_A}`, ledger),
+    ).toBe(`Fix the login redirect and ${SESSION_A}\n\nSession: ${SESSION_B}`);
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-refs.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-refs.ts
@@ -1,0 +1,489 @@
+/**
+ * Spoken references in the Desk voice transcript.
+ *
+ * A voice call mirrors what was said into the Desk session as plain text, and
+ * speech has no `#`: a PR comes out as "six four seven four", and a session
+ * the Desk just started is only ever named by title (the voice prompt forbids
+ * reading ids aloud, on purpose). The web renderer links `repo#6474` and a
+ * bare `bks-<uuidv7>` (frontend/lib/markdown.ts), so the transcript row has
+ * to carry those spellings for a chip to appear.
+ *
+ * The references themselves are not guessed from the speech: every tool call
+ * a call runs feeds a per-call ledger (PRs by repo and number, sessions by id
+ * and title), and an assistant row is rewritten only where a spoken number
+ * matches exactly one PR the call actually saw. Nothing else is touched, so
+ * a number that matches nothing, or matches PRs in two repos, stays as it
+ * was said.
+ *
+ * Pure module: no I/O, no timers, no imports with live effects.
+ */
+
+import { UUIDV7 } from "../frontend/lib/session-url";
+
+export interface PrRef {
+  repo: string;
+  number: number;
+}
+
+export interface SessionRef {
+  id: string;
+  title?: string;
+}
+
+export interface KnownRepo {
+  id: string;
+  /** GitHub `owner/name`, when the repo lives there. */
+  ghRepo?: string;
+}
+
+/** Most references a ledger keeps; the oldest go first. A call rarely sees
+ * more than a few dozen, so this only guards against a runaway tool. */
+export const LEDGER_MAX_REFS = 200;
+/** Only a title this long is distinctive enough to match against a row. */
+export const SESSION_TITLE_MIN_LENGTH = 8;
+const PR_NUMBER_MAX_DIGITS = 5;
+
+const SESSION_ID = new RegExp(`\\b(?:os|bks)-${UUIDV7}\\b`, "gi");
+/** `#123`, `PR 123`, `PR #123`, `PRs 123`. */
+const PR_NUMBER_ON_LINE = new RegExp(
+  `(?:#|\\b[Pp][Rr]s?\\s*#?)(\\d{1,${PR_NUMBER_MAX_DIGITS}})(?!\\w)`,
+  "g",
+);
+const GITHUB_PULL_URL =
+  /github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/(\d{1,5})(?!\d)/g;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function prKey(ref: PrRef): string {
+  return `${ref.repo}#${ref.number}`;
+}
+
+/** Keeps a Map at `max` entries by dropping its oldest insertions. */
+function trim<K, V>(map: Map<K, V>, max: number): void {
+  for (const key of map.keys()) {
+    if (map.size <= max) return;
+    map.delete(key);
+  }
+}
+
+/** Every string reachable inside a tool result, in document order. */
+function* strings(value: unknown, depth = 0): Generator<string> {
+  if (depth > 12) return;
+  if (typeof value === "string") yield value;
+  else if (Array.isArray(value))
+    for (const item of value) yield* strings(item, depth + 1);
+  else if (value && typeof value === "object")
+    for (const item of Object.values(value as Record<string, unknown>))
+      yield* strings(item, depth + 1);
+}
+
+/** Every object inside a tool result whose `id` is a session id, with its
+ * sibling `title` when it has one: list_current_work, inspect_session, the
+ * sessions MCP tools and start_session all shape their rows that way. */
+function* sessionObjects(
+  value: unknown,
+  depth = 0,
+): Generator<{ id: string; title?: string }> {
+  if (depth > 12 || !value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) yield* sessionObjects(item, depth + 1);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.id === "string" && isSessionId(record.id))
+    yield {
+      id: record.id,
+      ...(typeof record.title === "string" && record.title.trim()
+        ? { title: record.title.trim() }
+        : {}),
+    };
+  for (const item of Object.values(record))
+    yield* sessionObjects(item, depth + 1);
+}
+
+function isSessionId(s: string): boolean {
+  SESSION_ID.lastIndex = 0;
+  const m = SESSION_ID.exec(s);
+  return !!m && m[0].length === s.length;
+}
+
+/** The known repos a line of text names, by id or by GitHub `owner/name`,
+ * as whole words (`opensession` inside `opensession-server` does not count). */
+function reposNamedOn(line: string, repos: KnownRepo[]): KnownRepo[] {
+  const named: KnownRepo[] = [];
+  for (const repo of repos) {
+    const names = [repo.id, repo.ghRepo].filter((n): n is string => !!n);
+    const hit = names.some((name) =>
+      new RegExp(`(?<![\\w-])${escapeRegExp(name)}(?![\\w-])`, "i").test(line),
+    );
+    if (hit) named.push(repo);
+  }
+  return named;
+}
+
+export class VoiceReferenceLedger {
+  private prs = new Map<string, PrRef>();
+  private sessions = new Map<string, SessionRef>();
+  /** Sessions this call started or steered, awaiting their trailer. */
+  private pending = new Set<string>();
+
+  /** Records every reference a tool call surfaced, success or error. */
+  collect(
+    name: string,
+    args: Record<string, unknown>,
+    result: unknown,
+    repos: KnownRepo[],
+  ): void {
+    if (name === "start_session" || name === "steer_session") {
+      const id =
+        name === "start_session"
+          ? (result as { id?: unknown } | null)?.id
+          : args.session_id;
+      const ok =
+        !!result &&
+        typeof result === "object" &&
+        typeof (result as { error?: unknown }).error !== "string" &&
+        (result as { status?: unknown }).status !== "error";
+      if (typeof id === "string" && isSessionId(id) && ok) {
+        this.addSession({ id });
+        this.pending.add(id);
+      }
+    }
+    for (const session of sessionObjects(result)) this.addSession(session);
+    for (const record of prRefsFromSessionRows(result)) this.addPr(record);
+    for (const text of strings(result)) {
+      for (const line of text.split("\n")) {
+        for (const m of line.matchAll(GITHUB_PULL_URL)) {
+          const gh = `${m[1]}/${m[2]}`.toLowerCase();
+          const repo = repos.find((r) => r.ghRepo?.toLowerCase() === gh);
+          if (repo) this.addPr({ repo: repo.id, number: Number(m[3]) });
+        }
+        const named = reposNamedOn(line, repos);
+        if (named.length === 1)
+          for (const m of line.matchAll(PR_NUMBER_ON_LINE))
+            this.addPr({ repo: named[0].id, number: Number(m[1]) });
+        for (const m of line.matchAll(SESSION_ID))
+          this.addSession({ id: m[0] });
+      }
+    }
+  }
+
+  /** The PR refs a spoken number could mean; one is a link, more is not. */
+  prRefsFor(number: number): PrRef[] {
+    return [...this.prs.values()].filter((ref) => ref.number === number);
+  }
+
+  /** Sessions with a title worth matching against a row. */
+  titledSessions(): Array<SessionRef & { title: string }> {
+    return [...this.sessions.values()].filter(
+      (ref): ref is SessionRef & { title: string } =>
+        !!ref.title && ref.title.length >= SESSION_TITLE_MIN_LENGTH,
+    );
+  }
+
+  /** Sessions started or steered since the last take. Consumed once. */
+  takePending(): string[] {
+    const ids = [...this.pending];
+    this.pending.clear();
+    return ids;
+  }
+
+  private addPr(ref: PrRef): void {
+    if (!Number.isInteger(ref.number) || ref.number <= 0) return;
+    const key = prKey(ref);
+    this.prs.delete(key);
+    this.prs.set(key, ref);
+    trim(this.prs, LEDGER_MAX_REFS);
+  }
+
+  private addSession(ref: SessionRef): void {
+    const id = ref.id.toLowerCase();
+    const existing = this.sessions.get(id);
+    this.sessions.delete(id);
+    this.sessions.set(id, {
+      id,
+      ...(ref.title || existing?.title
+        ? { title: ref.title || existing?.title }
+        : {}),
+    });
+    trim(this.sessions, LEDGER_MAX_REFS);
+  }
+}
+
+/** `{repo, prNumber}` rows, as list_current_work / inspect_session return. */
+function* prRefsFromSessionRows(value: unknown, depth = 0): Generator<PrRef> {
+  if (depth > 12 || !value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) yield* prRefsFromSessionRows(item, depth + 1);
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.repo === "string" && typeof record.prNumber === "number")
+    yield { repo: record.repo, number: record.prNumber };
+  for (const item of Object.values(record))
+    yield* prRefsFromSessionRows(item, depth + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Spoken numbers. The voice transcript spells a PR number as words in one of
+// a few shapes: digit by digit ("six four seven four", "six, four, seven,
+// four"), in pairs ("sixty-four seventy-four"), or in full ("six thousand
+// four hundred seventy-four"); typed text and some transcripts carry digits.
+// A run of number words is cut into chunks wherever a word cannot continue
+// the number before it, and the chunks' digits are concatenated, so all four
+// spellings above come out as 6474.
+
+const UNITS: Record<string, number> = {
+  zero: 0,
+  oh: 0,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+};
+const TEENS: Record<string, number> = {
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+};
+const TENS: Record<string, number> = {
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fifty: 50,
+  sixty: 60,
+  seventy: 70,
+  eighty: 80,
+  ninety: 90,
+};
+
+type NumberToken =
+  | { kind: "unit" | "teen" | "tens" | "hundred" | "thousand"; value: number }
+  | { kind: "digits"; value: number; text: string };
+
+function numberToken(word: string): NumberToken | null {
+  const w = word.toLowerCase();
+  if (w in UNITS) return { kind: "unit", value: UNITS[w] };
+  if (w in TEENS) return { kind: "teen", value: TEENS[w] };
+  if (w in TENS) return { kind: "tens", value: TENS[w] };
+  if (w === "hundred") return { kind: "hundred", value: 100 };
+  if (w === "thousand") return { kind: "thousand", value: 1000 };
+  return null;
+}
+
+/** The digit string a run of number tokens spells, or null when the run is
+ * not a well-formed number (e.g. "hundred thousand hundred"). */
+export function spokenDigits(tokens: NumberToken[]): string | null {
+  const chunks: string[] = [];
+  let total = 0;
+  let part = 0;
+  let last: NumberToken["kind"] | null = null;
+  const close = () => {
+    if (last !== null) chunks.push(String(total + part));
+    total = 0;
+    part = 0;
+    last = null;
+  };
+  const afterScale = () => last === "hundred" || last === "thousand";
+  for (const token of tokens) {
+    switch (token.kind) {
+      case "digits":
+        close();
+        chunks.push(token.text);
+        break;
+      case "unit":
+        if (last === "tens" && token.value !== 0) part += token.value;
+        else if (afterScale() && token.value !== 0) part += token.value;
+        else {
+          close();
+          part = token.value;
+        }
+        last = "unit";
+        break;
+      case "teen":
+        if (afterScale()) part += token.value;
+        else {
+          close();
+          part = token.value;
+        }
+        last = "teen";
+        break;
+      case "tens":
+        if (afterScale()) part += token.value;
+        else {
+          close();
+          part = token.value;
+        }
+        last = "tens";
+        break;
+      case "hundred":
+        if (last === null || afterScale() || part <= 0 || part >= 100)
+          return null;
+        part *= 100;
+        last = "hundred";
+        break;
+      case "thousand":
+        if (last === null || last === "thousand" || part <= 0) return null;
+        total += part * 1000;
+        part = 0;
+        last = "thousand";
+        break;
+    }
+  }
+  close();
+  return chunks.join("");
+}
+
+interface SpokenNumber {
+  start: number;
+  end: number;
+  value: number;
+}
+
+const WORD_OR_DIGITS = /[A-Za-z]+|\d+/g;
+
+/**
+ * Every spoken or typed number in `text` that could be a PR number, with the
+ * span of text it occupies. Number words separated by spaces, hyphens or
+ * commas form one run; the run is cut at commas, unless every comma-separated
+ * piece is a lone digit word ("six, four, seven, four"), which is one number.
+ */
+export function spokenNumbers(text: string): SpokenNumber[] {
+  interface Piece {
+    start: number;
+    end: number;
+    tokens: NumberToken[];
+  }
+  const runs: Piece[][] = [];
+  let run: Piece[] = [];
+  let piece: Piece | null = null;
+  let lastEnd = -1;
+  const closePiece = () => {
+    if (piece) run.push(piece);
+    piece = null;
+  };
+  const closeRun = () => {
+    closePiece();
+    if (run.length) runs.push(run);
+    run = [];
+  };
+  for (const m of text.matchAll(WORD_OR_DIGITS)) {
+    let start = m.index;
+    const end = start + m[0].length;
+    let token: NumberToken | null = null;
+    if (/^\d+$/.test(m[0])) {
+      // A bare `#6474` is a PR number with no repo, which the repo-less Desk
+      // cannot link; its `#` joins the span so it becomes `repo#6474` too.
+      // Already qualified (`repo#6474`), glued to an id (`bks-91ec…`), a
+      // path or a decimal (`1.5`) is not a number that was said.
+      if (text[start - 1] === "#" && !/[\w/.-]/.test(text[start - 2] ?? ""))
+        start -= 1;
+      const before = text[start - 1] ?? "";
+      const after = text.slice(end, end + 2);
+      if (
+        !/[\w#/.-]/.test(before) &&
+        !/^[\w-]/.test(after) &&
+        !/^\.\d/.test(after) &&
+        m[0].length <= PR_NUMBER_MAX_DIGITS
+      )
+        token = { kind: "digits", value: Number(m[0]), text: m[0] };
+    } else token = numberToken(m[0]);
+    if (!token) {
+      closeRun();
+      lastEnd = end;
+      continue;
+    }
+    const between = lastEnd < 0 ? "" : text.slice(lastEnd, start);
+    // Only whitespace, a hyphen, or one comma may sit between two number
+    // words of the same run.
+    const joins = /^(?:\s*|\s*-\s*|\s*,\s*)$/.test(between);
+    if (!piece || !joins) closeRun();
+    else if (between.includes(",")) closePiece();
+    if (!piece) piece = { start, end, tokens: [] };
+    piece.tokens.push(token);
+    piece.end = end;
+    lastEnd = end;
+  }
+  closeRun();
+
+  const out: SpokenNumber[] = [];
+  const emit = (start: number, end: number, digits: string | null) => {
+    if (
+      !digits ||
+      digits.length < 2 ||
+      digits.length > PR_NUMBER_MAX_DIGITS ||
+      digits.startsWith("0")
+    )
+      return;
+    out.push({ start, end, value: Number(digits) });
+  };
+  for (const pieces of runs) {
+    const loneDigits =
+      pieces.length > 1 &&
+      pieces.every((p) => p.tokens.length === 1 && p.tokens[0].kind === "unit");
+    if (loneDigits) {
+      emit(
+        pieces[0].start,
+        pieces[pieces.length - 1].end,
+        spokenDigits(pieces.flatMap((p) => p.tokens)),
+      );
+      continue;
+    }
+    for (const p of pieces) emit(p.start, p.end, spokenDigits(p.tokens));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rewriting an assistant row.
+
+/**
+ * An assistant row with its spoken PR numbers written as `repo#N` wherever
+ * the ledger knows exactly one PR by that number, and a trailer naming the
+ * sessions the row is about: the ones the call just started or steered (once,
+ * on the first row after the tool result), and any listed session whose
+ * title the row says. User rows are never rewritten; the caller keeps them.
+ */
+export function linkSpokenReferences(
+  text: string,
+  ledger: VoiceReferenceLedger,
+): string {
+  let out = text;
+  const numbers = spokenNumbers(text);
+  for (let i = numbers.length - 1; i >= 0; i--) {
+    const n = numbers[i];
+    const refs = ledger.prRefsFor(n.value);
+    if (refs.length !== 1) continue;
+    out = `${out.slice(0, n.start)}${prKey(refs[0])}${out.slice(n.end)}`;
+  }
+
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const mention = (id: string) => {
+    const key = id.toLowerCase();
+    if (seen.has(key) || out.toLowerCase().includes(key)) return;
+    seen.add(key);
+    ids.push(key);
+  };
+  for (const id of ledger.takePending()) mention(id);
+  const lower = out.toLowerCase();
+  for (const ref of ledger.titledSessions())
+    if (lower.includes(ref.title.toLowerCase())) mention(ref.id);
+  if (ids.length)
+    out += `\n\n${ids.length === 1 ? "Session" : "Sessions"}: ${ids.join(", ")}`;
+  return out;
+}

--- a/packages/core/opensession-server/src/server/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/desk-voice.ts
@@ -390,6 +390,9 @@ export async function executeVoiceTool(
           title: s.title || "(untitled)",
           state: s.state,
           repo: s.repo,
+          // The PR a session opened, so a spoken "six four seven four" can
+          // be linked back to it in the transcript (desk-voice-refs.ts).
+          ...(s.prNumber ? { prNumber: s.prNumber } : {}),
           lastActivity: s.lastActivity,
         }));
       return { sessions };
@@ -404,6 +407,7 @@ export async function executeVoiceTool(
         state: s.state,
         repo: s.repo,
         branch: s.branch,
+        ...(s.prNumber ? { prNumber: s.prNumber } : {}),
         pendingQuestion: s.pendingQuestion,
         recent: (await control.transcriptTail(id, 10)).map((e) => ({
           type: e.type,


### PR DESCRIPTION
## Why

A GPT-Live Desk voice call mirrors spoken turns into the Desk transcript as plain text. Two references never became chips:

1. PR numbers are spoken as number words and land verbatim (`Six four seven four. Six four seven five, ...`), even though the call's own tool results had just returned those PRs.
2. Sessions the Desk starts are only ever named by title (the voice prompt forbids reading ids aloud, kept as is), while the `start_session` result right before carried the id.

The web renderer already chips `repo#6474` and a bare `bks-<uuidv7>`; the row just has to carry those spellings. The Desk session is repo-less, so the qualified `repo#N` form is required.

## What

- New pure module `src/server/desk-voice-refs.ts`:
  - `VoiceReferenceLedger.collect(name, args, result, repos)` records references from every tool call the call runs: `start_session`/`steer_session` sessions (pending a trailer), `{id,title,repo,prNumber}` rows from `list_current_work`/`inspect_session`, and, for any result text (MCP results included), `#N` / `PR N` on a line naming exactly one known repo, `github.com/<owner>/<name>/pull/N` URLs, and every session-shaped id. Bounded to the last 200 refs, idempotent.
  - `linkSpokenReferences(text, ledger)` for assistant rows: spoken numbers (digit runs, digit-by-digit incl. commas and `oh`, tens/teens, hundreds/thousands) that match exactly one PR in the ledger are rewritten in place to `repo#N`. No match, or a match in several repos, leaves the text untouched; already qualified mentions are left alone. Sessions just started/steered are appended once as a `Session: <id>` trailer to the next assistant row, as is a listed session whose exact title (>= 8 chars) the row says.
- `desk-voice-live.ts`: the `LiveCall` gets a ledger; `runTool` feeds it after `executeVoiceTool` (success or error); `onRow` passes assistant rows through `linkSpokenReferences` before `mirrorVoiceEntries`. User rows and typed text are untouched. The handoff copy gets the rewritten text.
- `desk-voice.ts`: `list_current_work` and `inspect_session` payloads include `prNumber` when present.
- `LIVE_BACKEND_INSTRUCTIONS` asks the backend to state PRs as repo + digits (e.g. `tella-fusion PR 6474`); sessions stay by title, never by id.

With the real transcript's refs in the ledger, the two rows from the report become:

```
Here are the reviewed ones. tella-fusion#6474. tella-fusion#6475, tella-fusion#6477, and tella-fusion#6478. The newer one still being reviewed is tella-fusion#6485, plus an approved allow attribute change at tella-fusion#6479.
```

```
I've kicked off work to make the transcript show up as I'm speaking

Session: bks-b72fa30b-31dd-7f7c-b4e2-bf83fdffe513
```

## Left out

- The native relay route `POST /api/desk/voice/transcript` is unchanged: it has no per-call ledger to rewrite against (iOS is out of scope).
- The optional frontend change (wrapping `DeskConversation` in `MarkdownRepoProvider`) is not in this PR: `DeskOverlay.tsx` and `DeskConversation.tsx` are mid-rework by another session in the shared checkout.

## Tests

`desk-voice-refs.test.ts` (bun:test): number-word parsing in every shape, the exact transcript sentence rewriting with and without ledger refs, cross-repo ambiguity, ledger bounds, and the one-shot start_session trailer. `bun run check` passes.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-91ec3036-d4e8-7a47-ace1-ad7d3ae8fcc9)
