### PR TITLE
Add check_pr_ready: one deterministic PR merge-readiness verdict

### DIFF
--- a/docs/generated/mcp-tools.md
+++ b/docs/generated/mcp-tools.md
@@ -49,7 +49,7 @@ touches an in-process tool:
 | [`opensession-humans`](#opensession-humans) | 3 | interactive, Slack loop, goal wake | Interactive runs need a session id (the answer routes back to it). |
 | [`opensession-keychain`](#opensession-keychain) | 3 | interactive | Needs a session id. |
 | [`opensession-publish`](#opensession-publish) | 4 | interactive | Needs a session id. |
-| [`opensession-repos`](#opensession-repos) | 5 | interactive | Needs a session id. |
+| [`opensession-repos`](#opensession-repos) | 6 | interactive | Needs a session id. |
 | [`opensession-memory`](#opensession-memory) | 9 | interactive | Needs a session id. |
 | [`opensession-web`](#opensession-web) | 3 | interactive, goal wake | Needs a session id. |
 | [`opensession-portals`](#opensession-portals) | 7 | interactive | Needs a session id. |
@@ -72,7 +72,7 @@ touches an in-process tool:
 | [`opensession-github`](#opensession-github) | 4 | Slack loop | – |
 | [`opensession-goal-self`](#opensession-goal-self) | 6 | goal wake | Only on a session that carries a goalId. |
 
-31 servers, 135 tools.
+31 servers, 136 tools.
 
 ## opensession-sessions
 
@@ -496,7 +496,7 @@ Stop a published app. It stays registered with its versions intact and can be st
 
 ## opensession-repos
 
-Attach or switch repos, link a PR to this session, and label PRs in any registered repo.
+Attach or switch repos, link a PR to this session, label PRs, and check whether a PR is ready to merge.
 
 - **Source** `packages/core/opensession-server/src/agents/slack/repos-tools.ts`
 - **Wired in** `packages/core/opensession-server/src/server/interactive-mcp.ts`
@@ -532,6 +532,12 @@ Link a pull request to this session so it shows in the session's Review tab besi
 `mcp__opensession-repos__label_pull_request` · input: `url` (string), `repo` (string), `number` (number), `add` (string[]), `remove` (string[])
 
 Add or remove labels on a pull request in any registered GitHub repo, including one this session does not have checked out. Labels are applied as the bot: the gateway mints a token for that repo, so this works where `gh` in your shell cannot see the repo. Pass the PR URL, or a repo id and number.
+
+### `check_pr_ready`
+
+`mcp__opensession-repos__check_pr_ready` · input: `url` (string), `repo` (string), `number` (number), `session` (string)
+
+Is a pull request ready to merge? One deterministic verdict from live GitHub state: ready or not, and every blocker: open/merged/closed, draft, merge conflicts, each check's latest run by name (failing, pending, passing), the review decision and who gave it, and the base branch's rules. The first line is a sentence to say as-is; the JSON block at the end is the same verdict for branching on. Pass a PR URL, a repo id and number, or a session id to check that session's PR (defaults to this session's own PR). Read-only, runs as the bot, works for any registered repo. Use this instead of piecing readiness together from transcripts or gh output.
 
 ## opensession-memory
 

--- a/packages/core/opensession-server/src/agents/slack/repos-tools.test.ts
+++ b/packages/core/opensession-server/src/agents/slack/repos-tools.test.ts
@@ -5,6 +5,7 @@ import { createReposMcpServer, type ReposToolContext } from "./repos-tools";
 
 function harness(overrides: Partial<ReposToolContext> = {}) {
   const labelCalls: Array<Record<string, unknown>> = [];
+  const readyCalls: Array<Record<string, unknown>> = [];
   const ctx: ReposToolContext = {
     sessionId: "os-test",
     attach: async () => {
@@ -26,9 +27,70 @@ function harness(overrides: Partial<ReposToolContext> = {}) {
         labels: ["preview-temporal", ...(input.add ?? [])],
       };
     },
+    checkPrReady: async (input) => {
+      readyCalls.push(input);
+      return {
+        ready: false,
+        summary:
+          'PR #368 "Keep budgets visible" is not ready to merge: it has merge conflicts with main and 1 check is failing (Native client CI / build-and-test).',
+        blockers: [
+          "it has merge conflicts with main",
+          "1 check is failing (Native client CI / build-and-test)",
+        ],
+        warnings: [],
+        pr: {
+          repo: "opensession",
+          ghRepo: "acme/opensession",
+          number: 368,
+          title: "Keep budgets visible",
+          url: "https://github.com/acme/opensession/pull/368",
+          author: "louise",
+          base: "main",
+          head: "budgets",
+          headSha: "0123456789abcdef",
+        },
+        state: "OPEN",
+        draft: false,
+        mergeable: "CONFLICTING",
+        mergeStateStatus: "DIRTY",
+        checks: {
+          total: 2,
+          passing: [
+            {
+              name: "CI / Type-check and tests",
+              outcome: "passing",
+              required: false,
+            },
+          ],
+          failing: [
+            {
+              name: "Native client CI / build-and-test",
+              outcome: "failing",
+              required: false,
+            },
+          ],
+          pending: [],
+          skipped: [],
+          missingRequired: [],
+        },
+        review: {
+          decision: "NONE",
+          approvedBy: [],
+          changesRequestedBy: [],
+          awaiting: [],
+          requiredApprovals: 0,
+        },
+        rules: {
+          readable: true,
+          requiredChecks: [],
+          requiredApprovals: 0,
+          strictUpToDate: false,
+        },
+      };
+    },
     ...overrides,
   };
-  return { server: createReposMcpServer(ctx), labelCalls };
+  return { server: createReposMcpServer(ctx), labelCalls, readyCalls };
 }
 
 async function call(
@@ -78,5 +140,40 @@ describe("label_pull_request", () => {
       add: ["x"],
     });
     expect(out).toBe('Couldn\'t label that PR: Unknown repo "nope"');
+  });
+});
+
+describe("check_pr_ready", () => {
+  test("passes the target through and leads with the spoken verdict", async () => {
+    const { server, readyCalls } = harness();
+    const out = await call(server, "check_pr_ready", {
+      url: "https://github.com/acme/opensession/pull/368",
+    });
+    expect(readyCalls).toEqual([
+      { url: "https://github.com/acme/opensession/pull/368" },
+    ]);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe(
+      'PR #368 "Keep budgets visible" is not ready to merge: it has merge conflicts with main and 1 check is failing (Native client CI / build-and-test).',
+    );
+    expect(out).toContain("✗ Native client CI / build-and-test");
+    expect(out).toContain("✓ CI / Type-check and tests");
+    // The verdict rides along as JSON for callers that branch on it.
+    const json = out.slice(out.indexOf("```json") + 7, out.lastIndexOf("```"));
+    expect(JSON.parse(json).ready).toBe(false);
+  });
+
+  test("a session with no PR comes back as a message, not a tool error", async () => {
+    const { server } = harness({
+      checkPrReady: async () => {
+        throw new Error(
+          "Session os-x has no pull request yet (opensession:feat)",
+        );
+      },
+    });
+    const out = await call(server, "check_pr_ready", { session: "os-x" });
+    expect(out).toBe(
+      "Couldn't check that PR: Session os-x has no pull request yet (opensession:feat)",
+    );
   });
 });

--- a/packages/core/opensession-server/src/agents/slack/repos-tools.ts
+++ b/packages/core/opensession-server/src/agents/slack/repos-tools.ts
@@ -17,6 +17,10 @@
 import { createSdkMcpServer, tool } from "../../server/inprocess-mcp";
 import { z } from "zod";
 import type { AttachedRepo, LinkedPr } from "../../server/types";
+import {
+  formatPrMergeVerdict,
+  type PrMergeVerdict,
+} from "../../server/pr-merge-readiness";
 
 export interface ReposToolContext {
   /** The session these tools act on. */
@@ -67,6 +71,17 @@ export interface ReposToolContext {
     add?: string[];
     remove?: string[];
   }) => Promise<{ repo: string; number: number; labels: string[] }>;
+  /**
+   * Is a PR ready to merge? Resolves a URL, repo id + number, or a session's
+   * own PR and answers with one deterministic verdict; throws with a human
+   * message when the PR cannot be found.
+   */
+  checkPrReady: (input: {
+    url?: string;
+    repo?: string;
+    number?: number;
+    session?: string;
+  }) => Promise<PrMergeVerdict>;
 }
 
 function text(s: string) {
@@ -236,6 +251,41 @@ export function createReposMcpServer(ctx: ReposToolContext) {
           );
         } catch (e: any) {
           return text(`Couldn't label that PR: ${e?.message || String(e)}`);
+        }
+      },
+    ),
+    tool(
+      "check_pr_ready",
+      "Is a pull request ready to merge? One deterministic verdict from live GitHub state: ready or not, and every blocker: open/merged/closed, draft, merge conflicts, each check's latest run by name (failing, pending, passing), the review decision and who gave it, and the base branch's rules. The first line is a sentence to say as-is; the JSON block at the end is the same verdict for branching on. Pass a PR URL, a repo id and number, or a session id to check that session's PR (defaults to this session's own PR). Read-only, runs as the bot, works for any registered repo. Use this instead of piecing readiness together from transcripts or gh output.",
+      {
+        url: z
+          .string()
+          .optional()
+          .describe("GitHub PR URL (https://github.com/owner/repo/pull/123)."),
+        repo: z
+          .string()
+          .optional()
+          .describe(
+            "Registered repo id. With number: names the PR. With session: narrows which of that session's PRs to check.",
+          ),
+        number: z.number().optional().describe("PR number in that repo."),
+        session: z
+          .string()
+          .optional()
+          .describe(
+            "Session id whose PR to check (its Review tab PR: primary branch, then attached repos, then linked PRs). Omit everything to check this session's own PR.",
+          ),
+      },
+      async (args: {
+        url?: string;
+        repo?: string;
+        number?: number;
+        session?: string;
+      }) => {
+        try {
+          return text(formatPrMergeVerdict(await ctx.checkPrReady(args)));
+        } catch (e: any) {
+          return text(`Couldn't check that PR: ${e?.message || String(e)}`);
         }
       },
     ),

--- a/packages/core/opensession-server/src/server/interactive-mcp.ts
+++ b/packages/core/opensession-server/src/server/interactive-mcp.ts
@@ -72,6 +72,7 @@ import {
 } from "./preview-path-leases";
 import {
   attachRepo,
+  checkPrMergeReadiness,
   linkPr,
   resolveSessionRepoContext,
   sessionRepoIds,
@@ -252,6 +253,7 @@ export function interactiveMcpServers(
               })),
             linkPr: (input) => linkPr(sessionId, input),
             labelPr: (input) => labelPr(sessionId, input),
+            checkPrReady: (input) => checkPrMergeReadiness(sessionId, input),
           }),
           // Durable repo/user/team memory, shared both ways with Slack's
           // channel memory. Write tools are

