### PR TITLE
Desk: tab-aware show_in_app, live-call indicator, fuzzy session lookup

### DIFF
--- a/docs/desk-voice-navigation.md
+++ b/docs/desk-voice-navigation.md
@@ -105,6 +105,12 @@ router switches the page without remounting Desk. Desktop keeps the floating Des
 open. Phone minimizes its covering sheet while the mounted conversation and voice
 client remain alive. Reopen Desk to access its controls.
 
+While a call is live behind a minimised Desk, the Desk trigger carries a pulsing
+dot and its label reads "Desk call in progress"; pushed phone pages, which have
+no Desk FAB, show a handset control in the top bar instead. Both reopen Desk.
+The indicator clears when the call ends or Desk is back up
+(`DeskOverlay.onCallActiveChange`).
+
 ## Code and tests
 
 Paths below are relative to `packages/core/opensession-server/`.

--- a/docs/desk-voice-navigation.md
+++ b/docs/desk-voice-navigation.md
@@ -2,14 +2,44 @@
 
 The Desk overlay supports `show_in_app` in both text-only chat and web voice
 calls, including messages typed during a call. The action accepts exactly one
-`session` or `workspace`, as an ID or title/name. It resolves existing catalog
-records, prefers exact names, and asks for clarification when an exact or partial
-name has multiple matches. Name searches omit archived sessions and the Desk
-itself. An explicit ID can open an archived session. The action never accepts a
-URL, path, selector, script, or arbitrary UI operation.
+`session` or `workspace`, as an ID or title/name, plus an optional `tab`
+(`chat`, `review`, `conversation`, or `video`). It resolves existing catalog
+records and asks for clarification when a name has several equally good
+matches. Name searches omit archived sessions and the Desk itself. An explicit
+ID can open an archived session. The action never accepts a URL, path, selector,
+script, or arbitrary UI operation.
 
 For example, "Show me the deploy workspace" opens the matching workspace beside
-Desk. It does not start another session or end the conversation.
+Desk, and "show me the review tab for this" lands on that session's Review
+tab. It does not start another session or end the conversation.
+
+### Name matching
+
+Exact titles win. Otherwise titles are scored with the shared fuzzy matcher
+(`src/shared/fuzzy-match.ts`, the same one behind the @ palette): every spoken
+term must land in the title, whole or within a small typo budget, so "profile
+subtitle sidebar" finds "Profile Subtitles sidebar opening". Filler a spoken
+request carries ("the", "my", "session") is dropped when other terms remain. A
+title containing the whole phrase outranks term-by-term matches; among fuzzy
+matches a clear leader is taken, a near tie is asked back.
+
+A session's derivatives, the auto-fix worker parented on it (`parentSessionId`,
+`spawnedBy`) and the headless PR review sharing its workspace
+(`automation`, `agentStarted`), carry near-copies of its title. They are dropped
+from the candidates whenever the primary scores at least as well, so "subtitles
+sidebar" opens the primary instead of asking which of two identical-looking
+sessions was meant. Phrasing that names the derivative ("the review of…",
+"PR 41 feedback") outscores the primary and reaches it directly.
+
+### Tabs
+
+`tab` names a fixed pane, never a route. For a workspace it becomes the
+existing `/review`, `/conversation`, or `/video` route suffix. For a session,
+`review` uses the sidebar's pending-open pulse so the Review tab is foregrounded
+once the session lands; `chat` clears the workspace's remembered pane so the
+transcript shows; `conversation` and `video` open the session's workspace on
+that pane. Panes that spawn something (terminal, desktop, preview) are not
+reachable. A session the browser has not listed yet opens on its default tab.
 
 ## Authorization and delivery
 
@@ -62,8 +92,8 @@ Registration failures do not prevent ordinary text from being sent.
 
 ## UI behavior
 
-Commands carry only a validated session/workspace ID, random command ID, and
-expiry. Only one command can wait per connection, for at most ten seconds. The
+Commands carry only a validated session/workspace ID, an optional fixed tab
+name, random command ID, and expiry. Only one command can wait per connection, for at most ten seconds. The
 client rejects expired/malformed commands and suppresses duplicate navigation.
 Success means the owning browser's app router accepted the action. A missing app
 handler, disconnect, timeout, or revoked turn returns failure; this does not claim

--- a/packages/core/opensession-server/src/frontend/AppContent.tsx
+++ b/packages/core/opensession-server/src/frontend/AppContent.tsx
@@ -76,7 +76,7 @@ import { getActiveViewTab, saveActiveViewTab } from "./lib/active-view-tab";
 import { cachedRepos, resolveWorkspaceApi } from "./lib/api";
 import { buildAppCommandActions } from "./components/app-command-actions";
 import { isToolView, parseRoute, routePath, type Route } from "./lib/app-route";
