### PR TITLE
Let Desk voice navigate its signed-in browser

### DIFF
--- a/docs/desk-voice-navigation.md
+++ b/docs/desk-voice-navigation.md
@@ -1,0 +1,64 @@
+# Desk voice navigation
+
+The web Desk's `show_in_app` action accepts exactly one `session` or `workspace`,
+as an ID or title/name. It resolves existing catalog records, prefers exact names,
+and asks for clarification when either an exact or partial name has multiple
+matches. Name searches omit archived sessions and the Desk itself. An explicit
+ID can open an archived session. The action never accepts a URL, path, selector,
+script, or arbitrary UI operation.
+
+## Authorization and delivery
+
+Navigation is advertised only when a browser requests the capability during
+`POST /api/desk/voice/live` and that request has a verified sign-in login. Older
+web clients, unsigned instances, native Realtime clients, and generic interactive
+or automation MCP tools do not receive this action.
+
+The call owns a fresh random navigation token returned only in its creation
+response. The token remains in the browser client's memory, not local storage,
+model context, tool results, transcript, or a WebSocket broadcast. The browser
+polls `/api/desk/voice/live/navigation` while the call is active. Both polling and
+acknowledgment require the same verified login and call token. A claimed name,
+another login with the same first name, or a second tab without the token cannot
+receive or acknowledge commands. A sign-in change fails closed on the next
+request. Hanging up invalidates pending navigation and aborts browser polling.
+
+Target visibility follows the current signed-in team UI: sessions and workspaces
+are shared, not private to their creators. This action adds no ownership-based
+visibility rule and reads no transcript. If resource ACLs are introduced, the
+resolver must apply those same ACLs before ID lookup and name matching.
+
+Commands carry only a validated session/workspace ID, a random command ID, and
+an expiry. Only one command can wait per call, for at most ten seconds. The client
+rejects expired/malformed commands and suppresses duplicate navigation. Success
+means the owning browser's app router accepted the action, not merely that a
+socket send succeeded. A missing app handler, disconnect, timeout, or hangup
+returns failure. This does not claim that every resource on the destination page
+has finished loading.
+
+The selected workspace is explicitly included in the active workspace list query,
+so an empty workspace or one containing only archived sessions still renders.
+The existing app router switches the page without remounting Desk. Desktop keeps
+the floating Desk open. Phone minimizes its covering sheet while the mounted voice
+client continues the call. Reopen Desk to access its call controls.
+
+## Code and tests
+
+- `src/shared/desk-navigation.ts`: wire validation.
+- `src/server/desk-voice-show.ts`: target lookup and voice tool.
+- `src/server/desk-voice-navigation.ts`: call-bound delivery and acknowledgment.
+- `src/server/desk-voice-live.ts`, `src/server/routes/desk-voice.ts`: capability
+  creation, tool dispatch, authenticated HTTP, and teardown.
+- `src/frontend/lib/desk-navigation-client.ts`, `desk-voice-client.ts`: polling,
+  validation, deduplication, acknowledgment, and call lifetime.
+- `src/frontend/lib/desk-show.ts`, `src/frontend/AppContent.tsx`: browser-local
+  router handoff and phone minimization.
+- `src/frontend/hooks/useWorkspaces.ts`, `src/frontend/lib/api/workspaces.ts`,
+  `src/server/routes/workspace.ts`: keep the selected workspace in the active
+  list projection, including empty and archived workspaces.
+
+Paths above are relative to `packages/core/opensession-server/`.
+Matching `desk-voice-show`, `desk-voice-navigation`, `desk-navigation-client`, and
+`desk-show` tests cover resolution, identity/token isolation, route rejection,
+acknowledgments, expiry, and hangup races. Existing `desk-voice-live` tests cover
+the voice tool loop and data-channel restrictions.

--- a/packages/core/opensession-server/src/frontend/AppContent.tsx
+++ b/packages/core/opensession-server/src/frontend/AppContent.tsx
@@ -75,7 +75,8 @@ import { useWorkspaces } from "./hooks/useWorkspaces";
 import { getActiveViewTab, saveActiveViewTab } from "./lib/active-view-tab";
 import { cachedRepos, resolveWorkspaceApi } from "./lib/api";
 import { buildAppCommandActions } from "./components/app-command-actions";