--- a/packages/core/opensession-server/src/server/mcp-capabilities.ts
+++ b/packages/core/opensession-server/src/server/mcp-capabilities.ts
@@ -64,9 +64,9 @@ export const INTERNAL_MCP_CAPABILITIES = {
   },
   "opensession-repos": {
     summary:
-      "Attach or switch repos, link a PR to this session, and label PRs in any registered repo.",
+      "Attach or switch repos, link a PR to this session, label PRs, and check whether a PR is ready to merge.",
     guidance:
-      "Attach or switch repositories and link pull requests while preserving this session's multi-repo context. Use label_pull_request to label a PR in any registered repo, including one your shell cannot reach.",
+      "Attach or switch repositories and link pull requests while preserving this session's multi-repo context. Use label_pull_request to label a PR in any registered repo, including one your shell cannot reach. Use check_pr_ready for one deterministic merge-readiness verdict (checks, reviews, conflicts, draft, branch rules) instead of reading transcripts or raw gh output.",
   },
   "opensession-memory": {
     summary:

--- a/packages/core/opensession-server/src/server/mcp-catalog.ts
+++ b/packages/core/opensession-server/src/server/mcp-catalog.ts
@@ -274,6 +274,7 @@ export const MCP_SERVER_CATALOG: McpServerCatalogEntry[] = [
         ],
         linkPr: () => unused("linkPr"),
         labelPr: () => unused("labelPr"),
+        checkPrReady: () => unused("checkPrReady"),
       }),
   },
   {

--- a/packages/core/opensession-server/src/server/pr-merge-readiness.test.ts
+++ b/packages/core/opensession-server/src/server/pr-merge-readiness.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assessPrMergeReadiness,
+  formatPrMergeVerdict,
+  type PrReadinessSource,
+} from "./pr-merge-readiness";
+import type { PrCheck } from "./pr-contract";
+
+function check(
+  name: string,
+  conclusion: string,
+  extra: Partial<PrCheck> = {},
+): PrCheck {
+  return {
+    name,
+    status: conclusion ? "COMPLETED" : "IN_PROGRESS",
+    conclusion,
+    workflowName: "CI",
+    startedAt: "2026-09-11T12:00:00Z",
+    ...extra,
+  };
+}
+
+function source(overrides: Partial<PrReadinessSource> = {}): PrReadinessSource {
+  return {
+    repoId: "opensession",
+    ghRepo: "acme/opensession",
+    number: 374,
+    title: "Port the dashboard",
+    url: "https://github.com/acme/opensession/pull/374",
+    author: "louise",
+    state: "OPEN",
+    isDraft: false,
+    baseRefName: "main",
+    headRefName: "dashboard",
+    headRefOid: "8442c0c35b7502b514579f9f6589efadf01ca01b",
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    reviewDecision: "",
+    checks: [
+      check("Type-check and tests", "SUCCESS"),
+      check("Install", "SUCCESS"),
+    ],
+    latestReviews: [],
+    reviewRequests: [],
+    rules: { requiredChecks: [], requiredApprovals: 0, strictUpToDate: false },
+    ...overrides,
+  };
+}
+
+describe("assessPrMergeReadiness", () => {
+  test("an open, clean, green PR with no review rule is ready", () => {
+    const v = assessPrMergeReadiness(source());
+    expect(v.ready).toBe(true);
+    expect(v.blockers).toEqual([]);
+    expect(v.summary).toBe(
+      'PR #374 "Port the dashboard" is ready to merge: all 2 checks passing, no review required, no conflicts.',
+    );
+    expect(v.warnings).toEqual([
+      "nobody has approved it, and no branch rule requires a review",
+    ]);
+    expect(v.checks.passing.map((c) => c.name)).toEqual([
+      "CI / Type-check and tests",
+      "CI / Install",
+    ]);
+  });
+
+  test("names the approver when there is one", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        reviewDecision: "APPROVED",
+        latestReviews: [
+          { login: "bot", state: "COMMENTED" },
+          { login: "michiel", state: "APPROVED" },
+        ],
+      }),
+    );
+    expect(v.ready).toBe(true);
+    expect(v.review).toEqual({
+      decision: "APPROVED",
+      approvedBy: ["michiel"],
+      changesRequestedBy: [],
+      awaiting: [],
+      requiredApprovals: 0,
+    });
+    expect(v.summary).toContain("approved by michiel");
+    expect(v.warnings).toEqual([]);
+  });
+
+  test("conflicts plus a failing check list both, in fix order", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        mergeable: "CONFLICTING",
+        mergeStateStatus: "DIRTY",
+        checks: [
+          check("build-and-test", "FAILURE", {
+            workflowName: "Native client CI",
+          }),
+          check("Type-check and tests", "SUCCESS"),
+          check("Deploy preview", "", { workflowName: "Vercel" }),
+        ],
+      }),
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toEqual([
+      "it has merge conflicts with main",
+      "1 check is failing (Native client CI / build-and-test)",
+      "1 check is still running (Vercel / Deploy preview)",
+    ]);
+    expect(v.summary).toBe(
+      'PR #374 "Port the dashboard" is not ready to merge: it has merge conflicts with main, 1 check is failing (Native client CI / build-and-test), and 1 check is still running (Vercel / Deploy preview).',
+    );
+    expect(v.checks.failing[0].name).toBe("Native client CI / build-and-test");
+    expect(v.checks.pending[0].name).toBe("Vercel / Deploy preview");
+  });
+
+  test("a draft is not ready even when everything else is green", () => {
+    const v = assessPrMergeReadiness(
+      source({ isDraft: true, mergeStateStatus: "DRAFT" }),
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toEqual(["it is still a draft"]);
+  });
+
+  test("changes requested names who asked", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        reviewDecision: "CHANGES_REQUESTED",
+        latestReviews: [
+          { login: "michiel", state: "CHANGES_REQUESTED" },
+          { login: "louise", state: "APPROVED" },
+        ],
+      }),
+    );
+    expect(v.blockers).toEqual(["michiel requested changes"]);
+    expect(v.review.decision).toBe("CHANGES_REQUESTED");
+    expect(v.review.approvedBy).toEqual(["louise"]);
+  });
+
+  test("derives changes requested from reviews when GitHub gives no decision", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        latestReviews: [{ login: "michiel", state: "CHANGES_REQUESTED" }],
+      }),
+    );
+    expect(v.ready).toBe(false);
+    expect(v.review.decision).toBe("CHANGES_REQUESTED");
+  });
+
+  test("review required by a rule blocks, and counts approvals against the rule", () => {
+    const required = assessPrMergeReadiness(
+      source({
+        reviewDecision: "REVIEW_REQUIRED",
+        mergeStateStatus: "BLOCKED",
+      }),
+    );
+    expect(required.blockers).toEqual(["it needs an approving review"]);
+
+    const short = assessPrMergeReadiness(
+      source({
+        rules: {
+          requiredChecks: [],
+          requiredApprovals: 2,
+          strictUpToDate: false,
+        },
+        latestReviews: [{ login: "louise", state: "APPROVED" }],
+      }),
+    );
+    expect(short.blockers).toEqual(["it needs 2 approving reviews and has 1"]);
+  });
+
+  test("a required check that has not reported blocks, and required ones are marked", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        rules: {
+          requiredChecks: ["Type-check and tests", "Secret scan"],
+          requiredApprovals: 0,
+          strictUpToDate: true,
+        },
+      }),
+    );
+    expect(v.blockers).toEqual([
+      "1 required check has not reported (Secret scan)",
+    ]);
+    expect(v.checks.missingRequired).toEqual(["Secret scan"]);
+    expect(
+      v.checks.passing.find((c) => c.name === "CI / Type-check and tests")
+        ?.required,
+    ).toBe(true);
+    expect(v.rules).toEqual({
+      readable: true,
+      requiredChecks: ["Type-check and tests", "Secret scan"],
+      requiredApprovals: 0,
+      strictUpToDate: true,
+    });
+  });
+
+  test("unknown mergeability is not ready and says to ask again", () => {
+    const v = assessPrMergeReadiness(
+      source({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }),
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toEqual([
+      "GitHub is still computing whether it merges cleanly, so ask again in a moment",
+    ]);
+  });
+
+  test("BLOCKED with nothing readable wrong is reported, never called ready", () => {
+    const v = assessPrMergeReadiness(
+      source({ mergeStateStatus: "BLOCKED", rules: null }),
+    );
+    expect(v.ready).toBe(false);
+    expect(v.blockers).toEqual([
+      "GitHub reports the merge is blocked by a branch rule that is not readable here",
+    ]);
+    expect(v.rules.readable).toBe(false);
+    expect(v.warnings[0]).toBe(
+      "branch rules could not be read, so the verdict leans on GitHub's merge state",
+    );
+  });
+
+  test("BEHIND asks for an update", () => {
+    const v = assessPrMergeReadiness(source({ mergeStateStatus: "BEHIND" }));
+    expect(v.blockers).toEqual([
+      "the branch is behind main and needs updating",
+    ]);
+  });
+
+  test("merged and closed PRs are terminal, not blockers to fix", () => {
+    const merged = assessPrMergeReadiness(
+      source({
+        state: "MERGED",
+        mergeable: "UNKNOWN",
+        mergeStateStatus: "UNKNOWN",
+      }),
+    );
+    expect(merged.ready).toBe(false);
+    expect(merged.summary).toBe(
+      'PR #374 "Port the dashboard" was already merged.',
+    );
+    expect(merged.blockers).toEqual(["it was already merged"]);
+
+    const closed = assessPrMergeReadiness(source({ state: "CLOSED" }));
+    expect(closed.summary).toBe(
+      'PR #374 "Port the dashboard" is closed and was not merged.',
+    );
+  });
+
+  test("status contexts and skipped runs are classified", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        checks: [
+          { name: "Vercel", status: "COMPLETED", conclusion: "PENDING" },
+          {
+            name: "Lint",
+            status: "COMPLETED",
+            conclusion: "SKIPPED",
+            workflowName: "CI",
+            startedAt: "2026-09-11T12:00:00Z",
+          },
+          {
+            name: "Build",
+            status: "COMPLETED",
+            conclusion: "SUCCESS",
+            workflowName: "CI",
+            startedAt: "2026-09-11T12:00:00Z",
+          },
+        ],
+      }),
+    );
+    expect(v.checks.pending.map((c) => c.name)).toEqual(["Vercel"]);
+    expect(v.checks.skipped.map((c) => c.name)).toEqual(["CI / Lint"]);
+    expect(v.blockers).toEqual(["1 check is still running (Vercel)"]);
+    expect(v.warnings).toContain("1 check skipped");
+  });
+
+  test("pending review requests are a note, not a blocker", () => {
+    const v = assessPrMergeReadiness(source({ reviewRequests: ["michiel"] }));
+    expect(v.ready).toBe(true);
+    expect(v.warnings).toContain("still awaiting a review from michiel");
+  });
+});
+
+describe("formatPrMergeVerdict", () => {
+  test("leads with the sentence, lists checks by state, ends with the JSON verdict", () => {
+    const v = assessPrMergeReadiness(
+      source({
+        checks: [
+          check("build-and-test", "FAILURE", {
+            workflowName: "Native client CI",
+          }),
+          check("Type-check and tests", "SUCCESS"),
+        ],
+        rules: {
+          requiredChecks: ["Type-check and tests"],
+          requiredApprovals: 1,
+          strictUpToDate: false,
+        },
+        latestReviews: [{ login: "michiel", state: "APPROVED" }],
+      }),
+    );
+    const out = formatPrMergeVerdict(v);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe(v.summary);
+    expect(lines[1]).toBe(v.pr.url);
+    expect(lines[2]).toBe(
+      "State: open · mergeable MERGEABLE (CLEAN) · dashboard → main @ 8442c0c",
+    );
+    expect(out).toContain("Checks: 1 passing, 1 failing, 0 pending");
+    expect(out).toContain("  ✗ Native client CI / build-and-test");
+    expect(out).toContain("  ✓ CI / Type-check and tests (required)");
+    expect(out).toContain("Review: approved · approved by michiel");
+    expect(out).toContain(
+      "Branch rules on main: required checks Type-check and tests · 1 approval required",
+    );
+    const json = out.slice(out.indexOf("```json") + 7, out.lastIndexOf("```"));
+    expect(JSON.parse(json)).toEqual(v);
+  });
+});

