### PR TITLE
Let Desk navigate from text chat and voice

### DIFF
--- a/docs/desk-voice-navigation.md
+++ b/docs/desk-voice-navigation.md
@@ -1,0 +1,103 @@
+# Desk navigation
+
+The Desk overlay supports `show_in_app` in both text-only chat and web voice
+calls, including messages typed during a call. The action accepts exactly one
+`session` or `workspace`, as an ID or title/name. It resolves existing catalog
+records, prefers exact names, and asks for clarification when an exact or partial
+name has multiple matches. Name searches omit archived sessions and the Desk
+itself. An explicit ID can open an archived session. The action never accepts a
+URL, path, selector, script, or arbitrary UI operation.
+
+For example, "Show me the deploy workspace" opens the matching workspace beside
+Desk. It does not start another session or end the conversation.
+
+## Authorization and delivery
+
+Both paths require a verified sign-in login and a private browser capability.
+Tokens remain in browser memory, never local storage, model context, tool results,
+transcripts, or WebSocket broadcasts. Polling and acknowledgment require the same
+verified login and token. Another login with the same first name, or another tab
+without the token, cannot receive or acknowledge commands. Sign-in changes fail
+closed on the next request.
+
+Target visibility follows the signed-in team UI: sessions and workspaces are
+shared, not private to their creators. This action adds no ownership-based
+visibility rule and reads no transcript. If resource ACLs are introduced, the
+resolver must apply those same ACLs before ID lookup and name matching.
+
+### Voice
+
+A capable browser requests navigation during `POST /api/desk/voice/live`. The
+server returns a fresh token for that call, advertises the voice action, and
+executes it on the sideband. `/api/desk/voice/live/navigation` accepts the call ID
+as `connectionId` plus its token. Hanging up invalidates pending navigation and
+aborts browser polling. Native Realtime clients do not receive this action.
+
+### Text-only Desk
+
+Before sending text, the Desk composer connects through
+`/api/desk/navigation/connect` and binds the prompt's existing `requestId` through
+`/bind`. The connect route requires an interactive Desk session. Registration
+alone grants nothing: the WebSocket must accept that exact prompt for the same
+session and verified login. The token is never added to the prompt frame or queue.
+
+When the durable queue starts a turn, its `sourceMessageIds` select the registered
+browser. A batch is eligible only when every source message was accepted from that
+same browser. Mixed tabs and machine messages fail closed. The server-owned
+`promptEntryId` travels with the run's MCP context, not model-controlled tool
+arguments. Only that dispatch receives `opensession-desk.show_in_app`; voice tool
+inventory, workflows, other sessions, and automation MCP sets do not inherit it.
+An older run token cannot select a newer dispatch by supplying a prompt ID.
+
+Turn completion revokes its tool closure and pending command. Steering from a
+different browser or a machine revokes the previous turn's navigation authority
+before the model receives that content. Queued turns keep their own browser
+bindings. A restart loses these ephemeral grants rather than replaying navigation.
+
+Text polling stops when no registered prompt or active turn remains. Disconnects
+expire after 60 seconds without polling; unconsumed prompt bindings expire after
+five minutes. Registration is bounded to 128 connections and 512 prompts. Closing
+the owning component disconnects explicitly. A hidden tab refuses navigation.
+Registration failures do not prevent ordinary text from being sent.
+
+## UI behavior
+
+Commands carry only a validated session/workspace ID, random command ID, and
+expiry. Only one command can wait per connection, for at most ten seconds. The
+client rejects expired/malformed commands and suppresses duplicate navigation.
+Success means the owning browser's app router accepted the action. A missing app
+handler, disconnect, timeout, or revoked turn returns failure; this does not claim
+that every resource on the destination page has finished loading.
+
+The selected workspace is included in the active workspace list query, so an
+empty workspace or one containing only archived sessions still renders. The app
+router switches the page without remounting Desk. Desktop keeps the floating Desk
+open. Phone minimizes its covering sheet while the mounted conversation and voice
+client remain alive. Reopen Desk to access its controls.
+
+## Code and tests
+
+Paths below are relative to `packages/core/opensession-server/`.
+
+- `src/shared/desk-navigation.ts`: wire validation.
+- `src/server/desk-voice-show.ts`: shared target lookup and navigation action.
+- `src/server/desk-voice-navigation.ts`: pending commands and acknowledgment.
+- `src/server/desk-voice-live.ts`, `src/server/routes/desk-voice.ts`: voice calls.
+- `src/server/desk-text-navigation.ts`, `src/server/routes/desk-navigation.ts`:
+  text browser registration, prompt admission, turn binding, and cleanup.
+- `src/server/desk-navigation-mcp.ts`, `interactive-mcp.ts`, `run-rpc.ts`:
+  dispatch-scoped text MCP capability.
+- `src/server/ws-handlers.ts`, `run-session.ts`, `queued-steer.ts`, `host-client.ts`,
+  `runner-session.ts`: authenticated intake and execution lifecycle.
+- `src/frontend/components/DeskConversation.tsx`,
+  `src/frontend/lib/desk-text-navigation-client.ts`: text-composer registration.
+- `src/frontend/lib/desk-navigation-client.ts`, `desk-voice-client.ts`:
+  polling, validation, deduplication, acknowledgment, and lifetime.
+- `src/frontend/lib/desk-show.ts`, `src/frontend/AppContent.tsx`: browser-local
+  router handoff and phone minimization.
+- `src/frontend/hooks/useWorkspaces.ts`, `src/frontend/lib/api/workspaces.ts`,
+  `src/server/routes/workspace.ts`: selected workspace projection.
+
+Matching navigation tests cover resolution, sender/token isolation, source-message
+binding, mixed-tab batches, stale tool closures, actual MCP dispatch, expiry,
+steering, and disconnect races. Voice tests retain native/tool-inventory coverage.

--- a/packages/core/opensession-server/src/frontend/AppContent.tsx
+++ b/packages/core/opensession-server/src/frontend/AppContent.tsx
@@ -75,7 +75,8 @@ import { useWorkspaces } from "./hooks/useWorkspaces";
 import { getActiveViewTab, saveActiveViewTab } from "./lib/active-view-tab";
 import { cachedRepos, resolveWorkspaceApi } from "./lib/api";
 import { buildAppCommandActions } from "./components/app-command-actions";