-import { onDeskShow } from "./lib/desk-show";
+import { onDeskShow, type DeskShowTarget } from "./lib/desk-show";
 import {
   APP_BODY,
   DETAIL_TOPBAR,
@@ -516,13 +516,6 @@ export function AppContent({
   const socketInject = useEffectEvent(inject);
   const socketNavigate = useEffectEvent(navigate);
   const socketGetCurrentRoute = useEffectEvent(getCurrentRoute);
-  const voiceShow = useEffectEvent((route: Route) => {
-    navigate(route);
-    // The phone sheet covers the page; minimise it so what was asked for is
-    // visible. The call keeps running in the mounted body.
-    if (isPhone) setDeskOverlay((desk) => ({ ...desk, open: false }));
-  });
-  useEffect(() => onDeskShow(voiceShow), []);
   useEffect(() => {
     return addHandler((msg) => {
       if (msg.type === "error") {
@@ -804,6 +797,43 @@ export function AppContent({
     openTicketWorkspace,
     openReviewForSession,
   } = workspacePanes;
+
+  // Desk's show_in_app landed here (lib/desk-show). A workspace pane is part
+  // of the route; a session's tab is applied the way the sidebar does it: Review
+  // through the pending-open pulse that survives the workspace-change reset,
+  // chat by clearing the workspace's remembered pane before the route lands.
+  const voiceShow = useEffectEvent((target: DeskShowTarget, route: Route) => {
+    const shownSession =
+      target.kind === "session" && target.tab
+        ? sessions.find(
+            (session) =>
+              session.id === target.id || session.aliasIds?.includes(target.id),
+          )
+        : undefined;
+    const sessionKey = wsKeyFor(shownSession);
+    if (shownSession && target.tab === "review") {
+      openReviewForSession(shownSession);
+    } else if (shownSession && sessionKey && target.tab === "chat") {
+      saveActiveViewTab(sessionKey, null);
+      setActiveViewTabState(null);
+      navigate(route);
+    } else if (
+      shownSession?.workspaceId &&
+      (target.tab === "conversation" || target.tab === "video")
+    ) {
+      navigate({
+        view: "workspace",
+        id: shownSession.workspaceId,
+        tab: target.tab,
+      });
+    } else {
+      navigate(route);
+    }
+    // The phone sheet covers the page; minimise it so what was asked for is
+    // visible. The call keeps running in the mounted body.
+    if (isPhone) setDeskOverlay((desk) => ({ ...desk, open: false }));
+  });
+  useEffect(() => onDeskShow(voiceShow), []);
 
   const sessionTabs = useSessionTabs({
     routing: {

--- a/packages/core/opensession-server/src/frontend/AppContent.tsx
+++ b/packages/core/opensession-server/src/frontend/AppContent.tsx
@@ -136,6 +136,7 @@ import { Button } from "./ui/button";
 import { cn } from "./ui/cn";
 import { EmptyState, LoadingState } from "./ui/state";
 import { ToastHost, toast } from "./ui/toast";
+import { PulseDot } from "./ui/status";
 import { Tooltip } from "./ui/tooltip";
 import { TopBar, TopBarActions, TopBarTitle } from "./ui/top-bar";
 
@@ -472,6 +473,9 @@ export function AppContent({
     setShortcutsOpen,
     taskCount,
   } = appViewState;
+  // A Desk voice call outlives a minimised Desk; the trigger shows it is live.
+  const [deskCallActive, setDeskCallActive] = useState(false);
+  const deskCallShown = deskCallActive && !deskOverlay.open;
   const { closePalette, startNewSessionCreate } = useNewSessionCreateStart({
     getCurrentRoute,
     navigate,
@@ -1288,6 +1292,10 @@ export function AppContent({
               topbarTitle={topbarTitle}
               phoneTitleHandedOver={phoneTitleHandedOver}
               commandMenuRef={commandMenuRef}
+              deskCallActive={deskCallShown}
+              onOpenDesk={() =>
+                setDeskOverlay({ open: true, origin: "bottom-right" })
+              }
               setAppHeaderEl={setAppHeaderEl}
               setHeaderRepoEl={setHeaderRepoEl}
               setHeaderModelEl={setHeaderModelEl}
@@ -1884,7 +1892,11 @@ export function AppContent({
 				    on the root page (see .desk-fab). ⌘J and the command palette still
 				    summon it too. */}
             {(!isPhone || !mobileDetail) && (
-              <Tooltip label="Desk" side="left" shortcut={["⌘", "J"]}>
+              <Tooltip
+                label={deskCallShown ? "Desk call in progress" : "Desk"}
+                side="left"
+                shortcut={["⌘", "J"]}
+              >
                 <button
                   className={DESK_FAB}
                   style={
@@ -1899,9 +1911,18 @@ export function AppContent({
                   onClick={() =>
                     setDeskOverlay({ open: true, origin: "bottom-right" })
                   }
-                  aria-label="Open the Desk"
+                  aria-label={
+                    deskCallShown
+                      ? "Desk call in progress. Open the Desk"
+                      : "Open the Desk"
+                  }
                 >
                   <IconDesk size={24} />
+                  {/* The call keeps running behind a minimised Desk; the dot
+                      says so until the call ends or Desk is back up. */}
+                  {deskCallShown && (
+                    <PulseDot className="absolute top-0 right-0 ring-2 ring-[var(--composer-surface)]" />
+                  )}
                 </button>
               </Tooltip>
             )}
@@ -1915,6 +1936,7 @@ export function AppContent({
               }
               phone={isPhone}
               onOpenSession={(id) => navigate({ view: "session", id })}
+              onCallActiveChange={setDeskCallActive}
             />
 
             {/* ⌘K command palette — actions, PRs, and sessions across every view. */}

--- a/packages/core/opensession-server/src/frontend/components/AppMobileHeader.tsx
+++ b/packages/core/opensession-server/src/frontend/components/AppMobileHeader.tsx
@@ -17,12 +17,14 @@ import {
   HEADER_TITLE_ROW,
   HEADER_TITLE_TEXT,
   MOBILE_SEARCH_BTN,
+  MOBILE_TOP_BAR_CONTROL,
 } from "../lib/app-header-classes";
 import type { Route } from "../lib/app-route";
 import { sessionWasAgentStarted } from "../lib/sidebar-placement";
 import type { UnifiedSession, Workspace } from "../lib/types";
 import { cn } from "../ui/cn";
 import { OverflowFadeText } from "../ui/overflow-fade-text";
+import { PulseDot } from "../ui/status";
 import {
   TopBar,
   TopBarActions,
@@ -32,7 +34,7 @@ import {
 import type { CommandMenuHandle } from "./CommandMenuHost";
 import { OrganizationSwitcher } from "./OrganizationSwitcher";
 import { UpdatePill } from "./UpdatePill";
-import { IconRobot, IconSearch } from "./icons";
+import { IconCall, IconRobot, IconSearch } from "./icons";
 
 interface AppMobileHeaderProps {
   route: Route;
@@ -47,6 +49,10 @@ interface AppMobileHeaderProps {
   topbarTitle: string;
   phoneTitleHandedOver: boolean;
   commandMenuRef: RefObject<CommandMenuHandle | null>;
+  /** A Desk voice call is live behind the minimised Desk sheet. Pushed pages
+   * have no Desk FAB, so the top bar carries the reminder and the way back. */
+  deskCallActive: boolean;
+  onOpenDesk: () => void;
   setAppHeaderEl: ReturnType<
     typeof useAppShell
   >["mobileTopbar"]["setAppHeaderEl"];
@@ -74,6 +80,8 @@ export function AppMobileHeader({
   topbarTitle,
   phoneTitleHandedOver,
   commandMenuRef,
+  deskCallActive,
+  onOpenDesk,
   setAppHeaderEl,
   setHeaderRepoEl,
   setHeaderModelEl,
@@ -221,6 +229,16 @@ export function AppMobileHeader({
                 aria-label="Open command menu"
               >
                 <IconSearch size={22} />
+              </button>
+            )}
+            {mobileDetail && deskCallActive && (
+              <button
+                className={cn(MOBILE_TOP_BAR_CONTROL, "relative")}
+                onClick={onOpenDesk}
+                aria-label="Desk call in progress. Open the Desk"
+              >
+                <IconCall size={22} />
+                <PulseDot className="absolute top-1.5 right-1.5 ring-2 ring-[var(--mobile-header-control-surface)]" />
               </button>
             )}
           </TopBarActions>

--- a/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
+++ b/packages/core/opensession-server/src/frontend/components/DeskOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useEffectEvent, useRef, useState } from "react";
 import { z } from "zod";
 import { BASE_PATH } from "../lib/base";
 import { getCurrentUser } from "./UserPicker";
@@ -50,6 +50,9 @@ interface DeskOverlayProps {
   phone: boolean;
   /** Open the Desk session in the full viewer. */
   onOpenSession: (sessionId: string) => void;
+  /** A voice call started or ended. The call outlives a minimised Desk, so
+   * the app shows it is still live on the trigger that reopens Desk. */
+  onCallActiveChange?: (active: boolean) => void;
 }
 
 function DeskBody({
@@ -57,6 +60,7 @@ function DeskBody({
   phone,
   onClose,
   onOpenSession,
+  onCallActiveChange,
   onGrab,
 }: Omit<DeskOverlayProps, "open" | "openOrigin"> & {
   active: boolean;
@@ -98,6 +102,17 @@ function DeskBody({
   );
 
   const voiceActive = voiceState !== "idle" && voiceState !== "error";
+  // Report through an effect event so a new callback identity does not
+  // re-announce an unchanged call; unmounting the body ends the call above.
+  const announceCall = useEffectEvent((active: boolean) =>
+    onCallActiveChange?.(active),
+  );
+  useEffect(() => {
+    announceCall(voiceActive);
+    return () => {
+      if (voiceActive) announceCall(false);
+    };
+  }, [voiceActive]);
   const voiceStatus: Record<DeskVoiceState, string | undefined> = {
     idle: undefined,
     error: undefined,
@@ -326,6 +341,7 @@ export function DeskOverlay({
   onClose,
   phone,
   onOpenSession,
+  onCallActiveChange,
 }: DeskOverlayProps) {
   // Base UI's keepMounted preserves the Desk after its first summon, but it
   // also mounts hidden content on a cold app load. Gate the body until then so
@@ -407,6 +423,7 @@ export function DeskOverlay({
             phone={phone}
             onClose={onClose}
             onOpenSession={onOpenSession}
+            onCallActiveChange={onCallActiveChange}
             onGrab={floating ? panel.startMove : undefined}
           />
         )}

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.test.ts
@@ -14,11 +14,26 @@ describe("deskShowRoute", () => {
     });
   });
 
+  test("a workspace tab rides the route; a session tab is applied after landing", () => {
+    expect(
+      deskShowRoute({ kind: "workspace", id: "ws-1", tab: "review" }),
+    ).toEqual({ view: "workspace", id: "ws-1", tab: "review" });
+    // The workspace home is its session, so chat adds no pane suffix.
+    expect(
+      deskShowRoute({ kind: "workspace", id: "ws-1", tab: "chat" }),
+    ).toEqual({ view: "workspace", id: "ws-1" });
+    expect(
+      deskShowRoute({ kind: "session", id: "s-1", tab: "review" }),
+    ).toEqual({ view: "session", id: "s-1" });
+  });
+
   test("the boundary drops anything outside the fixed route table", () => {
     for (const target of [
       null,
       { kind: "settings", id: "x" },
       { kind: "session", id: 5 },
+      { kind: "session", id: "s-1", tab: "terminal" },
+      { kind: "session", id: "s-1", tab: "/review" },
       ...[
         " ",
         "../settings",

--- a/packages/core/opensession-server/src/frontend/lib/desk-show.ts
+++ b/packages/core/opensession-server/src/frontend/lib/desk-show.ts
@@ -5,8 +5,14 @@ import {
 import type { Route } from "./app-route";
 export type { DeskShowTarget } from "../../shared/desk-navigation";
 
+/** The page a Desk target lands on. A workspace pane is part of the route; a
+ * session's tab is not, so the app applies that after navigating. */
 export function deskShowRoute(target: DeskShowTarget): Route {
-  return { view: target.kind, id: target.id };
+  if (target.kind === "workspace")
+    return target.tab && target.tab !== "chat"
+      ? { view: "workspace", id: target.id, tab: target.tab }
+      : { view: "workspace", id: target.id };
+  return { view: "session", id: target.id };
 }
 
 // Local to this browser's voice client, not a server WebSocket broadcast.
@@ -17,12 +23,14 @@ export function showDeskTarget(target: DeskShowTarget): boolean {
   );
 }
 
-export function onDeskShow(show: (route: Route) => void): () => void {
+export function onDeskShow(
+  show: (target: DeskShowTarget, route: Route) => void,
+): () => void {
   const listener = (event: Event) => {
     if (!(event instanceof CustomEvent)) return;
     const parsed = deskShowTargetSchema.safeParse(event.detail);
     if (!parsed.success) return;
-    show(deskShowRoute(parsed.data));
+    show(parsed.data, deskShowRoute(parsed.data));
     event.preventDefault();
   };
   window.addEventListener(SHOW_EVENT, listener);

--- a/packages/core/opensession-server/src/server/desk-navigation-mcp.ts
+++ b/packages/core/opensession-server/src/server/desk-navigation-mcp.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createSdkMcpServer, tool } from "./inprocess-mcp";
 import { deskTextNavigation } from "./desk-text-navigation";
 import { SHOW_IN_APP_TOOL, showInApp } from "./desk-voice-show";
+import { DESK_SHOW_TABS } from "../shared/desk-navigation";
 
 export function deskNavigationMcp(
   sessionId: string,
@@ -17,10 +18,11 @@ export function deskNavigationMcp(
       tools: [
         tool(
           SHOW_IN_APP_TOOL.name,
-          "Show a session or workspace in the browser that sent this Desk message. Use when the user asks to see, open, or go to it. Accepts an ID, title or distinctive part of the name, never a URL. Ask which one when names are ambiguous.",
+          "Show a session or workspace in the browser that sent this Desk message. Use when the user asks to see, open, or go to it. Accepts an ID, title or distinctive part of the name, never a URL. Set tab to land on a specific tab: review (the PR, its checks and comments), chat (the transcript), conversation, or video. Ask which one when names are ambiguous.",
           {
             session: z.string().max(256).optional(),
             workspace: z.string().max(256).optional(),
+            tab: z.enum(DESK_SHOW_TABS).optional(),
           },
           async (args) => ({
             content: [

--- a/packages/core/opensession-server/src/server/desk-voice-live.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-live.ts
@@ -168,7 +168,7 @@ export async function buildLiveSessionConfig(
         instructions:
           LIVE_BACKEND_INSTRUCTIONS +
           (navigationEnabled
-            ? "\nWhen the user asks to see, open, or go to a session or workspace, call show_in_app with its title or name. It opens that page beside the Desk. If it reports several matches, ask which one."
+            ? "\nWhen the user asks to see, open, or go to a session or workspace, call show_in_app with its title or name. It opens that page beside the Desk. When they name a tab (the review tab, the PR status, the chat), pass it as tab. If it reports several matches, ask which one."
             : ""),
         tools,
         tool_choice: "auto",

--- a/packages/core/opensession-server/src/server/desk-voice-show.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.test.ts
@@ -39,6 +39,28 @@ const sessions: Summary[] = [
   summary("s-lint", "Vendor lint rules"),
   summary("s-desk", "Desk", { desk: true }),
   summary("s-archived", "Archived captions work", { state: "archived" }),
+  // A primary session and the two derivatives the app opens from its PR: the
+  // headless review (same workspace, automation-owned) and the auto-fix worker
+  // (parented on it).
+  summary("s-subtitles", "Profile Subtitles sidebar opening", {
+    workspaceId: "ws-subtitles",
+    lastActivity: "2026-09-08T10:00:00.000Z",
+  }),
+  summary(
+    "s-subtitles-review",
+    "Review · PR #41 Profile Subtitles sidebar opening",
+    {
+      workspaceId: "ws-subtitles",
+      automation: "github-pr-review",
+      lastActivity: "2026-09-09T10:00:00.000Z",
+    },
+  ),
+  summary("s-subtitles-fix", "Fix PR 41 feedback and CI", {
+    workspaceId: "ws-subtitles",
+    parentSessionId: "s-subtitles",
+    agentStarted: true,
+    lastActivity: "2026-09-10T11:00:00.000Z",
+  }),
 ];
 
 const workspaces: Workspace[] = [
@@ -116,6 +138,59 @@ describe("show_in_app target resolution", () => {
         title: "Voice captions for the Desk",
       },
     });
+  });
+
+  test("tolerates a spoken near-miss of the title", async () => {
+    // Singular/plural and a different case: the real miss that motivated this.
+    expect(
+      await resolveShowTarget(
+        { session: "Profile subtitle sidebar opening" },
+        deps,
+      ),
+    ).toEqual({
+      target: {
+        kind: "session",
+        id: "s-subtitles",
+        title: "Profile Subtitles sidebar opening",
+      },
+    });
+    // Filler a voice request carries and a typo in a longer word.
+    expect(
+      await resolveShowTarget(
+        { session: "the profile subtitels sidebar session" },
+        deps,
+      ),
+    ).toMatchObject({ target: { id: "s-subtitles" } });
+    // Terms that land nowhere are still a miss, not a guess.
+    expect(
+      await resolveShowTarget({ session: "profile billing export" }, deps),
+    ).toMatchObject({ error: expect.stringContaining("No session") });
+  });
+
+  test("prefers a primary session over its own review and fix sessions", async () => {
+    // Both the primary and its review carry these words; without the
+    // derivative rule this is a flat two-item list and another round trip.
+    expect(
+      await resolveShowTarget({ session: "subtitles sidebar" }, deps),
+    ).toEqual({
+      target: {
+        kind: "session",
+        id: "s-subtitles",
+        title: "Profile Subtitles sidebar opening",
+      },
+    });
+    // Phrasing that singles the derivative out still reaches it.
+    expect(
+      await resolveShowTarget(
+        { session: "the review of profile subtitles" },
+        deps,
+      ),
+    ).toMatchObject({
+      target: { id: "s-subtitles-review" },
+    });
+    expect(
+      await resolveShowTarget({ session: "pr 41 feedback" }, deps),
+    ).toMatchObject({ target: { id: "s-subtitles-fix" } });
   });
 
   test("resolves a workspace by id or name", async () => {

--- a/packages/core/opensession-server/src/server/desk-voice-show.test.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.test.ts
@@ -193,6 +193,32 @@ describe("show_in_app target resolution", () => {
     ).toMatchObject({ target: { id: "s-subtitles-fix" } });
   });
 
+  test("carries a requested tab through to the target", async () => {
+    expect(
+      await resolveShowTarget({ session: "lint", tab: "review" }, deps),
+    ).toEqual({
+      target: {
+        kind: "session",
+        id: "s-lint",
+        title: "Vendor lint rules",
+        tab: "review",
+      },
+    });
+    expect(
+      await resolveShowTarget({ workspace: "ws-2", tab: "conversation" }, deps),
+    ).toEqual({
+      target: {
+        kind: "workspace",
+        id: "ws-2",
+        name: "Desk voice",
+        tab: "conversation",
+      },
+    });
+    expect(
+      await resolveShowTarget({ session: "lint", tab: "terminal" }, deps),
+    ).toMatchObject({ error: expect.stringContaining("Unknown tab") });
+  });
+
   test("resolves a workspace by id or name", async () => {
     expect(await resolveShowTarget({ workspace: "ws-2" }, deps)).toEqual({
       target: { kind: "workspace", id: "ws-2", name: "Desk voice" },
@@ -243,7 +269,7 @@ describe("show_in_app authorization and delivery", () => {
   test("returns success only after the owning browser acknowledges", async () => {
     registerStubControl();
     const nav = new DeskVoiceNavigation("signed-in-login");
-    const pending = showInApp(nav, { session: "lint" });
+    const pending = showInApp(nav, { session: "lint", tab: "review" });
     await Promise.resolve();
     const polled = nav.handle("signed-in-login", {
       action: "poll",
@@ -252,6 +278,11 @@ describe("show_in_app authorization and delivery", () => {
     });
     if (!polled || !("command" in polled) || !polled.command)
       throw new Error("missing command");
+    expect(polled.command.target).toEqual({
+      kind: "session",
+      id: "s-lint",
+      tab: "review",
+    });
     nav.handle("signed-in-login", {
       action: "ack",
       connectionId: "call",
@@ -264,6 +295,7 @@ describe("show_in_app authorization and delivery", () => {
       kind: "session",
       id: "s-lint",
       title: "Vendor lint rules",
+      tab: "review",
     });
     nav.close();
   });

--- a/packages/core/opensession-server/src/server/desk-voice-show.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.ts
@@ -1,6 +1,10 @@
 import { getSessionControl, type SessionControl } from "./session-control";
 import { getWorkspace, listWorkspaces, type Workspace } from "./workspaces";
-import { deskShowTargetSchema } from "../shared/desk-navigation";
+import {
+  DESK_SHOW_TABS,
+  deskShowTargetSchema,
+  type DeskShowTab,
+} from "../shared/desk-navigation";
 import { fuzzyScore } from "../shared/fuzzy-match";
 import type { DeskVoiceNavigation } from "./desk-voice-navigation";
 
@@ -8,7 +12,7 @@ export const SHOW_IN_APP_TOOL = {
   type: "function",
   name: "show_in_app",
   description:
-    "Bring a session or a workspace up in the user's own Open Session window, next to the Desk. Use when they ask to see, open, show, or go to something. Give the session's id or its title (a distinctive part is enough), or the workspace's id or name. Only changes the page shown in this voice call's browser.",
+    "Bring a session or a workspace up in the user's own Open Session window, next to the Desk. Use when they ask to see, open, show, or go to something. Give the session's id or its title (a distinctive part is enough), or the workspace's id or name. Add tab to land on a specific tab, such as review for the PR and CI status. Only changes the page shown in this voice call's browser.",
   parameters: {
     type: "object",
     properties: {
@@ -20,15 +24,22 @@ export const SHOW_IN_APP_TOOL = {
         type: "string",
         description: "Workspace id or name",
       },
+      tab: {
+        type: "string",
+        enum: [...DESK_SHOW_TABS],
+        description:
+          "Tab to bring up: review (the PR, its checks and comments), chat (the session transcript), conversation (a support thread), or video. Omit to keep the current tab.",
+      },
     },
     required: [],
     additionalProperties: false,
   },
 } as const;
 
-export type ShowTarget =
+export type ShowTarget = (
   | { kind: "session"; id: string; title: string }
-  | { kind: "workspace"; id: string; name: string };
+  | { kind: "workspace"; id: string; name: string }
+) & { tab?: DeskShowTab };
 
 export type ShowResolution =
   | { target: ShowTarget }
@@ -183,6 +194,13 @@ export function pick<T extends Pickable>(
   };
 }
 
+function isShowTab(value: unknown): value is DeskShowTab {
+  return (
+    typeof value === "string" &&
+    (DESK_SHOW_TABS as readonly string[]).includes(value)
+  );
+}
+
 export async function resolveShowTarget(
   args: Record<string, unknown>,
   deps: {
@@ -196,7 +214,9 @@ export async function resolveShowTarget(
     typeof args.workspace === "string" ? args.workspace.trim() : "";
 
   if (
-    Object.keys(args).some((key) => key !== "session" && key !== "workspace") ||
+    Object.keys(args).some(
+      (key) => key !== "session" && key !== "workspace" && key !== "tab",
+    ) ||
     Boolean(session) === Boolean(workspace) ||
     (args.session !== undefined && typeof args.session !== "string") ||
     (args.workspace !== undefined && typeof args.workspace !== "string") ||
@@ -205,13 +225,24 @@ export async function resolveShowTarget(
   ) {
     return { error: "Name exactly one session or workspace to show." };
   }
+  if (args.tab !== undefined && args.tab !== "" && !isShowTab(args.tab)) {
+    return {
+      error: `Unknown tab; use one of ${DESK_SHOW_TABS.join(", ")}.`,
+    };
+  }
+  const tab = isShowTab(args.tab) ? { tab: args.tab } : {};
 
   if (session) {
     // The Desk itself is hidden from every list; a call never lands on it.
     const byId = deps.control.getSession(session);
     if (byId && !byId.desk)
       return {
-        target: { kind: "session", id: byId.id, title: byId.title || "" },
+        target: {
+          kind: "session",
+          id: byId.id,
+          title: byId.title || "",
+          ...tab,
+        },
       };
     const visible = deps.control
       .listSessions()
@@ -229,14 +260,21 @@ export async function resolveShowTarget(
     const found = pick(session, visible, "session");
     if ("error" in found) return found;
     return {
-      target: { kind: "session", id: found.item.id, title: found.item.title },
+      target: {
+        kind: "session",
+        id: found.item.id,
+        title: found.item.title,
+        ...tab,
+      },
     };
   }
 
   if (workspace) {
     const byId = await deps.getWorkspace(workspace);
     if (byId)
-      return { target: { kind: "workspace", id: byId.id, name: byId.name } };
+      return {
+        target: { kind: "workspace", id: byId.id, name: byId.name, ...tab },
+      };
     const all = (await deps.listWorkspaces()).map((w) => ({
       id: w.id,
       title: w.name,
@@ -245,7 +283,12 @@ export async function resolveShowTarget(
     const found = pick(workspace, all, "workspace");
     if ("error" in found) return found;
     return {
-      target: { kind: "workspace", id: found.item.id, name: found.item.title },
+      target: {
+        kind: "workspace",
+        id: found.item.id,
+        name: found.item.title,
+        ...tab,
+      },
     };
   }
 
@@ -275,6 +318,7 @@ export async function showInApp(
   const safe = deskShowTargetSchema.safeParse({
     kind: target.kind,
     id: target.id,
+    ...(target.tab ? { tab: target.tab } : {}),
   });
   if (!safe.success)
     return { shown: false, error: "That page cannot be opened by voice." };

--- a/packages/core/opensession-server/src/server/desk-voice-show.ts
+++ b/packages/core/opensession-server/src/server/desk-voice-show.ts
@@ -1,6 +1,7 @@
 import { getSessionControl, type SessionControl } from "./session-control";
 import { getWorkspace, listWorkspaces, type Workspace } from "./workspaces";
 import { deskShowTargetSchema } from "../shared/desk-navigation";
+import { fuzzyScore } from "../shared/fuzzy-match";
 import type { DeskVoiceNavigation } from "./desk-voice-navigation";
 
 export const SHOW_IN_APP_TOOL = {
@@ -35,13 +36,106 @@ export type ShowResolution =
 
 /** How many near-matches the backend gets to disambiguate with. */
 const MAX_CANDIDATES = 5;
+/** Below this fuzzy score a title is not a candidate at all (fuzzy-match.ts:
+ * 60 per term found whole, 40/30 per term one or two edits away, 20 for an
+ * abbreviation). */
+const MIN_FUZZY_SCORE = 30;
+/** A whole-query hit (exact, prefix, or substring of the title) outranks any
+ * term-by-term match, so it is never disambiguated against one. */
+const WHOLE_QUERY_SCORE = 70;
+/** Two fuzzy candidates this close are a real toss-up; ask rather than guess. */
+const CLEAR_LEAD = 15;
+
+/** Words a spoken request carries that a title rarely does ("the profile
+ * subtitles one", "my deploy session"). Dropped only when other terms remain. */
+const FILLER_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "my",
+  "our",
+  "this",
+  "that",
+  "one",
+  "please",
+  "session",
+  "sessions",
+  "workspace",
+  "workspaces",
+  "of",
+  "for",
+  "to",
+  "in",
+  "on",
+  "with",
+  "about",
+]);
 
 function normalize(text: string): string {
   return text.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
-/** Exact names take precedence, but duplicate names always need clarification. */
-function pick<T extends { id: string; title: string; recency?: string }>(
+function stripFiller(query: string): string {
+  const kept = query.split(" ").filter((term) => !FILLER_WORDS.has(term));
+  return kept.length ? kept.join(" ") : query;
+}
+
+interface Pickable {
+  id: string;
+  title: string;
+  recency?: string;
+  parentSessionId?: string;
+  spawnedBy?: string;
+  agentStarted?: boolean;
+  automation?: string;
+  workspaceId?: string | null;
+}
+
+/** A session the app started on behalf of another: a spawned worker, the
+ * auto-fix opened from a PR panel, or the headless review of a PR the primary
+ * session owns. Their titles are near-copies of the primary's, so on a tie
+ * the person almost always means the primary. Phrasing that singles the
+ * derivative out ("the review of …") already outscores the primary above. */
+function derivedFrom(child: Pickable, parent: Pickable): boolean {
+  if (child.id === parent.id) return false;
+  if (child.parentSessionId === parent.id || child.spawnedBy === parent.id)
+    return true;
+  const sharesWorkspace =
+    !!child.workspaceId && child.workspaceId === parent.workspaceId;
+  return (
+    sharesWorkspace &&
+    !parent.agentStarted &&
+    !parent.automation &&
+    (child.agentStarted === true || !!child.automation)
+  );
+}
+
+function withoutDerivatives<T extends Pickable>(
+  scored: Array<{ item: T; score: number }>,
+): Array<{ item: T; score: number }> {
+  return scored.filter(
+    ({ item, score }) =>
+      !scored.some(
+        (other) => other.score >= score && derivedFrom(item, other.item),
+      ),
+  );
+}
+
+function byScoreThenRecency<T extends Pickable>(
+  a: { item: T; score: number },
+  b: { item: T; score: number },
+): number {
+  return (
+    b.score - a.score ||
+    (b.item.recency ?? "").localeCompare(a.item.recency ?? "")
+  );
+}
+
+/** Exact names take precedence, but duplicate names always need clarification.
+ * Otherwise titles are matched term by term with a small typo budget, so a
+ * spoken "profile subtitle sidebar" still finds "Profile Subtitles sidebar
+ * opening", and a derivative session never ties with its own primary. */
+export function pick<T extends Pickable>(
   query: string,
   items: T[],
   what: string,
@@ -50,18 +144,42 @@ function pick<T extends { id: string; title: string; recency?: string }>(
   | { error: string; candidates?: Array<{ id: string; title: string }> } {
   const q = normalize(query);
   if (!q) return { error: `Name the ${what} to show.` };
-  const exact = items.filter((i) => normalize(i.title) === q);
-  const partial = exact.length
-    ? exact
-    : items.filter((i) => normalize(i.title).includes(q));
-  if (partial.length === 1) return { item: partial[0]! };
-  if (!partial.length) return { error: `No ${what} matches "${query}".` };
-  partial.sort((a, b) => (b.recency ?? "").localeCompare(a.recency ?? ""));
+  const exact = withoutDerivatives(
+    items
+      .filter((item) => normalize(item.title) === q)
+      .map((item) => ({ item, score: 100 })),
+  );
+  let ranked = exact;
+  if (!exact.length) {
+    const stripped = stripFiller(q);
+    const scored = items
+      .map((item) => ({
+        item,
+        score: Math.max(
+          fuzzyScore(q, item.title),
+          stripped === q ? 0 : fuzzyScore(stripped, item.title),
+        ),
+      }))
+      .filter(({ score }) => score >= MIN_FUZZY_SCORE)
+      .sort(byScoreThenRecency);
+    if (!scored.length) return { error: `No ${what} matches "${query}".` };
+    // A title that contains the whole query beats any term-wise match.
+    const whole = scored.filter(({ score }) => score >= WHOLE_QUERY_SCORE);
+    ranked = withoutDerivatives(whole.length ? whole : scored);
+    if (
+      ranked.length > 1 &&
+      !whole.length &&
+      ranked[0]!.score - ranked[1]!.score >= CLEAR_LEAD
+    )
+      ranked = [ranked[0]!];
+  }
+  if (ranked.length === 1) return { item: ranked[0]!.item };
+  ranked.sort(byScoreThenRecency);
   return {
     error: `Several ${what}s match "${query}"; ask which one.`,
-    candidates: partial
+    candidates: ranked
       .slice(0, MAX_CANDIDATES)
-      .map(({ id, title }) => ({ id, title })),
+      .map(({ item: { id, title } }) => ({ id, title })),
   };
 }
 
@@ -102,6 +220,11 @@ export async function resolveShowTarget(
         id: s.id,
         title: s.title || "",
         recency: s.lastActivity ?? s.createdAt,
+        parentSessionId: s.parentSessionId,
+        spawnedBy: s.spawnedBy,
+        agentStarted: s.agentStarted,
+        automation: s.automation,
+        workspaceId: s.workspaceId,
       }));
     const found = pick(session, visible, "session");
     if ("error" in found) return found;

--- a/packages/core/opensession-server/src/server/desk.ts
+++ b/packages/core/opensession-server/src/server/desk.ts
@@ -130,7 +130,7 @@ export const DESK_NOTE = `## Your role: the Desk
 
 This session is the user's Desk — their standing concierge, summoned as a quick overlay on top of whatever they're doing. Discipline:
 
-- When asked to show, open, or go to a session or workspace, use show_in_app when available. It changes the page beside this Desk. Ask which one if names are ambiguous; never claim navigation succeeded without the tool result. If the tool is unavailable, say that this message has no connected browser to navigate.
+- When asked to show, open, or go to a session or workspace, use show_in_app when available. It changes the page beside this Desk. When they ask for a particular tab (the review tab with the PR and CI status, the chat), pass it as tab. Ask which one if names are ambiguous; never claim navigation succeeded without the tool result. If the tool is unavailable, say that this message has no connected browser to navigate.
 - Keep answers short and immediate; the user is mid-task and will close this overlay in seconds.
 - Manage their todo list with the opensession-todos tools: capture items the moment they mention wanting/needing to do something ("I want to finish X today" → add_todo), mark things done when they say so, and use list_todos before answering "what's on my plate?".
 - Ask mode only makes the repository checkout read-only; it does not prevent updating todos through their tools. If earlier messages in this Desk conversation claim otherwise, those refusals are outdated: correct them and use the requested Desk tool directly.

--- a/packages/core/opensession-server/src/shared/desk-navigation.ts
+++ b/packages/core/opensession-server/src/shared/desk-navigation.ts
@@ -1,10 +1,23 @@
 import { z } from "zod";
 
-// Only catalog IDs, never URLs, paths, query strings, or fragments.
+/** The tabs Desk may foreground once it lands: the transcript (`chat`) or one
+ * of the workspace panes the app router already addresses. Panes that spawn
+ * something (terminal, desktop, preview) are deliberately not reachable. */
+export const DESK_SHOW_TABS = [
+  "chat",
+  "review",
+  "conversation",
+  "video",
+] as const;
+export type DeskShowTab = (typeof DESK_SHOW_TABS)[number];
+
+// Only catalog IDs and a fixed tab name, never URLs, paths, query strings, or
+// fragments.
 export const deskShowTargetSchema = z
   .object({
     kind: z.enum(["session", "workspace"]),
     id: z.string().regex(/^[A-Za-z0-9_-]{1,128}$/),
+    tab: z.enum(DESK_SHOW_TABS).optional(),
   })
   .strict();
 export type DeskShowTarget = z.infer<typeof deskShowTargetSchema>;


### PR DESCRIPTION
Three Desk (concierge overlay) fixes, one per commit.

## 1. `show_in_app` can target a tab

**Root cause.** `show_in_app` carried only `{kind, id}`; the browser handoff (`lib/desk-show.ts`) mapped that onto `/session/<id>` or `/workspace/<id>`. A session's Review tab is not a URL at all: it is the workspace view tab (`activeViewTab`) the sidebar foregrounds through `openReviewForSession` / `pendingReviewOpen`. So the Desk had no way to ask for it and said it could not switch tabs.

**Fix.** Optional `tab` on the tool (voice and text MCP), validated to `chat | review | conversation | video` in the shared wire schema (still no URLs, paths or fragments; panes that spawn something, terminal/desktop/preview, are not reachable). For a workspace the tab becomes the existing `/review|/conversation|/video` route. For a session, `review` reuses the sidebar's pending-open pulse, `chat` clears the workspace's remembered pane, `conversation`/`video` open the session's workspace on that pane. The voice and Desk instructions mention the parameter so the model passes it.

## 2. A minimised Desk shows the live call

**Root cause.** `voiceState` lives inside `DeskBody`; nothing outside the overlay knew a call was running, and the Desk trigger is the only thing left on screen after minimising.

**Fix.** `DeskOverlay` reports `onCallActiveChange`; `AppContent` badges the Desk FAB with the app's `PulseDot` and relabels it "Desk call in progress" while the call is live and Desk is closed. Pushed phone pages have no FAB, so the mobile top bar carries a handset control instead. Both reopen Desk; the indicator clears on reopen or when the call ends.

## 3. Name lookup: fuzzy, filler-tolerant, derivative-aware

**Root cause.** `pick()` in `desk-voice-show.ts` was exact-or-substring. "Profile subtitle sidebar opening" is not a substring of "Profile Subtitles sidebar opening", so it was a full miss. And a primary session and its PR review (`Review · PR #N <same title>`) or auto-fix worker tied as two equal candidates.

**Fix.** Titles are scored with the shared `fuzzy-match.ts` (the @ palette's matcher: every term must land, whole or within a small edit budget). Spoken filler ("the", "my", "session") is dropped when other terms remain. A title containing the whole phrase outranks term-wise matches; among fuzzy matches a clear leader (15+ points) is taken, a near tie is asked back. Derivatives (`parentSessionId`/`spawnedBy`, or an `automation`/`agentStarted` session sharing the primary's workspace) are dropped whenever the primary scores at least as well, so "subtitles sidebar" opens the primary. Phrasing that names the derivative ("the review of…", "PR 41 feedback") outscores the primary and reaches it directly, which is how "unless the phrasing suggests otherwise" is handled rather than by a keyword list.

Tests in `desk-voice-show.test.ts` cover the real miss (singular/plural, filler, a typo), the derivative tie, the phrasing that reaches the derivative, an unknown-tab refusal, and the tab riding the acknowledged command.

## Verification

- `bun run check` (format, typecheck, lint, isolated unit tests, snapshots) green.
- Isolated demo instance (`verify-opensession`), desktop 1440x900 and phone 390x844:
  - Session page, then the browser-local show handoff with `tab: "review"`: the Review tab is selected (`tab "Review Close Review" [selected=true]`); `tab: "chat"` returns to the session tab. The server side of that command is covered by the real MCP dispatch test.
  - Real Desk UI: Start a voice call, Minimise Desk. The FAB carries the pulse dot and reads "Desk call in progress. Open the Desk"; reopening clears it; End call then minimise shows the plain trigger. On phone the root FAB is badged and a pushed page shows the top-bar handset control, which reopens Desk.
  - Limit: the demo has no OpenAI Live or microphone, so for the call captures the page's `getUserMedia` returned an empty stream and the `POST /api/desk/voice/live` request was left pending, holding the real client in its "Connecting…" (active) state. Nothing inside the app was stubbed.

Screenshots and accessibility snapshots (desktop and phone, before/after for both the tab handoff and the call indicator) are in the OS session's `artifacts/verification/opensession/verify-desk-20260911-141830-4119208/`; they are not committed.

Started by Michiel Westerbeek in [this OS session](https://os.tella.dev/session/bks-870f4595-455d-78f2-9899-561c46af6b4e)
