### PR TITLE
Remove blanket Git publishing restriction from run instructions

### DIFF
--- a/packages/core/opensession-server/src/server/run-instructions.test.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.test.ts
@@ -6,6 +6,20 @@ import {
 } from "./run-instructions";
 
 describe("buildRunInstructions", () => {
+  test("preserves attribution without imposing a blanket Git publishing restriction", () => {
+    const prompt = buildRunInstructions({ isAsk: false, hasSession: true });
+
+    expect(prompt).toContain(
+      "End each PR body with the attribution footer from the session context and follow its assignee rule.",
+    );
+    expect(prompt).toContain(
+      "Add the `Co-authored-by` trailer from the session context to every commit.",
+    );
+    expect(prompt).not.toContain(
+      "Never merge, approve, or push the default branch.",
+    );
+  });
+
   test("limits automatic reviewers to unattended automation pull requests", async () => {
     const prompt = buildRunInstructions({
       isAsk: false,

--- a/packages/core/opensession-server/src/server/run-instructions.ts
+++ b/packages/core/opensession-server/src/server/run-instructions.ts
@@ -152,7 +152,7 @@ export function buildRunInstructions(input: {
     parts.push(
       "## Pull requests\nEnd each PR body with the attribution footer from the session " +
         "context and follow its assignee rule. Add the `Co-authored-by` trailer from the " +
-        "session context to every commit. Never merge, approve, or push the default branch.",
+        "session context to every commit.",
     );
     if (input.prReviewer) {
       parts.push(


### PR DESCRIPTION
## Summary
Remove “Never merge, approve, or push the default branch.” from the generated run instructions so that sentence no longer overrides repository-specific workflow instructions.

Keep PR attribution, assignee, and co-author requirements. This is a prompt-only change: command guards and MCP behavior are unchanged. Separate from the Cloudflare MCP relay fix in #375.

## Verification
- Full `bun run check` passed.
- Regression test verifies the restriction is absent and attribution requirements remain.

Started by Jaap Frolich in [this OS session](https://os.tella.dev/session/os-01a0908a-c383-785d-b246-5e4e66039552)