### PR TITLE
Open session pills clicked inside the Desk

### DIFF
--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.test.ts
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.test.ts
@@ -22,3 +22,22 @@ test("the Desk modal keeps its full conversation until Clear chat", async () => 
     "entries.filter((e) => !e.timestamp || e.timestamp > hideBefore)",
   );
 });
+
+test("the Desk transcript opens session pills the way the session viewer does", async () => {
+  const conversation = await Bun.file(
+    new URL("./DeskConversation.tsx", import.meta.url),
+  ).text();
+  const viewerActions = await Bun.file(
+    new URL("../hooks/useSessionConversationState.ts", import.meta.url),
+  ).text();
+
+  // Markdown session chips and the tool row's spawned-session pill carry a
+  // bare data-session-id and rely on the scrolling pane to delegate the
+  // click. Both panes must read that click through the one shared helper,
+  // and the Desk must route it to the same place a spawned worker opens.
+  expect(conversation).toContain("sessionIdFromTranscriptClick(e)");
+  expect(viewerActions).toContain("sessionIdFromTranscriptClick(e)");
+  expect(conversation).toMatch(
+    /onClick=\{\s*onOpenSubagent\s*\?[\s\S]*?sessionIdFromTranscriptClick\(e\);\s*if \(!id\) return;\s*e\.preventDefault\(\);\s*onOpenSubagent\(id\);/,
+  );
+});

--- a/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskConversation.tsx
@@ -19,6 +19,7 @@ import {
 import { splitAttachments, type FileAttachment } from "../lib/images";
 import { Composer } from "./Composer";
 import { mergeTranscriptEntries } from "../lib/transcript-state";
+import { sessionIdFromTranscriptClick } from "../lib/transcript-session-click";
 import { CONTINUE_AFTER_FAILURE_PROMPT } from "../lib/continue-run";
 import { LiveTurnStore } from "../lib/live-turn-store";
 import { getLiveTypingPref } from "../lib/live-typing-pref";
@@ -581,6 +582,21 @@ export function DeskConversation({
         )}
         ref={bodyRef}
         onScroll={onScroll}
+        // Session chips and the tool row's spawned-session pill carry only a
+        // data-session-id; the pane they scroll in opens them, as the session
+        // viewer's does (handleMessagesClick). The Desk is mostly delegated
+        // work, so without this its transcript was full of pills that did
+        // nothing. Same destination as a spawned worker: the full viewer.
+        onClick={
+          onOpenSubagent
+            ? (e) => {
+                const id = sessionIdFromTranscriptClick(e);
+                if (!id) return;
+                e.preventDefault();
+                onOpenSubagent(id);
+              }
+            : undefined
+        }
       >
         {!hasContent ? (
           <>

--- a/packages/core/opensession-server/src/frontend/hooks/useSessionConversationState.ts
+++ b/packages/core/opensession-server/src/frontend/hooks/useSessionConversationState.ts
@@ -38,6 +38,7 @@ import {
 } from "../lib/session-viewer-actions";
 import { safetyContinuationPrompt } from "../lib/session-safety";
 import { CONTINUE_AFTER_FAILURE_PROMPT } from "../lib/continue-run";
+import { sessionIdFromTranscriptClick } from "../lib/transcript-session-click";
 import { getCurrentUser } from "../components/UserPicker";
 import { toast } from "../ui/toast";
 import { useConfirm } from "../ui/confirm";
@@ -373,16 +374,8 @@ export function useSessionConversationActions({
         openAsset(assetPath);
         return;
       }
-      const sessionCandidate = target.closest("[data-session-id]");
-      const sessionEl =
-        sessionCandidate instanceof HTMLElement ? sessionCandidate : null;
-      const id = sessionEl?.dataset.sessionId;
+      const id = sessionIdFromTranscriptClick(e);
       if (!id || !openSession) return;
-      if (
-        (e.metaKey || e.ctrlKey || e.shiftKey) &&
-        sessionEl?.getAttribute("href")
-      )
-        return;
       e.preventDefault();
       openSession(id);
     },

--- a/packages/core/opensession-server/src/frontend/lib/transcript-session-click.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-session-click.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sessionIdFromTranscriptClick } from "./transcript-session-click";
+
+const ID = "bks-a647de64-5a44-7f8d-b563-3ef568c1135e";
+
+// The frontend tests run without a DOM. The helper only asks an element for
+// `closest`, `dataset` and `getAttribute`, so a small stand-in for the two
+// globals it type-checks against is enough. It is an EventTarget so it can
+// be a click's target without a cast.
+class FakeElement implements EventTarget {
+  readonly dataset: Record<string, string | undefined>;
+  constructor(
+    private readonly attrs: Record<string, string>,
+    private readonly parent: FakeElement | null = null,
+  ) {
+    const id = attrs["data-session-id"];
+    this.dataset = id === undefined ? {} : { sessionId: id };
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+  closest(selector: string): FakeElement | null {
+    if (selector !== "[data-session-id]") throw new Error(selector);
+    let node: FakeElement | null = this;
+    while (node && !("data-session-id" in node.attrs)) node = node.parent;
+    return node;
+  }
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(): boolean {
+    return true;
+  }
+}
+
+const GLOBALS = ["Element", "HTMLElement"] as const;
+const saved = GLOBALS.map((key) => ({
+  key,
+  descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+}));
+beforeAll(() => {
+  for (const key of GLOBALS)
+    Object.defineProperty(globalThis, key, {
+      value: FakeElement,
+      configurable: true,
+      writable: true,
+    });
+});
+afterAll(() => {
+  for (const { key, descriptor } of saved) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+function click(
+  target: EventTarget | null,
+  mods: Partial<Record<"metaKey" | "ctrlKey" | "shiftKey", boolean>> = {},
+) {
+  return sessionIdFromTranscriptClick({
+    target,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    ...mods,
+  });
+}
+
+describe("sessionIdFromTranscriptClick", () => {
+  test("a click inside a chip without an href opens the session", () => {
+    const chip = new FakeElement({ role: "button", "data-session-id": ID });
+    const inner = new FakeElement({}, chip);
+    expect(click(inner)).toBe(ID);
+  });
+
+  test("a plain click on an href chip opens in place", () => {
+    const chip = new FakeElement({
+      href: `/session/${ID}`,
+      "data-session-id": ID,
+    });
+    expect(click(chip)).toBe(ID);
+  });
+
+  test("a modified click on an href chip is left to the browser", () => {
+    const chip = new FakeElement({
+      href: `/session/${ID}`,
+      "data-session-id": ID,
+    });
+    expect(click(chip, { metaKey: true })).toBeNull();
+    expect(click(chip, { shiftKey: true })).toBeNull();
+  });
+
+  test("a modified click on a chip without an href still opens", () => {
+    const chip = new FakeElement({ "data-session-id": ID });
+    expect(click(chip, { ctrlKey: true })).toBe(ID);
+  });
+
+  test("anything else is left alone", () => {
+    const p = new FakeElement({}, new FakeElement({}));
+    expect(click(p)).toBeNull();
+    expect(click(null)).toBeNull();
+    expect(click(new EventTarget())).toBeNull();
+  });
+});

--- a/packages/core/opensession-server/src/frontend/lib/transcript-session-click.ts
+++ b/packages/core/opensession-server/src/frontend/lib/transcript-session-click.ts
@@ -1,0 +1,39 @@
+/**
+ * Which session a click in a transcript wants to open, if any.
+ *
+ * Session references in a transcript carry `data-session-id` and no handler
+ * of their own: markdown chips come from `dangerouslySetInnerHTML` (lib/
+ * markdown.ts) and cannot carry React handlers, and the tool row's spawned
+ * session pill (ToolCallBlock) stays a plain span so it can live inside the
+ * row's button. Every pane that renders a transcript therefore has to
+ * delegate the click from its scroll container. There are two such panes,
+ * the session viewer and the Desk, and one reading of the click keeps them
+ * from drifting: a pill that opens in one place must open in the other.
+ */
+
+interface TranscriptClick {
+  target: EventTarget | null;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * The session id the click should open in place, or null to leave the event
+ * alone. A modified click on a chip with an href is left to the browser, so
+ * cmd/ctrl-click still opens a tab and shift-click a window. Pure: the caller
+ * prevents the default once it knows it can open the session.
+ */
+export function sessionIdFromTranscriptClick(
+  e: TranscriptClick,
+): string | null {
+  const target = e.target;
+  if (!(target instanceof Element)) return null;
+  const candidate = target.closest("[data-session-id]");
+  const el = candidate instanceof HTMLElement ? candidate : null;
+  const id = el?.dataset.sessionId;
+  if (!id) return null;
+  if ((e.metaKey || e.ctrlKey || e.shiftKey) && el?.getAttribute("href"))
+    return null;
+  return id;
+}

--- a/packages/core/opensession-server/src/server/pr-merge-readiness.ts
+++ b/packages/core/opensession-server/src/server/pr-merge-readiness.ts
@@ -79,7 +79,10 @@ export interface PrReadinessCheck {
 }
 
 export type PrReviewVerdict =
-  "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | "NONE";
+  | "APPROVED"
+  | "CHANGES_REQUESTED"
+  | "REVIEW_REQUIRED"
+  | "NONE";
 
 export interface PrMergeVerdict {
   ready: boolean;


### PR DESCRIPTION
## Bug

In the Desk overlay (⌘J / the Desk button), clicking a session reference in a message did nothing: a spawned-task pill such as "Add PR merge readiness check", a bare `bks-…`/`os-…` id chip, or the tool row's `Open` pill. The same pills work in the full session viewer.

## Root cause

Session references in a transcript carry only a `data-session-id` and no click handler of their own. Markdown chips come from `dangerouslySetInnerHTML` (`lib/markdown.ts`) and cannot carry React handlers, and `ToolCallBlock`'s spawned-session pill is deliberately a plain `span` so it can sit inside the row's button. They all rely on the transcript's scroll container to delegate the click.

`SessionViewerMainRegion` does that: its messages pane has `onClick={handleMessagesClick}`, which resolves `[data-session-id]` and calls `openSession`. `DeskConversation` renders the same `SessionTranscript` in its own `viewer-messages` pane but never attached an equivalent handler, so inside the Desk the click bubbled to nothing. It was not a router/provider issue: `DeskOverlay` already receives `onOpenSession` from `AppContent` and passes it down as `onOpenSubagent`, which closes the overlay and navigates to the session, exactly the destination the expand button and the subagent rows use.

## Fix

- New `lib/transcript-session-click.ts`: `sessionIdFromTranscriptClick(e)` is the one reading of "which session does this click want", including the existing modifier-key rule (cmd/ctrl/shift-click on a chip that has an `href` is left to the browser). Pure; the caller prevents the default.
- `useSessionConversationState.handleMessagesClick` now uses the helper. Same lines of behaviour as before, and `SessionViewer.navigation.test.ts`'s pinned guard is untouched.
- `DeskConversation`'s transcript pane gets `onClick` that routes the id to `onOpenSubagent`, so a session pill in the Desk closes the overlay and opens that session in the full viewer, the same way the expand button and the spawned-worker rows already do.
- Tests: unit tests for the helper (no DOM library in this tree, so a small `EventTarget`-shaped stand-in), and `DeskConversation.test.ts` asserts both panes read the click through the shared helper and that the Desk routes it to `onOpenSubagent`.

## Verification

Isolated demo instance via `verify-opensession` (fresh state, engine off), sent a Desk message carrying a bare-id codespan and a full session URL, then clicked each chip from inside the Desk:

- Desktop 1440x900: bare-id chip (`role=button`, the same shape as the spawned-task pill) navigated `/session/bks-demo-failed` → `/session/bks-demo-pr`; URL chip navigated `/session/bks-demo-pr` → `/session/bks-demo-failed`. The Desk closed each time. One page load for the whole run (`performance.getEntriesByType("navigation").length === 1`, single `Bundled page` in the server log), so these were in-app navigations.
- Phone 390x844: Desk sheet from the root page, bare-id chip navigated to `/session/bks-demo-pr` and the sheet closed.
- Re-ran the desktop check on the final code after the helper became pure.

Screenshots and accessibility snapshots are in the OS session (`artifacts/verification/opensession/verify-desk-pill-4054966/`, local, not committed).

Checks: `bun run typecheck`, `bun run lint`, `scripts/test-unit-isolated.sh`, `bun run test:snapshots` all pass. `bun run format:check` currently fails on `src/server/pr-merge-readiness.ts` from #378, which this branch does not touch.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-f301a59e-42c9-7183-9bd3-b4578a6ce648)
