### PR TITLE
Desk voice: stream the call's transcript as live captions

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -33,6 +33,8 @@ import { useAttachmentUploads } from "../hooks/useAttachmentUploads";
 import { foregroundFileComposerOwns, hasDraggedFiles } from "../lib/file-drag";
 import { FullPageFileDropOverlay } from "./FullPageFileDropOverlay";
 import { errorMessage } from "../lib/error-message";
+import type { VoiceCaptionStore } from "../lib/voice-captions";
+import { VoiceCaptions } from "./VoiceCaptions";
 
 interface DeskConversationProps {
   sessionId: string;
@@ -52,6 +54,9 @@ interface DeskConversationProps {
   voiceSend?: (text: string) => Promise<boolean>;
   /** The voice call control, rendered in the composer beside dictation. */
   voiceCall?: { active: boolean; status?: string; onToggle: () => void };
+  /** Live captions of the voice call, shown under the transcript until the
+   * server's mirrored row for each utterance lands here and replaces them. */
+  voiceCaptions?: VoiceCaptionStore;
   /** Drill into a session a tool call spawned (the Desk delegates constantly).
    *  The overlay has no side pane, so this opens it in the full viewer. */
   onOpenSubagent?: (sessionId: string) => void;
@@ -76,6 +81,7 @@ export function DeskConversation({
   hideBefore,
   voiceSend,
   voiceCall,
+  voiceCaptions,
   onOpenSubagent,
   suggestions,
 }: DeskConversationProps) {
@@ -86,6 +92,9 @@ export function DeskConversation({
   const [isRunning, setIsRunning] = useState(false);
   const [pending, setPending] = useState<string | null>(null);
   const [hasLiveText, setHasLiveText] = useState(false);
+  const [hasVoiceCaptions, setHasVoiceCaptions] = useState(
+    () => voiceCaptions?.hasCaptions() ?? false,
+  );
   const [dictationHidesSuggestions, setDictationHidesSuggestions] =
     useState(false);
   // Attachments staged for the next send. The Composer stages files to disk
@@ -159,6 +168,13 @@ export function DeskConversation({
   }
   const addDroppedAttachments = useEffectEvent((picked: FileList | File[]) => {
     void addDeskAttachments(picked);
+  });
+  // A mirrored voice row landing takes its caption down in the same render,
+  // so the words never show twice. Not a dependency of the watch effect: the
+  // store is stable for the overlay's lifetime.
+  const landVoiceCaptions = useEffectEvent((landed: TranscriptEntry[]) => {
+    if (!voiceCaptions) return;
+    for (const entry of landed) voiceCaptions.land(entry);
   });
 
   function resetFileDrag() {
@@ -240,7 +256,11 @@ export function DeskConversation({
     ? entries.filter((e) => !e.timestamp || e.timestamp > hideBefore)
     : entries;
   const hasContent =
-    visibleEntries.length > 0 || hasLiveText || isRunning || !!pending;
+    visibleEntries.length > 0 ||
+    hasLiveText ||
+    hasVoiceCaptions ||
+    isRunning ||
+    !!pending;
 
   useEffect(() => {
     fetchModels()
@@ -280,8 +300,10 @@ export function DeskConversation({
       switch (msg.type) {
         case "transcript_init":
           setEntries(msg.entries);
+          landVoiceCaptions(msg.entries);
           break;
         case "transcript_history":
+          landVoiceCaptions(msg.entries);
           setEntries((prev) =>
             mergeTranscriptEntries(prev, msg.entries, msg.v2 === true),
           );
@@ -290,6 +312,7 @@ export function DeskConversation({
           setEntries((prev) =>
             mergeTranscriptEntries(prev, msg.entries, msg.v2 === true),
           );
+          landVoiceCaptions(msg.entries);
           if (msg.entries.some((e) => e.type === "user")) setPending(null);
           const landed = msg.entries.filter(
             (e) => e.type === "assistant" && e.content,
@@ -379,6 +402,13 @@ export function DeskConversation({
     });
     return unsubscribe;
   }, [liveTurnStore]);
+  useEffect(() => {
+    if (!voiceCaptions) return;
+    setHasVoiceCaptions(voiceCaptions.hasCaptions());
+    return voiceCaptions.subscribe(() => {
+      setHasVoiceCaptions(voiceCaptions.hasCaptions());
+    });
+  }, [voiceCaptions]);
   const shouldMaintainEnd = () => followRef.current;
   const relayoutLive = () => {
     const el = bodyRef.current;
@@ -569,6 +599,10 @@ export function DeskConversation({
                 connected && !isRunning ? continueAfterFailure : undefined
               }
             />
+            {/* What the voice call is saying, ahead of the mirrored rows. */}
+            {voiceCaptions && (
+              <VoiceCaptions store={voiceCaptions} onLayout={relayoutLive} />
+            )}
             {/* Optimistic echo of the just-sent message — rendered as a normal
 						    sent bubble (not the dimmed "sending" look) so it reads as
 						    delivered the instant Enter lands; reconciles away when the

--- a/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
@@ -9,6 +9,7 @@ import { IconDesk, IconExpand, IconMinus } from "./icons";
 import { Button } from "../ui/button";
 import { DeskVoiceClient, type DeskVoiceState } from "../lib/desk-voice-client";
 import { getDeskVoicePref, onDeskVoiceChanged } from "../lib/desk-voice-pref";
+import { VoiceCaptionStore } from "../lib/voice-captions";
 import { cn } from "../ui/cn";
 import { errorMessage } from "../lib/error-message";
 import { useDeskPanel } from "../hooks/useDeskPanel";
@@ -73,11 +74,14 @@ function DeskBody({
   );
 
   // Voice mode (Settings → Desk voice): a GPT-Live call layered on this same
-  // Desk session. The server mirrors the call's transcript into the session,
-  // so the conversation below updates while you talk.
+  // Desk session. The server mirrors the call's transcript into the session
+  // one settled utterance at a time; the call's own transcript deltas fill
+  // the wait as live captions (one store for the body's lifetime, cleared as
+  // each call starts), so the conversation below moves while you talk.
   const [voiceEnabled, setVoiceEnabled] = useState(getDeskVoicePref);
   const [voiceState, setVoiceState] = useState<DeskVoiceState>("idle");
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [voiceCaptions] = useState(() => new VoiceCaptionStore());
   const voiceRef = useRef<DeskVoiceClient | null>(null);
   useEffect(
     () => onDeskVoiceChanged(() => setVoiceEnabled(getDeskVoicePref())),
@@ -87,8 +91,10 @@ function DeskBody({
   useEffect(
     () => () => {
       voiceRef.current?.stop();
+      voiceRef.current = null;
+      voiceCaptions.clear();
     },
-    [],
+    [voiceCaptions],
   );
 
   const voiceActive = voiceState !== "idle" && voiceState !== "error";
@@ -110,17 +116,30 @@ function DeskBody({
       return;
     }
     setVoiceError(null);
+    voiceCaptions.clear();
     const client = new DeskVoiceClient({
       user,
       onState: (s, detail) => {
+        if (voiceRef.current !== client) return;
         setVoiceState(s);
         if (s === "error") setVoiceError(detail || "Voice call failed");
+        // The call is over: its open rows are being mirrored, so the
+        // captions wait for them rather than vanishing and reappearing.
+        if (s === "idle" || s === "error") voiceCaptions.end();
+      },
+      onCallStarted: (callId) => {
+        if (voiceRef.current === client) voiceCaptions.start(callId);
+      },
+      onTranscript: (fragment) => {
+        if (voiceRef.current === client) voiceCaptions.push(fragment);
       },
     });
     voiceRef.current = client;
     void client.start().catch((error) => {
+      if (voiceRef.current !== client) return;
       setVoiceState("error");
       setVoiceError(errorMessage(error, "Voice call failed"));
+      voiceCaptions.end();
     });
   }
 
@@ -263,6 +282,7 @@ function DeskBody({
             model={settings.model}
             effort={settings.effort}
             hideBefore={clearedAt}
+            voiceCaptions={voiceCaptions}
             voiceSend={
               voiceActive
                 ? (text) =>

--- a/packages/core/opensession-server/src/frontend/components/VoiceCaptions.tsx
+++ b/packages/core/opensession-server/src/frontend/components/VoiceCaptions.tsx
@@ -1,0 +1,56 @@
+import React, { useLayoutEffect, useSyncExternalStore } from "react";
+import type { VoiceCaptionStore } from "../lib/voice-captions";
+import {
+  msgBodyStreaming,
+  msgBubbleUser,
+  msgOwnTurn,
+  msgRow,
+  msgStreamingRow,
+} from "../lib/msg-classes";
+import { cn } from "../ui/cn";
+
+/**
+ * What the voice call is saying right now. One row per speaker holds the
+ * transcript fragments the call has delivered and the server has not yet
+ * mirrored (lib/voice-captions.ts): the reply reads as the bubble a text run
+ * streams into, your own words as a sent bubble, and each drops out as the
+ * durable row lands in its place.
+ */
+export function VoiceCaptions({
+  store,
+  onLayout,
+}: {
+  store: VoiceCaptionStore;
+  /** Re-measure the host scroll region after a caption paints. */
+  onLayout?: () => void;
+}) {
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
+  );
+  useLayoutEffect(() => {
+    onLayout?.();
+  }, [snapshot.revision, onLayout]);
+  if (!snapshot.captions.length) return null;
+  return (
+    <>
+      {snapshot.captions.map((caption) =>
+        caption.role === "user" ? (
+          /* .msg-user stays as a hook: useSessionScroll finds turn
+					   boundaries by it, as on the settled row this becomes. */
+          <div key="user" className={cn(msgRow, msgOwnTurn, "msg-user")}>
+            <div className={msgBubbleUser}>{caption.text}</div>
+          </div>
+        ) : (
+          /* .msg-streaming + .msg-body-assistant stay as hooks: the streaming
+					   caret is a ::after on that pair (base-markdown.css). Plain text,
+					   not markdown: this is speech. */
+          <div key="assistant" className={cn(msgRow, msgStreamingRow)}>
+            <div className={msgBodyStreaming}>{caption.text}</div>
+          </div>
+        ),
+      )}
+    </>
+  );
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
@@ -3,10 +3,13 @@
 // with the instance key and hands back the answer. Tool calls, transcript
 // mirroring, and typed text all happen server-side over the session's
 // sideband (src/server/desk-voice-live.ts); the data channel here is limited
-// to lifecycle and transcript events plus `session.close`.
+// to lifecycle and transcript events plus `session.close`. The transcript
+// events double as live captions (`onTranscript`): the server mirrors a row
+// only once the utterance settles, and these arrive word by word.
 
 import { z } from "zod";
 import { BASE_PATH } from "./base";
+import type { VoiceCaptionFragment, VoiceCaptionRole } from "./voice-captions";
 
 export type DeskVoiceState =
   | "idle"
@@ -43,7 +46,14 @@ const liveEventSchema = z.object({
     .optional()
     .catch(undefined),
   message: z.string().optional(),
+  // Transcript deltas: the text plus its place on the session timeline. A
+  // malformed timestamp must not cost the state change the event carries.
+  delta: z.string().optional().catch(undefined),
+  start_ms: z.number().optional().catch(undefined),
+  end_ms: z.number().optional().catch(undefined),
 });
+
+type LiveEvent = z.infer<typeof liveEventSchema>;
 
 /** One audio-free, transcript-free line about how a call went, posted at
  * teardown to `/api/desk/voice/diag` (the server appends its own line with
@@ -122,6 +132,8 @@ function waitForIceGathering(pc: RTCPeerConnection): Promise<void> {
 export class DeskVoiceClient {
   private user: string;
   private onState: (s: DeskVoiceState, detail?: string) => void;
+  private onCallStarted?: (callId: string) => void;
+  private onTranscript?: (fragment: VoiceCaptionFragment) => void;
 
   private pc: RTCPeerConnection | null = null;
   private dc: RTCDataChannel | null = null;
@@ -174,12 +186,17 @@ export class DeskVoiceClient {
   constructor(opts: {
     user: string;
     onState: (s: DeskVoiceState, detail?: string) => void;
+    /** Every transcript fragment as the call delivers it, both speakers. */
+    onTranscript?: (fragment: VoiceCaptionFragment) => void;
+    onCallStarted?: (callId: string) => void;
   }) {
     this.user = opts.user;
     this.onState = (s, detail) => {
       if (s === "error") this.lastError = detail ?? "error";
       opts.onState(s, detail);
     };
+    this.onTranscript = opts.onTranscript;
+    this.onCallStarted = opts.onCallStarted;
   }
 
   /** Connecting or connected, and not hanging up: the handset shows this
@@ -283,6 +300,7 @@ export class DeskVoiceClient {
       }
       this.liveSessionId = live.liveSessionId;
       this.backendModel = live.backendModel ?? null;
+      this.onCallStarted?.(live.liveSessionId);
       await pc.setRemoteDescription({ type: "answer", sdp: live.sdp });
     } catch (e) {
       if (this.aborted) return;
@@ -462,8 +480,20 @@ export class DeskVoiceClient {
     );
   }
 
+  private transcript(role: VoiceCaptionRole, event: LiveEvent) {
+    if (!event.delta || !this.onTranscript) return;
+    // The same fallbacks the server's row grouping applies to these fields.
+    const startMs = event.start_ms ?? 0;
+    this.onTranscript({
+      role,
+      delta: event.delta,
+      startMs,
+      endMs: event.end_ms ?? startMs,
+    });
+  }
+
   private handleEvent(raw: string) {
-    let event: z.infer<typeof liveEventSchema>;
+    let event: LiveEvent;
     try {
       event = liveEventSchema.parse(JSON.parse(raw));
     } catch {
@@ -483,11 +513,13 @@ export class DeskVoiceClient {
         this.inputDeltas += 1;
         this.resetIdleTimer();
         this.onState("listening");
+        this.transcript("user", event);
         break;
       case "session.output_transcript.delta":
         this.outputDeltas += 1;
         this.resetIdleTimer();
         this.onState("speaking");
+        this.transcript("assistant", event);
         if (this.speakingTimer !== null)
           window.clearTimeout(this.speakingTimer);
         this.speakingTimer = window.setTimeout(() => {

--- a/packages/core/opensession-server/src/frontend/lib/voice-captions.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/voice-captions.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from "bun:test";
+import { VoiceCaptionStore, parseVoiceRowId } from "./voice-captions";
+
+const captions = (store: VoiceCaptionStore) =>
+  store.getSnapshot().captions.map(({ role, text }) => ({ role, text }));
+
+describe("parseVoiceRowId", () => {
+  test("reads the role and row start out of a mirrored voice row id", () => {
+    expect(parseVoiceRowId("voice-live_abc-assistant-1200-end-1800")).toEqual({
+      callId: "live_abc",
+      role: "assistant",
+      startMs: 1200,
+      endMs: 1800,
+    });
+    expect(parseVoiceRowId("voice-live_a-b-c-user-0-end-950")).toEqual({
+      callId: "live_a-b-c",
+      role: "user",
+      startMs: 0,
+      endMs: 950,
+    });
+  });
+
+  test("reads a legacy id without the row's end", () => {
+    expect(parseVoiceRowId("voice-live_abc-assistant-1200")).toEqual({
+      callId: "live_abc",
+      role: "assistant",
+      startMs: 1200,
+      endMs: null,
+    });
+  });
+
+  test("does not match typed messages or ordinary entries", () => {
+    expect(parseVoiceRowId("voice-typed-3f2a")).toBeNull();
+    expect(parseVoiceRowId("e123")).toBeNull();
+    expect(parseVoiceRowId("voice-live_abc-user-0-end-")).toBeNull();
+  });
+});
+
+describe("VoiceCaptionStore with the row's end in its id", () => {
+  test("a rewritten row still takes its fragments down", () => {
+    // The server links what the Desk said to PRs and sessions before
+    // mirroring it (desk-voice-refs.ts), so the durable text no longer
+    // matches the spoken fragments. The id's span settles it instead.
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({
+      role: "assistant",
+      delta: "I opened PR ",
+      startMs: 900,
+      endMs: 1300,
+    });
+    store.push({
+      role: "assistant",
+      delta: "forty two.",
+      startMs: 1300,
+      endMs: 1800,
+    });
+    expect(captions(store)).toEqual([
+      { role: "assistant", text: "I opened PR forty two." },
+    ]);
+    store.land({
+      id: "voice-live_abc-assistant-900-end-1800",
+      type: "assistant",
+      content: "I opened PR opensession#42.",
+    });
+    expect(captions(store)).toEqual([]);
+    expect(store.hasCaptions()).toBe(false);
+  });
+
+  test("late fragments inside the span stay hidden, the next row shows", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.land({
+      id: "voice-live_abc-assistant-900-end-1800",
+      type: "assistant",
+      content: "I opened PR opensession#42.",
+    });
+    store.push({
+      role: "assistant",
+      delta: "I opened PR ",
+      startMs: 900,
+      endMs: 1300,
+    });
+    store.push({
+      role: "assistant",
+      delta: "forty two.",
+      startMs: 1300,
+      endMs: 1800,
+    });
+    // Starts exactly at the row's end: the server joined it into that row.
+    store.push({
+      role: "assistant",
+      delta: " Done.",
+      startMs: 1800,
+      endMs: 2000,
+    });
+    expect(captions(store)).toEqual([]);
+    store.push({
+      role: "assistant",
+      delta: "Anything else?",
+      startMs: 5000,
+      endMs: 5600,
+    });
+    expect(captions(store)).toEqual([
+      { role: "assistant", text: "Anything else?" },
+    ]);
+  });
+
+  test("the row only covers its own span, not the tail after it", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "user", delta: "What is", startMs: 1000, endMs: 1200 });
+    store.push({
+      role: "user",
+      delta: " running?",
+      startMs: 1200,
+      endMs: 1800,
+    });
+    store.push({ role: "user", delta: "Also,", startMs: 5000, endMs: 5300 });
+    store.land({
+      id: "voice-live_abc-user-1000-end-1800",
+      type: "user",
+      content: "What is running?",
+    });
+    expect(captions(store)).toEqual([{ role: "user", text: "Also," }]);
+  });
+
+  test("an older row cannot cover fragments of the latest settled row", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.land({
+      id: "voice-live_abc-assistant-3000-end-3500",
+      type: "assistant",
+      content: "Latest.",
+    });
+    store.push({
+      role: "assistant",
+      delta: "Next",
+      startMs: 6000,
+      endMs: 6300,
+    });
+    store.land({
+      id: "voice-live_abc-assistant-1000-end-9000",
+      type: "assistant",
+      content: "Older.",
+    });
+    expect(captions(store)).toEqual([{ role: "assistant", text: "Next" }]);
+  });
+});
+
+describe("VoiceCaptionStore", () => {
+  test("shows each speaker's fragments as they arrive, in start order", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    let notified = 0;
+    store.subscribe(() => notified++);
+    store.push({ role: "user", delta: "What is", startMs: 0, endMs: 300 });
+    store.push({ role: "user", delta: " running?", startMs: 300, endMs: 800 });
+    store.push({ role: "assistant", delta: "Two ", startMs: 900, endMs: 1100 });
+    store.push({
+      role: "assistant",
+      delta: "sessions.",
+      startMs: 1100,
+      endMs: 1800,
+    });
+    expect(captions(store)).toEqual([
+      { role: "user", text: "What is running?" },
+      { role: "assistant", text: "Two sessions." },
+    ]);
+    expect(notified).toBe(4);
+    expect(store.hasCaptions()).toBe(true);
+  });
+
+  test("a mirrored row takes exactly its own fragments down and keeps the rest", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "user", delta: "What is", startMs: 1000, endMs: 1200 });
+    store.push({
+      role: "user",
+      delta: " running?",
+      startMs: 1200,
+      endMs: 1800,
+    });
+    // Past the server's gap: this fragment opens a new row there.
+    store.push({ role: "user", delta: "Also,", startMs: 5000, endMs: 5300 });
+    store.land({
+      id: "voice-live_abc-user-1000",
+      type: "user",
+      content: "What is running?",
+    });
+    expect(captions(store)).toEqual([{ role: "user", text: "Also," }]);
+    store.land({
+      id: "voice-live_abc-user-5000",
+      type: "user",
+      content: "Also,",
+    });
+    expect(captions(store)).toEqual([]);
+    expect(store.hasCaptions()).toBe(false);
+  });
+
+  test("ignores typed messages, other roles and rows it never saw", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "user", delta: "wait", startMs: 400, endMs: 700 });
+    store.land({ id: "voice-typed-3f2a", type: "user", content: "wait" });
+    store.land({
+      id: "voice-live_abc-assistant-400",
+      type: "assistant",
+      content: "wait",
+    });
+    store.land({ id: "voice-live_abc-user-9", type: "user", content: "wait" });
+    store.land({ id: "e77", type: "user", content: "wait" });
+    expect(captions(store)).toEqual([{ role: "user", text: "wait" }]);
+  });
+
+  test("a later row also clears stale fragments left ahead of it", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "assistant", delta: "stale", startMs: 100, endMs: 400 });
+    store.push({
+      role: "assistant",
+      delta: "Sure.",
+      startMs: 3000,
+      endMs: 3400,
+    });
+    store.push({
+      role: "assistant",
+      delta: " Next",
+      startMs: 6000,
+      endMs: 6300,
+    });
+    store.land({
+      id: "voice-live_abc-assistant-3000",
+      type: "assistant",
+      content: "Sure.",
+    });
+    expect(captions(store)).toEqual([{ role: "assistant", text: "Next" }]);
+  });
+
+  test("a row the browser has only part of supersedes what it holds", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "assistant", delta: "Two ", startMs: 900, endMs: 1100 });
+    store.land({
+      id: "voice-live_abc-assistant-900",
+      type: "assistant",
+      content: "Two sessions.",
+    });
+    expect(captions(store)).toEqual([]);
+  });
+
+  test("whitespace-only fragments show nothing", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "user", delta: "  ", startMs: 0, endMs: 100 });
+    store.push({ role: "assistant", delta: "", startMs: 0, endMs: 100 });
+    expect(captions(store)).toEqual([]);
+    expect(store.hasCaptions()).toBe(false);
+  });
+
+  test("the call's end keeps the tails for the grace, then clears them", async () => {
+    const store = new VoiceCaptionStore({ endGraceMs: 20 });
+    store.start("live_abc");
+    store.push({ role: "assistant", delta: "Bye.", startMs: 0, endMs: 300 });
+    store.end();
+    expect(captions(store)).toEqual([{ role: "assistant", text: "Bye." }]);
+    // The mirrored row lands within the grace: the caption goes with it.
+    store.land({
+      id: "voice-live_abc-assistant-0",
+      type: "assistant",
+      content: "Bye.",
+    });
+    expect(captions(store)).toEqual([]);
+    store.push({
+      role: "user",
+      delta: "never mirrored",
+      startMs: 500,
+      endMs: 900,
+    });
+    store.end();
+    await Bun.sleep(40);
+    expect(captions(store)).toEqual([]);
+  });
+
+  test("a new call clears captions and ignores the previous call's rows", async () => {
+    const store = new VoiceCaptionStore({ endGraceMs: 20 });
+    store.start("old");
+    store.push({ role: "assistant", delta: "Bye.", startMs: 0, endMs: 300 });
+    store.end();
+    store.start("new");
+    store.push({
+      role: "assistant",
+      delta: "Hi again",
+      startMs: 0,
+      endMs: 300,
+    });
+    store.land({
+      id: "voice-old-assistant-0",
+      type: "assistant",
+      content: "Bye.",
+    });
+    await Bun.sleep(40);
+    expect(captions(store)).toEqual([{ role: "assistant", text: "Hi again" }]);
+    store.clear();
+  });
+
+  test("late RTC fragments never resurrect a row that landed first", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.land({
+      id: "voice-live_abc-assistant-900",
+      type: "assistant",
+      content: "Two sessions.",
+    });
+    store.push({ role: "assistant", delta: "Two ", startMs: 900, endMs: 1100 });
+    expect(captions(store)).toEqual([]);
+    store.push({
+      role: "assistant",
+      delta: "sessions.",
+      startMs: 1100,
+      endMs: 1800,
+    });
+    expect(captions(store)).toEqual([]);
+    store.push({
+      role: "assistant",
+      delta: " Next reply.",
+      startMs: 5000,
+      endMs: 5500,
+    });
+    expect(captions(store)).toEqual([
+      { role: "assistant", text: "Next reply." },
+    ]);
+  });
+
+  test("a partial caption stays hidden when the remainder arrives after its row", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.push({ role: "assistant", delta: "Two ", startMs: 900, endMs: 1100 });
+    store.land({
+      id: "voice-live_abc-assistant-900",
+      type: "assistant",
+      content: "Two sessions.",
+    });
+    store.push({
+      role: "assistant",
+      delta: "sessions.",
+      startMs: 1100,
+      endMs: 1800,
+    });
+    expect(captions(store)).toEqual([]);
+  });
+
+  test("history replay and old deltas cannot replace the latest settled row", () => {
+    const store = new VoiceCaptionStore();
+    store.start("live_abc");
+    store.land({
+      id: "voice-live_abc-assistant-3000",
+      type: "assistant",
+      content: "Latest.",
+    });
+    store.land({
+      id: "voice-live_abc-assistant-1000",
+      type: "assistant",
+      content: "Older.",
+    });
+    store.push({
+      role: "assistant",
+      delta: "Older.",
+      startMs: 1000,
+      endMs: 1500,
+    });
+    store.push({
+      role: "assistant",
+      delta: "Latest.",
+      startMs: 3000,
+      endMs: 3500,
+    });
+    expect(captions(store)).toEqual([]);
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/voice-captions.ts
+++ b/packages/core/opensession-server/src/frontend/lib/voice-captions.ts
@@ -1,0 +1,199 @@
+// Call-local captions bridge RTC transcript deltas to settled Desk rows.
+// The server persists whole utterances; captions fill that wait without
+// changing transcript storage or the server's grouping rules.
+
+export type VoiceCaptionRole = "user" | "assistant";
+
+export interface VoiceCaptionFragment {
+  role: VoiceCaptionRole;
+  delta: string;
+  /** Session-timeline position, as the Live API reports it. */
+  startMs: number;
+  endMs: number;
+}
+
+export interface VoiceCaption {
+  role: VoiceCaptionRole;
+  text: string;
+  /** Timeline start of the first fragment still on screen. */
+  startMs: number;
+}
+
+export interface VoiceCaptionsSnapshot {
+  /** At most one caption per speaker, in the order they started. */
+  captions: VoiceCaption[];
+  revision: number;
+}
+
+/** How long a caption outlives its call. The server flushes every open row
+ * as the call ends and the mirrored entries land moments later; whatever has
+ * not landed by then comes down to avoid leaving a stale caption. */
+export const VOICE_CAPTION_END_GRACE_MS = 5_000;
+
+const EMPTY: VoiceCaptionsSnapshot = { captions: [], revision: 0 };
+
+/** Whether a settled row accounts for a fragment. The server joins every
+ * fragment that starts no later than the row's end into that row, so a row
+ * with a known end covers the whole span; a legacy row only covers what came
+ * before it started (its own fragments are matched by text in `publish`). */
+function covers(
+  landed: { startMs: number; endMs: number | null },
+  fragment: { startMs: number },
+): boolean {
+  if (fragment.startMs < landed.startMs) return true;
+  return landed.endMs !== null && fragment.startMs <= landed.endMs;
+}
+
+/** Mirrored voice rows are `voice-<call>-<role>-<startMs>-end-<endMs>`,
+ * spanning the row's first fragment to its last (desk-voice-live.ts). Rows
+ * mirrored before the end was recorded have no `-end-` part. Typed messages
+ * during a call are `voice-typed-<uuid>` and never match. */
+const ROW_ID =
+  /^voice-(.+)-(user|assistant)-(\d+(?:\.\d+)?)(?:-end-(\d+(?:\.\d+)?))?$/;
+
+export function parseVoiceRowId(id: string): {
+  callId: string;
+  role: VoiceCaptionRole;
+  startMs: number;
+  /** Null for a legacy id without the `-end-` part. */
+  endMs: number | null;
+} | null {
+  const match = ROW_ID.exec(id);
+  if (!match) return null;
+  return {
+    callId: match[1],
+    role: match[2] === "user" ? "user" : "assistant",
+    startMs: Number(match[3]),
+    endMs: match[4] === undefined ? null : Number(match[4]),
+  };
+}
+
+export class VoiceCaptionStore {
+  private fragments: Record<VoiceCaptionRole, VoiceCaptionFragment[]> = {
+    user: [],
+    assistant: [],
+  };
+  private callId: string | null = null;
+  private landed: Partial<
+    Record<
+      VoiceCaptionRole,
+      { startMs: number; endMs: number | null; text: string }
+    >
+  > = {};
+  private snapshot: VoiceCaptionsSnapshot = EMPTY;
+  private listeners = new Set<() => void>();
+  private endTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly opts: { endGraceMs?: number } = {}) {}
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = () => this.snapshot;
+  getServerSnapshot = () => EMPTY;
+  hasCaptions = () => this.snapshot.captions.length > 0;
+
+  start(callId: string): void {
+    this.clear();
+    this.callId = callId;
+  }
+
+  /** A transcript fragment from the call's data channel. */
+  push(fragment: VoiceCaptionFragment): void {
+    if (!this.callId || !fragment.delta) return;
+    this.cancelEnd();
+    const landed = this.landed[fragment.role];
+    if (landed && covers(landed, fragment)) return;
+    this.fragments[fragment.role].push(fragment);
+    this.publish();
+  }
+
+  /** A durable transcript entry arrived. A mirrored voice row takes its own
+   * fragments off the screen; every other entry is ignored. A row whose id
+   * carries its end covers every fragment up to that point, whatever its
+   * content: the server may have rewritten what the Desk said into
+   * references (desk-voice-refs.ts). */
+  land(entry: { id: string; type: string; content: string }): void {
+    const row = parseVoiceRowId(entry.id);
+    if (!row || row.role !== entry.type || row.callId !== this.callId) return;
+    const previous = this.landed[row.role];
+    if (previous && previous.startMs > row.startMs) return;
+    const landed = {
+      startMs: row.startMs,
+      endMs: row.endMs,
+      text: entry.content.trim(),
+    };
+    this.landed[row.role] = landed;
+    this.fragments[row.role] = this.fragments[row.role].filter(
+      (fragment) => !covers(landed, fragment),
+    );
+    this.publish();
+  }
+
+  /** The call ended. Its open rows are being mirrored right now, so the tails
+   * stay until they land and anything still up after the grace comes down. */
+  end(): void {
+    this.cancelEnd();
+    if (!this.fragments.user.length && !this.fragments.assistant.length) return;
+    this.endTimer = setTimeout(() => {
+      this.endTimer = null;
+      this.clear();
+    }, this.opts.endGraceMs ?? VOICE_CAPTION_END_GRACE_MS);
+  }
+
+  clear(): void {
+    this.cancelEnd();
+    this.fragments = { user: [], assistant: [] };
+    this.landed = {};
+    this.callId = null;
+    this.publish();
+  }
+
+  private publish() {
+    const captions: VoiceCaption[] = [];
+    for (const role of ["user", "assistant"] as const) {
+      let fragments = this.fragments[role];
+      const landed = this.landed[role];
+      // The sideband and RTC channel can arrive in either order. Retain the
+      // latest settled row so its late RTC fragments cannot reappear. Older
+      // fragments are pruned on land; only the latest row and live tail remain.
+      // A row without its end (legacy id) is matched by text instead.
+      if (
+        landed &&
+        landed.endMs === null &&
+        fragments[0]?.startMs === landed.startMs
+      ) {
+        let joined = "";
+        let hidden = 0;
+        for (const fragment of fragments) {
+          joined += fragment.delta;
+          if (!landed.text.startsWith(joined.trim())) break;
+          hidden++;
+          if (joined.trim() === landed.text) break;
+        }
+        fragments = fragments.slice(hidden);
+      }
+      if (!fragments.length) continue;
+      // Joined exactly as received: fragments carry their own spacing.
+      const text = fragments
+        .map((f) => f.delta)
+        .join("")
+        .trim();
+      if (!text) continue;
+      captions.push({ role, text, startMs: fragments[0].startMs });
+    }
+    captions.sort((a, b) => a.startMs - b.startMs);
+    this.snapshot = { captions, revision: this.snapshot.revision + 1 };
+    for (const listener of this.listeners) listener();
+  }
+
+  private cancelEnd() {
+    if (this.endTimer === null) return;
+    clearTimeout(this.endTimer);
+    this.endTimer = null;
+  }
+}

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -11,6 +11,7 @@ import {
   VoiceTranscriptRows,
   buildLiveSessionConfig,
   formatLiveUsage,
+  liveTranscriptSpan,
 } from "./desk-voice-live";
 import {
   setVoiceBackendModel,
@@ -377,6 +378,43 @@ describe("VoiceTranscriptRows", () => {
     r.push({ role: "user", delta: "  ", startMs: 0, endMs: 100 });
     r.flushAll();
     expect(out).toEqual([]);
+  });
+
+  test.each([
+    { start_ms: 1200, end_ms: "unknown", startMs: 1200, endMs: 1200 },
+    { start_ms: "unknown", end_ms: 1500, startMs: 0, endMs: 1500 },
+    { start_ms: null, end_ms: null, startMs: 0, endMs: 0 },
+    { start_ms: NaN, end_ms: Infinity, startMs: 0, endMs: 0 },
+    { start_ms: -Infinity, end_ms: {}, startMs: 0, endMs: 0 },
+    { start_ms: undefined, end_ms: undefined, startMs: 0, endMs: 0 },
+    { start_ms: 1200, end_ms: 1500, startMs: 1200, endMs: 1500 },
+  ])("normalizes sideband timestamps and drains captions: %j", (event) => {
+    const span = liveTranscriptSpan(event);
+    expect(span).toEqual({ startMs: event.startMs, endMs: event.endMs });
+    const captions = new VoiceCaptionStore();
+    captions.start("live_abc");
+    captions.push({
+      role: "assistant",
+      delta: "PR forty two.",
+      startMs: event.startMs,
+      endMs: event.endMs,
+    });
+    const r = new VoiceTranscriptRows({
+      gapMs: LIVE_ROW_GAP_MS,
+      idleMs: 60_000,
+      rowId: (role, startMs) => `voice-live_abc-${role}-${startMs}`,
+      onRow: (row) => {
+        captions.land({
+          id: `${row.id}-end-${row.endMs}`,
+          type: row.role,
+          content: "PR opensession#42.",
+        });
+      },
+    });
+    r.push({ role: "assistant", delta: "PR forty two.", ...span });
+    expect(captions.getSnapshot().captions).toHaveLength(1);
+    r.flushAll();
+    expect(captions.getSnapshot().captions).toEqual([]);
   });
 
   test("the browser's captions drain exactly as the mirrored rows land", () => {

--- a/packages/core/opensession-server/src/server/desk-voice-live.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.test.ts
@@ -20,6 +20,8 @@ import {
 } from "./desk-voice";
 import { stateDir } from "./paths";
 import { registerSessionControl, type SessionControl } from "./session-control";
+import { VoiceCaptionStore } from "../frontend/lib/voice-captions";
+import { VoiceReferenceLedger, linkSpokenReferences } from "./desk-voice-refs";
 
 // The voice store resolves its path per call, so pointing OPENSESSION_STATE_DIR
 // at a scratch dir here keeps every test below off the machine's real
@@ -259,10 +261,24 @@ describe("VoiceTranscriptRows", () => {
       gapMs: LIVE_ROW_GAP_MS,
       idleMs: 60_000,
       rowId: (role, startMs) => `${role}-${startMs}`,
-      onRow: (row) => out.push(row),
+      onRow: ({ id, role, text }) => out.push({ id, role, text }),
     });
     return { r, out };
   }
+
+  test("hands each row over with the span of its fragments", () => {
+    const out: Array<{ id: string; startMs: number; endMs: number }> = [];
+    const r = new VoiceTranscriptRows({
+      gapMs: LIVE_ROW_GAP_MS,
+      idleMs: 60_000,
+      rowId: (role, startMs) => `${role}-${startMs}`,
+      onRow: ({ id, startMs, endMs }) => out.push({ id, startMs, endMs }),
+    });
+    r.push({ role: "user", delta: "What is", startMs: 1000, endMs: 1200 });
+    r.push({ role: "user", delta: " running?", startMs: 1200, endMs: 1800 });
+    r.flushAll();
+    expect(out).toEqual([{ id: "user-1000", startMs: 1000, endMs: 1800 }]);
+  });
 
   test("joins fragments of one utterance and splits on a timeline gap", () => {
     const { r, out } = rows();
@@ -361,6 +377,74 @@ describe("VoiceTranscriptRows", () => {
     r.push({ role: "user", delta: "  ", startMs: 0, endMs: 100 });
     r.flushAll();
     expect(out).toEqual([]);
+  });
+
+  test("the browser's captions drain exactly as the mirrored rows land", () => {
+    // The browser sees the same fragments on its data channel and shows them
+    // as captions (frontend/lib/voice-captions.ts) until this class's row
+    // for them reaches the transcript. The mirrored id carries the row's
+    // span the way startLiveCall builds it, so the captions come down even
+    // when the Desk's words were rewritten into references on the way.
+    const captions = new VoiceCaptionStore();
+    captions.start("live_abc");
+    const ledger = new VoiceReferenceLedger();
+    ledger.collect(
+      "list_current_work",
+      {},
+      {
+        sessions: [
+          {
+            id: "bks-01900000-0000-7000-8000-000000000000",
+            title: "Work 0",
+            repo: "opensession",
+            prNumber: 42,
+          },
+        ],
+      },
+      [{ id: "opensession", ghRepo: "tellahq/opensession" }],
+    );
+    const mirrored: string[] = [];
+    const r = new VoiceTranscriptRows({
+      gapMs: LIVE_ROW_GAP_MS,
+      idleMs: 60_000,
+      rowId: (role, startMs) => `voice-live_abc-${role}-${startMs}`,
+      onRow: (row) => {
+        const content =
+          row.role === "assistant"
+            ? linkSpokenReferences(row.text, ledger)
+            : row.text;
+        mirrored.push(content);
+        captions.land({
+          id: `${row.id}-end-${row.endMs}`,
+          type: row.role,
+          content,
+        });
+      },
+    });
+    const shown = () =>
+      captions.getSnapshot().captions.map((c) => [c.role, c.text]);
+    const push = (
+      role: "user" | "assistant",
+      delta: string,
+      startMs: number,
+      endMs: number,
+    ) => {
+      captions.push({ role, delta, startMs, endMs });
+      r.push({ role, delta, startMs, endMs });
+    };
+    push("user", "What's", 0, 300);
+    push("user", " running?", 300, 800);
+    expect(shown()).toEqual([["user", "What's running?"]]);
+    // The reply starting closes the question's row; its caption goes with it.
+    push("assistant", "Two, and ", 900, 1100);
+    expect(shown()).toEqual([["assistant", "Two, and"]]);
+    push("assistant", "PR forty two is open.", 1100, 1800);
+    expect(shown()).toEqual([["assistant", "Two, and PR forty two is open."]]);
+    push("user", "Stop one.", 1900, 2400);
+    expect(shown()).toEqual([["user", "Stop one."]]);
+    expect(mirrored[1]).toBe("Two, and PR opensession#42 is open.");
+    r.flushAll();
+    expect(shown()).toEqual([]);
   });
 });
 

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -680,8 +680,8 @@ function finalize(call: LiveCall, reason: string, seconds?: number): void {
 interface LiveServerEvent {
   type: string;
   delta?: string;
-  start_ms?: number;
-  end_ms?: number;
+  start_ms?: unknown;
+  end_ms?: unknown;
   delegation_id?: string | null;
   event?: LiveResponseEvent;
   reason?: string;
@@ -689,6 +689,21 @@ interface LiveServerEvent {
   error?: { message?: string; code?: string };
   message?: string;
   code?: string;
+}
+
+export function liveTranscriptSpan(event: {
+  start_ms?: unknown;
+  end_ms?: unknown;
+}): { startMs: number; endMs: number } {
+  const startMs =
+    typeof event.start_ms === "number" && Number.isFinite(event.start_ms)
+      ? event.start_ms
+      : 0;
+  const endMs =
+    typeof event.end_ms === "number" && Number.isFinite(event.end_ms)
+      ? event.end_ms
+      : startMs;
+  return { startMs, endMs };
 }
 
 function handleSidebandEvent(call: LiveCall, event: LiveServerEvent): void {
@@ -702,8 +717,7 @@ function handleSidebandEvent(call: LiveCall, event: LiveServerEvent): void {
               ? "user"
               : "assistant",
           delta: event.delta,
-          startMs: event.start_ms ?? 0,
-          endMs: event.end_ms ?? event.start_ms ?? 0,
+          ...liveTranscriptSpan(event),
         });
         touch(call);
       }

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -223,7 +223,14 @@ export class VoiceTranscriptRows {
       gapMs: number;
       idleMs: number;
       rowId: (role: VoiceRole, startMs: number) => string;
-      onRow: (row: { id: string; role: VoiceRole; text: string }) => void;
+      onRow: (row: {
+        id: string;
+        role: VoiceRole;
+        text: string;
+        /** Timeline span of the fragments joined into this row. */
+        startMs: number;
+        endMs: number;
+      }) => void;
     },
   ) {}
 
@@ -286,7 +293,13 @@ export class VoiceTranscriptRows {
     const row = this.open[role];
     this.open[role] = null;
     if (row && row.text.trim())
-      this.opts.onRow({ id: row.id, role, text: row.text.trim() });
+      this.opts.onRow({
+        id: row.id,
+        role,
+        text: row.text.trim(),
+        startMs: row.startMs,
+        endMs: row.endMs,
+      });
   }
 
   private clearIdle(role: VoiceRole) {
@@ -838,10 +851,13 @@ async function createLiveVoiceCallNow(
       // Only what the Desk said is rewritten: a spoken PR number becomes
       // `repo#N` and a session it started gets named, so the mirrored row
       // renders chips. The user's words stay exactly as transcribed.
+      // The mirrored id carries the row's end too (`-end-<endMs>`), so the
+      // browser's captions (frontend/lib/voice-captions.ts) can take down
+      // exactly the fragments this row covers without matching its text.
       onRow: (row) =>
         mirrorVoiceEntries(user, [
           {
-            id: row.id,
+            id: `${row.id}-end-${row.endMs}`,
             role: row.role,
             text:
               row.role === "assistant"


### PR DESCRIPTION
## Problem

The web Desk's `DeskVoiceClient` receives `session.output_transcript.delta` and `session.input_transcript.delta` on the RTC data channel but only used them to flip the call status. The mirrored transcript row appears only once the server's `VoiceTranscriptRows` settles the utterance (2s timeline gap, 2.5s idle, or the other speaker starting), so while you talk the conversation sits still for seconds.

## Change

- `desk-voice-client.ts`: `onCallStarted` and `onTranscript` callbacks; transcript deltas parsed with `start_ms`/`end_ms` (a malformed timestamp cannot cost the state change the event carries).
- `lib/voice-captions.ts`: a call-scoped `VoiceCaptionStore` holding at most one streaming caption per speaker. Handles the sideband row arriving before its RTC fragments, late deltas, call restarts, history replay, and clears failed or unmirrored tails after a hangup grace.
- `components/VoiceCaptions.tsx` + `DeskConversation.tsx` + `DeskOverlay.tsx`: streaming caption rows rendered in the Desk, desktop and phone.
- `desk-voice-live.ts`: `VoiceTranscriptRows.onRow` now carries the row's `startMs`/`endMs`, and the production mirrored id is `voice-<call>-<role>-<startMs>-end-<endMs>`. The captions take fragments down by timeline span rather than by text, so they still clear when the server rewrites what the Desk said into PR/session references (`desk-voice-refs.ts`, #369). Legacy ids without `-end-` keep the content-matching fallback. Clients treat ids as opaque strings; no transcript schema change.

Durable transcript, audio, and permissions are unchanged. Native iOS uses its own Realtime engine with existing captions; Chrome has no GPT Live pipeline.

## Testing

- `bun run check` passes on the branch (rebased on #370).
- Targeted: `voice-captions.test.ts`, `desk-voice-live.test.ts`, `desk-voice-refs.test.ts` (55 pass), including regressions for rewritten durable content, late in-span fragments, and legacy ids.
- Browser (desktop 1440x900, phone 390x844, mocked HTTP/WebRTC only): first fragment visible immediately, later fragments append, malformed events ignored, hangup cleanup.
- Not tested against real OpenAI delivery/audio timing. Captions show only in the web Desk (incl. phone), not the expanded full-session view.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-6009b71f-633d-7fe1-a9f7-708897313e8c)