-import { isToolView, parseRoute, routePath } from "./lib/app-route";
+import { isToolView, parseRoute, routePath, type Route } from "./lib/app-route";
+import { onDeskShow } from "./lib/desk-show";
 import {
   APP_BODY,
   DETAIL_TOPBAR,
@@ -298,7 +299,7 @@ export function AppContent({
     workspaces,
     loaded: workspacesLoaded,
     refresh: refreshWorkspaces,
-  } = useWorkspaces();
+  } = useWorkspaces(route.view === "workspace" ? route.id : undefined);
   // Read by the PR-link opener, which runs from a document-level listener and
   // therefore can't close over the render's value.
   const workspacesRef = useRef(workspaces);
@@ -515,6 +516,13 @@ export function AppContent({
   const socketInject = useEffectEvent(inject);
   const socketNavigate = useEffectEvent(navigate);
   const socketGetCurrentRoute = useEffectEvent(getCurrentRoute);
+  const voiceShow = useEffectEvent((route: Route) => {
+    navigate(route);
+    // The phone sheet covers the page; minimise it so what was asked for is
+    // visible. The call keeps running in the mounted body.
+    if (isPhone) setDeskOverlay((desk) => ({ ...desk, open: false }));
+  });
+  useEffect(() => onDeskShow(voiceShow), []);
   useEffect(() => {
     return addHandler((msg) => {
       if (msg.type === "error") {

--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import type { ProtocolClientMessage, TranscriptEntry } from "../lib/types";
+import { DeskTextNavigationClient } from "../lib/desk-text-navigation-client";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { getCurrentUser } from "./UserPicker";
 import {
@@ -87,6 +88,12 @@ export function DeskConversation({
 }: DeskConversationProps) {
   const { connected, send, setTyping, addHandler } =
     useWebSocket(presenceActive);
+  const textNavigationRef = useRef<DeskTextNavigationClient | null>(null);
+  useEffect(() => {
+    const navigation = new DeskTextNavigationClient(sessionId);
+    textNavigationRef.current = navigation;
+    return () => navigation.dispose();
+  }, [sessionId]);
   const [entries, setEntries] = useState<TranscriptEntry[]>([]);
   const [typingUsers, setTypingUsers] = useState<string[]>([]);
   const [isRunning, setIsRunning] = useState(false);
@@ -514,12 +521,18 @@ export function DeskConversation({
     if (images.length) message.images = images;
     if (files.length) message.files = filePayload;
     if (pastedTexts.length) message.pastedTexts = pastedTexts;
-    send(message);
-    setPending(content);
-    setImages([]);
-    setFiles([]);
-    followRef.current = true;
-    return true;
+    const requestId = randomUUID();
+    message.requestId = requestId;
+    const navigation = textNavigationRef.current;
+    return (navigation?.prepare(requestId) ?? Promise.resolve()).then(() => {
+      if (navigation?.disposed) return false;
+      send(message);
+      setPending(content);
+      setImages([]);
+      setFiles([]);
+      followRef.current = true;
+      return true;
+    });
   }
 
   // Model and effort are settings of the Desk session, so the switch routes

--- a/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.test.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.test.ts
@@ -133,7 +133,9 @@ test("has a server-safe unloaded initial snapshot", () => {
 });
 
 test("delegates list ownership while keeping refresh identity explicit", () => {
-  expect(appSource).toContain("} = useWorkspaces();");
+  expect(appSource).toContain(
+    '} = useWorkspaces(route.view === "workspace" ? route.id : undefined);',
+  );
   expect(appSource).not.toContain("setWorkspaces");
   expect(appSource).not.toContain('"opensession:workspaces-changed"');
   expect(hookSource).toMatch(

--- a/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useWorkspaces.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { fetchWorkspaces } from "../lib/api";
 import { setWorkspaceTitles } from "../lib/markdown";
 import type { Workspace } from "../lib/types";
@@ -41,17 +41,31 @@ interface WorkspacesState {
   refresh: () => Promise<void>;
 }
 
-export function useWorkspaces(): WorkspacesState {
+export function useWorkspaces(selectedWorkspaceId?: string): WorkspacesState {
+  const selectedIdRef = useRef(selectedWorkspaceId);
+  useLayoutEffect(() => {
+    selectedIdRef.current = selectedWorkspaceId;
+  }, [selectedWorkspaceId]);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [loaded, setLoaded] = useState(false);
   // This identity is observable: the hook subscriptions and App's global
   // socket handler depend on it. Keep it stable in uncompiled development.
-  const [refresh] = useState(
-    () => () =>
-      loadWorkspaces(fetchWorkspaces, setWorkspaces, () => setLoaded(true)),
-  );
+  const [refresh] = useState(() => () => {
+    const includeWorkspaceId = selectedIdRef.current;
+    return loadWorkspaces(
+      () => fetchWorkspaces({ includeWorkspaceId }),
+      (rows) => {
+        // A prior route's slower refresh must not hide the selected workspace.
+        if (selectedIdRef.current === includeWorkspaceId) setWorkspaces(rows);
+      },
+      () => setLoaded(true),
+    );
+  });
 
-  useEffect(() => subscribeToWorkspaceRefreshes(window, refresh), [refresh]);
+  useEffect(
+    () => subscribeToWorkspaceRefreshes(window, refresh),
+    [refresh, selectedWorkspaceId],
+  );
   useEffect(() => {
     setWorkspaceTitles(
       workspaces.map((workspace) => [workspace.id, workspace.name] as const),

--- a/packages/core/opensession-server/src/frontend/lib/api.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api.test.ts
@@ -255,3 +255,13 @@ test("new workspace tabs create an idle sibling session", async () => {
     duplicate: true,
   });
 });
+
+test("workspace projection explicitly includes the selected workspace", async () => {
+  let url = "";
+  globalThis.fetch = stubFetch(async (input) => {
+    url = String(input);
+    return Response.json({ workspaces: [] });
+  });
+  await fetchWorkspaces({ includeWorkspaceId: "ws-archived" });
+  expect(url).toBe("/api/workspaces?active=1&includeWorkspaceId=ws-archived");
+});

--- a/packages/core/opensession-server/src/frontend/lib/api/workspaces.ts
+++ b/packages/core/opensession-server/src/frontend/lib/api/workspaces.ts
@@ -71,13 +71,16 @@ export function defaultWorkspaceModelSettings():
 }
 
 export async function fetchWorkspaces(options?: {
+  includeWorkspaceId?: string;
   onError?: (cause: unknown) => void;
 }): Promise<Workspace[]> {
   try {
     const data = await request<{
       workspaces?: Workspace[];
       defaultModelSettings?: Workspace["modelSettings"];
-    }>("/workspaces?active=1");
+    }>(
+      `/workspaces?active=1${options?.includeWorkspaceId ? `&includeWorkspaceId=${encodeURIComponent(options.includeWorkspaceId)}` : ""}`,
+    );
     if (data?.defaultModelSettings)
       defaultModelSettings = data.defaultModelSettings;
     const next = data?.workspaces ?? [];

--- a/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { DeskNavigationClient } from "./desk-navigation-client";
+import { DeskVoiceNavigation } from "../../server/desk-voice-navigation";
+import type { DeskNavigationRequest } from "../../shared/desk-navigation";
+
+const target = { kind: "workspace", id: "ws-1" } as const;
+
+describe("voice browser navigation", () => {
+  test("round trips a real command and acknowledgment without another tab following", async () => {
+    const server = new DeskVoiceNavigation("alice");
+    const shown: unknown[] = [];
+    const request = async (body: DeskNavigationRequest) =>
+      Response.json(server.handle("alice", body));
+    const owner = new DeskNavigationClient(
+      "call",
+      server.token,
+      (route) => {
+        shown.push(route);
+        return true;
+      },
+      request,
+    );
+    const otherTab = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        throw new Error("Wrong tab navigated");
+      },
+      request,
+    );
+    const result = server.show(target);
+    await expect(otherTab.poll()).rejects.toThrow();
+    await owner.poll();
+    expect(await result).toEqual({ shown: true });
+    expect(shown).toEqual([target]);
+    await owner.poll();
+    expect(shown).toHaveLength(1);
+    owner.stop();
+    otherTab.stop();
+    server.close();
+  });
+
+  test("does not navigate if hangup happens while a response is in flight", async () => {
+    let deliver: (value: Response) => void = () => {};
+    const response = new Promise<Response>((resolve) => {
+      deliver = resolve;
+    });
+    let navigated = false;
+    const client = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        navigated = true;
+        return true;
+      },
+      async () => response,
+    );
+    const pending = client.poll();
+    client.stop();
+    deliver(
+      Response.json({
+        command: {
+          id: crypto.randomUUID(),
+          target,
+          expiresAt: Date.now() + 10_000,
+        },
+      }),
+    );
+    await pending;
+    expect(navigated).toBe(false);
+  });
+
+  test("duplicate delivery reuses the acknowledgment without navigating twice", async () => {
+    const command = {
+      id: crypto.randomUUID(),
+      target,
+      expiresAt: Date.now() + 10_000,
+    };
+    let navigated = 0;
+    const acks: unknown[] = [];
+    const client = new DeskNavigationClient(
+      "call",
+      crypto.randomUUID(),
+      () => {
+        navigated++;
+        return true;
+      },
+      async (body) => {
+        if (body.action === "poll") return Response.json({ command });
+        acks.push(body);
+        return Response.json({ ok: true });
+      },
+    );
+    await client.poll();
+    await client.poll();
+    expect(navigated).toBe(1);
+    expect(acks).toHaveLength(2);
+    client.stop();
+  });
+
+  test("expired, malformed and arbitrary route commands never navigate", async () => {
+    let navigated = false;
+    for (const command of [
+      { id: crypto.randomUUID(), target, expiresAt: 0 },
+      {
+        id: crypto.randomUUID(),
+        target: { kind: "settings", id: "account" },
+        expiresAt: Date.now() + 10_000,
+      },
+      {
+        id: crypto.randomUUID(),
+        target: { kind: "session", id: "../settings" },
+        expiresAt: Date.now() + 10_000,
+      },
+    ]) {
+      const client = new DeskNavigationClient(
+        "call",
+        crypto.randomUUID(),
+        () => {
+          navigated = true;
+          return true;
+        },
+        async () => Response.json({ command }),
+      );
+      await client.poll().catch(() => {});
+      client.stop();
+    }
+    expect(navigated).toBe(false);
+  });
+
+  test("a missing app handler is reported as failure", async () => {
+    const server = new DeskVoiceNavigation("alice");
+    const client = new DeskNavigationClient(
+      "call",
+      server.token,
+      () => false,
+      async (body) => Response.json(server.handle("alice", body)),
+    );
+    const result = server.show(target);
+    await client.poll();
+    expect(await result).toMatchObject({ shown: false });
+    client.stop();
+    server.close();
+  });
+});
+
+test("text navigation stops polling when the server has retired the turn", async () => {
+  let requests = 0;
+  const client = new DeskNavigationClient(
+    "connection",
+    crypto.randomUUID(),
+    () => true,
+    async () => {
+      requests++;
+      return Response.json({ command: null, finished: true });
+    },
+  );
+  await client.start();
+  expect(client.active).toBe(false);
+  await client.poll();
+  expect(requests).toBe(1);
+});

--- a/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-navigation-client.ts
@@ -1,0 +1,104 @@
+import {
+  deskNavigationPollSchema,
+  type DeskNavigationRequest,
+} from "../../shared/desk-navigation";
+import { BASE_PATH } from "./base";
+import { showDeskTarget } from "./desk-show";
+
+/** Runs only inside the browser that owns this call. The token lives in memory
+ * and requests use the current sign-in cookie, so sign-out/re-login fails shut.
+ */
+export class DeskNavigationClient {
+  private readonly abort = new AbortController();
+  private started = false;
+  private lastResult: { id: string; shown: boolean } | null = null;
+
+  constructor(
+    private readonly connectionId: string,
+    private readonly token: string,
+    private readonly show = showDeskTarget,
+    private readonly request: (
+      body: DeskNavigationRequest,
+      signal: AbortSignal,
+    ) => Promise<Response> = async (body, signal) => {
+      const response = await fetch(
+        `${BASE_PATH}/api/desk/voice/live/navigation`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal,
+        },
+      );
+      if (!response.ok) throw new Error("Voice navigation disconnected");
+      return response;
+    },
+  ) {}
+
+  /** One bounded poll. Retries acknowledge the previous result, never navigate twice. */
+  async poll(): Promise<void> {
+    if (this.abort.signal.aborted) return;
+    const raw = await this.request(
+      { action: "poll", connectionId: this.connectionId, token: this.token },
+      this.abort.signal,
+    );
+    if (this.abort.signal.aborted) return;
+    if (!raw.ok) throw new Error("Voice navigation disconnected");
+    const { command, finished } = deskNavigationPollSchema.parse(
+      await raw.json(),
+    );
+    if (finished) {
+      this.stop();
+      return;
+    }
+    if (this.abort.signal.aborted) return;
+    if (!command || command.expiresAt <= Date.now()) return;
+    if (this.lastResult?.id !== command.id) {
+      this.lastResult = { id: command.id, shown: this.show(command.target) };
+    }
+    if (this.abort.signal.aborted) return;
+    const ack = await this.request(
+      {
+        action: "ack",
+        connectionId: this.connectionId,
+        token: this.token,
+        commandId: command.id,
+        shown: this.lastResult.shown,
+      },
+      this.abort.signal,
+    );
+    if (!ack.ok) throw new Error("Voice navigation disconnected");
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    try {
+      while (!this.abort.signal.aborted) {
+        await this.poll();
+        await new Promise<void>((resolve) => {
+          if (this.abort.signal.aborted) return resolve();
+          const finish = () => {
+            clearTimeout(timer);
+            this.abort.signal.removeEventListener("abort", finish);
+            resolve();
+          };
+          const timer = setTimeout(finish, 750);
+          this.abort.signal.addEventListener("abort", finish, { once: true });
+        });
+      }
+    } catch {
+      // No blind retry after an auth failure or changed login. A new call gets
+      // a new capability. Pending actions time out honestly on the server.
+      this.stop();
+    }
+  }
+
+  get active(): boolean {
+    return !this.abort.signal.aborted;
+  }
+
+  stop(): void {
+    this.abort.abort();
+  }
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { deskShowRoute } from "./desk-show";
+import { deskShowTargetSchema } from "../../shared/desk-navigation";
+
+describe("deskShowRoute", () => {
+  test("maps a session or workspace id onto its route", () => {
+    expect(deskShowRoute({ kind: "session", id: "s-1" })).toEqual({
+      view: "session",
+      id: "s-1",
+    });
+    expect(deskShowRoute({ kind: "workspace", id: "ws-1" })).toEqual({
+      view: "workspace",
+      id: "ws-1",
+    });
+  });
+
+  test("the boundary drops anything outside the fixed route table", () => {
+    for (const target of [
+      null,
+      { kind: "settings", id: "x" },
+      { kind: "session", id: 5 },
+      ...[
+        " ",
+        "../settings",
+        "https://example.invalid",
+        "s-1?x=1",
+        "s-1#x",
+        "%2e%2e",
+        "s/2",
+        "",
+      ].map((id) => ({ kind: "session", id })),
+    ]) {
+      expect(deskShowTargetSchema.safeParse(target).success).toBe(false);
+    }
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.ts
@@ -1,0 +1,30 @@
+import {
+  deskShowTargetSchema,
+  type DeskShowTarget,
+} from "../../shared/desk-navigation";
+import type { Route } from "./app-route";
+export type { DeskShowTarget } from "../../shared/desk-navigation";
+
+export function deskShowRoute(target: DeskShowTarget): Route {
+  return { view: target.kind, id: target.id };
+}
+
+// Local to this browser's voice client, not a server WebSocket broadcast.
+const SHOW_EVENT = "opensession:desk-show";
+export function showDeskTarget(target: DeskShowTarget): boolean {
+  return !window.dispatchEvent(
+    new CustomEvent(SHOW_EVENT, { detail: target, cancelable: true }),
+  );
+}
+
+export function onDeskShow(show: (route: Route) => void): () => void {
+  const listener = (event: Event) => {
+    if (!(event instanceof CustomEvent)) return;
+    const parsed = deskShowTargetSchema.safeParse(event.detail);
+    if (!parsed.success) return;
+    show(deskShowRoute(parsed.data));
+    event.preventDefault();
+  };
+  window.addEventListener(SHOW_EVENT, listener);
+  return () => window.removeEventListener(SHOW_EVENT, listener);
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-text-navigation-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-text-navigation-client.ts
@@ -1,0 +1,110 @@
+import {
+  deskNavigationConnectionSchema,
+  type DeskNavigationConnection,
+  type DeskNavigationBinding,
+  type DeskNavigationConnect,
+} from "../../shared/desk-navigation";
+import { DeskNavigationClient } from "./desk-navigation-client";
+import { showDeskTarget } from "./desk-show";
+import { BASE_PATH } from "./base";
+
+const API = `${BASE_PATH}/api/desk/navigation`;
+
+export class DeskTextNavigationClient {
+  private connection: {
+    connectionId: string;
+    token: string;
+    client: DeskNavigationClient;
+  } | null = null;
+  private connecting: Promise<void> | null = null;
+  private stopped = false;
+
+  constructor(private readonly sessionId: string) {}
+
+  get disposed() {
+    return this.stopped;
+  }
+
+  private async post(
+    path: "connect" | "bind" | "disconnect",
+    body:
+      | DeskNavigationConnection
+      | DeskNavigationBinding
+      | DeskNavigationConnect,
+  ) {
+    return fetch(`${API}/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(2_000),
+    });
+  }
+
+  private async connect() {
+    const response = await this.post("connect", { sessionId: this.sessionId });
+    if (!response.ok) return;
+    const connection = deskNavigationConnectionSchema.parse(
+      await response.json(),
+    );
+    if (this.stopped) {
+      void this.post("disconnect", connection).catch(() => {});
+      return;
+    }
+    const client = new DeskNavigationClient(
+      connection.connectionId,
+      connection.token,
+      (target) => !document.hidden && !this.stopped && showDeskTarget(target),
+      (body, signal) =>
+        fetch(`${API}/poll`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal,
+        }),
+    );
+    this.connection = { ...connection, client };
+  }
+
+  /** Register the existing prompt requestId before WebSocket intake. This is
+   * optional: a signed-out or disconnected client can still send ordinary text.
+   */
+  async prepare(requestId: string): Promise<void> {
+    if (this.stopped) return;
+    try {
+      if (!this.connection?.client.active) {
+        this.connecting ??= this.connect();
+        await this.connecting;
+        this.connecting = null;
+      }
+      const connection = this.connection;
+      if (!connection || this.stopped) return;
+      const response = await this.post("bind", {
+        connectionId: connection.connectionId,
+        token: connection.token,
+        requestId,
+      });
+      if (response.ok && !this.stopped) void connection.client.start();
+      else connection.client.stop();
+    } catch {
+      this.connecting = null;
+      // Navigation is optional, never a reason to lose the person's message.
+    }
+  }
+
+  dispose(): void {
+    this.stopped = true;
+    const connection = this.connection;
+    if (!connection) return;
+    connection.client.stop();
+    void fetch(`${API}/disconnect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        connectionId: connection.connectionId,
+        token: connection.token,
+      }),
+      keepalive: true,
+    }).catch(() => {});
+    this.connection = null;
+  }
+}

--- a/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-voice-client.ts
@@ -8,6 +8,7 @@
 // only once the utterance settles, and these arrive word by word.
 
 import { z } from "zod";
+import { DeskNavigationClient } from "./desk-navigation-client";
 import { BASE_PATH } from "./base";
 import type { VoiceCaptionFragment, VoiceCaptionRole } from "./voice-captions";
 
@@ -35,6 +36,7 @@ const liveResponseSchema = z.object({
   liveSessionId: z.string(),
   sdp: z.string(),
   sessionId: z.string(),
+  navigationToken: z.string().uuid().optional(),
   backendModel: z.string().optional(),
 });
 
@@ -82,7 +84,7 @@ export interface DeskVoiceDiagReport {
 }
 
 type VoiceRequest =
-  | { user: string; sdp: string }
+  | { user: string; sdp: string; navigation: true }
   | { user: string; liveSessionId: string; text: string }
   | { user: string; liveSessionId: string }
   | DeskVoiceDiagReport;
@@ -140,6 +142,7 @@ export class DeskVoiceClient {
   private micStream: MediaStream | null = null;
   private audioEl: HTMLAudioElement | null = null;
   private liveSessionId: string | null = null;
+  private navigation: DeskNavigationClient | null = null;
 
   private idleTimer: number | null = null;
   private speakingTimer: number | null = null;
@@ -289,7 +292,7 @@ export class DeskVoiceClient {
       if (!sdp) throw new Error("No local offer");
       const live = await postJson(
         "/live",
-        { user: this.user, sdp },
+        { user: this.user, sdp, navigation: true },
         liveResponseSchema,
       );
       if (this.aborted) {
@@ -299,6 +302,11 @@ export class DeskVoiceClient {
         return;
       }
       this.liveSessionId = live.liveSessionId;
+      if (live.navigationToken)
+        this.navigation = new DeskNavigationClient(
+          live.liveSessionId,
+          live.navigationToken,
+        );
       this.backendModel = live.backendModel ?? null;
       this.onCallStarted?.(live.liveSessionId);
       await pc.setRemoteDescription({ type: "answer", sdp: live.sdp });
@@ -345,6 +353,7 @@ export class DeskVoiceClient {
    * `session.closed` so pending backend work drains; tears down regardless.
    * `reason` is for the diag line only: who decided the call was over. */
   stop(reason = "hangup"): void {
+    this.navigation?.stop();
     if (this.closing || this.aborted) return;
     if (this.starting) {
       // Cancel the start in progress. Whatever step is awaiting sees
@@ -385,6 +394,8 @@ export class DeskVoiceClient {
   }
 
   private teardown() {
+    this.navigation?.stop();
+    this.navigation = null;
     this.postDiag("teardown");
     for (const key of ["idleTimer", "speakingTimer", "closeTimer"] as const) {
       const t = this[key];
@@ -503,6 +514,7 @@ export class DeskVoiceClient {
 
     switch (event.type) {
       case "session.started":
+        void this.navigation?.start();
         this.connected = true;
         this.startedAt ??= Date.now();
         this.resetIdleTimer();

--- a/packages/core/opensession-server/src/server/desk-navigation-mcp.test.ts
+++ b/packages/core/opensession-server/src/server/desk-navigation-mcp.test.ts
@@ -1,0 +1,168 @@
+import { expect, test } from "bun:test";
+import { z } from "zod";
+import type { DeskNavigationCommand } from "../shared/desk-navigation";
+import { deskTextNavigation } from "./desk-text-navigation";
+import { deskNavigationMcp } from "./desk-navigation-mcp";
+import { registerSessionControl, type SessionSummary } from "./session-control";
+import {
+  dispatchRunRpc,
+  registerInteractiveMcpBuilder,
+  registerRunToken,
+  unregisterRunToken,
+} from "./run-rpc";
+import { handleDeskNavigationRoutes } from "./routes/desk-navigation";
+
+const resultSchema = z.object({
+  result: z.object({
+    content: z.array(z.object({ type: z.literal("text"), text: z.string() })),
+  }),
+});
+
+test("the real text MCP uses server-owned prompt identity and the same acknowledged navigation action", async () => {
+  const sessionId = "desk-nav-mcp-test";
+  const requestId = crypto.randomUUID();
+  const promptEntryId = crypto.randomUUID();
+  const connection = deskTextNavigation.connect(sessionId, "alice-login");
+  if (!connection) throw new Error("No connection");
+  deskTextNavigation.bind(
+    "alice-login",
+    connection.connectionId,
+    connection.token,
+    requestId,
+  );
+  deskTextNavigation.accept(sessionId, requestId, "alice-login");
+  const finish = deskTextNavigation.begin(sessionId, promptEntryId, [
+    requestId,
+  ]);
+  const target: SessionSummary = {
+    id: "session-target",
+    title: "Fix uploads",
+    state: "idle",
+    queuedCount: 0,
+    controllable: true,
+    claudeSessionId: null,
+    source: "opensession",
+    branch: null,
+    worktreeDir: null,
+    startedBy: "Alice",
+    lastActivity: "2026-09-10T00:00:00Z",
+    createdAt: "2026-09-10T00:00:00Z",
+    isRunning: false,
+    transcriptPath: null,
+  };
+  registerSessionControl({
+    listSessions: () => [target],
+    getSession: (id) => (id === target.id ? target : undefined),
+    transcriptTail: async () => [],
+    answerQuestion: () => false,
+    deliverToSession: async () => ({ status: "error", message: "unused" }),
+    cancelSession: () => false,
+    reparentSession: async () => ({ ok: false, error: "unused" }),
+    createSession: async () => ({
+      id: "unused",
+      createdBy: "Test",
+      createdAt: "2026-09-10T00:00:00Z",
+    }),
+  });
+  registerInteractiveMcpBuilder((id, _user, prompt) =>
+    deskNavigationMcp(id, prompt),
+  );
+  const token = crypto.randomUUID();
+  const oldToken = crypto.randomUUID();
+  registerRunToken(token, { sessionId, user: "Alice", promptEntryId });
+  registerRunToken(oldToken, {
+    sessionId,
+    user: "Alice",
+    promptEntryId: "old-turn",
+  });
+  try {
+    expect(deskNavigationMcp(sessionId)).toEqual({});
+    const listed = await dispatchRunRpc("/mcp/list", {
+      token,
+      server: "opensession-desk",
+    });
+    expect(listed.kind).toBe("immediate");
+    if (listed.kind !== "immediate") throw new Error("Expected list");
+    expect(JSON.stringify(listed.body)).toContain("show_in_app");
+    expect(JSON.stringify(listed.body)).not.toContain(connection.token);
+    const forged = await dispatchRunRpc("/mcp/list", {
+      token: oldToken,
+      server: "opensession-desk",
+      promptEntryId,
+    });
+    expect(forged).toMatchObject({ kind: "immediate", body: { tools: [] } });
+    const called = await dispatchRunRpc("/mcp/call", {
+      token,
+      server: "opensession-desk",
+      tool: "show_in_app",
+      args: { session: "uploads" },
+    });
+    if (called.kind !== "call") throw new Error("Expected tool call");
+    // The SDK schedules the handler through its in-memory transport.
+    let command: DeskNavigationCommand | undefined;
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline) {
+      const response = deskTextNavigation.handle("alice-login", {
+        action: "poll",
+        ...connection,
+      });
+      if (response && "command" in response && response.command) {
+        command = response.command;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    if (!command) throw new Error("No navigation command");
+    expect(command.target).toEqual({ kind: "session", id: "session-target" });
+    deskTextNavigation.handle("alice-login", {
+      action: "ack",
+      ...connection,
+      commandId: command.id,
+      shown: true,
+    });
+    const result = resultSchema.parse(await called.done);
+    expect(JSON.parse(result.result.content[0]!.text)).toMatchObject({
+      shown: true,
+      id: "session-target",
+    });
+    finish();
+    expect(
+      await dispatchRunRpc("/mcp/list", { token, server: "opensession-desk" }),
+    ).toMatchObject({ kind: "immediate", body: { tools: [] } });
+  } finally {
+    finish();
+    deskTextNavigation.disconnect(
+      "alice-login",
+      connection.connectionId,
+      connection.token,
+    );
+    unregisterRunToken(token);
+    unregisterRunToken(oldToken);
+  }
+});
+
+test("text navigation HTTP refuses unsigned and malformed requests before looking up a session", async () => {
+  const url = new URL("http://localhost/api/desk/navigation/connect");
+  const unsigned = await handleDeskNavigationRoutes({
+    req: new Request(url, {
+      method: "POST",
+      body: JSON.stringify({ sessionId: "desk", user: "Alice" }),
+    }),
+    url,
+    path: url.pathname,
+    publicPrefix: "",
+    authUser: null,
+  });
+  expect(unsigned?.status).toBe(401);
+  const invalid = await handleDeskNavigationRoutes({
+    req: new Request(url, {
+      method: "POST",
+      body: JSON.stringify({ sessionId: "desk", user: "Alice" }),
+    }),
+    url,
+    path: url.pathname,
+    publicPrefix: "",
+    authUser: { login: "alice", name: "Alice" },
+  });
+  expect(invalid?.status).toBe(400);
+});

--- a/packages/core/opensession-server/src/server/desk-navigation-mcp.ts
+++ b/packages/core/opensession-server/src/server/desk-navigation-mcp.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { createSdkMcpServer, tool } from "./inprocess-mcp";
+import { deskTextNavigation } from "./desk-text-navigation";
+import { SHOW_IN_APP_TOOL, showInApp } from "./desk-voice-show";
+
+export function deskNavigationMcp(
+  sessionId: string,
+  promptEntryId?: string,
+): Record<string, unknown> {
+  // Grants exist only for validated Desk prompts in an interactive run.
+  const navigation = deskTextNavigation.forTurn(sessionId, promptEntryId);
+  if (!navigation) return {};
+  return {
+    "opensession-desk": createSdkMcpServer({
+      name: "opensession-desk",
+      version: "1.0.0",
+      tools: [
+        tool(
+          SHOW_IN_APP_TOOL.name,
+          "Show a session or workspace in the browser that sent this Desk message. Use when the user asks to see, open, or go to it. Accepts an ID, title or distinctive part of the name, never a URL. Ask which one when names are ambiguous.",
+          {
+            session: z.string().max(256).optional(),
+            workspace: z.string().max(256).optional(),
+          },
+          async (args) => ({
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(await showInApp(navigation, args)),
+              },
+            ],
+          }),
+        ),
+      ],
+    }),
+  };
+}

--- a/packages/core/opensession-server/src/server/desk-text-navigation.test.ts
+++ b/packages/core/opensession-server/src/server/desk-text-navigation.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { DeskTextNavigation } from "./desk-text-navigation";
+
+function setup(registry = new DeskTextNavigation(), login = "alice") {
+  const connection = registry.connect("desk", login);
+  if (!connection) throw new Error("missing connection");
+  const bind = () => {
+    const requestId = crypto.randomUUID();
+    expect(
+      registry.bind(
+        login,
+        connection.connectionId,
+        connection.token,
+        requestId,
+      ),
+    ).toBe(true);
+    return requestId;
+  };
+  const poll = () => registry.handle(login, { action: "poll", ...connection });
+  return { registry, connection, bind, poll };
+}
+const target = { kind: "workspace", id: "ws-1" } as const;
+
+describe("text Desk navigation authority", () => {
+  test("HTTP registration alone cannot authorize a run", () => {
+    const { registry, bind } = setup();
+    const request = bind();
+    registry.begin("desk", "turn", [request]);
+    expect(registry.forTurn("desk", "turn")).toBeUndefined();
+  });
+
+  test("requires the same verified sender and exact Desk session at intake", () => {
+    for (const [sessionId, login] of [
+      ["desk", undefined],
+      ["desk", "other-alice"],
+      ["other-desk", "alice"],
+    ]) {
+      const { registry, bind } = setup();
+      const request = bind();
+      registry.accept(sessionId!, request, login);
+      registry.begin("desk", "turn", [request]);
+      expect(registry.forTurn("desk", "turn")).toBeUndefined();
+    }
+  });
+
+  test("delivers only to the originating browser and waits for its acknowledgment", async () => {
+    const { registry, connection, bind, poll } = setup();
+    const request = bind();
+    registry.accept("desk", request, "alice");
+    const finish = registry.begin("desk", "turn", [request]);
+    const navigation = registry.forTurn("desk", "turn");
+    if (!navigation) throw new Error("missing navigation");
+    expect(registry.forTurn("desk", "different-turn")).toBeUndefined();
+    expect(registry.forTurn("other-desk", "turn")).toBeUndefined();
+    const shown = navigation.show(target);
+    expect(
+      registry.handle("other-alice", { action: "poll", ...connection }),
+    ).toBeNull();
+    expect(
+      registry.handle("alice", {
+        action: "poll",
+        ...connection,
+        token: crypto.randomUUID(),
+      }),
+    ).toBeNull();
+    const polled = poll();
+    if (!polled || !("command" in polled) || !polled.command)
+      throw new Error("missing command");
+    expect(polled.command.target).toEqual(target);
+    expect(
+      registry.handle("alice", {
+        action: "ack",
+        ...connection,
+        commandId: polled.command.id,
+        shown: true,
+      }),
+    ).toEqual({ ok: true });
+    expect(await shown).toEqual({ shown: true });
+    finish();
+    expect(await navigation.show(target)).toMatchObject({ shown: false });
+    expect(poll()).toEqual({ command: null, finished: true });
+    expect(poll()).toBeNull();
+  });
+
+  test("queue batches from one browser work; mixed tabs and machine messages fail closed", () => {
+    for (const mixed of [false, true]) {
+      const { registry, bind } = setup();
+      const other = mixed ? setup(registry).bind : bind;
+      const ids = [bind(), other()];
+      for (const id of ids) registry.accept("desk", id, "alice");
+      const finish = registry.begin("desk", "turn", ids);
+      expect(Boolean(registry.forTurn("desk", "turn"))).toBe(!mixed);
+      finish();
+    }
+    const { registry, bind } = setup();
+    const request = bind();
+    registry.accept("desk", request, "alice");
+    registry.begin("desk", "turn", [request, "machine-message"]);
+    expect(registry.forTurn("desk", "turn")).toBeUndefined();
+  });
+
+  test("a later queued turn cannot retarget an earlier tool closure", async () => {
+    const { registry, bind } = setup();
+    const a = bind();
+    registry.accept("desk", a, "alice");
+    const finishA = registry.begin("desk", "turn-a", [a]);
+    const previous = registry.forTurn("desk", "turn-a");
+    const b = setup(registry).bind();
+    registry.accept("desk", b, "alice");
+    finishA();
+    const finishB = registry.begin("desk", "turn-b", [b]);
+    expect(await previous?.show(target)).toMatchObject({ shown: false });
+    expect(registry.forTurn("desk", "turn-b")).toBeDefined();
+    finishB();
+  });
+
+  test("another browser cannot replace a message binding", () => {
+    const { registry, bind } = setup();
+    const request = bind();
+    const other = setup(registry).connection;
+    expect(
+      registry.bind("alice", other.connectionId, other.token, request),
+    ).toBe(false);
+  });
+
+  test("steering from another browser or machine revokes the original turn", async () => {
+    for (const sameBrowser of [true, false]) {
+      const { registry, bind } = setup();
+      const request = bind();
+      registry.accept("desk", request, "alice");
+      const finish = registry.begin("desk", "turn", [request]);
+      const navigation = registry.forTurn("desk", "turn");
+      const pending = navigation?.show(target);
+      const steer = sameBrowser ? bind() : "machine-message";
+      if (sameBrowser) registry.accept("desk", steer, "alice");
+      registry.steer("desk", steer);
+      expect(Boolean(registry.forTurn("desk", "turn"))).toBe(sameBrowser);
+      finish();
+      expect(await pending).toMatchObject({ shown: false });
+    }
+  });
+
+  test("disconnect, expiry and restart invalidate outstanding authority", async () => {
+    let now = 1_000;
+    const { registry, connection, bind } = setup(
+      new DeskTextNavigation(() => now),
+    );
+    const request = bind();
+    registry.accept("desk", request, "alice");
+    const finish = registry.begin("desk", "turn", [request]);
+    const navigation = registry.forTurn("desk", "turn");
+    const pending = navigation?.show(target);
+    now += 60_001;
+    expect(registry.forTurn("desk", "turn")).toBeUndefined();
+    expect(await pending).toMatchObject({ shown: false });
+    expect(await navigation?.show(target)).toMatchObject({ shown: false });
+    expect(
+      registry.disconnect("alice", connection.connectionId, connection.token),
+    ).toBe(false);
+    expect(new DeskTextNavigation().forTurn("desk", "turn")).toBeUndefined();
+    finish();
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-text-navigation.ts
+++ b/packages/core/opensession-server/src/server/desk-text-navigation.ts
@@ -1,0 +1,210 @@
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import type { DeskNavigationRequest } from "../shared/desk-navigation";
+
+const CONNECTION_TTL_MS = 60_000;
+const PROMPT_TTL_MS = 5 * 60_000;
+const MAX_CONNECTIONS = 128;
+const MAX_PROMPTS = 512;
+
+type Connection = {
+  id: string;
+  sessionId: string;
+  login: string;
+  navigation: DeskVoiceNavigation;
+  touchedAt: number;
+};
+type Prompt = { connection: Connection; accepted: boolean; expiresAt: number };
+type Turn = {
+  connection: Connection;
+  sessionId: string;
+  promptEntryId: string;
+};
+
+/** Ephemeral browser authority, never persisted with the prompt or exposed to
+ * the model. A restart loses the capability rather than replaying navigation.
+ */
+export class DeskTextNavigation {
+  private readonly connections = new Map<string, Connection>();
+  private readonly prompts = new Map<string, Prompt>();
+  private readonly turns = new Map<string, Turn>();
+
+  constructor(private readonly now = Date.now) {}
+
+  private remove(connection: Connection) {
+    connection.navigation.close();
+    this.connections.delete(connection.id);
+    for (const [id, prompt] of this.prompts) {
+      if (prompt.connection === connection) this.prompts.delete(id);
+    }
+    for (const [id, turn] of this.turns) {
+      if (turn.connection === connection) this.turns.delete(id);
+    }
+  }
+
+  private prune() {
+    for (const connection of this.connections.values()) {
+      if (this.now() - connection.touchedAt > CONNECTION_TTL_MS)
+        this.remove(connection);
+    }
+    for (const [id, prompt] of this.prompts) {
+      if (prompt.expiresAt <= this.now()) this.prompts.delete(id);
+    }
+  }
+
+  connect(sessionId: string, login: string) {
+    this.prune();
+    if (!login || this.connections.size >= MAX_CONNECTIONS) return null;
+    const connection: Connection = {
+      id: crypto.randomUUID(),
+      sessionId,
+      login: login.toLowerCase(),
+      navigation: new DeskVoiceNavigation(login),
+      touchedAt: this.now(),
+    };
+    this.connections.set(connection.id, connection);
+    return { connectionId: connection.id, token: connection.navigation.token };
+  }
+
+  private owned(login: string, connectionId: string, token: string) {
+    this.prune();
+    const connection = this.connections.get(connectionId);
+    if (
+      !connection ||
+      !login ||
+      connection.login !== login.toLowerCase() ||
+      connection.navigation.token !== token
+    )
+      return null;
+    connection.touchedAt = this.now();
+    return connection;
+  }
+
+  bind(
+    login: string,
+    connectionId: string,
+    token: string,
+    requestId: string,
+  ): boolean {
+    const connection = this.owned(login, connectionId, token);
+    if (!connection || this.prompts.size >= MAX_PROMPTS) return false;
+    const existing = this.prompts.get(requestId);
+    // A different tab must not overwrite an already registered message.
+    if (existing) return existing.connection === connection;
+    this.prompts.set(requestId, {
+      connection,
+      accepted: false,
+      expiresAt: this.now() + PROMPT_TTL_MS,
+    });
+    return true;
+  }
+
+  /** Called only after the authenticated WebSocket has validated the prompt.
+   * Registering over HTTP alone cannot authorize a later machine-delivered turn.
+   */
+  accept(sessionId: string, requestId: string, login: string | undefined) {
+    this.prune();
+    const prompt = this.prompts.get(requestId);
+    const accepted =
+      !!prompt &&
+      !!login &&
+      prompt.connection.sessionId === sessionId &&
+      prompt.connection.login === login.toLowerCase();
+    if (accepted) prompt.accepted = true;
+  }
+
+  /** A steer from another browser, native client, or machine invalidates the
+   * old turn's UI authority before that content reaches the running model. */
+  steer(sessionId: string, requestId: string) {
+    this.prune();
+    const prompt = this.prompts.get(requestId);
+    const connection =
+      prompt?.accepted && prompt.connection.sessionId === sessionId
+        ? prompt.connection
+        : undefined;
+    if (connection) this.prompts.delete(requestId);
+    for (const [key, turn] of this.turns) {
+      if (turn.sessionId === sessionId && turn.connection !== connection) {
+        turn.connection.navigation.cancelPending();
+        this.turns.delete(key);
+      }
+    }
+  }
+
+  /** A queue batch may navigate only if every source message came from the
+   * same verified browser. Mixed tabs or machine messages fail closed.
+   */
+  begin(
+    sessionId: string,
+    promptEntryId: string | undefined,
+    sourceMessageIds: string[] = [],
+  ): () => void {
+    this.prune();
+    if (!promptEntryId || sourceMessageIds.length === 0) return () => {};
+    const prompts = sourceMessageIds.map((id) => this.prompts.get(id));
+    const connection = prompts[0]?.connection;
+    for (const id of sourceMessageIds) {
+      if (this.prompts.get(id)?.connection.sessionId === sessionId)
+        this.prompts.delete(id);
+    }
+    if (
+      !connection ||
+      connection.sessionId !== sessionId ||
+      !prompts.every((p) => p?.accepted && p.connection === connection)
+    )
+      return () => {};
+    const key = `${sessionId}:${promptEntryId}`;
+    const turn: Turn = { connection, sessionId, promptEntryId };
+    this.turns.set(key, turn);
+    return () => {
+      if (this.turns.get(key) !== turn) return;
+      connection.navigation.cancelPending();
+      this.turns.delete(key);
+    };
+  }
+
+  forTurn(
+    sessionId: string,
+    promptEntryId: string | undefined,
+  ): Pick<DeskVoiceNavigation, "show"> | undefined {
+    this.prune();
+    if (!promptEntryId) return undefined;
+    const key = `${sessionId}:${promptEntryId}`;
+    const turn = this.turns.get(key);
+    if (!turn) return undefined;
+    return {
+      show: (target) => {
+        this.prune();
+        if (this.turns.get(key) !== turn)
+          return Promise.resolve({
+            shown: false,
+            error: "This text turn can no longer navigate its browser.",
+          });
+        return turn.connection.navigation.show(target);
+      },
+    };
+  }
+
+  handle(login: string, request: DeskNavigationRequest) {
+    const connection = this.owned(login, request.connectionId, request.token);
+    if (!connection) return null;
+    const result = connection.navigation.handle(login, request);
+    if (!result || request.action !== "poll") return result;
+    const pending =
+      [...this.prompts.values()].some((p) => p.connection === connection) ||
+      [...this.turns.values()].some((t) => t.connection === connection);
+    if (!pending) {
+      this.remove(connection);
+      return { command: null, finished: true };
+    }
+    return result;
+  }
+
+  disconnect(login: string, connectionId: string, token: string): boolean {
+    const connection = this.owned(login, connectionId, token);
+    if (!connection) return false;
+    this.remove(connection);
+    return true;
+  }
+}
+
+export const deskTextNavigation = new DeskTextNavigation();

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -48,6 +48,10 @@ import {
   type LiveBackendModel,
 } from "./desk-voice";
 
+import { SHOW_IN_APP_TOOL, showInApp } from "./desk-voice-show";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import type { DeskNavigationRequest } from "../shared/desk-navigation";
+
 export const DESK_LIVE_MODEL = "gpt-live-1";
 /** The default backend (Terra). The instance-wide choice between it and Luna
  * is stored beside the API key; see voiceBackendModel() in desk-voice.ts. */
@@ -123,6 +127,7 @@ export interface LiveFunctionTool {
 export async function buildLiveSessionConfig(
   sessionId: string,
   user = "Open Session",
+  navigationEnabled = false,
 ) {
   // Read per call: the setting can change between calls, and a running call
   // keeps whatever backend it started on.
@@ -130,6 +135,7 @@ export async function buildLiveSessionConfig(
   const turns = await recentDeskTurns(sessionId);
   const tools: LiveFunctionTool[] = [
     ...VOICE_TOOLS,
+    ...(navigationEnabled ? [SHOW_IN_APP_TOOL] : []),
     ...((await listVoiceMcpTools(
       user,
       sessionId,
@@ -159,7 +165,11 @@ export async function buildLiveSessionConfig(
       type: "responses",
       responses: {
         model: backendModel,
-        instructions: LIVE_BACKEND_INSTRUCTIONS,
+        instructions:
+          LIVE_BACKEND_INSTRUCTIONS +
+          (navigationEnabled
+            ? "\nWhen the user asks to see, open, or go to a session or workspace, call show_in_app with its title or name. It opens that page beside the Desk. If it reports several matches, ask which one."
+            : ""),
         tools,
         tool_choice: "auto",
         parallel_tool_calls: true,
@@ -567,6 +577,7 @@ export function formatLiveUsage(t: LiveUsageTotals): string {
 // Call registry.
 
 interface LiveCall {
+  navigation?: DeskVoiceNavigation;
   id: string;
   user: string;
   deskSessionId: string;
@@ -618,6 +629,7 @@ function sendEvent(call: LiveCall, event: Record<string, unknown>): boolean {
 
 function requestClose(call: LiveCall): void {
   if (call.finalized) return;
+  call.navigation?.close();
   sendEvent(call, { type: "session.close" });
   if (!call.closeTimer)
     call.closeTimer = setTimeout(
@@ -637,6 +649,7 @@ function touch(call: LiveCall): void {
 function finalize(call: LiveCall, reason: string, seconds?: number): void {
   if (call.finalized) return;
   call.finalized = true;
+  call.navigation?.close();
   calls.delete(call.id);
   for (const t of [call.idleTimer, call.maxTimer, call.closeTimer])
     if (t) clearTimeout(t);
@@ -786,6 +799,7 @@ function attachSideband(apiKey: string, liveId: string): Promise<WebSocket> {
 const starting = new Map<string, Promise<unknown>>();
 
 export interface LiveCallStarted {
+  navigationToken?: string;
   liveSessionId: string;
   sdp: string;
   sessionId: string;
@@ -796,11 +810,12 @@ export interface LiveCallStarted {
 export function createLiveVoiceCall(
   user: string,
   offerSdp: string,
+  navigationLogin?: string,
 ): Promise<LiveCallStarted> {
   const previous = starting.get(user) ?? Promise.resolve();
   const run = previous
     .catch(() => {})
-    .then(() => createLiveVoiceCallNow(user, offerSdp));
+    .then(() => createLiveVoiceCallNow(user, offerSdp, navigationLogin));
   starting.set(user, run);
   void run
     .catch(() => {})
@@ -813,6 +828,7 @@ export function createLiveVoiceCall(
 async function createLiveVoiceCallNow(
   user: string,
   offerSdp: string,
+  navigationLogin?: string,
 ): Promise<LiveCallStarted> {
   const key = await requireVoiceApiKey();
   const { sessionId } = ensureDeskSession(user);
@@ -822,7 +838,14 @@ async function createLiveVoiceCallNow(
   for (const existing of calls.values())
     if (existing.user === user) requestClose(existing);
 
-  const session = await buildLiveSessionConfig(sessionId, user);
+  const navigation = navigationLogin
+    ? new DeskVoiceNavigation(navigationLogin)
+    : undefined;
+  const session = await buildLiveSessionConfig(
+    sessionId,
+    user,
+    Boolean(navigation),
+  );
   const backendModel = session.delegation.responses.model;
   const res = await fetch(LIVE_SESSIONS_URL, {
     method: "POST",
@@ -853,6 +876,7 @@ async function createLiveVoiceCallNow(
   const socket = await attachSideband(key, liveId);
   const ledger = new VoiceReferenceLedger();
   const call: LiveCall = {
+    navigation,
     id: liveId,
     user,
     deskSessionId: sessionId,
@@ -885,7 +909,10 @@ async function createLiveVoiceCallNow(
       runTool: async (callId, name, args) => {
         let result: unknown;
         try {
-          result = await executeVoiceTool(user, name, args);
+          result =
+            name === SHOW_IN_APP_TOOL.name
+              ? await showInApp(call.navigation, args)
+              : await executeVoiceTool(user, name, args);
         } catch (e) {
           result = { error: e instanceof Error ? e.message : String(e) };
         }
@@ -926,7 +953,13 @@ async function createLiveVoiceCallNow(
   console.log(
     `[desk-voice-live] ${liveId} started user=${user} backend=${backendModel}`,
   );
-  return { liveSessionId: liveId, sdp: answer, sessionId, backendModel };
+  return {
+    liveSessionId: liveId,
+    sdp: answer,
+    sessionId,
+    backendModel,
+    ...(navigation ? { navigationToken: navigation.token } : {}),
+  };
 }
 
 /** The instance's repos, as the ledger needs them to resolve a PR mention:
@@ -980,4 +1013,14 @@ export function closeLiveVoiceCall(
   if (!call) return false;
   requestClose(call);
   return true;
+}
+
+/** Authenticated HTTP only. Neither caller identity nor token comes from the model. */
+export function handleLiveNavigation(
+  login: string,
+  request: DeskNavigationRequest,
+) {
+  return (
+    calls.get(request.connectionId)?.navigation?.handle(login, request) ?? null
+  );
 }

--- a/packages/core/opensession-server/src/server/desk-voice-navigation.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-navigation.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import { handleDeskVoiceRoutes } from "./routes/desk-voice";
+import { deskNavigationRequestSchema } from "../shared/desk-navigation";
+
+const target = { kind: "session", id: "s-1" } as const;
+const poll = (token: string) =>
+  ({ action: "poll", token, connectionId: "call" }) as const;
+
+describe("call-bound voice navigation", () => {
+  test("rejects a different login, missing identity, or another tab's token", async () => {
+    const nav = new DeskVoiceNavigation("alice-login");
+    const result = nav.show(target);
+    expect(nav.handle("other-alice-login", poll(nav.token))).toBeNull();
+    expect(nav.handle("", poll(nav.token))).toBeNull();
+    expect(nav.handle("alice-login", poll(crypto.randomUUID()))).toBeNull();
+    expect(nav.handle("ALICE-LOGIN", poll(nav.token))).toMatchObject({
+      command: { target },
+    });
+    nav.close();
+    expect(await result).toMatchObject({ shown: false });
+    expect(nav.handle("alice-login", poll(nav.token))).toBeNull();
+    expect(await nav.show(target)).toMatchObject({ shown: false });
+  });
+
+  test("bounds pending work, rejects wrong acknowledgments, and reports browser failure", async () => {
+    const nav = new DeskVoiceNavigation("alice");
+    const result = nav.show(target);
+    expect(await nav.show(target)).toMatchObject({ shown: false });
+    const response = nav.handle("alice", poll(nav.token));
+    if (!response || !("command" in response) || !response.command)
+      throw new Error("missing command");
+    const ack = {
+      action: "ack",
+      connectionId: "call",
+      token: nav.token,
+      commandId: response.command.id,
+      shown: false,
+    } as const;
+    expect(nav.handle("other", ack)).toBeNull();
+    expect(
+      nav.handle("alice", { ...ack, commandId: crypto.randomUUID() }),
+    ).toEqual({ ok: false });
+    expect(nav.handle("alice", ack)).toEqual({ ok: true });
+    expect(await result).toMatchObject({
+      shown: false,
+      error: expect.stringContaining("could not show"),
+    });
+    expect(nav.handle("alice", ack)).toEqual({ ok: false });
+    expect(nav.handle("alice", poll(nav.token))).toEqual({ command: null });
+    nav.close();
+  });
+
+  test("times out without claiming the page was shown", async () => {
+    const nav = new DeskVoiceNavigation("alice", 5);
+    expect(await nav.show(target)).toEqual({
+      shown: false,
+      error: "The voice window did not confirm navigation.",
+    });
+    expect(nav.handle("alice", poll(nav.token))).toEqual({ command: null });
+    nav.close();
+  });
+
+  test("HTTP rejects claimed users, malformed messages and unknown calls", async () => {
+    async function request(body: unknown, login?: string) {
+      const url = new URL("http://localhost/api/desk/voice/live/navigation");
+      return handleDeskVoiceRoutes({
+        req: new Request(url, {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+        }),
+        url,
+        path: url.pathname,
+        publicPrefix: "",
+        authUser: login ? { login, name: "Same Name" } : null,
+      });
+    }
+    expect(
+      (await request({ ...poll(crypto.randomUUID()), user: "Alice" }))?.status,
+    ).toBe(401);
+    expect(
+      (await request({ ...poll(crypto.randomUUID()), user: "Alice" }, "alice"))
+        ?.status,
+    ).toBe(400);
+    const missing = await request(poll(crypto.randomUUID()), "alice");
+    expect(missing?.status).toBe(404);
+    expect(missing?.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      deskNavigationRequestSchema.safeParse({
+        ...poll(crypto.randomUUID()),
+        action: "ack",
+        path: "/settings",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-navigation.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-navigation.ts
@@ -1,0 +1,98 @@
+import type {
+  DeskNavigationCommand,
+  DeskNavigationRequest,
+  DeskShowTarget,
+} from "../shared/desk-navigation";
+
+export type DeskNavigationResult =
+  | { shown: true }
+  | { shown: false; error: string };
+
+/** One browser capability per call, never included in prompts or transcripts.
+ * The HTTP route requires both its token and the verified login that started it.
+ * Nothing is broadcast to the user's other tabs or to a name-matched user.
+ */
+export class DeskVoiceNavigation {
+  readonly token = crypto.randomUUID();
+  private pending: {
+    command: DeskNavigationCommand;
+    finish: (result: DeskNavigationResult) => void;
+  } | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly login: string,
+    private readonly timeoutMs = 10_000,
+  ) {}
+
+  handle(
+    login: string,
+    request: DeskNavigationRequest,
+  ): { command: DeskNavigationCommand | null } | { ok: boolean } | null {
+    if (
+      this.closed ||
+      !login ||
+      login.toLowerCase() !== this.login.toLowerCase() ||
+      request.token !== this.token
+    )
+      return null;
+    if (request.action === "poll")
+      return { command: this.pending?.command ?? null };
+    if (this.pending?.command.id !== request.commandId) return { ok: false };
+    this.pending.finish(
+      request.shown
+        ? { shown: true }
+        : { shown: false, error: "The voice window could not show that page." },
+    );
+    return { ok: true };
+  }
+
+  show(target: DeskShowTarget): Promise<DeskNavigationResult> {
+    if (this.closed)
+      return Promise.resolve({
+        shown: false,
+        error: "The voice call has ended.",
+      });
+    if (this.pending)
+      return Promise.resolve({
+        shown: false,
+        error:
+          "Another navigation is pending. Wait for it before opening another page.",
+      });
+    return new Promise((resolve) => {
+      const timer = setTimeout(
+        () =>
+          finish({
+            shown: false,
+            error: "The voice window did not confirm navigation.",
+          }),
+        this.timeoutMs,
+      );
+      const finish = (result: DeskNavigationResult) => {
+        clearTimeout(timer);
+        this.pending = null;
+        resolve(result);
+      };
+      this.pending = {
+        command: {
+          id: crypto.randomUUID(),
+          target,
+          expiresAt: Date.now() + this.timeoutMs,
+        },
+        finish,
+      };
+    });
+  }
+
+  cancelPending(): void {
+    this.pending?.finish({
+      shown: false,
+      error: "The navigation request is no longer active.",
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.pending?.finish({ shown: false, error: "The voice call has ended." });
+  }
+}

--- a/packages/core/opensession-server/src/server/desk-voice-show.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SHOW_IN_APP_TOOL,
+  resolveShowTarget,
+  showInApp,
+} from "./desk-voice-show";
+import { buildLiveSessionConfig } from "./desk-voice-live";
+import { registerSessionControl, type SessionControl } from "./session-control";
+import type { Workspace } from "./workspaces";
+import { DeskVoiceNavigation } from "./desk-voice-navigation";
+import { buildVoiceSessionConfig } from "./desk-voice";
+
+type Summary = ReturnType<SessionControl["listSessions"]>[number];
+
+function summary(
+  id: string,
+  title: string,
+  extra: Partial<Summary> = {},
+): Summary {
+  return {
+    id,
+    title,
+    state: "idle",
+    queuedCount: 0,
+    controllable: true,
+    createdBy: "Michiel",
+    createdAt: "2026-09-10T09:00:00.000Z",
+    lastActivity: "2026-09-10T10:00:00.000Z",
+    ...extra,
+  } as Summary;
+}
+
+const sessions: Summary[] = [
+  summary("s-deploy", "Fix the deploy watchdog"),
+  summary("s-deploy-old", "Fix the deploy watchdog", {
+    lastActivity: "2026-09-01T10:00:00.000Z",
+  }),
+  summary("s-captions", "Voice captions for the Desk"),
+  summary("s-lint", "Vendor lint rules"),
+  summary("s-desk", "Desk", { desk: true }),
+  summary("s-archived", "Archived captions work", { state: "archived" }),
+];
+
+const workspaces: Workspace[] = [
+  {
+    id: "ws-1",
+    name: "Deploy reliability",
+    createdBy: "Michiel",
+    createdAt: "2026-09-01T09:00:00.000Z",
+  },
+  {
+    id: "ws-2",
+    name: "Desk voice",
+    createdBy: "Michiel",
+    createdAt: "2026-09-02T09:00:00.000Z",
+  },
+];
+
+function control(): Pick<SessionControl, "listSessions" | "getSession"> {
+  return {
+    listSessions: () => sessions,
+    getSession: (id) => sessions.find((s) => s.id === id),
+  };
+}
+
+const deps = {
+  control: control(),
+  listWorkspaces: async () => workspaces,
+  getWorkspace: async (id: string) =>
+    workspaces.find((w) => w.id === id) ?? null,
+};
+
+describe("show_in_app target resolution", () => {
+  test("takes a session id directly", async () => {
+    expect(await resolveShowTarget({ session: "s-lint" }, deps)).toEqual({
+      target: { kind: "session", id: "s-lint", title: "Vendor lint rules" },
+    });
+  });
+
+  test("asks which one even when duplicate titles match exactly", async () => {
+    expect(
+      await resolveShowTarget({ session: "fix the deploy watchdog" }, deps),
+    ).toMatchObject({
+      error: expect.stringContaining("Several"),
+      candidates: [
+        { id: "s-deploy", title: "Fix the deploy watchdog" },
+        { id: "s-deploy-old", title: "Fix the deploy watchdog" },
+      ],
+    });
+  });
+
+  test("accepts a distinctive part of a title", async () => {
+    expect(await resolveShowTarget({ session: "lint" }, deps)).toEqual({
+      target: { kind: "session", id: "s-lint", title: "Vendor lint rules" },
+    });
+  });
+
+  test("asks back with candidates when a part matches several", async () => {
+    const result = await resolveShowTarget({ session: "deploy" }, deps);
+    expect(result).toMatchObject({ error: expect.stringContaining("Several") });
+    expect("candidates" in result && result.candidates).toEqual([
+      { id: "s-deploy", title: "Fix the deploy watchdog" },
+      { id: "s-deploy-old", title: "Fix the deploy watchdog" },
+    ]);
+  });
+
+  test("never lands on the Desk or on archived sessions by title", async () => {
+    expect(await resolveShowTarget({ session: "s-desk" }, deps)).toMatchObject({
+      error: expect.stringContaining("No session"),
+    });
+    // "captions" would be ambiguous if the archived session counted.
+    expect(await resolveShowTarget({ session: "captions" }, deps)).toEqual({
+      target: {
+        kind: "session",
+        id: "s-captions",
+        title: "Voice captions for the Desk",
+      },
+    });
+  });
+
+  test("resolves a workspace by id or name", async () => {
+    expect(await resolveShowTarget({ workspace: "ws-2" }, deps)).toEqual({
+      target: { kind: "workspace", id: "ws-2", name: "Desk voice" },
+    });
+    expect(
+      await resolveShowTarget({ workspace: "deploy reliability" }, deps),
+    ).toEqual({
+      target: { kind: "workspace", id: "ws-1", name: "Deploy reliability" },
+    });
+  });
+
+  test("refuses an empty request and non-string arguments", async () => {
+    expect(await resolveShowTarget({}, deps)).toMatchObject({
+      error: expect.stringContaining("exactly one"),
+    });
+    expect(
+      await resolveShowTarget({ session: { id: "s-lint" } }, deps),
+    ).toMatchObject({ error: expect.any(String) });
+  });
+});
+
+describe("show_in_app authorization and delivery", () => {
+  function registerStubControl() {
+    registerSessionControl({
+      ...control(),
+      transcriptTail: async () => [],
+      answerQuestion: () => false,
+      deliverToSession: async () => ({
+        status: "error" as const,
+        message: "not used",
+      }),
+      cancelSession: () => false,
+      reparentSession: async () => ({ ok: false, error: "not used" }),
+      createSession: async () => ({
+        id: "unused",
+        createdBy: "Test",
+        createdAt: "2026-09-10T09:00:00.000Z",
+      }),
+    });
+  }
+
+  test("fails closed without a verified call capability", async () => {
+    expect(await showInApp(undefined, { session: "lint" })).toMatchObject({
+      shown: false,
+    });
+  });
+
+  test("returns success only after the owning browser acknowledges", async () => {
+    registerStubControl();
+    const nav = new DeskVoiceNavigation("signed-in-login");
+    const pending = showInApp(nav, { session: "lint" });
+    await Promise.resolve();
+    const polled = nav.handle("signed-in-login", {
+      action: "poll",
+      connectionId: "call",
+      token: nav.token,
+    });
+    if (!polled || !("command" in polled) || !polled.command)
+      throw new Error("missing command");
+    nav.handle("signed-in-login", {
+      action: "ack",
+      connectionId: "call",
+      token: nav.token,
+      commandId: polled.command.id,
+      shown: true,
+    });
+    expect(await pending).toEqual({
+      shown: true,
+      kind: "session",
+      id: "s-lint",
+      title: "Vendor lint rules",
+    });
+    nav.close();
+  });
+
+  test("rejects multiple targets, extra navigation parameters and oversized names", async () => {
+    for (const args of [
+      { session: "lint", workspace: "ws-1" },
+      { session: "lint", url: "https://example.invalid" },
+      { workspace: "x".repeat(257) },
+    ]) {
+      expect(await resolveShowTarget(args, deps)).toMatchObject({
+        error: expect.any(String),
+      });
+    }
+  });
+
+  test("is advertised only to a capable web voice backend, never native", async () => {
+    registerStubControl();
+    const enabled = await buildLiveSessionConfig(
+      "missing-test-session",
+      "Test",
+      true,
+    );
+    const disabled = await buildLiveSessionConfig("missing-test-session");
+    const native = await buildVoiceSessionConfig("missing-test-session");
+    expect(
+      enabled.delegation.responses.tools.some(
+        (t) => t.name === SHOW_IN_APP_TOOL.name,
+      ),
+    ).toBe(true);
+    expect(
+      disabled.delegation.responses.tools.some(
+        (t) => t.name === SHOW_IN_APP_TOOL.name,
+      ),
+    ).toBe(false);
+    expect(native.tools.some((t) => t.name === SHOW_IN_APP_TOOL.name)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/opensession-server/src/server/desk-voice-show.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.ts
@@ -1,0 +1,160 @@
+import { getSessionControl, type SessionControl } from "./session-control";
+import { getWorkspace, listWorkspaces, type Workspace } from "./workspaces";
+import { deskShowTargetSchema } from "../shared/desk-navigation";
+import type { DeskVoiceNavigation } from "./desk-voice-navigation";
+
+export const SHOW_IN_APP_TOOL = {
+  type: "function",
+  name: "show_in_app",
+  description:
+    "Bring a session or a workspace up in the user's own Open Session window, next to the Desk. Use when they ask to see, open, show, or go to something. Give the session's id or its title (a distinctive part is enough), or the workspace's id or name. Only changes the page shown in this voice call's browser.",
+  parameters: {
+    type: "object",
+    properties: {
+      session: {
+        type: "string",
+        description: "Session id, or its title or a distinctive part of it",
+      },
+      workspace: {
+        type: "string",
+        description: "Workspace id or name",
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  },
+} as const;
+
+export type ShowTarget =
+  | { kind: "session"; id: string; title: string }
+  | { kind: "workspace"; id: string; name: string };
+
+export type ShowResolution =
+  | { target: ShowTarget }
+  | { error: string; candidates?: Array<{ id: string; title: string }> };
+
+/** How many near-matches the backend gets to disambiguate with. */
+const MAX_CANDIDATES = 5;
+
+function normalize(text: string): string {
+  return text.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+/** Exact names take precedence, but duplicate names always need clarification. */
+function pick<T extends { id: string; title: string; recency?: string }>(
+  query: string,
+  items: T[],
+  what: string,
+):
+  | { item: T }
+  | { error: string; candidates?: Array<{ id: string; title: string }> } {
+  const q = normalize(query);
+  if (!q) return { error: `Name the ${what} to show.` };
+  const exact = items.filter((i) => normalize(i.title) === q);
+  const partial = exact.length
+    ? exact
+    : items.filter((i) => normalize(i.title).includes(q));
+  if (partial.length === 1) return { item: partial[0]! };
+  if (!partial.length) return { error: `No ${what} matches "${query}".` };
+  partial.sort((a, b) => (b.recency ?? "").localeCompare(a.recency ?? ""));
+  return {
+    error: `Several ${what}s match "${query}"; ask which one.`,
+    candidates: partial
+      .slice(0, MAX_CANDIDATES)
+      .map(({ id, title }) => ({ id, title })),
+  };
+}
+
+export async function resolveShowTarget(
+  args: Record<string, unknown>,
+  deps: {
+    control: Pick<SessionControl, "listSessions" | "getSession">;
+    listWorkspaces: () => Promise<Workspace[]>;
+    getWorkspace: (id: string) => Promise<Workspace | null>;
+  },
+): Promise<ShowResolution> {
+  const session = typeof args.session === "string" ? args.session.trim() : "";
+  const workspace =
+    typeof args.workspace === "string" ? args.workspace.trim() : "";
+
+  if (
+    Object.keys(args).some((key) => key !== "session" && key !== "workspace") ||
+    Boolean(session) === Boolean(workspace) ||
+    (args.session !== undefined && typeof args.session !== "string") ||
+    (args.workspace !== undefined && typeof args.workspace !== "string") ||
+    session.length > 256 ||
+    workspace.length > 256
+  ) {
+    return { error: "Name exactly one session or workspace to show." };
+  }
+
+  if (session) {
+    // The Desk itself is hidden from every list; a call never lands on it.
+    const byId = deps.control.getSession(session);
+    if (byId && !byId.desk)
+      return {
+        target: { kind: "session", id: byId.id, title: byId.title || "" },
+      };
+    const visible = deps.control
+      .listSessions()
+      .filter((s) => !s.desk && s.state !== "archived")
+      .map((s) => ({
+        id: s.id,
+        title: s.title || "",
+        recency: s.lastActivity ?? s.createdAt,
+      }));
+    const found = pick(session, visible, "session");
+    if ("error" in found) return found;
+    return {
+      target: { kind: "session", id: found.item.id, title: found.item.title },
+    };
+  }
+
+  if (workspace) {
+    const byId = await deps.getWorkspace(workspace);
+    if (byId)
+      return { target: { kind: "workspace", id: byId.id, name: byId.name } };
+    const all = (await deps.listWorkspaces()).map((w) => ({
+      id: w.id,
+      title: w.name,
+      recency: w.createdAt,
+    }));
+    const found = pick(workspace, all, "workspace");
+    if ("error" in found) return found;
+    return {
+      target: { kind: "workspace", id: found.item.id, name: found.item.title },
+    };
+  }
+
+  return { error: "Say which session or workspace to show." };
+}
+
+/** Team members can view the shared session/workspace catalog, as in the UI.
+ * The call-bound capability is the authorization to navigate one browser. It
+ * exists only for verified web callers, never for native or generic MCP calls.
+ */
+export async function showInApp(
+  navigation: Pick<DeskVoiceNavigation, "show"> | undefined,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  if (!navigation)
+    return {
+      shown: false,
+      error: "Navigation requires a signed-in browser connection.",
+    };
+  const resolved = await resolveShowTarget(args, {
+    control: getSessionControl(),
+    listWorkspaces,
+    getWorkspace,
+  });
+  if ("error" in resolved) return resolved;
+  const { target } = resolved;
+  const safe = deskShowTargetSchema.safeParse({
+    kind: target.kind,
+    id: target.id,
+  });
+  if (!safe.success)
+    return { shown: false, error: "That page cannot be opened by voice." };
+  const result = await navigation.show(safe.data);
+  return { ...target, ...result };
+}

--- a/packages/core/opensession-server/src/server/desk.ts
+++ b/packages/core/opensession-server/src/server/desk.ts
@@ -130,6 +130,7 @@ export const DESK_NOTE = `## Your role: the Desk
 
 This session is the user's Desk — their standing concierge, summoned as a quick overlay on top of whatever they're doing. Discipline:
 
+- When asked to show, open, or go to a session or workspace, use show_in_app when available. It changes the page beside this Desk. Ask which one if names are ambiguous; never claim navigation succeeded without the tool result. If the tool is unavailable, say that this message has no connected browser to navigate.
 - Keep answers short and immediate; the user is mid-task and will close this overlay in seconds.
 - Manage their todo list with the opensession-todos tools: capture items the moment they mention wanting/needing to do something ("I want to finish X today" → add_todo), mark things done when they say so, and use list_todos before answering "what's on my plate?".
 - Ask mode only makes the repository checkout read-only; it does not prevent updating todos through their tools. If earlier messages in this Desk conversation claim otherwise, those refusals are outdated: correct them and use the requested Desk tool directly.

--- a/packages/core/opensession-server/src/server/host-client.ts
+++ b/packages/core/opensession-server/src/server/host-client.ts
@@ -642,6 +642,7 @@ async function spawnHostRun(
     registerRunToken(rpcToken, {
       sessionId: opts.osSessionId,
       user: opts.user,
+      promptEntryId: opts.promptEntryId,
     });
 
   let handle: HostHandle | undefined;
@@ -1902,6 +1903,7 @@ export async function resumeLocalHostRun(
     registerRunToken(spec.rpcToken, {
       sessionId: spec.osSessionId,
       user: spec.user,
+      promptEntryId: spec.promptEntryId,
     });
   }
   const handle = new HostHandle(

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -13,6 +13,7 @@
  * papercutsServerFor and the automation guard in the run-rpc builder below.
  */
 
+import { deskNavigationMcp } from "./desk-navigation-mcp";
 import { createSessionsMcpServer } from "../agents/slack/sessions-tools";
 import { isDevInstance } from "./dev-mode";
 import { createRunnersMcpServer } from "./runners-mcp";
@@ -138,6 +139,7 @@ function desktopServerFor(sessionId: string): Record<string, unknown> {
 export function interactiveMcpServers(
   user?: string,
   sessionId?: string,
+  promptEntryId?: string,
 ): Record<string, unknown> {
   const createdBy = user || productName();
   return {
@@ -186,6 +188,7 @@ export function interactiveMcpServers(
     // the others) from automation runs — see the runSessionPrompt call site.
     ...(sessionId
       ? {
+          ...deskNavigationMcp(sessionId, promptEntryId),
           "opensession-humans": createHumansMcpServer({
             sessionId,
             createdBy,
@@ -504,7 +507,7 @@ export async function automationSessionMcp(
   };
 }
 
-registerInteractiveMcpBuilder(async (sessionId, user) => {
+registerInteractiveMcpBuilder(async (sessionId, user, promptEntryId) => {
   // Automation-owned sessions run on untrusted event/ticket text. Their runs
   // only ever carry the automation-bar set (automationSessionMcp above), but
   // this builder is also run-rpc's FALLBACK resolver for any registered run
@@ -514,7 +517,7 @@ registerInteractiveMcpBuilder(async (sessionId, user) => {
   if (sessionId && session?.automation) {
     return automationSessionMcp(session, sessionId);
   }
-  const servers = interactiveMcpServers(user, sessionId);
+  const servers = interactiveMcpServers(user, sessionId, promptEntryId);
   const goalId = session?.goalId;
   if (goalId)
     (servers as Record<string, unknown>)["opensession-goal-self"] =

--- a/packages/core/opensession-server/src/server/queued-steer.ts
+++ b/packages/core/opensession-server/src/server/queued-steer.ts
@@ -1,3 +1,4 @@
+import { deskTextNavigation } from "./desk-text-navigation";
 import {
   currentAgentRunToken,
   interruptAndSteerAgentRunToken,
@@ -144,6 +145,7 @@ export async function prepareAndSteerQueuedPrompt(
       throw new Error("Pending steer changed before fenced rejection");
     return "rejected";
   }
+  deskTextNavigation.steer(input.sessionId, input.itemId);
   if (!deps.steer(before.token, input.text, input.images, input.itemId)) {
     if (!(await deps.reject(input.sessionId, input.itemId, before)))
       throw new Error("Pending steer changed before fenced rejection");

--- a/packages/core/opensession-server/src/server/routes/desk-navigation.ts
+++ b/packages/core/opensession-server/src/server/routes/desk-navigation.ts
@@ -1,0 +1,78 @@
+import type { RouteContext } from "./context";
+import { findSessionAsync } from "../session-cache";
+import { deskTextNavigation } from "../desk-text-navigation";
+import {
+  deskNavigationBindSchema,
+  deskNavigationConnectSchema,
+  deskNavigationConnectionSchema,
+  deskNavigationRequestSchema,
+} from "../../shared/desk-navigation";
+
+export async function handleDeskNavigationRoutes(
+  ctx: RouteContext,
+): Promise<Response | undefined> {
+  if (
+    !ctx.path.startsWith("/api/desk/navigation/") ||
+    ctx.req.method !== "POST"
+  )
+    return undefined;
+  const reply = (body: object, status = 200) =>
+    Response.json(body, { status, headers: { "Cache-Control": "no-store" } });
+  const identity = ctx.authUser;
+  if (
+    !identity?.login ||
+    ("automation" in identity && identity.automation === true)
+  )
+    return reply({ error: "Sign in to navigate from Desk." }, 401);
+  const body = await ctx.req.json().catch(() => null);
+  const login = identity.login;
+  switch (ctx.path) {
+    case "/api/desk/navigation/connect": {
+      const parsed = deskNavigationConnectSchema.safeParse(body);
+      if (!parsed.success) return reply({ error: "Invalid Desk session" }, 400);
+      const session = await findSessionAsync(parsed.data.sessionId);
+      // A Desk is a shared team-readable session, but only this verified sender's
+      // browser receives the capability. No capability for ordinary/automated work.
+      if (
+        !session?.desk ||
+        session.automation ||
+        session.automationDescendantPolicy
+      )
+        return reply({ error: "Not an interactive Desk session" }, 403);
+      const connection = deskTextNavigation.connect(session.id, login);
+      return connection
+        ? reply(connection, 201)
+        : reply({ error: "Too many navigation connections" }, 429);
+    }
+    case "/api/desk/navigation/bind": {
+      const parsed = deskNavigationBindSchema.safeParse(body);
+      if (!parsed.success)
+        return reply({ error: "Invalid navigation binding" }, 400);
+      const { connectionId, token, requestId } = parsed.data;
+      const ok = deskTextNavigation.bind(login, connectionId, token, requestId);
+      return reply({ ok }, ok ? 200 : 404);
+    }
+    case "/api/desk/navigation/poll": {
+      const parsed = deskNavigationRequestSchema.safeParse(body);
+      if (!parsed.success)
+        return reply({ error: "Invalid navigation request" }, 400);
+      const result = deskTextNavigation.handle(login, parsed.data);
+      return result
+        ? reply(result)
+        : reply({ error: "No navigation connection" }, 404);
+    }
+    case "/api/desk/navigation/disconnect": {
+      const parsed = deskNavigationConnectionSchema.strict().safeParse(body);
+      if (!parsed.success)
+        return reply({ error: "Invalid navigation connection" }, 400);
+      const ok = deskTextNavigation.disconnect(
+        login,
+        parsed.data.connectionId,
+        parsed.data.token,
+      );
+      return reply({ ok }, ok ? 200 : 404);
+    }
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/opensession-server/src/server/routes/desk-voice.ts
+++ b/packages/core/opensession-server/src/server/routes/desk-voice.ts
@@ -30,9 +30,12 @@ import {
 } from "../desk-voice";
 import {
   closeLiveVoiceCall,
+  handleLiveNavigation,
   createLiveVoiceCall,
   sendLiveVoiceText,
 } from "../desk-voice-live";
+
+import { deskNavigationRequestSchema } from "../../shared/desk-navigation";
 
 /** An SDP offer is a few KB; anything bigger is not a browser offer. */
 const MAX_SDP_BYTES = 64 * 1024;
@@ -86,6 +89,29 @@ export async function handleDeskVoiceRoutes(
     return voiceStatus();
   }
 
+  if (path === "/api/desk/voice/live/navigation" && req.method === "POST") {
+    // Unlike legacy voice attribution, navigation never trusts body.user or a
+    // first name. The unguessable capability is returned only to the call's tab.
+    if (!ctx.authUser?.login)
+      return Response.json(
+        { error: "Sign in to navigate by voice." },
+        { status: 401 },
+      );
+    const parsed = deskNavigationRequestSchema.safeParse(
+      await req.json().catch(() => null),
+    );
+    if (!parsed.success)
+      return Response.json(
+        { error: "Invalid navigation request" },
+        { status: 400 },
+      );
+    const result = handleLiveNavigation(ctx.authUser.login, parsed.data);
+    return Response.json(result ?? { error: "No navigation-capable call" }, {
+      status: result ? 200 : 404,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
   if (path === "/api/desk/voice/live" && req.method === "POST") {
     const body = await req.json().catch(() => null);
     if (
@@ -101,9 +127,16 @@ export async function handleDeskVoiceRoutes(
     const user = requestUser(ctx, body.user);
     if (!user) return Response.json({ error: "missing user" }, { status: 400 });
     try {
-      return Response.json(await createLiveVoiceCall(user, body.sdp), {
-        status: 201,
-      });
+      return Response.json(
+        await createLiveVoiceCall(
+          user,
+          body.sdp,
+          body.navigation === true ? ctx.authUser?.login : undefined,
+        ),
+        {
+          status: 201,
+        },
+      );
     } catch (e: any) {
       return Response.json({ error: e?.message || String(e) }, { status: 502 });
     }

--- a/packages/core/opensession-server/src/server/routes/index.ts
+++ b/packages/core/opensession-server/src/server/routes/index.ts
@@ -48,6 +48,7 @@ import { handlePapercutsRoutes } from "./papercuts";
 import { handleLibraryRoutes } from "./library";
 import { handleTodosRoutes } from "./todos";
 import { handleDeskVoiceRoutes } from "./desk-voice";
+import { handleDeskNavigationRoutes } from "./desk-navigation";
 import { handleWorkflowsRoutes } from "./workflows";
 import { handleReportsRoutes } from "./reports";
 import { handleAnalyticsRoutes } from "./analytics";
@@ -110,6 +111,7 @@ export const routeHandlers: RouteHandler[] = [
   handleLibraryRoutes,
   handleTodosRoutes,
   handleDeskVoiceRoutes,
+  handleDeskNavigationRoutes,
   handleWorkflowsRoutes,
   handleReportsRoutes,
   handleAnalyticsRoutes,

--- a/packages/core/opensession-server/src/server/routes/workspace.ts
+++ b/packages/core/opensession-server/src/server/routes/workspace.ts
@@ -494,6 +494,8 @@ export async function handleWorkspaceRoutes(
     // defaults on every row multiplied the payload by the workspace count.
     let workspaces = await listWorkspaces();
     const activeOnly = url.searchParams.get("active") === "1";
+    // Keep a directly opened empty/archived workspace in the sidebar projection.
+    const includeWorkspaceId = url.searchParams.get("includeWorkspaceId");
     if (activeOnly) {
       const indexedIds = await indexedActiveWorkspaceIds();
       const activeWorkspaceIds = new Set(
@@ -505,6 +507,7 @@ export async function handleWorkspaceRoutes(
       const openPrs = getOpenPrs();
       workspaces = workspaces.filter(
         (workspace) =>
+          workspace.id === includeWorkspaceId ||
           activeWorkspaceIds.has(workspace.id) ||
           !!workspace.draft ||
           workspaceBacksOpenPr(workspace, openPrs, defaultRepo().id),

--- a/packages/core/opensession-server/src/server/run-rpc.ts
+++ b/packages/core/opensession-server/src/server/run-rpc.ts
@@ -42,6 +42,8 @@ const g = globalThis as any;
 const RPC_TOOL_CALL_TIMEOUT_MS = 30 * 60 * 1000;
 
 export interface RunTokenContext {
+  /** Server-owned dispatch identity, never accepted from an MCP request body. */
+  promptEntryId?: string;
   sessionId: string;
   user?: string;
 }
@@ -90,6 +92,7 @@ export function timingSafeEqStr(a: string, b: string): boolean {
 export type InteractiveMcpBuilder = (
   sessionId: string,
   user?: string,
+  promptEntryId?: string,
 ) => Record<string, any> | Promise<Record<string, any>>;
 
 export function registerInteractiveMcpBuilder(b: InteractiveMcpBuilder): void {
@@ -165,7 +168,7 @@ export async function dispatchRunRpc(
   const perSession = sessionServers.get(ctx.sessionId);
   const cfg =
     perSession?.[serverName] ??
-    (await builder(ctx.sessionId, ctx.user))[serverName];
+    (await builder(ctx.sessionId, ctx.user, ctx.promptEntryId))[serverName];
   if (!cfg?.instance) {
     // tools/list for a server this session doesn't carry (shared servers list
     // the union of in-process servers in their config) answers with an empty

--- a/packages/core/opensession-server/src/server/run-session.ts
+++ b/packages/core/opensession-server/src/server/run-session.ts
@@ -8,6 +8,7 @@
  * cache in session-cache.ts.
  */
 
+import { deskTextNavigation } from "./desk-text-navigation";
 import type { McpScope } from "./runner-shared";
 import { randomUUIDv7 } from "bun";
 import { existsSync, mkdirSync, readFileSync } from "fs";
@@ -710,6 +711,7 @@ export async function steerQueuedPrompt(
       undefined,
       undefined,
       promptEntryId,
+      [item.id],
     ).catch(async (e) => {
       console.error(`[queue] Send-now delivery failed for ${sessionId}:`, e);
       await failPromptDispatch(sessionId, promptEntryId);
@@ -1826,6 +1828,7 @@ export function sandboxRunSecuritySpec(
   session: UnifiedSession,
   opts: {
     isAutomationSession: boolean;
+    promptEntryId?: string;
     user?: string;
     accountUser?: string;
     mcpServers?: McpScope;
@@ -1851,7 +1854,9 @@ export function sandboxRunSecuritySpec(
     proxyMcpServers: opts.isAutomationSession
       ? []
       : [
-          ...Object.keys(interactiveMcpServers(opts.user, session.id)),
+          ...Object.keys(
+            interactiveMcpServers(opts.user, session.id, opts.promptEntryId),
+          ),
           ...(session.goalId ? ["opensession-goal-self"] : []),
         ],
     reposNote: undefined,
@@ -2114,6 +2119,7 @@ export async function maybeLaunchSandboxedRun(
     registerRunToken(rpcToken, {
       sessionId: session.id,
       user: opts.isAutomationSession ? undefined : opts.user,
+      promptEntryId: opts.promptEntryId,
     });
     // Detached sandbox hosts cannot read the server's workspace store. Resolve
     // the picker-only workspace preset before crossing that boundary. A preset
@@ -2557,6 +2563,11 @@ export async function runSessionPrompt(
     watchExternalRunAndDrain(sessionId);
     throw new RunPreparationDeferredError(sessionId);
   }
+  const finishDeskNavigation = deskTextNavigation.begin(
+    sessionId,
+    durablePromptEntryId,
+    sourceMessageIds,
+  );
   try {
     await runSessionPromptInner(
       sessionId,
@@ -2590,6 +2601,7 @@ export async function runSessionPrompt(
       await acknowledgePromptDispatch(sessionId, durablePromptEntryId);
     throw e;
   } finally {
+    finishDeskNavigation();
     unmarkSessionStarting(sessionId, startToken);
   }
 }
@@ -3152,7 +3164,13 @@ async function runSessionPromptInner(
             : isAutomationSession
               ? Object.keys(automationMcp)
               : [
-                  ...Object.keys(interactiveMcpServers(user, sessionId)),
+                  ...Object.keys(
+                    interactiveMcpServers(
+                      user,
+                      sessionId,
+                      durablePromptEntryId,
+                    ),
+                  ),
                   ...(session.goalId ? ["opensession-goal-self"] : []),
                 ],
           reposNote: isAutomationSession
@@ -3186,12 +3204,16 @@ async function runSessionPromptInner(
               ? automationMcp
               : session.goalId
                 ? {
-                    ...interactiveMcpServers(user, sessionId),
+                    ...interactiveMcpServers(
+                      user,
+                      sessionId,
+                      durablePromptEntryId,
+                    ),
                     "opensession-goal-self": createGoalSelfMcpServer(
                       session.goalId,
                     ),
                   }
-                : interactiveMcpServers(user, sessionId),
+                : interactiveMcpServers(user, sessionId, durablePromptEntryId),
         })
       : null;
 
@@ -3265,12 +3287,12 @@ async function runSessionPromptInner(
           ? automationMcp
           : session.goalId
             ? {
-                ...interactiveMcpServers(user, sessionId),
+                ...interactiveMcpServers(user, sessionId, durablePromptEntryId),
                 "opensession-goal-self": createGoalSelfMcpServer(
                   session.goalId,
                 ),
               }
-            : interactiveMcpServers(user, sessionId),
+            : interactiveMcpServers(user, sessionId, durablePromptEntryId),
       reposNote: isAutomationSession
         ? undefined
         : await buildSessionNote(session, user),

--- a/packages/core/opensession-server/src/server/runner-session.ts
+++ b/packages/core/opensession-server/src/server/runner-session.ts
@@ -238,7 +238,11 @@ export async function maybeLaunchRunnerRun(
     startedAt: priorRun?.startedAt ?? new Date().toISOString(),
   };
   await journalSet(run);
-  registerRunToken(rpcToken, { sessionId: session.id, user: runUser });
+  registerRunToken(rpcToken, {
+    sessionId: session.id,
+    user: runUser,
+    promptEntryId: opts.promptEntryId,
+  });
   registerRunWsHost(hostId, wsToken);
   const hostSpecs = new Map<string, RunHostSpec>([[hostId, spec]]);
 
@@ -445,7 +449,11 @@ export async function resumeRunnerRun(
       : candidates.at(-1);
   if (!candidate) return null;
   const spec = candidate.spec;
-  registerRunToken(spec.rpcToken!, { sessionId: session.id, user: spec.user });
+  registerRunToken(spec.rpcToken!, {
+    sessionId: session.id,
+    user: spec.user,
+    promptEntryId: spec.promptEntryId,
+  });
   registerRunWsHost(spec.hostId, spec.wsToken!);
   const alive = await runnerHostStatus(run.runnerId, {
     sessionId: session.id,

--- a/packages/core/opensession-server/src/server/ws-handlers.ts
+++ b/packages/core/opensession-server/src/server/ws-handlers.ts
@@ -5,6 +5,7 @@
  * run-ws.ts before any of this runs.
  */
 
+import { deskTextNavigation } from "./desk-text-navigation";
 import { parseSidebarSessionScope } from "./sidebar-session-scope";
 import type { WebSocketHandler } from "bun";
 import type { WSClientData } from "./ws-hub";
@@ -1413,6 +1414,20 @@ export const websocketHandlers: WebSocketHandler<WSClientData> = {
           // stop latch here rather than inside the run the latch prevents. Without
           // this the message below queues durably and the drain parks it forever.
           await liftUserStop(sessionId);
+
+          if (
+            session.desk &&
+            !session.automation &&
+            !session.automationDescendantPolicy
+          ) {
+            deskTextNavigation.accept(
+              sessionId,
+              msg.requestId,
+              ws.data.authAutomation
+                ? undefined
+                : ws.data.authLogin || undefined,
+            );
+          }
 
           // Busy sends queue by default, so the user can still delete/edit or
           // manually steer the message. Settings can opt the composer into

--- a/packages/core/opensession-server/src/shared/desk-navigation.ts
+++ b/packages/core/opensession-server/src/shared/desk-navigation.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+// Only catalog IDs, never URLs, paths, query strings, or fragments.
+export const deskShowTargetSchema = z
+  .object({
+    kind: z.enum(["session", "workspace"]),
+    id: z.string().regex(/^[A-Za-z0-9_-]{1,128}$/),
+  })
+  .strict();
+export type DeskShowTarget = z.infer<typeof deskShowTargetSchema>;
+
+export const deskNavigationCommandSchema = z.object({
+  id: z.string().uuid(),
+  target: deskShowTargetSchema,
+  expiresAt: z.number().finite(),
+});
+export type DeskNavigationCommand = z.infer<typeof deskNavigationCommandSchema>;
+
+export const deskNavigationRequestSchema = z.discriminatedUnion("action", [
+  z
+    .object({
+      action: z.literal("poll"),
+      connectionId: z.string().min(1).max(256),
+      token: z.string().uuid(),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal("ack"),
+      connectionId: z.string().min(1).max(256),
+      token: z.string().uuid(),
+      commandId: z.string().uuid(),
+      shown: z.boolean(),
+    })
+    .strict(),
+]);
+export type DeskNavigationRequest = z.infer<typeof deskNavigationRequestSchema>;
+
+export const deskNavigationPollSchema = z.object({
+  command: deskNavigationCommandSchema.nullable(),
+  finished: z.boolean().optional(),
+});
+
+export const deskNavigationConnectionSchema = z.object({
+  connectionId: z.string().uuid(),
+  token: z.string().uuid(),
+});
+export const deskNavigationConnectSchema = z
+  .object({ sessionId: z.string().regex(/^[A-Za-z0-9_-]{1,128}$/) })
+  .strict();
+export const deskNavigationBindSchema = deskNavigationConnectionSchema
+  .extend({ requestId: z.string().uuid() })
+  .strict();
+
+export type DeskNavigationConnection = z.infer<
+  typeof deskNavigationConnectionSchema
+>;
+export type DeskNavigationBinding = z.infer<typeof deskNavigationBindSchema>;
+export type DeskNavigationConnect = z.infer<typeof deskNavigationConnectSchema>;


### PR DESCRIPTION
## Summary
Supersedes #372 with the combined voice and text implementation on current main.

- Make `show_in_app` available in text-only Desk chat as well as web voice calls. Resolve existing session/workspace IDs or names through the same fixed internal routes and ask about ambiguous matches.
- Bind text messages to their verified browser at WebSocket intake. Carry the server-owned dispatch identity into the MCP context, so an old run or another browser cannot redirect a later message.
- Keep tokens out of prompts, transcripts and broadcasts. Revoke authority on turn completion, cross-browser steering, disconnect or expiry; require browser acknowledgment before reporting success.
- Preserve the team UI's existing resource visibility. No arbitrary URLs, selectors or scripts. Native voice, ordinary sessions and automation tools do not receive this capability.
- Keep Desk open on desktop; minimize the covering sheet on phone. Include a selected empty/archived workspace in the active workspace projection so it renders correctly.

## Verification
- `bun run check` passed: formatting, typechecking, React Compiler/lint, isolated unit tests and strict transcript snapshots.
- Targeted navigation tests passed, including a real MCP dispatch/acknowledgment round trip, forged prompt identity, mixed-tab queue batches, stale closures, steering, expiry and disconnects.
- Module side-effect check passed for 519 server/executor modules.
- Verified text-only session and workspace navigation at 1440×900 and 390×844 in an isolated demo, with voice disabled and simulated model/navigation transport. No live model call was tested. Earlier voice proof is recorded in this session.

Implementation and security details: `docs/desk-voice-navigation.md`.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-184e4209-a04b-7d1f-bddd-38c7832cd014)