--- a/packages/core/opensession-server/src/server/pr-merge-readiness.ts
+++ b/packages/core/opensession-server/src/server/pr-merge-readiness.ts
@@ -1,0 +1,568 @@
+/**
+ * Is this pull request ready to merge? One deterministic verdict from the
+ * PR's live GitHub state: open/merged/closed, draft, mergeability, the latest
+ * run of every check by name, the review decision and who made it, and the
+ * base branch's rulesets where the token can read them. The verdict is a
+ * sentence the Desk can say aloud plus the detail behind it, never raw API
+ * JSON.
+ *
+ * Read-only. The fetch runs `gh` as the bot for the PR's repository, the same
+ * credential path pr-info uses, so it works for any registered repo whether
+ * or not the session has it checked out.
+ */
+
+import {
+  resolveGithubCredential,
+  serviceGithubCredential,
+  type GithubCredential,
+} from "./github-auth";
+import type { PrCheck } from "./pr-contract";
+import {
+  isNoPrError,
+  latestWorkflowChecks,
+  prApiErrorMessage,
+} from "./pr-info";
+
+export interface PrReadinessTarget {
+  /** Registered repo id. */
+  repoId: string;
+  /** GitHub owner/name. */
+  ghRepo: string;
+  number: number;
+}
+
+/** What the base branch's rulesets demand of a PR before it can merge. */
+export interface PrBranchRules {
+  /** Names (contexts) of checks a ruleset requires. */
+  requiredChecks: string[];
+  /** Approving reviews a ruleset requires; 0 when none does. */
+  requiredApprovals: number;
+  /** A ruleset requires the head to be up to date with the base. */
+  strictUpToDate: boolean;
+}
+
+/** Everything the verdict is computed from. */
+export interface PrReadinessSource {
+  repoId: string;
+  ghRepo: string;
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  state: "OPEN" | "MERGED" | "CLOSED";
+  isDraft: boolean;
+  baseRefName: string;
+  headRefName: string;
+  headRefOid: string;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  /** GitHub's mergeStateStatus: CLEAN, DIRTY, BLOCKED, BEHIND, UNSTABLE, DRAFT, HAS_HOOKS, UNKNOWN. */
+  mergeStateStatus: string;
+  /** GitHub's reviewDecision; empty when no rule requires a review. */
+  reviewDecision: string;
+  /** Latest run of every check, already collapsed by latestWorkflowChecks. */
+  checks: PrCheck[];
+  /** The latest review per reviewer. */
+  latestReviews: Array<{ login: string; state: string }>;
+  /** Reviewers asked who have not answered. */
+  reviewRequests: string[];
+  /** Null when the rules endpoint was not readable with this token. */
+  rules: PrBranchRules | null;
+}
+
+export type PrCheckOutcome = "passing" | "failing" | "pending" | "skipped";
+
+export interface PrReadinessCheck {
+  name: string;
+  outcome: PrCheckOutcome;
+  required: boolean;
+  url?: string;
+}
+
+export type PrReviewVerdict =
+  "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "NONE";
+
+export interface PrMergeVerdict {
+  ready: boolean;
+  /** One sentence a voice assistant can say as-is. */
+  summary: string;
+  /** Why it cannot merge, in the order they should be fixed. Empty when ready. */
+  blockers: string[];
+  /** Worth knowing, but not blocking. */
+  warnings: string[];
+  pr: {
+    repo: string;
+    ghRepo: string;
+    number: number;
+    title: string;
+    url: string;
+    author: string;
+    base: string;
+    head: string;
+    headSha: string;
+  };
+  state: "OPEN" | "MERGED" | "CLOSED";
+  draft: boolean;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  mergeStateStatus: string;
+  checks: {
+    total: number;
+    passing: PrReadinessCheck[];
+    failing: PrReadinessCheck[];
+    pending: PrReadinessCheck[];
+    skipped: PrReadinessCheck[];
+    /** Required by a ruleset but absent from the PR's rollup. */
+    missingRequired: string[];
+  };
+  review: {
+    decision: PrReviewVerdict;
+    approvedBy: string[];
+    changesRequestedBy: string[];
+    awaiting: string[];
+    requiredApprovals: number;
+  };
+  rules: {
+    /** False when the rulesets endpoint was not readable; the verdict then leans on mergeStateStatus. */
+    readable: boolean;
+    requiredChecks: string[];
+    requiredApprovals: number;
+    strictUpToDate: boolean;
+  };
+}
+
+function checkOutcome(check: PrCheck): PrCheckOutcome {
+  const conclusion = (check.conclusion || "").toUpperCase();
+  const status = (check.status || "").toUpperCase();
+  if (/^(SUCCESS)$/.test(conclusion)) return "passing";
+  if (/^(NEUTRAL|SKIPPED)$/.test(conclusion)) return "skipped";
+  if (
+    /^(FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED|ERROR|STARTUP_FAILURE|STALE)$/.test(
+      conclusion,
+    )
+  )
+    return "failing";
+  // No conclusion yet, or a PENDING/EXPECTED status context, or a run that
+  // is still queued or in progress.
+  if (!conclusion || status !== "COMPLETED") return "pending";
+  return "pending";
+}
+
+function joinList(items: string[]): string {
+  if (items.length <= 1) return items.join("");
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function plural(n: number, one: string, many = `${one}s`): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+/** Match a ruleset's required context against a check's reported name. */
+function checkMatches(check: PrCheck, required: string): boolean {
+  const name = check.name.trim().toLowerCase();
+  const wanted = required.trim().toLowerCase();
+  return (
+    name === wanted ||
+    (!!check.workflowName &&
+      `${check.workflowName} / ${check.name}`.trim().toLowerCase() === wanted)
+  );
+}
+
+/**
+ * The verdict, computed from the source alone: same input, same answer.
+ * Blockers are phrased so the summary reads aloud as one sentence.
+ */
+export function assessPrMergeReadiness(src: PrReadinessSource): PrMergeVerdict {
+  const rules = src.rules ?? {
+    requiredChecks: [],
+    requiredApprovals: 0,
+    strictUpToDate: false,
+  };
+  const requiredNames = rules.requiredChecks;
+  const classified: PrReadinessCheck[] = src.checks.map((check) => ({
+    name: check.workflowName
+      ? `${check.workflowName} / ${check.name}`
+      : check.name,
+    outcome: checkOutcome(check),
+    required: requiredNames.some((r) => checkMatches(check, r)),
+    ...(check.url ? { url: check.url } : {}),
+  }));
+  const by = (outcome: PrCheckOutcome) =>
+    classified.filter((c) => c.outcome === outcome);
+  const missingRequired = requiredNames.filter(
+    (r) => !src.checks.some((c) => checkMatches(c, r)),
+  );
+  const checks = {
+    total: classified.length,
+    passing: by("passing"),
+    failing: by("failing"),
+    pending: by("pending"),
+    skipped: by("skipped"),
+    missingRequired,
+  };
+
+  const approvedBy = src.latestReviews
+    .filter((r) => r.state.toUpperCase() === "APPROVED")
+    .map((r) => r.login);
+  const changesRequestedBy = src.latestReviews
+    .filter((r) => r.state.toUpperCase() === "CHANGES_REQUESTED")
+    .map((r) => r.login);
+  // GitHub only fills reviewDecision when a rule requires a review; without
+  // one, derive it from the latest review per reviewer the way pr-cache does.
+  const decision: PrReviewVerdict = (() => {
+    const given = src.reviewDecision.toUpperCase();
+    if (
+      given === "APPROVED" ||
+      given === "CHANGES_REQUESTED" ||
+      given === "REVIEW_REQUIRED"
+    )
+      return given;
+    if (changesRequestedBy.length) return "CHANGES_REQUESTED";
+    if (approvedBy.length) return "APPROVED";
+    return "NONE";
+  })();
+  const review = {
+    decision,
+    approvedBy,
+    changesRequestedBy,
+    awaiting: src.reviewRequests,
+    requiredApprovals: rules.requiredApprovals,
+  };
+
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  const base = src.baseRefName;
+
+  if (src.state === "OPEN") {
+    if (src.isDraft) blockers.push("it is still a draft");
+    if (src.mergeable === "CONFLICTING")
+      blockers.push(`it has merge conflicts with ${base}`);
+    else if (src.mergeable === "UNKNOWN")
+      blockers.push(
+        "GitHub is still computing whether it merges cleanly, so ask again in a moment",
+      );
+    if (checks.failing.length)
+      blockers.push(
+        `${plural(checks.failing.length, "check is", "checks are")} failing (${checks.failing.map((c) => c.name).join(", ")})`,
+      );
+    if (checks.pending.length)
+      blockers.push(
+        `${plural(checks.pending.length, "check is", "checks are")} still running (${checks.pending.map((c) => c.name).join(", ")})`,
+      );
+    if (missingRequired.length)
+      blockers.push(
+        `${plural(missingRequired.length, "required check has", "required checks have")} not reported (${missingRequired.join(", ")})`,
+      );
+    if (decision === "CHANGES_REQUESTED")
+      blockers.push(
+        changesRequestedBy.length
+          ? `${joinList(changesRequestedBy)} requested changes`
+          : "changes were requested",
+      );
+    else if (decision === "REVIEW_REQUIRED")
+      blockers.push("it needs an approving review");
+    else if (rules.requiredApprovals > approvedBy.length)
+      blockers.push(
+        `it needs ${plural(rules.requiredApprovals, "approving review")} and has ${approvedBy.length}`,
+      );
+    const mss = src.mergeStateStatus.toUpperCase();
+    if (mss === "BEHIND")
+      blockers.push(`the branch is behind ${base} and needs updating`);
+    else if (mss === "BLOCKED" && !blockers.length)
+      // Everything readable looks fine, yet GitHub says no: a rule this
+      // token cannot see (classic branch protection, code owners, a
+      // deployment gate). Say so rather than call it ready.
+      blockers.push(
+        "GitHub reports the merge is blocked by a branch rule that is not readable here",
+      );
+
+    if (!src.rules)
+      warnings.push(
+        "branch rules could not be read, so the verdict leans on GitHub's merge state",
+      );
+    if (decision === "NONE" && !approvedBy.length && !rules.requiredApprovals)
+      warnings.push(
+        "nobody has approved it, and no branch rule requires a review",
+      );
+    if (review.awaiting.length)
+      warnings.push(
+        `still awaiting a review from ${joinList(review.awaiting)}`,
+      );
+    if (checks.skipped.length)
+      warnings.push(`${plural(checks.skipped.length, "check")} skipped`);
+  } else if (src.state === "MERGED") {
+    blockers.push("it was already merged");
+  } else {
+    blockers.push("it was closed without merging");
+  }
+
+  const ready = src.state === "OPEN" && blockers.length === 0;
+  const label = `PR #${src.number} "${src.title}"`;
+  const summary = (() => {
+    if (src.state === "MERGED") return `${label} was already merged.`;
+    if (src.state === "CLOSED") return `${label} is closed and was not merged.`;
+    if (!ready) return `${label} is not ready to merge: ${joinList(blockers)}.`;
+    const why = [
+      checks.total
+        ? `all ${plural(checks.passing.length, "check")} passing`
+        : "no checks reported",
+      approvedBy.length
+        ? `approved by ${joinList(approvedBy)}`
+        : "no review required",
+      "no conflicts",
+    ];
+    return `${label} is ready to merge: ${why.join(", ")}.`;
+  })();
+
+  return {
+    ready,
+    summary,
+    blockers,
+    warnings,
+    pr: {
+      repo: src.repoId,
+      ghRepo: src.ghRepo,
+      number: src.number,
+      title: src.title,
+      url: src.url,
+      author: src.author,
+      base: src.baseRefName,
+      head: src.headRefName,
+      headSha: src.headRefOid,
+    },
+    state: src.state,
+    draft: src.isDraft,
+    mergeable: src.mergeable,
+    mergeStateStatus: src.mergeStateStatus,
+    checks,
+    review,
+    rules: {
+      readable: src.rules !== null,
+      requiredChecks: rules.requiredChecks,
+      requiredApprovals: rules.requiredApprovals,
+      strictUpToDate: rules.strictUpToDate,
+    },
+  };
+}
+
+/** The tool's text: the spoken summary first, the detail under it, then the
+ * verdict as JSON for anything that wants to branch on it. */
+export function formatPrMergeVerdict(v: PrMergeVerdict): string {
+  const mark = (c: PrReadinessCheck) =>
+    c.outcome === "passing"
+      ? "✓"
+      : c.outcome === "failing"
+        ? "✗"
+        : c.outcome === "pending"
+          ? "…"
+          : "–";
+  const lines = [
+    v.summary,
+    v.pr.url,
+    `State: ${v.state.toLowerCase()}${v.draft ? ", draft" : ""} · mergeable ${v.mergeable}${v.mergeStateStatus ? ` (${v.mergeStateStatus})` : ""} · ${v.pr.head} → ${v.pr.base} @ ${v.pr.headSha.slice(0, 7)}`,
+  ];
+  if (v.blockers.length) lines.push(`Blockers: ${v.blockers.join("; ")}`);
+  if (v.warnings.length) lines.push(`Notes: ${v.warnings.join("; ")}`);
+  const ordered = [
+    ...v.checks.failing,
+    ...v.checks.pending,
+    ...v.checks.passing,
+    ...v.checks.skipped,
+  ];
+  lines.push(
+    `Checks: ${v.checks.total ? `${v.checks.passing.length} passing, ${v.checks.failing.length} failing, ${v.checks.pending.length} pending${v.checks.skipped.length ? `, ${v.checks.skipped.length} skipped` : ""}` : "none reported"}`,
+  );
+  for (const c of ordered)
+    lines.push(`  ${mark(c)} ${c.name}${c.required ? " (required)" : ""}`);
+  for (const name of v.checks.missingRequired)
+    lines.push(`  ? ${name} (required, not reported)`);
+  lines.push(
+    `Review: ${v.review.decision.toLowerCase().replace(/_/g, " ")}` +
+      ` · approved by ${v.review.approvedBy.join(", ") || "nobody"}` +
+      (v.review.changesRequestedBy.length
+        ? ` · changes requested by ${v.review.changesRequestedBy.join(", ")}`
+        : "") +
+      (v.review.awaiting.length
+        ? ` · awaiting ${v.review.awaiting.join(", ")}`
+        : ""),
+  );
+  lines.push(
+    v.rules.readable
+      ? `Branch rules on ${v.pr.base}: ${
+          v.rules.requiredChecks.length || v.rules.requiredApprovals
+            ? [
+                v.rules.requiredChecks.length
+                  ? `required checks ${v.rules.requiredChecks.join(", ")}`
+                  : "",
+                v.rules.requiredApprovals
+                  ? `${plural(v.rules.requiredApprovals, "approval")} required`
+                  : "",
+                v.rules.strictUpToDate ? "must be up to date" : "",
+              ]
+                .filter(Boolean)
+                .join(" · ")
+            : "no rulesets"
+        }`
+      : `Branch rules on ${v.pr.base}: not readable with this token`,
+  );
+  lines.push("", "```json", JSON.stringify(v), "```");
+  return lines.join("\n");
+}
+
+const PR_FIELDS =
+  "number,title,url,state,isDraft,baseRefName,headRefName,headRefOid,author,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,latestReviews,reviewRequests";
+
+async function gh(args: string[], credential: GithubCredential) {
+  const proc = Bun.spawn(["gh", ...args], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...credential.env },
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { out, err, code };
+}
+
+/** Rulesets that apply to the base branch; null when the token cannot read them. */
+async function fetchBranchRules(
+  ghRepo: string,
+  branch: string,
+  credential: GithubCredential,
+): Promise<PrBranchRules | null> {
+  const { out, code } = await gh(
+    ["api", `repos/${ghRepo}/rules/branches/${encodeURIComponent(branch)}`],
+    credential,
+  );
+  if (code !== 0) return null;
+  let rules: any[];
+  try {
+    rules = JSON.parse(out);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(rules)) return null;
+  const result: PrBranchRules = {
+    requiredChecks: [],
+    requiredApprovals: 0,
+    strictUpToDate: false,
+  };
+  for (const rule of rules) {
+    const params = rule?.parameters ?? {};
+    if (rule?.type === "required_status_checks") {
+      for (const c of params.required_status_checks ?? [])
+        if (typeof c?.context === "string" && c.context.trim())
+          result.requiredChecks.push(c.context.trim());
+      if (params.strict_required_status_checks_policy)
+        result.strictUpToDate = true;
+    } else if (rule?.type === "pull_request") {
+      const n = Number(params.required_approving_review_count ?? 0);
+      if (Number.isFinite(n) && n > result.requiredApprovals)
+        result.requiredApprovals = n;
+    }
+  }
+  result.requiredChecks = [...new Set(result.requiredChecks)];
+  return result;
+}
+
+// GitHub computes `mergeable` lazily: after the base moves, every open PR
+// answers UNKNOWN until a query triggers the recomputation, and GitHub's own
+// guidance is to poll briefly. Three short waits keep the tool immediate in
+// practice while an honest UNKNOWN still reaches the verdict if it persists.
+const MERGEABLE_RETRY_DELAYS_MS = [1500, 2500, 3500];
+
+async function viewPr(target: PrReadinessTarget, credential: GithubCredential) {
+  const { out, err, code } = await gh(
+    [
+      "pr",
+      "view",
+      String(target.number),
+      "--repo",
+      target.ghRepo,
+      "--json",
+      PR_FIELDS,
+    ],
+    credential,
+  );
+  if (code !== 0) {
+    const msg = err.trim().slice(0, 300);
+    if (isNoPrError(msg))
+      throw new Error(`No PR #${target.number} in ${target.ghRepo}`);
+    throw new Error(
+      /rate limit|authentication|bad credentials|resource not accessible/i.test(
+        msg,
+      )
+        ? prApiErrorMessage(msg)
+        : msg || `gh pr view failed for ${target.ghRepo}#${target.number}`,
+    );
+  }
+  return JSON.parse(out);
+}
+
+/**
+ * Read one PR's readiness inputs as the bot for its repository. Throws with
+ * a human message when the PR does not exist or GitHub is unreachable.
+ */
+export async function fetchPrReadinessSource(
+  target: PrReadinessTarget,
+  credential: GithubCredential = serviceGithubCredential,
+  retryDelaysMs: readonly number[] = MERGEABLE_RETRY_DELAYS_MS,
+): Promise<PrReadinessSource> {
+  const resolved = await resolveGithubCredential(credential, {
+    repo: target.ghRepo,
+  });
+  let pr = await viewPr(target, resolved);
+  for (const delay of retryDelaysMs) {
+    if (pr.state !== "OPEN" || pr.mergeable !== "UNKNOWN") break;
+    await new Promise((r) => setTimeout(r, delay));
+    pr = await viewPr(target, resolved);
+  }
+  const baseRefName = String(pr.baseRefName || "");
+  const rules = baseRefName
+    ? await fetchBranchRules(target.ghRepo, baseRefName, resolved).catch(
+        () => null,
+      )
+    : null;
+  return {
+    repoId: target.repoId,
+    ghRepo: target.ghRepo,
+    number: pr.number,
+    title: pr.title || "",
+    url: pr.url || "",
+    author: pr.author?.login || "",
+    state: pr.state,
+    isDraft: !!pr.isDraft,
+    baseRefName,
+    headRefName: pr.headRefName || "",
+    headRefOid: pr.headRefOid || "",
+    mergeable:
+      pr.mergeable === "MERGEABLE" || pr.mergeable === "CONFLICTING"
+        ? pr.mergeable
+        : "UNKNOWN",
+    mergeStateStatus: pr.mergeStateStatus || "",
+    reviewDecision: pr.reviewDecision || "",
+    checks: latestWorkflowChecks(
+      (pr.statusCheckRollup || []).map((c: any) => ({
+        name: c.name || c.context || "check",
+        status: c.status || (c.state ? "COMPLETED" : ""),
+        conclusion: c.conclusion || c.state || "",
+        url: c.detailsUrl || c.targetUrl || undefined,
+        startedAt: c.startedAt || undefined,
+        completedAt: c.completedAt || undefined,
+        workflowName: c.workflowName || undefined,
+      })),
+    ),
+    latestReviews: (pr.latestReviews || [])
+      .map((r: any) => ({
+        login: r.author?.login || "",
+        state: String(r.state || ""),
+      }))
+      .filter((r: { login: string }) => r.login),
+    reviewRequests: (pr.reviewRequests || [])
+      .map((r: any) => r.login || r.name || r.slug || "")
+      .filter(Boolean),
+    rules,
+  };
+}

--- a/packages/core/opensession-server/src/server/session-repos.ts
+++ b/packages/core/opensession-server/src/server/session-repos.ts
@@ -56,6 +56,15 @@ import type {
 } from "./types";
 import { defaultRepo } from "./config";
 import { hostRepoId } from "./pr-host";
+import { resolveRegisteredPr } from "./pr-labels";
+import { prMetaForBranch } from "./pr-info";
+import { cachedPrNumberByBranch } from "./pr-cache";
+import {
+  assessPrMergeReadiness,
+  fetchPrReadinessSource,
+  type PrMergeVerdict,
+  type PrReadinessTarget,
+} from "./pr-merge-readiness";
 
 export interface SessionRepoContext {
   repo: string;
@@ -844,6 +853,70 @@ export async function linkPr(
   ];
   touchNativeSession(sessionId, { linkedPrs: all });
   return { linked, all };
+}
+
+/**
+ * The PR a merge-readiness question is about. A URL or repo id + number
+ * names it outright. Otherwise it is the PR of a session: the given one, or
+ * the caller's own. The session's PR targets are the ones its Review tab
+ * shows (primary branch, attached repos, linked PRs, in that order); the
+ * first target with an open PR wins, else the first with any PR. `repo`
+ * narrows a session lookup to that repo.
+ */
+export async function resolvePrReadinessTarget(
+  sessionId: string,
+  input: { url?: string; repo?: string; number?: number; session?: string },
+): Promise<PrReadinessTarget> {
+  if (input.url || input.number) {
+    const { repo, number } = resolveRegisteredPr(input);
+    return { repoId: repo.id, ghRepo: repo.ghRepo, number };
+  }
+  const targetSession = (input.session || sessionId).trim();
+  const session = findSession(targetSession);
+  if (!session) throw new Error(`Session ${targetSession} not found`);
+  const repoFilter = input.repo?.trim();
+  if (repoFilter && !REPOS[repoFilter])
+    throw new Error(`Unknown repo "${repoFilter}"`);
+  const targets = projectPrTargets(session).filter(
+    (t) =>
+      (!repoFilter || t.repoId === repoFilter) &&
+      REPOS[t.repoId] &&
+      REPOS[t.repoId].host !== "codestorage" &&
+      REPOS[t.repoId].ghRepo,
+  );
+  if (!targets.length)
+    throw new Error(
+      repoFilter
+        ? `Session ${targetSession} has no branch or linked PR in ${repoFilter}`
+        : `Session ${targetSession} has no branch or linked PR to check`,
+    );
+  let fallback: PrReadinessTarget | null = null;
+  for (const t of targets) {
+    const ghRepo = REPOS[t.repoId].ghRepo;
+    const cached = cachedPrNumberByBranch(ghRepo, t.branch);
+    if (cached !== undefined)
+      return { repoId: t.repoId, ghRepo, number: cached };
+    const meta = await prMetaForBranch(t.branch, ghRepo);
+    if (!meta) continue;
+    const found = { repoId: t.repoId, ghRepo, number: meta.number };
+    if (meta.state === "OPEN") return found;
+    fallback ??= found;
+  }
+  if (fallback) return fallback;
+  throw new Error(
+    `Session ${targetSession} has no pull request yet (${targets
+      .map((t) => `${t.repoId}:${t.branch}`)
+      .join(", ")})`,
+  );
+}
+
+/** The interactive entrypoint behind check_pr_ready: resolve, fetch, judge. */
+export async function checkPrMergeReadiness(
+  sessionId: string,
+  input: { url?: string; repo?: string; number?: number; session?: string },
+): Promise<PrMergeVerdict> {
+  const target = await resolvePrReadinessTarget(sessionId, input);
+  return assessPrMergeReadiness(await fetchPrReadinessSource(target));
 }
 
 /** Remove a linked PR from a session (the link only — the PR is untouched). */


### PR DESCRIPTION
## Why

The Desk had no reliable way to answer "is this PR ready to merge?" for a session's PR. It pieced the answer together from `inspect_session` / `get_session` transcript reads, which do not reliably surface CI status, review state, or mergeability.

## What

A new read-only tool on the existing `opensession-repos` in-process MCP server: **`check_pr_ready`** (`mcp__opensession-repos__check_pr_ready`), beside `link_pr` and `label_pull_request`.

**Input** (any one of):
- `url`: a GitHub PR URL
- `repo` + `number`: registered repo id and PR number
- `session`: a session id; resolves that session's Review-tab PR (primary branch, then attached repos, then linked PRs; first open PR wins, else the first found). `repo` narrows the lookup. With no arguments it checks the calling session's own PR.

**Output**: text whose first line is a one-sentence verdict a voice assistant can say as-is, then the supporting detail, then the same verdict as a ```json block for branching on:

```ts
{
  ready: boolean;
  summary: string;                // the spoken sentence
  blockers: string[];             // in fix order, empty when ready
  warnings: string[];             // non-blocking notes
  pr: { repo, ghRepo, number, title, url, author, base, head, headSha };
  state: "OPEN" | "MERGED" | "CLOSED";
  draft: boolean;
  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
  mergeStateStatus: string;       // CLEAN, DIRTY, BLOCKED, BEHIND, ...
  checks: { total, passing[], failing[], pending[], skipped[], missingRequired[] };  // each { name, outcome, required, url? }
  review: { decision: APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | NONE, approvedBy[], changesRequestedBy[], awaiting[], requiredApprovals };
  rules: { readable, requiredChecks[], requiredApprovals, strictUpToDate };
}
```

**Verdict rules** (`assessPrMergeReadiness`, pure): merged/closed are terminal; an open PR is ready only when it is not a draft, `mergeable` is `MERGEABLE`, no check's latest run is failing or pending, every ruleset-required check has reported, the review decision is not `CHANGES_REQUESTED` / `REVIEW_REQUIRED`, the ruleset's approval count is met, and `mergeStateStatus` is not `BEHIND`/`BLOCKED`. A `BLOCKED` with nothing readable wrong is reported as "blocked by a branch rule that is not readable here", never as ready. When GitHub gives no `reviewDecision` (no rule requires a review) the decision is derived from the latest review per reviewer, the same way `pr-cache.ts` does.

**Auth**: the fetch runs `gh pr view --json ...` plus `gh api repos/{owner}/{repo}/rules/branches/{base}` as the bot for the PR's repository through the existing `resolveGithubCredential(serviceGithubCredential, { repo })` path that `pr-info.ts` uses. No new credential path. Works for any registered GitHub repo whether or not the session has it checked out.

GitHub computes `mergeable` lazily: after `main` moves, every open PR answers `UNKNOWN` until a query triggers recomputation. An open PR answering `UNKNOWN` is re-queried up to three times (1.5s, 2.5s, 3.5s) before an honest `UNKNOWN` reaches the verdict.

## Files

- `src/server/pr-merge-readiness.ts`: types, `assessPrMergeReadiness`, `formatPrMergeVerdict`, `fetchPrReadinessSource`
- `src/server/session-repos.ts`: `resolvePrReadinessTarget` (URL / repo+number / session) and `checkPrMergeReadiness`
- `src/agents/slack/repos-tools.ts`: the tool and `ReposToolContext.checkPrReady`
- `src/server/interactive-mcp.ts`, `mcp-catalog.ts`, `mcp-capabilities.ts`: wiring, catalog entry, capability text
- `docs/generated/mcp-tools.md`: regenerated

## Verification

- `pr-merge-readiness.test.ts`: 15 cases on the pure verdict and formatter (ready, approver named, conflicts + failing + pending, draft, changes requested by name, derived decision, review required and approval counts, missing required check, unknown mergeability, BLOCKED fallback, BEHIND, merged/closed, status contexts and skipped runs, pending review requests).
- `repos-tools.test.ts`: the tool passes its target through, leads with the spoken sentence, and turns a lookup failure into a message rather than a tool error.
- `bun run check` passes (format, typecheck, lint, isolated unit tests, snapshots).
- Ran `fetchPrReadinessSource` + `assessPrMergeReadiness` against real PRs in this repo:

**Open, clean (#374):**
```
PR #374 "Port TikTok hooks dashboard and importer to Open Session" is ready to merge: all 7 checks passing, no review required, no conflicts.
https://github.com/tellahq/opensession/pull/374
State: open · mergeable MERGEABLE (CLEAN) · louise/tiktok-hooks-opensession → main @ 8442c0c
Notes: nobody has approved it, and no branch rule requires a review
Checks: 7 passing, 0 failing, 0 pending
  ✓ Vercel
  ✓ Vercel Preview Comments
  ✓ CI / Type-check and tests
  ✓ Secret scan / Current tree and history
  ✓ CI / Install (ubuntu-latest)
  ✓ CI / Install (macos-latest)
  ✓ CI / Windows runner client
Review: none · approved by nobody
Branch rules on main: no rulesets
```

**Open, conflicting with a failing check (#368):**
```
PR #368 "Keep scoped weekly budgets visible in native model settings" is not ready to merge: it has merge conflicts with main and 1 check is failing (Native client CI / build-and-test).
https://github.com/tellahq/opensession/pull/368
State: open · mergeable CONFLICTING (DIRTY) · report-keep-weekly-scope-visible → main @ d8f5d56
Blockers: it has merge conflicts with main; 1 check is failing (Native client CI / build-and-test)
Checks: 7 passing, 1 failing, 0 pending
  ✗ Native client CI / build-and-test
  ✓ Vercel
  ...
```

**Merged (#375):**
```
PR #375 "Fix MCP relay token sharing across runner processes" was already merged.
https://github.com/tellahq/opensession/pull/375
State: merged · mergeable UNKNOWN (UNKNOWN) · fix/mcp-relay-cross-process → main @ 47fe872
Blockers: it was already merged
```

Not verified live: the `session` input path end to end (it needs a running gateway with session state), and required-check / approval rules (this repo has no rulesets on `main`; the parsing is covered by unit tests).

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-a647de64-5a44-7f8d-b563-3ef568c1135e)