-import { isToolView, parseRoute, routePath } from "./lib/app-route";
+import { isToolView, parseRoute, routePath, type Route } from "./lib/app-route";
+import { onDeskShow } from "./lib/desk-show";
 import {
   APP_BODY,
   DETAIL_TOPBAR,
@@ -298,7 +299,7 @@ export function AppContent({
     workspaces,
     loaded: workspacesLoaded,
     refresh: refreshWorkspaces,
-  } = useWorkspaces();
+  } = useWorkspaces(route.view === "workspace" ? route.id : undefined);
   // Read by the PR-link opener, which runs from a document-level listener and
   // therefore can't close over the render's value.
   const workspacesRef = useRef(workspaces);
@@ -515,6 +516,13 @@ export function AppContent({
   const socketInject = useEffectEvent(inject);
   const socketNavigate = useEffectEvent(navigate);
   const socketGetCurrentRoute = useEffectEvent(getCurrentRoute);
+  const voiceShow = useEffectEvent((route: Route) => {
+    navigate(route);
+    // The phone sheet covers the page; minimise it so what was asked for is
+    // visible. The call keeps running in the mounted body.
+    if (isPhone) setDeskOverlay((desk) => ({ ...desk, open: false }));
+  });
+  useEffect(() => onDeskShow(voiceShow), []);
   useEffect(() => {
     return addHandler((msg) => {
       if (msg.type === "error") {

--- a/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.test.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.test.ts
@@ -133,7 +133,9 @@ test("has a server-safe unloaded initial snapshot", () => {
 });
 
 test("delegates list ownership while keeping refresh identity explicit", () => {
-  expect(appSource).toContain("} = useWorkspaces();");
+  expect(appSource).toContain(
+    '} = useWorkspaces(route.view === "workspace" ? route.id : undefined);',
+  );
   expect(appSource).not.toContain("setWorkspaces");
   expect(appSource).not.toContain('"opensession:workspaces-changed"');
   expect(hookSource).toMatch(

--- a/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { fetchWorkspaces } from "../lib/api";
 import { setWorkspaceTitles } from "../lib/markdown";
 import type { Workspace } from "../lib/types";
@@ -41,17 +41,31 @@ interface WorkspacesState {
   refresh: () => Promise<void>;
 }
 
-export function useWorkspaces(): WorkspacesState {
+export function useWorkspaces(selectedWorkspaceId?: string): WorkspacesState {
+  const selectedIdRef = useRef(selectedWorkspaceId);
+  useLayoutEffect(() => {
+    selectedIdRef.current = selectedWorkspaceId;
+  }, [selectedWorkspaceId]);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [loaded, setLoaded] = useState(false);
   // This identity is observable: the hook subscriptions and App's global
   // socket handler depend on it. Keep it stable in uncompiled development.
-  const [refresh] = useState(
-    () => () =>
-      loadWorkspaces(fetchWorkspaces, setWorkspaces, () => setLoaded(true)),
-  );
+  const [refresh] = useState(() => () => {
+    const includeWorkspaceId = selectedIdRef.current;
+    return loadWorkspaces(
+      () => fetchWorkspaces({ includeWorkspaceId }),
+      (rows) => {
+        // A prior route's slower refresh must not hide the selected workspace.
+        if (selectedIdRef.current === includeWorkspaceId) setWorkspaces(rows);
+      },
+      () => setLoaded(true),
+    );
+  });
 
-  useEffect(() => subscribeToWorkspaceRefreshes(window, refresh), [refresh]);
+  useEffect(
+    () => subscribeToWorkspaceRefreshes(window, refresh),
+    [refresh, selectedWorkspaceId],
+  );
   useEffect(() => {
     setWorkspaceTitles(
       workspaces.map((workspace) => [workspace.id, workspace.name] as const),

--- a/packages/core/opensession-server/src/frontend/lib/api.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api.test.ts
@@ -255,3 +255,13 @@ test("new workspace tabs create an idle sibling session", async () => {
     duplicate: true,
   });
 });
+
+test("workspace projection explicitly includes the selected workspace", async () => {
+  let url = "";
+  globalThis.fetch = stubFetch(async (input) => {
+    url = String(input);
+    return Response.json({ workspaces: [] });
+  });
+  await fetchWorkspaces({ includeWorkspaceId: "ws-archived" });
+  expect(url).toBe("/api/workspaces?active=1&includeWorkspaceId=ws-archived");
+});

--- a/packages/core/opensession-server/src/frontend/lib/api/workspaces.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/workspaces.ts
@@ -71,13 +71,16 @@ export function defaultWorkspaceModelSettings():
 }
 
 export async function fetchWorkspaces(options?: {
+  includeWorkspaceId?: string;
   onError?: (cause: unknown) => void;
 }): Promise<Workspace[]> {
   try {
     const data = await request<{
       workspaces?: Workspace[];
       defaultModelSettings?: Workspace["modelSettings"];
-    }>("/workspaces?active=1");
+    }>(
+      `/workspaces?active=1${options?.includeWorkspaceId ? `&includeWorkspaceId=${encodeURIComponent(options.includeWorkspaceId)}` : ""}`,
+    );
     if (data?.defaultModelSettings)
       defaultModelSettings = data.defaultModelSettings;
     const next = data?.workspaces ?? [];

--- a/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { DeskNavigationClient } from "./desk-navigation-client";
+import { DeskVoiceNavigation } from "../../server/desk-voice-navigation";
+import type { DeskNavigationRequest } from "../../shared/desk-navigation";
+
+const target = { kind: "workspace", id: "ws-1" } as const;
+
+describe("voice browser navigation", () => {
+  test("round trips a real command and acknowledgment without another tab following", async () => {
+    const server = new DeskVoiceNavigation("alice");
+    const shown: unknown[] = [];
+    const request = async (body: DeskNavigationRequest) =>
+      Response.json(server.handle("alice", body));
+    const owner = new DeskNavigationClient(
+      "call",
+      server.token,
+      (route) => {
+        shown.push(route);
+        return true;
+      },
+      request,
+    );
+    const otherTab = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        throw new Error("Wrong tab navigated");
+      },
+      request,
+    );
+    const result = server.show(target);
+    await expect(otherTab.poll()).rejects.toThrow();
+    await owner.poll();
+    expect(await result).toEqual({ shown: true });
+    expect(shown).toEqual([target]);
+    await owner.poll();
+    expect(shown).toHaveLength(1);
+    owner.stop();
+    otherTab.stop();
+    server.close();
+  });
+
+  test("does not navigate if hangup happens while a response is in flight", async () => {
+    let deliver: (value: Response) => void = () => {};
+    const response = new Promise<Response>((resolve) => {
+      deliver = resolve;
+    });
+    let navigated = false;
+    const client = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        navigated = true;
+        return true;
+      },
+      async () => response,
+    );
+    const pending = client.poll();
+    client.stop();
+    deliver(
+      Response.json({
+        command: {
+          id: crypto.randomUUID(),
+          target,
+          expiresAt: Date.now() + 10_000,
+        },
+      }),
+    );
+    await pending;
+    expect(navigated).toBe(false);
+  });
+
+  test("duplicate delivery reuses the acknowledgment without navigating twice", async () => {
+    const command = {
+      id: crypto.randomUUID(),
+      target,
+      expiresAt: Date.now() + 10_000,
+    };
+    let navigated = 0;
+    const acks: unknown[] = [];
+    const client = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        navigated++;
+        return true;
+      },
+      async (body) => {
+        if (body.action === "poll") return Response.json({ command });
+        acks.push(body);
+        return Response.json({ ok: true });
+      },
+    );
+    await client.poll();
+    await client.poll();
+    expect(navigated).toBe(1);
+    expect(acks).toHaveLength(2);
+    client.stop();
+  });
+
+  test("expired, malformed and arbitrary route commands never navigate", async () => {
+    let navigated = false;
+    for (const command of [
+      { id: crypto.randomUUID(), target, expiresAt: 0 },
+      {
+        id: crypto.randomUUID(),
+        target: { kind: "settings", id: "account" },
+        expiresAt: Date.now() + 10_000,
+      },
+      {
+        id: crypto.randomUUID(),
+        target: { kind: "session", id: "../settings" },
+        expiresAt: Date.now() + 10_000,
+      },
+    ]) {
+      const client = new DeskNavigationClient(
+        "call",
+        crypto.randomUUID(),
+        () => {
+          navigated = true;
+          return true;
+        },
+        async () => Response.json({ command }),
+      );
+      await client.poll().catch(() => {});
+      client.stop();
+    }
+    expect(navigated).toBe(false);
+  });
+
+  test("a missing app handler is reported as failure", async () => {
+    const server = new DeskVoiceNavigation("alice");
+    const client = new DeskNavigationClient(
+      "call",
+      server.token,
+      () => false,
+      async (body) => Response.json(server.handle("alice", body)),
+    );
+    const result = server.show(target);
+    await client.poll();
+    expect(await result).toMatchObject({ shown: false });
+    client.stop();
+    server.close();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.ts
@@ -1,0 +1,94 @@
+import {
+  deskNavigationPollSchema,
+  type DeskNavigationRequest,
+} from "../../shared/desk-navigation";
+import { BASE_PATH } from "./base";
+import { showDeskTarget } from "./desk-show";
+
+/** Runs only inside the browser that owns this call. The token lives in memory
+ * and requests use the current sign-in cookie, so sign-out/re-login fails shut.
+ */
+export class DeskNavigationClient {
+  private readonly abort = new AbortController();
+  private started = false;
+  private lastResult: { id: string; shown: boolean } | null = null;
+
+  constructor(
+    private readonly liveSessionId: string,
+    private readonly token: string,
+    private readonly show = showDeskTarget,
+    private readonly request: (
+      body: DeskNavigationRequest,
+      signal: AbortSignal,
+    ) => Promise<Response> = async (body, signal) => {
+      const response = await fetch(
+        `${BASE_PATH}/api/desk/voice/live/navigation`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal,
+        },
+      );
+      if (!response.ok) throw new Error("Voice navigation disconnected");
+      return response;
+    },
+  ) {}
+
+  /** One bounded poll. Retries acknowledge the previous result, never navigate twice. */
+  async poll(): Promise<void> {
+    if (this.abort.signal.aborted) return;
+    const raw = await this.request(
+      { action: "poll", liveSessionId: this.liveSessionId, token: this.token },
+      this.abort.signal,
+    );
+    if (this.abort.signal.aborted) return;
+    if (!raw.ok) throw new Error("Voice navigation disconnected");
+    const { command } = deskNavigationPollSchema.parse(await raw.json());
+    if (this.abort.signal.aborted) return;
+    if (!command || command.expiresAt <= Date.now()) return;
+    if (this.lastResult?.id !== command.id) {
+      this.lastResult = { id: command.id, shown: this.show(command.target) };
+    }
+    if (this.abort.signal.aborted) return;
+    const ack = await this.request(
+      {
+        action: "ack",
+        liveSessionId: this.liveSessionId,
+        token: this.token,
+        commandId: command.id,
+        shown: this.lastResult.shown,
+      },
+      this.abort.signal,
+    );
+    if (!ack.ok) throw new Error("Voice navigation disconnected");
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    try {
+      while (!this.abort.signal.aborted) {
+        await this.poll();
+        await new Promise<void>((resolve) => {
+          if (this.abort.signal.aborted) return resolve();
+          const finish = () => {
+            clearTimeout(timer);
+            this.abort.signal.removeEventListener("abort", finish);
+            resolve();
+          };
+          const timer = setTimeout(finish, 750);
+          this.abort.signal.addEventListener("abort", finish, { once: true });
+        });
+      }
+    } catch {
+      // No blind retry after an auth failure or changed login. A new call gets
+      // a new capability. Pending actions time out honestly on the server.
+      this.stop();
+    }
+  }
+
+  stop(): void {
+    this.abort.abort();
+  }
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { deskShowRoute } from "./desk-show";
+import { deskShowTargetSchema } from "../../shared/desk-navigation";
+
+describe("deskShowRoute", () => {
+  test("maps a session or workspace id onto its route", () => {
+    expect(deskShowRoute({ kind: "session", id: "s-1" })).toEqual({
+      view: "session",
+      id: "s-1",
+    });
+    expect(deskShowRoute({ kind: "workspace", id: "ws-1" })).toEqual({
+      view: "workspace",
+      id: "ws-1",
+    });
+  });
+
+  test("the boundary drops anything outside the fixed route table", () => {
+    for (const target of [
+      null,
+      { kind: "settings", id: "x" },
+      { kind: "session", id: 5 },
+      ...[
+        " ",
+        "../settings",
+        "https://example.invalid",
+        "s-1?x=1",
+        "s-1#x",
+        "%2e%2e",
+        "s/2",
+        "",
+      ].map((id) => ({ kind: "session", id })),
+    ]) {
+      expect(deskShowTargetSchema.safeParse(target).success).toBe(false);
+    }
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.ts
@@ -1,0 +1,30 @@
+import {
+  deskShowTargetSchema,
+  type DeskShowTarget,
+} from "../../shared/desk-navigation";
+import type { Route } from "./app-route";
+export type { DeskShowTarget } from "../../shared/desk-navigation";
+
+export function deskShowRoute(target: DeskShowTarget): Route {
+  return { view: target.kind, id: target.id };
+}
+
+// Local to this browser's voice client, not a server WebSocket broadcast.
+const SHOW_EVENT = "opensession:desk-show";
+export function showDeskTarget(target: DeskShowTarget): boolean {
+  return !window.dispatchEvent(
+    new CustomEvent(SHOW_EVENT, { detail: target, cancelable: true }),
+  );
+}
+
+export function onDeskShow(show: (route: Route) => void): () => void {
+  const listener = (event: Event) => {
+    if (!(event instanceof CustomEvent)) return;
+    const parsed = deskShowTargetSchema.safeParse(event.detail);
+    if (!parsed.success) return;
+    show(deskShowRoute(parsed.data));
+    event.preventDefault();
+  };
+  window.addEventListener(SHOW_EVENT, listener);
+  return () => window.removeEventListener(SHOW_EVENT, listener);
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
@@ -6,6 +6,7 @@
 // to lifecycle and transcript events plus `session.close`.
 
 import { z } from "zod";
+import { DeskNavigationClient } from "./desk-navigation-client";
 import { BASE_PATH } from "./base";
 
 export type DeskVoiceState =
@@ -32,6 +33,7 @@ const liveResponseSchema = z.object({
   liveSessionId: z.string(),
   sdp: z.string(),
   sessionId: z.string(),
+  navigationToken: z.string().uuid().optional(),
   backendModel: z.string().optional(),
 });
 
@@ -72,7 +74,7 @@ export interface DeskVoiceDiagReport {
 }
 
 type VoiceRequest =
-  | { user: string; sdp: string }
+  | { user: string; sdp: string; navigation: true }
   | { user: string; liveSessionId: string; text: string }
   | { user: string; liveSessionId: string }
   | DeskVoiceDiagReport;
@@ -128,6 +130,7 @@ export class DeskVoiceClient {
   private micStream: MediaStream | null = null;
   private audioEl: HTMLAudioElement | null = null;
   private liveSessionId: string | null = null;
+  private navigation: DeskNavigationClient | null = null;
 
   private idleTimer: number | null = null;
   private speakingTimer: number | null = null;
@@ -272,7 +275,7 @@ export class DeskVoiceClient {
       if (!sdp) throw new Error("No local offer");
       const live = await postJson(
         "/live",
-        { user: this.user, sdp },
+        { user: this.user, sdp, navigation: true },
         liveResponseSchema,
       );
       if (this.aborted) {
@@ -282,6 +285,11 @@ export class DeskVoiceClient {
         return;
       }
       this.liveSessionId = live.liveSessionId;
+      if (live.navigationToken)
+        this.navigation = new DeskNavigationClient(
+          live.liveSessionId,
+          live.navigationToken,
+        );
       this.backendModel = live.backendModel ?? null;
       await pc.setRemoteDescription({ type: "answer", sdp: live.sdp });
     } catch (e) {
@@ -327,6 +335,7 @@ export class DeskVoiceClient {
    * `session.closed` so pending backend work drains; tears down regardless.
    * `reason` is for the diag line only: who decided the call was over. */
   stop(reason = "hangup"): void {
+    this.navigation?.stop();
     if (this.closing || this.aborted) return;
     if (this.starting) {
       // Cancel the start in progress. Whatever step is awaiting sees
@@ -367,6 +376,8 @@ export class DeskVoiceClient {
   }
 
   private teardown() {
+    this.navigation?.stop();
+    this.navigation = null;
     this.postDiag("teardown");
     for (const key of ["idleTimer", "speakingTimer", "closeTimer"] as const) {
       const t = this[key];
@@ -473,6 +484,7 @@ export class DeskVoiceClient {
 
     switch (event.type) {
       case "session.started":
+        void this.navigation?.start();
         this.connected = true;
         this.startedAt ??= Date.now();
         this.resetIdleTimer();

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -48,6 +48,10 @@ import {
   type LiveBackendModel,
 } from "./desk-voice";
 
+import { SHOW_IN_APP_TOOL, showInApp } from "./desk-voice-show";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import type { DeskNavigationRequest } from "../shared/desk-navigation";
+
 export const DESK_LIVE_MODEL = "gpt-live-1";
 /** The default backend (Terra). The instance-wide choice between it and Luna
  * is stored beside the API key; see voiceBackendModel() in desk-voice.ts. */
@@ -123,6 +127,7 @@ export interface LiveFunctionTool {
 export async function buildLiveSessionConfig(
   sessionId: string,
   user = "Open Session",
+  navigationEnabled = false,
 ) {
   // Read per call: the setting can change between calls, and a running call
   // keeps whatever backend it started on.
@@ -130,6 +135,7 @@ export async function buildLiveSessionConfig(
   const turns = await recentDeskTurns(sessionId);
   const tools: LiveFunctionTool[] = [
     ...VOICE_TOOLS,
+    ...(navigationEnabled ? [SHOW_IN_APP_TOOL] : []),
     ...((await listVoiceMcpTools(
       user,
       sessionId,
@@ -159,7 +165,11 @@ export async function buildLiveSessionConfig(
       type: "responses",
       responses: {
         model: backendModel,
-        instructions: LIVE_BACKEND_INSTRUCTIONS,
+        instructions:
+          LIVE_BACKEND_INSTRUCTIONS +
+          (navigationEnabled
+            ? "\nWhen the user asks to see, open, or go to a session or workspace, call show_in_app with its title or name. It opens that page beside the Desk. If it reports several matches, ask which one."
+            : ""),
         tools,
         tool_choice: "auto",
         parallel_tool_calls: true,
@@ -554,6 +564,7 @@ export function formatLiveUsage(t: LiveUsageTotals): string {
 // Call registry.
 
 interface LiveCall {
+  navigation?: DeskVoiceNavigation;
   id: string;
   user: string;
   deskSessionId: string;
@@ -605,6 +616,7 @@ function sendEvent(call: LiveCall, event: Record<string, unknown>): boolean {
 
 function requestClose(call: LiveCall): void {
   if (call.finalized) return;
+  call.navigation?.close();
   sendEvent(call, { type: "session.close" });
   if (!call.closeTimer)
     call.closeTimer = setTimeout(
@@ -624,6 +636,7 @@ function touch(call: LiveCall): void {
 function finalize(call: LiveCall, reason: string, seconds?: number): void {
   if (call.finalized) return;
   call.finalized = true;
+  call.navigation?.close();
   calls.delete(call.id);
   for (const t of [call.idleTimer, call.maxTimer, call.closeTimer])
     if (t) clearTimeout(t);
@@ -759,6 +772,7 @@ function attachSideband(apiKey: string, liveId: string): Promise<WebSocket> {
 const starting = new Map<string, Promise<unknown>>();
 
 export interface LiveCallStarted {
+  navigationToken?: string;
   liveSessionId: string;
   sdp: string;
   sessionId: string;
@@ -769,11 +783,12 @@ export interface LiveCallStarted {
 export function createLiveVoiceCall(
   user: string,
   offerSdp: string,
+  navigationLogin?: string,
 ): Promise<LiveCallStarted> {
   const previous = starting.get(user) ?? Promise.resolve();
   const run = previous
     .catch(() => {})
-    .then(() => createLiveVoiceCallNow(user, offerSdp));
+    .then(() => createLiveVoiceCallNow(user, offerSdp, navigationLogin));
   starting.set(user, run);
   void run
     .catch(() => {})
@@ -786,6 +801,7 @@ export function createLiveVoiceCall(
 async function createLiveVoiceCallNow(
   user: string,
   offerSdp: string,
+  navigationLogin?: string,
 ): Promise<LiveCallStarted> {
   const key = await requireVoiceApiKey();
   const { sessionId } = ensureDeskSession(user);
@@ -795,7 +811,14 @@ async function createLiveVoiceCallNow(
   for (const existing of calls.values())
     if (existing.user === user) requestClose(existing);
 
-  const session = await buildLiveSessionConfig(sessionId, user);
+  const navigation = navigationLogin
+    ? new DeskVoiceNavigation(navigationLogin)
+    : undefined;
+  const session = await buildLiveSessionConfig(
+    sessionId,
+    user,
+    Boolean(navigation),
+  );
   const backendModel = session.delegation.responses.model;
   const res = await fetch(LIVE_SESSIONS_URL, {
     method: "POST",
@@ -826,6 +849,7 @@ async function createLiveVoiceCallNow(
   const socket = await attachSideband(key, liveId);
   const ledger = new VoiceReferenceLedger();
   const call: LiveCall = {
+    navigation,
     id: liveId,
     user,
     deskSessionId: sessionId,
@@ -855,7 +879,10 @@ async function createLiveVoiceCallNow(
       runTool: async (callId, name, args) => {
         let result: unknown;
         try {
-          result = await executeVoiceTool(user, name, args);
+          result =
+            name === SHOW_IN_APP_TOOL.name
+              ? await showInApp(call.navigation, args)
+              : await executeVoiceTool(user, name, args);
         } catch (e) {
           result = { error: e instanceof Error ? e.message : String(e) };
         }
@@ -896,7 +923,13 @@ async function createLiveVoiceCallNow(
   console.log(
     `[desk-voice-live] ${liveId} started user=${user} backend=${backendModel}`,
   );
-  return { liveSessionId: liveId, sdp: answer, sessionId, backendModel };
+  return {
+    liveSessionId: liveId,
+    sdp: answer,
+    sessionId,
+    backendModel,
+    ...(navigation ? { navigationToken: navigation.token } : {}),
+  };
 }
 
 /** The instance's repos, as the ledger needs them to resolve a PR mention:
@@ -950,4 +983,14 @@ export function closeLiveVoiceCall(
   if (!call) return false;
   requestClose(call);
   return true;
+}
+
+/** Authenticated HTTP only. Neither caller identity nor token comes from the model. */
+export function handleLiveNavigation(
+  login: string,
+  request: DeskNavigationRequest,
+) {
+  return (
+    calls.get(request.liveSessionId)?.navigation?.handle(login, request) ?? null
+  );
 }

--- a/packages/core/opensession-server/src/server/desk-voice-navigation.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-navigation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import { handleDeskVoiceRoutes } from "./routes/desk-voice";
+import { deskNavigationRequestSchema } from "../shared/desk-navigation";
+
+const target = { kind: "session", id: "s-1" } as const;
+const poll = (token: string) =>
+  ({ action: "poll", token, liveSessionId: "call" }) as const;
+
+describe("call-bound voice navigation", () => {
+  test("rejects a different login, missing identity, or another tab's token", async () => {
+    const nav = new DeskVoiceNavigation("alice-login");
+    const result = nav.show(target);
+    expect(nav.handle("other-alice-login", poll(nav.token))).toBeNull();
+    expect(nav.handle("", poll(nav.token))).toBeNull();
+    expect(nav.handle("alice-login", poll(crypto.randomUUID()))).toBeNull();
+    expect(nav.handle("ALICE-LOGIN", poll(nav.token))).toMatchObject({
+      command: { target },
+    });
+    nav.close();
+    expect(await result).toMatchObject({ shown: false });
+    expect(nav.handle("alice-login", poll(nav.token))).toBeNull();
+    expect(await nav.show(target)).toMatchObject({ shown: false });
+  });
+
+  test("bounds pending work, rejects wrong acknowledgments, and reports browser failure", async () => {
+    const nav = new DeskVoiceNavigation("alice");
+    const result = nav.show(target);
+    expect(await nav.show(target)).toMatchObject({ shown: false });
+    const response = nav.handle("alice", poll(nav.token));
+    if (!response || !("command" in response) || !response.command)
+      throw new Error("missing command");
+    const ack = {
+      action: "ack",
+      liveSessionId: "call",
+      token: nav.token,
+      commandId: response.command.id,
+      shown: false,
+    } as const;
+    expect(nav.handle("other", ack)).toBeNull();
+    expect(
+      nav.handle("alice", { ...ack, commandId: crypto.randomUUID() }),
+    ).toEqual({ ok: false });
+    expect(nav.handle("alice", ack)).toEqual({ ok: true });
+    expect(await result).toMatchObject({
+      shown: false,
+      error: expect.stringContaining("could not show"),
+    });
+    expect(nav.handle("alice", ack)).toEqual({ ok: false });
+    expect(nav.handle("alice", poll(nav.token))).toEqual({ command: null });
+    nav.close();
+  });
+
+  test("times out without claiming the page was shown", async () => {
+    const nav = new DeskVoiceNavigation("alice", 5);
+    expect(await nav.show(target)).toEqual({
+      shown: false,
+      error: "The voice window did not confirm navigation.",
+    });
+    expect(nav.handle("alice", poll(nav.token))).toEqual({ command: null });
+    nav.close();
+  });
+
+  test("HTTP rejects claimed users, malformed messages and unknown calls", async () => {
+    async function request(body: unknown, login?: string) {
+      const url = new URL("http://localhost/api/desk/voice/live/navigation");
+      return handleDeskVoiceRoutes({
+        req: new Request(url, {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+        }),
+        url,
+        path: url.pathname,
+        publicPrefix: "",
+        authUser: login ? { login, name: "Same Name" } : null,
+      });
+    }
+    expect(
+      (await request({ ...poll(crypto.randomUUID()), user: "Alice" }))?.status,
+    ).toBe(401);
+    expect(
+      (await request({ ...poll(crypto.randomUUID()), user: "Alice" }, "alice"))
+        ?.status,
+    ).toBe(400);
+    const missing = await request(poll(crypto.randomUUID()), "alice");
+    expect(missing?.status).toBe(404);
+    expect(missing?.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      deskNavigationRequestSchema.safeParse({
+        ...poll(crypto.randomUUID()),
+        action: "ack",
+        path: "/settings",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-navigation.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-navigation.ts
@@ -1,0 +1,91 @@
+import type {
+  DeskNavigationCommand,
+  DeskNavigationRequest,
+  DeskShowTarget,
+} from "../shared/desk-navigation";
+
+export type DeskNavigationResult =
+  | { shown: true }
+  | { shown: false; error: string };
+
+/** One browser capability per call, never included in prompts or transcripts.
+ * The HTTP route requires both its token and the verified login that started it.
+ * Nothing is broadcast to the user's other tabs or to a name-matched user.
+ */
+export class DeskVoiceNavigation {
+  readonly token = crypto.randomUUID();
+  private pending: {
+    command: DeskNavigationCommand;
+    finish: (result: DeskNavigationResult) => void;
+  } | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly login: string,
+    private readonly timeoutMs = 10_000,
+  ) {}
+
+  handle(
+    login: string,
+    request: DeskNavigationRequest,
+  ): { command: DeskNavigationCommand | null } | { ok: boolean } | null {
+    if (
+      this.closed ||
+      !login ||
+      login.toLowerCase() !== this.login.toLowerCase() ||
+      request.token !== this.token
+    )
+      return null;
+    if (request.action === "poll")
+      return { command: this.pending?.command ?? null };
+    if (this.pending?.command.id !== request.commandId) return { ok: false };
+    this.pending.finish(
+      request.shown
+        ? { shown: true }
+        : { shown: false, error: "The voice window could not show that page." },
+    );
+    return { ok: true };
+  }
+
+  show(target: DeskShowTarget): Promise<DeskNavigationResult> {
+    if (this.closed)
+      return Promise.resolve({
+        shown: false,
+        error: "The voice call has ended.",
+      });
+    if (this.pending)
+      return Promise.resolve({
+        shown: false,
+        error:
+          "Another navigation is pending. Wait for it before opening another page.",
+      });
+    return new Promise((resolve) => {
+      const timer = setTimeout(
+        () =>
+          finish({
+            shown: false,
+            error: "The voice window did not confirm navigation.",
+          }),
+        this.timeoutMs,
+      );
+      const finish = (result: DeskNavigationResult) => {
+        clearTimeout(timer);
+        this.pending = null;
+        resolve(result);
+      };
+      this.pending = {
+        command: {
+          id: crypto.randomUUID(),
+          target,
+          expiresAt: Date.now() + this.timeoutMs,
+        },
+        finish,
+      };
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.pending?.finish({ shown: false, error: "The voice call has ended." });
+  }
+}

--- a/packages/core/opensession-server/src/server/desk-voice-show.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SHOW_IN_APP_TOOL,
+  resolveShowTarget,
+  showInApp,
+} from "./desk-voice-show";
+import { buildLiveSessionConfig } from "./desk-voice-live";
+import { registerSessionControl, type SessionControl } from "./session-control";
+import type { Workspace } from "./workspaces";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import { buildVoiceSessionConfig } from "./desk-voice";
+
+type Summary = ReturnType<SessionControl["listSessions"]>[number];
+
+function summary(
+  id: string,
+  title: string,
+  extra: Partial<Summary> = {},
+): Summary {
+  return {
+    id,
+    title,
+    state: "idle",
+    queuedCount: 0,
+    controllable: true,
+    createdBy: "Michiel",
+    createdAt: "2026-09-10T09:00:00.000Z",
+    lastActivity: "2026-09-10T10:00:00.000Z",
+    ...extra,
+  } as Summary;
+}
+
+const sessions: Summary[] = [
+  summary("s-deploy", "Fix the deploy watchdog"),
+  summary("s-deploy-old", "Fix the deploy watchdog", {
+    lastActivity: "2026-09-01T10:00:00.000Z",
+  }),
+  summary("s-captions", "Voice captions for the Desk"),
+  summary("s-lint", "Vendor lint rules"),
+  summary("s-desk", "Desk", { desk: true }),
+  summary("s-archived", "Archived captions work", { state: "archived" }),
+];
+
+const workspaces: Workspace[] = [
+  {
+    id: "ws-1",
+    name: "Deploy reliability",
+    createdBy: "Michiel",
+    createdAt: "2026-09-01T09:00:00.000Z",
+  },
+  {
+    id: "ws-2",
+    name: "Desk voice",
+    createdBy: "Michiel",
+    createdAt: "2026-09-02T09:00:00.000Z",
+  },
+];
+
+function control(): Pick<SessionControl, "listSessions" | "getSession"> {
+  return {
+    listSessions: () => sessions,
+    getSession: (id) => sessions.find((s) => s.id === id),
+  };
+}
+
+const deps = {
+  control: control(),
+  listWorkspaces: async () => workspaces,
+  getWorkspace: async (id: string) =>
+    workspaces.find((w) => w.id === id) ?? null,
+};
+
+describe("show_in_app target resolution", () => {
+  test("takes a session id directly", async () => {
+    expect(await resolveShowTarget({ session: "s-lint" }, deps)).toEqual({
+      target: { kind: "session", id: "s-lint", title: "Vendor lint rules" },
+    });
+  });
+
+  test("asks which one even when duplicate titles match exactly", async () => {
+    expect(
+      await resolveShowTarget({ session: "fix the deploy watchdog" }, deps),
+    ).toMatchObject({
+      error: expect.stringContaining("Several"),
+      candidates: [
+        { id: "s-deploy", title: "Fix the deploy watchdog" },
+        { id: "s-deploy-old", title: "Fix the deploy watchdog" },
+      ],
+    });
+  });
+
+  test("accepts a distinctive part of a title", async () => {
+    expect(await resolveShowTarget({ session: "lint" }, deps)).toEqual({
+      target: { kind: "session", id: "s-lint", title: "Vendor lint rules" },
+    });
+  });
+
+  test("asks back with candidates when a part matches several", async () => {
+    const result = await resolveShowTarget({ session: "deploy" }, deps);
+    expect(result).toMatchObject({ error: expect.stringContaining("Several") });
+    expect("candidates" in result && result.candidates).toEqual([
+      { id: "s-deploy", title: "Fix the deploy watchdog" },
+      { id: "s-deploy-old", title: "Fix the deploy watchdog" },
+    ]);
+  });
+
+  test("never lands on the Desk or on archived sessions by title", async () => {
+    expect(await resolveShowTarget({ session: "s-desk" }, deps)).toMatchObject({
+      error: expect.stringContaining("No session"),
+    });
+    // "captions" would be ambiguous if the archived session counted.
+    expect(await resolveShowTarget({ session: "captions" }, deps)).toEqual({
+      target: {
+        kind: "session",
+        id: "s-captions",
+        title: "Voice captions for the Desk",
+      },
+    });
+  });
+
+  test("resolves a workspace by id or name", async () => {
+    expect(await resolveShowTarget({ workspace: "ws-2" }, deps)).toEqual({
+      target: { kind: "workspace", id: "ws-2", name: "Desk voice" },
+    });
+    expect(
+      await resolveShowTarget({ workspace: "deploy reliability" }, deps),
+    ).toEqual({
+      target: { kind: "workspace", id: "ws-1", name: "Deploy reliability" },
+    });
+  });
+
+  test("refuses an empty request and non-string arguments", async () => {
+    expect(await resolveShowTarget({}, deps)).toMatchObject({
+      error: expect.stringContaining("exactly one"),
+    });
+    expect(
+      await resolveShowTarget({ session: { id: "s-lint" } }, deps),
+    ).toMatchObject({ error: expect.any(String) });
+  });
+});
+
+describe("show_in_app authorization and delivery", () => {
+  function registerStubControl() {
+    registerSessionControl({
+      ...control(),
+      transcriptTail: async () => [],
+      answerQuestion: () => false,
+      deliverToSession: async () => ({
+        status: "error" as const,
+        message: "not used",
+      }),
+      cancelSession: () => false,
+      reparentSession: async () => ({ ok: false, error: "not used" }),
+      createSession: async () => ({
+        id: "unused",
+        createdBy: "Test",
+        createdAt: "2026-09-10T09:00:00.000Z",
+      }),
+    });
+  }
+
+  test("fails closed without a verified call capability", async () => {
+    expect(await showInApp(undefined, { session: "lint" })).toMatchObject({
+      shown: false,
+    });
+  });
+
+  test("returns success only after the owning browser acknowledges", async () => {
+    registerStubControl();
+    const nav = new DeskVoiceNavigation("signed-in-login");
+    const pending = showInApp(nav, { session: "lint" });
+    await Promise.resolve();
+    const polled = nav.handle("signed-in-login", {
+      action: "poll",
+      liveSessionId: "call",
+      token: nav.token,
+    });
+    if (!polled || !("command" in polled) || !polled.command)
+      throw new Error("missing command");
+    nav.handle("signed-in-login", {
+      action: "ack",
+      liveSessionId: "call",
+      token: nav.token,
+      commandId: polled.command.id,
+      shown: true,
+    });
+    expect(await pending).toEqual({
+      shown: true,
+      kind: "session",
+      id: "s-lint",
+      title: "Vendor lint rules",
+    });
+    nav.close();
+  });
+
+  test("rejects multiple targets, extra navigation parameters and oversized names", async () => {
+    for (const args of [
+      { session: "lint", workspace: "ws-1" },
+      { session: "lint", url: "https://example.invalid" },
+      { workspace: "x".repeat(257) },
+    ]) {
+      expect(await resolveShowTarget(args, deps)).toMatchObject({
+        error: expect.any(String),
+      });
+    }
+  });
+
+  test("is advertised only to a capable web voice backend, never native", async () => {
+    registerStubControl();
+    const enabled = await buildLiveSessionConfig(
+      "missing-test-session",
+      "Test",
+      true,
+    );
+    const disabled = await buildLiveSessionConfig("missing-test-session");
+    const native = await buildVoiceSessionConfig("missing-test-session");
+    expect(
+      enabled.delegation.responses.tools.some(
+        (t) => t.name === SHOW_IN_APP_TOOL.name,
+      ),
+    ).toBe(true);
+    expect(
+      disabled.delegation.responses.tools.some(
+        (t) => t.name === SHOW_IN_APP_TOOL.name,
+      ),
+    ).toBe(false);
+    expect(native.tools.some((t) => t.name === SHOW_IN_APP_TOOL.name)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-show.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.ts
@@ -1,0 +1,160 @@
+import { getSessionControl, type SessionControl } from "./session-control";
+import { getWorkspace, listWorkspaces, type Workspace } from "./workspaces";
+import { deskShowTargetSchema } from "../shared/desk-navigation";
+import type { DeskVoiceNavigation } from "./desk-voice-navigation";
+
+export const SHOW_IN_APP_TOOL = {
+  type: "function",
+  name: "show_in_app",
+  description:
+    "Bring a session or a workspace up in the user's own Open Session window, next to the Desk. Use when they ask to see, open, show, or go to something. Give the session's id or its title (a distinctive part is enough), or the workspace's id or name. Only changes the page shown in this voice call's browser.",
+  parameters: {
+    type: "object",
+    properties: {
+      session: {
+        type: "string",
+        description: "Session id, or its title or a distinctive part of it",
+      },
+      workspace: {
+        type: "string",
+        description: "Workspace id or name",
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  },
+} as const;
+
+export type ShowTarget =
+  | { kind: "session"; id: string; title: string }
+  | { kind: "workspace"; id: string; name: string };
+
+export type ShowResolution =
+  | { target: ShowTarget }
+  | { error: string; candidates?: Array<{ id: string; title: string }> };
+
+/** How many near-matches the backend gets to disambiguate with. */
+const MAX_CANDIDATES = 5;
+
+function normalize(text: string): string {
+  return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/** Exact names take precedence, but duplicate names always need clarification. */
+function pick<T extends { id: string; title: string; recency?: string }>(
+  query: string,
+  items: T[],
+  what: string,
+):
+  | { item: T }
+  | { error: string; candidates?: Array<{ id: string; title: string }> } {
+  const q = normalize(query);
+  if (!q) return { error: `Name the ${what} to show.` };
+  const exact = items.filter((i) => normalize(i.title) === q);
+  const partial = exact.length
+    ? exact
+    : items.filter((i) => normalize(i.title).includes(q));
+  if (partial.length === 1) return { item: partial[0]! };
+  if (!partial.length) return { error: `No ${what} matches "${query}".` };
+  partial.sort((a, b) => (b.recency ?? "").localeCompare(a.recency ?? ""));
+  return {
+    error: `Several ${what}s match "${query}"; ask which one.`,
+    candidates: partial
+      .slice(0, MAX_CANDIDATES)
+      .map(({ id, title }) => ({ id, title })),
+  };
+}
+
+export async function resolveShowTarget(
+  args: Record<string, unknown>,
+  deps: {
+    control: Pick<SessionControl, "listSessions" | "getSession">;
+    listWorkspaces: () => Promise<Workspace[]>;
+    getWorkspace: (id: string) => Promise<Workspace | null>;
+  },
+): Promise<ShowResolution> {
+  const session = typeof args.session === "string" ? args.session.trim() : "";
+  const workspace =
+    typeof args.workspace === "string" ? args.workspace.trim() : "";
+
+  if (
+    Object.keys(args).some((key) => key !== "session" && key !== "workspace") ||
+    Boolean(session) === Boolean(workspace) ||
+    (args.session !== undefined && typeof args.session !== "string") ||
+    (args.workspace !== undefined && typeof args.workspace !== "string") ||
+    session.length > 256 ||
+    workspace.length > 256
+  ) {
+    return { error: "Name exactly one session or workspace to show." };
+  }
+
+  if (session) {
+    // The Desk itself is hidden from every list; a call never lands on it.
+    const byId = deps.control.getSession(session);
+    if (byId && !byId.desk)
+      return {
+        target: { kind: "session", id: byId.id, title: byId.title || "" },
+      };
+    const visible = deps.control
+      .listSessions()
+      .filter((s) => !s.desk && s.state !== "archived")
+      .map((s) => ({
+        id: s.id,
+        title: s.title || "",
+        recency: s.lastActivity ?? s.createdAt,
+      }));
+    const found = pick(session, visible, "session");
+    if ("error" in found) return found;
+    return {
+      target: { kind: "session", id: found.item.id, title: found.item.title },
+    };
+  }
+
+  if (workspace) {
+    const byId = await deps.getWorkspace(workspace);
+    if (byId)
+      return { target: { kind: "workspace", id: byId.id, name: byId.name } };
+    const all = (await deps.listWorkspaces()).map((w) => ({
+      id: w.id,
+      title: w.name,
+      recency: w.createdAt,
+    }));
+    const found = pick(workspace, all, "workspace");
+    if ("error" in found) return found;
+    return {
+      target: { kind: "workspace", id: found.item.id, name: found.item.title },
+    };
+  }
+
+  return { error: "Say which session or workspace to show." };
+}
+
+/** Team members can view the shared session/workspace catalog, as in the UI.
+ * The call-bound capability is the authorization to navigate one browser. It
+ * exists only for verified web callers, never for native or generic MCP calls.
+ */
+export async function showInApp(
+  navigation: DeskVoiceNavigation | undefined,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  if (!navigation)
+    return {
+      shown: false,
+      error: "Navigation requires a signed-in web voice call.",
+    };
+  const resolved = await resolveShowTarget(args, {
+    control: getSessionControl(),
+    listWorkspaces,
+    getWorkspace,
+  });
+  if ("error" in resolved) return resolved;
+  const { target } = resolved;
+  const safe = deskShowTargetSchema.safeParse({
+    kind: target.kind,
+    id: target.id,
+  });
+  if (!safe.success)
+    return { shown: false, error: "That page cannot be opened by voice." };
+  const result = await navigation.show(safe.data);
+  return { ...target, ...result };
+}

--- a/packages/core/opensession-server/src/server/routes/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/routes/desk-voice.ts
@@ -30,9 +30,12 @@ import {
 } from "../desk-voice";
 import {
   closeLiveVoiceCall,
+  handleLiveNavigation,
   createLiveVoiceCall,
   sendLiveVoiceText,
 } from "../desk-voice-live";
+
+import { deskNavigationRequestSchema } from "../../shared/desk-navigation";
 
 /** An SDP offer is a few KB; anything bigger is not a browser offer. */
 const MAX_SDP_BYTES = 64 * 1024;
@@ -86,6 +89,29 @@ export async function handleDeskVoiceRoutes(
     return voiceStatus();
   }
 
+  if (path === "/api/desk/voice/live/navigation" && req.method === "POST") {
+    // Unlike legacy voice attribution, navigation never trusts body.user or a
+    // first name. The unguessable capability is returned only to the call's tab.
+    if (!ctx.authUser?.login)
+      return Response.json(
+        { error: "Sign in to navigate by voice." },
+        { status: 401 },
+      );
+    const parsed = deskNavigationRequestSchema.safeParse(
+      await req.json().catch(() => null),
+    );
+    if (!parsed.success)
+      return Response.json(
+        { error: "Invalid navigation request" },
+        { status: 400 },
+      );
+    const result = handleLiveNavigation(ctx.authUser.login, parsed.data);
+    return Response.json(result ?? { error: "No navigation-capable call" }, {
+      status: result ? 200 : 404,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
   if (path === "/api/desk/voice/live" && req.method === "POST") {
     const body = await req.json().catch(() => null);
     if (
@@ -101,9 +127,16 @@ export async function handleDeskVoiceRoutes(
     const user = requestUser(ctx, body.user);
     if (!user) return Response.json({ error: "missing user" }, { status: 400 });
     try {
-      return Response.json(await createLiveVoiceCall(user, body.sdp), {
-        status: 201,
-      });
+      return Response.json(
+        await createLiveVoiceCall(
+          user,
+          body.sdp,
+          body.navigation === true ? ctx.authUser?.login : undefined,
+        ),
+        {
+          status: 201,
+        },
+      );
     } catch (e: any) {
       return Response.json({ error: e?.message || String(e) }, { status: 502 });
     }

--- a/packages/core/opensession-server/src/server/routes/workspace.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.ts
@@ -494,6 +494,8 @@ export async function handleWorkspaceRoutes(
     // defaults on every row multiplied the payload by the workspace count.
     let workspaces = await listWorkspaces();
     const activeOnly = url.searchParams.get("active") === "1";
+    // Keep a directly opened empty/archived workspace in the sidebar projection.
+    const includeWorkspaceId = url.searchParams.get("includeWorkspaceId");
     if (activeOnly) {
       const indexedIds = await indexedActiveWorkspaceIds();
       const activeWorkspaceIds = new Set(
@@ -505,6 +507,7 @@ export async function handleWorkspaceRoutes(
       const openPrs = getOpenPrs();
       workspaces = workspaces.filter(
         (workspace) =>
+          workspace.id === includeWorkspaceId ||
           activeWorkspaceIds.has(workspace.id) ||
           !!workspace.draft ||
           workspaceBacksOpenPr(workspace, openPrs, defaultRepo().id),

--- a/packages/core/opensession-server/src/shared/desk-navigation.ts
+++ b/packages/core/opensession-server/src/shared/desk-navigation.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+// Only catalog IDs, never URLs, paths, query strings, or fragments.
+export const deskShowTargetSchema = z
+  .object({
+    kind: z.enum(["session", "workspace"]),
+    id: z.string().regex(/^[A-Za-z0-9_-]{1,128}$/),
+  })
+  .strict();
+export type DeskShowTarget = z.infer<typeof deskShowTargetSchema>;
+
+export const deskNavigationCommandSchema = z.object({
+  id: z.string().uuid(),
+  target: deskShowTargetSchema,
+  expiresAt: z.number().finite(),
+});
+export type DeskNavigationCommand = z.infer<typeof deskNavigationCommandSchema>;
+
+export const deskNavigationRequestSchema = z.discriminatedUnion("action", [
+  z
+    .object({
+      action: z.literal("poll"),
+      liveSessionId: z.string().min(1).max(256),
+      token: z.string().uuid(),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal("ack"),
+      liveSessionId: z.string().min(1).max(256),
+      token: z.string().uuid(),
+      commandId: z.string().uuid(),
+      shown: z.boolean(),
+    })
+    .strict(),
+]);
+export type DeskNavigationRequest = z.infer<typeof deskNavigationRequestSchema>;
+
+export const deskNavigationPollSchema = z.object({
+  command: deskNavigationCommandSchema.nullable(),
+});


### PR DESCRIPTION
## Summary
- Add `show_in_app` to signed-in web voice calls. Resolve session/workspace IDs or names, ask about ambiguous matches, and allow only fixed internal routes.
- Bind navigation to the verified login and a private per-call browser token. Wait for browser acknowledgment; reject stale commands and invalidate pending actions on hangup.
- Keep Desk open on desktop; minimize its covering sheet on phone without ending the call. Include the selected empty/archived workspace in the active workspace projection.
- Preserve the existing team-wide resource visibility. Native voice and generic MCP/automation tools do not receive this capability.

## Verification
- `bun run check` passed, including formatting, typechecking, React Compiler/lint, isolated unit tests, and strict transcript snapshots.
- 63 targeted tests passed across seven files.
- Module import side-effect checks passed.
- Verified session/workspace navigation at 1440×900 and 390×844 in an isolated demo using simulated voice transport. Confirmed navigation did not close the call. No live OpenAI voice call was tested.

Implementation and security details: `docs/desk-voice-navigation.md`.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-184e4209-a04b-7d1f-bddd-38c7832cd014)
